### PR TITLE
Handle unstaged / staged changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "git-ai",
  "git2",
  "indicatif",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 
 [dependencies]
-git2 = "0.20.2"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -17,9 +16,13 @@ smol = "1.3"
 rusqlite = { version = "0.31", features = ["bundled"] }
 libc = "0.2"
 once_cell = "1.21.3"
+git2 = { version = "0.20.2", optional = true }
 
+[features]
+test-support = ["git2"]
 
 [dev-dependencies]
+git-ai = { path = ".", features = ["test-support"] }
 tempfile = "3.8"
 assert_cmd = "2.0"
 predicates = "3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum GitAiError {
+    #[cfg(feature = "test-support")]
     GitError(git2::Error),
     IoError(std::io::Error),
     /// Errors from invoking the git CLI that exited with a non-zero status
@@ -20,6 +21,7 @@ pub enum GitAiError {
 impl fmt::Display for GitAiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(feature = "test-support")]
             GitAiError::GitError(e) => write!(f, "Git error: {}", e),
             GitAiError::IoError(e) => write!(f, "IO error: {}", e),
             GitAiError::GitCliError { code, stderr, args } => match code {
@@ -43,6 +45,7 @@ impl fmt::Display for GitAiError {
 
 impl std::error::Error for GitAiError {}
 
+#[cfg(feature = "test-support")]
 impl From<git2::Error> for GitAiError {
     fn from(err: git2::Error) -> Self {
         GitAiError::GitError(err)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -8,4 +8,5 @@ pub use repository::{find_repository, find_repository_in_path};
 pub mod repo_storage;
 pub mod rewrite_log;
 pub mod status;
+#[cfg(feature = "test-support")]
 pub mod test_utils;

--- a/src/git/post_commit.rs
+++ b/src/git/post_commit.rs
@@ -1,11 +1,14 @@
 use crate::commands::checkpoint_agent::agent_preset::CursorPreset;
 use crate::error::GitAiError;
 use crate::git::refs::put_reference;
-use crate::git::repo_storage::RepoStorage;
 use crate::git::repository::Repository;
+use crate::git::status::{EntryKind, StatusCode};
+use crate::log_fmt::authorship_log::LineRange;
 use crate::log_fmt::authorship_log_serialization::AuthorshipLog;
 use crate::log_fmt::working_log::Checkpoint;
 use crate::utils::debug_log;
+use similar::{ChangeTag, TextDiff};
+use std::collections::HashMap;
 
 // @todo Acunniffe - move this and simplify.
 pub fn post_commit(repo: &Repository) -> Result<(String, AuthorshipLog), GitAiError> {
@@ -71,11 +74,32 @@ pub fn post_commit(repo: &Repository) -> Result<(String, AuthorshipLog), GitAiEr
     };
 
     // --- NEW: Serialize authorship log and store it in refs/ai/authorship/{commit_sha} ---
-    let authorship_log = AuthorshipLog::from_working_log_with_base_commit_and_human_author(
+    let mut authorship_log = AuthorshipLog::from_working_log_with_base_commit_and_human_author(
         &filtered_working_log,
         &parent_sha,
         human_author.as_deref(),
     );
+
+    // Filter the authorship log to only include committed lines
+    // We need to keep ONLY lines that are in the commit, not filter out unstaged lines
+    let committed_hunks = collect_committed_hunks(repo, &parent_sha, &commit_sha)?;
+
+    // Keep only the lines that were actually committed
+    authorship_log.filter_to_committed_lines(&committed_hunks);
+
+    // Check if there are unstaged AI-authored lines to preserve in working log
+    let unstaged_hunks = collect_unstaged_hunks(repo)?;
+    let has_unstaged_ai_lines = if !unstaged_hunks.is_empty() {
+        // Check if any unstaged lines match the working log
+        let parent_working_log = repo_storage.working_log_for_base_commit(&parent_sha);
+        let parent_checkpoints = parent_working_log
+            .read_all_checkpoints()
+            .unwrap_or_default();
+
+        !parent_checkpoints.is_empty() && parent_checkpoints.iter().any(|cp| cp.agent_id.is_some())
+    } else {
+        false
+    };
 
     // Serialize the authorship log
     let authorship_json = authorship_log
@@ -95,12 +119,68 @@ pub fn post_commit(repo: &Repository) -> Result<(String, AuthorshipLog), GitAiEr
         commit_sha
     ));
 
-    repo_storage.delete_working_log_for_base_commit(&parent_sha)?;
+    // Only delete the working log if there are no unstaged AI-authored lines
+    // If there are unstaged AI lines, filter and transfer the working log to the new commit
+    if !has_unstaged_ai_lines {
+        repo_storage.delete_working_log_for_base_commit(&parent_sha)?;
 
-    debug_log(&format!(
-        "Working log deleted for base commit: {}",
-        parent_sha
-    ));
+        debug_log(&format!(
+            "Working log deleted for base commit: {}",
+            parent_sha
+        ));
+    } else {
+        // Filter the working log to remove committed lines, keeping only unstaged ones
+        let parent_working_log = repo_storage.working_log_for_base_commit(&parent_sha);
+        let parent_checkpoints = parent_working_log.read_all_checkpoints()?;
+
+        let new_working_log = repo_storage.working_log_for_base_commit(&commit_sha);
+
+        for mut checkpoint in parent_checkpoints {
+            // Filter entries to only include unstaged lines
+            for entry in &mut checkpoint.entries {
+                if let Some(unstaged_ranges) = unstaged_hunks.get(&entry.file) {
+                    // Expand all lines from added_lines, filter to unstaged, then recompress
+                    let mut all_lines: Vec<u32> = Vec::new();
+                    for line in &entry.added_lines {
+                        match line {
+                            crate::log_fmt::working_log::Line::Single(l) => all_lines.push(*l),
+                            crate::log_fmt::working_log::Line::Range(start, end) => {
+                                all_lines.extend(*start..=*end);
+                            }
+                        }
+                    }
+
+                    // Keep only unstaged lines
+                    all_lines.retain(|l| unstaged_ranges.iter().any(|range| range.contains(*l)));
+
+                    // Recompress to Line format
+                    entry.added_lines = crate::log_fmt::authorship_log_serialization::compress_lines_to_working_log_format(&all_lines);
+
+                    // Clear deleted_lines since they're relative to the old base commit
+                    // After a commit, the base commit changes, so old deletions are no longer relevant
+                    entry.deleted_lines.clear();
+                }
+            }
+
+            // Remove entries with no lines left
+            checkpoint
+                .entries
+                .retain(|entry| !entry.added_lines.is_empty());
+
+            // Only append if there are entries left
+            if !checkpoint.entries.is_empty() {
+                new_working_log.append_checkpoint(&checkpoint)?;
+            }
+        }
+
+        // Delete the old working log
+        repo_storage.delete_working_log_for_base_commit(&parent_sha)?;
+
+        debug_log(&format!(
+            "Working log filtered and transferred from {} to {} (unstaged AI lines only)",
+            parent_sha, commit_sha
+        ));
+    }
 
     Ok((ref_name, authorship_log))
 }
@@ -157,4 +237,273 @@ fn filter_untracked_files(
     }
 
     Ok(filtered_checkpoints)
+}
+
+/// Collect line ranges that were committed (present in current commit but added from parent)
+///
+/// This function diffs the parent commit against the current commit to find all lines
+/// that were added/changed in this commit. Only these lines should be in the authorship log.
+fn collect_committed_hunks(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+) -> Result<HashMap<String, Vec<LineRange>>, GitAiError> {
+    let mut committed_hunks: HashMap<String, Vec<LineRange>> = HashMap::new();
+
+    // Handle initial commit (no parent)
+    if parent_sha == "initial" {
+        // For initial commit, all lines in all files are "committed"
+        // We can just get all files from the status
+        let current_commit = repo.find_commit(commit_sha.to_string())?;
+        let current_tree = current_commit.tree()?;
+
+        // Use workdir to list files
+        if let Ok(workdir) = repo.workdir() {
+            use std::fs;
+            fn visit_dirs(
+                dir: &std::path::Path,
+                repo_root: &std::path::Path,
+                files: &mut Vec<String>,
+            ) -> std::io::Result<()> {
+                if dir.is_dir() {
+                    for entry in fs::read_dir(dir)? {
+                        let entry = entry?;
+                        let path = entry.path();
+                        // Skip .git directory
+                        if path.file_name().and_then(|s| s.to_str()) == Some(".git") {
+                            continue;
+                        }
+                        if path.is_dir() {
+                            visit_dirs(&path, repo_root, files)?;
+                        } else if path.is_file() {
+                            if let Ok(rel_path) = path.strip_prefix(repo_root) {
+                                files.push(rel_path.to_string_lossy().to_string());
+                            }
+                        }
+                    }
+                }
+                Ok(())
+            }
+
+            let mut files = Vec::new();
+            visit_dirs(&workdir, &workdir, &mut files)?;
+
+            for file_path in files {
+                if let Ok(entry) = current_tree.get_path(std::path::Path::new(&file_path)) {
+                    if let Ok(blob) = repo.find_blob(entry.id()) {
+                        let content = blob.content()?;
+                        let content_str = String::from_utf8_lossy(&content);
+                        let line_count = content_str.lines().count() as u32;
+                        if line_count > 0 {
+                            let lines: Vec<u32> = (1..=line_count).collect();
+                            committed_hunks.insert(file_path, LineRange::compress_lines(&lines));
+                        }
+                    }
+                }
+            }
+        }
+
+        return Ok(committed_hunks);
+    }
+
+    let parent_commit = repo.find_commit(parent_sha.to_string())?;
+    let parent_tree = parent_commit.tree()?;
+
+    let current_commit = repo.find_commit(commit_sha.to_string())?;
+    let current_tree = current_commit.tree()?;
+
+    // Get diff between parent and current commit
+    let diff = repo.diff_tree_to_tree(Some(&parent_tree), Some(&current_tree), None)?;
+
+    for delta in diff.deltas() {
+        let file_path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .ok_or_else(|| GitAiError::Generic("File path not available".to_string()))?;
+        let file_path = file_path.to_string_lossy().to_string();
+
+        // Get content from both commits
+        let parent_content = match parent_tree.get_path(std::path::Path::new(&file_path)) {
+            Ok(tree_entry) => {
+                if let Ok(blob) = repo.find_blob(tree_entry.id()) {
+                    let blob_content = blob.content()?;
+                    String::from_utf8_lossy(&blob_content).to_string()
+                } else {
+                    String::new()
+                }
+            }
+            Err(_) => String::new(),
+        };
+
+        let current_content = match current_tree.get_path(std::path::Path::new(&file_path)) {
+            Ok(tree_entry) => {
+                if let Ok(blob) = repo.find_blob(tree_entry.id()) {
+                    let blob_content = blob.content()?;
+                    String::from_utf8_lossy(&blob_content).to_string()
+                } else {
+                    String::new()
+                }
+            }
+            Err(_) => String::new(),
+        };
+
+        if parent_content == current_content {
+            continue; // No changes in this file
+        }
+
+        // Normalize line endings
+        let parent_norm = if parent_content.ends_with('\n') {
+            parent_content.clone()
+        } else if !parent_content.is_empty() {
+            format!("{}\n", parent_content)
+        } else {
+            parent_content.clone()
+        };
+        let current_norm = if current_content.ends_with('\n') {
+            current_content.clone()
+        } else if !current_content.is_empty() {
+            format!("{}\n", current_content)
+        } else {
+            current_content.clone()
+        };
+
+        let diff = TextDiff::from_lines(&parent_norm, &current_norm);
+        let mut modified_lines = Vec::new();
+        let mut current_line = 1u32;
+
+        for change in diff.iter_all_changes() {
+            match change.tag() {
+                ChangeTag::Equal => {
+                    current_line += change.value().lines().count() as u32;
+                }
+                ChangeTag::Delete => {
+                    // Deletions don't add lines to the current commit
+                }
+                ChangeTag::Insert => {
+                    let insert_start = current_line;
+                    let insert_count = change.value().lines().count() as u32;
+                    for i in 0..insert_count {
+                        modified_lines.push(insert_start + i);
+                    }
+                    current_line += insert_count;
+                }
+            }
+        }
+
+        if !modified_lines.is_empty() {
+            modified_lines.sort_unstable();
+            let line_ranges = LineRange::compress_lines(&modified_lines);
+            committed_hunks.insert(file_path.clone(), line_ranges);
+        }
+    }
+
+    Ok(committed_hunks)
+}
+
+/// Collect all unstaged line ranges from the working directory
+///
+/// This function diffs the HEAD commit (what was just committed) against the working directory
+/// to find all lines that exist in the working directory but weren't part of the commit.
+/// These lines should be excluded from the authorship log.
+fn collect_unstaged_hunks(
+    repo: &Repository,
+) -> Result<HashMap<String, Vec<LineRange>>, GitAiError> {
+    let mut unstaged_hunks: HashMap<String, Vec<LineRange>> = HashMap::new();
+
+    // Get all files with unstaged changes
+    let statuses = repo.status()?;
+    debug_log(&format!("Git status found {} entries", statuses.len()));
+
+    // Get the HEAD commit tree (what was just committed)
+    let head = repo.head()?;
+    let head_commit = repo.find_commit(head.target().unwrap())?;
+    let head_tree = head_commit.tree()?;
+
+    let repo_workdir = repo.workdir()?;
+
+    for entry in &statuses {
+        debug_log(&format!(
+            "Status entry: {} staged={:?} unstaged={:?}",
+            entry.path, entry.staged, entry.unstaged
+        ));
+        // Skip files without unstaged changes
+        if entry.unstaged == StatusCode::Unmodified || entry.kind == EntryKind::Ignored {
+            continue;
+        }
+
+        let file_path = &entry.path;
+        let abs_path = repo_workdir.join(file_path);
+
+        // Get content from HEAD (what was just committed)
+        let head_content = match head_tree.get_path(std::path::Path::new(file_path)) {
+            Ok(tree_entry) => {
+                if let Ok(blob) = repo.find_blob(tree_entry.id()) {
+                    let blob_content = blob.content()?;
+                    String::from_utf8_lossy(&blob_content).to_string()
+                } else {
+                    String::new()
+                }
+            }
+            Err(_) => String::new(), // File not in HEAD (untracked/new file)
+        };
+
+        // Get content from working directory
+        let working_content = std::fs::read_to_string(&abs_path).unwrap_or_else(|_| String::new());
+
+        debug_log(&format!(
+            "HEAD content lines: {}",
+            head_content.lines().count()
+        ));
+        debug_log(&format!(
+            "Working content lines: {}",
+            working_content.lines().count()
+        ));
+
+        // Normalize trailing newlines
+        let head_norm = if head_content.ends_with('\n') {
+            head_content.clone()
+        } else {
+            format!("{}\n", head_content)
+        };
+        let working_norm = if working_content.ends_with('\n') {
+            working_content.clone()
+        } else {
+            format!("{}\n", working_content)
+        };
+
+        // Diff HEAD (committed content) against working directory to find unstaged changes
+        let diff = TextDiff::from_lines(&head_norm, &working_norm);
+        let mut modified_lines = Vec::new();
+        let mut current_line = 1u32;
+
+        for change in diff.iter_all_changes() {
+            match change.tag() {
+                ChangeTag::Equal => {
+                    current_line += change.value().lines().count() as u32;
+                }
+                ChangeTag::Delete => {
+                    // Deletions don't add lines to the working directory
+                }
+                ChangeTag::Insert => {
+                    // These are the lines that exist in the working directory but not in HEAD
+                    let insert_start = current_line;
+                    let insert_count = change.value().lines().count() as u32;
+                    for i in 0..insert_count {
+                        modified_lines.push(insert_start + i);
+                    }
+                    current_line += insert_count;
+                }
+            }
+        }
+
+        // Convert line numbers to LineRange format
+        if !modified_lines.is_empty() {
+            modified_lines.sort_unstable();
+            let line_ranges = LineRange::compress_lines(&modified_lines);
+            unstaged_hunks.insert(file_path.clone(), line_ranges);
+        }
+    }
+
+    Ok(unstaged_hunks)
 }

--- a/tests/simple_additions.rs
+++ b/tests/simple_additions.rs
@@ -1,4 +1,5 @@
 use git_ai::git::test_utils::TmpRepo;
+use git_ai::log_fmt::authorship_log::LineRange;
 use insta::assert_debug_snapshot;
 
 #[test]
@@ -85,566 +86,664 @@ fn test_simple_additions_new_file_not_git_added() {
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // Append 3 more lines from Claude
-    file.append("Line 4 from Claude\nLine 5 from Claude\nLine 6 from Claude\n")
-        .unwrap();
+    file.append("Line 4 from AI\nLine 5 from AI\n").unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Now commit (which will add all files including the new one)
+    // Git add and commit
+    let authorship_log = tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // The file should only have the AI lines attributed (lines 4-5)
+    // Because the file wasn't tracked when test_user's checkpoint ran
+    assert_debug_snapshot!(authorship_log);
+}
+
+#[test]
+fn test_ai_human_interleaved_line_attribution() {
+    let (tmp_repo, mut file, _) = TmpRepo::new_with_base_commit().unwrap();
+
+    // AI adds line
+    file.append("AI Line 1\n").unwrap();
     tmp_repo
-        .commit_with_message("Add new file with mixed authorship")
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
+
+    // Human adds line
+    file.append("Human Line 1\n").unwrap();
+    tmp_repo
+        .trigger_checkpoint_with_author("test_user")
+        .unwrap();
+
+    // AI adds another line
+    file.append("AI Line 2\n").unwrap();
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    tmp_repo.commit_with_message("Interleaved commit").unwrap();
 
     let blame = tmp_repo.blame_for_file(&file, None).unwrap();
     assert_debug_snapshot!(blame);
 }
 
 #[test]
-fn test_ai_adds_then_human_deletes_and_replaces() {
+fn test_simple_ai_then_human_deletion() {
     let tmp_repo = TmpRepo::new().unwrap();
 
-    // Start with a base file
     let mut file = tmp_repo
-        .write_file("xyz.ts", "line1\nline2\n", true)
+        .write_file("test.txt", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n", true)
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines at the end
-    file.append("ai_line1\nai_line2\nai_line3\nai_line4\n")
-        .unwrap();
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    file.append("AI Line\n").unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Human deletes the AI lines and adds their own
-    file.replace_range(3, 7, "human_line1\n").unwrap();
+    tmp_repo.commit_with_message("AI adds line").unwrap();
+
+    // Human deletes all AI lines by replacing them with empty
+    file.replace_range(6, 7, "").unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    tmp_repo
-        .commit_with_message("AI adds lines, human deletes and replaces")
+    let authorship_log = tmp_repo
+        .commit_with_message("Human deletes AI line")
         .unwrap();
 
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
+    // The authorship log should have no attestations since we only deleted lines
+    assert_eq!(authorship_log.attestations.len(), 0);
 
-    assert_debug_snapshot!(blame);
-}
-
-#[test]
-fn test_ai_adds_middle_then_human_deletes_and_replaces() {
-    let tmp_repo = TmpRepo::new().unwrap();
-
-    // Start with a base file
-    let mut file = tmp_repo
-        .write_file("middle_test.ts", "line1\nline2\nline3\nline4\n", true)
-        .unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    // AI adds lines in the middle (after line 2)
-    file.append("ai_middle1\nai_middle2\nai_middle3\n").unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
-        .unwrap();
-
-    // Human deletes 2 AI lines and adds 1 human line
-    file.replace_range(5, 8, "human_middle\n").unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    tmp_repo
-        .commit_with_message("AI adds middle lines, human deletes and replaces")
-        .unwrap();
-
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-
-    assert_debug_snapshot!(blame);
+    assert_debug_snapshot!(authorship_log);
 }
 
 #[test]
 fn test_multiple_ai_checkpoints_with_human_deletions() {
     let tmp_repo = TmpRepo::new().unwrap();
 
-    // Start with a base file
-    let mut file = tmp_repo
-        .write_file("multi_ai.ts", "base1\nbase2\n", true)
-        .unwrap();
+    let mut file = tmp_repo.write_file("test.txt", "Base\n", true).unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // First AI session adds lines
-    file.append("ai1_line1\nai1_line2\n").unwrap();
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // First AI session
+    file.append("AI1 Line 1\nAI1 Line 2\n").unwrap();
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Second AI session adds more lines
-    file.append("ai2_line1\nai2_line2\n").unwrap();
+    // Second AI session
+    file.append("AI2 Line 1\nAI2 Line 2\n").unwrap();
     tmp_repo
-        .trigger_checkpoint_with_ai("GPT-4", Some("gpt-4"), Some("windsurf"))
+        .trigger_checkpoint_with_ai("GPT-4", Some("gpt-4"), Some("openai"))
         .unwrap();
 
-    // Human deletes lines from both AI sessions
-    file.replace_range(3, 6, "human_replacement\n").unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    tmp_repo
-        .commit_with_message("Multiple AI sessions with selective human deletions")
-        .unwrap();
-
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-
-    assert_debug_snapshot!(blame);
-}
-
-#[test]
-fn test_ai_adds_then_human_deletes_all_ai_lines() {
-    let tmp_repo = TmpRepo::new().unwrap();
-
-    // Start with a base file
-    let mut file = tmp_repo
-        .write_file("delete_all.ts", "human_base\n", true)
-        .unwrap();
-
+    // Human deletes first AI session's lines
+    file.replace_range(2, 4, "").unwrap();
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines
-    file.append("ai_line1\nai_line2\nai_line3\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
-        .unwrap();
+    let authorship_log = tmp_repo.commit_with_message("Complex commit").unwrap();
 
-    // Human deletes ALL AI lines and adds only human content
-    file.replace_range(2, 5, "human_only1\nhuman_only2\n")
-        .unwrap();
+    // Should only have AI2's lines attributed
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let file_att = &authorship_log.attestations[0];
+    assert_eq!(file_att.entries.len(), 1); // Only one AI session
 
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    tmp_repo
-        .commit_with_message("AI adds lines, human deletes all AI content")
-        .unwrap();
-
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    assert_debug_snapshot!(blame);
-}
-
-#[test]
-fn test_human_adds_then_ai_modifies_then_human_deletes() {
-    let tmp_repo = TmpRepo::new().unwrap();
-
-    // Start with a base file
-    let mut file = tmp_repo
-        .write_file("reverse_test.ts", "base\n", true)
-        .unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    // Human adds lines
-    file.append("human_line1\nhuman_line2\nhuman_line3\n")
-        .unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    // AI modifies some human lines
-    file.replace_range(2, 3, "ai_modified_human1\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
-        .unwrap();
-
-    // Human deletes the AI modifications and adds their own
-    file.replace_range(2, 4, "human_final1\nhuman_final2\n")
-        .unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    tmp_repo
-        .commit_with_message("Human adds, AI modifies, human deletes AI changes")
-        .unwrap();
-
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    assert_debug_snapshot!(blame);
+    assert_debug_snapshot!(authorship_log);
 }
 
 #[test]
 fn test_complex_mixed_additions_and_deletions() {
     let tmp_repo = TmpRepo::new().unwrap();
 
+    let mut file = tmp_repo
+        .write_file(
+            "test.txt",
+            "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10\n",
+            true,
+        )
+        .unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_author("test_user")
+        .unwrap();
+
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI deletes lines 2-3 and replaces with new content
+    file.replace_range(2, 4, "NEW LINE A\nNEW LINE B\nNEW LINE C\n")
+        .unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    // AI inserts at the end
+    file.append("END LINE 1\nEND LINE 2\n").unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    let authorship_log = tmp_repo.commit_with_message("Complex edits").unwrap();
+
+    // Should have lines 2-4 and the last 2 lines attributed to AI
+    assert_eq!(authorship_log.attestations.len(), 1);
+
+    assert_debug_snapshot!(authorship_log);
+}
+
+#[test]
+fn test_ai_adds_lines_with_unstaged_modifications() {
+    // Test that unstaged lines are NOT included in the authorship log after commit
+    let tmp_repo = TmpRepo::new().unwrap();
+
     // Start with a base file
-    let mut file = tmp_repo.write_file("complex.ts", "start\n", true).unwrap();
+    let mut file = tmp_repo.write_file("test.ts", "base_line\n", true).unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines
-    file.append("ai1\nai2\nai3\n").unwrap();
+    // Create initial commit
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI adds 5 lines and we stage them
+    tmp_repo
+        .append_and_stage_file(
+            &mut file,
+            "ai_line1\nai_line2\nai_line3\nai_line4\nai_line5\n",
+        )
+        .unwrap();
+
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Human adds lines
-    file.append("human1\nhuman2\n").unwrap();
+    // Now add more AI lines that won't be staged
     tmp_repo
-        .trigger_checkpoint_with_author("test_user")
+        .append_unstaged_file(&mut file, "unstaged_ai_line1\nunstaged_ai_line2\n")
         .unwrap();
 
-    // AI adds more lines
-    file.append("ai4\nai5\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("GPT-4", Some("gpt-4"), Some("windsurf"))
-        .unwrap();
-
-    // Human deletes some AI lines and some human lines, adds new content
-    file.replace_range(2, 5, "mixed1\nmixed2\n").unwrap();
-
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
-        .unwrap();
-
-    // AI modifies the mixed content
-    file.replace_range(2, 3, "ai_final\n").unwrap();
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    tmp_repo
-        .commit_with_message("Complex mixed additions and deletions")
+    // Commit only the staged changes
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("AI adds lines with unstaged modifications")
         .unwrap();
 
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
+    // The authorship log should only include lines 2-6 (the staged AI lines)
+    // Lines 7-8 (unstaged_ai_line1, unstaged_ai_line2) should NOT be in the authorship log
+    assert_debug_snapshot!(authorship_log);
+
+    // Verify the blame only includes the committed lines
+    let blame = tmp_repo.blame_for_file(&file, Some((1, 6))).unwrap();
     assert_debug_snapshot!(blame);
 }
 
 #[test]
-fn test_ai_adds_then_human_deletes_all_with_empty_replacement() {
+fn test_partial_staging_filters_unstaged_lines() {
+    // Test where AI makes changes but only some are staged
     let tmp_repo = TmpRepo::new().unwrap();
 
     // Start with a base file
     let mut file = tmp_repo
-        .write_file("empty_replacement.ts", "base_line\n", true)
+        .write_file("partial.ts", "line1\nline2\nline3\n", true)
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines
-    file.append("ai_line1\nai_line2\nai_line3\nai_line4\n")
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI modifies lines 2-3 and stage
+    file.replace_range(2, 4, "ai_modified2\nai_modified3\n")
+        .unwrap();
+    tmp_repo.stage_file("partial.ts").unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    // Now AI adds more lines that won't be staged
+    tmp_repo
+        .append_unstaged_file(&mut file, "unstaged_line1\nunstaged_line2\n")
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Human deletes ALL AI lines and replaces with empty string
-    file.replace_range(2, 6, "").unwrap();
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("Partial staging")
+        .unwrap();
+
+    // Should only include lines 2-3 (the modifications), not the unstaged additions
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let entry = &authorship_log.attestations[0].entries[0];
+    assert_eq!(entry.line_ranges, vec![LineRange::Range(2, 3)]);
+
+    assert_debug_snapshot!(authorship_log);
+}
+
+#[test]
+fn test_human_stages_some_ai_lines() {
+    // Test where AI adds multiple lines but human only stages some of them
+    let tmp_repo = TmpRepo::new().unwrap();
+
+    let mut file = tmp_repo
+        .write_file("test.ts", "line1\nline2\nline3\n", true)
+        .unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_author("test_user")
+        .unwrap();
+
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI adds lines 4-8
+    file.append("ai_line4\nai_line5\nai_line6\nai_line7\nai_line8\n")
+        .unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    // Stage only lines 4-6 (first 3 AI lines)
+    tmp_repo.stage_lines_from_file(&file, &[(4, 6)]).unwrap();
+
+    // Human adds an unstaged line
+    file.append("human_unstaged\n").unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
     let authorship_log = tmp_repo
-        .commit_with_message("AI adds lines, human deletes all AI content with empty replacement")
+        .commit_staged_with_message("Partial AI commit")
         .unwrap();
 
-    // has prompt, but not attestations
+    // Should only have lines 4-6 from AI
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let entry = &authorship_log.attestations[0].entries[0];
+    assert_eq!(entry.line_ranges, vec![LineRange::Range(4, 6)]);
+
     assert_debug_snapshot!(authorship_log);
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    assert_debug_snapshot!(blame);
 }
 
 #[test]
-fn test_ai_adds_lines_and_human_deletes_most_of_them() {
+fn test_multiple_ai_sessions_with_partial_staging() {
+    // Multiple AI sessions, but only one has staged changes
     let tmp_repo = TmpRepo::new().unwrap();
 
-    // Start with a base file
     let mut file = tmp_repo
-        .write_file("empty_replacement.ts", "base_line\n", true)
+        .write_file("test.ts", "line1\nline2\n", true)
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines
-    file.append("ai_line1\nai_line2\nai_line3\nai_line4\n")
-        .unwrap();
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // First AI session adds lines and they get staged
+    file.append("ai1_line1\nai1_line2\n").unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Human deletes ALL AI lines and replaces with empty string
-    file.replace_range(2, 3, "").unwrap();
+    tmp_repo.stage_file("test.ts").unwrap();
+
+    // Second AI session adds lines but they DON'T get staged
+    file.append("ai2_line1\nai2_line2\n").unwrap();
 
     tmp_repo
-        .trigger_checkpoint_with_author("test_user")
+        .trigger_checkpoint_with_ai("GPT", Some("gpt-4"), Some("windsurf"))
         .unwrap();
 
     let authorship_log = tmp_repo
-        .commit_with_message("AI adds lines, human deletes all AI content with empty replacement")
+        .commit_staged_with_message("Commit first AI session only")
         .unwrap();
 
+    // Should only have the first AI session's lines
+    assert_eq!(authorship_log.attestations.len(), 1);
+    assert_eq!(authorship_log.attestations[0].entries.len(), 1);
+
+    // Verify the lines are 3-4
+    let entry = &authorship_log.attestations[0].entries[0];
+    assert_eq!(entry.line_ranges, vec![LineRange::Range(3, 4)]);
+
+    // Verify the hash corresponds to the first AI session (Claude)
+    let hash = &entry.hash;
+    let prompt_record = authorship_log.metadata.prompts.get(hash).unwrap();
+    assert_eq!(prompt_record.agent_id.tool, "cursor");
+
     assert_debug_snapshot!(authorship_log);
-
-    // Assert on specific fields
-    let prompt = authorship_log.metadata.prompts.values().next().unwrap();
-    assert_eq!(prompt.total_additions, 4);
-    assert_eq!(prompt.total_deletions, 0);
-    assert_eq!(prompt.accepted_lines, 3); // Fixed: now correctly tracking all 3 remaining AI lines
-
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    assert_debug_snapshot!(blame);
 }
 
 #[test]
-fn test_ai_prepending_lines() {
+fn test_stage_specific_lines_only() {
+    // Test staging specific non-contiguous lines
     let tmp_repo = TmpRepo::new().unwrap();
 
-    // Start with a base file
     let mut file = tmp_repo
-        .write_file("test.ts", "human_line1\nhuman_line2\n", true)
+        .write_file("test.ts", "line1\nline2\nline3\nline4\n", true)
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines
-    file.prepend("ai_line1\nai_line2\nai_line3\nai_line4\n")
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI adds lines 5-10
+    file.append("ai_line5\nai_line6\nai_line7\nai_line8\nai_line9\nai_line10\n")
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    // Human deletes ALL AI lines and replaces with empty string
-    file.replace_range(1, 2, "NEW HUMAN LINE").unwrap();
+    // Stage only lines 5-7 (contiguous range)
+    tmp_repo.stage_lines_from_file(&file, &[(5, 7)]).unwrap();
 
-    tmp_repo
-        .trigger_checkpoint_with_author("test_user")
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("Commit specific lines")
         .unwrap();
 
-    let _authorship_log = tmp_repo.commit_with_message("test commit").unwrap();
+    // Should have lines 5-7
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let entry = &authorship_log.attestations[0].entries[0];
 
-    // println!("Authorship log: {:?}", authorship_log);
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    // println!("Blame: {:?}", blame);
-    assert_debug_snapshot!(blame);
+    let lines: Vec<u32> = entry.line_ranges.iter().flat_map(|r| r.expand()).collect();
+    assert_eq!(lines, vec![5, 6, 7]);
+
+    assert_debug_snapshot!(authorship_log);
 }
 
 #[test]
-fn test_duplicate_prompt_entries_bug() {
-    // This test reproduces the bug where the same AI session creates multiple
-    // separate attestation entries instead of consolidating them
+fn test_stage_middle_lines_leave_edges_unstaged() {
+    // AI adds lines, stage only the middle ones
     let tmp_repo = TmpRepo::new().unwrap();
 
-    // Start with a base file
     let mut file = tmp_repo
-        .write_file("file.txt", "line1\nline2\n", true)
+        .write_file("test.ts", "line1\nline2\n", true)
         .unwrap();
 
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines 3-4
-    file.append("ai_line3\nai_line4\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("some-ai"))
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI adds 6 lines (lines 3-8)
+    file.append("ai_line3\nai_line4\nai_line5\nai_line6\nai_line7\nai_line8\n")
         .unwrap();
 
-    // Human adds line 5
-    file.append("human_line5\n").unwrap();
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    // Stage lines 3-5 (leave 6, 7, 8 unstaged)
+    tmp_repo.stage_lines_from_file(&file, &[(3, 5)]).unwrap();
+
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("Commit middle lines")
+        .unwrap();
+
+    // Should have lines 3-5
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let entry = &authorship_log.attestations[0].entries[0];
+    assert_eq!(entry.line_ranges, vec![LineRange::Range(3, 5)]);
+
+    assert_debug_snapshot!(authorship_log);
+}
+
+#[test]
+fn test_multiple_ai_sessions_with_line_level_staging() {
+    // Multiple AI sessions with line-level staging
+    let tmp_repo = TmpRepo::new().unwrap();
+
+    let mut file = tmp_repo
+        .write_file("test.ts", "line1\nline2\n", true)
+        .unwrap();
+
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds lines 6-8 (SAME AI SESSION as before)
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // First AI session adds lines 3-5
+    file.append("ai1_line3\nai1_line4\nai1_line5\n").unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
+        .unwrap();
+
+    // Second AI session adds lines 6-8
+    file.append("ai2_line6\nai2_line7\nai2_line8\n").unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_ai("GPT", Some("gpt-4"), Some("windsurf"))
+        .unwrap();
+
+    // Stage lines 3-5 from first session (will capture all of AI1's changes)
+    tmp_repo.stage_lines_from_file(&file, &[(3, 5)]).unwrap();
+
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("First AI session only")
+        .unwrap();
+
+    // Should have 1 entry for the first AI session
+    assert_eq!(authorship_log.attestations.len(), 1);
+    assert_eq!(authorship_log.attestations[0].entries.len(), 1);
+
+    // Verify it's attributed to Claude (first session)
+    let hash = &authorship_log.attestations[0].entries[0].hash;
+    let prompt_record = authorship_log.metadata.prompts.get(hash).unwrap();
+    assert_eq!(prompt_record.agent_id.tool, "cursor");
+
+    assert_debug_snapshot!(authorship_log);
+}
+
+#[test]
+fn test_interleaved_staged_unstaged_hunks() {
+    // Complex case with interleaved staged/unstaged content
+    let tmp_repo = TmpRepo::new().unwrap();
+
+    let mut file = tmp_repo
+        .write_file("test.ts", "line1\nline2\nline3\nline4\nline5\n", true)
+        .unwrap();
+
+    tmp_repo
+        .trigger_checkpoint_with_author("test_user")
+        .unwrap();
+
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI modifies/adds throughout the file
+    file.replace_range(2, 3, "ai_modified_line2\n").unwrap();
+    file.replace_range(4, 5, "ai_modified_line4\n").unwrap();
     file.append("ai_line6\nai_line7\nai_line8\n").unwrap();
+
     tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("some-ai"))
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    let authorship_log = tmp_repo.commit_with_message("Test commit").unwrap();
+    // Stage lines 2 and 6-7 (leave line 4 and 8 unstaged)
+    tmp_repo
+        .stage_lines_from_file(&file, &[(2, 2), (6, 7)])
+        .unwrap();
 
-    // Debug: print the authorship log
-    println!("{}", authorship_log.serialize_to_string().unwrap());
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("Interleaved staging")
+        .unwrap();
 
-    // Check that there's only ONE prompt entry for this AI session
-    assert_eq!(authorship_log.metadata.prompts.len(), 1);
+    // Should have lines 2, 6, 7
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let file_att = &authorship_log.attestations[0];
+    assert!(!file_att.entries.is_empty());
 
-    // Check that there's only ONE attestation entry for this file+prompt pair
-    let file_attestation = authorship_log
-        .attestations
-        .iter()
-        .find(|f| f.file_path == "file.txt")
-        .expect("Should have attestation for file.txt");
+    // Verify line 5 is NOT in the ranges
+    for entry in &file_att.entries {
+        for range in &entry.line_ranges {
+            match range {
+                LineRange::Single(l) => {
+                    assert_ne!(*l, 5, "Line 5 should not be attributed (it was unstaged)");
+                }
+                LineRange::Range(start, end) => {
+                    if *start <= 5 && *end >= 5 {
+                        panic!("Line 5 should not be in any range (it was unstaged)");
+                    }
+                }
+            }
+        }
+    }
 
-    // BUG: This currently fails because we have multiple entries with the same hash!
-    // Expected: 1 entry with consolidated line ranges like "3-4,6-8"
-    // Actual: 2 entries both with the same hash
-    assert_eq!(
-        file_attestation.entries.len(),
-        1,
-        "Should have exactly 1 attestation entry, but got: {:?}",
-        file_attestation.entries
-    );
-
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
     assert_debug_snapshot!(authorship_log);
+
+    let blame = tmp_repo.blame_for_file(&file, Some((1, 8))).unwrap();
     assert_debug_snapshot!(blame);
 }
 
 #[test]
-fn test_ai_human_interleaved_line_attribution() {
-    // This test checks that line ranges are correctly attributed when
-    // AI and human alternate making changes
+fn test_unstaged_ai_lines_saved_to_working_log() {
+    // Test that unstaged AI-authored lines are saved to the working log for the next commit
     let tmp_repo = TmpRepo::new().unwrap();
 
-    let mut file = tmp_repo.write_file("file.txt", "", true).unwrap();
-
-    // AI adds 3 lines (lines 1-3)
-    file.append("ai1\nai2\nai3\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("some-ai"))
+    let mut file = tmp_repo
+        .write_file("test.ts", "line1\nline2\nline3\n", true)
         .unwrap();
 
-    // Human deletes line 2 and adds a human line
-    // Expected: ai1, human, ai3
-    file.replace_range(2, 3, "human\n").unwrap();
     tmp_repo
         .trigger_checkpoint_with_author("test_user")
         .unwrap();
 
-    // AI adds 3 more lines at the end (lines 4-6)
-    file.append("ai4\nai5\nai6\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("some-ai"))
+    tmp_repo.commit_with_message("Initial commit").unwrap();
+
+    // AI adds lines 4-7
+    file.append("ai_line4\nai_line5\nai_line6\nai_line7\n")
         .unwrap();
 
-    // Human removes line 5
-    file.replace_range(5, 6, "").unwrap();
     tmp_repo
-        .trigger_checkpoint_with_author("test_user")
+        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("cursor"))
         .unwrap();
 
-    let authorship_log = tmp_repo.commit_with_message("Test commit").unwrap();
+    // Stage only lines 4-5, leaving 6-7 unstaged
+    tmp_repo.stage_lines_from_file(&file, &[(4, 5)]).unwrap();
 
-    // Debug: print the authorship log
-    println!("{}", authorship_log.serialize_to_string().unwrap());
+    // Commit only the staged lines
+    let authorship_log = tmp_repo
+        .commit_staged_with_message("Partial AI commit")
+        .unwrap();
 
-    // Final file should be:
-    // 1: ai1 (AI)
-    // 2: human (HUMAN)
-    // 3: ai3 (AI)
-    // 4: ai4 (AI)
-    // 5: ai6 (AI) - was line 6, shifted up after line 5 deletion
+    // The authorship log should only have lines 4-5
+    assert_eq!(authorship_log.attestations.len(), 1);
+    let file_att = &authorship_log.attestations[0];
+    assert_eq!(file_att.entries.len(), 1);
 
-    // Check the attestation entries
-    let file_attestation = authorship_log
-        .attestations
-        .iter()
-        .find(|f| f.file_path == "file.txt")
-        .expect("Should have attestation for file.txt");
+    // Lines 6-7 should have been saved to the working log
+    // Let's verify by staging them and committing
+    tmp_repo.stage_lines_from_file(&file, &[(6, 7)]).unwrap();
 
-    println!("Attestation entries: {:?}", file_attestation.entries);
+    let second_authorship_log = tmp_repo
+        .commit_staged_with_message("Commit remaining AI lines")
+        .unwrap();
 
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    assert_debug_snapshot!(authorship_log);
-    assert_debug_snapshot!(blame);
+    // The second commit should also attribute lines 6-7 to the AI
+    // because they were saved to the working log
+    assert_eq!(second_authorship_log.attestations.len(), 1);
+    let second_file_att = &second_authorship_log.attestations[0];
+    assert!(!second_file_att.entries.is_empty());
+
+    // Verify the same AI session hash is used (from working log)
+    let first_hash = &file_att.entries[0].hash;
+    let second_hash = &second_file_att.entries[0].hash;
+    assert_eq!(
+        first_hash, second_hash,
+        "Both commits should be attributed to the same AI session"
+    );
+
+    assert_debug_snapshot!((authorship_log, second_authorship_log));
 }
 
+/// Test: New file with partial staging across two commits
+/// AI creates a new file with many lines, stage only some, then commit the rest
 #[test]
-fn test_simple_ai_then_human_deletion() {
-    // Simplified test: AI adds 3 lines, human deletes the middle one
+fn test_new_file_partial_staging_two_commits() {
     let tmp_repo = TmpRepo::new().unwrap();
-    let mut file = tmp_repo.write_file("file.txt", "", true).unwrap();
+    tmp_repo.commit_with_message("Initial commit").unwrap();
 
-    // AI adds 3 lines (lines 1-3: ai1, ai2, ai3)
-    file.append("ai1\nai2\nai3\n").unwrap();
-    tmp_repo
-        .trigger_checkpoint_with_ai("Claude", Some("claude-3-sonnet"), Some("some-ai"))
+    // AI creates a brand new file with a long list
+    let mut file = tmp_repo
+        .write_file(
+            "planets.txt",
+            "Mercury\nVenus\nEarth\nMars\nJupiter\nSaturn\nUranus\nNeptune\nPluto (dwarf)\n",
+            false, // Don't stage yet
+        )
         .unwrap();
 
-    println!("\n=== After AI adds 3 lines ===");
-    println!("File content:\n{}", file.contents());
-
-    // Human deletes line 2 (ai2)
-    file.replace_range(2, 3, "").unwrap();
     tmp_repo
-        .trigger_checkpoint_with_author("test_user")
+        .trigger_checkpoint_with_ai("Claude", Some("gpt-4"), Some("cursor"))
         .unwrap();
 
-    println!("\n=== After human deletes line 2 ===");
-    println!("File content:\n{}", file.contents());
+    // Stage only the first 5 lines (inner planets + Jupiter)
+    tmp_repo.stage_lines_from_file(&file, &[(1, 5)]).unwrap();
 
-    let authorship_log = tmp_repo.commit_with_message("Test commit").unwrap();
+    // First commit with partial staging
+    let log1 = tmp_repo
+        .commit_staged_with_message("Add inner planets and Jupiter")
+        .unwrap();
 
-    println!("\n=== Authorship Log ===");
-    println!("{}", authorship_log.serialize_to_string().unwrap());
+    // Check first commit's authorship log
+    assert_eq!(log1.attestations.len(), 1);
+    assert_eq!(log1.attestations[0].file_path, "planets.txt");
 
-    // Final file should be:
-    // Line 1: ai1 (AI)
-    // Line 2: ai3 (AI)
+    // Should have lines 1-5
+    let entry1 = &log1.attestations[0].entries[0];
+    assert_eq!(entry1.line_ranges, vec![LineRange::Range(1, 5)]);
 
-    // Check the attestation
-    let file_attestation = authorship_log
-        .attestations
-        .iter()
-        .find(|f| f.file_path == "file.txt")
-        .expect("Should have attestation for file.txt");
+    // Now stage the remaining lines
+    tmp_repo.stage_file("planets.txt").unwrap();
 
-    println!("\n=== Attestation entries ===");
-    for entry in &file_attestation.entries {
-        println!("  Hash: {}, Ranges: {:?}", entry.hash, entry.line_ranges);
-    }
+    // Second commit
+    let log2 = tmp_repo
+        .commit_staged_with_message("Add outer planets")
+        .unwrap();
 
-    let blame = tmp_repo.blame_for_file(&file, None).unwrap();
-    println!("\n=== Blame ===");
-    for (line, author) in &blame {
-        println!("  Line {}: {}", line, author);
-    }
+    // Check second commit's authorship log
+    assert_eq!(log2.attestations.len(), 1);
 
-    // Both lines should be attributed to AI
-    assert_eq!(
-        blame.get(&1),
-        Some(&"some-ai".to_string()),
-        "Line 1 should be AI"
-    );
-    assert_eq!(
-        blame.get(&2),
-        Some(&"some-ai".to_string()),
-        "Line 2 should be AI"
-    );
+    // Should have lines 6-9 (the previously unstaged lines)
+    let entry2 = &log2.attestations[0].entries[0];
+    assert_eq!(entry2.line_ranges, vec![LineRange::Range(6, 9)]);
 
-    assert_debug_snapshot!(authorship_log);
+    // Verify both commits use the same AI session hash
+    assert_eq!(entry1.hash, entry2.hash);
+
+    // Verify with blame
+    let blame1 = tmp_repo.blame_for_file(&file, Some((1, 5))).unwrap();
+    let blame2 = tmp_repo.blame_for_file(&file, Some((6, 9))).unwrap();
+
+    assert_debug_snapshot!((log1, log2, blame1, blame2));
 }

--- a/tests/snapshots/simple_additions__ai_adds_lines_with_unstaged_modifications-2.snap
+++ b/tests/snapshots/simple_additions__ai_adds_lines_with_unstaged_modifications-2.snap
@@ -1,0 +1,12 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "cursor",
+    3: "cursor",
+    4: "cursor",
+    5: "cursor",
+    6: "cursor",
+}

--- a/tests/snapshots/simple_additions__ai_adds_lines_with_unstaged_modifications.snap
+++ b/tests/snapshots/simple_additions__ai_adds_lines_with_unstaged_modifications.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
                             2,
-                            4,
-                        ),
-                        Range(
-                            12,
-                            13,
+                            6,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "b82b8fa3b85de492123de23d6aa6268f47522bd8",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -37,9 +33,9 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 5,
-                total_deletions: 2,
-                accepted_lines: 5,
+                total_additions: 7,
+                total_deletions: 0,
+                accepted_lines: 7,
             },
         },
     },

--- a/tests/snapshots/simple_additions__ai_adds_then_human_deletes_all_with_empty_replacement.snap
+++ b/tests/snapshots/simple_additions__ai_adds_then_human_deletes_all_with_empty_replacement.snap
@@ -7,21 +7,6 @@ AuthorshipLogV3 {
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
         base_commit_sha: "initial",
-        prompts: {
-            "1cee1d9": PromptRecord {
-                agent_id: AgentId {
-                    tool: "cursor",
-                    id: "test_session_fixed",
-                    model: "claude-3-sonnet",
-                },
-                human_author: Some(
-                    "Test User <test@example.com>",
-                ),
-                messages: [],
-                total_additions: 4,
-                total_deletions: 0,
-                accepted_lines: 0,
-            },
-        },
+        prompts: {},
     },
 }

--- a/tests/snapshots/simple_additions__ai_human_interleaved_line_attribution.snap
+++ b/tests/snapshots/simple_additions__ai_human_interleaved_line_attribution.snap
@@ -1,45 +1,42 @@
 ---
 source: tests/simple_additions.rs
-expression: authorship_log
+expression: blame
 ---
-AuthorshipLogV3 {
-    attestations: [
-        FileAttestation {
-            file_path: "file.txt",
-            entries: [
-                AttestationEntry {
-                    hash: "d6f9ad9",
-                    line_ranges: [
-                        Single(
-                            1,
-                        ),
-                        Range(
-                            3,
-                            5,
-                        ),
-                    ],
-                },
-            ],
-        },
-    ],
-    metadata: AuthorshipMetadata {
-        schema_version: "authorship/3.0.0",
-        base_commit_sha: "initial",
-        prompts: {
-            "d6f9ad9": PromptRecord {
-                agent_id: AgentId {
-                    tool: "some-ai",
-                    id: "test_session_fixed",
-                    model: "claude-3-sonnet",
-                },
-                human_author: Some(
-                    "Test User <test@example.com>",
-                ),
-                messages: [],
-                total_additions: 6,
-                total_deletions: 1,
-                accepted_lines: 4,
-            },
-        },
-    },
+{
+    1: "Test User",
+    2: "Test User",
+    3: "Test User",
+    4: "Test User",
+    5: "Test User",
+    6: "Test User",
+    7: "Test User",
+    8: "Test User",
+    9: "Test User",
+    10: "Test User",
+    11: "Test User",
+    12: "Test User",
+    13: "Test User",
+    14: "Test User",
+    15: "Test User",
+    16: "Test User",
+    17: "Test User",
+    18: "Test User",
+    19: "Test User",
+    20: "Test User",
+    21: "Test User",
+    22: "Test User",
+    23: "Test User",
+    24: "Test User",
+    25: "Test User",
+    26: "Test User",
+    27: "Test User",
+    28: "Test User",
+    29: "Test User",
+    30: "Test User",
+    31: "Test User",
+    32: "Test User",
+    33: "Test User",
+    34: "cursor",
+    35: "Test User",
+    36: "cursor",
 }

--- a/tests/snapshots/simple_additions__human_stages_some_ai_lines-2.snap
+++ b/tests/snapshots/simple_additions__human_stages_some_ai_lines-2.snap
@@ -1,0 +1,10 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "cursor",
+    3: "cursor",
+    4: "cursor",
+}

--- a/tests/snapshots/simple_additions__human_stages_some_ai_lines.snap
+++ b/tests/snapshots/simple_additions__human_stages_some_ai_lines.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
-                            2,
                             4,
-                        ),
-                        Range(
-                            12,
-                            13,
+                            6,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "00821120258f267c87c2548a84e47f0dc14e8bf7",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -38,7 +34,7 @@ AuthorshipLogV3 {
                 ),
                 messages: [],
                 total_additions: 5,
-                total_deletions: 2,
+                total_deletions: 0,
                 accepted_lines: 5,
             },
         },

--- a/tests/snapshots/simple_additions__interleaved_staged_unstaged_hunks-2.snap
+++ b/tests/snapshots/simple_additions__interleaved_staged_unstaged_hunks-2.snap
@@ -1,0 +1,14 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "cursor",
+    3: "Test User",
+    4: "Not Committed Yet",
+    5: "Test User",
+    6: "cursor",
+    7: "cursor",
+    8: "Not Committed Yet",
+}

--- a/tests/snapshots/simple_additions__interleaved_staged_unstaged_hunks.snap
+++ b/tests/snapshots/simple_additions__interleaved_staged_unstaged_hunks.snap
@@ -5,18 +5,17 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
-                        Range(
+                        Single(
                             2,
-                            4,
                         ),
                         Range(
-                            12,
-                            13,
+                            6,
+                            7,
                         ),
                     ],
                 },
@@ -25,7 +24,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "37595bbba1d6b917a7b15f4a956ef6d60a3d1168",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {

--- a/tests/snapshots/simple_additions__multiple_ai_checkpoints_with_human_deletions.snap
+++ b/tests/snapshots/simple_additions__multiple_ai_checkpoints_with_human_deletions.snap
@@ -1,10 +1,42 @@
 ---
 source: tests/simple_additions.rs
-expression: blame
+expression: authorship_log
 ---
-{
-    1: "Test User",
-    2: "Test User",
-    3: "Test User",
-    4: "windsurf",
+AuthorshipLogV3 {
+    attestations: [
+        FileAttestation {
+            file_path: "test.txt",
+            entries: [
+                AttestationEntry {
+                    hash: "b60a61e",
+                    line_ranges: [
+                        Range(
+                            2,
+                            3,
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "c0d2e8fadf955c94f15033f9d8a51ea1a2151014",
+        prompts: {
+            "b60a61e": PromptRecord {
+                agent_id: AgentId {
+                    tool: "openai",
+                    id: "test_session_fixed",
+                    model: "gpt-4",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
+            },
+        },
+    },
 }

--- a/tests/snapshots/simple_additions__multiple_ai_sessions_with_line_level_staging-2.snap
+++ b/tests/snapshots/simple_additions__multiple_ai_sessions_with_line_level_staging-2.snap
@@ -1,0 +1,11 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "Test User",
+    3: "Test User",
+    4: "cursor",
+    5: "Not Committed Yet",
+}

--- a/tests/snapshots/simple_additions__multiple_ai_sessions_with_line_level_staging.snap
+++ b/tests/snapshots/simple_additions__multiple_ai_sessions_with_line_level_staging.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
-                            2,
-                            4,
-                        ),
-                        Range(
-                            12,
-                            13,
+                            3,
+                            5,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "048d69c4a04d183327c0182f27d4b9004a1db9de",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -37,9 +33,9 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 5,
-                total_deletions: 2,
-                accepted_lines: 5,
+                total_additions: 3,
+                total_deletions: 0,
+                accepted_lines: 3,
             },
         },
     },

--- a/tests/snapshots/simple_additions__multiple_ai_sessions_with_partial_staging-2.snap
+++ b/tests/snapshots/simple_additions__multiple_ai_sessions_with_partial_staging-2.snap
@@ -1,0 +1,9 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "cursor",
+    3: "cursor",
+}

--- a/tests/snapshots/simple_additions__multiple_ai_sessions_with_partial_staging.snap
+++ b/tests/snapshots/simple_additions__multiple_ai_sessions_with_partial_staging.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
-                            2,
+                            3,
                             4,
-                        ),
-                        Range(
-                            12,
-                            13,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "048d69c4a04d183327c0182f27d4b9004a1db9de",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -37,9 +33,9 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 5,
-                total_deletions: 2,
-                accepted_lines: 5,
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
             },
         },
     },

--- a/tests/snapshots/simple_additions__new_file_partial_staging_two_commits.snap
+++ b/tests/snapshots/simple_additions__new_file_partial_staging_two_commits.snap
@@ -1,0 +1,95 @@
+---
+source: tests/simple_additions.rs
+expression: "(log1, log2, blame1, blame2)"
+---
+(
+    AuthorshipLogV3 {
+        attestations: [
+            FileAttestation {
+                file_path: "planets.txt",
+                entries: [
+                    AttestationEntry {
+                        hash: "1cee1d9",
+                        line_ranges: [
+                            Range(
+                                1,
+                                5,
+                            ),
+                        ],
+                    },
+                ],
+            },
+        ],
+        metadata: AuthorshipMetadata {
+            schema_version: "authorship/3.0.0",
+            base_commit_sha: "6da30bcc5a08c892cdc390d22ff0f1ccd24f30ba",
+            prompts: {
+                "1cee1d9": PromptRecord {
+                    agent_id: AgentId {
+                        tool: "cursor",
+                        id: "test_session_fixed",
+                        model: "gpt-4",
+                    },
+                    human_author: Some(
+                        "Test User <test@example.com>",
+                    ),
+                    messages: [],
+                    total_additions: 9,
+                    total_deletions: 1,
+                    accepted_lines: 9,
+                },
+            },
+        },
+    },
+    AuthorshipLogV3 {
+        attestations: [
+            FileAttestation {
+                file_path: "planets.txt",
+                entries: [
+                    AttestationEntry {
+                        hash: "1cee1d9",
+                        line_ranges: [
+                            Range(
+                                6,
+                                9,
+                            ),
+                        ],
+                    },
+                ],
+            },
+        ],
+        metadata: AuthorshipMetadata {
+            schema_version: "authorship/3.0.0",
+            base_commit_sha: "50c72a11a400ff9e49d90ca4db5a038ecebbfe48",
+            prompts: {
+                "1cee1d9": PromptRecord {
+                    agent_id: AgentId {
+                        tool: "cursor",
+                        id: "test_session_fixed",
+                        model: "gpt-4",
+                    },
+                    human_author: Some(
+                        "Test User <test@example.com>",
+                    ),
+                    messages: [],
+                    total_additions: 4,
+                    total_deletions: 0,
+                    accepted_lines: 4,
+                },
+            },
+        },
+    },
+    {
+        1: "cursor",
+        2: "cursor",
+        3: "cursor",
+        4: "cursor",
+        5: "cursor",
+    },
+    {
+        6: "cursor",
+        7: "cursor",
+        8: "cursor",
+        9: "cursor",
+    },
+)

--- a/tests/snapshots/simple_additions__partial_staging_filters_unstaged_lines-2.snap
+++ b/tests/snapshots/simple_additions__partial_staging_filters_unstaged_lines-2.snap
@@ -1,0 +1,9 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "cursor",
+    3: "cursor",
+}

--- a/tests/snapshots/simple_additions__partial_staging_filters_unstaged_lines.snap
+++ b/tests/snapshots/simple_additions__partial_staging_filters_unstaged_lines.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "partial.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
                             2,
-                            4,
-                        ),
-                        Range(
-                            12,
-                            13,
+                            3,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "264124f8d3a8d230b83c8622812d8f5ed4c3ce19",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -37,9 +33,9 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 5,
+                total_additions: 4,
                 total_deletions: 2,
-                accepted_lines: 5,
+                accepted_lines: 4,
             },
         },
     },

