### PR TITLE
Load custom VSCode names from config file

### DIFF
--- a/agent-support/vscode/src/utils/host-kind.ts
+++ b/agent-support/vscode/src/utils/host-kind.ts
@@ -53,9 +53,15 @@ export function detectIDEHost(): IDEHostConfiguration {
   // If we don't recognize the IDE, check if it's a custom VSCode-like IDE that should be treated as VSCode by checking the configuration file.
   if (kind === "unknown") {
     const vscodeIdeNames = loadVscodeIdeNames();
-    if (vscodeIdeNames.some(has)) {
-      kind = "vscode";
+    if (vscodeIdeNames.length > 0) {
+      console.log('[git-ai] Checking for VSCode-like IDE: ', vscodeIdeNames);
+      if (vscodeIdeNames.some(has)) {
+        kind = "vscode";
+        console.log('[git-ai] Found VSCode-like IDE: ', kind);
+      }
     }
+  } else {
+    console.log('[git-ai] Recognized IDE: ', kind);
   }
 
   return { kind, appName: vscode.env.appName, uriScheme: vscode.env.uriScheme, execPath: process.execPath };


### PR DESCRIPTION
Allows users with custom forks of VSCode to configure a file at `$HOME/.git-ai/VSCODE_IDE_NAMES`, that will treat any of the IDE names in that file as VSCode instead of `unknown`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
