### PR TITLE
Fix Windows daemon stash attribution replay

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -716,9 +716,7 @@ fn normalize_commit_carryover_snapshot(
     carryover_snapshot: Option<&HashMap<String, String>>,
     committed_final_state: Option<&HashMap<String, String>>,
 ) -> Option<HashMap<String, String>> {
-    let Some(carryover_snapshot) = carryover_snapshot else {
-        return None;
-    };
+    let carryover_snapshot = carryover_snapshot?;
 
     let mut normalized = carryover_snapshot.clone();
     if let Some(committed_final_state) = committed_final_state {


### PR DESCRIPTION
## Summary
- normalize daemon commit carryover snapshots against committed blobs when they differ only by line endings
- keep true post-commit carryover edits intact so daemon replay semantics do not change
- add focused regression tests for the CRLF/LF normalization behavior

## Root cause
On Windows daemon mode, the carryover snapshot used during commit replay could come from the CRLF worktree while the committed blob stored in Git was LF-normalized. The daemon replay path treated that line-ending-only difference as a real content delta, which polluted the synthetic replay checkpoint and caused stash pop across branches to misattribute preserved human lines as AI.

## Validation
- `cargo test --lib daemon::tests::normalize_commit_carryover_snapshot -- --nocapture`
- `GIT_AI_TEST_GIT_MODE=daemon cargo test --package git-ai --test integration stash_attribution::test_stash_pop_across_branches -- --nocapture`
- `GIT_AI_TEST_GIT_MODE=wrapper-daemon cargo test --package git-ai --test integration stash_attribution::test_stash_pop_across_branches -- --nocapture`
- `cargo fmt -- --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
