### PR TITLE
Remove hardcoded host to allow host agnostic Authenticated URL

### DIFF
--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -68,9 +68,11 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     // Authenticate the clone URL with GITHUB_TOKEN if available
     let authenticated_url = if let Ok(token) = std::env::var("GITHUB_TOKEN") {
         // Replace https://github.com/ with https://x-access-token:TOKEN@github.com/
-        clone_url.replace(
-            "https://github.com/",
-            &format!("https://x-access-token:{}@github.com/", token),
+        // Supports both public and enterprise github instances.
+        format!(
+            "https://x-access-token:{}@{}",
+            token,
+            clone_url.strip_prefix("https://").unwrap_or(&clone_url)
         )
     } else {
         clone_url


### PR DESCRIPTION
## Summary
- This change fixes [Issue 594](https://github.com/git-ai-project/git-ai/issues/594)
- Removes the hardcoded github.com and introduces a generic way to form authenticated url.
- Works for both github.com and any enterprise github instances.

## Validation
- cargo fmt

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
