### PR TITLE
Fix flaky prompt_picker_test race conditions in parallel test execution

### DIFF
--- a/tests/prompt_picker_test.rs
+++ b/tests/prompt_picker_test.rs
@@ -25,7 +25,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static TEST_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn unique_id(base: &str) -> String {
-    format!("{}-{}", base, TEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
+    format!(
+        "{}-{}",
+        base,
+        TEST_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 /// Helper to create a test PromptDbRecord
@@ -68,9 +72,7 @@ fn create_test_prompt(
 /// Helper to populate internal database with test prompts
 fn populate_test_database(_repo: &TestRepo, prompts: Vec<PromptDbRecord>) {
     let db = InternalDatabase::global().expect("Failed to get global database");
-    let mut db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     for prompt in prompts {
         db_guard
@@ -458,9 +460,7 @@ fn test_database_list_prompts_no_filter() {
 
     // List all prompts
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     let results = db_guard.list_prompts(None, None, 10, 0).unwrap();
 
     assert!(results.len() >= 2, "Should have at least 2 prompts");
@@ -503,9 +503,7 @@ fn test_database_list_prompts_with_workdir_filter() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
     let results = db_guard.list_prompts(Some(&workdir), None, 10, 0).unwrap();
 
     assert!(
@@ -549,9 +547,7 @@ fn test_database_list_prompts_pagination() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     // First page: limit 2, offset 0
     let page1 = db_guard.list_prompts(None, None, 2, 0).unwrap();
@@ -610,9 +606,7 @@ fn test_database_search_prompts_finds_matches() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     // Search for "authentication" scoped to this test's workdir
     let results = db_guard
@@ -650,9 +644,7 @@ fn test_database_search_prompts_case_insensitive() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     // Search with lowercase scoped to this test's workdir
     let results = db_guard
@@ -688,9 +680,7 @@ fn test_database_search_prompts_no_matches() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     let results = db_guard
         .search_prompts("nonexistent_term_xyz", Some(&workdir), 10, 0)
@@ -734,9 +724,7 @@ fn test_database_search_prompts_with_workdir_filter() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     let results = db_guard
         .search_prompts("Fix bug", Some(&workdir), 10, 0)
@@ -780,9 +768,7 @@ fn test_database_search_prompts_pagination() {
     populate_test_database(&repo, prompts);
 
     let db = InternalDatabase::global().unwrap();
-    let db_guard = db
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let db_guard = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
 
     // First page scoped to this test's workdir
     let page1 = db_guard


### PR DESCRIPTION
# Fix flaky prompt_picker_test race conditions in parallel execution

## Summary

Six tests in `prompt_picker_test.rs` were failing intermittently in CI due to race conditions when Rust runs tests in parallel. All database tests share a single `InternalDatabase` singleton (via `OnceLock<Mutex<...>>`), causing two problems:

1. **Primary key collisions**: Tests used hardcoded IDs like `"prompt1"`, `"prompt2"`. The `upsert_prompt` `ON CONFLICT DO UPDATE` clause would silently overwrite one test's data with another's (e.g., changing the `workdir`), causing assertions to fail.
2. **Unscoped searches**: `search_prompts` calls without a workdir filter could return results from concurrent tests. For example, searching `"authentication"` could match another test's `"AUTHENTICATION"` prompt, and the case-sensitive Rust `.contains()` assertion would fail.
3. **PoisonError cascade**: When a test panicked while holding the `MutexGuard`, the mutex was poisoned, causing all subsequent tests to fail with `PoisonError`.

**Fixes applied:**
- Atomic counter (`TEST_ID_COUNTER`) generates unique prompt IDs per test invocation
- `search_prompts` calls now scoped by each test's unique workdir (from `TestRepo` temp directory)
- Mutex locks use `unwrap_or_else(|e| e.into_inner())` to recover from poisoned state

Verified with 10/10 consecutive local passes (previously failing ~1-2/10). All 15 CI checks now passing.

## Review & Testing Checklist for Human

- [ ] The poisoned mutex recovery (`unwrap_or_else(|poisoned| poisoned.into_inner())`) intentionally swallows prior panics — verify this doesn't mask real database corruption across tests. If a test panics mid-write, the next test proceeds with whatever partial state was left behind.
- [ ] `test_database_list_prompts_no_filter` and `test_database_list_prompts_pagination` still query with `None` workdir — their loose assertions (`>= 2`, `<= 2`) could still be affected by cross-test data accumulation in edge cases
- [ ] `test_database_search_prompts_no_matches` now scopes by workdir, changing semantics from "no global matches" to "no matches in this workdir" — confirm this is acceptable
- [ ] Recommended test plan: run `cargo test` in a loop locally (e.g. `for i in $(seq 1 20); do cargo test || break; done`) to gain confidence in the fix under contention

### Notes
- Link to Devin run: https://app.devin.ai/sessions/5c559e2b2e454d9887acaa3c5a2da1f9
- Requested by: @svarlamov
- Reference failing CI run: https://github.com/git-ai-project/git-ai/actions/runs/22126553530/job/63957675865