### PR TITLE
feat: emit agent usage metrics even when not in a git repo

### DIFF
--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -86,7 +86,7 @@ fn build_checkpoint_attrs(
 
 /// Persistent local rate limit keyed by prompt ID hash.
 #[cfg(not(any(test, feature = "test-support")))]
-fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
+pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
     let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
     let now_ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -107,7 +107,7 @@ fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
 
 /// Always returns false in test mode — no metrics DB access needed.
 #[cfg(any(test, feature = "test-support"))]
-fn should_emit_agent_usage(_agent_id: &AgentId) -> bool {
+pub(crate) fn should_emit_agent_usage(_agent_id: &AgentId) -> bool {
     false
 }
 


### PR DESCRIPTION
# feat: emit agent usage metrics even when not in a git repo

## Summary

When `git-ai checkpoint <agent>` is invoked outside a git repository, the process previously exited early without recording any metrics. This PR ensures the `AgentUsage` metric event is still emitted at the two no-repo exit paths in `handle_checkpoint`:

1. Multi-repo file detection finds no repositories for the edited files
2. No edited files provided and working directory is not a git repo

A new `emit_no_repo_agent_metrics` helper in `git_ai_handlers.rs` builds `EventAttributes` with the available agent info (tool, model, prompt_id) but without repo-specific fields (repo_url, branch, base_commit_sha), records the `AgentUsage` event, and triggers a background flush.

`should_emit_agent_usage` in `checkpoint.rs` was changed from private to `pub(crate)` so the rate-limiting logic can be reused.

## Review & Testing Checklist for Human

- [ ] **Verify `spawn_background_flush` vs `process::exit(0)` timing**: The metric is written synchronously to the local log file via `record()`, but `spawn_background_flush()` is called right before `std::process::exit(0)`. Confirm the background flush either completes or that the local log file will be picked up on the next flush cycle — otherwise the metric may never reach the server.
- [ ] **Confirm only `AgentUsage` is needed (not per-file `Checkpoint` events)**: This PR does not emit `Checkpoint` (event ID 4) events in the no-repo path since per-file line stats can't be computed without a repository. Verify this matches the intended requirement.
- [ ] **Nullable attrs on server side**: The `AgentUsage` events emitted here will lack `repo_url`, `branch`, and `base_commit_sha`. Confirm the metrics ingestion server handles these as nullable without errors.
- [ ] **Test manually**: Run `git-ai checkpoint claude --hook-input '<valid_json>'` from a non-git directory and verify an `AgentUsage` event appears in the local observability log.

### Notes
- [Link to Devin run](https://app.devin.ai/sessions/36b7734359144ea492b0a6d50ae45235)
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
