### PR TITLE
Fix UTF-8 BOM config parsing on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -510,7 +510,8 @@ try {
         $cfg = @{
             git_path = $stdGitPath
         } | ConvertTo-Json -Compress
-        $cfg | Out-File -FilePath $configJsonPath -Encoding UTF8 -Force
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($configJsonPath, $cfg, $utf8NoBom)
     }
 } catch {
     Write-Host "Warning: Failed to write config.json: $($_.Exception.Message)" -ForegroundColor Yellow

--- a/src/config.rs
+++ b/src/config.rs
@@ -732,7 +732,14 @@ fn resolve_git_path(file_cfg: &Option<FileConfig>) -> String {
 fn load_file_config() -> Option<FileConfig> {
     let path = config_file_path()?;
     let data = fs::read(&path).ok()?;
-    serde_json::from_slice::<FileConfig>(&data).ok()
+    parse_file_config_bytes(&data).ok()
+}
+
+fn parse_file_config_bytes(data: &[u8]) -> Result<FileConfig, serde_json::Error> {
+    // Windows PowerShell 5.1 writes UTF-8 with BOM by default for `Out-File -Encoding UTF8`.
+    // Tolerate BOM-prefixed config files so upgrades/installers don't brick config parsing.
+    let data = data.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(data);
+    serde_json::from_slice::<FileConfig>(data)
 }
 
 fn config_file_path() -> Option<PathBuf> {
@@ -824,8 +831,7 @@ pub fn load_file_config_public() -> Result<FileConfig, String> {
 
     let data = fs::read(&path).map_err(|e| format!("Failed to read config file: {}", e))?;
 
-    serde_json::from_slice::<FileConfig>(&data)
-        .map_err(|e| format!("Failed to parse config file: {}", e))
+    parse_file_config_bytes(&data).map_err(|e| format!("Failed to parse config file: {}", e))
 }
 
 /// Save the file config
@@ -1436,5 +1442,25 @@ mod tests {
             ),
         ];
         assert!(!config.is_allowed_repository_with_remotes(Some(&remotes)));
+    }
+
+    #[test]
+    fn test_parse_file_config_bytes_accepts_utf8_bom() {
+        let mut data = vec![0xEF, 0xBB, 0xBF];
+        data.extend_from_slice(br#"{"git_path":"C:\\Program Files\\Git\\cmd\\git.exe"}"#);
+
+        let parsed = parse_file_config_bytes(&data).expect("BOM-prefixed config should parse");
+        assert_eq!(
+            parsed.git_path.as_deref(),
+            Some(r"C:\Program Files\Git\cmd\git.exe")
+        );
+    }
+
+    #[test]
+    fn test_parse_file_config_bytes_without_bom_still_parses() {
+        let data = br#"{"git_path":"/usr/bin/git"}"#;
+
+        let parsed = parse_file_config_bytes(data).expect("regular config should parse");
+        assert_eq!(parsed.git_path.as_deref(), Some("/usr/bin/git"));
     }
 }

--- a/tests/hooks_feature_flags.rs
+++ b/tests/hooks_feature_flags.rs
@@ -475,3 +475,39 @@ fn cli_config_unset_hooks_externally_managed() {
         }
     }
 }
+
+#[test]
+#[serial]
+fn cli_config_set_succeeds_with_utf8_bom_prefixed_config_file() {
+    let _mode = EnvVarGuard::set("GIT_AI_TEST_GIT_MODE", "wrapper");
+    let repo = TestRepo::new();
+
+    let test_home = repo.test_home_path();
+    let config_dir = test_home.join(".git-ai");
+    let config_path = config_dir.join("config.json");
+    fs::create_dir_all(&config_dir).expect("failed to create config directory");
+
+    let mut config_bytes = vec![0xEF, 0xBB, 0xBF];
+    config_bytes.extend_from_slice(br#"{"git_path":"C:\\Program Files\\Git\\cmd\\git.exe"}"#);
+    fs::write(&config_path, config_bytes).expect("failed to write BOM-prefixed config");
+
+    let home = test_home.to_string_lossy().to_string();
+    repo.git_ai_with_env(
+        &["config", "set", "feature_flags.git_hooks_enabled", "true"],
+        &[("HOME", &home), ("USERPROFILE", &home)],
+    )
+    .expect("config set should succeed for BOM-prefixed config");
+
+    let result = repo
+        .git_ai_with_env(
+            &["config", "feature_flags.git_hooks_enabled"],
+            &[("HOME", &home), ("USERPROFILE", &home)],
+        )
+        .expect("config get should succeed for BOM-prefixed config");
+
+    assert!(
+        result.contains("true"),
+        "config get should return true after set, got: {}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary
- tolerate UTF-8 BOM when loading `~/.git-ai/config.json`
- add unit tests for BOM and non-BOM config parsing paths
- add CLI regression test for `git-ai config set` with BOM-prefixed config
- update Windows installer to write `config.json` as UTF-8 without BOM

## Verification
- cargo fmt -- --check
- cargo clippy
- cargo test --lib test_parse_file_config_bytes_accepts_utf8_bom -- --nocapture
- cargo test --lib test_parse_file_config_bytes_without_bom_still_parses -- --nocapture
- cargo test --test hooks_feature_flags cli_config_set_succeeds_with_utf8_bom_prefixed_config_file -- --nocapture
