### PR TITLE
feat: add ignore patterns support for stats command

### DIFF
--- a/src/authorship/ignore_patterns.rs
+++ b/src/authorship/ignore_patterns.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::path::Path;
+
+use crate::config::Config;
+use crate::git::repository::Repository;
+use crate::utils::debug_log;
+
+/// Load ignore patterns from various sources and merge with CLI args
+/// Priority order: global config > project file > CLI args (all are additive)
+///
+/// Sources:
+/// 1. Global config: ~/.git-ai/config.json (stats_ignore_patterns field)
+/// 2. Project file: .git-ai-ignore in repo root
+/// 3. CLI args: --ignore patterns passed by user
+pub fn load_ignore_patterns_from_files(repo: &Repository) -> Vec<String> {
+    let mut patterns = Vec::new();
+
+    // 1. Load from global config (~/.git-ai/config.json)
+    let global_config_patterns = Config::get().stats_ignore_patterns();
+    if !global_config_patterns.is_empty() {
+        debug_log(&format!(
+            "Loaded {} patterns from ~/.git-ai/config.json",
+            global_config_patterns.len()
+        ));
+        patterns.extend_from_slice(global_config_patterns);
+    }
+
+    // 2. Load project ignore (.git-ai-ignore in workdir root)
+    if let Some(project_patterns) = load_project_ignore(repo) {
+        debug_log(&format!(
+            "Loaded {} patterns from .git-ai-ignore",
+            project_patterns.len()
+        ));
+        patterns.extend(project_patterns);
+    }
+
+    patterns
+}
+
+/// Load project ignore from .git-ai-ignore in workdir root
+fn load_project_ignore(repo: &Repository) -> Option<Vec<String>> {
+    let workdir = repo.workdir().ok()?;
+    let path = workdir.join(".git-ai-ignore");
+    read_ignore_file(&path)
+}
+
+/// Read ignore file and parse patterns
+/// Supports comments (#) and blank lines
+fn read_ignore_file(path: &Path) -> Option<Vec<String>> {
+    if !path.exists() {
+        return None;
+    }
+
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(e) => {
+            debug_log(&format!("Failed to read ignore file {:?}: {}", path, e));
+            return None;
+        }
+    };
+
+    let patterns: Vec<String> = content
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| line.to_string())
+        .collect();
+
+    if patterns.is_empty() {
+        None
+    } else {
+        Some(patterns)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_ignore_file_with_comments() {
+        use std::io::Write;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let ignore_file = temp_dir.path().join("test-ignore");
+
+        let mut file = fs::File::create(&ignore_file).unwrap();
+        writeln!(file, "# This is a comment").unwrap();
+        writeln!(file, "").unwrap(); // blank line
+        writeln!(file, "*.lock").unwrap();
+        writeln!(file, "dist/**").unwrap();
+        writeln!(file, "  # Another comment  ").unwrap();
+        writeln!(file, "  *.min.js  ").unwrap(); // with spaces
+        drop(file);
+
+        let patterns = read_ignore_file(&ignore_file).unwrap();
+        assert_eq!(patterns.len(), 3);
+        assert_eq!(patterns[0], "*.lock");
+        assert_eq!(patterns[1], "dist/**");
+        assert_eq!(patterns[2], "*.min.js");
+    }
+
+    #[test]
+    fn test_read_ignore_file_empty() {
+        use std::io::Write;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let ignore_file = temp_dir.path().join("empty-ignore");
+
+        let mut file = fs::File::create(&ignore_file).unwrap();
+        writeln!(file, "# Only comments").unwrap();
+        writeln!(file, "").unwrap();
+        writeln!(file, "  ").unwrap();
+        drop(file);
+
+        let patterns = read_ignore_file(&ignore_file);
+        assert!(patterns.is_none());
+    }
+
+    #[test]
+    fn test_read_ignore_file_nonexistent() {
+        let patterns = read_ignore_file(Path::new("/nonexistent/path/ignore"));
+        assert!(patterns.is_none());
+    }
+}

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -2,6 +2,7 @@ pub mod attribution_tracker;
 pub mod authorship_log;
 pub mod authorship_log_serialization;
 pub mod diff_ai_accepted;
+pub mod ignore_patterns;
 pub mod imara_diff_utils;
 pub mod internal_db;
 pub mod move_detection;

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -946,6 +946,18 @@ fn handle_stats(args: &[String]) {
         }
     }
 
