### PR TITLE
docs(README.md): add DeepWiki badge to project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 </div>
 <p align="left">Track the AI Code in your repositories</p>
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/acunniffe/git-ai)
+
 <video src="https://github.com/user-attachments/assets/68304ca6-b262-4638-9fb6-0a26f55c7986" muted loop controls autoplay></video>
 
 ## Quick Start


### PR DESCRIPTION
Add the DeepWiki badge to automatically update the wiki and facilitate a better understanding of the project.

> What is DeepWiki?
> 
> DeepWiki provides up-to-date documentation you can talk to, for every repo in the world. Add this badge to your repository to help users find documentation.