### PR TITLE
test: reuse existing tests in worktree mode

### DIFF
--- a/tests/cherry_pick.rs
+++ b/tests/cherry_pick.rs
@@ -571,3 +571,16 @@ fn test_cherry_pick_empty_commits() {
         "File content should be preserved after cherry-pick/abort"
     );
 }
+
+reuse_tests_in_worktree!(
+    test_single_commit_cherry_pick,
+    test_cherry_pick_preserves_human_only_commit_note_metadata,
+    test_cherry_pick_preserves_prompt_only_commit_note_metadata,
+    test_multiple_commits_cherry_pick,
+    test_cherry_pick_with_conflict_and_continue,
+    test_cherry_pick_abort,
+    test_cherry_pick_no_ai_authorship,
+    test_cherry_pick_multiple_ai_sessions,
+    test_cherry_pick_identical_trees,
+    test_cherry_pick_empty_commits,
+);

--- a/tests/repos/mod.rs
+++ b/tests/repos/mod.rs
@@ -323,3 +323,21 @@ macro_rules! worktree_test_wrappers {
         }
     };
 }
+
+#[macro_export]
+macro_rules! reuse_tests_in_worktree {
+    (
+        $( $test_name:ident ),+ $(,)?
+    ) => {
+        paste::paste! {
+            $(
+                #[test]
+                fn [<$test_name _in_worktree>]() {
+                    $crate::repos::test_repo::with_worktree_mode(|| {
+                        $test_name();
+                    })
+                }
+            )+
+        }
+    };
+}

--- a/tests/simple_additions.rs
+++ b/tests/simple_additions.rs
@@ -1271,3 +1271,16 @@ fn test_ai_edits_file_with_spaces_in_filename() {
         "Line 3".human(),
     ]);
 }
+
+reuse_tests_in_worktree!(
+    test_simple_additions_empty_repo,
+    test_simple_additions_with_base_commit,
+    test_simple_additions_on_top_of_ai_contributions,
+    test_simple_additions_new_file_not_git_added,
+    test_ai_human_interleaved_line_attribution,
+    test_simple_ai_then_human_deletion,
+    test_multiple_ai_checkpoints_with_human_deletions,
+    test_complex_mixed_additions_and_deletions,
+    test_partial_staging_filters_unstaged_lines,
+    test_human_stages_some_ai_lines,
+);

--- a/tests/stash_attribution.rs
+++ b/tests/stash_attribution.rs
@@ -997,3 +997,24 @@ fn test_stash_apply_reset_apply_again() {
         "Expected AI prompts in authorship log after multiple apply/reset cycles"
     );
 }
+
+reuse_tests_in_worktree!(
+    test_stash_pop_with_ai_attribution,
+    test_stash_apply_with_ai_attribution,
+    test_stash_apply_named_reference,
+    test_stash_pop_with_existing_stack_entries,
+    test_stash_multiple_files,
+    test_stash_with_existing_initial_attributions,
+    test_stash_pop_default_reference,
+    test_stash_pop_empty_repo,
+    test_stash_mixed_human_and_ai,
+    test_stash_push_with_pathspec_single_file,
+    test_stash_push_with_pathspec_directory,
+    test_stash_push_multiple_pathspecs,
+    test_stash_pop_with_conflict,
+    test_stash_mixed_staged_and_unstaged,
+    test_stash_pop_onto_head_with_ai_changes,
+    test_stash_pop_across_branches,
+    test_stash_pop_across_branches_with_conflict,
+    test_stash_apply_reset_apply_again,
+);


### PR DESCRIPTION
# test: reuse existing tests in worktree mode

## Summary
This PR adds a lightweight way to re-run existing integration tests against a linked git worktree without rewriting the test bodies.

Key pieces:
- Adds `with_worktree_mode(...)` + a thread-local `WORKTREE_MODE` flag in the `TestRepo` harness. When enabled, `TestRepo::new()` transparently returns a worktree-backed repo, and `insta` snapshots get a `worktree` suffix.  
- Implements a worktree-backed `TestRepo::new_worktree_variant()` that:
  - creates a base repo
  - ensures there’s at least one commit (worktree requirement)
  - moves the base repo off `main` so a worktree can check out `main`
  - creates a linked worktree and returns a `TestRepo` pointing to it
  - cleans up both base+worktree paths on drop
- Adds `reuse_tests_in_worktree!(...)` macro to generate a second `#[test]` that calls the original test function inside `with_worktree_mode`.
- Demonstrates usage by reusing tests in:
  - `tests/cherry_pick.rs` (all tests)
  - `tests/stash_attribution.rs` (all tests)
  - `tests/simple_additions.rs` (subset of 10 tests)

Stacked on: `codex/worktree-support-complete` (PR #582).

## Review & Testing Checklist for Human
- [ ] Sanity-check `TestRepo::new_worktree_variant()` semantics: base branch switching + worktree checkout on `main` is correct for all modes, and doesn’t break tests that assume current branch is `main`.
- [ ] Review cleanup logic in `Drop` for worktree-backed repos (base/worktree deletion + `git worktree remove --force`): ensure it can’t delete an unintended directory and behaves well on CI.
- [ ] Confirm the macro-generated test naming (`<original>_in_worktree`) won’t collide with existing tests in the crate(s) you plan to apply it to.
- [ ] Consider CI/runtime impact: this duplicates selected tests; verify overall test runtime is still acceptable.
- [ ] Run a representative local subset (or in CI) to confirm the reused tests actually exercise worktree paths (i.e., `TestRepo::new()` is being hit) and don’t silently fall back to non-worktree flows.

### Notes
- Devin run: https://app.devin.ai/sessions/1044345a7d8a4379a2940713b5c02133  
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
