### PR TITLE
vscode extension settings from window -> global

### DIFF
--- a/agent-support/vscode/package.json
+++ b/agent-support/vscode/package.json
@@ -42,6 +42,7 @@
             "all"
           ],
           "default": "line",
+          "scope": "application",
           "enumDescriptions": [
             "Disable gutter decorations (status bar still shows current line info)",
             "Show gutter decorations for the current line's prompt only",


### PR DESCRIPTION
The VSCode extension settings were resetting each time a workspace was opened forcing users to turn on AI mode (or in cases they weren't into it, turn it off) over and over again. 

The PR moves the preference to an `application` scope