### PR TITLE
ci: bump flake.nix version alongside Cargo.toml in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,6 +455,10 @@ jobs:
           sed -i.bak "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" Cargo.toml
           rm Cargo.toml.bak
           
+          # Update flake.nix version to match
+          sed -i.bak "s/version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" flake.nix
+          rm flake.nix.bak
+          
           # Update Cargo.lock
           cargo check
           
@@ -465,7 +469,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock
+          git add Cargo.toml Cargo.lock flake.nix
           git commit -m "chore: bump version to ${{ steps.bump-version.outputs.new_version }} [skip ci]"
           git push origin main
 


### PR DESCRIPTION
## Summary

Updates the CI release workflow's post-release version bump step to also update the `version` field in `flake.nix`, keeping it in sync with `Cargo.toml`. Previously this was done manually (see [09693c9](https://github.com/git-ai-project/git-ai/commit/09693c997115a1fdb3c7ac48177d196562b08e48)).

Changes:
- Added a `sed` replacement for the version string in `flake.nix` during the patch bump step
- Added `flake.nix` to the `git add` in the commit step

## Review & Testing Checklist for Human

- [ ] Verify the `sed` pattern for `flake.nix` is specific enough — it matches `version = "X.Y.Z"` without a `^` anchor (correct, since the line is indented in flake.nix), but confirm there are no other lines in `flake.nix` that could inadvertently match `version = "<current_cargo_version>"`
- [ ] Confirm on next production release that the automated commit updates all three files (`Cargo.toml`, `Cargo.lock`, `flake.nix`) correctly

### Notes
- This change only affects the production release path (`inputs.release_production == true`), so it cannot be validated without triggering an actual release or manually running the workflow
- Link to Devin session: https://app.devin.ai/sessions/2ab034463a8e4f83af5b5a9b260ecb7b
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
