### PR TITLE
Overlapping AI inserts bug reproduction

### DIFF
--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -11,6 +11,8 @@ use diff_match_patch_rs::traits::{Compat, Efficient};
 use diff_match_patch_rs::{DiffMatchPatch, Ops};
 use std::collections::HashMap;
 
+pub const INITIAL_ATTRIBUTION_TS: u128 = 42;
+
 /// Represents a single attribution range in the file.
 /// Ranges can overlap (multiple authors can be attributed to the same text).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -1,4 +1,4 @@
-use crate::authorship::attribution_tracker::{Attribution, AttributionTracker, LineAttribution};
+use crate::authorship::attribution_tracker::{Attribution, AttributionTracker, INITIAL_ATTRIBUTION_TS, LineAttribution};
 use crate::authorship::working_log::CheckpointKind;
 use crate::authorship::working_log::{Checkpoint, WorkingLogEntry};
 use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
@@ -601,7 +601,7 @@ fn get_checkpoint_entry_for_file(
             crate::authorship::attribution_tracker::line_attributions_to_attributions(
                 &prev_line_attributions,
                 content_for_line_conversion,
-                ts,
+                INITIAL_ATTRIBUTION_TS,
             );
 
         // When we have INITIAL attributions, they describe the current state of the file.

--- a/tests/prompt_across_commit.rs
+++ b/tests/prompt_across_commit.rs
@@ -23,29 +23,20 @@ fn test_change_across_commits() {
     println!("file: {}", file.lines.iter().map(|line| line.contents.clone()).collect::<Vec<String>>().join("\n"));
 
     let commit = repo.stage_all_and_commit("Initial all AI").unwrap();
-    // commit.print_authorship();
     let initial_ai_entry = commit.authorship_log.attestations.first().unwrap().entries.first().unwrap();
-    println!("initial_ai_entry: {:?}", initial_ai_entry);
 
     file.replace_at(4, "    print(f\"Hello, {name.upper()}!\")".ai());
-    println!("file: {}", file.lines.iter().map(|line| line.contents.clone()).collect::<Vec<String>>().join("\n"));
     file.insert_at(4, lines!["    name = name.upper()".human()]);
-    println!("file: {}", file.lines.iter().map(|line| line.contents.clone()).collect::<Vec<String>>().join("\n"));
 
     let commit = repo.stage_all_and_commit("add more AI").unwrap();
-    // commit.print_authorship();
 
     let file_attestation = commit.authorship_log.attestations.first().unwrap();
-    println!("file_attestation: {:?}", file_attestation);
     assert_eq!(file_attestation.entries.len(), 1);
+
     let second_ai_prompt_hash = commit.authorship_log.metadata.prompts.keys().next().unwrap();
-    println!("second_ai_prompt_hash: {}", second_ai_prompt_hash);
     assert_ne!(*second_ai_prompt_hash, initial_ai_entry.hash);
+
     let second_ai_entry = file_attestation.entries.first().unwrap();
-    println!("second_ai_entry: {:?}", second_ai_entry);
     assert_eq!(second_ai_entry.line_ranges, vec![LineRange::Single(6)]);
-    // This is failing, because for some reason, even though the edit is coming from a new AI prompt,
-    // and we confirmed that the new AI prompt is showing up properly in the prompts section,
-    // we are crediting the old prompt for the edit.
     assert_ne!(second_ai_entry.hash, initial_ai_entry.hash);
 }


### PR DESCRIPTION
- [x] AI Code sandwiched between previous AI code, can be attributed to old prompt if it's similar to the old contents. 
- [ ] Add more tests for similar cases in rewrites