### PR TITLE
claude code preset hook

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ impl fmt::Display for GitAiError {
             GitAiError::JsonError(e) => write!(f, "JSON error: {}", e),
             GitAiError::Utf8Error(e) => write!(f, "UTF-8 error: {}", e),
             GitAiError::FromUtf8Error(e) => write!(f, "From UTF-8 error: {}", e),
-            GitAiError::PresetError(e) => write!(f, "Preset error: {}", e),
+            GitAiError::PresetError(e) => write!(f, "{}", e),
             GitAiError::Generic(e) => write!(f, "Generic error: {}", e),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,7 @@ fn handle_checkpoint(args: &[String]) {
     let mut _prompt_json = None;
     let mut prompt_path = None;
     let mut prompt_id = None;
+    let mut hook_input = None;
 
     let mut i = 0;
     while i < args.len() {
@@ -194,6 +195,15 @@ fn handle_checkpoint(args: &[String]) {
                     std::process::exit(1);
                 }
             }
+            "--hook-input" => {
+                if i + 1 < args.len() {
+                    hook_input = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --hook-input requires a value");
+                    std::process::exit(1);
+                }
+            }
 
             _ => {
                 i += 1;
@@ -207,28 +217,22 @@ fn handle_checkpoint(args: &[String]) {
         match args[0].as_str() {
             "claude" => {
                 match ClaudePreset.run(AgentCheckpointFlags {
-                    transcript: None,
-                    model: model.clone(),
                     prompt_id: prompt_id.clone(),
-                    prompt_path: prompt_path.clone(),
-                    workspace_id: None,
+                    hook_input: hook_input.clone(),
                 }) {
                     Ok(agent_run) => {
                         agent_run_result = Some(agent_run);
                     }
                     Err(e) => {
-                        eprintln!("Error running Claude preset: {}", e);
+                        eprintln!("Claude preset error: {}", e);
                         std::process::exit(1);
                     }
                 }
             }
             "cursor" => {
                 match CursorPreset.run(AgentCheckpointFlags {
-                    transcript: None,
-                    model: None,
                     prompt_id: None,
-                    prompt_path: None,
-                    workspace_id: None,
+                    hook_input: None,
                 }) {
                     Ok(agent_run) => {
                         agent_run_result = Some(agent_run);


### PR DESCRIPTION
Implemented a `checkpoint claude` preset for easier use from hooks.  

A few points
1. claude hooks pass JSON into the process you spawn as a string. Not every computer can be expected to have `jq` installed, so I decided to make parsing that JSON the responsibility of `git-ai`
2. All hooks run from the cwd you started Claude Code in, for our purposes that is probably right, but we may want to swallow errors int he event you run it outside of a git repo

Here's what my `~/.claude/settings.json` looks like:

```
{
        "hooks": {
            "PreToolUse": [
                {
                    "matcher": "Write|Edit|MultiEdit",
                    "hooks": [
                        {
                            "type": "command",
                            "command": "git-ai checkpoint"
                        }
                    ]
                }
            ],
            "PostToolUse": [
                {
                    "matcher": "Write|Edit|MultiEdit",
                    "hooks": [
                        {
                            "type": "command",
                            "command": "git-ai checkpoint claude --hook-input \"$(cat)\""
                        }
                    ]
                }
            ]
        }
    }

```


#25 