### PR TITLE
fix: use OnceLock instead of OnceCell for Repository thread safety

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1182,7 +1182,7 @@ pub struct Repository {
     /// On Windows, this uses the \\?\ UNC prefix format
     canonical_workdir: PathBuf,
     /// Cached git author identity resolved via `git var GIT_COMMITTER_IDENT`.
-    cached_author_identity: std::cell::OnceCell<GitAuthorIdentity>,
+    cached_author_identity: std::sync::OnceLock<GitAuthorIdentity>,
 }
 
 impl Repository {
@@ -2498,7 +2498,7 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
         pre_reset_target_commit: None,
         workdir,
         canonical_workdir,
-        cached_author_identity: std::cell::OnceCell::new(),
+        cached_author_identity: std::sync::OnceLock::new(),
     })
 }
 
@@ -2587,7 +2587,7 @@ pub fn from_bare_repository(git_dir: &Path) -> Result<Repository, GitAiError> {
         pre_reset_target_commit: None,
         workdir,
         canonical_workdir,
-        cached_author_identity: std::cell::OnceCell::new(),
+        cached_author_identity: std::sync::OnceLock::new(),
     })
 }
 


### PR DESCRIPTION
## Summary

Replaces `std::cell::OnceCell` with `std::sync::OnceLock` for the `cached_author_identity` field on `Repository`. `OnceCell` is `!Sync`, which makes `Repository` `!Send` across `.await` points — breaking downstream consumers (monorepo) that pass `&Repository` into `tokio::spawn` blocks after bumping to v1.1.9.

`OnceLock` has an identical `get_or_init` API and is `Send + Sync`.

## Review & Testing Checklist for Human

- [ ] Verify that the `authorship_log: std::cell::OnceCell` field on the `Commit` struct (line ~631) doesn't also need this fix — it's a different struct and isn't currently causing issues, but could bite if `Commit` is ever shared across threads
- [ ] Confirm existing tests pass (no new tests needed — this is a transparent stdlib type swap)

### Notes
- [Devin Session](https://app.devin.ai/sessions/aa2469dc6aa44a36b9177a92a9ba3a9f)
- Requested by @svarlamov
- This fix unblocks bumping git-ai in the monorepo to pick up the agent detection module from PR #631
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
