### PR TITLE
fix: use ~/.git-ai/tmp/ for install script instead of /tmp

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -442,8 +442,13 @@ fn run_install_script(script_content: &str, tag: &str, silent: bool) -> Result<(
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
 
-        // Write script to a temp file
-        let temp_dir = std::env::temp_dir();
+        // Write script to ~/.git-ai/tmp/ to avoid /tmp noexec or permission issues.
+        // Fall back to the system temp dir if the home-based path is unavailable.
+        let temp_dir = crate::config::git_ai_dir_path()
+            .map(|p| p.join("tmp"))
+            .unwrap_or_else(std::env::temp_dir);
+        fs::create_dir_all(&temp_dir)
+            .map_err(|e| format!("Failed to create temp directory: {}", e))?;
         let script_path = temp_dir.join(format!("git-ai-install-{}.sh", std::process::id()));
 
         // Write and make executable


### PR DESCRIPTION
## Problem

The background auto-upgrade silently fails on systems where `/tmp` is mounted with `noexec` or has restricted write permissions (common in corporate/hardened environments).

In `run_install_script` (Unix path), the install script is written to `std::env::temp_dir()` (typically `/tmp`) before execution. If `File::create` fails, the background process exits with code 1 — but since stdout/stderr are suppressed in the background worker, the user sees nothing and stays on the old version indefinitely.

Closes #643

## Fix

Use `~/.git-ai/tmp/` (via `config::git_ai_dir_path()`) as the temp dir for the install script. git-ai already has guaranteed write access to this directory (it stores config, internal state, etc. there). The directory is created if it doesn't exist. Falls back to `std::env::temp_dir()` if the home path is unavailable.

## Changes

- `src/commands/upgrade.rs`: replace `std::env::temp_dir()` with `~/.git-ai/tmp/` for the Unix install script temp path
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
