### PR TITLE
fix: route git-ai dash to /dashboard

### DIFF
--- a/src/commands/personal_dashboard.rs
+++ b/src/commands/personal_dashboard.rs
@@ -5,7 +5,7 @@ pub fn handle_personal_dashboard(_args: &[String]) {
     let config = config::Config::get();
     let api_base_url = config.api_base_url();
 
-    let dashboard_url = format!("{}/me", api_base_url);
+    let dashboard_url = format!("{}/dashboard", api_base_url);
 
     eprintln!("Opening dashboard: {}", dashboard_url);
 


### PR DESCRIPTION
## Summary
- update `git-ai dash` / `git-ai dashboard` to open `/dashboard` instead of `/me`
- `/me` currently returns 404, while `/dashboard` is the valid dashboard/sign-in entry route

## Test plan
- [x] Run `git-ai dash` and confirm URL now points to `/dashboard`
- [x] Verify route behavior manually (`/dashboard` redirects to sign-in, `/me` returns 404)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