--- a/tests/snapshots/simple_additions__simple_additions_new_file_not_git_added.snap
+++ b/tests/snapshots/simple_additions__simple_additions_new_file_not_git_added.snap
@@ -1,12 +1,42 @@
 ---
 source: tests/simple_additions.rs
-expression: blame
+expression: authorship_log
 ---
-{
-    1: "Test User",
-    2: "Test User",
-    3: "Test User",
-    4: "cursor",
-    5: "cursor",
-    6: "cursor",
+AuthorshipLogV3 {
+    attestations: [
+        FileAttestation {
+            file_path: "new_file.txt",
+            entries: [
+                AttestationEntry {
+                    hash: "1cee1d9",
+                    line_ranges: [
+                        Range(
+                            4,
+                            5,
+                        ),
+                    ],
+                },
+            ],
+        },
+    ],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "initial",
+        prompts: {
+            "1cee1d9": PromptRecord {
+                agent_id: AgentId {
+                    tool: "cursor",
+                    id: "test_session_fixed",
+                    model: "claude-3-sonnet",
+                },
+                human_author: Some(
+                    "Test User <test@example.com>",
+                ),
+                messages: [],
+                total_additions: 2,
+                total_deletions: 0,
+                accepted_lines: 2,
+            },
+        },
+    },
 }

