### PR TITLE
Fix post-commit stats not showing with git aliases

### DIFF
--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -116,9 +116,17 @@ pub fn handle_git(args: &[String]) {
         // Initialize the daemon telemetry handle so we can send wrapper state
         let _ = crate::daemon::telemetry_handle::init_daemon_telemetry_handle();
 
-        let parsed = parse_git_cli_args(args);
+        let mut parsed = parse_git_cli_args(args);
         let repository = find_repository(&parsed.global_args).ok();
         let worktree = repository.as_ref().and_then(|r| r.workdir().ok());
+
+        // Resolve aliases so that e.g. `git cm` (alias for `commit`) is
+        // recognised as a commit for post-commit stats display.
+        if let Some(repo) = repository.as_ref()
+            && let Some(resolved) = resolve_alias_invocation(&parsed, repo)
+        {
+            parsed = resolved;
+        }
 
         let pre_state = worktree
             .as_deref()

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -716,6 +716,40 @@ fn async_mode_post_commit_still_processing_when_no_daemon() {
 }
 
 #[test]
+fn async_mode_post_commit_shows_stats_with_commit_alias() {
+    let repo = TestRepo::new_with_mode(GitTestMode::WrapperDaemon);
+
+    // Configure a git alias: cm = commit (mimics common user setup)
+    repo.git(&["config", "alias.cm", "commit"]).unwrap();
+
+    // Base commit (human only).
+    let mut file = repo.filename("alias_test.txt");
+    file.set_contents(crate::lines!["Base line 1", "Base line 2"]);
+    repo.stage_all_and_commit("Base commit").unwrap();
+
+    // Add AI-attributed lines.
+    file.insert_at(2, crate::lines!["AI line 1".ai(), "AI line 2".ai()]);
+
+    repo.git(&["add", "-A"]).expect("add should succeed");
+
+    // Commit using the alias instead of "commit" directly.
+    let output = repo
+        .git_with_env(
+            &["cm", "-m", "AI additions via alias"],
+            &[("GIT_AI_TEST_FORCE_TTY", "1")],
+            None,
+        )
+        .expect("aliased commit should succeed");
+
+    // The wrapper should resolve the alias and still show the stats bar.
+    assert!(
+        output.contains("you") && output.contains("ai"),
+        "expected stats output when committing via alias, got:\n{}",
+        output
+    );
+}
+
+#[test]
 fn async_mode_post_commit_skips_stats_for_large_commit() {
     let repo = TestRepo::new_with_mode(GitTestMode::WrapperDaemon);
 


### PR DESCRIPTION
## Summary

- The async (wrapper-daemon) code path in `handle_git` parsed CLI args but never resolved git aliases before checking whether the command was `"commit"`. When a user had e.g. `alias.cm = commit`, `parsed.command` was `"cm"` which didn't match the `Some("commit")` gate, so post-commit stats were silently skipped.
- Added `resolve_alias_invocation` call in the async path (matching what the non-async wrapper path at line 190 already does).
- Added a regression test (`async_mode_post_commit_shows_stats_with_commit_alias`) that configures `alias.cm = commit`, commits AI content via the alias, and asserts the stats bar appears.

## Test plan

- [x] New test `async_mode_post_commit_shows_stats_with_commit_alias` passes
- [x] All existing `async_mode_post_commit_*` tests still pass (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
