### PR TITLE
Fix nightly upgrade workflow GitHub API rate limiting

### DIFF
--- a/.github/workflows/nightly-upgrade.yml
+++ b/.github/workflows/nightly-upgrade.yml
@@ -25,6 +25,8 @@ jobs:
         id: versions
         if: runner.os != 'Windows'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -34,10 +36,15 @@ jobs:
           import re
           import urllib.request
 
+          token = os.environ.get("GITHUB_TOKEN", "")
           url = "https://api.github.com/repos/git-ai-project/git-ai/releases?per_page=100"
-          req = urllib.request.Request(
-              url, headers={"Accept": "application/vnd.github+json"}
-          )
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "User-Agent": "git-ai-nightly-upgrade",
+          }
+          if token:
+              headers["Authorization"] = f"Bearer {token}"
+          req = urllib.request.Request(url, headers=headers)
           with urllib.request.urlopen(req) as response:
               releases = json.load(response)
 
@@ -88,6 +95,8 @@ jobs:
         id: versions-windows
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $ErrorActionPreference = 'Stop'
           $script = @'
@@ -97,10 +106,15 @@ jobs:
           import re
           import urllib.request
 
+          token = os.environ.get("GITHUB_TOKEN", "")
           url = "https://api.github.com/repos/git-ai-project/git-ai/releases?per_page=100"
-          req = urllib.request.Request(
-              url, headers={"Accept": "application/vnd.github+json"}
-          )
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "User-Agent": "git-ai-nightly-upgrade",
+          }
+          if token:
+              headers["Authorization"] = f"Bearer {token}"
+          req = urllib.request.Request(url, headers=headers)
           with urllib.request.urlopen(req) as response:
               releases = json.load(response)
 


### PR DESCRIPTION
# Avoid GitHub API rate limit failures in nightly upgrade workflow

## Summary
The nightly upgrade validation workflow was intermittently failing with `HTTP Error 403: rate limit exceeded` when calling the GitHub Releases API unauthenticated (shared runner IPs can quickly exhaust the unauthenticated limit).

This PR:
- Passes `secrets.GITHUB_TOKEN` into the “Select random older versions” steps (bash + Windows pwsh)
- Uses `Authorization: Bearer $GITHUB_TOKEN` (when present) and adds an explicit `User-Agent` header for the GitHub API request

## Review & Testing Checklist for Human
- [ ] Confirm `GITHUB_TOKEN` is available for the scheduled workflow in this repo/org (permissions/policy) and that this doesn’t require any additional workflow permissions.
- [ ] Sanity-check the Windows step: the Python snippet is embedded in a PowerShell here-string; verify the updated block is syntactically correct and still executes on `windows-latest`.
- [ ] Optionally re-run the workflow (or a `workflow_dispatch`) and confirm the “Select random older versions” steps no longer fail with 403 rate limits.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/542cbe6f96cc42d6b9e173485666d7b0
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