--- a/tests/snapshots/simple_additions__simple_ai_then_human_deletion.snap
+++ b/tests/snapshots/simple_additions__simple_ai_then_human_deletion.snap
@@ -3,40 +3,10 @@ source: tests/simple_additions.rs
 expression: authorship_log
 ---
 AuthorshipLogV3 {
-    attestations: [
-        FileAttestation {
-            file_path: "file.txt",
-            entries: [
-                AttestationEntry {
-                    hash: "d6f9ad9",
-                    line_ranges: [
-                        Range(
-                            1,
-                            2,
-                        ),
-                    ],
-                },
-            ],
-        },
-    ],
+    attestations: [],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "initial",
-        prompts: {
-            "d6f9ad9": PromptRecord {
-                agent_id: AgentId {
-                    tool: "some-ai",
-                    id: "test_session_fixed",
-                    model: "claude-3-sonnet",
-                },
-                human_author: Some(
-                    "Test User <test@example.com>",
-                ),
-                messages: [],
-                total_additions: 3,
-                total_deletions: 1,
-                accepted_lines: 2,
-            },
-        },
+        base_commit_sha: "fd8e89860a69ca38d30084d9580dbbf01f219f8f",
+        prompts: {},
     },
 }

--- a/tests/snapshots/simple_additions__stage_middle_lines_leave_edges_unstaged-2.snap
+++ b/tests/snapshots/simple_additions__stage_middle_lines_leave_edges_unstaged-2.snap
@@ -1,0 +1,12 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Not Committed Yet",
+    2: "Test User",
+    3: "cursor",
+    4: "cursor",
+    5: "cursor",
+    6: "Not Committed Yet",
+}

