### PR TITLE
migration to git notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          submodules: true
+          # submodules: true
           fetch-depth: 0
-
-      - name: Fetch all submodule references
-        run: |
-          cd tests/gitflow-repo
-          git fetch --all
-          git fetch origin '+refs/*:refs/*'
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/src/authorship/snapshots/git_ai__authorship__rebase_authorship__tests__in_order.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__rebase_authorship__tests__in_order.snap.new
@@ -1,0 +1,13 @@
+---
+source: src/authorship/rebase_authorship.rs
+assertion_line: 877
+expression: authorship_log
+---
+AuthorshipLogV3 {
+    attestations: [],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "",
+        prompts: {},
+    },
+}

--- a/src/authorship/snapshots/git_ai__authorship__rebase_authorship__tests__with_out_of_band_commits.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__rebase_authorship__tests__with_out_of_band_commits.snap.new
@@ -1,0 +1,13 @@
+---
+source: src/authorship/rebase_authorship.rs
+assertion_line: 897
+expression: authorship_log
+---
+AuthorshipLogV3 {
+    attestations: [],
+    metadata: AuthorshipMetadata {
+        schema_version: "authorship/3.0.0",
+        base_commit_sha: "",
+        prompts: {},
+    },
+}

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1,8 +1,8 @@
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::error::GitAiError;
 use crate::git::refs::get_reference_as_authorship_log_v3;
 use crate::git::repository::Repository;
 use crate::git::repository::exec_git;
-use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use std::collections::HashMap;
 use std::fs;
