### PR TITLE
Add tests for custom_attributes preservation in rebase, cherry-pick, amend, squash

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -3380,7 +3380,10 @@ mod tests {
                 accepted_lines: 5,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E100".to_string()),
+                    ("team".to_string(), "test".to_string()),
+                ])),
             },
         );
 
@@ -3569,7 +3572,10 @@ mod tests {
                 accepted_lines: 13,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E200".to_string()),
+                    ("team".to_string(), "platform".to_string()),
+                ])),
             },
         );
         prompts.insert(
@@ -3587,7 +3593,10 @@ mod tests {
                 accepted_lines: 6,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E200".to_string()),
+                    ("team".to_string(), "platform".to_string()),
+                ])),
             },
         );
 
@@ -3694,7 +3703,10 @@ mod tests {
                 accepted_lines: 3,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E300".to_string()),
+                    ("team".to_string(), "infra".to_string()),
+                ])),
             },
         );
 
@@ -3834,7 +3846,10 @@ mod tests {
                 accepted_lines: 4,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E400".to_string()),
+                    ("team".to_string(), "backend".to_string()),
+                ])),
             },
         );
         let old_wl = repo
@@ -3957,7 +3972,10 @@ mod tests {
                 accepted_lines: 8,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E400".to_string()),
+                    ("team".to_string(), "backend".to_string()),
+                ])),
             },
         );
         let v1_wl = repo
@@ -4125,7 +4143,10 @@ mod tests {
                 accepted_lines: 13,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E500".to_string()),
+                    ("team".to_string(), "security".to_string()),
+                ])),
             },
         );
         prompts.insert(
@@ -4143,7 +4164,10 @@ mod tests {
                 accepted_lines: 16,
                 overriden_lines: 0,
                 messages_url: None,
-                custom_attributes: None,
+                custom_attributes: Some(HashMap::from([
+                    ("employee_id".to_string(), "E500".to_string()),
+                    ("team".to_string(), "security".to_string()),
+                ])),
             },
         );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,8 @@ pub struct ConfigPatch {
     pub disable_auto_updates: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_storage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_attributes: Option<HashMap<String, String>>,
 }
 
 impl Config {
@@ -942,6 +944,9 @@ fn apply_test_config_patch(config: &mut Config) {
                     prompt_storage
                 );
             }
+        }
+        if let Some(custom_attributes) = patch.custom_attributes {
+            config.custom_attributes = custom_attributes;
         }
     }
 }

--- a/tests/amend.rs
+++ b/tests/amend.rs
@@ -1,7 +1,30 @@
 #[macro_use]
 mod repos;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::TestRepo;
+use std::collections::HashMap;
+use std::process::Command;
+
+fn read_authorship_note(repo: &TestRepo, commit_sha: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo.path().to_str().unwrap(),
+            "notes",
+            "--ref",
+            "ai",
+            "show",
+            commit_sha,
+        ])
+        .output()
+        .expect("failed to run git notes show");
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        None
+    }
+}
 
 /// Test amending a commit by adding AI-authored lines at the top of the file.
 #[test]
