### PR TITLE
Update CI workflow to copy notes from fork after merge

### DIFF
--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -390,6 +390,7 @@ mod tests {
             head_sha: "def456".to_string(),
             base_ref: "main".to_string(),
             base_sha: "ghi789".to_string(),
+            fork_clone_url: None,
         };
 
         let debug_str = format!("{:?}", event);
@@ -426,6 +427,7 @@ mod tests {
             head_sha: "def".to_string(),
             base_ref: "main".to_string(),
             base_sha: "ghi".to_string(),
+            fork_clone_url: None,
         };
 
         let context = CiContext::with_repository(repo, event);
@@ -445,6 +447,7 @@ mod tests {
             head_sha: "def".to_string(),
             base_ref: "main".to_string(),
             base_sha: "ghi".to_string(),
+            fork_clone_url: None,
         };
 
         let context = CiContext::with_repository(repo, event);
@@ -470,6 +473,7 @@ mod tests {
             head_sha: "def".to_string(),
             base_ref: "main".to_string(),
             base_sha: "ghi".to_string(),
+            fork_clone_url: None,
         };
 
         let context = CiContext {
@@ -543,6 +547,7 @@ mod tests {
             head_sha: commit3.to_string(),
             base_ref: "main".to_string(),
             base_sha: commit1.to_string(),
+            fork_clone_url: None,
         };
 
         let context = CiContext::with_repository(gitai_repo, event);
@@ -584,6 +589,7 @@ mod tests {
             head_sha: commit.to_string(),
             base_ref: "main".to_string(),
             base_sha: "base".to_string(),
+            fork_clone_url: None,
         };
 
         let context = CiContext::with_repository(gitai_repo, event);
@@ -607,6 +613,7 @@ mod tests {
             head_sha: "def".to_string(),
             base_ref: "main".to_string(),
             base_sha: "ghi".to_string(),
+            fork_clone_url: None,
         };
 
         let context = CiContext::with_repository(repo, event);

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -7,10 +7,15 @@ use crate::git::refs::{
     copy_ref, get_reference_as_authorship_log_v3, merge_notes_from_ref, ref_exists,
     show_authorship_note,
 };
-use crate::git::repository::{exec_git, CommitRange, Repository};
+use crate::git::repository::{CommitRange, Repository, exec_git};
 use crate::git::sync_authorship::fetch_authorship_notes;
 use std::fs;
 use std::path::PathBuf;
+
+#[cfg(windows)]
+const NULL_HOOKS: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_HOOKS: &str = "/dev/null";
 
 #[derive(Debug)]
 pub enum CiEvent {
@@ -319,7 +324,7 @@ impl CiContext {
         let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
         let mut fetch_args = repo.global_args_for_exec();
         fetch_args.push("-c".to_string());
-        fetch_args.push("core.hooksPath=/dev/null".to_string());
+        fetch_args.push(format!("core.hooksPath={}", NULL_HOOKS));
         fetch_args.push("fetch".to_string());
         fetch_args.push("--no-tags".to_string());
         fetch_args.push("--recurse-submodules=no".to_string());

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -368,7 +368,9 @@ mod tests {
             "sha": "abc123",
             "merge_commit_sha": "def456",
             "squash_commit_sha": null,
-            "squash": false
+            "squash": false,
+            "source_project_id": 123,
+            "target_project_id": 456
         }"#;
         let mr: GitLabMergeRequest = serde_json::from_str(json).unwrap();
         assert_eq!(mr.iid, 42);
@@ -379,6 +381,8 @@ mod tests {
         assert_eq!(mr.merge_commit_sha, Some("def456".to_string()));
         assert!(mr.squash_commit_sha.is_none());
         assert_eq!(mr.squash, Some(false));
+        assert_eq!(mr.source_project_id, 123);
+        assert_eq!(mr.target_project_id, 456);
     }
 
     #[test]
@@ -391,12 +395,16 @@ mod tests {
             "sha": "head123",
             "merge_commit_sha": "merge456",
             "squash_commit_sha": "squash789",
-            "squash": true
+            "squash": true,
+            "source_project_id": 123,
+            "target_project_id": 123
         }"#;
         let mr: GitLabMergeRequest = serde_json::from_str(json).unwrap();
         assert_eq!(mr.iid, 99);
         assert_eq!(mr.squash_commit_sha, Some("squash789".to_string()));
         assert_eq!(mr.squash, Some(true));
+        assert_eq!(mr.source_project_id, 123);
+        assert_eq!(mr.target_project_id, 123);
     }
 
     #[test]
@@ -405,7 +413,9 @@ mod tests {
             "iid": 1,
             "source_branch": "dev",
             "target_branch": "main",
-            "sha": "abc"
+            "sha": "abc",
+            "source_project_id": 999,
+            "target_project_id": 999
         }"#;
         let mr: GitLabMergeRequest = serde_json::from_str(json).unwrap();
         assert_eq!(mr.iid, 1);
@@ -413,6 +423,8 @@ mod tests {
         assert!(mr.merge_commit_sha.is_none());
         assert!(mr.squash_commit_sha.is_none());
         assert!(mr.squash.is_none());
+        assert_eq!(mr.source_project_id, 999);
+        assert_eq!(mr.target_project_id, 999);
     }
 
     #[test]

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -16,6 +16,12 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
         CiRunResult::SkippedSimpleMerge => {
             println!("{}: skipped simple merge (authorship preserved)", prefix);
         }
+        CiRunResult::ForkNotesPreserved => {
+            println!(
+                "{}: fork notes fetched and pushed (merge commit from fork)",
+                prefix
+            );
+        }
         CiRunResult::SkippedFastForward => {
             println!("{}: skipped fast-forward merge", prefix);
         }
@@ -242,6 +248,8 @@ fn handle_ci_local(args: &[String]) {
                 }
             };
 
+            let fork_clone_url = flag("--fork-clone-url");
+
             let ctx = CiContext {
                 repo,
                 event: CiEvent::Merge {
@@ -250,6 +258,7 @@ fn handle_ci_local(args: &[String]) {
                     head_sha,
                     base_ref,
                     base_sha,
+                    fork_clone_url,
                 },
                 // Not used for local runs; teardown not invoked
                 temp_dir: std::path::PathBuf::from("."),
@@ -291,7 +300,7 @@ fn print_ci_help_and_exit() -> ! {
     eprintln!("                   Usage: git-ai ci local <event> [flags]");
     eprintln!("                   Events:");
     eprintln!(
-        "                     merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha>"
+        "                     merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha> [--fork-clone-url <url>]"
     );
     std::process::exit(1);
 }

--- a/src/commands/git_hook_handlers.rs
+++ b/src/commands/git_hook_handlers.rs
@@ -3003,6 +3003,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn mark_repo_hooks_enabled_is_idempotent() {
         let tmp = tempfile::tempdir().expect("failed to create tempdir");
         let repo = init_repo(&tmp.path().join("repo"));

--- a/tests/ci_fork_notes.rs
+++ b/tests/ci_fork_notes.rs
@@ -329,7 +329,9 @@ fn test_ci_fork_merge_commit_no_notes_skips_without_push_error() {
 
     file.set_contents(lines!["// Original code"]);
     upstream.git_og(&["add", "-A"]).unwrap();
-    upstream.git_og(&["commit", "-m", "Initial commit"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Initial commit"])
+        .unwrap();
     let base_sha = upstream
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()

--- a/tests/ci_fork_notes.rs
+++ b/tests/ci_fork_notes.rs
@@ -1,0 +1,491 @@
+#[macro_use]
+mod repos;
+use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunResult};
+use git_ai::git::refs::get_reference_as_authorship_log_v3;
+use git_ai::git::repository as GitAiRepository;
+use repos::test_file::ExpectedLineExt;
+use repos::test_repo::TestRepo;
+
+/// Helper: set up "origin" as a self-referencing remote so fetch_authorship_notes("origin")
+/// doesn't fail. In real CI the repo is cloned from origin, so it always exists.
+fn add_self_origin(repo: &TestRepo) {
+    let path = repo.path().to_str().unwrap();
+    repo.git_og(&["remote", "add", "origin", path]).ok(); // ok() in case it already exists
+}
+
+/// Test that CI preserves fork notes for a squash merge from a fork.
+///
+/// Scenario:
+/// 1. Contributor works in a fork with git-ai, creating AI-attributed code
+/// 2. Maintainer squash-merges the PR into the upstream repo
+/// 3. CI runs and should fetch notes from the fork, then rewrite them
+///    onto the squash commit
+#[test]
+fn test_ci_fork_squash_merge() {
+    // Setup: create "upstream" repo with initial commit
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code", "function original() {}"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create "fork" repo and give it the upstream's history
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    // Fork contributor adds AI code using git-ai
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI added function".ai(),
+        "function aiFeature() {".ai(),
+        "  return 'from fork';".ai(),
+        "}".ai()
+    ]);
+    let fork_commit = fork.stage_all_and_commit("Add AI feature in fork").unwrap();
+    let fork_head_sha = fork_commit.commit_sha.clone();
+
+    // Verify fork has authorship notes
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    assert!(
+        get_reference_as_authorship_log_v3(&fork_repo, &fork_head_sha).is_ok(),
+        "Fork commit should have authorship notes"
+    );
+
+    // Make the fork's commits accessible from upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Simulate squash merge in upstream: maintainer creates a squash commit.
+    // Use git_og (raw git) to avoid git-ai auto-creating notes on this commit,
+    // which simulates the real CI scenario where the squash commit has no notes.
+    file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI added function",
+        "function aiFeature() {",
+        "  return 'from fork';",
+        "}"
+    ]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork PR via squash (#1)"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI context with fork_clone_url set
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha.clone(),
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // Verify the result is AuthorshipRewritten (squash merge rewrites notes)
+    assert!(
+        matches!(result, CiRunResult::AuthorshipRewritten { .. }),
+        "Expected AuthorshipRewritten for fork squash merge, got {:?}",
+        result
+    );
+
+    // Verify authorship is preserved in the squash commit
+    file.assert_lines_and_blame(lines![
+        "// Original code".human(),
+        "function original() {}".human(),
+        "// AI added function".ai(),
+        "function aiFeature() {".ai(),
+        "  return 'from fork';".ai(),
+        "}".ai()
+    ]);
+}
+
+/// Test that CI preserves fork notes for a merge commit (non-squash, non-rebase).
+///
+/// For merge commits from forks, the merged commits keep their original SHAs.
+/// The CI should fetch notes from the fork and push them to origin.
+#[test]
+fn test_ci_fork_merge_commit() {
+    // Setup: create "upstream" repo with initial commit
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code", "function original() {}"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create "fork" as separate repo with shared history
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    // Fork contributor adds AI code
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI feature from fork".ai(),
+        "function forkFeature() {".ai(),
+        "  return true;".ai(),
+        "}".ai()
+    ]);
+    let fork_commit = fork.stage_all_and_commit("Add AI feature in fork").unwrap();
+    let fork_head_sha = fork_commit.commit_sha.clone();
+
+    // Verify fork has authorship notes
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    assert!(
+        get_reference_as_authorship_log_v3(&fork_repo, &fork_head_sha).is_ok(),
+        "Fork commit should have authorship notes"
+    );
+
+    // Fetch fork commits and create merge commit in upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Create a merge commit (--no-ff ensures a merge commit is created)
+    upstream
+        .git_og(&[
+            "merge",
+            "--no-ff",
+            "refs/fork/main",
+            "-m",
+            "Merge fork PR (#1)",
+        ])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI context with fork_clone_url
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha.clone(),
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // For merge commits from forks, notes should be preserved (not rewritten)
+    assert!(
+        matches!(result, CiRunResult::ForkNotesPreserved),
+        "Expected ForkNotesPreserved for fork merge commit, got {:?}",
+        result
+    );
+
+    // Verify the fork commit's authorship is accessible in upstream
+    let upstream_repo2 =
+        GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+            .expect("Failed to find upstream repository");
+    let authorship_log = get_reference_as_authorship_log_v3(&upstream_repo2, &fork_head_sha);
+    assert!(
+        authorship_log.is_ok(),
+        "Fork commit's authorship should be accessible in upstream after CI run"
+    );
+}
+
+/// Test that CI handles fork PRs with no notes gracefully.
+///
+/// If a fork contributor doesn't use git-ai, there are no notes to fetch.
+/// The CI should handle this gracefully without errors.
+#[test]
+fn test_ci_fork_no_notes() {
+    // Setup upstream
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create fork WITHOUT git-ai (using git_og for all operations)
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    // Fork contributor adds code without git-ai
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines!["// Original code", "// Added in fork"]);
+    fork.git_og(&["add", "-A"]).unwrap();
+    fork.git_og(&["commit", "-m", "Add feature in fork"])
+        .unwrap();
+    let fork_head_sha = fork
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Fetch fork commits into upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Simulate squash merge in upstream (using raw git to avoid auto-notes)
+    file.set_contents(lines!["// Original code", "// Added in fork"]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork PR via squash"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI with fork URL
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha,
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    // Should complete without errors, even though fork has no notes
+    let result = ci_context.run().unwrap();
+    assert!(
+        matches!(result, CiRunResult::NoAuthorshipAvailable),
+        "Expected NoAuthorshipAvailable for fork with no git-ai notes, got {:?}",
+        result
+    );
+}
+
+/// Test that non-fork PRs (fork_clone_url = None) still work as before.
+/// Merge commits without fork_clone_url should still be skipped.
+#[test]
+fn test_ci_non_fork_merge_commit_still_skipped() {
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create feature branch (same repo, not a fork)
+    upstream.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = upstream.filename("feature.js");
+    feature_file.set_contents(lines![
+        "// Original code",
+        "// Feature addition".ai(),
+        "function feature() {}".ai()
+    ]);
+    let feature_commit = upstream.stage_all_and_commit("Add feature").unwrap();
+    let feature_sha = feature_commit.commit_sha.clone();
+
+    // Merge with --no-ff to create merge commit
+    upstream.git(&["checkout", "main"]).unwrap();
+    upstream
+        .git_og(&["merge", "--no-ff", "feature", "-m", "Merge feature"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha,
+            head_ref: "feature".to_string(),
+            head_sha: feature_sha,
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: None, // Not a fork
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // Should still be SkippedSimpleMerge for non-fork merge commits
+    assert!(
+        matches!(result, CiRunResult::SkippedSimpleMerge),
+        "Expected SkippedSimpleMerge for non-fork merge commit, got {:?}",
+        result
+    );
+}
+
+/// Test squash merge from fork with multiple commits containing AI code.
+/// Verify that authorship is rewritten (fork notes are fetched and processed).
+#[test]
+fn test_ci_fork_squash_merge_multiple_commits() {
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("app.js");
+
+    file.set_contents(lines!["// App v1", ""]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create fork with multiple AI commits
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    let mut fork_file = fork.filename("app.js");
+
+    // First commit: AI adds function 1
+    fork_file.insert_at(
+        1,
+        lines!["// AI function 1".ai(), "function ai1() { }".ai()],
+    );
+    fork.stage_all_and_commit("Add AI function 1").unwrap();
+
+    // Second commit: AI adds function 2
+    fork_file.insert_at(
+        3,
+        lines!["// AI function 2".ai(), "function ai2() { }".ai()],
+    );
+    fork.stage_all_and_commit("Add AI function 2").unwrap();
+
+    // Third commit: Human adds function
+    fork_file.insert_at(5, lines!["// Human function", "function human() { }"]);
+    let fork_last_commit = fork.stage_all_and_commit("Add human function").unwrap();
+    let fork_head_sha = fork_last_commit.commit_sha.clone();
+
+    // Fetch fork commits into upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Simulate squash merge in upstream (using raw git to avoid auto-notes)
+    file.set_contents(lines![
+        "// App v1",
+        "// AI function 1",
+        "function ai1() { }",
+        "// AI function 2",
+        "function ai2() { }",
+        "// Human function",
+        "function human() { }"
+    ]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork multi-commit PR (#2)"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI with fork URL
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha,
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // Verify fork notes were fetched and authorship was rewritten
+    assert!(
+        matches!(result, CiRunResult::AuthorshipRewritten { .. }),
+        "Expected AuthorshipRewritten for multi-commit fork squash merge, got {:?}",
+        result
+    );
+
+    // Verify authorship log exists on the merge commit
+    let upstream_repo2 =
+        GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+            .expect("Failed to find upstream repository");
+    let authorship_log = get_reference_as_authorship_log_v3(&upstream_repo2, &merge_sha);
+    assert!(
+        authorship_log.is_ok(),
+        "Squash commit should have authorship log from fork notes"
+    );
+    let log = authorship_log.unwrap();
+    assert!(
+        !log.attestations.is_empty(),
+        "Authorship log should have attestations from fork's AI code"
+    );
+}

--- a/tests/ci_handlers_comprehensive.rs
+++ b/tests/ci_handlers_comprehensive.rs
@@ -76,6 +76,7 @@ fn test_ci_event_merge_structure() {
         head_sha: "def456".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi789".to_string(),
+        fork_clone_url: Some("https://example.com/fork.git".to_string()),
     };
 
     match event {
@@ -85,12 +86,17 @@ fn test_ci_event_merge_structure() {
             head_sha,
             base_ref,
             base_sha,
+            fork_clone_url,
         } => {
             assert_eq!(merge_commit_sha, "abc123");
             assert_eq!(head_ref, "feature");
             assert_eq!(head_sha, "def456");
             assert_eq!(base_ref, "main");
             assert_eq!(base_sha, "ghi789");
+            assert_eq!(
+                fork_clone_url,
+                Some("https://example.com/fork.git".to_string())
+            );
         }
     }
 }
@@ -329,6 +335,7 @@ fn test_ci_context_with_temp_dir() {
         head_sha: sha.clone(),
         base_ref: "main".to_string(),
         base_sha: sha.clone(),
+        fork_clone_url: None,
     };
 
     let ctx = CiContext {


### PR DESCRIPTION
Fixes: https://github.com/git-ai-project/git-ai/issues/411

## Summary

- Adds fork-aware notes handling in CI merge flows so AI authorship from forked PRs/MRs is preserved.
- Detects fork source repos in both GitHub and GitLab CI contexts, fetches refs/notes/ai from the fork, and merges/copies notes locally before attribution processing.
- Extends git-ai ci local merge with --fork-clone-url and adds integration coverage in tests/ci_fork_notes.rs for fork-notes and no-notes scenarios.

## Why

Fork merges (especially merge-commit paths) can miss authorship notes if only the base remote is checked; this ensures attribution survives common fork workflows without failing when fork notes are absent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
