### PR TITLE
fix: Post-commit no longer crashes on empty repos

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -19,7 +19,12 @@ pub fn rewrite_authorship_if_needed(
     match last_event {
         RewriteLogEvent::Commit { commit } => {
             // This is going to become the regualar post-commit
-            post_commit::post_commit(repo, commit_author)?;
+            post_commit::post_commit(
+                repo,
+                commit.base_commit.clone(),
+                commit.commit_sha.clone(),
+                commit_author,
+            )?;
         }
         RewriteLogEvent::CommitAmend { commit_amend } => {
             rewrite_authorship_after_commit_amend(

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -474,8 +474,15 @@ impl Repository {
             return;
         }
 
-        self.pre_command_base_commit = Some(self.head().unwrap().target().unwrap().to_string());
-        self.pre_command_refname = Some(self.head().unwrap().name().unwrap().to_string());
+        // Safely handle empty repositories
+        if let Ok(head_ref) = self.head() {
+            if let Ok(target) = head_ref.target() {
+                let target_string = target;
+                let refname = head_ref.name().map(|n| n.to_string());
+                self.pre_command_base_commit = Some(target_string);
+                self.pre_command_refname = refname;
+            }
+        }
     }
 
     pub fn handle_rewrite_log_event(

--- a/src/git/rewrite_log.rs
+++ b/src/git/rewrite_log.rs
@@ -102,7 +102,7 @@ impl RewriteLogEvent {
         }
     }
 
-    pub fn commit(base_commit: String, commit_sha: String) -> Self {
+    pub fn commit(base_commit: Option<String>, commit_sha: String) -> Self {
         Self::Commit {
             commit: CommitEvent::new(base_commit, commit_sha),
         }
@@ -324,13 +324,13 @@ impl CommitAmendEvent {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CommitEvent {
-    pub base_commit: String,
+    pub base_commit: Option<String>,
     pub commit_sha: String,
 }
 
 impl CommitEvent {
     /// Create a new CommitEvent with the given parameters
-    pub fn new(base_commit: String, commit_sha: String) -> Self {
+    pub fn new(base_commit: Option<String>, commit_sha: String) -> Self {
         Self {
             base_commit,
             commit_sha,


### PR DESCRIPTION
We had encoded an assumption that there was always a parent commit and git-ai was throwing exemptions pre-commit and post-commit