### PR TITLE
fix: use control-socket-only check for daemon teardown on async disable

### DIFF
--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -221,8 +221,16 @@ fn maybe_teardown_async_mode(dry_run: bool) {
     }
 
     // Shut down any leftover daemon from when async_mode was enabled.
+    // Use a control-socket-only check instead of daemon_is_up(), which
+    // requires both the control AND trace sockets to be connectable.
+    // If the trace socket is down but the control socket is up, we still
+    // need to send the shutdown — otherwise the daemon lingers.
     if let Ok(daemon_config) = DaemonConfig::from_env_or_default_paths()
-        && crate::commands::daemon::daemon_is_up(&daemon_config)
+        && crate::daemon::local_socket_connects_with_timeout(
+            &daemon_config.control_socket_path,
+            std::time::Duration::from_millis(100),
+        )
+        .is_ok()
     {
         let _ = crate::daemon::send_control_request(
             &daemon_config.control_socket_path,


### PR DESCRIPTION
## Summary
- `maybe_teardown_async_mode` used `daemon_is_up()` to decide whether to send a shutdown, but that helper requires **both** the control and trace sockets to be connectable
- If the trace socket was down while the control socket was still up, the shutdown was silently skipped and the daemon process lingered
- Replaced with a direct control-socket-only connectivity check, matching the behavior of `git-ai d shutdown` which worked fine in the same scenario

## Test plan
- [ ] Disable async mode while daemon is running, run `install-hooks`, verify daemon is shut down
- [ ] Verify `install-hooks` still works normally with async mode enabled (daemon restart path unaffected)
- [ ] Verify `install-hooks --dry-run` skips teardown as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