--- a/tests/snapshots/simple_additions__stage_middle_lines_leave_edges_unstaged.snap
+++ b/tests/snapshots/simple_additions__stage_middle_lines_leave_edges_unstaged.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
-                            2,
-                            4,
-                        ),
-                        Range(
-                            12,
-                            13,
+                            3,
+                            5,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "048d69c4a04d183327c0182f27d4b9004a1db9de",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -37,9 +33,9 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 5,
-                total_deletions: 2,
-                accepted_lines: 5,
+                total_additions: 6,
+                total_deletions: 0,
+                accepted_lines: 6,
             },
         },
     },

--- a/tests/snapshots/simple_additions__stage_specific_lines_only-2.snap
+++ b/tests/snapshots/simple_additions__stage_specific_lines_only-2.snap
@@ -1,0 +1,11 @@
+---
+source: tests/simple_additions.rs
+expression: blame
+---
+{
+    1: "Test User",
+    2: "cursor",
+    3: "Test User",
+    4: "Not Committed Yet",
+    5: "cursor",
+}

--- a/tests/snapshots/simple_additions__stage_specific_lines_only.snap
+++ b/tests/snapshots/simple_additions__stage_specific_lines_only.snap
@@ -5,18 +5,14 @@ expression: authorship_log
 AuthorshipLogV3 {
     attestations: [
         FileAttestation {
-            file_path: "test.txt",
+            file_path: "test.ts",
             entries: [
                 AttestationEntry {
                     hash: "1cee1d9",
                     line_ranges: [
                         Range(
-                            2,
-                            4,
-                        ),
-                        Range(
-                            12,
-                            13,
+                            5,
+                            7,
                         ),
                     ],
                 },
@@ -25,7 +21,7 @@ AuthorshipLogV3 {
     ],
     metadata: AuthorshipMetadata {
         schema_version: "authorship/3.0.0",
-        base_commit_sha: "1387fa7644fb10e1edbe7dc1fd07a931b798cf0b",
+        base_commit_sha: "9f611ed52a6ceaa44363d4e574a65166de356095",
         prompts: {
             "1cee1d9": PromptRecord {
                 agent_id: AgentId {
@@ -37,9 +33,9 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 5,
-                total_deletions: 2,
-                accepted_lines: 5,
+                total_additions: 6,
+                total_deletions: 0,
+                accepted_lines: 6,
             },
         },
     },

--- a/tests/snapshots/simple_additions__unstaged_ai_lines_saved_to_working_log.snap
+++ b/tests/snapshots/simple_additions__unstaged_ai_lines_saved_to_working_log.snap
@@ -1,0 +1,82 @@
+---
+source: tests/simple_additions.rs
+expression: "(authorship_log, second_authorship_log)"
+---
+(
+    AuthorshipLogV3 {
+        attestations: [
+            FileAttestation {
+                file_path: "test.ts",
+                entries: [
+                    AttestationEntry {
+                        hash: "1cee1d9",
+                        line_ranges: [
+                            Range(
+                                4,
+                                5,
+                            ),
+                        ],
+                    },
+                ],
+            },
+        ],
+        metadata: AuthorshipMetadata {
+            schema_version: "authorship/3.0.0",
+            base_commit_sha: "00821120258f267c87c2548a84e47f0dc14e8bf7",
+            prompts: {
+                "1cee1d9": PromptRecord {
+                    agent_id: AgentId {
+                        tool: "cursor",
+                        id: "test_session_fixed",
+                        model: "claude-3-sonnet",
+                    },
+                    human_author: Some(
+                        "Test User <test@example.com>",
+                    ),
+                    messages: [],
+                    total_additions: 4,
+                    total_deletions: 0,
+                    accepted_lines: 4,
+                },
+            },
+        },
+    },
+    AuthorshipLogV3 {
+        attestations: [
+            FileAttestation {
+                file_path: "test.ts",
+                entries: [
+                    AttestationEntry {
+                        hash: "1cee1d9",
+                        line_ranges: [
+                            Range(
+                                6,
+                                7,
+                            ),
+                        ],
+                    },
+                ],
+            },
+        ],
+        metadata: AuthorshipMetadata {
+            schema_version: "authorship/3.0.0",
+            base_commit_sha: "725417747aa03b4507540cf3d2c9846743f635fa",
+            prompts: {
+                "1cee1d9": PromptRecord {
+                    agent_id: AgentId {
+                        tool: "cursor",
+                        id: "test_session_fixed",
+                        model: "claude-3-sonnet",
+                    },
+                    human_author: Some(
+                        "Test User <test@example.com>",
+                    ),
+                    messages: [],
+                    total_additions: 2,
+                    total_deletions: 0,
+                    accepted_lines: 2,
+                },
+            },
+        },
+    },
+)


### PR DESCRIPTION
A user reported that unstaged changes were being considered staged when generating authorship logs. 
- This caused misattribution by shifting many of the line #s 
- No attribution unstaged AI changes in the next commit (once staged)

This PR solves this by
- [x] Filtering authorship log to only include authored hunks
- [x] Seeding new commit with a first entry in the working log that attributed unstaged code to AI/human. 