@@ -487,6 +510,74 @@ fn test_amend_repeated_round_trips_preserve_exact_line_authorship() {
         "}".ai(),
         "// Footer".ai(),
         "// AI trailing note".ai()
+    ]);
+}
+
+/// Test that custom attributes set via config are preserved through an amend
+/// when the real post-commit pipeline injects them.
+#[test]
+fn test_amend_preserves_custom_attributes_from_config() {
+    let mut repo = TestRepo::new();
+
+    // Configure custom attributes via config patch
+    let mut attrs = HashMap::new();
+    attrs.insert("employee_id".to_string(), "E202".to_string());
+    attrs.insert("team".to_string(), "security".to_string());
+    repo.patch_git_ai_config(|patch| {
+        patch.custom_attributes = Some(attrs.clone());
+    });
+
+    // Create initial commit with AI content
+    let mut file = repo.filename("code.txt");
+    file.set_contents(lines![
+        "// AI generated code".ai(),
+        "function init() {}".ai()
+    ]);
+    repo.stage_all_and_commit("Initial AI commit").unwrap();
+
+    // Verify custom attributes were set on the original commit
+    let original_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let original_note = read_authorship_note(&repo, &original_sha)
+        .expect("original commit should have authorship note");
+    let original_log =
+        AuthorshipLog::deserialize_from_string(&original_note).expect("parse original note");
+    for (_id, prompt) in &original_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "precondition: original commit should have custom_attributes from config"
+        );
+    }
+
+    // Amend the commit with additional AI lines
+    file.insert_at(2, lines!["// More AI code".ai()]);
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "--amend", "-m", "Initial AI commit (amended)"])
+        .unwrap();
+
+    // Verify custom attributes survived the amend
+    let amended_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let amended_note = read_authorship_note(&repo, &amended_sha)
+        .expect("amended commit should have authorship note");
+    let amended_log =
+        AuthorshipLog::deserialize_from_string(&amended_note).expect("parse amended note");
+    assert!(
+        !amended_log.metadata.prompts.is_empty(),
+        "amended commit should have prompt records"
+    );
+    for (_id, prompt) in &amended_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "custom_attributes should be preserved through amend"
+        );
+    }
+
+    // Also verify the AI attribution itself survived
+    file.assert_lines_and_blame(lines![
+        "// AI generated code".ai(),
+        "function init() {}".ai(),
+        "// More AI code".ai()
     ]);
 }
 

