### PR TITLE
fix: filter out non-existent commits in grep_ai_notes for shallow clones

### DIFF
--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -325,12 +325,51 @@ pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
     // If we have multiple results, sort by commit date (newest first)
     if shas.len() > 1 {
         let sha_vec: Vec<String> = shas.into_iter().collect();
+        
+        eprintln!("[DEBUG] Found {} commits with pattern '{}' in git notes", sha_vec.len(), pattern);
+        for sha in &sha_vec {
+            eprintln!("[DEBUG]   - {}", sha);
+        }
+        
+        // FILTER OUT NON-EXISTENT COMMITS using git cat-file -e
+        let existing_shas: Vec<String> = sha_vec
+            .into_iter()
+            .filter(|sha| {
+                let mut args = repo.global_args_for_exec();
+                args.push("cat-file".to_string());
+                args.push("-e".to_string());
+                args.push(sha.clone());
+                
+                let exists = exec_git(&args).is_ok();
+                if !exists {
+                    eprintln!("[DEBUG] Filtering out non-existent commit: {}", sha);
+                }
+                exists
+            })
+            .collect();
+        
+        eprintln!("[DEBUG] After filtering: {} existing commits", existing_shas.len());
+        for sha in &existing_shas {
+            eprintln!("[DEBUG]   - {}", sha);
+        }
+        
+        if existing_shas.is_empty() {
+            return Err(GitAiError::Generic(
+                "No existing commits found in git notes for pattern".to_string()
+            ));
+        }
+        
+        if existing_shas.len() == 1 {
+            return Ok(existing_shas);
+        }
+        
+        // Sort only existing commits by date
         let mut args = repo.global_args_for_exec();
         args.push("log".to_string());
         args.push("--format=%H".to_string());
         args.push("--date-order".to_string());
         args.push("--no-walk".to_string());
-        for sha in &sha_vec {
+        for sha in &existing_shas {
             args.push(sha.clone());
         }
 
@@ -340,6 +379,25 @@ pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
 
         Ok(stdout.lines().map(|s| s.to_string()).collect())
     } else {
-        Ok(shas.into_iter().collect())
+        // Single or no result - verify it exists
+        let sha_vec: Vec<String> = shas.into_iter().collect();
+        if !sha_vec.is_empty() {
+            let sha = &sha_vec[0];
+            let mut args = repo.global_args_for_exec();
+            args.push("cat-file".to_string());
+            args.push("-e".to_string());
+            args.push(sha.clone());
+            
+            if exec_git(&args).is_ok() {
+                Ok(sha_vec)
+            } else {
+                eprintln!("[DEBUG] Single commit {} does not exist", sha);
+                Err(GitAiError::Generic(
+                    "Commit referenced in git notes does not exist".to_string()
+                ))
+            }
+        } else {
+            Ok(sha_vec)
+        }
     }
 }


### PR DESCRIPTION
Fixes orphaned git notes issue where git-ai stats would fail or return 0 AI lines when some commits referenced in git notes don't exist locally.

This happens in:
- Shallow clones (--depth=N)
- Partial clones missing commits from other branches
- Repos after force-push/rebase where old commits are gone

The fix:
1. Use git cat-file -e to verify each commit exists before sorting
2. Filter out non-existent commits from the list
3. Only pass existing commits to git log --no-walk
4. Handle edge cases (no commits exist, only one exists)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
