### PR TITLE
fix: show working log output in production mode when --show-working-log flag is provided

### DIFF
--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -315,10 +315,7 @@ pub fn run(
                 for entry in &checkpoint.entries {
                     eprintln!("    File: {}", entry.file);
                     eprintln!("    Blob SHA: {}", entry.blob_sha);
-                    eprintln!(
-                        "    Line Attributions: {:?}",
-                        entry.line_attributions
-                    );
+                    eprintln!("    Line Attributions: {:?}", entry.line_attributions);
                     eprintln!("    Attributions: {:?}", entry.attributions);
                 }
                 eprintln!();


### PR DESCRIPTION
## Summary

`git-ai checkpoint --show-working-log` produced no output in production mode because all output in the `show_working_log` block used `debug_log()`, which only prints when `GIT_AI_DEBUG=1` is set. Replaced with `eprintln!()` so the working log is always displayed when the flag is explicitly provided.

Fixes #96

## Review & Testing Checklist for Human
- [ ] Note that `debug_log` prefixes output with a colored `[git-ai]` tag — the new `eprintln!` calls do not. Confirm this is acceptable or if a prefix should be added for consistency.
- [ ] Test `git-ai checkpoint --show-working-log` in a repo with existing checkpoints (without `GIT_AI_DEBUG=1`) and verify output appears on stderr.

### Notes
- All existing tests pass `show_working_log: false`, so this code path has no automated test coverage.
- [Link to Devin run](https://app.devin.ai/sessions/0433482eb1394f44938dee868f7c2c56)
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
