### PR TITLE
Opencode: Rename plugin directory from 'plugin' to 'plugins' in code and tests

### DIFF
--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -7,8 +7,8 @@
  *
  * Installation:
  *   - Automatically installed by `git-ai install-hooks`
- *   - Or manually copy to ~/.config/opencode/plugin/git-ai.ts (global)
- *   - Or to .opencode/plugin/git-ai.ts (project-local)
+ *   - Or manually copy to ~/.config/opencode/plugins/git-ai.ts (global)
+ *   - Or to .opencode/plugins/git-ai.ts (project-local)
  *
  * Requirements:
  *   - git-ai must be installed (path is injected at install time)

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -150,7 +150,7 @@ mod tests {
             .path()
             .join(".config")
             .join("opencode")
-            .join("plugin")
+            .join("plugins")
             .join("git-ai.ts");
         (temp_dir, plugin_path)
     }
@@ -279,7 +279,7 @@ mod tests {
             .path()
             .join(".config")
             .join("opencode")
-            .join("plugin")
+            .join("plugins")
             .join("git-ai.ts");
 
         assert!(!plugin_path.parent().unwrap().exists());


### PR DESCRIPTION
## Summary

Fixes the OpenCode plugin directory path from `.config/opencode/plugin/` to `.config/opencode/plugins/`, matching the [OpenCode documentation](https://opencode.ai/docs/plugins/).

Cherry-picks the original rename commit from PR #694 (by @prydt) and adds a follow-up commit that:
- Updates test helpers (`setup_test_env` and `test_opencode_plugin_handles_empty_directory`) to use `plugins/` consistently with production `plugin_path()`
- Updates manual installation comments in `agent-support/opencode/git-ai.ts` to reference the correct `plugins/` directory

## Review & Testing Checklist for Human

- [ ] Grep the codebase for any remaining references to the old `plugin` (singular) path in opencode-related code — there could be other files or docs referencing the old directory name
- [ ] Confirm the OpenCode docs at https://opencode.ai/docs/plugins/ specify `plugins/` as the correct directory name
- [ ] Run `git-ai install-hooks` with OpenCode present and verify the plugin is written to `~/.config/opencode/plugins/git-ai.ts`

### Notes
- All 7 existing opencode tests pass locally
- Lint and format checks pass
- Commit 1 preserves original author credit (pry); commit 2 adds the test and TS comment fixes

Link to Devin session: https://app.devin.ai/sessions/3b38fcf765784d999e2c9ad63ed7c443
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
