### PR TITLE
fix: handle UTF-8 BOM in Cursor hook input

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -294,7 +294,7 @@ fn handle_checkpoint(args: &[String]) {
             }
             "--hook-input" => {
                 if i + 1 < args.len() {
-                    hook_input = Some(args[i + 1].clone());
+                    hook_input = Some(strip_utf8_bom(args[i + 1].clone()));
                     if hook_input.as_ref().unwrap() == "stdin" {
                         let mut stdin = std::io::stdin();
                         let mut buffer = String::new();
@@ -303,7 +303,7 @@ fn handle_checkpoint(args: &[String]) {
                             std::process::exit(0);
                         }
                         if !buffer.trim().is_empty() {
-                            hook_input = Some(buffer);
+                            hook_input = Some(strip_utf8_bom(buffer));
                         } else {
                             eprintln!("No hook input provided (via --hook-input or stdin).");
                             std::process::exit(0);
@@ -931,6 +931,14 @@ fn handle_checkpoint(args: &[String]) {
 
     if local_checkpoint_failed {
         std::process::exit(0);
+    }
+}
+
+fn strip_utf8_bom(input: String) -> String {
+    if let Some(stripped) = input.strip_prefix('\u{feff}') {
+        stripped.to_string()
+    } else {
+        input
     }
 }
 

--- a/tests/cursor.rs
+++ b/tests/cursor.rs
@@ -325,6 +325,32 @@ fn test_cursor_preset_human_checkpoint_no_filepath() {
 }
 
 #[test]
+fn test_cursor_checkpoint_stdin_with_utf8_bom() {
+    let repo = TestRepo::new();
+    let hook_input = format!(
+        "\u{feff}{}",
+        serde_json::json!({
+            "conversation_id": "test-conversation-id",
+            "workspace_roots": [repo.canonical_path().to_string_lossy().to_string()],
+            "hook_event_name": "beforeSubmitPrompt",
+            "model": "model-name-from-hook-test"
+        })
+    );
+
+    let output = repo
+        .git_ai_with_stdin(
+            &["checkpoint", "cursor", "--hook-input", "stdin"],
+            hook_input.as_bytes(),
+        )
+        .expect("checkpoint should parse stdin payload with UTF-8 BOM");
+
+    assert!(
+        !output.contains("Invalid JSON in hook_input"),
+        "Should not fail JSON parsing when stdin has UTF-8 BOM. Output: {output}"
+    );
+}
+
+#[test]
 fn test_cursor_e2e_with_attribution() {
     use std::fs;
 


### PR DESCRIPTION
## Summary
- strip a leading UTF-8 BOM from `--hook-input` values before preset parsing
- apply BOM stripping to both direct `--hook-input <json>` and `--hook-input stdin` paths
- add a Cursor regression test covering BOM-prefixed stdin hook payloads

## Testing
- cargo test --test cursor test_cursor_checkpoint_stdin_with_utf8_bom -- --nocapture

Refs #604

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
