### PR TITLE
Don't write agent metrics in test runner mode

### DIFF
--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -85,6 +85,7 @@ fn build_checkpoint_attrs(
 }
 
 /// Persistent local rate limit keyed by prompt ID hash.
+#[cfg(not(any(test, feature = "test-support")))]
 fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
     let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
     let now_ts = SystemTime::now()
@@ -102,6 +103,12 @@ fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
     db_lock
         .should_emit_agent_usage(&prompt_id, now_ts, AGENT_USAGE_MIN_INTERVAL_SECS)
         .unwrap_or(true)
+}
+
+/// Always returns false in test mode — no metrics DB access needed.
+#[cfg(any(test, feature = "test-support"))]
+fn should_emit_agent_usage(_agent_id: &AgentId) -> bool {
+    false
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/commands/flush_metrics_db.rs
+++ b/src/commands/flush_metrics_db.rs
@@ -10,7 +10,7 @@ use crate::metrics::{MetricEvent, MetricsBatch};
 const MAX_BATCH_SIZE: usize = 250;
 
 /// Spawn a background process to flush metrics DB
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "test-support")))]
 pub fn spawn_background_metrics_db_flush() {
     use std::process::Command;
 
@@ -24,7 +24,7 @@ pub fn spawn_background_metrics_db_flush() {
 }
 
 /// No-op in test mode.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub fn spawn_background_metrics_db_flush() {}
 
 /// Handle the flush-metrics-db command

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -233,11 +233,13 @@ fn should_spawn_background_flush() -> bool {
 /// Events are batched into envelopes of up to 250 events each.
 /// The flush-logs command will then upload them to the API or
 /// store them in SQLite for later upload.
-pub fn log_metrics(#[cfg_attr(test, allow(unused))] events: Vec<MetricEvent>) {
-    #[cfg(test)]
+pub fn log_metrics(
+    #[cfg_attr(any(test, feature = "test-support"), allow(unused))] events: Vec<MetricEvent>,
+) {
+    #[cfg(any(test, feature = "test-support"))]
     return;
 
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-support")))]
     {
         if events.is_empty() {
             return;


### PR DESCRIPTION
Some OSS contributors were reporting their top AI model was Mock Ai - a clue that their test runs locally were being logged to their personal dashboards. 

This PR disabled saving events to the metrics DB when cfg test 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
