### PR TITLE
fix: use open_in_memory() for DB init fallback to avoid PermissionDenied panic

### DIFF
--- a/src/authorship/internal_db.rs
+++ b/src/authorship/internal_db.rs
@@ -290,13 +290,14 @@ impl InternalDatabase {
                         &e,
                         Some(serde_json::json!({"function": "InternalDatabase::global"})),
                     );
-                    // Create a dummy connection that will fail on any operation
-                    // This allows the program to continue even if DB init fails
-                    let temp_path = std::env::temp_dir().join("git-ai-db-failed");
-                    let conn = Connection::open(&temp_path).expect("Failed to create temp DB");
+                    // Create a dummy in-memory connection that will fail on any operation
+                    // (no schema). This allows the program to continue even if DB init
+                    // fails, without touching the filesystem (avoids PermissionDenied panic).
+                    let conn = Connection::open_in_memory()
+                        .expect("Failed to create in-memory fallback DB");
                     Mutex::new(InternalDatabase {
                         conn,
-                        _db_path: temp_path,
+                        _db_path: PathBuf::new(),
                     })
                 }
             }

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -52,9 +52,10 @@ impl MetricsDatabase {
                 Ok(db) => Mutex::new(db),
                 Err(e) => {
                     eprintln!("[Error] Failed to initialize metrics database: {}", e);
-                    // Create a dummy connection that will fail on any operation
-                    let temp_path = std::env::temp_dir().join("git-ai-metrics-db-failed");
-                    let conn = Connection::open(&temp_path).expect("Failed to create temp DB");
+                    // Create a dummy in-memory connection that will fail on any operation
+                    // (no schema). Avoids PermissionDenied panic on restricted /tmp.
+                    let conn = Connection::open_in_memory()
+                        .expect("Failed to create in-memory fallback DB");
                     Mutex::new(MetricsDatabase { conn })
                 }
             }


### PR DESCRIPTION
## Problem

On systems where `/tmp` is permission-restricted, `git-ai checkpoint` panics:

```
called `Result::unwrap()` on an `Err` value: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
```

Backtrace:
```
 8: core::result::unwrap_failed
 9: git_ai::commands::git_ai_handlers::handle_checkpoint
10: git_ai::main
```

## Root Cause

When `InternalDatabase::new()` fails (e.g. due to `SQLITE_BUSY` from concurrent processes), both `global()` functions fall back to a dummy connection via `std::env::temp_dir()`. On systems where `/tmp` is `noexec` or permission-restricted, `Connection::open(&temp_path).expect(...)` panics — turning a graceful degradation into a crash.

```rust
// src/authorship/internal_db.rs and src/metrics/db.rs
let temp_path = std::env::temp_dir().join("git-ai-db-failed");
let conn = Connection::open(&temp_path).expect("Failed to create temp DB"); // panics on PermissionDenied
```

Additionally, the fixed path `git-ai-db-failed` is shared across all processes — if multiple processes hit the fallback simultaneously, they contend on the same file, potentially causing the same lock error again.

The comment already describes the intent:
```rust
// Create a dummy connection that will fail on any operation
// This allows the program to continue even if DB init fails
```

## Fix

Replace the fallback with an in-memory connection in both `src/authorship/internal_db.rs` and `src/metrics/db.rs`:

```rust
let conn = Connection::open_in_memory()
    .expect("Failed to create in-memory fallback DB");
Mutex::new(InternalDatabase {
    conn,
    _db_path: PathBuf::new(),
})
```

`open_in_memory()` matches the original intent exactly — all SQL operations still fail (no schema initialized), the program continues without panic, no filesystem dependency, and each process gets its own independent connection.

## Impact

- `git-ai stats` is **not affected** (reads from git notes, not `internal_db`)
- Core AI attribution tracking is **not affected** (DB writes are non-fatal)
- Affected when fallback triggers: `git-ai search`, `git-ai prompts`, `git-ai show-prompt`, `git-ai share` — return errors or empty results (same as before, just without the panic)

Fixes #645
