### PR TITLE
fix: sqlite was added to parse cursor localstorage and broke windows builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ similar = "2.7.0"
 chrono = "0.4.41"
 indicatif = "0.17"
 smol = "1.3"
-rusqlite = { version = "0.31" }
+rusqlite = { version = "0.31", features = ["bundled"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
These changes bundle the missing lib for windows platform