### PR TITLE
Fix: Ignore automated formatting changes in authorship (fixes #725)

### DIFF
--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -1013,9 +1013,25 @@ impl AttributionTracker {
                     let is_whitespace_only = data_is_whitespace(diff.data());
                     let contains_newline = diff.data().contains(&b'\n');
                     let is_formatting_pair = prev_whitespace_delete && is_whitespace_only;
-                    #[allow(clippy::if_same_then_else)]
-                    let (author_id, attribution_ts) = if contains_newline {
+                    let (author_id, attribution_ts) = if contains_newline && is_substantive_insert
+                    {
+                        // New substantive line content — attribute to current author
                         (current_author.to_string(), ts)
+                    } else if contains_newline && !is_substantive_insert {
+                        // Line re-inserted with only formatting/whitespace changes (e.g. by a
+                        // code formatter like `mvn spotless:apply`).  Preserve the original
+                        // attribution instead of crediting the human author.
+                        if let Some(attr) = find_attribution_for_insertion(
+                            old_attributions,
+                            old_pos,
+                            &mut insertion_attr_cursor,
+                        ) {
+                            (attr.author_id.clone(), attr.ts)
+                        } else if let Some(attr) = new_attributions.last() {
+                            (attr.author_id.clone(), attr.ts)
+                        } else {
+                            (current_author.to_string(), ts)
+                        }
                     } else if is_substantive_insert {
                         (current_author.to_string(), ts)
                     } else if is_formatting_pair {


### PR DESCRIPTION
Automated code formatting changes (e.g., mvn spotless:apply) are incorrectly calculated as human authorship.Fixes #725
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
