### PR TITLE
revert flag to address concerns of enterprise security team for fleet wide oauth

### DIFF
--- a/src/auth/client.rs
+++ b/src/auth/client.rs
@@ -10,29 +10,24 @@ pub struct OAuthClient {
 }
 
 /// Validate that a URL uses HTTPS (security requirement for OAuth)
-/// Only enforced in release builds - HTTP allowed in debug mode for local dev
+/// In release builds, only HTTPS is accepted — the HTTP path is not compiled in.
+/// In debug builds, HTTP is also allowed for local development.
+#[cfg(not(debug_assertions))]
 fn validate_https_url(url: &str) -> Result<(), String> {
-    let insecure_oauth = false;
-    #[cfg(not(debug_assertions))]
-    {
-        let insecure_oauth = true;
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        let insecure_oauth = std::env::var("GIT_AI_DEBUG_OAUTH_HTTP").unwrap_or_default() == "1";
-    }
-
-    if !insecure_oauth {
-        if !url.starts_with("https://") && !url.starts_with("http://") {
-            return Err(format!("Invalid URL scheme: {}", url));
-        }
-    } else if !url.starts_with("https://") {
+    if !url.starts_with("https://") {
         return Err(format!(
             "Security error: OAuth requires HTTPS. URL '{}' is not secure.",
             url
         ));
     }
+    Ok(())
+}
 
+#[cfg(debug_assertions)]
+fn validate_https_url(url: &str) -> Result<(), String> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err(format!("Invalid URL scheme: {}", url));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Introduced the ability to override oauth protections in release builds to help debug some real-world login issues. An enterprise security flagged and asked us to remove. AFAIK this could not and did not cause any issues in the wild, but it's a fair ask so we're removing it. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
