### PR TITLE
fix: use --git-dir instead of --absolute-git-dir for Git < 2.13 compat

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1835,7 +1835,10 @@ impl Repository {
 pub fn find_repository(global_args: &Vec<String>) -> Result<Repository, GitAiError> {
     let mut args = global_args.clone();
     args.push("rev-parse".to_string());
-    args.push("--absolute-git-dir".to_string());
+    // Use --git-dir instead of --absolute-git-dir for compatibility with Git < 2.13
+    // (--absolute-git-dir was added in Git 2.13; older versions output the literal
+    // string "absolute-git-dir" instead of the resolved path).
+    args.push("--git-dir".to_string());
     args.push("--show-toplevel".to_string());
 
     let output = exec_git(&args)?;
@@ -1854,8 +1857,13 @@ pub fn find_repository(global_args: &Vec<String>) -> Result<Repository, GitAiErr
 
     let git_dir_str = lines[0];
     let workdir_str = lines[1];
-    let git_dir = PathBuf::from(git_dir_str);
     let workdir = PathBuf::from(workdir_str);
+    // --git-dir may return a relative path (e.g. ".git"); resolve it against the toplevel
+    let git_dir = if Path::new(git_dir_str).is_relative() {
+        workdir.join(git_dir_str)
+    } else {
+        PathBuf::from(git_dir_str)
+    };
     if !git_dir.is_dir() {
         return Err(GitAiError::Generic(format!(
             "Git directory does not exist: {}",


### PR DESCRIPTION
The --absolute-git-dir flag was added in Git 2.13. On older versions
(e.g. 2.11.1), git rev-parse outputs the literal string "absolute-git-dir"
instead of the resolved path, causing repository detection to fail.

Replace --absolute-git-dir with --git-dir and resolve relative paths
(e.g. ".git") against the toplevel working directory.

Fixes #425

https://claude.ai/code/session_01JpFmHufP3AorZr2b1ad3iD