### PR TITLE
Print git-ai version when installing (for CI debugging).

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,10 @@ PATH_CMD="export PATH=\"$INSTALL_DIR:\$PATH\""
 success "Successfully installed git-ai into ${INSTALL_DIR}"
 success "You can now run 'git-ai' from your terminal"
 
+# Print installed version
+INSTALLED_VERSION=$(${INSTALL_DIR}/git-ai --version 2>&1 || echo "unknown")
+echo "Installed git-ai ${INSTALLED_VERSION}"
+
 # Install hooks
 echo "Setting up IDE/agent hooks..."
 if ! ${INSTALL_DIR}/git-ai install-hooks; then


### PR DESCRIPTION
While debugging the GitHub CI squash workflow, I found it difficult to know which version of `git-ai` a workflow was using.

This PR updates the `install.sh` script so that on install, the version installed is printed.