### PR TITLE
Remove ancestry-path flag

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1286,16 +1286,16 @@ impl Repository {
             }
         };
 
-        // Build: git log --format=%H --reverse --ancestry-path <branch> --not <other branches>
-        // --ancestry-path narrows the output to only commits that are ancestors of <branch>
-        // AND descendants of the excluded commits (<merge_target>). This filters out commits
-        // brought in by merging the merge target INTO the branch (e.g. "merge main into feature"
-        // to stay up-to-date), keeping only the commits that were directly authored on the branch.
+        // Build: git log --format=%H --reverse <branch> --not <merge_target>
+        // Note: we intentionally do NOT use --ancestry-path here. That flag requires
+        // commits to be descendants of the merge-target's tip, which fails when the
+        // merge target was previously merged INTO the branch (a common workflow to
+        // stay up-to-date). In that case, the branch's unique commits descend from
+        // the pre-merge side and --ancestry-path filters them all out.
         let mut log_args = self.global_args_for_exec();
         log_args.push("log".to_string());
         log_args.push("--format=%H".to_string());
         log_args.push("--reverse".to_string());
-        log_args.push("--ancestry-path".to_string());
         log_args.push(fq_branch.to_string());
         log_args.push("--not".to_string());
         log_args.push(fq_merge_target.to_string());


### PR DESCRIPTION
When merging main into your feature branch to stay current, the branch's own commits end up on the pre-merge side of the graph — --ancestry-path would filter them all out, leaving you with zero commits. Therefore, should be removed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
