### PR TITLE
checkpoint stats should ignore empty lines

### DIFF
--- a/src/authorship/snapshots/git_ai__authorship__rebase_authorship__tests__amend_multiple_changes.snap
+++ b/src/authorship/snapshots/git_ai__authorship__rebase_authorship__tests__amend_multiple_changes.snap
@@ -90,7 +90,7 @@ AuthorshipLogV3 {
                     "Test User <test@example.com>",
                 ),
                 messages: [],
-                total_additions: 4,
+                total_additions: 3,
                 total_deletions: 0,
                 accepted_lines: 1,
                 overriden_lines: 0,


### PR DESCRIPTION
Stats (for both humans and AI) will ignore empty lines. This also ensures that the human:AI lines ratio is corrected (since it was being thrown off earlier with humans' newlines being counted vs not for AI)