### PR TITLE
Fix: no human prompts in attributions

### DIFF
--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -823,11 +823,6 @@ impl VirtualAttributions {
             let file_committed_hunks = committed_hunks.get(file_path);
 
             for line_attr in line_attrs {
-                // Skip human attributions - we only track AI attributions
-                if line_attr.author_id == CheckpointKind::Human.to_str() {
-                    continue;
-                }
-
                 // Check each line individually
                 for workdir_line_num in line_attr.start_line..=line_attr.end_line {
                     // Check if this line is unstaged (in working directory but not in commit)
@@ -874,6 +869,11 @@ impl VirtualAttributions {
             if !committed_lines_map.is_empty() {
                 // Create attestation entries from committed lines
                 for (author_id, mut lines) in committed_lines_map {
+                    // Skip human attributions - we only track AI attributions in the output
+                    if author_id == CheckpointKind::Human.to_str() {
+                        continue;
+                    }
+
                     lines.sort();
                     lines.dedup();
 
@@ -932,6 +932,11 @@ impl VirtualAttributions {
                 // Convert the map into line attributions
                 let mut uncommitted_line_attrs = Vec::new();
                 for (author_id, mut lines) in uncommitted_lines_map {
+                    // Skip human attributions - we only track AI attributions in the output
+                    if author_id == CheckpointKind::Human.to_str() {
+                        continue;
+                    }
+
                     lines.sort();
                     lines.dedup();
 
@@ -1046,11 +1051,6 @@ impl VirtualAttributions {
             let mut committed_lines_map: StdHashMap<String, Vec<u32>> = StdHashMap::new();
 
             for line_attr in line_attrs {
-                // Skip human attributions - we only track AI attributions
-                if line_attr.author_id == CheckpointKind::Human.to_str() {
-                    continue;
-                }
-
                 // Since we're not dealing with unstaged hunks, the line numbers in VirtualAttributions
                 // are already in the right coordinates (working log coordinates = commit coordinates)
                 for line_num in line_attr.start_line..=line_attr.end_line {
@@ -1072,6 +1072,11 @@ impl VirtualAttributions {
             if !committed_lines_map.is_empty() {
                 // Create attestation entries from committed lines
                 for (author_id, mut lines) in committed_lines_map {
+                    // Skip human attributions - we only track AI attributions in the output
+                    if author_id == CheckpointKind::Human.to_str() {
+                        continue;
+                    }
+
                     lines.sort();
                     lines.dedup();
 
@@ -1213,13 +1218,10 @@ impl VirtualAttributions {
         }
 
         // Calculate overridden_lines: count lines where overrode field matches session_id
+        // NOTE: We intentionally include human attributions here because when a human
+        // overrides an AI line, the attribution has author_id="human" and overrode="ai_prompt_id"
         let mut session_overridden_lines: HashMap<String, u32> = HashMap::new();
         for line_attr in &all_line_attributions {
-            // Skip human attributions - we only track AI prompt metrics
-            if line_attr.author_id == CheckpointKind::Human.to_str() {
-                continue;
-            }
-
             if let Some(overrode_id) = &line_attr.overrode {
                 let mut overridden_lines: HashSet<u32> = HashSet::new();
                 for line in line_attr.start_line..=line_attr.end_line {


### PR DESCRIPTION
When unstaged changes have attributions, they'd initial attributions would be seeded with `human` attributions. 