### PR TITLE
feat: add drizzle migration meta pattern to default ignores

### DIFF
--- a/src/authorship/ignore.rs
+++ b/src/authorship/ignore.rs
@@ -24,6 +24,7 @@ const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
     "**/__snapshots__/**",
     "**/*.snap",
     "**/*.snap.new",
+    "**/drizzle/meta/**",
 ];
 
 #[derive(Clone, Debug)]
@@ -318,6 +319,30 @@ mod tests {
         assert!(defaults.contains(&"**/*.snap".to_string()));
         assert!(defaults.contains(&"Cargo.lock".to_string()));
         assert!(defaults.contains(&"*.generated.*".to_string()));
+    }
+
+    #[test]
+    fn defaults_ignore_drizzle_meta_files() {
+        let defaults = default_ignore_patterns();
+        let matcher = build_ignore_matcher(&defaults);
+
+        assert!(should_ignore_file_with_matcher(
+            "web/drizzle/meta/_journal.json",
+            &matcher
+        ));
+        assert!(should_ignore_file_with_matcher(
+            "web/drizzle/meta/0001_snapshot.json",
+            &matcher
+        ));
+        assert!(should_ignore_file_with_matcher(
+            "drizzle/meta/0032_snapshot.json",
+            &matcher
+        ));
+        // Should not ignore non-meta drizzle files
+        assert!(!should_ignore_file_with_matcher(
+            "drizzle/0001_initial.sql",
+            &matcher
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `**/drizzle/meta/**` to `DEFAULT_IGNORE_PATTERNS` in `src/authorship/ignore.rs` so that Drizzle ORM migration metadata files (snapshot JSON files, `_journal.json`) are excluded from authorship analysis by default.

Includes a unit test verifying the pattern matches nested paths (e.g. `web/drizzle/meta/0001_snapshot.json`) while not matching non-meta drizzle files (e.g. `drizzle/0001_initial.sql`).

The monorepo's worker delegates to `git_ai::authorship::ignore::default_ignore_patterns()`, so it will inherit this change automatically on the next dependency update.

## Review & Testing Checklist for Human
- [ ] Confirm the glob `**/drizzle/meta/**` matches your expected drizzle meta file paths and doesn't over-match other files you care about
- [ ] Verify the monorepo picks up the new default after bumping the `git-ai` dependency

### Notes
- [Devin Session](https://app.devin.ai/sessions/0747fe6aab534eb1a35548c4e94a2993)
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
