### PR TITLE
shave 100 ms off every checkpoint

### DIFF
--- a/src/authorship/working_log.rs
+++ b/src/authorship/working_log.rs
@@ -18,18 +18,6 @@ pub struct WorkingLogEntry {
     pub attributions: Vec<Attribution>,
     #[serde(default)]
     pub line_attributions: Vec<LineAttribution>,
-    /// Line statistics for this file (additions/deletions)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub line_stats: Option<FileLineStats>,
-}
-
-/// Per-file line statistics
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct FileLineStats {
-    pub additions: u32,
-    pub deletions: u32,
-    pub additions_sloc: u32,
-    pub deletions_sloc: u32,
 }
 
 impl WorkingLogEntry {
@@ -45,24 +33,6 @@ impl WorkingLogEntry {
             blob_sha,
             attributions,
             line_attributions,
-            line_stats: None,
-        }
-    }
-
-    /// Create a new working log entry with line stats
-    pub fn new_with_line_stats(
-        file: String,
-        blob_sha: String,
-        attributions: Vec<Attribution>,
-        line_attributions: Vec<LineAttribution>,
-        line_stats: FileLineStats,
-    ) -> Self {
-        Self {
-            file,
-            blob_sha,
-            attributions,
-            line_attributions,
-            line_stats: Some(line_stats),
         }
     }
 }


### PR DESCRIPTION
The "Aidan edited 2 of 4 files..." log line from checkpoint command was calling git diff to get its line stats. Redundant, slow, most people will never see it since Agents use Checkpoint