### PR TITLE
Add include_prompts_in_repositories whitelist for prompt storage

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -1,11 +1,11 @@
 use crate::api::{ApiClient, ApiContext};
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
-use crate::authorship::prompt_utils::{update_prompt_from_tool, PromptUpdateResult};
+use crate::authorship::prompt_utils::{PromptUpdateResult, update_prompt_from_tool};
 use crate::authorship::secrets::{redact_secrets_from_prompts, strip_prompt_messages};
 use crate::authorship::stats::{stats_for_commit_stats, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::{Checkpoint, CheckpointKind};
-use crate::config::Config;
+use crate::config::{Config, PromptStorageMode};
 use crate::error::GitAiError;
 use crate::git::refs::notes_add;
 use crate::git::repository::Repository;
@@ -88,38 +88,31 @@ pub fn post_commit(
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 
-    // Handle prompts based on prompt_storage setting and exclusion rules
-    let should_exclude = Config::get().should_exclude_prompts(&Some(repo.clone()));
-    let prompt_storage = Config::get().prompt_storage();
+    // Handle prompts based on effective prompt storage mode for this repository
+    // The effective mode considers include/exclude lists and fallback settings
+    let effective_storage = Config::get().effective_prompt_storage(&Some(repo.clone()));
 
-    match prompt_storage {
-        "local" => {
+    match effective_storage {
+        PromptStorageMode::Local => {
             // Local only: strip all messages from notes (they stay in sqlite only)
             strip_prompt_messages(&mut authorship_log.metadata.prompts);
         }
-        "notes" => {
+        PromptStorageMode::Notes => {
             // Store in notes: redact secrets but keep messages in notes
-            if should_exclude {
-                strip_prompt_messages(&mut authorship_log.metadata.prompts);
-            } else {
-                let count = redact_secrets_from_prompts(&mut authorship_log.metadata.prompts);
-                if count > 0 {
-                    debug_log(&format!("Redacted {} secrets from prompts", count));
-                }
+            let count = redact_secrets_from_prompts(&mut authorship_log.metadata.prompts);
+            if count > 0 {
+                debug_log(&format!("Redacted {} secrets from prompts", count));
             }
         }
-        _ => {
+        PromptStorageMode::Default => {
             // "default" - attempt CAS upload, NEVER keep messages in notes
             // Check conditions for CAS upload:
-            // - prompt_storage == "default" (implied here)
-            // - repo not in exclusion list
             // - user is logged in OR using custom API URL
             let context = ApiContext::new(None);
             let client = ApiClient::new(context);
             let using_custom_api =
                 Config::get().api_base_url() != crate::config::DEFAULT_API_BASE_URL;
-            let should_enqueue_cas =
-                !should_exclude && (client.is_logged_in() || using_custom_api);
+            let should_enqueue_cas = client.is_logged_in() || using_custom_api;
 
             if should_enqueue_cas {
                 // Redact secrets before uploading to CAS
@@ -335,7 +328,10 @@ fn batch_upsert_prompts_to_db(
 /// - Set messages_url (format: {api_base_url}/cas/{hash}) and clear messages
 fn enqueue_prompt_messages_to_cas(
     repo: &Repository,
-    prompts: &mut std::collections::BTreeMap<String, crate::authorship::authorship_log::PromptRecord>,
+    prompts: &mut std::collections::BTreeMap<
+        String,
+        crate::authorship::authorship_log::PromptRecord,
+    >,
 ) -> Result<(), GitAiError> {
     use crate::authorship::internal_db::InternalDatabase;
 
@@ -355,14 +351,12 @@ fn enqueue_prompt_messages_to_cas(
         .ok()
         .flatten()
         .and_then(|remote_name| {
-            repo.remotes_with_urls()
-                .ok()
-                .and_then(|remotes| {
-                    remotes
-                        .into_iter()
-                        .find(|(name, _)| name == &remote_name)
-                        .map(|(_, url)| url)
-                })
+            repo.remotes_with_urls().ok().and_then(|remotes| {
+                remotes
+                    .into_iter()
+                    .find(|(name, _)| name == &remote_name)
+                    .map(|(_, url)| url)
+            })
         });
 
     if let Some(url) = repo_url {

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,5 +1,5 @@
-use serde_json::Value;
 use dirs;
+use serde_json::Value;
 
 use crate::git::repository::find_repository_in_path;
 
@@ -107,6 +107,8 @@ fn print_config_help() {
     eprintln!("  feature_flags                Feature flags (object)");
     eprintln!("  api_key                      API key for X-API-Key header");
     eprintln!("  prompt_storage               Prompt storage mode (default/notes/local)");
+    eprintln!("  include_prompts_in_repositories  Repos to include for prompt storage (array)");
+    eprintln!("  default_prompt_storage       Fallback storage mode for non-included repos");
     eprintln!("");
     eprintln!("Repository Patterns:");
     eprintln!("  For exclude/allow/exclude_prompts_in_repositories, you can provide:");
@@ -283,6 +285,22 @@ fn show_all_config() -> Result<(), String> {
         Value::String(runtime_config.prompt_storage().to_string()),
     );
 
+    // include_prompts_in_repositories
+    if let Some(ref repos) = file_config.include_prompts_in_repositories {
+        effective_config.insert(
+            "include_prompts_in_repositories".to_string(),
+            serde_json::to_value(repos).unwrap_or(Value::Array(vec![])),
+        );
+    }
+
+    // default_prompt_storage
+    if let Some(ref storage) = file_config.default_prompt_storage {
+        effective_config.insert(
+            "default_prompt_storage".to_string(),
+            Value::String(storage.clone()),
+        );
+    }
+
     // Feature flags - show effective flags with defaults applied
     let flags_value = serde_json::to_value(runtime_config.get_feature_flags())
         .unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
@@ -356,6 +374,20 @@ fn get_config_value(key: &str) -> Result<(), String> {
                 }
             }
             "prompt_storage" => Value::String(runtime_config.prompt_storage().to_string()),
+            "include_prompts_in_repositories" => {
+                if let Some(ref repos) = file_config.include_prompts_in_repositories {
+                    serde_json::to_value(repos).unwrap()
+                } else {
+                    Value::Array(vec![])
+                }
+            }
+            "default_prompt_storage" => {
+                if let Some(ref storage) = file_config.default_prompt_storage {
+                    Value::String(storage.clone())
+                } else {
+                    Value::Null
+                }
+            }
             _ => return Err(format!("Unknown config key: {}", key)),
         };
 
@@ -484,6 +516,32 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.prompt_storage = Some(value.to_string());
                 crate::config::save_file_config(&file_config)?;
                 eprintln!("[prompt_storage]: {}", value);
+            }
+            "include_prompts_in_repositories" => {
+                let resolved = resolve_repository_value(value)?;
+                if add_mode {
+                    let mut list = file_config
+                        .include_prompts_in_repositories
+                        .unwrap_or_default();
+                    for pattern in &resolved {
+                        if !list.contains(pattern) {
+                            list.push(pattern.clone());
+                        }
+                    }
+                    file_config.include_prompts_in_repositories = Some(list);
+                } else {
+                    file_config.include_prompts_in_repositories = Some(resolved.clone());
+                }
+                crate::config::save_file_config(&file_config)?;
+                for pattern in resolved {
+                    eprintln!("[include_prompts_in_repositories]: {}", pattern);
+                }
+            }
+            "default_prompt_storage" => {
+                validate_prompt_storage_value(value)?;
+                file_config.default_prompt_storage = Some(value.to_string());
+                crate::config::save_file_config(&file_config)?;
+                eprintln!("[default_prompt_storage]: {}", value);
             }
             _ => return Err(format!("Unknown config key: {}", key)),
         }
@@ -633,6 +691,20 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     eprintln!("- [prompt_storage]: {}", v);
+                }
+            }
+            "include_prompts_in_repositories" => {
+                let old_value = file_config.include_prompts_in_repositories.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    eprintln!("- [include_prompts_in_repositories]: {:?}", v);
+                }
+            }
+            "default_prompt_storage" => {
+                let old_value = file_config.default_prompt_storage.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    eprintln!("- [default_prompt_storage]: {}", v);
                 }
             }
             _ => return Err(format!("Unknown config key: {}", key)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
+use dirs;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
-use dirs;
 
 use glob::Pattern;
 use serde::{Deserialize, Serialize};
@@ -16,9 +16,46 @@ use std::sync::RwLock;
 /// Default API base URL for comparison
 pub const DEFAULT_API_BASE_URL: &str = "https://usegitai.com";
 
+/// Prompt storage mode enum for type-safe handling
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromptStorageMode {
+    /// Default mode: prompts uploaded via CAS API, stripped from git notes
+    Default,
+    /// Notes mode: prompts stored in git notes (after secret redaction)
+    Notes,
+    /// Local mode: prompts only stored in local SQLite, never shared
+    Local,
+}
+
+impl PromptStorageMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PromptStorageMode::Default => "default",
+            PromptStorageMode::Notes => "notes",
+            PromptStorageMode::Local => "local",
+        }
+    }
+
+    pub fn from_str(input: &str) -> Option<Self> {
+        match input.trim().to_lowercase().as_str() {
+            "default" => Some(PromptStorageMode::Default),
+            "notes" => Some(PromptStorageMode::Notes),
+            "local" => Some(PromptStorageMode::Local),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PromptStorageMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 pub struct Config {
     git_path: String,
     exclude_prompts_in_repositories: Vec<Pattern>,
+    include_prompts_in_repositories: Vec<Pattern>,
     allow_repositories: Vec<Pattern>,
     exclude_repositories: Vec<Pattern>,
     telemetry_oss_disabled: bool,
@@ -29,6 +66,7 @@ pub struct Config {
     feature_flags: FeatureFlags,
     api_base_url: String,
     prompt_storage: String,
+    default_prompt_storage: Option<String>,
     api_key: Option<String>,
 }
 
@@ -67,6 +105,8 @@ pub struct FileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_prompts_in_repositories: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_prompts_in_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_repositories: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_repositories: Option<Vec<String>>,
@@ -86,6 +126,8 @@ pub struct FileConfig {
     pub api_base_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_storage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_prompt_storage: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 }
@@ -251,6 +293,71 @@ impl Config {
         &self.prompt_storage
     }
 
+    /// Returns the default prompt storage mode for repos not in the include list.
+    /// Returns None if not configured (defaults to "local" behavior).
+    pub fn default_prompt_storage(&self) -> Option<&str> {
+        self.default_prompt_storage.as_deref()
+    }
+
+    /// Returns the effective prompt storage mode for a given repository.
+    ///
+    /// The resolution order is:
+    /// 1. If repo matches exclude_prompts_in_repositories → always "local" (exclusion wins)
+    /// 2. If include_prompts_in_repositories is empty → use prompt_storage (legacy behavior)
+    /// 3. If repo matches include_prompts_in_repositories → use prompt_storage
+    /// 4. If repo doesn't match include list → use default_prompt_storage, or "local" if not set
+    ///
+    /// This enables two use cases:
+    /// - User A: git-ai everywhere, CAS for work repos, notes for others
+    ///   (prompt_storage="default", include_prompts=["positron-ai/*"], default_prompt_storage="notes")
+    /// - User B: git-ai only in work repos (via allow_repositories), CAS there
+    ///   (prompt_storage="default", no include list needed)
+    pub fn effective_prompt_storage(&self, repository: &Option<Repository>) -> PromptStorageMode {
+        // Step 1: Check exclusion list first (deny always wins)
+        if self.should_exclude_prompts(repository) {
+            return PromptStorageMode::Local;
+        }
+
+        // Step 2: If no include list, use the global prompt_storage (legacy behavior)
+        if self.include_prompts_in_repositories.is_empty() {
+            return PromptStorageMode::from_str(&self.prompt_storage)
+                .unwrap_or(PromptStorageMode::Default);
+        }
+
+        // Step 3: Check if repo matches include list
+        let remotes = repository
+            .as_ref()
+            .and_then(|repo| repo.remotes_with_urls().ok());
+
+        let matches_include = match &remotes {
+            Some(remotes) if !remotes.is_empty() => {
+                // Has remotes - check if any match inclusion patterns
+                remotes.iter().any(|remote| {
+                    self.include_prompts_in_repositories
+                        .iter()
+                        .any(|pattern| pattern.matches(&remote.1))
+                })
+            }
+            _ => {
+                // No remotes or no repository - check for wildcard "*" in include patterns
+                self.include_prompts_in_repositories
+                    .iter()
+                    .any(|pattern| pattern.as_str() == "*")
+            }
+        };
+
+        if matches_include {
+            // Step 3a: Repo is in include list → use primary prompt_storage
+            PromptStorageMode::from_str(&self.prompt_storage).unwrap_or(PromptStorageMode::Default)
+        } else {
+            // Step 4: Repo not in include list → use fallback
+            self.default_prompt_storage
+                .as_ref()
+                .and_then(|s| PromptStorageMode::from_str(s))
+                .unwrap_or(PromptStorageMode::Local) // Safe default
+        }
+    }
+
     /// Returns the API key if configured
     pub fn api_key(&self) -> Option<&str> {
         self.api_key.as_deref()
@@ -315,6 +422,22 @@ fn build_config() -> Config {
                 .ok()
         })
         .collect();
+    let include_prompts_in_repositories = file_cfg
+        .as_ref()
+        .and_then(|c| c.include_prompts_in_repositories.clone())
+        .unwrap_or(vec![])
+        .into_iter()
+        .filter_map(|pattern_str| {
+            Pattern::new(&pattern_str)
+                .map_err(|e| {
+                    eprintln!(
+                        "Warning: Invalid glob pattern in include_prompts_in_repositories '{}': {}",
+                        pattern_str, e
+                    );
+                })
+                .ok()
+        })
+        .collect();
     let allow_repositories = file_cfg
         .as_ref()
         .and_then(|c| c.allow_repositories.clone())
@@ -359,8 +482,7 @@ fn build_config() -> Config {
 
     // Default to disabled (true) unless this is an OSS build
     // OSS builds set OSS_BUILD env var at compile time to "1", which enables auto-updates by default
-    let auto_update_flags_default_disabled =
-        option_env!("OSS_BUILD").is_none() || option_env!("OSS_BUILD").unwrap() != "1";
+    let auto_update_flags_default_disabled = option_env!("OSS_BUILD") != Some("1");
 
     let disable_version_checks = file_cfg
         .as_ref()
@@ -405,6 +527,23 @@ fn build_config() -> Config {
         }
     };
 
+    // Get default_prompt_storage setting (fallback for repos not in include list)
+    // Valid values: "default", "notes", "local", or None (defaults to "local")
+    let default_prompt_storage = file_cfg
+        .as_ref()
+        .and_then(|c| c.default_prompt_storage.clone())
+        .and_then(|s| {
+            if matches!(s.as_str(), "default" | "notes" | "local") {
+                Some(s)
+            } else {
+                eprintln!(
+                    "Warning: Invalid default_prompt_storage value '{}', ignoring",
+                    s
+                );
+                None
+            }
+        });
+
     // Get API key from env var or config file (env var takes precedence)
     let api_key = env::var("GIT_AI_API_KEY")
         .ok()
@@ -421,6 +560,7 @@ fn build_config() -> Config {
         let mut config = Config {
             git_path,
             exclude_prompts_in_repositories,
+            include_prompts_in_repositories,
             allow_repositories,
             exclude_repositories,
             telemetry_oss_disabled,
@@ -431,6 +571,7 @@ fn build_config() -> Config {
             feature_flags,
             api_base_url,
             prompt_storage,
+            default_prompt_storage,
             api_key,
         };
         apply_test_config_patch(&mut config);
@@ -441,6 +582,7 @@ fn build_config() -> Config {
     Config {
         git_path,
         exclude_prompts_in_repositories,
+        include_prompts_in_repositories,
         allow_repositories,
         exclude_repositories,
         telemetry_oss_disabled,
@@ -451,6 +593,7 @@ fn build_config() -> Config {
         feature_flags,
         api_base_url,
         prompt_storage,
+        default_prompt_storage,
         api_key,
     }
 }
@@ -651,6 +794,7 @@ mod tests {
         Config {
             git_path: "/usr/bin/git".to_string(),
             exclude_prompts_in_repositories: vec![],
+            include_prompts_in_repositories: vec![],
             allow_repositories: allow_repositories
                 .into_iter()
                 .filter_map(|s| Pattern::new(&s).ok())
@@ -667,6 +811,7 @@ mod tests {
             feature_flags: FeatureFlags::default(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             prompt_storage: "default".to_string(),
+            default_prompt_storage: None,
             api_key: None,
         }
     }
@@ -761,6 +906,7 @@ mod tests {
                 .into_iter()
                 .filter_map(|s| Pattern::new(&s).ok())
                 .collect(),
+            include_prompts_in_repositories: vec![],
             allow_repositories: vec![],
             exclude_repositories: vec![],
             telemetry_oss_disabled: false,
@@ -771,6 +917,7 @@ mod tests {
             feature_flags: FeatureFlags::default(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             prompt_storage: "default".to_string(),
+            default_prompt_storage: None,
             api_key: None,
         }
     }
@@ -799,9 +946,15 @@ mod tests {
 
         // Test that pattern is compiled correctly
         assert!(!config.exclude_prompts_in_repositories.is_empty());
-        assert!(config.exclude_prompts_in_repositories[0].matches("https://github.com/myorg/repo1"));
-        assert!(config.exclude_prompts_in_repositories[0].matches("https://github.com/myorg/repo2"));
-        assert!(!config.exclude_prompts_in_repositories[0].matches("https://github.com/other/repo"));
+        assert!(
+            config.exclude_prompts_in_repositories[0].matches("https://github.com/myorg/repo1")
+        );
+        assert!(
+            config.exclude_prompts_in_repositories[0].matches("https://github.com/myorg/repo2")
+        );
+        assert!(
+            !config.exclude_prompts_in_repositories[0].matches("https://github.com/other/repo")
+        );
     }
 
     #[test]
@@ -837,12 +990,196 @@ mod tests {
 
     #[test]
     fn test_should_exclude_prompts_respects_patterns_when_remotes_exist() {
-        let config =
-            create_test_config_with_exclude_prompts(vec!["https://github.com/private/*".to_string()]);
+        let config = create_test_config_with_exclude_prompts(vec![
+            "https://github.com/private/*".to_string(),
+        ]);
 
         // Pattern should match private repos (to exclude)
-        assert!(config.exclude_prompts_in_repositories[0].matches("https://github.com/private/repo"));
+        assert!(
+            config.exclude_prompts_in_repositories[0].matches("https://github.com/private/repo")
+        );
         // Pattern should not match other repos
-        assert!(!config.exclude_prompts_in_repositories[0].matches("https://github.com/public/repo"));
+        assert!(
+            !config.exclude_prompts_in_repositories[0].matches("https://github.com/public/repo")
+        );
+    }
+
+    // Tests for effective_prompt_storage() with include_prompts_in_repositories
+
+    fn create_test_config_with_include_prompts(
+        include_patterns: Vec<String>,
+        exclude_patterns: Vec<String>,
+        prompt_storage: &str,
+        default_prompt_storage: Option<&str>,
+    ) -> Config {
+        Config {
+            git_path: "/usr/bin/git".to_string(),
+            exclude_prompts_in_repositories: exclude_patterns
+                .into_iter()
+                .filter_map(|s| Pattern::new(&s).ok())
+                .collect(),
+            include_prompts_in_repositories: include_patterns
+                .into_iter()
+                .filter_map(|s| Pattern::new(&s).ok())
+                .collect(),
+            allow_repositories: vec![],
+            exclude_repositories: vec![],
+            telemetry_oss_disabled: false,
+            telemetry_enterprise_dsn: None,
+            disable_version_checks: false,
+            disable_auto_updates: false,
+            update_channel: UpdateChannel::Latest,
+            feature_flags: FeatureFlags::default(),
+            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+            prompt_storage: prompt_storage.to_string(),
+            default_prompt_storage: default_prompt_storage.map(|s| s.to_string()),
+            api_key: None,
+        }
+    }
+
+    #[test]
+    fn test_effective_prompt_storage_no_include_list_uses_global() {
+        // No include list = legacy behavior, use global prompt_storage
+        let config = create_test_config_with_include_prompts(vec![], vec![], "notes", None);
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Notes
+        );
+
+        let config = create_test_config_with_include_prompts(vec![], vec![], "local", None);
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Local
+        );
+
+        let config = create_test_config_with_include_prompts(vec![], vec![], "default", None);
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Default
+        );
+    }
+
+    #[test]
+    fn test_effective_prompt_storage_exclude_always_wins() {
+        // Exclusion with wildcard should always return Local, regardless of include list
+        let config = create_test_config_with_include_prompts(
+            vec!["https://github.com/work/*".to_string()],
+            vec!["*".to_string()], // Exclude everything
+            "default",
+            Some("notes"),
+        );
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Local
+        );
+    }
+
+    #[test]
+    fn test_effective_prompt_storage_wildcard_include_matches_no_repo() {
+        // Wildcard include should match repos without remotes (None case)
+        let config = create_test_config_with_include_prompts(
+            vec!["*".to_string()],
+            vec![],
+            "default",
+            Some("notes"),
+        );
+        // With wildcard include and None repo, should use prompt_storage (not fallback)
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Default
+        );
+    }
+
+    #[test]
+    fn test_effective_prompt_storage_non_wildcard_include_no_match_uses_fallback() {
+        // Non-wildcard include with None repo = no match, use fallback
+        let config = create_test_config_with_include_prompts(
+            vec!["https://github.com/work/*".to_string()],
+            vec![],
+            "default",
+            Some("notes"),
+        );
+        // None repo can't match non-wildcard pattern, should use default_prompt_storage
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Notes
+        );
+    }
+
+    #[test]
+    fn test_effective_prompt_storage_no_fallback_defaults_to_local() {
+        // Non-wildcard include with None repo and no fallback = Local
+        let config = create_test_config_with_include_prompts(
+            vec!["https://github.com/work/*".to_string()],
+            vec![],
+            "default",
+            None, // No fallback configured
+        );
+        // None repo can't match, and no fallback, should default to Local
+        assert_eq!(
+            config.effective_prompt_storage(&None),
+            PromptStorageMode::Local
+        );
+    }
+
+    #[test]
+    fn test_effective_prompt_storage_include_pattern_matching() {
+        let config = create_test_config_with_include_prompts(
+            vec!["https://github.com/positron-ai/*".to_string()],
+            vec![],
+            "default",
+            Some("notes"),
+        );
+
+        // Test that patterns are compiled correctly
+        assert!(!config.include_prompts_in_repositories.is_empty());
+        assert!(
+            config.include_prompts_in_repositories[0]
+                .matches("https://github.com/positron-ai/repo1")
+        );
+        assert!(
+            config.include_prompts_in_repositories[0]
+                .matches("https://github.com/positron-ai/project")
+        );
+        assert!(
+            !config.include_prompts_in_repositories[0].matches("https://github.com/other-org/repo")
+        );
+    }
+
+    #[test]
+    fn test_prompt_storage_mode_from_str() {
+        assert_eq!(
+            PromptStorageMode::from_str("default"),
+            Some(PromptStorageMode::Default)
+        );
+        assert_eq!(
+            PromptStorageMode::from_str("DEFAULT"),
+            Some(PromptStorageMode::Default)
+        );
+        assert_eq!(
+            PromptStorageMode::from_str("notes"),
+            Some(PromptStorageMode::Notes)
+        );
+        assert_eq!(
+            PromptStorageMode::from_str("NOTES"),
+            Some(PromptStorageMode::Notes)
+        );
+        assert_eq!(
+            PromptStorageMode::from_str("local"),
+            Some(PromptStorageMode::Local)
+        );
+        assert_eq!(
+            PromptStorageMode::from_str("LOCAL"),
+            Some(PromptStorageMode::Local)
+        );
+        assert_eq!(PromptStorageMode::from_str("invalid"), None);
+        assert_eq!(PromptStorageMode::from_str(""), None);
+    }
+
+    #[test]
+    fn test_prompt_storage_mode_as_str() {
+        assert_eq!(PromptStorageMode::Default.as_str(), "default");
+        assert_eq!(PromptStorageMode::Notes.as_str(), "notes");
+        assert_eq!(PromptStorageMode::Local.as_str(), "local");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `include_prompts_in_repositories` config option to whitelist repositories for enterprise prompt storage (CAS)
- Adds `default_prompt_storage` config option to specify fallback storage mode for non-whitelisted repos
- Adds `PromptStorageMode` enum for type-safe handling of storage modes
- Updates `effective_prompt_storage()` resolver to handle the new whitelist logic with proper precedence

## Motivation

This enables two common use cases:

**User A** (wants git-ai everywhere, CAS for work repos, notes for OSS):
```json
{
  "prompt_storage": "default",
  "include_prompts_in_repositories": ["https://github.com/myorg/*"],
  "default_prompt_storage": "notes"
}
```

**User B** (wants git-ai only for work repos with CAS):
```json
{
  "prompt_storage": "default",
  "allow_repositories": ["https://github.com/myorg/*"],
  "include_prompts_in_repositories": ["*"]
}
```

## Changes

- `src/config.rs`: Added `PromptStorageMode` enum, new config fields, `effective_prompt_storage()` resolver, and tests
- `src/authorship/post_commit.rs`: Updated to use new `effective_prompt_storage()` resolver
- `src/commands/config.rs`: Added CLI support for get/set/unset of new config options

## Test plan

- [x] Added unit tests for `PromptStorageMode::from_str()` and `as_str()`
- [x] Added unit tests for `effective_prompt_storage()` covering:
  - No include list uses global prompt_storage (legacy behavior)
  - Exclude list always wins (returns Local)
  - Wildcard include matches repos without remotes
  - Non-wildcard include with no match uses fallback
  - No fallback configured defaults to Local
  - Pattern matching works correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)