### PR TITLE
Fix xdg-open error spam during login on headless Linux

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -107,15 +107,10 @@ fn open_browser(url: &str) -> Result<(), String> {
         cmd
     };
 
-    let status = cmd
-        .stdout(std::process::Stdio::null())
+    cmd.stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .status()
+        .spawn()
         .map_err(|e| e.to_string())?;
 
-    if status.success() {
-        Ok(())
-    } else {
-        Err("browser command failed".to_string())
-    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Suppress stdout/stderr from the browser-open command during `git-ai login` so `xdg-open` errors don't spam the terminal on headless Linux environments
- Refactor platform-specific command construction into shared `let mut cmd` blocks, then apply `Stdio::null()` redirects before spawning
- Keep `.spawn()` (non-blocking, fire-and-forget) so the login/token-polling flow is never stalled by a slow or hanging browser command

## Updates since last revision
- Reverted from `.status()` back to `.spawn()` to address [Devin Review feedback](https://github.com/git-ai-project/git-ai/pull/641#discussion_r2893320640): `.status()` blocks until the process exits, which can stall the login flow and cause the device authorization code to expire before token polling begins. The `Stdio::null()` redirects are kept to suppress error output.

## Review & Testing Checklist for Human
- [ ] Run `git-ai login` on a headless Linux environment (e.g. Docker/sandbox) and confirm no `xdg-open` error output appears in the terminal
- [ ] Run `git-ai login` on macOS/Linux with a desktop and confirm the browser still opens normally and login completes without delay
- [ ] Verify the "(Could not open browser automatically)" message appears when the browser command is not found (e.g. `xdg-open` not installed)

### Notes
- The fallback message at line 47 only triggers when `.spawn()` itself fails (command not found), not when the browser command exits with an error code. This matches the original pre-PR behavior.
- 🤖 Generated with [Claude Code](https://claude.com/claude-code)

Link to Devin session: https://app.devin.ai/sessions/a17b93339b0b4c55b240c81e9bdb4886
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
