### PR TITLE
Configure Git Bash shell profiles during Windows install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -448,11 +448,10 @@ try {
 
     # Detect if Git Bash is installed
     $gitBashInstalled = $false
-    $gitForWindowsPaths = @(
-        (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
-        (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
-        (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
-    )
+    $gitForWindowsPaths = @()
+    if ($env:ProgramFiles) { $gitForWindowsPaths += Join-Path $env:ProgramFiles 'Git\bin\bash.exe' }
+    if (${env:ProgramFiles(x86)}) { $gitForWindowsPaths += Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe' }
+    if ($env:LOCALAPPDATA) { $gitForWindowsPaths += Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe' }
     foreach ($p in $gitForWindowsPaths) {
         if ($p -and (Test-Path -LiteralPath $p)) {
             $gitBashInstalled = $true


### PR DESCRIPTION
# Configure Git Bash shell profiles during Windows install

## Summary
Fixes #517. Git Bash (MSYS2/MinGW) prepends `/mingw64/bin` to `PATH` during its own shell initialization, which shadows the `git-ai` shim even when the Windows PATH has been correctly set by `Set-PathPrependBeforeGit`. This adds a new section to `install.ps1` that writes `export PATH="$HOME/.git-ai/bin:$PATH"` into the user's `~/.bashrc` or `~/.bash_profile`, mirroring what `install.sh` already does for Unix shells.

The new block:
1. Detects Git for Windows by checking common install paths (`Program Files`, `Program Files (x86)`, `LocalAppData\Programs`), guarding each path against null env vars
2. Finds existing `.bashrc` or `.bash_profile` (or creates `.bashrc` if neither exists)
3. Checks for an existing `.git-ai/bin` marker to avoid duplicate entries
4. Appends the PATH export using BOM-less UTF-8 encoding (via `[System.IO.File]::AppendAllText` with `UTF8Encoding($false)`)
5. Wraps everything in try/catch so a failure here never blocks the rest of the install

### Updates since last revision
- Fixed UTF-8 BOM issue: replaced `Add-Content -Encoding UTF8` with `[System.IO.File]::AppendAllText()` using `UTF8Encoding($false)` to avoid writing a BOM that would cause `command not found` errors in bash on PowerShell 5.1.
- Fixed null env var issue: `Join-Path` calls for Git Bash detection paths are now guarded with `if` checks so a null `ProgramFiles(x86)` (e.g. on 32-bit Windows) doesn't abort the entire Git Bash config block under `Set-StrictMode`.

## Review & Testing Checklist for Human
- [ ] **Test on a real Windows machine with Git Bash installed** — this change is entirely in PowerShell and cannot be verified by the Rust test suite or Linux CI. Run the installer, then open Git Bash and confirm `which git` resolves to `~/.git-ai/bin/git` (not `/mingw64/bin/git`)
- [ ] **Verify no UTF-8 BOM in created .bashrc** — the code now uses `UTF8Encoding($false)` + `AppendAllText`, but confirm the written file has no BOM bytes (`EF BB BF`) at the start, especially when `.bashrc` is newly created (no pre-existing file)
- [ ] **Test idempotency** — run the installer twice and confirm the PATH export is not duplicated in `.bashrc`
- [ ] **Test with no existing .bashrc** — confirm the installer creates `.bashrc` and the export line is correct. Consider whether creating `.bashrc` when a user has never used Git Bash is desirable, or if this should only append to existing files

### Notes
- Git Bash detection only covers standard Git for Windows install paths. Custom locations (Scoop, Chocolatey portable, etc.) won't be detected, but the code simply skips configuration in that case — no harm done.
- No admin permissions required — writes only to user-scoped files (`%USERPROFILE%\.bashrc` / `.bash_profile`).
- [Link to Devin run](https://app.devin.ai/sessions/e8857ddab4984d2aa9e2db1ac3ece160)
- Requested by @svarlamov