--- a/tests/cherry_pick.rs
+++ b/tests/cherry_pick.rs
@@ -6,6 +6,7 @@ use git_ai::authorship::working_log::AgentId;
 use git_ai::git::refs::notes_add;
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::TestRepo;
+use std::collections::HashMap;
 use std::process::Command;
 
 fn read_authorship_note(repo: &TestRepo, commit_sha: &str) -> Option<String> {
@@ -165,6 +166,11 @@ fn test_cherry_pick_preserves_prompt_only_commit_note_metadata() {
         "precondition: source commit should not have prompts before test mutation"
     );
 
+    let mut test_attrs = HashMap::new();
+    test_attrs.insert("employee_id".to_string(), "E456".to_string());
+    test_attrs.insert("team".to_string(), "backend".to_string());
+    test_attrs.insert("device_id".to_string(), "MAC-002".to_string());
+
     source_log.metadata.prompts.insert(
         "prompt-only-session".to_string(),
         PromptRecord {
@@ -180,7 +186,7 @@ fn test_cherry_pick_preserves_prompt_only_commit_note_metadata() {
             accepted_lines: 0,
             overriden_lines: 0,
             messages_url: None,
-            custom_attributes: None,
+            custom_attributes: Some(test_attrs.clone()),
         },
     );
 
@@ -218,6 +224,11 @@ fn test_cherry_pick_preserves_prompt_only_commit_note_metadata() {
     assert_eq!(prompt.agent_id.model, "test-model");
     assert_eq!(prompt.total_additions, 11);
     assert_eq!(prompt.total_deletions, 2);
+    assert_eq!(
+        prompt.custom_attributes,
+        Some(test_attrs),
+        "custom_attributes should be preserved through cherry-pick"
+    );
 }
 
 /// Test cherry-picking multiple commits in sequence
@@ -571,6 +582,71 @@ fn test_cherry_pick_empty_commits() {
         "Line 1\nFeature line",
         "File content should be preserved after cherry-pick/abort"
     );
+}
+
+/// Test that custom attributes set via config are preserved through a cherry-pick
+/// when the real post-commit pipeline injects them.
+#[test]
+fn test_cherry_pick_preserves_custom_attributes_from_config() {
+    let mut repo = TestRepo::new();
+
+    // Configure custom attributes via config patch
+    let mut attrs = HashMap::new();
+    attrs.insert("employee_id".to_string(), "E101".to_string());
+    attrs.insert("team".to_string(), "frontend".to_string());
+    attrs.insert("device_id".to_string(), "LNX-007".to_string());
+    repo.patch_git_ai_config(|patch| {
+        patch.custom_attributes = Some(attrs.clone());
+    });
+
+    // Create initial commit on default branch
+    let mut file = repo.filename("file.txt");
+    file.set_contents(lines!["Initial content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let main_branch = repo.current_branch();
+
+    // Create feature branch with AI-authored changes
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.insert_at(1, lines!["AI feature line".ai()]);
+    repo.stage_all_and_commit("Add AI feature").unwrap();
+    let feature_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // Verify custom attributes were set on the original commit
+    let original_note = read_authorship_note(&repo, &feature_commit)
+        .expect("original commit should have authorship note");
+    let original_log =
+        AuthorshipLog::deserialize_from_string(&original_note).expect("parse original note");
+    for (_id, prompt) in &original_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "precondition: original commit should have custom_attributes from config"
+        );
+    }
+
+    // Switch back to main and cherry-pick the feature commit
+    repo.git(&["checkout", &main_branch]).unwrap();
+    repo.git(&["cherry-pick", &feature_commit]).unwrap();
+
+    // Verify custom attributes survived the cherry-pick
+    let new_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let new_note = read_authorship_note(&repo, &new_commit)
+        .expect("cherry-picked commit should have authorship note");
+    let new_log = AuthorshipLog::deserialize_from_string(&new_note).expect("parse new note");
+    assert!(
+        !new_log.metadata.prompts.is_empty(),
+        "cherry-picked commit should have prompt records"
+    );
+    for (_id, prompt) in &new_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "custom_attributes should be preserved through cherry-pick"
+        );
+    }
+
+    // Also verify the AI attribution itself survived
+    file.assert_lines_and_blame(lines!["Initial content".human(), "AI feature line".ai()]);
 }
 
 reuse_tests_in_worktree!(

--- a/tests/rebase.rs
+++ b/tests/rebase.rs
@@ -6,6 +6,7 @@ use git_ai::authorship::working_log::AgentId;
 use git_ai::git::refs::notes_add;
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::TestRepo;
+use std::collections::HashMap;
 use std::process::Command;
 
 fn read_authorship_note(repo: &TestRepo, commit_sha: &str) -> Option<String> {
@@ -384,6 +385,10 @@ fn test_rebase_preserves_prompt_only_commit_note_metadata() {
         "precondition: source commit should not have prompts before test mutation"
     );
 
+    let mut test_attrs = HashMap::new();
+    test_attrs.insert("employee_id".to_string(), "E123".to_string());
+    test_attrs.insert("team".to_string(), "platform".to_string());
+
     original_log.metadata.prompts.insert(
         "prompt-only-session".to_string(),
         PromptRecord {
@@ -399,7 +404,7 @@ fn test_rebase_preserves_prompt_only_commit_note_metadata() {
             accepted_lines: 0,
             overriden_lines: 0,
             messages_url: None,
-            custom_attributes: None,
+            custom_attributes: Some(test_attrs.clone()),
         },
     );
 
@@ -432,6 +437,11 @@ fn test_rebase_preserves_prompt_only_commit_note_metadata() {
     assert_eq!(prompt.agent_id.model, "test-model");
     assert_eq!(prompt.total_additions, 17);
     assert_eq!(prompt.total_deletions, 3);
+    assert_eq!(
+        prompt.custom_attributes,
+        Some(test_attrs),
+        "custom_attributes should be preserved through rebase"
+    );
 }
 
 /// Test empty rebase (fast-forward)
@@ -1449,6 +1459,78 @@ cat {} > "$1"
         "// AI feature 3".ai(),
         "function feature3() {}".ai()
     ]);
+}
+
+/// Test that custom attributes set via config are preserved through a rebase
+/// when the real post-commit pipeline injects them.
+#[test]
+fn test_rebase_preserves_custom_attributes_from_config() {
+    let mut repo = TestRepo::new();
+
+    // Configure custom attributes via config patch
+    let mut attrs = HashMap::new();
+    attrs.insert("employee_id".to_string(), "E789".to_string());
+    attrs.insert("team".to_string(), "infra".to_string());
+    repo.patch_git_ai_config(|patch| {
+        patch.custom_attributes = Some(attrs.clone());
+    });
+
+    // Create initial commit on default branch
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let default_branch = repo.current_branch();
+
+    // Create feature branch with AI commit
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.set_contents(lines!["// AI feature code".ai()]);
+    repo.stage_all_and_commit("AI feature").unwrap();
+
+    // Verify custom attributes were set on the original commit
+    let original_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let original_note = read_authorship_note(&repo, &original_sha)
+        .expect("original commit should have authorship note");
+    let original_log =
+        AuthorshipLog::deserialize_from_string(&original_note).expect("parse original note");
+    for (_id, prompt) in &original_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "precondition: original commit should have custom_attributes from config"
+        );
+    }
+
+    // Advance default branch (non-conflicting)
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let mut other_file = repo.filename("other.txt");
+    other_file.set_contents(lines!["other content"]);
+    repo.stage_all_and_commit("Main advances").unwrap();
+
+    // Rebase feature onto default branch
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+
+    // Verify custom attributes survived the rebase
+    let rebased_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let rebased_note = read_authorship_note(&repo, &rebased_sha)
+        .expect("rebased commit should have authorship note");
+    let rebased_log =
+        AuthorshipLog::deserialize_from_string(&rebased_note).expect("parse rebased note");
+    assert!(
+        !rebased_log.metadata.prompts.is_empty(),
+        "rebased commit should have prompt records"
+    );
+    for (_id, prompt) in &rebased_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "custom_attributes should be preserved through rebase"
+        );
+    }
+
+    // Also verify the AI attribution itself survived
+    feature_file.assert_lines_and_blame(lines!["// AI feature code".ai()]);
 }
 
 reuse_tests_in_worktree!(

--- a/tests/repos/test_repo.rs
+++ b/tests/repos/test_repo.rs
@@ -172,6 +172,16 @@ impl TestRepo {
                 serde_json::Value::String(prompt_storage.clone()),
             );
         }
