### PR TITLE
Detect REPO during release, making it easier to test on forks.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,19 +292,22 @@ jobs:
       - name: Generate version-pinned install script
         run: |
           VERSION="${{ steps.release-meta.outputs.tag_name }}"
+          REPO="${{ github.repository }}"
           # Convert checksums to pipe-separated format for embedding
           CHECKSUMS=$(tr '\n' '|' < release/SHA256SUMS | sed 's/|$//')
           if [ -z "$CHECKSUMS" ]; then
             CHECKSUMS="__CHECKSUMS_PLACEHOLDER__"
           fi
-          # Replace only the variable assignment lines (line 17 and 22) to preserve comparison strings
-          awk -v version="$VERSION" -v checksums="$CHECKSUMS" '
-            NR==17 { sub(/__VERSION_PLACEHOLDER__/, version) }
-            NR==22 { sub(/__CHECKSUMS_PLACEHOLDER__/, checksums) }
+          # Replace variable assignment lines to embed release-specific values
+          # Line 15: REPO, Line 22: PINNED_VERSION, Line 27: EMBEDDED_CHECKSUMS
+          awk -v repo="$REPO" -v version="$VERSION" -v checksums="$CHECKSUMS" '
+            NR==15 { sub(/__REPO_PLACEHOLDER__/, repo) }
+            NR==22 { sub(/__VERSION_PLACEHOLDER__/, version) }
+            NR==27 { sub(/__CHECKSUMS_PLACEHOLDER__/, checksums) }
             { print }
           ' repo/install.sh > release/install.sh
           chmod +x release/install.sh
-          echo "Generated version-pinned install.sh for $VERSION"
+          echo "Generated version-pinned install.sh for $VERSION from $REPO"
           echo "Embedded checksums: $CHECKSUMS"
 
       - name: Generate attestations for release artifacts

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,12 @@ YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # GitHub repository details
-REPO="acunniffe/git-ai"
+# Replaced during release builds with the actual repository (e.g., "acunniffe/git-ai")
+# When set to __REPO_PLACEHOLDER__, defaults to "acunniffe/git-ai"
+REPO="__REPO_PLACEHOLDER__"
+if [ "$REPO" = "__REPO_PLACEHOLDER__" ]; then
+    REPO="acunniffe/git-ai"
+fi
 
 # Version placeholder - replaced during release builds with actual version (e.g., "v1.0.24")
 # When set to __VERSION_PLACEHOLDER__, defaults to "latest"


### PR DESCRIPTION
I was testing `git-ai-project/action` changes on a fork of mine, and because of the hardcoded `origin` `REPO`, it made it difficult to test.

This allows the REPO value to be defined when releasing, making it easier to develop on forks.