### PR TITLE
First class support for Cursor via Hooks Preset

### DIFF
--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -61,6 +61,27 @@ pub fn run(
                         .map(|id| id.tool.clone())
                         .unwrap_or_default()
                 ));
+
+                // Display first user message from transcript if available
+                if let Some(transcript) = &checkpoint.transcript {
+                    if let Some(first_message) = transcript.messages().first() {
+                        if let crate::log_fmt::transcript::Message::User { text, .. } =
+                            first_message
+                        {
+                            let agent_info = checkpoint
+                                .agent_id
+                                .as_ref()
+                                .map(|id| format!(" (Agent: {})", id.tool))
+                                .unwrap_or_default();
+                            let message_count = transcript.messages().len();
+                            debug_log(&format!(
+                                "  First message{} ({} messages): {}",
+                                agent_info, message_count, text
+                            ));
+                        }
+                    }
+                }
+
                 debug_log("  Entries:");
                 for entry in &checkpoint.entries {
                     debug_log(&format!("    File: {}", entry.file));
@@ -126,7 +147,7 @@ pub fn run(
 
         // Set transcript and agent_id if provided
         if let Some(agent_run) = &agent_run_result {
-            checkpoint.transcript = Some(agent_run.transcript.clone());
+            checkpoint.transcript = Some(agent_run.transcript.clone().unwrap_or_default());
             checkpoint.agent_id = Some(agent_run.agent_id.clone());
         }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -2,4 +2,4 @@ pub mod post_commit;
 pub mod pre_commit;
 pub mod refs;
 pub mod repository;
-pub use repository::find_repository;
+pub use repository::{find_repository, find_repository_in_path};

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -4,3 +4,7 @@ use git2::Repository;
 pub fn find_repository() -> Result<Repository, GitAiError> {
     Repository::discover(".").map_err(GitAiError::GitError)
 }
+
+pub fn find_repository_in_path(path: &str) -> Result<Repository, GitAiError> {
+    Repository::discover(path).map_err(GitAiError::GitError)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,14 +232,14 @@ fn handle_checkpoint(args: &[String]) {
             }
             "cursor" => {
                 match CursorPreset.run(AgentCheckpointFlags {
-                    prompt_id: None,
-                    hook_input: None,
+                    prompt_id: prompt_id.clone(),
+                    hook_input: hook_input.clone(),
                 }) {
                     Ok(agent_run) => {
                         agent_run_result = Some(agent_run);
                     }
                     Err(e) => {
-                        eprintln!("Error running Claude preset: {}", e);
+                        eprintln!("Error running Cursor preset: {}", e);
                         std::process::exit(1);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use utils::debug_log;
 use crate::commands::checkpoint_agent::agent_preset::{
     AgentCheckpointFlags, AgentCheckpointPreset, ClaudePreset, CursorPreset,
 };
+use crate::git::find_repository_in_path;
 use crate::git::refs::DEFAULT_REFSPEC;
 
 #[derive(Parser)]
@@ -127,6 +128,8 @@ fn main() {
 }
 
 fn handle_checkpoint(args: &[String]) {
+    let repository_working_dir = std::env::current_dir().unwrap();
+
     // Parse checkpoint-specific arguments
     let mut author = None;
     let mut show_working_log = false;
@@ -245,8 +248,12 @@ fn handle_checkpoint(args: &[String]) {
         }
     }
 
+    let final_working_dir = agent_run_result
+        .as_ref()
+        .and_then(|r| r.repo_working_dir.clone())
+        .unwrap_or_else(|| repository_working_dir.to_string_lossy().to_string());
     // Find the git repository
-    let repo = match find_repository() {
+    let repo = match find_repository_in_path(&final_working_dir) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);

--- a/src/tmp_repo.rs
+++ b/src/tmp_repo.rs
@@ -308,7 +308,8 @@ impl TmpRepo {
         // Create agent run result
         let agent_run_result = AgentRunResult {
             agent_id,
-            transcript,
+            transcript: Some(transcript),
+            is_human: false,
             repo_working_dir: None,
         };
 

--- a/src/tmp_repo.rs
+++ b/src/tmp_repo.rs
@@ -309,6 +309,7 @@ impl TmpRepo {
         let agent_run_result = AgentRunResult {
             agent_id,
             transcript,
+            repo_working_dir: None,
         };
 
         checkpoint(


### PR DESCRIPTION
The Cursor team enabled hooks feature flag for some git-ai contributors. It's in 1.7.x https://cursor.com/nightlydownload and will launch more broadly soon. 

We reported a few bugs/limitations to the team that we expect them to fix

- [ ] Unlike claude code, cursor does not use the system shell's configuration (looks like they just run bash). This makes it difficult to reliably call user installed binaries x-platform. Hoping this is resolved, for now a mac compatible solution `zsh -c 'source ~/.zprofile; source ~/.zshrc;` is being used for testing
- [x] Shared a preference for`beforeFileEdit`. _It's on their roadmap and hoping it makes the cut for public release_ 
- [ ] Clarification - will these hooks work with `cursor-agent `CLI or just the IDE.


To test, add the following to `~/.cursor/hooks.json`

```json
{
  "version": 1,
  "hooks": {
    "beforeSubmitPrompt": [
      {
        "command": "zsh -c 'source ~/.zprofile; source ~/.zshrc; git-ai checkpoint cursor --hook-input \"$(cat)\"' >/dev/null 2>&1"
      }
    ],
    "afterFileEdit": [
      {
        "command": "zsh -c 'source ~/.zprofile; source ~/.zshrc; git-ai checkpoint cursor --hook-input \"$(cat)\"' >/dev/null 2>&1"
      }
    ]
  }
}
```

You'll notice both of these commands are the same -- for the cursor preset git-ai is responsible for deciding whether it should mark code as AI or human based on the JSON stdin. It's not safe to assume people have jq or other JSON tools on their shell so we're insourcing that concern. When the `hook_event_name` is  `beforeSubmitPrompt` a human checkpoint is created, when it is `afterFileEdit` an AI checkpoint is created. 
```
{
  "conversation_id": string // an identifier for the conversation as a whole
  "hook_event_name": string // the name of the hook this is being called in response to
  "workspace_roots": string[] // The roots of the folders in the workspace.  Usually just one, but multiroot can have many
}
```


Known issues: 

- [ ] Race condition. The last assistant message is not persisting until after the hook runs. Planning to fetch latest messages when preparing the authorship logs in post-commit. The many seconds between code being generated, reviewed, tested and committed should guarantee changes have hit the SQLlite on disk.  
 