### PR TITLE
fix empty prompts in prompt analysis when using CAS

### DIFF
--- a/src/commands/prompts_db.rs
+++ b/src/commands/prompts_db.rs
@@ -737,7 +737,13 @@ fn fetch_from_internal_db(
             new_count += 1;
         }
 
-        let messages_json = serde_json::to_string(&record.messages).ok();
+        // Don't overwrite existing messages with empty array — messages may have
+        // been cleared locally after being uploaded to CAS
+        let messages_json = if record.messages.messages.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&record.messages).ok()
+        };
         let start_time = record.messages.first_message_timestamp_unix();
         let last_time = record.messages.last_message_timestamp_unix();
 
@@ -860,7 +866,13 @@ fn fetch_from_git_notes(
                     let created_at = start_time.unwrap_or(now);
                     let updated_at = last_time.unwrap_or(created_at);
 
-                    let messages_json = serde_json::to_string(&prompt_record.messages).ok();
+                    // Don't overwrite existing messages with empty array — messages may have
+                    // been cleared locally after being uploaded to CAS
+                    let messages_json = if prompt_record.messages.is_empty() {
+                        None
+                    } else {
+                        serde_json::to_string(&prompt_record.messages).ok()
+                    };
 
                     upsert_prompt(
                         conn,


### PR DESCRIPTION
Some users with Cloud or Enterprise accounts reported not being able to do local analysis of their own prompts using the prompt-analysis skill 

The problem was that users who are logged in and sharing prompts with their team have `[]` for the messages in their Git notes. The prompt analysis logic copies local prompts into a scratchpad sqlite, and was overriding local transcripts with the `[]` from git notes. 

Latest Git AI prompt analysis only finds messages for 42/255 of my recent prompts
With these changes version finds them all.