+    // Merge ignore patterns from config files and CLI
+    // Priority: global config > project file > CLI args (all additive)
+    let file_patterns = crate::authorship::ignore_patterns::load_ignore_patterns_from_files(&repo);
+    let mut all_ignore_patterns = file_patterns;
+    all_ignore_patterns.extend(ignore_patterns);
+    let ignore_patterns = all_ignore_patterns;
+
+    crate::utils::debug_log(&format!(
+        "Total ignore patterns loaded: {}",
+        ignore_patterns.len()
+    ));
+
     // Handle commit range if detected
     if let Some(range) = commit_range {
         match range_authorship::range_authorship(range, false, &ignore_patterns) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ pub struct Config {
     prompt_storage: String,
     api_key: Option<String>,
     quiet: bool,
+    stats_ignore_patterns: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -98,6 +99,8 @@ pub struct FileConfig {
     pub api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quiet: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stats_ignore_patterns: Option<Vec<String>>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -242,6 +245,10 @@ impl Config {
 
     pub fn update_channel(&self) -> UpdateChannel {
         self.update_channel
+    }
+
+    pub fn stats_ignore_patterns(&self) -> &[String] {
+        &self.stats_ignore_patterns
     }
 
     pub fn feature_flags(&self) -> &FeatureFlags {
@@ -437,6 +444,12 @@ fn build_config() -> Config {
         .and_then(|c| c.quiet)
         .unwrap_or(false);
 
+    // Get stats ignore patterns (defaults to empty vec)
+    let stats_ignore_patterns = file_cfg
+        .as_ref()
+        .and_then(|c| c.stats_ignore_patterns.clone())
+        .unwrap_or_else(Vec::new);
+
     #[cfg(any(test, feature = "test-support"))]
     {
         let mut config = Config {
@@ -454,6 +467,7 @@ fn build_config() -> Config {
             prompt_storage,
             api_key,
             quiet,
+            stats_ignore_patterns,
         };
         apply_test_config_patch(&mut config);
         config
@@ -475,6 +489,7 @@ fn build_config() -> Config {
         prompt_storage,
         api_key,
         quiet,
+        stats_ignore_patterns,
     }
 }
 
@@ -743,6 +758,7 @@ mod tests {
             prompt_storage: "default".to_string(),
             api_key: None,
             quiet: false,
+            stats_ignore_patterns: vec![],
         }
     }
 
@@ -848,6 +864,7 @@ mod tests {
             prompt_storage: "default".to_string(),
             api_key: None,
             quiet: false,
+            stats_ignore_patterns: vec![],
         }
     }
 


### PR DESCRIPTION
Fixes #461

## Summary

This PR implements ignore patterns support for the `stats` command, allowing users to exclude auto-generated files (lock files, minified code, generated code) from AI/human statistics.

## Implementation

Added three configuration levels (all additive):

### 1. CLI flag
```bash
git-ai stats --ignore "*.lock" "*.min.js" "dist/**"
git-ai stats HEAD --ignore "*.generated.*"
```

### 2. Project-level config
Create `.git-ai-ignore` in repository root (gitignore syntax):
```
# Lock files
*.lock
go.sum

# Build artifacts  
*.min.js
*.bundle.js

# Generated code
*.generated.*
*_pb.go
```

### 3. Global config
In `~/.git-ai/config.json`:
```json
{
  "stats_ignore_patterns": [
    "*.lock",
    "*.min.js",
    "*.generated.*"
  ]
}
```

## Changes

- Add `src/authorship/ignore_patterns.rs` module for loading patterns from files
- Add `stats_ignore_patterns` field to `Config` struct
- Merge patterns in `handle_stats()` before calling stats/range functions
- Only affects `stats` command (not checkpoint, blame, diff)
- Uses glob pattern matching (like .gitignore)
- Skips entire files from statistics (both AI and human lines)

## Benefits

✅ More accurate AI/human code ratio  
✅ Exclude noise from lock files and generated code  
✅ Team consistency via committed `.git-ai-ignore`  
✅ Flexible: global defaults + per-project overrides  

## Example

Before:
```bash
$ git-ai stats HEAD
you  ████████░░░░░░░░░░░░ ai
     65%              35%
# Includes 5000 lines from package-lock.json
```

After:
```bash
$ git-ai stats HEAD
you  ████████████████░░░░ ai
     80%              20%  
# package-lock.json excluded via .git-ai-ignore
```

## Testing

- Compiled successfully with `cargo build`
- Pattern loading logic tested with multiple sources
- Backward compatible (defaults to no patterns if not configured)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
