### PR TITLE
Enable git-ai when GIT_TRACE is on

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,13 +13,17 @@ fn is_debug_enabled() -> bool {
         cfg!(debug_assertions)
             || std::env::var("GIT_AI_DEBUG").unwrap_or_default() == "1"
             || std::env::var("GIT_AI_DEBUG_PERFORMANCE").unwrap_or_default() == "1"
+            || std::env::var("GIT_TRACE").unwrap_or_default() == "1"
     })
 }
 
 fn is_debug_performance_enabled() -> bool {
     is_debug_enabled()
         && *DEBUG_PERFORMANCE_ENABLED
-            .get_or_init(|| std::env::var("GIT_AI_DEBUG_PERFORMANCE").unwrap_or_default() == "1")
+            .get_or_init(|| {
+                std::env::var("GIT_AI_DEBUG_PERFORMANCE").unwrap_or_default() == "1"
+                    || std::env::var("GIT_TRACE").unwrap_or_default() == "1"
+            })
 }
 
 pub fn debug_performance_log(msg: &str) {
@@ -31,7 +35,7 @@ pub fn debug_performance_log(msg: &str) {
 /// Debug logging utility function
 ///
 /// Prints debug messages with a colored prefix when debug assertions are enabled or when
-/// the `GIT_AI_DEBUG` environment variable is set to "1".
+/// the `GIT_AI_DEBUG`, `GIT_AI_DEBUG_PERFORMANCE`, or `GIT_TRACE` environment variable is set to "1".
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
## Summary

This PR enables git-ai debug logging when the `GIT_TRACE` environment variable is set. This allows developers debugging Git operations to automatically see git-ai debug output without needing to set additional environment variables.

## Changes

- Added `GIT_TRACE` environment variable check to `is_debug_enabled()` function
- Added `GIT_TRACE` environment variable check to `is_debug_performance_enabled()` function
- Updated documentation comment to reflect that `GIT_TRACE` now enables debug logging
