### PR TITLE
Add patch and multiedit tools to opencode plugin

### DIFF
--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -24,7 +24,7 @@ import { dirname } from "path"
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
 
 // Tools that modify files and should be tracked
-const FILE_EDIT_TOOLS = ["edit", "write"]
+const FILE_EDIT_TOOLS = ["edit", "write", "patch", "multiedit"]
 
 export const GitAiPlugin: Plugin = async (ctx) => {
   const { $ } = ctx


### PR DESCRIPTION
Hi, I found that the Opencode plugin did not detect any of my AI edits with Opencode and I realized that the models I have been using the new patch and multiedit tools often.

This should fix attribution for those tools. Please let me know if there is anything else I should do / if I should create an issue first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
