### PR TITLE
fix: migrate working log on non-ancestor reset instead of deleting it

### DIFF
--- a/src/commands/hooks/reset_hooks.rs
+++ b/src/commands/hooks/reset_hooks.rs
@@ -199,15 +199,13 @@ fn handle_reset_preserve_working_dir(
     let is_backward = is_ancestor(repository, target_commit_sha, old_head_sha);
 
     if !is_backward {
-        // Forward reset or unrelated history - treat as no-op for authorship
-        // The commits we're "gaining" already have their authorship logs
-        debug_log("Reset forward or to unrelated commit, no reconstruction needed");
-
-        // Still need to delete old working log since the base commit changed
+        // Non-ancestor reset (e.g. branch restacked to a rebased version of the same commit).
+        // The working directory is preserved (--keep/--mixed/--soft), so the checkpoint data
+        // is still valid — just re-key it under the new HEAD.
+        debug_log("Reset to non-ancestor commit, migrating working log");
         let _ = repository
             .storage
-            .delete_working_log_for_base_commit(old_head_sha);
-
+            .rename_working_log(old_head_sha, target_commit_sha);
         return;
     }
 


### PR DESCRIPTION
When `gt sync` restacks a branch via `commit-tree` + `git reset --keep`, the old and new HEADs are different rebases of the same commit (neither is an ancestor of the other). The reset hook was deleting the working log in this case, causing all checkpoint data from before the sync to be lost and resulting in under-reported AI authorship.

Now migrates (renames) the working log to the new HEAD SHA instead, matching the approach used by the switch hook.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
