### PR TITLE
opencode: Fix checkpoints for OpenAI model patches

### DIFF
--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -73,7 +73,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
       // Patches have the path in patchText only, so this needs to be extracted
       const filePath = (output.args?.filePath ??
         (output.args?.patchText as string | undefined)
-          ?.match(/\*\* Update File: (.+?)\n/)?.[1]
+          ?.match(/\*\*\* (?:Update|Add) File: (.+?)\n/)?.[1]
           ?.trim()) as string | undefined;
 
       if (!filePath) {


### PR DESCRIPTION
When I was using OpenAI models with OpenCode, no changes were getting reported. This seems to be be cause of two things together:

- The tool they get is now called `apply_patch`
- The path can't be accessed in the same way and is only present in the patch text, so it needs to be extracted

There's probably a cleaner way of extracting the path, but this appears to be enough for changes to start getting reported in my local environment