### PR TITLE
Reduce git network usage

### DIFF
--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -359,10 +359,6 @@ fn run_pre_command_hooks(
                 command_hooks_context.push_authorship_handle =
                     push_hooks::push_pre_command_hook(parsed_args, repository);
             }
-            Some("fetch") => {
-                command_hooks_context.fetch_authorship_handle =
-                    fetch_hooks::fetch_pull_pre_command_hook(parsed_args, repository);
-            }
             Some("pull") => {
                 fetch_hooks::pull_pre_command_hook(parsed_args, repository, command_hooks_context);
             }
@@ -418,12 +414,6 @@ fn run_post_command_hooks(
                 parsed_args,
                 exit_status,
                 repository,
-                command_hooks_context,
-            ),
-            Some("fetch") => fetch_hooks::fetch_pull_post_command_hook(
-                repository,
-                parsed_args,
-                exit_status,
                 command_hooks_context,
             ),
             Some("pull") => fetch_hooks::pull_post_command_hook(

--- a/src/commands/git_hook_handlers.rs
+++ b/src/commands/git_hook_handlers.rs
@@ -1569,12 +1569,19 @@ fn load_pull_hook_state(repo: &Repository) -> Option<PullHookState> {
     serde_json::from_slice(&data).ok()
 }
 
-fn fetch_notes_from_all_remotes(repo: &Repository) {
-    if let Ok(remotes) = repo.remotes() {
-        for remote in remotes {
-            let _ = fetch_authorship_notes(repo, &remote);
-        }
-    }
+fn fetch_notes_from_pull_remote(repo: &Repository) {
+    let remote = repo
+        .upstream_remote()
+        .ok()
+        .flatten()
+        .or_else(|| repo.get_default_remote().ok().flatten());
+
+    let Some(remote) = remote else {
+        debug_log("pull hooks: could not resolve remote for authorship fetch; skipping");
+        return;
+    };
+
+    let _ = fetch_authorship_notes(repo, &remote);
 }
 
 fn was_fast_forward_pull(repository: &Repository, expected_new_head: &str) -> bool {
@@ -1860,7 +1867,7 @@ fn maybe_handle_pull_post_merge(repo: &mut Repository) {
         return;
     }
 
-    fetch_notes_from_all_remotes(repo);
+    fetch_notes_from_pull_remote(repo);
 
     let Ok(new_head) = repo.head().and_then(|head| head.target()) else {
         return;
@@ -1886,7 +1893,7 @@ fn maybe_handle_pull_post_rewrite(repo: &mut Repository) {
         return;
     }
 
-    fetch_notes_from_all_remotes(repo);
+    fetch_notes_from_pull_remote(repo);
 
     let Ok(new_head) = repo.head().and_then(|head| head.target()) else {
         clear_pull_hook_state(repo);

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -83,47 +83,8 @@ pub fn fetch_authorship_notes(
         remote_name, tracking_ref
     ));
 
-    // First, check if the remote has refs/notes/ai using ls-remote
-    // This is important for bare repos where the refmap might not be configured
-    let mut ls_remote_args = repository.global_args_for_exec();
-    ls_remote_args.push("ls-remote".to_string());
-    ls_remote_args.push(remote_name.to_string());
-    ls_remote_args.push("refs/notes/ai".to_string());
-
-    debug_log(&format!("ls-remote command: {:?}", ls_remote_args));
-
-    match exec_git(&ls_remote_args) {
-        Ok(output) => {
-            let result = String::from_utf8_lossy(&output.stdout).to_string();
-            debug_log(&format!("ls-remote stdout: '{}'", result));
-            debug_log(&format!(
-                "ls-remote stderr: '{}'",
-                String::from_utf8_lossy(&output.stderr)
-            ));
-
-            if result.trim().is_empty() {
-                debug_log(&format!(
-                    "no authorship notes found on remote '{}', nothing to sync",
-                    remote_name
-                ));
-                return Ok(NotesExistence::NotFound);
-            }
-            debug_log(&format!(
-                "found authorship notes on remote '{}'",
-                remote_name
-            ));
-        }
-        Err(e) => {
-            debug_log(&format!(
-                "failed to check for authorship notes on remote '{}': {}",
-                remote_name, e
-            ));
-            // Return error instead of assuming no notes - we don't know the state
-            return Err(e);
-        }
-    }
-
-    // Now fetch the notes to the tracking ref with explicit refspec
+    // Fetch notes to tracking ref with explicit refspec.
+    // If the remote does not have refs/notes/ai yet, treat that as NotFound.
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
 
     // Build the internal authorship fetch with explicit flags and disabled hooks.
@@ -148,6 +109,13 @@ pub fn fetch_authorship_notes(
             ));
         }
         Err(e) => {
+            if is_missing_remote_notes_ref_error(&e) {
+                debug_log(&format!(
+                    "no authorship notes found on remote '{}', nothing to sync",
+                    remote_name
+                ));
+                return Ok(NotesExistence::NotFound);
+            }
             debug_log(&format!("authorship fetch failed: {}", e));
             return Err(e);
         }
@@ -186,6 +154,19 @@ pub fn fetch_authorship_notes(
     }
 
     Ok(NotesExistence::Found)
+}
+
+fn is_missing_remote_notes_ref_error(error: &GitAiError) -> bool {
+    let GitAiError::GitCliError { stderr, .. } = error else {
+        return false;
+    };
+
+    let stderr_lower = stderr.to_ascii_lowercase();
+    stderr_lower.contains("refs/notes/ai")
+        && (stderr_lower.contains("couldn't find remote ref")
+            || stderr_lower.contains("could not find remote ref")
+            || stderr_lower.contains("remote ref does not exist")
+            || stderr_lower.contains("not our ref"))
 }
 // for use with post-push hook
 pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Result<(), GitAiError> {
@@ -367,5 +348,26 @@ mod tests {
                 .any(|pair| pair[0] == "-c" && pair[1] == disabled_hooks)
         );
         assert!(args.contains(&"push".to_string()));
+    }
+
+    #[test]
+    fn missing_remote_notes_ref_error_is_detected() {
+        let err = GitAiError::GitCliError {
+            code: Some(128),
+            stderr: "fatal: couldn't find remote ref refs/notes/ai".to_string(),
+            args: vec!["fetch".to_string(), "origin".to_string()],
+        };
+        assert!(is_missing_remote_notes_ref_error(&err));
+    }
+
+    #[test]
+    fn missing_remote_notes_ref_error_ignores_unrelated_git_errors() {
+        let err = GitAiError::GitCliError {
+            code: Some(128),
+            stderr: "fatal: Authentication failed for 'https://github.com/org/repo.git/'"
+                .to_string(),
+            args: vec!["fetch".to_string(), "origin".to_string()],
+        };
+        assert!(!is_missing_remote_notes_ref_error(&err));
     }
 }


### PR DESCRIPTION
Remove authorship sync from git fetch wrapper hooks.
Edit git_handlers.rs to stop calling fetch_pull_pre_command_hook for Some("fetch"). Keep pull behavior unchanged.

Keep pre-push notes fetch/merge as-is.
No change to push_hooks.rs and sync_authorship.rs push flow.

Remove ls-remote precheck and do direct notes fetch.
In sync_authorship.rs, delete the ls-remote refs/notes/ai call and run a single git fetch ... +refs/notes/ai:<tracking_ref>. Treat “remote ref not found” fetch failures as NotesExistence::NotFound; keep real transport/auth failures as errors.

Reduce pull-time sync scope to one remote, not all remotes.
Replace fetch_notes_from_all_remotes() usage in git_hook_handlers.rs with single-remote resolution (pull remote if known, else upstream, else default remote).

Preserve existing sync entry points outside git fetch.
Keep sync on git pull, git clone, and explicit git-ai fetch-authorship-notes in clone_hooks.rs and git_ai_handlers.rs.

Test coverage updates.
Update/add tests for: git fetch no longer triggers authorship sync, direct-fetch NotFound behavior without ls-remote, and pull hooks syncing only one remote.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