+        if let Some(custom_attributes) = &patch.custom_attributes {
+            let attrs_map: serde_json::Map<String, serde_json::Value> = custom_attributes
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+                .collect();
+            config.insert(
+                "custom_attributes".to_string(),
+                serde_json::Value::Object(attrs_map),
+            );
+        }
 
         let config_dir = self.test_home.join(".git-ai");
         fs::create_dir_all(&config_dir).expect("failed to create test HOME config directory");

--- a/tests/squash_merge.rs
+++ b/tests/squash_merge.rs
@@ -1,8 +1,31 @@
 #[macro_use]
 mod repos;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::TestRepo;
+use std::collections::HashMap;
+use std::process::Command;
 use std::time::Duration;
+
+fn read_authorship_note(repo: &TestRepo, commit_sha: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo.path().to_str().unwrap(),
+            "notes",
+            "--ref",
+            "ai",
+            "show",
+            commit_sha,
+        ])
+        .output()
+        .expect("failed to run git notes show");
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        None
+    }
+}
 
 /// Test merge --squash with a simple feature branch containing AI and human edits
 #[test]
@@ -292,6 +315,84 @@ fn test_prepare_working_log_squash_with_mixed_additions() {
         total_accepted, stats.ai_accepted,
         "Sum of accepted_lines across prompts should match ai_accepted stat"
     );
