### PR TITLE
Persist install API base in config

### DIFF
--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -854,9 +854,7 @@ mod tests {
     #[test]
     fn parse_git_og_cmd_path_extracts_wrapped_git_path() {
         assert_eq!(
-            parse_git_og_cmd_path(
-                "@echo off\r\n\"C:\\Program Files\\Git\\bin\\git.exe\" %*\r\n"
-            ),
+            parse_git_og_cmd_path("@echo off\r\n\"C:\\Program Files\\Git\\bin\\git.exe\" %*\r\n"),
             Some("C:\\Program Files\\Git\\bin\\git.exe".to_string())
         );
     }


### PR DESCRIPTION
## Summary
- persist `API_BASE` into `~/.git-ai/config.json` during `git-ai install-hooks`
- preserve any existing `git_path`, and backfill it from the installer-created `git-og` shim when config must be created early
- add focused tests covering config creation, preservation, and dry-run/no-env behavior

## Validation
- cargo fmt -- --check
- cargo clippy --all-targets --all-features
- cargo test persist_install_api_base --lib
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
