### PR TITLE
Opencode: Rename plugin directory from 'plugin' to 'plugins'

### DIFF
--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -17,7 +17,7 @@ impl OpenCodeInstaller {
         home_dir()
             .join(".config")
             .join("opencode")
-            .join("plugin")
+            .join("plugins")
             .join("git-ai.ts")
     }
 


### PR DESCRIPTION
The plugins directory for Opencode is "plugins" not "plugin"

https://opencode.ai/docs/plugins/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