+}
+
+/// Test that custom attributes set via config are preserved through a squash merge
+/// when the real post-commit pipeline injects them.
+#[test]
+fn test_squash_merge_preserves_custom_attributes_from_config() {
+    let mut repo = TestRepo::new();
+
+    // Configure custom attributes via config patch
+    let mut attrs = HashMap::new();
+    attrs.insert("employee_id".to_string(), "E303".to_string());
+    attrs.insert("team".to_string(), "data".to_string());
+    repo.patch_git_ai_config(|patch| {
+        patch.custom_attributes = Some(attrs.clone());
+    });
+
+    // Create initial commit on default branch
+    let mut file = repo.filename("main.txt");
+    file.set_contents(lines!["line 1", "line 2", "line 3"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let default_branch = repo.current_branch();
+
+    // Create feature branch with AI commit
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.insert_at(3, lines!["// AI feature line".ai()]);
+    repo.stage_all_and_commit("Add AI feature").unwrap();
+
+    std::thread::sleep(Duration::from_secs(1));
+
+    // Add another AI commit on the feature branch
+    file.insert_at(4, lines!["// AI feature line 2".ai()]);
+    repo.stage_all_and_commit("Add AI feature 2").unwrap();
+
+    // Verify custom attributes were set on the feature commits
+    let feature_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let feature_note = read_authorship_note(&repo, &feature_sha)
+        .expect("feature commit should have authorship note");
+    let feature_log =
+        AuthorshipLog::deserialize_from_string(&feature_note).expect("parse feature note");
+    for (_id, prompt) in &feature_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "precondition: feature commit should have custom_attributes from config"
+        );
+    }
+
+    // Go back to default branch and squash merge
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    repo.commit("Squashed feature").unwrap();
+
+    // Verify custom attributes survived the squash merge
+    let squash_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let squash_note = read_authorship_note(&repo, &squash_sha)
+        .expect("squash commit should have authorship note");
+    let squash_log =
+        AuthorshipLog::deserialize_from_string(&squash_note).expect("parse squash note");
+    assert!(
+        !squash_log.metadata.prompts.is_empty(),
+        "squash commit should have prompt records"
+    );
+    for (_id, prompt) in &squash_log.metadata.prompts {
+        assert_eq!(
+            prompt.custom_attributes.as_ref(),
+            Some(&attrs),
+            "custom_attributes should be preserved through squash merge"
+        );
+    }
+
+    // Also verify the AI attribution itself survived
+    file.assert_lines_and_blame(lines![
+        "line 1".human(),
+        "line 2".human(),
+        "line 3".human(),
+        "// AI feature line".ai(),
+        "// AI feature line 2".ai()
+    ]);
 }
 
 reuse_tests_in_worktree!(


### PR DESCRIPTION
# Add tests for custom_attributes preservation in rebase, cherry-pick, amend, squash

## Summary

Adds test coverage to verify that `custom_attributes` (from PR #650) are properly preserved through rebase, cherry-pick, amend, and squash merge operations. Previously all tests used `custom_attributes: None`, making it impossible to detect if attributes were dropped during these operations.

**Two testing patterns used:**

1. **Direct PromptRecord mutation** — Existing tests (`test_rebase_preserves_prompt_only_commit_note_metadata`, `test_cherry_pick_preserves_prompt_only_commit_note_metadata`) updated to inject non-None `custom_attributes` into PromptRecords and assert they survive the operation.

2. **Config-pipeline (end-to-end)** — Four new tests that set `custom_attributes` via `ConfigPatch`, create commits through the real post-commit hook, then verify attributes survive each operation:
   - `test_rebase_preserves_custom_attributes_from_config`
   - `test_cherry_pick_preserves_custom_attributes_from_config`
   - `test_squash_merge_preserves_custom_attributes_from_config`
   - `test_amend_preserves_custom_attributes_from_config`

**Infrastructure changes:**
- Added `custom_attributes` field to `ConfigPatch` struct
- Updated `apply_test_config_patch` to apply custom_attributes to config
- Updated `sync_test_home_config_for_hooks` to serialize custom_attributes into test config JSON

**Unit test updates:**
- All 8 instances of `custom_attributes: None` in `rebase_authorship.rs` internal tests replaced with actual HashMap values

## Review & Testing Checklist for Human

- [ ] Verify the 4 new end-to-end tests actually exercise the custom_attributes propagation path — confirm that `patch_git_ai_config` → post-commit hook → authorship note is the real pipeline (not a shortcut that could pass even if production code is broken)
- [ ] Check that `sync_test_home_config_for_hooks` in `test_repo.rs` correctly serializes the `custom_attributes` map to match the format expected by `Config::load()` — a serialization mismatch would silently produce None attributes
- [ ] Run the full test suite locally to confirm no regressions: `cd ~/repos/git-ai && unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL && task test`

### Notes

**Note:** The commit message mentions "Add custom_attributes field to monorepo TS types" but those changes are not in this PR — they'll be in a separate monorepo PR. This PR is git-ai only.

Link to Devin Session: https://app.devin.ai/sessions/d964ecf877df44c99dc67bd524b84918  
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
