### PR TITLE
Skip VS Code extension installation in GitHub Codespaces

### DIFF
--- a/src/mdm/agents/vscode.rs
+++ b/src/mdm/agents/vscode.rs
@@ -116,7 +116,7 @@ impl HookInstaller for VSCodeInstaller {
             results.push(InstallResult {
                 changed: false,
                 diff: None,
-                message: "VS Code: Skipped in GitHub Codespaces. Add the extension to your devcontainer.json: \"customizations\": { \"vscode\": { \"extensions\": [\"git-ai.git-ai-vscode\"] } }".to_string(),
+                message: "VS Code: Unable to install extension in GitHub Codespaces. Add to your devcontainer.json: \"customizations\": { \"vscode\": { \"extensions\": [\"git-ai.git-ai-vscode\"] } }".to_string(),
             });
             return Ok(results);
         }

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -524,28 +524,32 @@ mod tests {
         // Save original value
         let original = std::env::var("CODESPACES").ok();
 
-        // Test when CODESPACES is not set
-        std::env::remove_var("CODESPACES");
-        assert!(!is_github_codespaces());
+        // SAFETY: This test modifies environment variables which is inherently
+        // unsafe in multi-threaded contexts. This test should run in isolation.
+        unsafe {
+            // Test when CODESPACES is not set
+            std::env::remove_var("CODESPACES");
+            assert!(!is_github_codespaces());
 
-        // Test when CODESPACES is set to "true"
-        std::env::set_var("CODESPACES", "true");
-        assert!(is_github_codespaces());
+            // Test when CODESPACES is set to "true"
+            std::env::set_var("CODESPACES", "true");
+            assert!(is_github_codespaces());
 
-        // Test when CODESPACES is set to other values
-        std::env::set_var("CODESPACES", "false");
-        assert!(!is_github_codespaces());
+            // Test when CODESPACES is set to other values
+            std::env::set_var("CODESPACES", "false");
+            assert!(!is_github_codespaces());
 
-        std::env::set_var("CODESPACES", "1");
-        assert!(!is_github_codespaces());
+            std::env::set_var("CODESPACES", "1");
+            assert!(!is_github_codespaces());
 
-        std::env::set_var("CODESPACES", "");
-        assert!(!is_github_codespaces());
+            std::env::set_var("CODESPACES", "");
+            assert!(!is_github_codespaces());
 
-        // Restore original value
-        match original {
-            Some(val) => std::env::set_var("CODESPACES", val),
-            None => std::env::remove_var("CODESPACES"),
+            // Restore original value
+            match original {
+                Some(val) => std::env::set_var("CODESPACES", val),
+                None => std::env::remove_var("CODESPACES"),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `is_github_codespaces()` helper to detect Codespaces environment via `CODESPACES=true` env var
- Skip VS Code extension CLI installation in Codespaces with a helpful message
- Provide devcontainer.json configuration guidance for users

## Test plan

- [x] Added unit test for `is_github_codespaces()` function
- [x] CI validates compilation and tests pass
- [x] Functional test: `CODESPACES=true git-ai install-hooks --dry-run` shows skip message
- [x] Functional test: Normal environment continues with extension installation

### Unit test output
```
test mdm::utils::tests::test_is_github_codespaces ... ok
```

### Functional test output

**Without CODESPACES (normal behavior):**
```
✓ VS Code: Hooks already up to date
✓ VS Code: Extension already installed
```

**With CODESPACES=true:**
```
✓ VS Code: Hooks already up to date
⚠ VS Code: Unable to install extension in GitHub Codespaces. Add to your devcontainer.json: "customizations": { "vscode": { "extensions": ["git-ai.git-ai-vscode"] } }
```

Fixes #231

🤖 Generated with [Claude Code](https://claude.ai/code)