### PR TITLE
fix: redirect clone hook output to stderr, respect quiet config and allow_repositories

### DIFF
--- a/src/commands/hooks/clone_hooks.rs
+++ b/src/commands/hooks/clone_hooks.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::git::cli_parser::{ParsedGitInvocation, extract_clone_target_directory};
 use crate::git::repository::find_repository_in_path;
 use crate::git::sync_authorship::fetch_authorship_notes;
@@ -25,7 +26,6 @@ pub fn post_clone_hook(parsed_args: &ParsedGitInvocation, exit_status: std::proc
         target_dir
     ));
 
-    print!("Fetching git-ai authorship notes");
     // Open the newly cloned repository
     let repository = match find_repository_in_path(&target_dir) {
         Ok(repo) => repo,
@@ -38,12 +38,34 @@ pub fn post_clone_hook(parsed_args: &ParsedGitInvocation, exit_status: std::proc
         }
     };
 
+    // Check if the newly cloned repository is allowed by allow_repositories config
+    let config = config::Config::get();
+    if !config.is_allowed_repository(&Some(repository.clone())) {
+        debug_log(
+            "Skipping authorship fetch for cloned repository: not in allow_repositories list",
+        );
+        return;
+    }
+
+    // Determine if output should be suppressed: respect quiet config and --quiet/-q git flags
+    let suppress_output = config.is_quiet()
+        || parsed_args.has_command_flag("--quiet")
+        || parsed_args.has_command_flag("-q");
+
+    if !suppress_output {
+        eprint!("Fetching git-ai authorship notes");
+    }
+
     // Fetch authorship notes from origin
     if let Err(e) = fetch_authorship_notes(&repository, "origin") {
         debug_log(&format!("authorship fetch from origin failed: {}", e));
-        println!(", failed.");
+        if !suppress_output {
+            eprintln!(", failed.");
+        }
     } else {
         debug_log("successfully fetched authorship notes from origin");
-        println!(", done.");
+        if !suppress_output {
+            eprintln!(", done.");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #659 — `git-ai` was printing "Fetching git-ai authorship notes" to **stdout** during `git clone`, which pollutes piped output for tools like [antidote](https://github.com/mattmc3/antidote) that capture `git` stdout.

Three changes in `post_clone_hook`:
1. **stdout → stderr**: `print!`/`println!` → `eprint!`/`eprintln!`
2. **Respect quiet mode**: Suppresses output when `quiet: true` is set in config or `--quiet`/`-q` flags are passed to git clone
3. **allow_repositories check**: After the repo is cloned and opened, checks `is_allowed_repository()` and skips the authorship fetch if the repo doesn't match the allowlist

## Review & Testing Checklist for Human

- [ ] **Verify the `allow_repositories` check is reachable**: `handle_git()` already gates `post_clone_hook` behind `!skip_hooks`, which uses `is_allowed_repository(&None)`. When an allowlist is configured and no repo exists yet, this returns `false` and the hook is never called. The new check inside `post_clone_hook` is defense-in-depth but may be unreachable when `allow_repositories` is non-empty. Confirm whether this is the desired layering or if the pre-clone gate in `handle_git` should be adjusted to allow clone through and let `post_clone_hook` decide.
- [ ] **End-to-end test**: Clone a repo with git-ai active and confirm: (a) "Fetching git-ai authorship notes" appears on stderr, not stdout; (b) with `quiet: true` or `--quiet`, no message appears; (c) notes are still fetched correctly.
- [ ] **No new tests**: This PR doesn't add integration tests for the changed behavior. Consider whether a test in the `tests/` harness could exercise clone hooks.

### Notes
- Link to Devin session: https://app.devin.ai/sessions/e713f21d4e41430681bec943e8a21803
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
