### PR TITLE
ci: run E2E tests nightly and on integration label only

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,16 +1,19 @@
 name: E2E Tests
 
 on:
+  schedule:
+    - cron: '0 2 * * *'  # 2 AM UTC nightly
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-  merge_group:
-    branches: [main]
+    types: [labeled]
+  workflow_dispatch:
 
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'integration')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Remove broad `pull_request`, `push`, and `merge_group` triggers from `e2e-tests.yml` that caused the full suite to run on every PR
- Add a nightly `schedule` (2 AM UTC), `pull_request: types: [labeled]`, and `workflow_dispatch` triggers instead
- Add a job-level `if` guard so labeled events only fire the suite when the `integration` label is applied (not any label)

## Test plan

- [ ] Verify no E2E run triggers on a plain PR push
- [ ] Apply the `integration` label to a test PR and confirm the workflow starts
- [ ] Confirm the nightly schedule fires at 2 AM UTC
- [ ] Confirm `workflow_dispatch` still allows manual runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
