### PR TITLE
Fix corehooks hook-contract regressions and stale INITIAL handling

### DIFF
--- a/src/commands/core_hook_trampoline.rs
+++ b/src/commands/core_hook_trampoline.rs
@@ -128,6 +128,8 @@ fn reference_transaction_has_relevant_refs(stdin: &str) -> bool {
         }
 
         if reference == "ORIG_HEAD"
+            || reference == "HEAD"
+            || reference.starts_with("refs/heads/")
             || reference == "refs/stash"
             || reference == "CHERRY_PICK_HEAD"
             || reference.starts_with("refs/remotes/")
@@ -392,6 +394,10 @@ mod tests {
     fn reference_transaction_prefilter_detects_relevant_refs() {
         assert!(reference_transaction_has_relevant_refs(
             "000 111 ORIG_HEAD\n"
+        ));
+        assert!(reference_transaction_has_relevant_refs("000 111 HEAD\n"));
+        assert!(reference_transaction_has_relevant_refs(
+            "000 111 refs/heads/main\n"
         ));
         assert!(reference_transaction_has_relevant_refs(
             "000 111 refs/remotes/origin/main\n"

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1,6 +1,7 @@
 use crate::commands::core_hooks::{
     INSTALLED_HOOKS, PENDING_STASH_APPLY_MARKER_FILE, PREVIOUS_HOOKS_PATH_FILE,
-    managed_core_hooks_dir, normalize_hook_binary_path, write_core_hook_scripts,
+    WORKING_LOG_INITIAL_FILE, managed_core_hooks_dir, normalize_hook_binary_path,
+    write_core_hook_scripts,
 };
 use crate::commands::flush_metrics_db::spawn_background_metrics_db_flush;
 use crate::error::GitAiError;
@@ -808,6 +809,7 @@ fn core_hook_scripts_up_to_date(hooks_dir: &Path, binary_path: &Path) -> bool {
                 ))
                 && content.contains(&format!("export {}=", GIT_AI_GIT_CMD_ENV))
                 && content.contains(previous_hooks_nonempty_check)
+                && content.contains("refs/heads/")
                 && script_contains_binary(&content, &binary)
         } else if *hook == "pre-commit" {
             hook_path.exists()
@@ -821,6 +823,7 @@ fn core_hook_scripts_up_to_date(hooks_dir: &Path, binary_path: &Path) -> bool {
                 && content.contains(previous_hooks_nonempty_check)
                 && content.contains("checkpoints.jsonl")
                 && content.contains("blobs")
+                && content.contains(WORKING_LOG_INITIAL_FILE)
                 && script_contains_binary(&content, &binary)
         } else if *hook == "post-commit" {
             hook_path.exists()
@@ -834,6 +837,7 @@ fn core_hook_scripts_up_to_date(hooks_dir: &Path, binary_path: &Path) -> bool {
                 && content.contains(previous_hooks_nonempty_check)
                 && content.contains("pending_cherry_pick")
                 && content.contains("refs/notes/ai")
+                && content.contains(WORKING_LOG_INITIAL_FILE)
                 && script_contains_binary(&content, &binary)
         } else if *hook == "post-index-change" {
             hook_path.exists()


### PR DESCRIPTION
## Summary
- restore relevant ref detection coverage for `reference-transaction` prefilter (`HEAD` and `refs/heads/*`)
- include `INITIAL` in non-empty working-log detection and hook prefilter dispatch checks
- remove stale `INITIAL` file when writing empty initial attributions
- update install-hooks script freshness checks for new prefilter signatures
- add regression tests for INITIAL-only logs and ref prefilter coverage

## Validation
- `cargo fmt -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy`
- `cargo test -- --test-threads=8`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
