### PR TITLE
feat: add X-Author-Identity header to API client when API key is set

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,6 +1,7 @@
 use crate::auth::{CredentialStore, OAuthClient};
 use crate::config;
 use crate::error::GitAiError;
+use crate::git::repository::{exec_git, parse_git_var_identity};
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 use url::Url;
@@ -59,6 +60,24 @@ fn try_load_auth_token() -> Option<String> {
     // Mutex guard is automatically released when _guard is dropped
 }
 
+/// Resolve the git author identity without requiring a Repository instance.
+///
+/// Runs `git var GIT_COMMITTER_IDENT` to get the current user's identity,
+/// respecting the full git precedence chain (env vars > config > system defaults).
+/// Returns `None` if the identity cannot be determined.
+fn resolve_git_identity() -> Option<String> {
+    let args = vec!["var".to_string(), "GIT_COMMITTER_IDENT".to_string()];
+    if let Ok(output) = exec_git(&args)
+        && let Ok(stdout) = String::from_utf8(output.stdout)
+    {
+        let identity = parse_git_var_identity(&stdout);
+        if let Some(formatted) = identity.formatted() {
+            return Some(formatted);
+        }
+    }
+    None
+}
+
 /// API client context with optional authentication
 #[derive(Debug, Clone)]
 pub struct ApiContext {
@@ -68,6 +87,8 @@ pub struct ApiContext {
     pub auth_token: Option<String>,
     /// Optional API key for X-API-Key header
     pub api_key: Option<String>,
+    /// Optional git author identity for X-Author-Identity header (only sent when API key is set)
+    pub author_identity: Option<String>,
     /// Request timeout in seconds
     pub timeout_secs: Option<u64>,
 }
@@ -104,10 +125,17 @@ impl ApiContext {
     /// If base_url is None, uses api_base_url from config (which can be set via config file, env var, or defaults)
     pub fn new(base_url: Option<String>) -> Self {
         let cfg = config::Config::get();
+        let api_key = cfg.api_key().map(|s| s.to_string());
+        let author_identity = if api_key.is_some() {
+            resolve_git_identity()
+        } else {
+            None
+        };
         Self {
             base_url: base_url.unwrap_or_else(Self::default_base_url),
             auth_token: try_load_auth_token(),
-            api_key: cfg.api_key().map(|s| s.to_string()),
+            api_key,
+            author_identity,
             timeout_secs: Some(30),
         }
     }
@@ -117,10 +145,17 @@ impl ApiContext {
     #[allow(dead_code)]
     pub fn without_auth(base_url: Option<String>) -> Self {
         let cfg = config::Config::get();
+        let api_key = cfg.api_key().map(|s| s.to_string());
+        let author_identity = if api_key.is_some() {
+            resolve_git_identity()
+        } else {
+            None
+        };
         Self {
             base_url: base_url.unwrap_or_else(Self::default_base_url),
             auth_token: None,
-            api_key: cfg.api_key().map(|s| s.to_string()),
+            api_key,
+            author_identity,
             timeout_secs: Some(30),
         }
     }
@@ -130,10 +165,17 @@ impl ApiContext {
     #[allow(dead_code)]
     pub fn with_auth(base_url: Option<String>, auth_token: String) -> Self {
         let cfg = config::Config::get();
+        let api_key = cfg.api_key().map(|s| s.to_string());
+        let author_identity = if api_key.is_some() {
+            resolve_git_identity()
+        } else {
+            None
+        };
         Self {
             base_url: base_url.unwrap_or_else(Self::default_base_url),
             auth_token: Some(auth_token),
-            api_key: cfg.api_key().map(|s| s.to_string()),
+            api_key,
+            author_identity,
             timeout_secs: Some(30),
         }
     }
@@ -169,6 +211,9 @@ impl ApiContext {
 
         if let Some(api_key) = &self.api_key {
             request = request.with_header("X-API-Key", api_key);
+            if let Some(identity) = &self.author_identity {
+                request = request.with_header("X-Author-Identity", identity);
+            }
         }
         if let Some(token) = &self.auth_token {
             request = request.with_header("Authorization", format!("Bearer {}", token));
@@ -194,6 +239,9 @@ impl ApiContext {
 
         if let Some(api_key) = &self.api_key {
             request = request.with_header("X-API-Key", api_key);
+            if let Some(identity) = &self.author_identity {
+                request = request.with_header("X-Author-Identity", identity);
+            }
         }
         if let Some(token) = &self.auth_token {
             request = request.with_header("Authorization", format!("Bearer {}", token));

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1131,7 +1131,7 @@ impl GitAuthorIdentity {
 ///
 /// The output format is: `Name <email> unix-timestamp timezone`
 /// For example: `John Doe <john@example.com> 1234567890 +0000`
-fn parse_git_var_identity(output: &str) -> GitAuthorIdentity {
+pub fn parse_git_var_identity(output: &str) -> GitAuthorIdentity {
     let trimmed = output.trim();
     if trimmed.is_empty() {
         return GitAuthorIdentity::default();


### PR DESCRIPTION
# feat: add X-Author-Identity header to API client when API key is set

## Summary

When an API key is configured, the API client now resolves the local git identity via `git var GIT_COMMITTER_IDENT` and sends it as an `X-Author-Identity` header (format: `Name <email>`) alongside the `X-API-Key` header on all GET and POST requests. If no git identity can be determined (e.g., git not installed, not in a repo, no user configured), the header is silently omitted.

**Changes:**
- Added `resolve_git_identity()` in `src/api/client.rs` — shells out to `git var GIT_COMMITTER_IDENT` without requiring a `Repository` instance
- Added `author_identity: Option<String>` field to `ApiContext`, populated only when `api_key` is `Some`
- `X-Author-Identity` header attached inside the existing `if let Some(api_key)` blocks in both `post_json()` and `get()`
- Made `parse_git_var_identity` public in `src/git/repository.rs` (was previously crate-private)

## Review & Testing Checklist for Human

- [ ] **Verify the header value format (`Name <email>`) matches what the server expects to parse.** There is no schema contract enforced here — the format comes from `GitAuthorIdentity::formatted()`.
- [ ] **Assess performance impact**: `resolve_git_identity()` spawns a `git` subprocess on every `ApiContext` construction when an API key is set. If API contexts are created frequently (e.g., in hot paths or loops), this could add measurable latency. Consider whether caching is needed.
- [ ] **No new tests were added** for `resolve_git_identity()` or for verifying the header is attached to requests. Consider whether unit tests should be added before merge, especially for the graceful-failure path (no git, no identity).
- [ ] **Confirm making `parse_git_var_identity` public is acceptable** — it expands the public API surface of `git::repository`.

**Suggested test plan:** Configure an API key locally (`git-ai config set api_key <key>`), run a command that triggers an API call (e.g., `git-ai flush-cas` or `git-ai whoami`), and inspect outgoing HTTP traffic to confirm the `X-Author-Identity` header is present with the expected `Name <email>` value. Also verify that without an API key set, the header is absent.

### Notes
- Link to Devin session: https://app.devin.ai/sessions/3d5d70148ec64f01ac926ec534e422ac
- Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
