### PR TITLE
feat: add quiet config option to suppress chart output after commits

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -173,8 +173,8 @@ pub fn post_commit(
     // // Clean up old working log
     repo_storage.delete_working_log_for_base_commit(&parent_sha)?;
 
-    if !supress_output {
-        // Only print stats if we're in an interactive terminal
+    if !supress_output && !Config::get().is_quiet() {
+        // Only print stats if we're in an interactive terminal and quiet mode is disabled
         let is_interactive = std::io::stdout().is_terminal();
         write_stats_to_terminal(&stats, is_interactive);
     }


### PR DESCRIPTION
## Summary
- Adds a new `quiet` configuration option to suppress the "you vs AI %" chart displayed after commits
- Users can enable with `git-ai config set quiet true`

## Changes
- Added `quiet` field to Config and FileConfig structs
- Added `is_quiet()` accessor method  
- Wired up quiet config in post_commit to suppress chart output
- Added config command support (get/set/unset)
- Added unit tests for quiet config and parse_bool function

## Usage
```bash
git-ai config set quiet true   # Enable quiet mode
git-ai config set quiet false  # Disable quiet mode  
git-ai config quiet            # Check current value
git-ai config unset quiet      # Reset to default (false)
```

## Testing
- Tested locally with `task debug:local`
- Verified chart appears with `quiet: false` (default)
- Verified chart is suppressed with `quiet: true`
- All existing tests pass