### PR TITLE
Local rewrites for authorship 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 .DS_Store
 .task/
-scripts/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .DS_Store
 .task/
+scripts/target

--- a/src/commands/commit_hooks.rs
+++ b/src/commands/commit_hooks.rs
@@ -73,7 +73,7 @@ pub fn commit_post_command_hook(
     // }
 }
 
-fn get_commit_default_author(repo: &Repository, args: &[String]) -> String {
+pub fn get_commit_default_author(repo: &Repository, args: &[String]) -> String {
     // According to git commit manual, --author flag overrides all other author information
     if let Some(author_spec) = extract_author_from_args(args) {
         if let Ok(Some(resolved_author)) = repo.resolve_author_spec(&author_spec) {

--- a/src/commands/commit_hooks.rs
+++ b/src/commands/commit_hooks.rs
@@ -54,10 +54,11 @@ pub fn commit_post_command_hook(
     } else {
         repository.handle_rewrite_log_event(RewriteLogEvent::commit(
             repository.pre_command_base_commit.clone().unwrap(),
-            repository.pre_command_refname.clone().unwrap(),
+            repository.head().unwrap().target().unwrap(),
         ));
     }
 
+    // @todo @acunniffe -> this should be trigged by handle_rewrite
     if let Err(e) = post_commit::post_commit(&repository) {
         eprintln!("git-ai authorship log generation failed: {}", e);
     }

--- a/src/commands/commit_hooks.rs
+++ b/src/commands/commit_hooks.rs
@@ -10,7 +10,7 @@ pub fn commit_pre_command_hook(parsed_args: &ParsedGitInvocation) -> bool {
     }
 
     // Find the git repository
-    let repo = match find_repository(parsed_args.global_args.clone()) {
+    let repo = match find_repository(&parsed_args.global_args) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);
@@ -49,7 +49,7 @@ pub fn commit_post_command_hook(
     }
 
     // Find the git repository
-    let repo = match find_repository(parsed_args.global_args.clone()) {
+    let repo = match find_repository(&parsed_args.global_args) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);

--- a/src/commands/commit_hooks.rs
+++ b/src/commands/commit_hooks.rs
@@ -66,11 +66,6 @@ pub fn commit_post_command_hook(
             true,
         );
     }
-
-    // // @todo @acunniffe -> this should be trigged by handle_rewrite
-    // if let Err(e) = post_commit::post_commit(&repository) {
-    //     eprintln!("git-ai authorship log generation failed: {}", e);
-    // }
 }
 
 pub fn get_commit_default_author(repo: &Repository, args: &[String]) -> String {

--- a/src/commands/commit_hooks.rs
+++ b/src/commands/commit_hooks.rs
@@ -1,34 +1,46 @@
 use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
+use crate::git::find_repository;
+use crate::git::post_commit;
+use crate::git::pre_commit;
 use crate::git::repository::Repository;
-use crate::git::rewrite_log::RewriteLogEvent;
 
-pub fn commit_pre_command_hook(
-    parsed_args: &ParsedGitInvocation,
-    repository_option: &mut Option<Repository>,
-) {
-    if is_dry_run(&parsed_args.command_args) || repository_option.is_none() {
-        return;
+pub fn commit_pre_command_hook(parsed_args: &ParsedGitInvocation) -> bool {
+    if is_dry_run(&parsed_args.command_args) {
+        return false;
     }
 
-    let repo: &mut Repository = repository_option.as_mut().unwrap();
-    // store this so it's availible after
-    repo.require_pre_command_head();
+    // Find the git repository
+    let repo = match find_repository(parsed_args.global_args.clone()) {
+        Ok(repo) => repo,
+        Err(e) => {
+            eprintln!("Failed to find repository: {}", e);
+            std::process::exit(1);
+        }
+    };
 
-    // @todo add back this logic
-    // // repo.resolve_author_spec(author_spec)
-    // // Run pre-commit logic
-    // if let Err(e) = pre_commit::pre_commit(&repo, "Aidan".to_string()) {
-    //     eprintln!("Pre-commit failed: {}", e);
-    //     std::process::exit(1);
-    // }
+    let default_author = get_commit_default_author(&repo, &parsed_args.command_args);
+
+    // Run pre-commit logic
+    if let Err(e) = pre_commit::pre_commit(&repo, default_author.clone()) {
+        if e.to_string()
+            .contains("Cannot run checkpoint on bare repositories")
+        {
+            eprintln!(
+                "Cannot run checkpoint on bare repositories (skipping git-ai pre-commit hook)"
+            );
+            return false;
+        }
+        eprintln!("Pre-commit failed: {}", e);
+        std::process::exit(1);
+    }
+    return true;
 }
 
 pub fn commit_post_command_hook(
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
-    repository_option: &mut Option<Repository>,
 ) {
-    if is_dry_run(&parsed_args.command_args) || repository_option.is_none() {
+    if is_dry_run(&parsed_args.command_args) {
         return;
     }
 
@@ -36,59 +48,28 @@ pub fn commit_post_command_hook(
         return;
     }
 
-    let repo: &mut Repository = repository_option.as_mut().unwrap();
+    // Find the git repository
+    let repo = match find_repository(parsed_args.global_args.clone()) {
+        Ok(repo) => repo,
+        Err(e) => {
+            eprintln!("Failed to find repository: {}", e);
+            std::process::exit(1);
+        }
+    };
 
-    if parsed_args.has_command_flag("--amend") {
-        repo.handle_rewrite_log_event(RewriteLogEvent::commit_amend(
-            repo.pre_command_base_commit.as_ref().unwrap().clone(),
-            repo.head().unwrap().target().unwrap().to_string(),
-        ))
+    if let Err(e) = post_commit::post_commit(&repo) {
+        eprintln!("Post-commit failed: {}", e);
     }
-
-    // repo.storage
-    //     .append_rewrite_event(RewriteLogEvent::CommitAmend {
-    //         commit_amend: CommitAmendEvent {
-    //             // original_commit: parsed_args.command_args[0].clone(),
-    //             // amended_commit_sha: repo.head().unwrap().target().unwrap().to_string(),
-    //             // success: exit_status.success(),
-    //             // changed_files: vec![],
-    //         },
-    //     })
-
-    // TODO Take global args into account
-    // TODO Remove this once we migrate off of libgit2
-    // // Find the git repository
-    // let repo = match find_repository() {
-    //     Ok(repo) => repo,
-    //     Err(e) => {
-    //         eprintln!("Failed to find repository: {}", e);
-    //         std::process::exit(1);
-    //     }
-    // };
-
-    // if let Err(e) = post_commit::post_commit(&repo, false) {
-    //     eprintln!("Post-commit failed: {}", e);
-    // }
-
-    // let amended_commit_sha = repo.head().unwrap().target().unwrap().to_string();
-
-    // let repo_storage = RepoStorage::for_repo_path(repo.path());
-    // repo_storage
-    //     .append_rewrite_event(RewriteLogEvent::CommitAmend {
-    //         commit_amend: CommitAmendEvent {
-    //             original_commit: parsed_args.command_args[0].clone(),
-    //             amended_commit_sha,
-    //             success: true,         // success - assuming it will succeed
-    //             changed_files: vec![], // changed_files - could be populated from git diff
-    //         },
-    //     })
-    //     .unwrap();
 }
 
-fn get_commit_default_user_name(repo: &git2::Repository, args: &[String]) -> String {
+fn get_commit_default_author(repo: &Repository, args: &[String]) -> String {
     // According to git commit manual, --author flag overrides all other author information
     if let Some(author_spec) = extract_author_from_args(args) {
-        return resolve_author_spec(repo, &author_spec);
+        if let Ok(Some(resolved_author)) = repo.resolve_author_spec(&author_spec) {
+            if !resolved_author.trim().is_empty() {
+                return resolved_author.trim().to_string();
+            }
+        }
     }
 
     // Normal precedence when --author is not specified:
@@ -105,11 +86,9 @@ fn get_commit_default_user_name(repo: &git2::Repository, args: &[String]) -> Str
     }
 
     // Fall back to git config user.name
-    if let Ok(config) = repo.config() {
-        if let Ok(name) = config.get_string("user.name") {
-            if !name.trim().is_empty() {
-                return name.trim().to_string();
-            }
+    if let Ok(Some(name)) = repo.config_get_str("user.name") {
+        if !name.trim().is_empty() {
+            return name.trim().to_string();
         }
     }
 
@@ -150,44 +129,4 @@ fn extract_author_from_args(args: &[String]) -> Option<String> {
         i += 1;
     }
     None
-}
-
-fn resolve_author_spec(repo: &git2::Repository, author_spec: &str) -> String {
-    // According to git commit docs, --author can be:
-    // 1. "A U Thor <author@example.com>" format - use as explicit author
-    // 2. A pattern to search for existing commits via git rev-list --all -i --author=<pattern>
-
-    // If it looks like "Name <email>" format, extract the name part
-    if let Some(email_start) = author_spec.rfind('<') {
-        let name_part = author_spec[..email_start].trim();
-        if !name_part.is_empty() {
-            return name_part.to_string();
-        }
-    }
-
-    // If it doesn't look like an explicit format, treat it as a search pattern
-    // Try to find an existing commit by that author
-    if let Ok(mut revwalk) = repo.revwalk() {
-        if revwalk.push_glob("refs/*").is_ok() {
-            for oid_result in revwalk {
-                if let Ok(oid) = oid_result {
-                    if let Ok(commit) = repo.find_commit(oid) {
-                        let author = commit.author();
-                        if let Some(author_name) = author.name() {
-                            // Case-insensitive search (like git rev-list -i --author)
-                            if author_name
-                                .to_lowercase()
-                                .contains(&author_spec.to_lowercase())
-                            {
-                                return author_name.to_string();
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // If no matching commit found, use the pattern as-is
-    author_spec.trim().to_string()
 }

--- a/src/commands/fetch_hooks.rs
+++ b/src/commands/fetch_hooks.rs
@@ -13,7 +13,7 @@ pub fn fetch_post_command_hook(
     }
 
     // Find the git repository
-    let repo = match find_repository(parsed_args.global_args.clone()) {
+    let repo = match find_repository(&parsed_args.global_args) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);

--- a/src/commands/fetch_hooks.rs
+++ b/src/commands/fetch_hooks.rs
@@ -1,13 +1,12 @@
 use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
 use crate::git::find_repository;
 use crate::git::refs::AI_AUTHORSHIP_REFSPEC;
-use crate::git::repository::{Repository, exec_git};
+use crate::git::repository::exec_git;
 use crate::utils::debug_log;
 
 pub fn fetch_post_command_hook(
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
-    repository_option: &Option<Repository>,
 ) {
     if is_dry_run(&parsed_args.command_args) || !exit_status.success() {
         return;

--- a/src/commands/fetch_hooks.rs
+++ b/src/commands/fetch_hooks.rs
@@ -1,12 +1,13 @@
 use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
 use crate::git::find_repository;
 use crate::git::refs::AI_AUTHORSHIP_REFSPEC;
-use crate::git::repository::exec_git;
+use crate::git::repository::{Repository, exec_git};
 use crate::utils::debug_log;
 
 pub fn fetch_post_command_hook(
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
+    repository_option: &Option<Repository>,
 ) {
     if is_dry_run(&parsed_args.command_args) || !exit_status.success() {
         return;

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -278,7 +278,7 @@ fn handle_stats_delta(args: &[String]) {
 
     // TODO: Do we have any 'global' args for the stats-delta?
     // Find the git repository
-    let repo = match find_repository(Vec::<String>::new()) {
+    let repo = match find_repository(&Vec::<String>::new()) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);
@@ -300,7 +300,7 @@ fn handle_ai_blame(args: &[String]) {
 
     // TODO: Do we have any 'global' args for the ai-blame?
     // Find the git repository
-    let repo = match find_repository(Vec::<String>::new()) {
+    let repo = match find_repository(&Vec::<String>::new()) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -3,7 +3,8 @@ use crate::commands::fetch_hooks;
 use crate::commands::push_hooks;
 use crate::config;
 use crate::git::cli_parser::{ParsedGitInvocation, parse_git_cli_args};
-use crate::utils::debug_log;
+use crate::git::find_repository;
+use crate::git::repository::Repository;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 #[cfg(unix)]
@@ -47,10 +48,6 @@ fn uninstall_forwarding_handlers() {
     }
 }
 
-struct CommandHooksContext {
-    pre_commit_hook_result: Option<bool>,
-}
-
 pub fn handle_git(args: &[String]) {
     // If we're being invoked from a shell completion context, bypass git-ai logic
     // and delegate directly to the real git so existing completion scripts work.
@@ -60,57 +57,51 @@ pub fn handle_git(args: &[String]) {
         return;
     }
 
-    let mut command_hooks_context = CommandHooksContext {
-        pre_commit_hook_result: None,
-    };
-
     let parsed_args = parse_git_cli_args(args);
+
+    let mut repository_option = find_repository(parsed_args.clone().global_args).ok();
+
     // println!("command: {:?}", parsed_args.command);
     // println!("global_args: {:?}", parsed_args.global_args);
     // println!("command_args: {:?}", parsed_args.command_args);
     // println!("to_invocation_vec: {:?}", parsed_args.to_invocation_vec());
     if !parsed_args.is_help {
-        run_pre_command_hooks(&mut command_hooks_context, &parsed_args);
+        run_pre_command_hooks(&parsed_args, &mut repository_option);
     }
     let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false);
     if !parsed_args.is_help {
-        run_post_command_hooks(&mut command_hooks_context, &parsed_args, exit_status);
+        run_post_command_hooks(&parsed_args, exit_status, &mut repository_option);
     }
     exit_with_status(exit_status);
 }
 
 fn run_pre_command_hooks(
-    command_hooks_context: &mut CommandHooksContext,
     parsed_args: &ParsedGitInvocation,
+    repository_option: &mut Option<Repository>,
 ) {
     // Pre-command hooks
     match parsed_args.command.as_deref() {
-        Some("commit") => {
-            command_hooks_context.pre_commit_hook_result =
-                Some(commit_hooks::commit_pre_command_hook(parsed_args));
-        }
+        Some("commit") => commit_hooks::commit_pre_command_hook(parsed_args, repository_option),
         _ => {}
     }
 }
 
 fn run_post_command_hooks(
-    command_hooks_context: &mut CommandHooksContext,
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
+    repository_option: &mut Option<Repository>,
 ) {
     // Post-command hooks
     match parsed_args.command.as_deref() {
         Some("commit") => {
-            if let Some(pre_commit_hook_result) = command_hooks_context.pre_commit_hook_result {
-                if !pre_commit_hook_result {
-                    debug_log("Skipping git-ai post-commit hook because pre-commit hook failed");
-                    return;
-                }
-            }
-            commit_hooks::commit_post_command_hook(parsed_args, exit_status);
+            commit_hooks::commit_post_command_hook(parsed_args, exit_status, repository_option)
         }
-        Some("fetch") => fetch_hooks::fetch_post_command_hook(parsed_args, exit_status),
-        Some("push") => push_hooks::push_post_command_hook(parsed_args, exit_status),
+        Some("fetch") => {
+            fetch_hooks::fetch_post_command_hook(parsed_args, exit_status, repository_option)
+        }
+        Some("push") => {
+            push_hooks::push_post_command_hook(parsed_args, exit_status, repository_option)
+        }
         _ => {}
     }
 }

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -138,6 +138,20 @@ fn run_post_command_hooks(
         }
         Some("fetch") => fetch_hooks::fetch_post_command_hook(parsed_args, exit_status),
         Some("push") => push_hooks::push_post_command_hook(parsed_args, exit_status),
+        Some("reset") => {
+            if parsed_args.has_command_flag("--hard") {
+                let base_head = repository.head().unwrap().target().unwrap().to_string();
+                let _ = repository
+                    .storage
+                    .delete_working_log_for_base_commit(&base_head);
+
+                debug_log(&format!(
+                    "Reset --hard: deleted working log for {}",
+                    base_head
+                ));
+            }
+            // soft and mixed coming soon
+        }
         Some("merge") => {
             if parsed_args.has_command_flag("--squash")
                 && exit_status.success()

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -3,8 +3,7 @@ use crate::commands::fetch_hooks;
 use crate::commands::push_hooks;
 use crate::config;
 use crate::git::cli_parser::{ParsedGitInvocation, parse_git_cli_args};
-use crate::git::find_repository;
-use crate::git::repository::Repository;
+use crate::utils::debug_log;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 #[cfg(unix)]
@@ -48,6 +47,10 @@ fn uninstall_forwarding_handlers() {
     }
 }
 
+struct CommandHooksContext {
+    pre_commit_hook_result: Option<bool>,
+}
+
 pub fn handle_git(args: &[String]) {
     // If we're being invoked from a shell completion context, bypass git-ai logic
     // and delegate directly to the real git so existing completion scripts work.
@@ -57,51 +60,57 @@ pub fn handle_git(args: &[String]) {
         return;
     }
 
+    let mut command_hooks_context = CommandHooksContext {
+        pre_commit_hook_result: None,
+    };
+
     let parsed_args = parse_git_cli_args(args);
-
-    let mut repository_option = find_repository(parsed_args.clone().global_args).ok();
-
     // println!("command: {:?}", parsed_args.command);
     // println!("global_args: {:?}", parsed_args.global_args);
     // println!("command_args: {:?}", parsed_args.command_args);
     // println!("to_invocation_vec: {:?}", parsed_args.to_invocation_vec());
     if !parsed_args.is_help {
-        run_pre_command_hooks(&parsed_args, &mut repository_option);
+        run_pre_command_hooks(&mut command_hooks_context, &parsed_args);
     }
     let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false);
     if !parsed_args.is_help {
-        run_post_command_hooks(&parsed_args, exit_status, &mut repository_option);
+        run_post_command_hooks(&mut command_hooks_context, &parsed_args, exit_status);
     }
     exit_with_status(exit_status);
 }
 
 fn run_pre_command_hooks(
+    command_hooks_context: &mut CommandHooksContext,
     parsed_args: &ParsedGitInvocation,
-    repository_option: &mut Option<Repository>,
 ) {
     // Pre-command hooks
     match parsed_args.command.as_deref() {
-        Some("commit") => commit_hooks::commit_pre_command_hook(parsed_args, repository_option),
+        Some("commit") => {
+            command_hooks_context.pre_commit_hook_result =
+                Some(commit_hooks::commit_pre_command_hook(parsed_args));
+        }
         _ => {}
     }
 }
 
 fn run_post_command_hooks(
+    command_hooks_context: &mut CommandHooksContext,
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
-    repository_option: &mut Option<Repository>,
 ) {
     // Post-command hooks
     match parsed_args.command.as_deref() {
         Some("commit") => {
-            commit_hooks::commit_post_command_hook(parsed_args, exit_status, repository_option)
+            if let Some(pre_commit_hook_result) = command_hooks_context.pre_commit_hook_result {
+                if !pre_commit_hook_result {
+                    debug_log("Skipping git-ai post-commit hook because pre-commit hook failed");
+                    return;
+                }
+            }
+            commit_hooks::commit_post_command_hook(parsed_args, exit_status);
         }
-        Some("fetch") => {
-            fetch_hooks::fetch_post_command_hook(parsed_args, exit_status, repository_option)
-        }
-        Some("push") => {
-            push_hooks::push_post_command_hook(parsed_args, exit_status, repository_option)
-        }
+        Some("fetch") => fetch_hooks::fetch_post_command_hook(parsed_args, exit_status),
+        Some("push") => push_hooks::push_post_command_hook(parsed_args, exit_status),
         _ => {}
     }
 }

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -149,7 +149,7 @@ fn run_post_command_hooks(
                 let commit_author =
                     get_commit_default_author(&repository, &parsed_args.command_args);
 
-                let source_branch = parsed_args.command_args.iter().nth(1).unwrap();
+                let source_branch = parsed_args.pos_command(0).unwrap();
 
                 let source_head_sha = match repository
                     .revparse_single(source_branch.as_str())

--- a/src/commands/push_hooks.rs
+++ b/src/commands/push_hooks.rs
@@ -20,7 +20,7 @@ pub fn push_post_command_hook(
     }
 
     // Find the git repository
-    let repo = match find_repository(parsed_args.global_args.clone()) {
+    let repo = match find_repository(&parsed_args.global_args) {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("Failed to find repository: {}", e);

--- a/src/commands/push_hooks.rs
+++ b/src/commands/push_hooks.rs
@@ -1,12 +1,13 @@
 use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
 use crate::git::find_repository;
 use crate::git::refs::AI_AUTHORSHIP_REFSPEC;
-use crate::git::repository::exec_git;
+use crate::git::repository::{Repository, exec_git};
 use crate::utils::debug_log;
 
 pub fn push_post_command_hook(
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
+    repository_option: &Option<Repository>,
 ) {
     if is_dry_run(&parsed_args.command_args)
         || !exit_status.success()

--- a/src/commands/push_hooks.rs
+++ b/src/commands/push_hooks.rs
@@ -1,13 +1,12 @@
 use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
 use crate::git::find_repository;
 use crate::git::refs::AI_AUTHORSHIP_REFSPEC;
-use crate::git::repository::{Repository, exec_git};
+use crate::git::repository::exec_git;
 use crate::utils::debug_log;
 
 pub fn push_post_command_hook(
     parsed_args: &ParsedGitInvocation,
     exit_status: std::process::ExitStatus,
-    repository_option: &Option<Repository>,
 ) {
     if is_dry_run(&parsed_args.command_args)
         || !exit_status.success()

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_bottom.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_bottom.snap
@@ -1,0 +1,42 @@
+---
+source: src/commands/rebase_authorship.rs
+expression: authorship_log
+---
+AuthorshipLogV3 {
+    attestations: [
+        FileAttestation {
+            file_path: "test.txt",
+            entries: [
+                AttestationEntry {
+                    hash: "1cee1d9",
+                    line_ranges: [
+                        Range(
+                            6,
+                            7,
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "",
+        prompts: {
+            "1cee1d9": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "test_session_fixed",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
+            },
+        },
+    },
+}

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_bottom.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_bottom.snap
@@ -8,7 +8,7 @@ AuthorshipLogV3 {
             file_path: "test.txt",
             entries: [
                 AttestationEntry {
-                    hash: "1cee1d9",
+                    hash: "976aa32",
                     line_ranges: [
                         Range(
                             6,
@@ -23,10 +23,10 @@ AuthorshipLogV3 {
         schema_version: "authorship/3.0.0",
         base_commit_sha: "",
         prompts: {
-            "1cee1d9": PromptRecord {
+            "976aa32": PromptRecord {
                 agent_id: AgentId {
                     tool: "cursor",
-                    id: "test_session_fixed",
+                    id: "ai_agent",
                     model: "gpt-4",
                 },
                 human_author: Some(

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_top.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_top.snap
@@ -8,7 +8,7 @@ AuthorshipLogV3 {
             file_path: "test.txt",
             entries: [
                 AttestationEntry {
-                    hash: "1cee1d9",
+                    hash: "976aa32",
                     line_ranges: [
                         Range(
                             1,
@@ -23,10 +23,10 @@ AuthorshipLogV3 {
         schema_version: "authorship/3.0.0",
         base_commit_sha: "",
         prompts: {
-            "1cee1d9": PromptRecord {
+            "976aa32": PromptRecord {
                 agent_id: AgentId {
                     tool: "cursor",
-                    id: "test_session_fixed",
+                    id: "ai_agent",
                     model: "gpt-4",
                 },
                 human_author: Some(

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_top.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_at_top.snap
@@ -1,0 +1,42 @@
+---
+source: src/commands/rebase_authorship.rs
+expression: authorship_log
+---
+AuthorshipLogV3 {
+    attestations: [
+        FileAttestation {
+            file_path: "test.txt",
+            entries: [
+                AttestationEntry {
+                    hash: "1cee1d9",
+                    line_ranges: [
+                        Range(
+                            1,
+                            2,
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "",
+        prompts: {
+            "1cee1d9": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "test_session_fixed",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
+            },
+        },
+    },
+}

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_in_middle.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_in_middle.snap
@@ -1,0 +1,42 @@
+---
+source: src/commands/rebase_authorship.rs
+expression: authorship_log
+---
+AuthorshipLogV3 {
+    attestations: [
+        FileAttestation {
+            file_path: "test.txt",
+            entries: [
+                AttestationEntry {
+                    hash: "1cee1d9",
+                    line_ranges: [
+                        Range(
+                            3,
+                            4,
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "",
+        prompts: {
+            "1cee1d9": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "test_session_fixed",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
+            },
+        },
+    },
+}

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_in_middle.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_add_lines_in_middle.snap
@@ -8,7 +8,7 @@ AuthorshipLogV3 {
             file_path: "test.txt",
             entries: [
                 AttestationEntry {
-                    hash: "1cee1d9",
+                    hash: "976aa32",
                     line_ranges: [
                         Range(
                             3,
@@ -23,10 +23,10 @@ AuthorshipLogV3 {
         schema_version: "authorship/3.0.0",
         base_commit_sha: "",
         prompts: {
-            "1cee1d9": PromptRecord {
+            "976aa32": PromptRecord {
                 agent_id: AgentId {
                     tool: "cursor",
-                    id: "test_session_fixed",
+                    id: "ai_agent",
                     model: "gpt-4",
                 },
                 human_author: Some(

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_multiple_changes.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_multiple_changes.snap
@@ -8,11 +8,36 @@ AuthorshipLogV3 {
             file_path: "code.js",
             entries: [
                 AttestationEntry {
-                    hash: "1cee1d9",
+                    hash: "5de9ea1",
+                    line_ranges: [
+                        Single(
+                            1,
+                        ),
+                    ],
+                },
+                AttestationEntry {
+                    hash: "9d9ddf6",
                     line_ranges: [
                         Range(
-                            1,
+                            2,
+                            5,
+                        ),
+                    ],
+                },
+                AttestationEntry {
+                    hash: "b8613a4",
+                    line_ranges: [
+                        Range(
+                            6,
                             7,
+                        ),
+                    ],
+                },
+                AttestationEntry {
+                    hash: "e5efa95",
+                    line_ranges: [
+                        Single(
+                            3,
                         ),
                     ],
                 },
@@ -23,19 +48,61 @@ AuthorshipLogV3 {
         schema_version: "authorship/3.0.0",
         base_commit_sha: "",
         prompts: {
-            "1cee1d9": PromptRecord {
+            "5de9ea1": PromptRecord {
                 agent_id: AgentId {
                     tool: "cursor",
-                    id: "test_session_fixed",
+                    id: "ai_agent_2",
                     model: "gpt-4",
                 },
                 human_author: Some(
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 4,
+                total_additions: 1,
                 total_deletions: 0,
-                accepted_lines: 7,
+                accepted_lines: 1,
+            },
+            "9d9ddf6": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "ai_agent_1",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 0,
+                total_deletions: 0,
+                accepted_lines: 4,
+            },
+            "b8613a4": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "ai_agent_4",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
+            },
+            "e5efa95": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "ai_agent_3",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 1,
+                total_deletions: 0,
+                accepted_lines: 1,
             },
         },
     },

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_multiple_changes.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__amend_multiple_changes.snap
@@ -1,0 +1,42 @@
+---
+source: src/commands/rebase_authorship.rs
+expression: authorship_log
+---
+AuthorshipLogV3 {
+    attestations: [
+        FileAttestation {
+            file_path: "code.js",
+            entries: [
+                AttestationEntry {
+                    hash: "1cee1d9",
+                    line_ranges: [
+                        Range(
+                            1,
+                            7,
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "",
+        prompts: {
+            "1cee1d9": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "test_session_fixed",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 4,
+                total_deletions: 0,
+                accepted_lines: 7,
+            },
+        },
+    },
+}

--- a/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__with_out_of_band_commits.snap
+++ b/src/commands/snapshots/git_ai__commands__rebase_authorship__tests__with_out_of_band_commits.snap
@@ -8,24 +8,25 @@ AuthorshipLogV3 {
             file_path: "hello-world.ts",
             entries: [
                 AttestationEntry {
-                    hash: "7e197766-8599-448c-a070-da444c376b9d",
+                    hash: "67fced12-038d-4b9e-983a-ac1e4b270a92",
                     line_ranges: [
+                        Range(
+                            66,
+                            70,
+                        ),
                         Single(
-                            4,
+                            72,
                         ),
                         Range(
-                            8,
-                            9,
+                            75,
+                            79,
                         ),
                         Range(
-                            13,
-                            14,
+                            81,
+                            86,
                         ),
                         Single(
-                            18,
-                        ),
-                        Single(
-                            38,
+                            89,
                         ),
                     ],
                 },
@@ -36,10 +37,10 @@ AuthorshipLogV3 {
         schema_version: "authorship/3.0.0",
         base_commit_sha: "",
         prompts: {
-            "7e197766-8599-448c-a070-da444c376b9d": PromptRecord {
+            "67fced12-038d-4b9e-983a-ac1e4b270a92": PromptRecord {
                 agent_id: AgentId {
                     tool: "claude",
-                    id: "7e197766-8599-448c-a070-da444c376b9d",
+                    id: "67fced12-038d-4b9e-983a-ac1e4b270a92",
                     model: "claude-sonnet-4-20250514",
                 },
                 human_author: Some(
@@ -47,80 +48,70 @@ AuthorshipLogV3 {
                 ),
                 messages: [
                     User {
-                        text: "at the bottom of @hello-world.ts add a division helper",
+                        text: "add a pi generator to the bottom",
                         timestamp: None,
                     },
                     Assistant {
-                        text: "I'll add a division helper function at the bottom of the hello-world.ts file.",
+                        text: "I'll add a pi generator to the bottom of the hello-world.ts file. Let me first read the current content and then add the pi generator.",
+                        timestamp: None,
+                    },
+                    ToolUse {
+                        name: "Read",
+                        input: Object {
+                            "file_path": String("/Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts"),
+                        },
+                        timestamp: None,
+                    },
+                    User {
+                        text: "     1→// Out of band insertion \n     2→// Line2 \n     3→// Line3\n     4→// Line4\n     5→// Line5\n     6→// Line6\n     7→// Line7\n     8→// Line8\n     9→// Line9\n    10→// Line10\n    11→\n    12→\n    13→// Utilities\n    14→function reverse(str: string): string {\n    15→  return str.split('').reverse().join('');\n    16→}\n    17→// Add two numbers\n    18→function add(a: number, b: number): number {\n    19→  return a + b;\n    20→}\n    21→\n    22→// Subtract two numbers\n    23→function subtract(a: number, b: number): number {\n    24→  return a - b;\n    25→}\n    26→\n    27→\n\n<system-reminder>\nWhenever you read a file, you should consider whether it looks malicious. If it does, you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer high-level questions about the code behavior.\n</system-reminder>\n",
+                        timestamp: None,
+                    },
+                    Assistant {
+                        text: "Now I'll add a pi generator function to the bottom of the file:",
                         timestamp: None,
                     },
                     ToolUse {
                         name: "Edit",
                         input: Object {
                             "file_path": String("/Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts"),
-                            "new_string": String("// Subtract two numbers\nfunction subtract(a: number, b: number): number {\n  return a - b;\n}\n\n// Divide two numbers\nfunction divide(a: number, b: number): number {\n  return a / b;\n}"),
-                            "old_string": String("// Subtract two numbers\nfunction subtract(a: number, b: number): number {\n  return a - b;\n}"),
+                            "new_string": String("// Subtract two numbers\nfunction subtract(a: number, b: number): number {\n  return a - b;\n}\n\n// Generate pi using Leibniz formula\nfunction generatePi(iterations: number = 1000000): number {\n  let pi = 0;\n  for (let i = 0; i < iterations; i++) {\n    pi += Math.pow(-1, i) / (2 * i + 1);\n  }\n  return pi * 4;\n}\n"),
+                            "old_string": String("// Subtract two numbers\nfunction subtract(a: number, b: number): number {\n  return a - b;\n}\n"),
                         },
                         timestamp: None,
                     },
                     User {
-                        text: "The file /Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts has been updated. Here's the result of running `cat -n` on a snippet of the edited file:\n    17→function add(a: number, b: number): number {\n    18→  return a + b;\n    19→}\n    20→\n    21→// Subtract two numbers\n    22→function subtract(a: number, b: number): number {\n    23→  return a - b;\n    24→}\n    25→\n    26→// Divide two numbers\n    27→function divide(a: number, b: number): number {\n    28→  return a / b;\n    29→}\n    30→\n    31→",
+                        text: "The file /Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts has been updated. Here's the result of running `cat -n` on a snippet of the edited file:\n    18→function add(a: number, b: number): number {\n    19→  return a + b;\n    20→}\n    21→\n    22→// Subtract two numbers\n    23→function subtract(a: number, b: number): number {\n    24→  return a - b;\n    25→}\n    26→\n    27→// Generate pi using Leibniz formula\n    28→function generatePi(iterations: number = 1000000): number {\n    29→  let pi = 0;\n    30→  for (let i = 0; i < iterations; i++) {\n    31→    pi += Math.pow(-1, i) / (2 * i + 1);\n    32→  }\n    33→  return pi * 4;\n    34→}\n    35→\n    36→",
                         timestamp: None,
                     },
                     Assistant {
-                        text: "Added a `divide` helper function at the bottom of hello-world.ts:26-29.",
+                        text: "Added a pi generator function using the Leibniz formula to the bottom of the file.",
                         timestamp: None,
                     },
                     User {
-                        text: "we want to help kids learn, so do it via the long division appraoch they teach in schools and console.log every step",
+                        text: "now write a count primes function with a max prime of 10,000 ",
                         timestamp: None,
                     },
                     Assistant {
-                        text: "I'll modify the divide function to use the long division approach and log each step to help kids learn.",
+                        text: "I'll add a count primes function that counts all prime numbers up to 10,000. Let me add it to the bottom of the file:",
                         timestamp: None,
                     },
                     ToolUse {
                         name: "Edit",
                         input: Object {
                             "file_path": String("/Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts"),
-                            "new_string": String("// Divide two numbers using long division approach for learning\nfunction divide(dividend: number, divisor: number): number {\n  console.log(`\\n--- Long Division: ${dividend} ÷ ${divisor} ---`);\n\n  if (divisor === 0) {\n    console.log(\"Cannot divide by zero!\");\n    return NaN;\n  }\n\n  if (dividend === 0) {\n    console.log(\"0 divided by anything is 0\");\n    return 0;\n  }\n\n  let quotient = 0;\n  let remainder = Math.abs(dividend);\n  const absDivisor = Math.abs(divisor);\n\n  console.log(`Step 1: We're dividing ${Math.abs(dividend)} by ${absDivisor}`);\n\n  while (remainder >= absDivisor) {\n    remainder -= absDivisor;\n    quotient++;\n    console.log(`Step ${quotient + 1}: ${absDivisor} goes into ${remainder + absDivisor}, subtract ${absDivisor}, remainder is ${remainder}`);\n  }\n\n  console.log(`Final result: ${dividend} ÷ ${divisor} = ${quotient} with remainder ${remainder}`);\n\n  // Handle negative numbers\n  const isNegative = (dividend < 0) !== (divisor < 0);\n  const result = isNegative ? -quotient : quotient;\n\n  if (isNegative) {\n    console.log(`Since one number is negative, the result is negative: ${result}`);\n  }\n\n  return result;\n}"),
-                            "old_string": String("// Divide two numbers\nfunction divide(a: number, b: number): number {\n  return a / b;\n}"),
+                            "new_string": String("// Generate pi using Leibniz formula\nfunction generatePi(iterations: number = 1000000): number {\n  let pi = 0;\n  for (let i = 0; i < iterations; i++) {\n    pi += Math.pow(-1, i) / (2 * i + 1);\n  }\n  return pi * 4;\n}\n\n// Count prime numbers up to 10,000 using Sieve of Eratosthenes\nfunction countPrimes(): number {\n  const maxPrime = 10000;\n  const isPrime = new Array(maxPrime + 1).fill(true);\n  isPrime[0] = isPrime[1] = false;\n\n  for (let i = 2; i * i <= maxPrime; i++) {\n    if (isPrime[i]) {\n      for (let j = i * i; j <= maxPrime; j += i) {\n        isPrime[j] = false;\n      }\n    }\n  }\n\n  return isPrime.filter(prime => prime).length;\n}"),
+                            "old_string": String("// Generate pi using Leibniz formula\nfunction generatePi(iterations: number = 1000000): number {\n  let pi = 0;\n  for (let i = 0; i < iterations; i++) {\n    pi += Math.pow(-1, i) / (2 * i + 1);\n  }\n  return pi * 4;\n}"),
                         },
                         timestamp: None,
                     },
                     User {
-                        text: "The file /Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts has been updated. Here's the result of running `cat -n` on a snippet of the edited file:\n    22→function subtract(a: number, b: number): number {\n    23→  return a - b;\n    24→}\n    25→\n    26→// Divide two numbers using long division approach for learning\n    27→function divide(dividend: number, divisor: number): number {\n    28→  console.log(`\\n--- Long Division: ${dividend} ÷ ${divisor} ---`);\n    29→\n    30→  if (divisor === 0) {\n    31→    console.log(\"Cannot divide by zero!\");\n    32→    return NaN;\n    33→  }\n    34→\n    35→  if (dividend === 0) {\n    36→    console.log(\"0 divided by anything is 0\");\n    37→    return 0;\n    38→  }\n    39→\n    40→  let quotient = 0;\n    41→  let remainder = Math.abs(dividend);\n    42→  const absDivisor = Math.abs(divisor);\n    43→\n    44→  console.log(`Step 1: We're dividing ${Math.abs(dividend)} by ${absDivisor}`);\n    45→\n    46→  while (remainder >= absDivisor) {\n    47→    remainder -= absDivisor;\n    48→    quotient++;\n    49→    console.log(`Step ${quotient + 1}: ${absDivisor} goes into ${remainder + absDivisor}, subtract ${absDivisor}, remainder is ${remainder}`);\n    50→  }\n    51→\n    52→  console.log(`Final result: ${dividend} ÷ ${divisor} = ${quotient} with remainder ${remainder}`);\n    53→\n    54→  // Handle negative numbers\n    55→  const isNegative = (dividend < 0) !== (divisor < 0);\n    56→  const result = isNegative ? -quotient : quotient;\n    57→\n    58→  if (isNegative) {\n    59→    console.log(`Since one number is negative, the result is negative: ${result}`);\n    60→  }\n    61→\n    62→  return result;\n    63→}\n    64→\n    65→",
-                        timestamp: None,
-                    },
-                    Assistant {
-                        text: "Updated the divide function to use the long division approach with step-by-step console logging. The function now:\n\n- Shows each step of the division process\n- Handles division by zero and edge cases\n- Works with negative numbers\n- Demonstrates the repeated subtraction method that kids learn in school\n- Returns the quotient (ignoring decimal remainders for simplicity)\n\nThe function is at hello-world.ts:26-63.",
-                        timestamp: None,
-                    },
-                    User {
-                        text: "add this function back to the VERY VERY TOP of the file",
-                        timestamp: None,
-                    },
-                    Assistant {
-                        text: "I'll add the divide function to the very top of the file.",
-                        timestamp: None,
-                    },
-                    ToolUse {
-                        name: "Edit",
-                        input: Object {
-                            "file_path": String("/Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts"),
-                            "new_string": String("// Divide two numbers using long division approach for learning\nfunction divide(dividend: number, divisor: number): number {\n  console.log(`\\n--- Long Division: ${dividend} ÷ ${divisor} ---`);\n\n  if (divisor === 0) {\n    console.log(\"Cannot divide by zero!\");\n    return NaN;\n  }\n\n  if (dividend === 0) {\n    console.log(\"0 divided by anything is 0\");\n    return 0;\n  }\n\n  let quotient = 0;\n  let remainder = Math.abs(dividend);\n  const absDivisor = Math.abs(divisor);\n\n  console.log(`Step 1: We're dividing ${Math.abs(dividend)} by ${absDivisor}`);\n\n  while (remainder >= absDivisor) {\n    remainder -= absDivisor;\n    quotient++;\n    console.log(`Step ${quotient + 1}: ${absDivisor} goes into ${remainder + absDivisor}, subtract ${absDivisor}, remainder is ${remainder}`);\n  }\n\n  console.log(`Final result: ${dividend} ÷ ${divisor} = ${quotient} with remainder ${remainder}`);\n\n  // Handle negative numbers\n  const isNegative = (dividend < 0) !== (divisor < 0);\n  const result = isNegative ? -quotient : quotient;\n\n  if (isNegative) {\n    console.log(`Since one number is negative, the result is negative: ${result}`);\n  }\n\n  return result;\n}\n\n// Out of band insertion"),
-                            "old_string": String("// Out of band insertion "),
-                        },
-                        timestamp: None,
-                    },
-                    User {
-                        text: "The file /Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts has been updated. Here's the result of running `cat -n` on a snippet of the edited file:\n     1→// Divide two numbers using long division approach for learning\n     2→function divide(dividend: number, divisor: number): number {\n     3→  console.log(`\\n--- Long Division: ${dividend} ÷ ${divisor} ---`);\n     4→\n     5→  if (divisor === 0) {\n     6→    console.log(\"Cannot divide by zero!\");\n     7→    return NaN;\n     8→  }\n     9→\n    10→  if (dividend === 0) {\n    11→    console.log(\"0 divided by anything is 0\");\n    12→    return 0;\n    13→  }\n    14→\n    15→  let quotient = 0;\n    16→  let remainder = Math.abs(dividend);\n    17→  const absDivisor = Math.abs(divisor);\n    18→\n    19→  console.log(`Step 1: We're dividing ${Math.abs(dividend)} by ${absDivisor}`);\n    20→\n    21→  while (remainder >= absDivisor) {\n    22→    remainder -= absDivisor;\n    23→    quotient++;\n    24→    console.log(`Step ${quotient + 1}: ${absDivisor} goes into ${remainder + absDivisor}, subtract ${absDivisor}, remainder is ${remainder}`);\n    25→  }\n    26→\n    27→  console.log(`Final result: ${dividend} ÷ ${divisor} = ${quotient} with remainder ${remainder}`);\n    28→\n    29→  // Handle negative numbers\n    30→  const isNegative = (dividend < 0) !== (divisor < 0);\n    31→  const result = isNegative ? -quotient : quotient;\n    32→\n    33→  if (isNegative) {\n    34→    console.log(`Since one number is negative, the result is negative: ${result}`);\n    35→  }\n    36→\n    37→  return result;\n    38→}\n    39→\n    40→// Out of band insertion\n    41→// Line2 \n    42→// Line3\n    43→// Line4\n    44→// Line5",
+                        text: "The file /Users/aidancunniffe/Desktop/git-ai-test/hello-world.ts has been updated. Here's the result of running `cat -n` on a snippet of the edited file:\n    23→function subtract(a: number, b: number): number {\n    24→  return a - b;\n    25→}\n    26→\n    27→// Generate pi using Leibniz formula\n    28→function generatePi(iterations: number = 1000000): number {\n    29→  let pi = 0;\n    30→  for (let i = 0; i < iterations; i++) {\n    31→    pi += Math.pow(-1, i) / (2 * i + 1);\n    32→  }\n    33→  return pi * 4;\n    34→}\n    35→\n    36→// Count prime numbers up to 10,000 using Sieve of Eratosthenes\n    37→function countPrimes(): number {\n    38→  const maxPrime = 10000;\n    39→  const isPrime = new Array(maxPrime + 1).fill(true);\n    40→  isPrime[0] = isPrime[1] = false;\n    41→\n    42→  for (let i = 2; i * i <= maxPrime; i++) {\n    43→    if (isPrime[i]) {\n    44→      for (let j = i * i; j <= maxPrime; j += i) {\n    45→        isPrime[j] = false;\n    46→      }\n    47→    }\n    48→  }\n    49→\n    50→  return isPrime.filter(prime => prime).length;\n    51→}\n    52→\n    53→",
                         timestamp: None,
                     },
                 ],
                 total_additions: 0,
                 total_deletions: 0,
-                accepted_lines: 7,
+                accepted_lines: 18,
             },
         },
     },

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -46,6 +46,9 @@ impl ParsedGitInvocation {
         v.extend(self.command_args.iter().cloned());
         v
     }
+    pub fn has_command_flag(&self, flag: &str) -> bool {
+        self.command_args.iter().any(|arg| arg == flag)
+    }
 }
 
 pub fn parse_git_cli_args(args: &[String]) -> ParsedGitInvocation {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -6,5 +6,6 @@ pub mod refs;
 pub mod repository;
 pub use repository::{find_repository, find_repository_in_path};
 pub mod repo_storage;
+pub mod rewrite_log;
 pub mod status;
 pub mod test_utils;

--- a/src/git/post_commit.rs
+++ b/src/git/post_commit.rs
@@ -7,6 +7,7 @@ use crate::log_fmt::authorship_log_serialization::AuthorshipLog;
 use crate::log_fmt::working_log::Checkpoint;
 use crate::utils::debug_log;
 
+// @todo Acunniffe - move this and simplify.
 pub fn post_commit(repo: &Repository) -> Result<(String, AuthorshipLog), GitAiError> {
     // Get the current commit SHA (the commit that was just made)
     let head = repo.head()?;
@@ -28,7 +29,7 @@ pub fn post_commit(repo: &Repository) -> Result<(String, AuthorshipLog), GitAiEr
     };
 
     // Initialize the new storage system
-    let repo_storage = RepoStorage::for_repo_path(repo.path());
+    let repo_storage = &repo.storage;
     let working_log = repo_storage.working_log_for_base_commit(&parent_sha);
 
     // Pull all working log entries from the parent commit

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -76,9 +76,13 @@ impl RepoStorage {
 
     /* Rewrite Log Persistance */
 
-    /// Append a rewrite event to the rewrite log file
-    pub fn append_rewrite_event(&self, event: RewriteLogEvent) -> Result<(), GitAiError> {
-        append_event_to_file(&self.rewrite_log, event)
+    /// Append a rewrite event to the rewrite log file and return the full log
+    pub fn append_rewrite_event(
+        &self,
+        event: RewriteLogEvent,
+    ) -> Result<Vec<RewriteLogEvent>, GitAiError> {
+        append_event_to_file(&self.rewrite_log, event)?;
+        self.read_rewrite_events()
     }
 
     /// Read all rewrite events from the rewrite log file

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -1,4 +1,5 @@
 use crate::error::GitAiError;
+use crate::git::rewrite_log::{RewriteLogEvent, append_event_to_file};
 use crate::log_fmt::working_log::Checkpoint;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -69,7 +70,22 @@ impl RepoStorage {
         Ok(())
     }
 
-    /* Authorship Log Persistance */
+    /* Rewrite Log Persistance */
+
+    /// Append a rewrite event to the rewrite log file
+    pub fn append_rewrite_event(&self, event: RewriteLogEvent) -> Result<(), GitAiError> {
+        append_event_to_file(&self.rewrite_log, event)
+    }
+
+    /// Read all rewrite events from the rewrite log file
+    pub fn read_rewrite_events(&self) -> Result<Vec<RewriteLogEvent>, GitAiError> {
+        if !self.rewrite_log.exists() {
+            return Ok(Vec::new());
+        }
+
+        let content = fs::read_to_string(&self.rewrite_log)?;
+        crate::git::rewrite_log::deserialize_events_from_jsonl(&content)
+    }
 }
 
 pub struct PersistedWorkingLog {

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -23,9 +23,13 @@ impl RepoStorage {
             rewrite_log: rewrite_log_file,
         };
 
+        // @todo - @acunniffe, make this lazy on a read or write.
+        // it's probably fine to run this when Repository is loaded but there
+        // are many git commands for which it is not needed
         config.ensure_config_directory().unwrap();
         return config;
     }
+
     fn ensure_config_directory(&self) -> Result<(), GitAiError> {
         let ai_dir = self.repo_path.join("ai");
 

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -916,7 +916,7 @@ impl Repository {
     }
 }
 
-pub fn find_repository(global_args: Vec<String>) -> Result<Repository, GitAiError> {
+pub fn find_repository(global_args: &Vec<String>) -> Result<Repository, GitAiError> {
     let mut args = global_args.clone();
     args.push("rev-parse".to_string());
     args.push("--absolute-git-dir".to_string());
@@ -934,7 +934,7 @@ pub fn find_repository(global_args: Vec<String>) -> Result<Repository, GitAiErro
     }
 
     Ok(Repository {
-        global_args,
+        global_args: global_args.clone(),
         storage: RepoStorage::for_repo_path(&path),
         git_dir: path,
         pre_command_base_commit: None,
@@ -944,7 +944,7 @@ pub fn find_repository(global_args: Vec<String>) -> Result<Repository, GitAiErro
 
 pub fn find_repository_in_path(path: &str) -> Result<Repository, GitAiError> {
     let global_args = vec!["-C".to_string(), path.to_string()];
-    return find_repository(global_args);
+    return find_repository(&global_args);
 }
 
 /// Helper to execute a git command

--- a/src/git/rewrite_log.rs
+++ b/src/git/rewrite_log.rs
@@ -1,0 +1,358 @@
+use crate::error::GitAiError;
+use serde::{Deserialize, Serialize};
+
+/// Simple case classes for rewrite events
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RewriteLogEvent {
+    Merge {
+        merge: MergeEvent,
+    },
+    MergeSquash {
+        merge_squash: MergeSquashEvent,
+    },
+    RebaseInteractive {
+        rebase_interactive: RebaseInteractiveEvent,
+    },
+    Rebase {
+        rebase: RebaseEvent,
+    },
+    CherryPick {
+        cherry_pick: CherryPickEvent,
+    },
+    RevertMixed {
+        revert_mixed: RevertMixedEvent,
+    },
+    ResetSoft {
+        reset_soft: ResetSoftEvent,
+    },
+    ResetHard {
+        reset_hard: ResetHardEvent,
+    },
+    CommitAmend {
+        commit_amend: CommitAmendEvent,
+    },
+    Stash {
+        stash: StashEvent,
+    },
+}
+
+/// Simple case classes - no timestamps, git already has that data
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MergeEvent {
+    pub source_branch: String,
+    pub target_branch: String,
+    pub merge_commit_sha: Option<String>,
+    pub success: bool,
+    pub conflicts: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MergeSquashEvent {
+    pub source_branch: String,
+    pub target_branch: String,
+    pub squash_commit_sha: Option<String>,
+    pub success: bool,
+    pub squashed_commits: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RebaseInteractiveEvent {
+    pub base_commit: String,
+    pub commit_count: u32,
+    pub state: RebaseState,
+    pub original_commits: Vec<String>,
+    pub new_commits: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RebaseEvent {
+    pub base_commit: String,
+    pub state: RebaseState,
+    pub commit_count: u32,
+    pub current_commit: Option<String>,
+    pub original_commits: Vec<String>,
+    pub new_commits: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CherryPickEvent {
+    pub source_commit: String,
+    pub target_branch: String,
+    pub new_commit_sha: Option<String>,
+    pub success: bool,
+    pub conflicts: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RevertMixedEvent {
+    pub reverted_commit: String,
+    pub success: bool,
+    pub affected_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResetSoftEvent {
+    pub target_commit: String,
+    pub previous_head: String,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResetHardEvent {
+    pub target_commit: String,
+    pub previous_head: String,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommitAmendEvent {
+    pub original_commit: String,
+    pub amended_commit_sha: String,
+    pub success: bool,
+    pub changed_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StashEvent {
+    pub operation: StashOperation,
+    pub stash_ref: Option<String>,
+    pub success: bool,
+    pub affected_files: Vec<String>,
+}
+
+/// Rebase state tracking
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RebaseState {
+    /// Rebase started
+    Start,
+    /// Rebase in progress
+    InProgress,
+    /// Rebase continued after conflict resolution
+    Continue,
+    /// Rebase aborted
+    Abort,
+    /// Rebase completed successfully
+    Complete,
+}
+
+/// Stash operation types
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StashOperation {
+    /// Create new stash
+    Create,
+    /// Apply stash (keep stash)
+    Apply,
+    /// Pop stash (remove after applying)
+    Pop,
+    /// Drop stash
+    Drop,
+    /// List stashes
+    List,
+}
+
+/// Serialize events to JSONL format (newest events first)
+pub fn serialize_events_to_jsonl(events: &[RewriteLogEvent]) -> Result<String, serde_json::Error> {
+    let mut lines = Vec::new();
+
+    // Write each event as a separate line
+    for event in events {
+        lines.push(serde_json::to_string(event)?);
+    }
+
+    Ok(lines.join("\n"))
+}
+
+/// Maximum number of events to keep in the rewrite log
+const MAX_EVENTS: usize = 200;
+
+/// Deserialize events from JSONL format, skipping malformed entries
+pub fn deserialize_events_from_jsonl(jsonl: &str) -> Result<Vec<RewriteLogEvent>, GitAiError> {
+    let mut events = Vec::new();
+
+    for line in jsonl.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Skip malformed entries instead of failing
+        if let Ok(event) = serde_json::from_str::<RewriteLogEvent>(line) {
+            events.push(event);
+        }
+        // Silently skip lines that don't parse - they're probably old format
+    }
+
+    // Trim to max events (keep newest, which are first due to newest-first ordering)
+    if events.len() > MAX_EVENTS {
+        events.truncate(MAX_EVENTS);
+    }
+
+    Ok(events)
+}
+
+/// Append a single event to JSONL file (prepends to maintain newest-first order)
+pub fn append_event_to_file(
+    file_path: &std::path::Path,
+    new_event: RewriteLogEvent,
+) -> Result<(), GitAiError> {
+    // Serialize new event
+    let new_event_json = serde_json::to_string(&new_event)?;
+
+    if !file_path.exists() {
+        // File doesn't exist - create it with just the new event
+        std::fs::write(file_path, format!("{}\n", new_event_json))?;
+        return Ok(());
+    }
+
+    // Read existing content
+    let existing_content = std::fs::read_to_string(file_path)?;
+
+    if existing_content.trim().is_empty() {
+        // Empty file - just write the new event
+        std::fs::write(file_path, format!("{}\n", new_event_json))?;
+        return Ok(());
+    }
+
+    // Parse existing events (this will trim to MAX_EVENTS and skip malformed entries)
+    let existing_events = deserialize_events_from_jsonl(&existing_content)?;
+
+    // Create new content with new event first (newest-first order)
+    let mut lines = vec![new_event_json];
+    for event in existing_events {
+        lines.push(serde_json::to_string(&event)?);
+    }
+
+    // Trim to max events (new event + existing events)
+    if lines.len() > MAX_EVENTS {
+        lines.truncate(MAX_EVENTS);
+    }
+
+    // Write back to file
+    std::fs::write(file_path, lines.join("\n"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_event_serialization() {
+        let event = RewriteLogEvent::Merge {
+            merge: MergeEvent {
+                source_branch: "feature-branch".to_string(),
+                target_branch: "main".to_string(),
+                merge_commit_sha: Some("abc123def456".to_string()),
+                success: true,
+                conflicts: vec![],
+            },
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: RewriteLogEvent = serde_json::from_str(&json).unwrap();
+
+        match deserialized {
+            RewriteLogEvent::Merge { merge } => {
+                assert_eq!(merge.source_branch, "feature-branch");
+                assert_eq!(merge.target_branch, "main");
+                assert_eq!(merge.merge_commit_sha, Some("abc123def456".to_string()));
+                assert!(merge.success);
+                assert!(merge.conflicts.is_empty());
+            }
+            _ => panic!("Expected Merge event"),
+        }
+    }
+
+    #[test]
+    fn test_events_jsonl_serialization() {
+        let event1 = RewriteLogEvent::Merge {
+            merge: MergeEvent {
+                source_branch: "feature".to_string(),
+                target_branch: "main".to_string(),
+                merge_commit_sha: Some("abc123".to_string()),
+                success: true,
+                conflicts: vec![],
+            },
+        };
+
+        let event2 = RewriteLogEvent::CherryPick {
+            cherry_pick: CherryPickEvent {
+                source_commit: "def456".to_string(),
+                target_branch: "main".to_string(),
+                new_commit_sha: Some("ghi789".to_string()),
+                success: true,
+                conflicts: vec![],
+            },
+        };
+
+        let events = vec![event1.clone(), event2.clone()];
+        let jsonl = serialize_events_to_jsonl(&events).unwrap();
+        let deserialized = deserialize_events_from_jsonl(&jsonl).unwrap();
+
+        println!("JSON L: {}", jsonl);
+
+        assert_eq!(deserialized.len(), 2);
+
+        match &deserialized[0] {
+            RewriteLogEvent::Merge { merge } => {
+                assert_eq!(merge.source_branch, "feature");
+            }
+            _ => panic!("Expected Merge event"),
+        }
+
+        match &deserialized[1] {
+            RewriteLogEvent::CherryPick { cherry_pick } => {
+                assert_eq!(cherry_pick.source_commit, "def456");
+            }
+            _ => panic!("Expected CherryPick event"),
+        }
+    }
+
+    #[test]
+    fn test_append_event_to_jsonl() {
+        let event1 = RewriteLogEvent::Merge {
+            merge: MergeEvent {
+                source_branch: "feature".to_string(),
+                target_branch: "main".to_string(),
+                merge_commit_sha: Some("abc123".to_string()),
+                success: true,
+                conflicts: vec![],
+            },
+        };
+
+        let event2 = RewriteLogEvent::CherryPick {
+            cherry_pick: CherryPickEvent {
+                source_commit: "def456".to_string(),
+                target_branch: "main".to_string(),
+                new_commit_sha: Some("ghi789".to_string()),
+                success: true,
+                conflicts: vec![],
+            },
+        };
+
+        let initial_jsonl = serialize_events_to_jsonl(&[event1.clone()]).unwrap();
+        // Test with temp file
+        let temp_file = std::env::temp_dir().join("test_rewrite_log.jsonl");
+        std::fs::write(&temp_file, &initial_jsonl).unwrap();
+        append_event_to_file(&temp_file, event2.clone()).unwrap();
+        let updated_jsonl = std::fs::read_to_string(&temp_file).unwrap();
+        let deserialized = deserialize_events_from_jsonl(&updated_jsonl).unwrap();
+
+        assert_eq!(deserialized.len(), 2);
+        // event2 should be first (newest) since it was appended
+        match &deserialized[0] {
+            RewriteLogEvent::CherryPick { cherry_pick } => {
+                assert_eq!(cherry_pick.source_commit, "def456");
+            }
+            _ => panic!("Expected CherryPick event"),
+        }
+
+        match &deserialized[1] {
+            RewriteLogEvent::Merge { merge } => {
+                assert_eq!(merge.source_branch, "feature");
+            }
+            _ => panic!("Expected Merge event"),
+        }
+    }
+}

--- a/src/git/rewrite_log.rs
+++ b/src/git/rewrite_log.rs
@@ -150,26 +150,23 @@ impl MergeEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MergeSquashEvent {
     pub source_branch: String,
-    pub target_branch: String,
-    pub squash_commit_sha: Option<String>,
-    pub success: bool,
-    pub squashed_commits: Vec<String>,
+    pub source_head: String,
+    pub base_branch: String,
+    pub base_head: String,
 }
 
 impl MergeSquashEvent {
     pub fn new(
         source_branch: String,
-        target_branch: String,
-        squash_commit_sha: Option<String>,
-        success: bool,
-        squashed_commits: Vec<String>,
+        source_head: String,
+        base_branch: String,
+        base_head: String,
     ) -> Self {
         Self {
             source_branch,
-            target_branch,
-            squash_commit_sha,
-            success,
-            squashed_commits,
+            source_head,
+            base_branch,
+            base_head,
         }
     }
 }

--- a/src/git/rewrite_log.rs
+++ b/src/git/rewrite_log.rs
@@ -38,6 +38,9 @@ pub enum RewriteLogEvent {
     Stash {
         stash: StashEvent,
     },
+    AuthorshipLogsSynced {
+        authorship_logs_synced: AuthorshipLogsSyncedEvent,
+    },
 }
 
 impl RewriteLogEvent {
@@ -107,6 +110,12 @@ impl RewriteLogEvent {
 
     pub fn stash(event: StashEvent) -> Self {
         Self::Stash { stash: event }
+    }
+
+    pub fn authorship_logs_synced(event: AuthorshipLogsSyncedEvent) -> Self {
+        Self::AuthorshipLogsSynced {
+            authorship_logs_synced: event,
+        }
     }
 }
 
@@ -352,6 +361,26 @@ impl StashEvent {
             stash_ref,
             success,
             affected_files,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuthorshipLogsSyncedEvent {
+    pub synced: Vec<String>,
+    pub origin: Vec<String>,
+    pub timestamp: u64,
+}
+
+impl AuthorshipLogsSyncedEvent {
+    pub fn new(synced: Vec<String>, origin: Vec<String>) -> Self {
+        Self {
+            synced,
+            origin,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
         }
     }
 }

--- a/src/git/rewrite_log.rs
+++ b/src/git/rewrite_log.rs
@@ -449,13 +449,13 @@ mod tests {
 
     #[test]
     fn test_merge_event_serialization() {
-        let event = RewriteLogEvent::merge(MergeEvent::new(
+        let event = RewriteLogEvent::merge(
             "feature-branch".to_string(),
             "main".to_string(),
             Some("abc123def456".to_string()),
             true,
             vec![],
-        ));
+        );
 
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: RewriteLogEvent = serde_json::from_str(&json).unwrap();
@@ -474,13 +474,13 @@ mod tests {
 
     #[test]
     fn test_events_jsonl_serialization() {
-        let event1 = RewriteLogEvent::merge(MergeEvent::new(
+        let event1 = RewriteLogEvent::merge(
             "feature".to_string(),
             "main".to_string(),
             Some("abc123".to_string()),
             true,
             vec![],
-        ));
+        );
 
         let event2 = RewriteLogEvent::cherry_pick(CherryPickEvent::new(
             "def456".to_string(),
@@ -539,13 +539,13 @@ mod tests {
 
     #[test]
     fn test_append_event_to_jsonl() {
-        let event1 = RewriteLogEvent::merge(MergeEvent::new(
+        let event1 = RewriteLogEvent::merge(
             "feature".to_string(),
             "main".to_string(),
             Some("abc123".to_string()),
             true,
             vec![],
-        ));
+        );
 
         let event2 = RewriteLogEvent::cherry_pick(CherryPickEvent::new(
             "def456".to_string(),

--- a/src/git/rewrite_log.rs
+++ b/src/git/rewrite_log.rs
@@ -32,6 +32,9 @@ pub enum RewriteLogEvent {
     CommitAmend {
         commit_amend: CommitAmendEvent,
     },
+    Commit {
+        commit: CommitEvent,
+    },
     Stash {
         stash: StashEvent,
     },
@@ -93,6 +96,12 @@ impl RewriteLogEvent {
     pub fn commit_amend(original_commit: String, amended_commit_sha: String) -> Self {
         Self::CommitAmend {
             commit_amend: CommitAmendEvent::new(original_commit, amended_commit_sha),
+        }
+    }
+
+    pub fn commit(base_commit: String, commit_sha: String) -> Self {
+        Self::Commit {
+            commit: CommitEvent::new(base_commit, commit_sha),
         }
     }
 
@@ -303,6 +312,22 @@ impl CommitAmendEvent {
         Self {
             original_commit,
             amended_commit_sha,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommitEvent {
+    pub base_commit: String,
+    pub commit_sha: String,
+}
+
+impl CommitEvent {
+    /// Create a new CommitEvent with the given parameters
+    pub fn new(base_commit: String, commit_sha: String) -> Self {
+        Self {
+            base_commit,
+            commit_sha,
         }
     }
 }

--- a/src/log_fmt/working_log.rs
+++ b/src/log_fmt/working_log.rs
@@ -130,6 +130,8 @@ pub struct Checkpoint {
     pub timestamp: u64,
     pub transcript: Option<AiTranscript>,
     pub agent_id: Option<AgentId>,
+    #[serde(default)]
+    pub allow_reset_to_checkpoint: bool,
 }
 
 impl Checkpoint {
@@ -146,6 +148,7 @@ impl Checkpoint {
             timestamp,
             transcript: None,
             agent_id: None,
+            allow_reset_to_checkpoint: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,15 @@ fn main() {
         .unwrap_or("git-ai".to_string());
 
     let cli = Cli::parse();
+
+    #[cfg(debug_assertions)]
+    {
+        if std::env::var("GIT_AI").as_deref() == Ok("git") {
+            commands::git_handlers::handle_git(&cli.args);
+            return;
+        }
+    }
+
     if binary_name == "git-ai" {
         commands::git_ai_handlers::handle_git_ai(&cli.args);
         std::process::exit(0);


### PR DESCRIPTION
Rewrites authorship and working logs to support history rewriting operations. 

Introduces patterns, `rewirte_log` and triggers off these commands 

`commit --amend`
`merge --squash` 
`reset --hard` 

---

Next up in future PRs
- revert
- reset
- cherrypick
- rebase

Known issues

- [x] Better support for any ordering of merge, refname and `--squash` flags 
- [ ] Does not support multiple commits `git merge [<options>] <commit>...`