### PR TITLE
chore: replace mentions of the old repo path with the new organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div>
-<img src="https://github.com/acunniffe/git-ai/raw/main/assets/docs/git-ai.png" align="right"
-     alt="Git AI by acunniffe/git-ai" width="100" height="100" />
+<img src="https://github.com/git-ai-project/git-ai/raw/main/assets/docs/git-ai.png" align="right"
+     alt="Git AI by git-ai-project/git-ai" width="100" height="100" />
 
 </div>
 <div>
@@ -26,7 +26,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "irm http://usegitai.com/
 
 🎊 That's it! **No per-repo setup.** Once installed Git AI will work OOTB with any of these **Supported Agents**:
 
-<img src="https://github.com/acunniffe/git-ai/raw/main/assets/docs/supported-agents.png" width="320" />
+<img src="https://github.com/git-ai-project/git-ai/raw/main/assets/docs/supported-agents.png" width="320" />
 
 ### Documentation https://usegitai.com/docs
 - [AI Blame](https://usegitai.com/docs/cli/ai-blame)
@@ -38,7 +38,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "irm http://usegitai.com/
 
 Build as usual. Just prompt, edit and commit. Git AI will track every line of AI-Code and record the Coding Agent, Model, and prompt that generated it. 
 
-<img src="https://github.com/acunniffe/git-ai/raw/main/assets/docs/graph.jpg" width="400" />
+<img src="https://github.com/git-ai-project/git-ai/raw/main/assets/docs/graph.jpg" width="400" />
 
 #### How Does it work? 
 
@@ -99,5 +99,5 @@ Aggregate `git-ai` data at the PR, developer, Repository and Organization levels
 - AI-Code Halflife (how durable is the AI code)
 > [Get early access by chatting with the maintainers](https://calendly.com/acunniffe/meeting-with-git-ai-authors)
 
-![alt](https://github.com/acunniffe/git-ai/raw/main/assets/docs/dashboard.png)
+![alt](https://github.com/git-ai-project/git-ai/raw/main/assets/docs/dashboard.png)
 

--- a/agent-support/opencode/README.md
+++ b/agent-support/opencode/README.md
@@ -1,6 +1,6 @@
 # git-ai Plugin for OpenCode
 
-A plugin that integrates [git-ai](https://github.com/acunniffe/git-ai) with [OpenCode](https://opencode.ai) to automatically track AI-generated code.
+A plugin that integrates [git-ai](https://github.com/git-ai-project/git-ai) with [OpenCode](https://opencode.ai) to automatically track AI-generated code.
 
 ## Overview
 
@@ -17,7 +17,7 @@ Build `git-ai` (`cargo build`) and then run the `git-ai install-hooks` or `cargo
 
 ## Requirements
 
-- [git-ai](https://github.com/acunniffe/git-ai) must be installed and available in PATH
+- [git-ai](https://github.com/git-ai-project/git-ai) must be installed and available in PATH
 - [OpenCode](https://opencode.ai) with plugin support
 
 ## How It Works
@@ -50,6 +50,6 @@ yarn install
 
 ## See Also
 
-- [git-ai Documentation](https://github.com/acunniffe/git-ai)
+- [git-ai Documentation](https://github.com/git-ai-project/git-ai)
 - [OpenCode Plugin Documentation](https://opencode.ai/docs/plugins/)
 

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -13,7 +13,7 @@
  * Requirements:
  *   - git-ai must be installed and available in PATH
  *
- * @see https://github.com/acunniffe/git-ai
+ * @see https://github.com/git-ai-project/git-ai
  * @see https://opencode.ai/docs/plugins/
  */
 

--- a/agent-support/vscode/README.md
+++ b/agent-support/vscode/README.md
@@ -1,21 +1,21 @@
 # git-ai Extension for VS Code & Cursor
 
-A VS Code and Cursor extension that tracks AI-generated code using [git-ai](https://github.com/acunniffe/git-ai?tab=readme-ov-file#quick-start).
+A VS Code and Cursor extension that tracks AI-generated code using [git-ai](https://github.com/git-ai-project/git-ai?tab=readme-ov-file#quick-start).
 
 ## Manual Install
 
-The [git-ai quickstart](https://github.com/acunniffe/git-ai?tab=readme-ov-file#quick-start) install script should automatically install both the Cursor and VS Code extensions automatically, however, if that didn't work or you'd like to install the extension manually, please follow the instructions below:
+The [git-ai quickstart](https://github.com/git-ai-project/git-ai?tab=readme-ov-file#quick-start) install script should automatically install both the Cursor and VS Code extensions automatically, however, if that didn't work or you'd like to install the extension manually, please follow the instructions below:
 
 ### Cursor
 
 1. **Install the extension** We recommend installing the Cursor extension by searching for `git-ai` in the extensions tab. To open the extensions tab, you can press `Cmd+Shift+P` and search for `>Extensions: Install Extensions`.
-2. **Install [`git-ai`](https://github.com/acunniffe/git-ai)** Follow the `git-ai` installation [instructions](https://github.com/acunniffe/git-ai?tab=readme-ov-file#quick-start) for your platform.
+2. **Install [`git-ai`](https://github.com/git-ai-project/git-ai)** Follow the `git-ai` installation [instructions](https://github.com/git-ai-project/git-ai?tab=readme-ov-file#quick-start) for your platform.
 3. **Restart VS Code**
 
 ### VS Code
 
 1. **Install the extension** We recommend installing from the [VS Code Extension marketplace](https://marketplace.visualstudio.com/items?itemName=git-ai.git-ai-vscode)
-2. **Install [`git-ai`](https://github.com/acunniffe/git-ai)** Follow the `git-ai` installation [instructions](https://github.com/acunniffe/git-ai?tab=readme-ov-file#quick-start) for your platform.
+2. **Install [`git-ai`](https://github.com/git-ai-project/git-ai)** Follow the `git-ai` installation [instructions](https://github.com/git-ai-project/git-ai?tab=readme-ov-file#quick-start) for your platform.
 3. **Restart VS Code**
 
 ### Debug logging

--- a/agent-support/vscode/package.json
+++ b/agent-support/vscode/package.json
@@ -7,7 +7,7 @@
   "publisher": "git-ai",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acunniffe/git-ai"
+    "url": "https://github.com/git-ai-project/git-ai"
   },
   "engines": {
     "vscode": ">=1.99.3",

--- a/agent-support/vscode/src/ai-edit-manager.ts
+++ b/agent-support/vscode/src/ai-edit-manager.ts
@@ -414,7 +414,7 @@ export class AIEditManager {
           if (!this.hasShownGitAiErrorMessage) {
             // Show startup notification
             vscode.window.showInformationMessage(
-              "git-ai not installed. Visit https://github.com/acunniffe/git-ai to install it."
+              "git-ai not installed. Visit https://github.com/git-ai-project/git-ai to install it."
             );
             this.hasShownGitAiErrorMessage = true;
           }

--- a/agent-support/vscode/src/blame-service.ts
+++ b/agent-support/vscode/src/blame-service.ts
@@ -394,7 +394,7 @@ export class BlameService {
     ).then((choice) => {
       if (choice === 'Learn More') {
         vscode.env.openExternal(
-          vscode.Uri.parse('https://github.com/acunniffe/git-ai')
+          vscode.Uri.parse('https://github.com/git-ai-project/git-ai')
         );
       }
     });

--- a/agent-support/vscode/src/consts.ts
+++ b/agent-support/vscode/src/consts.ts
@@ -3,7 +3,7 @@ import { IDEHostKind } from "./utils/host-kind";
 export const MIN_GIT_AI_VERSION = "1.0.23";
 
 // Use GitHub URL to avoid VS Code open URL safety prompt
-export const GIT_AI_INSTALL_DOCS_URL = "https://github.com/acunniffe/git-ai?tab=readme-ov-file#quick-start";
+export const GIT_AI_INSTALL_DOCS_URL = "https://github.com/git-ai-project/git-ai?tab=readme-ov-file#quick-start";
 
 // IDE-specific AI tab completion commands
 export const TAB_AI_COMPLETION_COMMANDS: Partial<Record<IDEHostKind, string>> = {

--- a/install.ps1
+++ b/install.ps1
@@ -85,11 +85,11 @@ function Verify-Checksum {
 }
 
 # GitHub repository details
-# Replaced during release builds with the actual repository (e.g., "acunniffe/git-ai")
-# When set to __REPO_PLACEHOLDER__, defaults to "acunniffe/git-ai"
+# Replaced during release builds with the actual repository (e.g., "git-ai-project/git-ai")
+# When set to __REPO_PLACEHOLDER__, defaults to "git-ai-project/git-ai"
 $Repo = '__REPO_PLACEHOLDER__'
 if ($Repo -eq '__REPO_PLACEHOLDER__') {
-    $Repo = 'acunniffe/git-ai'
+    $Repo = 'git-ai-project/git-ai'
 }
 
 # Version placeholder - replaced during release builds with actual version (e.g., "v1.0.24")
@@ -147,14 +147,14 @@ function Get-StdGitPath {
 
     # If still not found, fail with a clear message
     if (-not $gitPath) {
-        Write-ErrorAndExit "Could not detect a standard git binary on PATH. Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/acunniffe/git-ai/issues."
+        Write-ErrorAndExit "Could not detect a standard git binary on PATH. Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/git-ai-project/git-ai/issues."
     }
 
     try {
         & $gitPath --version | Out-Null
         if ($LASTEXITCODE -ne 0) { throw 'bad' }
     } catch {
-        Write-ErrorAndExit "Detected git at $gitPath is not usable (--version failed). Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/acunniffe/git-ai/issues."
+        Write-ErrorAndExit "Detected git at $gitPath is not usable (--version failed). Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/git-ai-project/git-ai/issues."
     }
 
     return $gitPath

--- a/install.sh
+++ b/install.sh
@@ -10,11 +10,11 @@ YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 # GitHub repository details
-# Replaced during release builds with the actual repository (e.g., "acunniffe/git-ai")
-# When set to __REPO_PLACEHOLDER__, defaults to "acunniffe/git-ai"
+# Replaced during release builds with the actual repository (e.g., "git-ai-project/git-ai")
+# When set to __REPO_PLACEHOLDER__, defaults to "git-ai-project/git-ai"
 REPO="__REPO_PLACEHOLDER__"
 if [ "$REPO" = "__REPO_PLACEHOLDER__" ]; then
-    REPO="acunniffe/git-ai"
+    REPO="git-ai-project/git-ai"
 fi
 
 # Version placeholder - replaced during release builds with actual version (e.g., "v1.0.24")
@@ -168,12 +168,12 @@ detect_std_git() {
 
     # Fail if we couldn't find a standard git
     if [ -z "$git_path" ]; then
-        error "Could not detect a standard git binary on PATH. Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/acunniffe/git-ai/issues."
+        error "Could not detect a standard git binary on PATH. Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/git-ai-project/git-ai/issues."
     fi
 
     # Verify detected git is usable
     if ! "$git_path" --version >/dev/null 2>&1; then
-        error "Detected git at $git_path is not usable (--version failed). Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/acunniffe/git-ai/issues."
+        error "Detected git at $git_path is not usable (--version failed). Please ensure you have Git installed and available on your PATH. If you believe this is a bug with the installer, please file an issue at https://github.com/git-ai-project/git-ai/issues."
     fi
 
     echo "$git_path"

--- a/specs/git_ai_standard_v3.0.0.md
+++ b/specs/git_ai_standard_v3.0.0.md
@@ -6,7 +6,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ---
 
-The [Git AI project](https://github.com/acunniffe/git-ai) is a full, production-ready implementation of this standard built as a Git extension. Another project would be considered compliant with this standard if it also attached AI Authorship Logs with Git Notes, even if it was implemented in another way. 
+The [Git AI project](https://github.com/git-ai-project/git-ai) is a full, production-ready implementation of this standard built as a Git extension. Another project would be considered compliant with this standard if it also attached AI Authorship Logs with Git Notes, even if it was implemented in another way. 
 
 If you are trying to add support for your Coding Agent to Git AI format, that is best done by [integrating with published implementation](https://usegitai.com/docs/cli/add-your-agent), not implementing this spec. 
 

--- a/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display-2.snap
+++ b/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display-2.snap
@@ -2,4 +2,4 @@
 source: src/authorship/stats.rs
 expression: ai_only_output
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ░░░░░░░░░░░░░░░░░░░░  0%\n🤖 ai     ░███████████████████  95%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.1 lines generated for every 1 accepted\n- 45 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ░░░░░░░░░░░░░░░░░░░░  0%\n🤖 ai     ░███████████████████  95%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.1 lines generated for every 1 accepted\n- 45 seconds waiting for AI \n\n</details>"

--- a/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display-3.snap
+++ b/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display-3.snap
@@ -2,4 +2,4 @@
 source: src/authorship/stats.rs
 expression: human_only_output
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ████████████████████  100%\n🤖 ai     ░░░░░░░░░░░░░░░░░░░░  0%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 0.0 lines generated for every 1 accepted\n- 0 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ████████████████████  100%\n🤖 ai     ░░░░░░░░░░░░░░░░░░░░  0%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 0.0 lines generated for every 1 accepted\n- 0 seconds waiting for AI \n\n</details>"

--- a/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display-4.snap
+++ b/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display-4.snap
@@ -2,4 +2,4 @@
 source: src/authorship/stats.rs
 expression: minimal_human_output
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    █░░░░░░░░░░░░░░░░░░░  2%\n🤖 ai     ░███████████████████  93%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.1 lines generated for every 1 accepted\n- 30 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    █░░░░░░░░░░░░░░░░░░░  2%\n🤖 ai     ░███████████████████  93%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.1 lines generated for every 1 accepted\n- 30 seconds waiting for AI \n\n</details>"

--- a/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display.snap
+++ b/src/authorship/snapshots/git_ai__authorship__stats__tests__markdown_stats_display.snap
@@ -2,4 +2,4 @@
 source: src/authorship/stats.rs
 expression: mixed_output
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    █████████████░░░░░░░  63%\n🤝 mixed  ░░░░░░░░░░░░░██████████  50%\n🤖 ai     ░░░░░░░░░░░░░░██████  31%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 4.0 lines generated for every 1 accepted\n- 1200 minutes waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    █████████████░░░░░░░  63%\n🤝 mixed  ░░░░░░░░░░░░░██████████  50%\n🤖 ai     ░░░░░░░░░░░░░░██████  31%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 4.0 lines generated for every 1 accepted\n- 1200 minutes waiting for AI \n\n</details>"

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -392,7 +392,7 @@ pub fn write_stats_to_markdown(stats: &CommitStats) -> String {
         0
     };
 
-    output.push_str("Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n");
+    output.push_str("Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n");
     // Build the fenced code block
     output.push_str("```text\n");
 

--- a/src/commands/checkpoint_agent/agent_v1_preset.rs
+++ b/src/commands/checkpoint_agent/agent_v1_preset.rs
@@ -42,7 +42,7 @@ impl AgentCheckpointPreset for AgentV1Preset {
 
         let agent_v1_input: AgentV1Input = serde_json::from_str(&hook_input_json).map_err(|e| {
             crate::error::GitAiError::PresetError(format!(
-                "Invalid AgentV1Input JSON. Format is documented here: https://github.com/acunniffe/git-ai/blob/main/docs/add-your-agent.mdx: \n\n Error: {}",
+                "Invalid AgentV1Input JSON. Format is documented here: https://usegitai.com/docs/cli/add-your-agent: \n\n Error: {}",
                 e
             ))
         })?;

--- a/tests/e2e/user-scenarios.bats
+++ b/tests/e2e/user-scenarios.bats
@@ -956,7 +956,7 @@ EOF
 }
 
 @test "AI refactors its own code - squash-authorship should show no ai_deletions" {
-    skip "https://github.com/acunniffe/git-ai/issues/162"
+    skip "https://github.com/git-ai-project/git-ai/issues/162"
     touch fibonacci.ts
     git add fibonacci.ts
     git commit -m "Initial empty file"
@@ -1055,7 +1055,7 @@ EOF
 }
 
 @test "Two AI commits, reset last commit, then recommit" {
-    skip "https://github.com/acunniffe/git-ai/issues/169"
+    skip "https://github.com/git-ai-project/git-ai/issues/169"
     # COMMIT 1: AI creates first file
     cat > module1.py <<EOF
 def function_one():

--- a/tests/snapshots/stats__markdown_stats_all_ai.snap
+++ b/tests/snapshots/stats__markdown_stats_all_ai.snap
@@ -2,4 +2,4 @@
 source: tests/stats.rs
 expression: markdown
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ░░░░░░░░░░░░░░░░░░░░  0%\n🤖 ai     ████████████████████  100%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.0 lines generated for every 1 accepted\n- 30 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ░░░░░░░░░░░░░░░░░░░░  0%\n🤖 ai     ████████████████████  100%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.0 lines generated for every 1 accepted\n- 30 seconds waiting for AI \n\n</details>"

--- a/tests/snapshots/stats__markdown_stats_all_human.snap
+++ b/tests/snapshots/stats__markdown_stats_all_human.snap
@@ -2,4 +2,4 @@
 source: tests/stats.rs
 expression: markdown
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ████████████████████  100%\n🤖 ai     ░░░░░░░░░░░░░░░░░░░░  0%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 0.0 lines generated for every 1 accepted\n- 0 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ████████████████████  100%\n🤖 ai     ░░░░░░░░░░░░░░░░░░░░  0%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 0.0 lines generated for every 1 accepted\n- 0 seconds waiting for AI \n\n</details>"

--- a/tests/snapshots/stats__markdown_stats_formatting.snap
+++ b/tests/snapshots/stats__markdown_stats_formatting.snap
@@ -2,4 +2,4 @@
 source: tests/stats.rs
 expression: markdown
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ████████░░░░░░░░░░░░  38%\n🤝 mixed  ░░░░░░░░███░░░░░░░░░  15%\n🤖 ai     ░░░░░░░░░░░█████████  46%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.7 lines generated for every 1 accepted\n- 25 seconds waiting for AI \n- Top model: cursor::claude-3.5-sonnet (6 accepted lines, 10 generated lines)\n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ████████░░░░░░░░░░░░  38%\n🤝 mixed  ░░░░░░░░███░░░░░░░░░  15%\n🤖 ai     ░░░░░░░░░░░█████████  46%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.7 lines generated for every 1 accepted\n- 25 seconds waiting for AI \n- Top model: cursor::claude-3.5-sonnet (6 accepted lines, 10 generated lines)\n\n</details>"

--- a/tests/snapshots/stats__markdown_stats_minimal_human.snap
+++ b/tests/snapshots/stats__markdown_stats_minimal_human.snap
@@ -2,4 +2,4 @@
 source: tests/stats.rs
 expression: markdown
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    █░░░░░░░░░░░░░░░░░░░  2%\n🤖 ai     ████████████████████  98%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.0 lines generated for every 1 accepted\n- 10 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    █░░░░░░░░░░░░░░░░░░░  2%\n🤖 ai     ████████████████████  98%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.0 lines generated for every 1 accepted\n- 10 seconds waiting for AI \n\n</details>"

--- a/tests/snapshots/stats__markdown_stats_mixed.snap
+++ b/tests/snapshots/stats__markdown_stats_mixed.snap
@@ -2,4 +2,4 @@
 source: tests/stats.rs
 expression: markdown
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ███████░░░░░░░░░░░░░  33%\n🤝 mixed  ░░░░░░░███░░░░░░░░░░  17%\n🤖 ai     ░░░░░░░░░░██████████  50%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.7 lines generated for every 1 accepted\n- 45 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ███████░░░░░░░░░░░░░  33%\n🤝 mixed  ░░░░░░░███░░░░░░░░░░  17%\n🤖 ai     ░░░░░░░░░░██████████  50%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.7 lines generated for every 1 accepted\n- 45 seconds waiting for AI \n\n</details>"

--- a/tests/snapshots/stats__markdown_stats_no_mixed.snap
+++ b/tests/snapshots/stats__markdown_stats_no_mixed.snap
@@ -2,4 +2,4 @@
 source: tests/stats.rs
 expression: markdown
 ---
-"Stats powered by [Git AI](https://github.com/acunniffe/git-ai)\n\n```text\n🧠 you    ████████░░░░░░░░░░░░  40%\n🤖 ai     ░░░░░░░░████████████  60%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.0 lines generated for every 1 accepted\n- 15 seconds waiting for AI \n\n</details>"
+"Stats powered by [Git AI](https://github.com/git-ai-project/git-ai)\n\n```text\n🧠 you    ████████░░░░░░░░░░░░  40%\n🤖 ai     ░░░░░░░░████████████  60%\n```\n\n<details>\n<summary>More stats</summary>\n\n- 1.0 lines generated for every 1 accepted\n- 15 seconds waiting for AI \n\n</details>"


### PR DESCRIPTION
obviously didn't replaced "acunniffe" where it still did make sense, i.e. git commit author, submodule or calendly link  
as a bonus, updated a documentation link that no longer exists to the website

I made this PR while reviewing the powershell script before installing, and then I noticed that the repo name mismatched with the actual one, probably after you moved the repo to its own orga.  
While GitHub provides automatic link redirection between the old and new name, it is still a good idea to update it ^^  
goes with git-ai-project/action#2 too