### PR TITLE
Revert pwsh preference for Windows upgrades

### DIFF
--- a/.github/workflows/nightly-upgrade.yml
+++ b/.github/workflows/nightly-upgrade.yml
@@ -1,0 +1,196 @@
+name: Nightly Upgrade Validation
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  upgrade-from-older:
+    name: Upgrade from older versions on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Select random older versions (non-Windows)
+        id: versions
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import random
+          import re
+          import urllib.request
+
+          url = "https://api.github.com/repos/git-ai-project/git-ai/releases?per_page=100"
+          req = urllib.request.Request(
+              url, headers={"Accept": "application/vnd.github+json"}
+          )
+          with urllib.request.urlopen(req) as response:
+              releases = json.load(response)
+
+          pattern = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+          versions = {}
+          for release in releases:
+              tag = release.get("tag_name", "")
+              match = pattern.match(tag)
+              if not match:
+                  continue
+              version_tuple = tuple(int(part) for part in match.groups())
+              normalized = "v" + ".".join(match.groups())
+              versions[version_tuple] = normalized
+
+          if not versions:
+              raise SystemExit("No semver releases found")
+
+          min_upgrade_tuple = (1, 0, 26)
+
+          latest_tuple = max(versions)
+          latest_tag = versions[latest_tuple]
+          older = [
+              tag
+              for ver, tag in versions.items()
+              if min_upgrade_tuple < ver < latest_tuple
+          ]
+          if not older:
+              raise SystemExit("No older versions found")
+
+          random.shuffle(older)
+          sample = older[: min(3, len(older))]
+          output_path = os.environ["GITHUB_OUTPUT"]
+          with open(output_path, "a", encoding="utf-8") as output:
+              output.write(f"latest={latest_tag}\n")
+              output.write(
+                  f"min_upgrade=v{'.'.join(str(part) for part in min_upgrade_tuple)}\n"
+              )
+              output.write(f"versions={' '.join(sample)}\n")
+          print(f"Selected versions: {' '.join(sample)}")
+          print(f"Latest: {latest_tag}")
+          print(
+              "Minimum upgrade version: v"
+              + ".".join(str(part) for part in min_upgrade_tuple)
+          )
+          PY
+
+      - name: Select random older versions (Windows)
+        id: versions-windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $script = @'
+          import json
+          import os
+          import random
+          import re
+          import urllib.request
+
+          url = "https://api.github.com/repos/git-ai-project/git-ai/releases?per_page=100"
+          req = urllib.request.Request(
+              url, headers={"Accept": "application/vnd.github+json"}
+          )
+          with urllib.request.urlopen(req) as response:
+              releases = json.load(response)
+
+          pattern = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+          versions = {}
+          for release in releases:
+              tag = release.get("tag_name", "")
+              match = pattern.match(tag)
+              if not match:
+                  continue
+              version_tuple = tuple(int(part) for part in match.groups())
+              normalized = "v" + ".".join(match.groups())
+              versions[version_tuple] = normalized
+
+          if not versions:
+              raise SystemExit("No semver releases found")
+
+          min_upgrade_tuple = (1, 0, 26)
+
+          latest_tuple = max(versions)
+          latest_tag = versions[latest_tuple]
+          older = [
+              tag
+              for ver, tag in versions.items()
+              if min_upgrade_tuple < ver < latest_tuple
+          ]
+          if not older:
+              raise SystemExit("No older versions found")
+
+          random.shuffle(older)
+          sample = older[: min(3, len(older))]
+          output_path = os.environ["GITHUB_OUTPUT"]
+          with open(output_path, "a", encoding="utf-8") as output:
+              output.write(f"latest={latest_tag}\n")
+              output.write(
+                  f"min_upgrade=v{'.'.join(str(part) for part in min_upgrade_tuple)}\n"
+              )
+              output.write(f"versions={' '.join(sample)}\n")
+          print(f"Selected versions: {' '.join(sample)}")
+          print(f"Latest: {latest_tag}")
+          print(
+              "Minimum upgrade version: v"
+              + ".".join(str(part) for part in min_upgrade_tuple)
+          )
+          '@
+          python -c $script
+
+      - name: Install older versions and upgrade (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="$HOME/.git-ai/bin:$PATH"
+          latest="${{ steps.versions.outputs.latest }}"
+          latest="${latest#v}"
+          for version in ${{ steps.versions.outputs.versions }}; do
+            echo "Installing ${version}"
+            GIT_AI_RELEASE_TAG="$version" ./install.sh
+            git-ai --version
+            git-ai upgrade
+            installed=$(git-ai --version | awk '{print $NF}')
+            installed="${installed#v}"
+            if [ "$installed" != "$latest" ]; then
+              echo "Expected ${latest}, got ${installed}"
+              exit 1
+            fi
+          done
+
+      - name: Install older versions and upgrade (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $latest = "${{ steps.versions-windows.outputs.latest }}"
+          $latest = $latest.TrimStart('v')
+          $versions = "${{ steps.versions-windows.outputs.versions }}".Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+          $env:PATH = "$HOME\.git-ai\bin;$env:PATH"
+          foreach ($version in $versions) {
+            Write-Host "Installing $version"
+            $env:GIT_AI_RELEASE_TAG = $version
+            pwsh -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
+            & "$HOME\.git-ai\bin\git-ai" --version | Out-Host
+            & "$HOME\.git-ai\bin\git-ai" upgrade
+            $installed = (& "$HOME\.git-ai\bin\git-ai" --version).Trim().Split()[-1].TrimStart('v')
+            $deadline = (Get-Date).AddMinutes(3)
+            while ($installed -ne $latest -and (Get-Date) -lt $deadline) {
+              Start-Sleep -Seconds 5
+              $installed = (& "$HOME\.git-ai\bin\git-ai" --version).Trim().Split()[-1].TrimStart('v')
+            }
+            if ($installed -ne $latest) {
+              throw "Expected $latest after upgrade, got $installed"
+            }
+          }


### PR DESCRIPTION
### Motivation
- Simplify Windows upgrade behavior by reverting the pwsh-first spawn logic because the PowerShell checksum fallback implemented in `install.ps1` removes the need to prefer `pwsh`.

### Description
- Remove the `spawn_powershell` closure that tried `pwsh` then `powershell` and instead invoke `powershell` directly via `Command::new("powershell")` while keeping `-NoProfile`, `-ExecutionPolicy Bypass`, `-Command`, `CREATE_NO_WINDOW`, the `GIT_AI_RELEASE_ENV` env var, and the silent `stdout`/`stderr` behavior.

### Testing
- No automated tests were run as part of this change (CI/integration validation is expected to run in workflows).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988bfee2060832cacedd646d620ee40)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
