### PR TITLE
add GIT_AI_CLOUD_AGENT=1 override for custom background agents

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -207,6 +207,8 @@ pub fn is_in_background_agent() -> bool {
             // Cloud agent environment (CLOUD_AGENT_* prefix)
             || std::env::vars().any(|(k, _)| k.starts_with("CLOUD_AGENT_"))
             || std::path::Path::new("/opt/.devin").is_dir()
+            // Explicit opt-in for cloud/background agent environments
+            || std::env::var("GIT_AI_CLOUD_AGENT").map(|v| v == "1").unwrap_or(false)
     })
 }
 


### PR DESCRIPTION
Adds `GIT_AI_CLOUD_AGENT` env flag for custom background agents
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
