### PR TITLE
Use `git-ai d` as the primary command

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -24,31 +24,31 @@ pub fn handle_daemon(args: &[String]) {
     match args[0].as_str() {
         "start" => {
             if let Err(e) = handle_start(&args[1..]) {
-                eprintln!("Failed to start daemon: {}", e);
+                eprintln!("Failed to start: {}", e);
                 std::process::exit(1);
             }
         }
         "run" => {
             if let Err(e) = handle_run(&args[1..]) {
-                eprintln!("Failed to run daemon: {}", e);
+                eprintln!("Failed to run: {}", e);
                 std::process::exit(1);
             }
         }
         "status" => {
             let repo = parse_repo_arg(&args[1..]).unwrap_or_else(default_repo_path);
             if let Err(e) = handle_status(repo) {
-                eprintln!("Failed to get daemon status: {}", e);
+                eprintln!("Failed to get status: {}", e);
                 std::process::exit(1);
             }
         }
         "shutdown" => {
             if let Err(e) = handle_shutdown() {
-                eprintln!("Failed to shut down daemon: {}", e);
+                eprintln!("Failed to shut down: {}", e);
                 std::process::exit(1);
             }
         }
         _ => {
-            eprintln!("Unknown daemon subcommand: {}", args[0]);
+            eprintln!("Unknown subcommand: {}", args[0]);
             print_help();
             std::process::exit(1);
         }
@@ -264,7 +264,7 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
     #[cfg(windows)]
     {
         let script = format!(
-            "Start-Process -FilePath {} -ArgumentList @('daemon','run') -WorkingDirectory {} -WindowStyle Hidden",
+            "Start-Process -FilePath {} -ArgumentList @('d','run') -WorkingDirectory {} -WindowStyle Hidden",
             powershell_single_quote_literal(exe.as_os_str()),
             powershell_single_quote_literal(Path::new(&runtime_dir).as_os_str())
         );
@@ -305,7 +305,7 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
     {
         let mut child = Command::new(exe);
         child
-            .arg("daemon")
+            .arg("d")
             .arg("run")
             .current_dir(&runtime_dir)
             .stdin(Stdio::null())
@@ -323,7 +323,7 @@ fn spawn_daemon_run_with_piped_stderr(
     let runtime_dir = daemon_runtime_dir(config)?;
     let mut child = Command::new(exe);
     child
-        .arg("daemon")
+        .arg("d")
         .arg("run")
         .current_dir(&runtime_dir)
         .stdin(Stdio::null())
@@ -410,11 +410,11 @@ fn is_help(value: &str) -> bool {
 }
 
 fn print_help() {
-    eprintln!("git-ai daemon - run and control git-ai daemon mode");
+    eprintln!("git-ai d - run and control git-ai background service");
     eprintln!();
     eprintln!("Usage:");
-    eprintln!("  git-ai daemon start");
-    eprintln!("  git-ai daemon run");
-    eprintln!("  git-ai daemon status [--repo <path>]");
-    eprintln!("  git-ai daemon shutdown");
+    eprintln!("  git-ai d start");
+    eprintln!("  git-ai d run");
+    eprintln!("  git-ai d status [--repo <path>]");
+    eprintln!("  git-ai d shutdown");
 }

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -37,13 +37,13 @@ pub fn handle_git_ai(args: &[String]) {
         return;
     }
 
-    // In daemon/async mode, initialize the global telemetry handle so that
+    // In async mode, initialize the global telemetry handle so that
     // observability and CAS events are routed over the control socket instead
     // of being written to per-PID log files.
     //
-    // Skip for commands that must work without a running daemon (help, version,
-    // config, daemon management, debug, upgrade) so users can always diagnose
-    // and recover from a broken daemon state.
+    // Skip for commands that must work without a running background service
+    // (help, version, config, d management, debug, upgrade) so users can
+    // always diagnose and recover from a broken state.
     if config::Config::get().feature_flags().async_mode {
         let needs_daemon = !matches!(
             args[0].as_str(),
@@ -54,6 +54,7 @@ pub fn handle_git_ai(args: &[String]) {
                 | "--version"
                 | "-v"
                 | "config"
+                | "d"
                 | "daemon"
                 | "debug"
                 | "upgrade"
@@ -68,8 +69,11 @@ pub fn handle_git_ai(args: &[String]) {
             match init_daemon_telemetry_handle() {
                 DaemonTelemetryInitResult::Connected | DaemonTelemetryInitResult::Skipped => {}
                 DaemonTelemetryInitResult::Failed(err) => {
-                    // Hard error for git-ai commands: the daemon must be reachable.
-                    eprintln!("error: failed to connect to git-ai daemon: {}", err);
+                    // Hard error for git-ai commands: the background service must be reachable.
+                    eprintln!(
+                        "error: failed to connect to git-ai background service: {}",
+                        err
+                    );
                     std::process::exit(1);
                 }
             }
@@ -106,7 +110,7 @@ pub fn handle_git_ai(args: &[String]) {
         "debug" => {
             commands::debug::handle_debug(&args[1..]);
         }
-        "daemon" => {
+        "d" | "daemon" => {
             commands::daemon::handle_daemon(&args[1..]);
         }
         "stats" => {
@@ -291,7 +295,7 @@ fn print_help() {
     eprintln!("    --add <key> <value>   Add to array or upsert into object");
     eprintln!("    unset <key>           Remove config value (reverts to default)");
     eprintln!("  debug              Print support/debug diagnostics");
-    eprintln!("  daemon             Run and control git-ai daemon mode");
+    eprintln!("  d                  Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");
     eprintln!("  git-hooks ensure   Ensure repo-local git-ai hooks are installed/healed");
@@ -1299,7 +1303,7 @@ fn log_daemon_checkpoint_delegate_failure(
     message: &str,
 ) {
     eprintln!(
-        "[git-ai] daemon checkpoint delegate {}: {}; falling back to local checkpoint",
+        "[git-ai] checkpoint delegate {}: {}; falling back to local checkpoint",
         phase, message
     );
 

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -285,7 +285,10 @@ fn maybe_ensure_daemon(dry_run: bool) {
     if let Err(e) =
         crate::commands::daemon::ensure_daemon_running(std::time::Duration::from_secs(5))
     {
-        eprintln!("[git-ai] warning: failed to start daemon: {}", e);
+        eprintln!(
+            "[git-ai] warning: failed to start background service: {}",
+            e
+        );
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -301,7 +301,9 @@ impl DaemonLock {
             fs::create_dir_all(parent)?;
         }
         let lock = LockFile::try_acquire(path).ok_or_else(|| {
-            GitAiError::Generic("git-ai daemon is already running (lock held)".to_string())
+            GitAiError::Generic(
+                "git-ai background service is already running (lock held)".to_string(),
+            )
         })?;
         Ok(Self { _lock: lock })
     }
@@ -6124,7 +6126,7 @@ impl ActorDaemonCoordinator {
 
             if tokio::time::Instant::now() >= deadline {
                 eprintln!(
-                    "git-ai daemon: wrapper state timeout for invocation {} (pre={}, post={}), using daemon state",
+                    "git-ai: wrapper state timeout for invocation {} (pre={}, post={}), using internal state",
                     invocation_id, has_pre, has_post
                 );
                 let mut states = self

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -172,7 +172,7 @@ fn daemon_status_response(home_repo: &TestRepo, target_repo: &TestRepo) -> Value
     let output = daemon_command_output(
         home_repo,
         &[
-            "daemon",
+            "d",
             "status",
             "--repo",
             target_repo.canonical_path().to_string_lossy().as_ref(),
@@ -198,11 +198,7 @@ fn assert_daemon_status_ok_after_launch_repo_removed(home_repo: &TestRepo, targe
 }
 
 fn shutdown_daemon(home_repo: &TestRepo) {
-    let output = daemon_command_output(
-        home_repo,
-        &["daemon", "shutdown"],
-        home_repo.test_home_path(),
-    );
+    let output = daemon_command_output(home_repo, &["d", "shutdown"], home_repo.test_home_path());
     assert!(
         output.status.success(),
         "daemon shutdown command should succeed: stdout={} stderr={}",
@@ -293,7 +289,7 @@ fn install_hooks_async_mode_trace2_target_routes_real_git_trace_to_daemon() {
     git_ai_with_async_daemon_env(&repo, &["install-hooks", "--dry-run=false"])
         .expect("install-hooks should succeed in async mode");
 
-    let start_output = daemon_command_output(&repo, &["daemon", "start"], repo.path());
+    let start_output = daemon_command_output(&repo, &["d", "start"], repo.path());
     assert!(
         start_output.status.success(),
         "daemon start should succeed: stdout={} stderr={}",
@@ -387,7 +383,7 @@ fn daemon_status_does_not_self_emit_trace2_events() {
 
     let mut daemon_cmd = Command::new(repos::test_repo::get_binary_path());
     daemon_cmd
-        .arg("daemon")
+        .arg("d")
         .arg("run")
         .current_dir(repo.path())
         .stdout(Stdio::null())
@@ -438,7 +434,7 @@ fn daemon_run_survives_deleted_launch_repo_cwd() {
 
     let mut daemon_cmd = Command::new(get_binary_path());
     daemon_cmd
-        .arg("daemon")
+        .arg("d")
         .arg("run")
         .current_dir(launch_repo.path())
         .stdout(Stdio::null())
@@ -461,7 +457,7 @@ fn daemon_start_survives_deleted_launch_repo_cwd() {
     let launch_repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
     let target_repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
 
-    let output = daemon_command_output(&launch_repo, &["daemon", "start"], launch_repo.path());
+    let output = daemon_command_output(&launch_repo, &["d", "start"], launch_repo.path());
     assert!(
         output.status.success(),
         "daemon start should succeed: stdout={} stderr={}",
@@ -509,7 +505,7 @@ fn daemon_telemetry_and_cas_over_persistent_connection() {
     let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
 
     // Start the daemon
-    let start_output = daemon_command_output(&repo, &["daemon", "start"], repo.path());
+    let start_output = daemon_command_output(&repo, &["d", "start"], repo.path());
     assert!(
         start_output.status.success(),
         "daemon start should succeed: stdout={} stderr={}",

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -150,7 +150,7 @@ impl DaemonGuard {
         let trace_socket_path = daemon_trace_socket_path(repo);
         let mut command = Command::new(get_binary_path());
         command
-            .arg("daemon")
+            .arg("d")
             .arg("run")
             .current_dir(repo.path())
             .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
@@ -165,9 +165,7 @@ impl DaemonGuard {
             &trace_socket_path,
         );
 
-        let child = command
-            .spawn()
-            .expect("failed to spawn git-ai daemon subprocess");
+        let child = command.spawn().expect("failed to spawn git-ai subprocess");
         let mut daemon = Self {
             child,
             control_socket_path,
@@ -593,7 +591,7 @@ fn daemon_start_spawns_detached_run_process() {
 
     let mut command = Command::new(get_binary_path());
     command
-        .arg("daemon")
+        .arg("d")
         .arg("start")
         .current_dir(repo.path())
         .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
@@ -3337,7 +3335,7 @@ fn spawn_daemon_with_env(repo: &TestRepo, extra_env: &[(&str, String)]) -> Child
 
     let mut command = Command::new(get_binary_path());
     command
-        .arg("daemon")
+        .arg("d")
         .arg("run")
         .current_dir(repo.path())
         .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -127,7 +127,7 @@ impl DaemonProcess {
 
         let mut command = Command::new(get_binary_path());
         command
-            .arg("daemon")
+            .arg("d")
             .arg("run")
             .current_dir(test_home)
             .env("GIT_AI_TEST_DB_PATH", test_db_path)
@@ -145,7 +145,7 @@ impl DaemonProcess {
 
         let mut child = command
             .spawn()
-            .expect("failed to spawn git-ai daemon subprocess for test mode");
+            .expect("failed to spawn git-ai subprocess for test mode");
         let pid = child.id();
 
         let daemon = Self {


### PR DESCRIPTION
## Summary
- Makes `git-ai d` the recommended/primary command name for the background service (previously `git-ai daemon`)
- Removes the word "daemon" from all user-facing strings: help text, error messages, CLI output
- Updates internal subprocess spawns to use `git-ai d` instead of `git-ai daemon`
- Keeps `daemon` as a hidden alias for backward compatibility
- Updates all test subprocess invocations to use the new short form

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] Integration tests (wrapper mode) — 3025 passed
- [x] Daemon mode tests — 43 passed
- [x] Async mode tests — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
