### PR TITLE
fix: download directly from GitHub in Mac/Linux install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -223,15 +223,15 @@ if [ -n "${GIT_AI_LOCAL_BINARY:-}" ]; then
 elif [ "$PINNED_VERSION" != "__VERSION_PLACEHOLDER__" ]; then
     # Version-pinned install script from a release
     RELEASE_TAG="$PINNED_VERSION"
-    DOWNLOAD_URL="https://usegitai.com/worker/releases/download/${RELEASE_TAG}/${BINARY_NAME}"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${BINARY_NAME}"
 elif [ -n "${GIT_AI_RELEASE_TAG:-}" ] && [ "${GIT_AI_RELEASE_TAG:-}" != "latest" ]; then
     # Environment variable override
     RELEASE_TAG="$GIT_AI_RELEASE_TAG"
-    DOWNLOAD_URL="https://usegitai.com/worker/releases/download/${RELEASE_TAG}/${BINARY_NAME}"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${BINARY_NAME}"
 else
     # Default to latest
     RELEASE_TAG="latest"
-    DOWNLOAD_URL="https://usegitai.com/worker/releases/download/latest/${BINARY_NAME}"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY_NAME}"
 fi
 
 # Install into the user's bin directory ~/.git-ai/bin


### PR DESCRIPTION
## Summary

Companion to #665 — switches the Mac/Linux `install.sh` download URLs from `usegitai.com` to `github.com` directly, so that corporate proxies that block `usegitai.com` but allow `github.com` don't break the installer.

All three download URL branches (pinned version, env var override, latest) are updated. The GitHub URL structure is preserved correctly: `releases/download/{tag}/{binary}` for specific versions, `releases/latest/download/{binary}` for latest.

## Review & Testing Checklist for Human

- [ ] Verify that GitHub release assets are named exactly `git-ai-{os}-{arch}` (e.g. `git-ai-linux-x64`, `git-ai-macos-arm64`) — the script constructs `BINARY_NAME` this way and there's no `.exe` suffix for Unix
- [ ] Test the install script on a fresh machine (or Docker container) to confirm the GitHub download URL resolves and the binary downloads correctly for both `latest` and a pinned version (e.g. `GIT_AI_RELEASE_TAG=v1.1.11`)

### Notes
- Link to Devin session: https://app.devin.ai/sessions/9b204cb9c84a47e392c9c16716247a4f
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
