### PR TITLE
allow nonce to fallback to api-base in config for enterprise

### DIFF
--- a/src/auth/client.rs
+++ b/src/auth/client.rs
@@ -231,6 +231,18 @@ impl OAuthClient {
         self.exchange_token(body)
             .map_err(|e| format!("Nonce exchange failed: {}", e))
     }
+
+    /// Exchange an impersonation nonce for credentials (background agent auth)
+    pub fn exchange_impersonation_nonce(&self, nonce: &str) -> Result<StoredCredentials, String> {
+        let body = serde_json::json!({
+            "grant_type": "impersonation_nonce",
+            "impersonation_nonce": nonce,
+            "client_id": "git-ai-cli"
+        });
+
+        self.exchange_token(body)
+            .map_err(|e| format!("Impersonation nonce exchange failed: {}", e))
+    }
 }
 
 impl Default for OAuthClient {

--- a/src/commands/exchange_nonce.rs
+++ b/src/commands/exchange_nonce.rs
@@ -1,11 +1,13 @@
-//! Exchange install nonce for credentials (auto-login from web install page)
+//! Exchange a nonce for credentials
 //!
-//! This command is called by the install script to exchange a nonce for
-//! OAuth credentials.
+//! Two modes:
+//!   1. Install nonce (default): nonce from INSTALL_NONCE env var
+//!   2. Impersonation nonce:     --impersonation-nonce <NONCE>
 //!
-//! Usage: git-ai exchange-nonce [NONCE]
+//! Usage:
+//!   git-ai exchange-nonce                          # install nonce from env
+//!   git-ai exchange-nonce --impersonation-nonce X  # impersonation nonce
 //!
-//! Nonce can be passed as the first argument or via INSTALL_NONCE env var.
 //! API base is resolved from API_BASE env var, falling back to the
 //! configured api_base_url (config file / GIT_AI_API_BASE_URL / default).
 //!
@@ -16,23 +18,31 @@ use crate::auth::CredentialStore;
 use crate::auth::client::OAuthClient;
 use crate::config;
 
-/// Handle the exchange-nonce command (internal - called by install scripts)
+/// Handle the exchange-nonce command (internal - called by install scripts and background agents)
 ///
 /// Exits with code 1 on failure (silently) so install script can run `git-ai login`.
 /// Exits with code 0 on success.
 pub fn handle_exchange_nonce(args: &[String]) {
-    // Nonce: first arg, or INSTALL_NONCE env var
-    let nonce = args.first().filter(|s| !s.is_empty()).cloned().or_else(|| {
-        std::env::var("INSTALL_NONCE")
-            .ok()
-            .filter(|s| !s.is_empty())
-    });
-
     // API base: API_BASE env var, or config fallback
     let api_base = std::env::var("API_BASE")
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| config::Config::get().api_base_url().to_string());
+
+    // Check for --impersonation-nonce flag
+    let impersonation_nonce = parse_flag(args, "--impersonation-nonce");
+
+    if let Some(nonce) = impersonation_nonce {
+        if exchange_impersonation_nonce(&nonce, &api_base).is_err() {
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    // Install nonce from env only
+    let nonce = std::env::var("INSTALL_NONCE")
+        .ok()
+        .filter(|s| !s.is_empty());
 
     // If no nonce provided, silently exit success (not an error - just means no auto-login)
     let Some(nonce) = nonce else {
@@ -41,22 +51,40 @@ pub fn handle_exchange_nonce(args: &[String]) {
 
     // Perform the exchange - exit with failure code on error (silently)
     // The error is already recorded server-side, so no need to print anything
-    if exchange_nonce(&nonce, &api_base).is_err() {
+    if exchange_install_nonce(&nonce, &api_base).is_err() {
         std::process::exit(1);
     }
 }
 
-fn exchange_nonce(nonce: &str, api_base: &str) -> Result<(), String> {
-    // Create OAuth client with custom base URL
-    let client = OAuthClient::with_base_url(api_base)?;
+/// Parse a --flag value pair from args
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == flag {
+            return iter.next().cloned();
+        }
+    }
+    None
+}
 
-    // Exchange the nonce for credentials
+fn exchange_install_nonce(nonce: &str, api_base: &str) -> Result<(), String> {
+    let client = OAuthClient::with_base_url(api_base)?;
     let credentials = client.exchange_install_nonce(nonce)?;
 
-    // Store credentials
     let store = CredentialStore::new();
     store.store(&credentials)?;
 
     eprintln!("\x1b[32m✓ Logged in automatically\x1b[0m");
+    Ok(())
+}
+
+fn exchange_impersonation_nonce(nonce: &str, api_base: &str) -> Result<(), String> {
+    let client = OAuthClient::with_base_url(api_base)?;
+    let credentials = client.exchange_impersonation_nonce(nonce)?;
+
+    let store = CredentialStore::new();
+    store.store(&credentials)?;
+
+    eprintln!("\x1b[32m✓ Authenticated via impersonation nonce\x1b[0m");
     Ok(())
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
