### PR TITLE
Fix directory pathspec matching in reset and add test

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -1548,7 +1548,13 @@ pub fn reconstruct_working_log_after_reset(
     let pathspecs: Vec<String> = if let Some(user_paths) = user_pathspecs {
         all_changed_files
             .into_iter()
-            .filter(|f| user_paths.iter().any(|p| f == p || f.starts_with(p)))
+            .filter(|f| {
+                user_paths.iter().any(|p| {
+                    f == p
+                        || (p.ends_with('/') && f.starts_with(p))
+                        || f.starts_with(&format!("{}/", p))
+                })
+            })
             .collect()
     } else {
         all_changed_files

--- a/src/commands/hooks/checkout_hooks.rs
+++ b/src/commands/hooks/checkout_hooks.rs
@@ -180,5 +180,9 @@ fn remove_attributions_for_pathspecs(repository: &Repository, head: &str, pathsp
 }
 
 fn matches_any_pathspec(file: &str, pathspecs: &[String]) -> bool {
-    pathspecs.iter().any(|p| file == p || file.starts_with(p))
+    pathspecs.iter().any(|p| {
+        file == p
+            || (p.ends_with('/') && file.starts_with(p))
+            || file.starts_with(&format!("{}/", p))
+    })
 }

--- a/src/commands/hooks/reset_hooks.rs
+++ b/src/commands/hooks/reset_hooks.rs
@@ -276,9 +276,11 @@ fn handle_reset_pathspec_preserve_working_dir(
     let mut non_pathspec_checkpoints = Vec::new();
     for mut checkpoint in existing_checkpoints {
         checkpoint.entries.retain(|entry| {
-            !pathspecs
-                .iter()
-                .any(|pathspec| entry.file == *pathspec || entry.file.starts_with(pathspec))
+            !pathspecs.iter().any(|pathspec| {
+                entry.file == *pathspec
+                    || (pathspec.ends_with('/') && entry.file.starts_with(pathspec))
+                    || entry.file.starts_with(&format!("{}/", pathspec))
+            })
         });
         if !checkpoint.entries.is_empty() {
             non_pathspec_checkpoints.push(checkpoint);


### PR DESCRIPTION
# Fix directory pathspec matching in reset, checkout, and rebase authorship

## Summary

Fixes a bug where pathspec matching used bare `starts_with(pathspec)` without a directory separator check. This meant a pathspec like `src` could incorrectly match files like `srcutils/foo.txt` (false positive). The fix ensures directory boundaries are respected by checking for a trailing `/` separator, consistent with the existing correct implementation in `stash_hooks.rs::file_matches_pathspecs`.

**Files changed:**
- `src/commands/hooks/reset_hooks.rs` — checkpoint entry filtering during pathspec reset
- `src/authorship/rebase_authorship.rs` — file filtering in `reconstruct_working_log_after_reset`
- `src/commands/hooks/checkout_hooks.rs` — `matches_any_pathspec` helper
- `tests/reset.rs` — new `test_reset_with_directory_pathspec` test

Closes #234

## Review & Testing Checklist for Human

- [ ] Verify the matching logic handles edge cases: pathspec `src` should match `src/file.txt` but NOT `srcfile.txt`; pathspec `src/` (trailing slash) should also match `src/file.txt`
- [ ] The test only asserts that files **outside** the reset directory retain AI authorship — it does **not** verify that `src/app.rs` actually lost its AI attribution after reset. Consider whether this gap matters.
- [ ] The fix in `checkout_hooks.rs` has no dedicated test coverage — verify manually or add a test if concerned
- [ ] Note: unlike `stash_hooks.rs::file_matches_pathspecs`, this PR does not add glob pattern support (`src/*`). Confirm this is acceptable.

**Suggested test plan:** Run `git reset <commit> -- <directory>` in a repo with files in sibling directories (e.g., `src/` and `srclib/`) and confirm only the intended directory is affected.

### Notes
- [Link to Devin run](https://app.devin.ai/sessions/5b637e49b5b74c2991b3f8ef17e25a2c)
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