@@ -491,8 +491,7 @@ fn overlay_ai_authorship(
             cached.clone()
         } else {
             // Try to get authorship log for this commit
-            let ref_name = format!("ai/authorship/{}", hunk.commit_sha);
-            let authorship = match get_reference_as_authorship_log_v3(repo, &ref_name) {
+            let authorship = match get_reference_as_authorship_log_v3(repo, &hunk.commit_sha) {
                 Ok(v3_log) => Some(v3_log),
                 Err(_) => None, // No AI authorship data for this commit
             };

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -1,69 +1,66 @@
 use crate::authorship::authorship_log_serialization::{AUTHORSHIP_LOG_VERSION, AuthorshipLog};
 use crate::authorship::working_log::Checkpoint;
 use crate::error::GitAiError;
-use crate::git::repository::Repository;
+use crate::git::repository::{Repository, exec_git, exec_git_stdin};
 use serde_json;
 use std::fs;
 
-pub const AI_AUTHORSHIP_REFSPEC: &str = "+refs/ai/authorship/*:refs/ai/authorship/*";
+pub const AI_AUTHORSHIP_REFSPEC: &str = "+refs/notes/ai/:refs/notes/ai/";
 
-///
-pub fn put_reference(
+pub fn notes_add(
     repo: &Repository,
-    ref_name: &str,
-    content: &str,
-    message: &str,
+    commit_sha: &str,
+    note_content: &str,
 ) -> Result<(), GitAiError> {
-    // Create the AI namespace directory structure
-    let git_dir = repo.path();
-    let ai_refs_dir = git_dir.join("refs").join("ai");
+    let mut args = repo.global_args_for_exec();
+    args.push("notes".to_string());
+    args.push("--ref=ai".to_string());
+    args.push("add".to_string());
+    args.push("-f".to_string()); // Always force overwrite
+    args.push("-F".to_string());
+    args.push("-".to_string()); // Read note content from stdin
+    args.push(commit_sha.to_string());
 
-    // Create the directory if it doesn't exist
-    fs::create_dir_all(&ai_refs_dir)?;
-
-    // Create the blob object
-    let oid = repo.blob(content.as_bytes())?;
-
-    // Create the reference
-    let full_ref_name = format!("refs/{}", ref_name);
-    repo.reference(&full_ref_name, oid, true, message)?;
-
+    // Use stdin to provide the note content to avoid command line length limits
+    exec_git_stdin(&args, note_content.as_bytes())?;
     Ok(())
 }
 
-pub fn get_reference(repo: &Repository, ref_name: &str) -> Result<String, GitAiError> {
-    let full_ref_name = format!("refs/{}", ref_name);
+// Show an authorship note and return its JSON content if found, or None if it doesn't exist.
+pub fn show_authorship_note(repo: &Repository, commit_sha: &str) -> Option<String> {
+    let mut args = repo.global_args_for_exec();
+    args.push("notes".to_string());
+    args.push("--ref=ai".to_string());
+    args.push("show".to_string());
+    args.push(commit_sha.to_string());
 
-    // Get the reference
-    let reference = repo.find_reference(&full_ref_name)?;
-
-    // Get the object that the reference points to
-    let object = reference.peel_to_blob()?;
-
-    // Get the content of the blob
-    let content = object.content()?;
-
-    // Convert the blob content to a string, handling invalid UTF-8 gracefully
-    let content = String::from_utf8_lossy(&content);
-
-    Ok(content.to_string())
+    match exec_git(&args) {
+        Ok(output) => String::from_utf8(output.stdout)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        Err(GitAiError::GitCliError { code: Some(1), .. }) => None,
+        Err(_) => None,
+    }
 }
 
 #[allow(dead_code)]
 pub fn get_reference_as_working_log(
     repo: &Repository,
-    ref_name: &str,
+    commit_sha: &str,
 ) -> Result<Vec<Checkpoint>, GitAiError> {
-    let content = get_reference(repo, ref_name)?;
+    let content = show_authorship_note(repo, commit_sha)
+        .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
     let working_log = serde_json::from_str(&content)?;
     Ok(working_log)
 }
 
 pub fn get_reference_as_authorship_log_v3(
     repo: &Repository,
-    ref_name: &str,
+    commit_sha: &str,
 ) -> Result<AuthorshipLog, GitAiError> {
-    let content = get_reference(repo, ref_name)?;
+    let content = show_authorship_note(repo, commit_sha)
+        .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
 
     // Try to deserialize as AuthorshipLog
     let authorship_log = match AuthorshipLog::deserialize_from_string(&content) {
@@ -86,20 +83,45 @@ pub fn get_reference_as_authorship_log_v3(
     Ok(authorship_log)
 }
 
-// TODO Implement later if needed (requires a new reference.delete() method in repository.rs)
-// #[allow(dead_code)]
-// pub fn delete_reference(repo: &Repository, ref_name: &str) -> Result<(), GitAiError> {
-//     let full_ref_name = format!("refs/{}", ref_name);
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::test_utils::TmpRepo;
 
-//     // Try to find and delete the reference
-//     match repo.find_reference(&full_ref_name) {
-//         Ok(mut reference) => {
-//             reference.delete()?;
-//             Ok(())
-//         }
-//         Err(_) => {
-//             // Reference doesn't exist, which is fine for deletion
-//             Ok(())
-//         }
-//     }
-// }
+    #[test]
+    fn test_notes_add_and_show_authorship_note() {
+        // Create a temporary repository
+        let tmp_repo = TmpRepo::new().expect("Failed to create tmp repo");
+
+        // Create a commit first
+        tmp_repo
+            .commit_with_message("Initial commit")
+            .expect("Failed to create initial commit");
+
+        // Get the commit SHA
+        let commit_sha = tmp_repo
+            .get_head_commit_sha()
+            .expect("Failed to get head commit SHA");
+
+        // Test data - simple string content
+        let note_content = "This is a test authorship note with some random content!";
+
+        // Add the authorship note (force overwrite since commit_with_message already created one)
+        notes_add(tmp_repo.gitai_repo(), &commit_sha, note_content)
+            .expect("Failed to add authorship note");
+
+        // Read the note back
+        let retrieved_content = show_authorship_note(tmp_repo.gitai_repo(), &commit_sha)
+            .expect("Failed to retrieve authorship note");
+
+        // Assert the content matches exactly
+        assert_eq!(retrieved_content, note_content);
+
+        // Test that non-existent commit returns None
+        let non_existent_content = show_authorship_note(
+            tmp_repo.gitai_repo(),
+            "0000000000000000000000000000000000000000",
+        );
+        assert!(non_existent_content.is_none());
+    }
+}

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -5,7 +5,7 @@ use crate::git::repository::{Repository, exec_git, exec_git_stdin};
 use serde_json;
 use std::fs;
 
-pub const AI_AUTHORSHIP_REFSPEC: &str = "+refs/notes/ai/:refs/notes/ai/";
+pub const AI_AUTHORSHIP_REFSPEC: &str = "+refs/notes/ai/*:refs/notes/ai/*";
 
 pub fn notes_add(
     repo: &Repository,

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -5,7 +5,7 @@ use crate::git::repository::{Repository, exec_git, exec_git_stdin};
 use serde_json;
 use std::fs;
 
-pub const AI_AUTHORSHIP_REFSPEC: &str = "+refs/notes/ai/*:refs/notes/ai/*";
+pub const AI_AUTHORSHIP_REFSPEC: &str = "+refs/notes/ai:refs/notes/ai";
 
 pub fn notes_add(
     repo: &Repository,

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -650,7 +650,6 @@ impl Repository {
             ref_name: name.to_string(),
         })
     }
-
     // Find a merge base between two commits
     pub fn merge_base(&self, one: String, two: String) -> Result<String, GitAiError> {
         let mut args = self.global_args_for_exec();

--- a/src/git/test_utils/mod.rs
+++ b/src/git/test_utils/mod.rs
@@ -915,15 +915,13 @@ impl TmpRepo {
     ) -> Result<crate::authorship::authorship_log_serialization::AuthorshipLog, GitAiError> {
         let head = self.repo_git2.head()?;
         let commit_id = head.target().unwrap().to_string();
-        let ref_name = format!("ai/authorship/{}", commit_id);
-
-        match crate::git::refs::get_reference(&self.repo_gitai, &ref_name) {
-            Ok(content) => {
-                // Parse the authorship log from the reference content
+        match crate::git::refs::show_authorship_note(&self.repo_gitai, &commit_id) {
+            Some(content) => {
+                // Parse the authorship log from the note content
                 crate::authorship::authorship_log_serialization::AuthorshipLog::deserialize_from_string(&content)
                     .map_err(|e| GitAiError::Generic(format!("Failed to parse authorship log: {}", e)))
             }
-            Err(_) => Err(GitAiError::Generic("No authorship log found".to_string())),
+            None => Err(GitAiError::Generic("No authorship log found".to_string())),
         }
     }
 


### PR DESCRIPTION
We decided to move to git notes ahead of 1.0 for a few reasons 
- authorship refs are under a tree (namespace in notes parlance) for faster lookup. 
- gc and tools that clean / reduce size of git repos are not clean up / delete hanging notes

Practically it's not much different, but feel like it's good to move the project this direction before marking 1.0