### PR TITLE
Fix test branch name mismatch in checkout_switch tests

### DIFF
--- a/tests/repos/test_repo.rs
+++ b/tests/repos/test_repo.rs
@@ -616,17 +616,23 @@ static COMPILED_BINARY: OnceLock<PathBuf> = OnceLock::new();
 static DEFAULT_BRANCH_NAME: OnceLock<String> = OnceLock::new();
 
 fn get_default_branch_name() -> String {
-    let output = Command::new("git")
-        .args(["config", "--global", "init.defaultBranch"])
-        .output()
-        .expect("Failed to execute git config command");
+    // Use git2 to read the config directly, just like Repository::init() does
+    // This ensures consistency between what default_branchname() returns and what
+    // branch name git2::Repository::init() actually creates
+    use git2::Config;
 
-    if output.status.success() {
-        String::from_utf8_lossy(&output.stdout).trim().to_string()
-    } else {
-        // Fallback to "master" if not configured
-        "master".to_string()
+    // Open the global git config
+    if let Ok(config) = Config::open_default() {
+        if let Ok(branch_name) = config.get_string("init.defaultBranch") {
+            if !branch_name.is_empty() {
+                return branch_name;
+            }
+        }
     }
+
+    // Fallback to "master" if not configured
+    // This matches libgit2's default behavior
+    "master".to_string()
 }
 
 pub fn default_branchname() -> &'static str {


### PR DESCRIPTION
## Summary

This PR fixes three failing tests in `tests/checkout_switch.rs` that were experiencing branch name mismatches:
- `test_checkout_same_branch_no_op`
- `test_switch_discard_changes_deletes_working_log`
- `test_switch_force_flag_deletes_working_log`

## Root Cause

The tests were failing because `default_branchname()` and `git2::Repository::init()` were using different methods to determine the default branch name:

1. **`get_default_branch_name()`** was spawning a `git` subprocess to read `init.defaultBranch` config
2. In the test environment, the `git` command is intercepted by the git-ai wrapper binary
3. The wrapper fails with "dev binary not found" during test execution
4. This caused `default_branchname()` to fall back to `"master"`
5. Meanwhile, `git2::Repository::init()` uses libgit2's internal config reading and correctly created `"main"` branches

This mismatch caused tests to look for "master" when "main" actually existed.

## Solution

Changed `get_default_branch_name()` in `tests/repos/test_repo.rs` to use git2's Config API directly instead of spawning a subprocess:

```rust
fn get_default_branch_name() -> String {
    use git2::Config;
    
    if let Ok(config) = Config::open_default() {
        if let Ok(branch_name) = config.get_string("init.defaultBranch") {
            if !branch_name.is_empty() {
                return branch_name;
            }
        }
    }
    
    "master".to_string()
}
```

This ensures both `default_branchname()` and `git2::Repository::init()` read the config using the same method (libgit2), eliminating the mismatch.

## Testing

All 11 tests in the `checkout_switch` test suite now pass:
```
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Notes

- libgit2 v1.1.0+ properly respects the `init.defaultBranch` configuration
- Using git2's API directly is more reliable than spawning git commands in test environments where wrapper scripts may interfere
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
