### PR TITLE
Don't run git-ai on PR close events.

### DIFF
--- a/src/ci/workflow_templates/github.yaml
+++ b/src/ci/workflow_templates/github.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   git-ai:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
We were seeing some % of our `git-ai` PR runs fail with:

```
git-ai	Run git-ai	2025-11-11T07:28:09.7089153Z No GitHub CI context found
```

After looking into this, it's because the PRs were closed.
Since we don't need to maintain authorship data from a closed PR (in fact it would lead to bad state), I've updated to only run on merged PRs.