### PR TITLE
fix: correct operator precedence bug causing false 'Committers are not using git-ai' message

### DIFF
--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -435,7 +435,7 @@ pub fn print_range_authorship_stats(stats: &RangeAuthorshipStats) {
     println!("\n");
 
     // If there's no AI authorship in the range, show the special message
-    if !stats.authorship_stats.commits_with_authorship > stats.authorship_stats.total_commits {
+    if stats.authorship_stats.commits_with_authorship == 0 {
         println!("Committers are not using git-ai");
         return;
     }


### PR DESCRIPTION
## Summary

Fixes a critical bug where `git-ai stats` incorrectly displays "Committers are not using git-ai" even when valid authorship data exists.

## Root Cause Analysis

This bug was introduced in commit c9303a0 (PR #288) while fixing issue #287. The problematic code at `src/authorship/range_authorship.rs:438`:

```rust
if !stats.authorship_stats.commits_with_authorship > stats.authorship_stats.total_commits {
    println!("Committers are not using git-ai");
    return;
}
```

### The Problem

Due to Rust's **operator precedence rules**, the unary `!` (NOT) operator has **higher precedence** than the `>` (comparison) operator. This means the expression is parsed as:

```rust
(!commits_with_authorship) > total_commits
```

**NOT** as the author likely intended:
```rust
!(commits_with_authorship > total_commits)
```

### Why This is Wrong for Integers

In Rust, when `!` is applied to an integer (like `usize`), it performs **bitwise NOT**, not boolean NOT:

| Expression | Result |
|------------|--------|
| `!0usize` | `18446744073709551615` (usize::MAX) |
| `!1usize` | `18446744073709551614` (usize::MAX - 1) |
| `!n` for any small n | A very large number |

So the condition becomes:
```
(HUGE_NUMBER) > total_commits
```

Which is **almost always true**, causing the error message to display incorrectly.

## The Fix

Replace the broken condition with the straightforward check that was clearly intended:

```rust
if stats.authorship_stats.commits_with_authorship == 0 {
    println!("Committers are not using git-ai");
    return;
}
```

This correctly identifies when no commits in the range have authorship logs.

## Reproduction

Before the fix:
```bash
git-ai stats HEAD~2..HEAD
# Shows: Committers are not using git-ai (even with valid data)

git-ai stats HEAD~2..HEAD --json
# Shows valid data: {"human_additions":1,"ai_additions":3,...}
```

After the fix:
```bash
git-ai stats HEAD~2..HEAD
# Correctly shows the authorship statistics bar graph
```

## Testing

- [x] `cargo build --release` - compiles successfully
- [x] `cargo test` - all tests pass
- [x] Manual testing confirms the fix works correctly

## Related

- Regression introduced in PR #288 (commit c9303a0)
- Original issue that PR #288 was fixing: #287