### PR TITLE
Cut Windows wrapper overhead for read-only and small commands

### DIFF
--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -258,11 +258,7 @@ pub fn handle_git(args: &[String]) {
 }
 
 fn should_passthrough_read_only_command(parsed_args: &ParsedGitInvocation) -> bool {
-    !parsed_args.is_help
-        && parsed_args
-            .command
-            .as_deref()
-            .is_some_and(crate::git::command_classification::is_definitely_read_only_command)
+    crate::git::command_classification::is_read_only_invocation(parsed_args)
 }
 
 /// Handle alias invocations
@@ -797,10 +793,7 @@ fn proxy_to_git(
     // trace2 events for the daemon to match wrapper state entries.
     let suppress_trace2 = wrapper_invocation_id.is_none() && {
         let parsed = parse_git_cli_args(args);
-        parsed
-            .command
-            .as_deref()
-            .is_some_and(crate::git::command_classification::is_definitely_read_only_command)
+        crate::git::command_classification::is_read_only_invocation(&parsed)
     };
 
     // Use spawn for interactive commands
@@ -1120,6 +1113,12 @@ mod tests {
     #[test]
     fn passthrough_read_only_command_for_status() {
         let parsed = parse_git_cli_args(&["status".to_string(), "--short".to_string()]);
+        assert!(should_passthrough_read_only_command(&parsed));
+    }
+
+    #[test]
+    fn passthrough_read_only_command_for_branch_show_current() {
+        let parsed = parse_git_cli_args(&["branch".to_string(), "--show-current".to_string()]);
         assert!(should_passthrough_read_only_command(&parsed));
     }
 

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -113,9 +113,15 @@ pub fn handle_git(args: &[String]) {
     let mut parsed_args = parse_git_cli_args(args);
 
     let mut repository_option = find_repository(&parsed_args.global_args).ok();
-    parsed_args = resolve_wrapper_invocation(&parsed_args, repository_option.as_ref());
 
-    if should_passthrough_read_only_command(&parsed_args) {
+    // Resolve aliases early so the read-only check sees the real command.
+    if let Some(repo) = repository_option.as_ref()
+        && let Some(resolved) = resolve_alias_invocation(&parsed_args, repo)
+    {
+        parsed_args = resolved;
+    }
+
+    if crate::git::command_classification::is_read_only_invocation(&parsed_args) {
         let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false, None, None);
         exit_with_status(exit_status);
     }
@@ -270,18 +276,6 @@ pub fn handle_git(args: &[String]) {
     exit_with_status(exit_status);
 }
 
-fn should_passthrough_read_only_command(parsed_args: &ParsedGitInvocation) -> bool {
-    crate::git::command_classification::is_read_only_invocation(parsed_args)
-}
-
-fn resolve_wrapper_invocation(
-    parsed_args: &ParsedGitInvocation,
-    repository: Option<&Repository>,
-) -> ParsedGitInvocation {
-    repository
-        .and_then(|repo| resolve_alias_invocation(parsed_args, repo))
-        .unwrap_or_else(|| parsed_args.clone())
-}
 
 /// Handle alias invocations
 #[cfg(feature = "test-support")]
@@ -1002,10 +996,8 @@ fn in_shell_completion_context() -> bool {
 #[cfg(test)]
 mod tests {
     use super::parse_alias_tokens;
-    use super::{
-        parse_git_cli_args, resolve_child_git_hooks_path_override, resolve_wrapper_invocation,
-        should_passthrough_read_only_command,
-    };
+    use super::{parse_git_cli_args, resolve_alias_invocation, resolve_child_git_hooks_path_override};
+    use crate::git::command_classification::is_read_only_invocation;
     use crate::git::find_repository_in_path;
     use std::process::Command;
     use tempfile::tempdir;
@@ -1135,32 +1127,32 @@ mod tests {
     #[test]
     fn passthrough_read_only_command_for_status() {
         let parsed = parse_git_cli_args(&["status".to_string(), "--short".to_string()]);
-        assert!(should_passthrough_read_only_command(&parsed));
+        assert!(is_read_only_invocation(&parsed));
     }
 
     #[test]
     fn passthrough_read_only_command_for_branch_show_current() {
         let parsed = parse_git_cli_args(&["branch".to_string(), "--show-current".to_string()]);
-        assert!(should_passthrough_read_only_command(&parsed));
+        assert!(is_read_only_invocation(&parsed));
     }
 
     #[test]
     fn passthrough_read_only_command_rejects_mutating_commands() {
         let parsed =
             parse_git_cli_args(&["commit".to_string(), "-m".to_string(), "msg".to_string()]);
-        assert!(!should_passthrough_read_only_command(&parsed));
+        assert!(!is_read_only_invocation(&parsed));
     }
 
     #[test]
     fn passthrough_read_only_command_accepts_help_invocations() {
         let parsed = parse_git_cli_args(&["status".to_string(), "--help".to_string()]);
-        assert!(should_passthrough_read_only_command(&parsed));
+        assert!(is_read_only_invocation(&parsed));
     }
 
     #[test]
     fn passthrough_read_only_command_accepts_top_level_version() {
         let parsed = parse_git_cli_args(&["--version".to_string()]);
-        assert!(should_passthrough_read_only_command(&parsed));
+        assert!(is_read_only_invocation(&parsed));
     }
 
     #[test]
@@ -1191,11 +1183,11 @@ mod tests {
         let repo = find_repository_in_path(&temp.path().to_string_lossy())
             .expect("repository should be discovered");
         let parsed = parse_git_cli_args(&["st".to_string()]);
-        let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
+        let resolved = resolve_alias_invocation(&parsed, &repo).unwrap_or_else(|| parsed.clone());
 
         assert_eq!(resolved.command.as_deref(), Some("status"));
         assert!(resolved.command_args.iter().any(|arg| arg == "--short"));
-        assert!(should_passthrough_read_only_command(&resolved));
+        assert!(is_read_only_invocation(&resolved));
     }
 
     #[test]
@@ -1226,10 +1218,10 @@ mod tests {
         let repo = find_repository_in_path(&temp.path().to_string_lossy())
             .expect("repository should be discovered");
         let parsed = parse_git_cli_args(&["ci".to_string(), "-m".to_string(), "msg".to_string()]);
-        let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
+        let resolved = resolve_alias_invocation(&parsed, &repo).unwrap_or_else(|| parsed.clone());
 
         assert_eq!(resolved.command.as_deref(), Some("commit"));
-        assert!(!should_passthrough_read_only_command(&resolved));
+        assert!(!is_read_only_invocation(&resolved));
     }
 
     #[test]
@@ -1261,10 +1253,10 @@ mod tests {
             .expect("repository should be discovered");
         let parsed = parse_git_cli_args(&["status".to_string()]);
 
-        let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
+        let resolved = resolve_alias_invocation(&parsed, &repo).unwrap_or_else(|| parsed.clone());
         assert_eq!(resolved.command.as_deref(), Some("branch"));
         assert!(resolved.command_args.iter().any(|arg| arg == "aliased"));
-        assert!(!should_passthrough_read_only_command(&resolved));
+        assert!(!is_read_only_invocation(&resolved));
     }
 
     #[cfg(unix)]

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -121,7 +121,16 @@ pub fn handle_git(args: &[String]) {
         parsed_args = resolved;
     }
 
-    if crate::git::command_classification::is_read_only_invocation(&parsed_args) {
+    // Fast-path: commands that are unconditionally read-only (status, log, diff,
+    // etc.) or help/version invocations can skip all hooks and daemon state.
+    let is_read_only = parsed_args.is_help
+        || parsed_args.command.is_none()
+        || parsed_args
+            .command
+            .as_deref()
+            .is_some_and(crate::git::command_classification::is_definitely_read_only_command);
+
+    if is_read_only {
         let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false, None, None);
         exit_with_status(exit_status);
     }
@@ -805,7 +814,12 @@ fn proxy_to_git(
     // trace2 events for the daemon to match wrapper state entries.
     let suppress_trace2 = wrapper_invocation_id.is_none() && {
         let parsed = parse_git_cli_args(args);
-        crate::git::command_classification::is_read_only_invocation(&parsed)
+        parsed.is_help
+            || parsed.command.is_none()
+            || parsed
+                .command
+                .as_deref()
+                .is_some_and(crate::git::command_classification::is_definitely_read_only_command)
     };
 
     // Use spawn for interactive commands
@@ -995,7 +1009,7 @@ mod tests {
     use super::{
         parse_git_cli_args, resolve_alias_invocation, resolve_child_git_hooks_path_override,
     };
-    use crate::git::command_classification::is_read_only_invocation;
+    use crate::git::command_classification::is_definitely_read_only_command;
     use crate::git::find_repository_in_path;
     use std::process::Command;
     use tempfile::tempdir;
@@ -1124,33 +1138,32 @@ mod tests {
 
     #[test]
     fn passthrough_read_only_command_for_status() {
-        let parsed = parse_git_cli_args(&["status".to_string(), "--short".to_string()]);
-        assert!(is_read_only_invocation(&parsed));
-    }
-
-    #[test]
-    fn passthrough_read_only_command_for_branch_show_current() {
-        let parsed = parse_git_cli_args(&["branch".to_string(), "--show-current".to_string()]);
-        assert!(is_read_only_invocation(&parsed));
+        assert!(is_definitely_read_only_command("status"));
     }
 
     #[test]
     fn passthrough_read_only_command_rejects_mutating_commands() {
-        let parsed =
-            parse_git_cli_args(&["commit".to_string(), "-m".to_string(), "msg".to_string()]);
-        assert!(!is_read_only_invocation(&parsed));
+        assert!(!is_definitely_read_only_command("commit"));
     }
 
     #[test]
     fn passthrough_read_only_command_accepts_help_invocations() {
         let parsed = parse_git_cli_args(&["status".to_string(), "--help".to_string()]);
-        assert!(is_read_only_invocation(&parsed));
+        assert!(parsed.is_help);
     }
 
     #[test]
     fn passthrough_read_only_command_accepts_top_level_version() {
+        // `git --version` is rewritten to `git version` by the parser.
         let parsed = parse_git_cli_args(&["--version".to_string()]);
-        assert!(is_read_only_invocation(&parsed));
+        assert!(
+            parsed.is_help
+                || parsed.command.is_none()
+                || parsed
+                    .command
+                    .as_deref()
+                    .is_some_and(is_definitely_read_only_command)
+        );
     }
 
     #[test]
@@ -1185,7 +1198,9 @@ mod tests {
 
         assert_eq!(resolved.command.as_deref(), Some("status"));
         assert!(resolved.command_args.iter().any(|arg| arg == "--short"));
-        assert!(is_read_only_invocation(&resolved));
+        assert!(is_definitely_read_only_command(
+            resolved.command.as_deref().unwrap()
+        ));
     }
 
     #[test]
@@ -1219,7 +1234,9 @@ mod tests {
         let resolved = resolve_alias_invocation(&parsed, &repo).unwrap_or_else(|| parsed.clone());
 
         assert_eq!(resolved.command.as_deref(), Some("commit"));
-        assert!(!is_read_only_invocation(&resolved));
+        assert!(!is_definitely_read_only_command(
+            resolved.command.as_deref().unwrap()
+        ));
     }
 
     #[test]
@@ -1254,7 +1271,9 @@ mod tests {
         let resolved = resolve_alias_invocation(&parsed, &repo).unwrap_or_else(|| parsed.clone());
         assert_eq!(resolved.command.as_deref(), Some("branch"));
         assert!(resolved.command_args.iter().any(|arg| arg == "aliased"));
-        assert!(!is_read_only_invocation(&resolved));
+        assert!(!is_definitely_read_only_command(
+            resolved.command.as_deref().unwrap()
+        ));
     }
 
     #[cfg(unix)]

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -110,25 +110,19 @@ pub fn handle_git(args: &[String]) {
         return;
     }
 
+    let parsed_args = parse_git_cli_args(args);
+
+    // Direct read-only commands never participate in git-ai hooks, so avoid the
+    // wrapper's repository/config preflight entirely and behave like a pure
+    // passthrough. This keeps commands like `git status` fast on Windows.
+    if should_passthrough_read_only_command(&parsed_args) {
+        let exit_status = proxy_to_git(args, false, None, None);
+        exit_with_status(exit_status);
+    }
+
     // Async mode: wrapper should behave as a pure passthrough to git,
     // but capture and send authoritative pre/post state to the daemon.
     if config::Config::get().feature_flags().async_mode {
-        let parsed = parse_git_cli_args(args);
-
-        // Read-only commands don't need wrapper state (the daemon fast-paths
-        // their trace events and never processes them through the normalizer).
-        // Skip the invocation_id so we can also suppress trace2 for them,
-        // avoiding unnecessary daemon work and wrapper_states memory leaks.
-        let is_read_only = parsed
-            .command
-            .as_deref()
-            .is_some_and(crate::git::command_classification::is_definitely_read_only_command);
-
-        if is_read_only {
-            let exit_status = proxy_to_git(args, false, None, None);
-            exit_with_status(exit_status);
-        }
-
         // Initialize the daemon telemetry handle so we can send wrapper state
         if let crate::daemon::telemetry_handle::DaemonTelemetryInitResult::Failed(e) =
             crate::daemon::telemetry_handle::init_daemon_telemetry_handle()
@@ -136,7 +130,7 @@ pub fn handle_git(args: &[String]) {
             debug_log(&format!("wrapper: daemon telemetry init failed: {}", e));
         }
 
-        let repository = find_repository(&parsed.global_args).ok();
+        let repository = find_repository(&parsed_args.global_args).ok();
         let worktree = repository.as_ref().and_then(|r| r.workdir().ok());
 
         let pre_state = worktree
@@ -159,16 +153,16 @@ pub fn handle_git(args: &[String]) {
         // After a successful commit, wait briefly for the daemon to produce an
         // authorship note so we can show stats inline (same UX as plain wrapper mode).
         if exit_status.success()
-            && parsed.command.as_deref() == Some("commit")
+            && parsed_args.command.as_deref() == Some("commit")
             && let Some(repo) = repository.as_ref()
         {
-            maybe_show_async_post_commit_stats(&parsed, repo);
+            maybe_show_async_post_commit_stats(&parsed_args, repo);
         }
 
         exit_with_status(exit_status);
     }
 
-    let mut parsed_args = parse_git_cli_args(args);
+    let mut parsed_args = parsed_args;
 
     let mut repository_option = find_repository(&parsed_args.global_args).ok();
 
@@ -261,6 +255,14 @@ pub fn handle_git(args: &[String]) {
         )
     };
     exit_with_status(exit_status);
+}
+
+fn should_passthrough_read_only_command(parsed_args: &ParsedGitInvocation) -> bool {
+    !parsed_args.is_help
+        && parsed_args
+            .command
+            .as_deref()
+            .is_some_and(crate::git::command_classification::is_definitely_read_only_command)
 }
 
 /// Handle alias invocations
@@ -985,7 +987,10 @@ fn in_shell_completion_context() -> bool {
 #[cfg(test)]
 mod tests {
     use super::parse_alias_tokens;
-    use super::{parse_git_cli_args, resolve_child_git_hooks_path_override};
+    use super::{
+        parse_git_cli_args, resolve_child_git_hooks_path_override,
+        should_passthrough_read_only_command,
+    };
     use crate::git::find_repository_in_path;
     use std::process::Command;
     use tempfile::tempdir;
@@ -1110,6 +1115,25 @@ mod tests {
             resolve_child_git_hooks_path_override(&parsed, Some(&repo)),
             None
         );
+    }
+
+    #[test]
+    fn passthrough_read_only_command_for_status() {
+        let parsed = parse_git_cli_args(&["status".to_string(), "--short".to_string()]);
+        assert!(should_passthrough_read_only_command(&parsed));
+    }
+
+    #[test]
+    fn passthrough_read_only_command_rejects_mutating_commands() {
+        let parsed =
+            parse_git_cli_args(&["commit".to_string(), "-m".to_string(), "msg".to_string()]);
+        assert!(!should_passthrough_read_only_command(&parsed));
+    }
+
+    #[test]
+    fn passthrough_read_only_command_rejects_help_invocations() {
+        let parsed = parse_git_cli_args(&["status".to_string(), "--help".to_string()]);
+        assert!(!should_passthrough_read_only_command(&parsed));
     }
 
     #[cfg(unix)]

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -1130,9 +1130,15 @@ mod tests {
     }
 
     #[test]
-    fn passthrough_read_only_command_rejects_help_invocations() {
+    fn passthrough_read_only_command_accepts_help_invocations() {
         let parsed = parse_git_cli_args(&["status".to_string(), "--help".to_string()]);
-        assert!(!should_passthrough_read_only_command(&parsed));
+        assert!(should_passthrough_read_only_command(&parsed));
+    }
+
+    #[test]
+    fn passthrough_read_only_command_accepts_top_level_version() {
+        let parsed = parse_git_cli_args(&["--version".to_string()]);
+        assert!(should_passthrough_read_only_command(&parsed));
     }
 
     #[cfg(unix)]

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -126,19 +126,8 @@ pub fn handle_git(args: &[String]) {
         exit_with_status(exit_status);
     }
 
-    // Repo-creating commands (clone, init) have no meaningful pre/post
-    // repo state — the target repo doesn't exist yet. The wrapper would
-    // either capture nothing (clone from outside a repo) or the wrong
-    // repo (clone from inside a different repo). Skip the invocation_id
-    // so the daemon doesn't wait for wrapper state that never arrives or
-    // is misleading; trace2 events still flow normally (trace2 suppression
-    // requires *both* no invocation_id and a read-only command).
-    if parsed_args
-        .command
-        .as_deref()
-        .is_some_and(|cmd| matches!(cmd, "clone" | "init"))
-        && !parsed_args.is_help
-    {
+    // `init` has no post-hooks, so it can always passthrough early.
+    if parsed_args.command.as_deref() == Some("init") && !parsed_args.is_help {
         let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false, None, None);
         exit_with_status(exit_status);
     }
@@ -146,6 +135,14 @@ pub fn handle_git(args: &[String]) {
     // Async mode: wrapper should behave as a pure passthrough to git,
     // but capture and send authoritative pre/post state to the daemon.
     if config::Config::get().feature_flags().async_mode {
+        // Clone in async mode has no meaningful pre/post repo state — the
+        // target repo doesn't exist yet. Skip daemon telemetry so the daemon
+        // doesn't wait for wrapper state that never arrives or is misleading.
+        if parsed_args.command.as_deref() == Some("clone") && !parsed_args.is_help {
+            let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false, None, None);
+            exit_with_status(exit_status);
+        }
+
         // Initialize the daemon telemetry handle so we can send wrapper state
         if let crate::daemon::telemetry_handle::DaemonTelemetryInitResult::Failed(e) =
             crate::daemon::telemetry_handle::init_daemon_telemetry_handle()

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -110,13 +110,21 @@ pub fn handle_git(args: &[String]) {
         return;
     }
 
-    let parsed_args = parse_git_cli_args(args);
+    let mut parsed_args = parse_git_cli_args(args);
 
     // Direct read-only commands never participate in git-ai hooks, so avoid the
     // wrapper's repository/config preflight entirely and behave like a pure
     // passthrough. This keeps commands like `git status` fast on Windows.
     if should_passthrough_read_only_command(&parsed_args) {
         let exit_status = proxy_to_git(args, false, None, None);
+        exit_with_status(exit_status);
+    }
+
+    let mut repository_option = find_repository(&parsed_args.global_args).ok();
+    parsed_args = resolve_wrapper_invocation(&parsed_args, repository_option.as_ref());
+
+    if should_passthrough_read_only_command(&parsed_args) {
+        let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false, None, None);
         exit_with_status(exit_status);
     }
 
@@ -130,8 +138,7 @@ pub fn handle_git(args: &[String]) {
             debug_log(&format!("wrapper: daemon telemetry init failed: {}", e));
         }
 
-        let repository = find_repository(&parsed_args.global_args).ok();
-        let worktree = repository.as_ref().and_then(|r| r.workdir().ok());
+        let worktree = repository_option.as_ref().and_then(|r| r.workdir().ok());
 
         let pre_state = worktree
             .as_deref()
@@ -142,7 +149,12 @@ pub fn handle_git(args: &[String]) {
         // processes the atexit trace event and starts the wrapper state timeout.
         send_wrapper_pre_state_to_daemon(&invocation_id, worktree.as_deref(), &pre_state);
 
-        let exit_status = proxy_to_git(args, false, None, Some(&invocation_id));
+        let exit_status = proxy_to_git(
+            &parsed_args.to_invocation_vec(),
+            false,
+            None,
+            Some(&invocation_id),
+        );
 
         let post_state = worktree
             .as_deref()
@@ -154,17 +166,13 @@ pub fn handle_git(args: &[String]) {
         // authorship note so we can show stats inline (same UX as plain wrapper mode).
         if exit_status.success()
             && parsed_args.command.as_deref() == Some("commit")
-            && let Some(repo) = repository.as_ref()
+            && let Some(repo) = repository_option.as_ref()
         {
             maybe_show_async_post_commit_stats(&parsed_args, repo);
         }
 
         exit_with_status(exit_status);
     }
-
-    let mut parsed_args = parsed_args;
-
-    let mut repository_option = find_repository(&parsed_args.global_args).ok();
 
     let has_repo = repository_option.is_some();
 
@@ -203,10 +211,6 @@ pub fn handle_git(args: &[String]) {
         };
 
         let repository = repository_option.as_mut().unwrap();
-
-        if let Some(resolved) = resolve_alias_invocation(&parsed_args, repository) {
-            parsed_args = resolved;
-        }
 
         let pre_command_start = Instant::now();
         run_pre_command_hooks(&mut command_hooks_context, &mut parsed_args, repository);
@@ -259,6 +263,15 @@ pub fn handle_git(args: &[String]) {
 
 fn should_passthrough_read_only_command(parsed_args: &ParsedGitInvocation) -> bool {
     crate::git::command_classification::is_read_only_invocation(parsed_args)
+}
+
+fn resolve_wrapper_invocation(
+    parsed_args: &ParsedGitInvocation,
+    repository: Option<&Repository>,
+) -> ParsedGitInvocation {
+    repository
+        .and_then(|repo| resolve_alias_invocation(parsed_args, repo))
+        .unwrap_or_else(|| parsed_args.clone())
 }
 
 /// Handle alias invocations
@@ -981,7 +994,7 @@ fn in_shell_completion_context() -> bool {
 mod tests {
     use super::parse_alias_tokens;
     use super::{
-        parse_git_cli_args, resolve_child_git_hooks_path_override,
+        parse_git_cli_args, resolve_child_git_hooks_path_override, resolve_wrapper_invocation,
         should_passthrough_read_only_command,
     };
     use crate::git::find_repository_in_path;
@@ -1139,6 +1152,75 @@ mod tests {
     fn passthrough_read_only_command_accepts_top_level_version() {
         let parsed = parse_git_cli_args(&["--version".to_string()]);
         assert!(should_passthrough_read_only_command(&parsed));
+    }
+
+    #[test]
+    fn wrapper_resolves_read_only_alias_before_passthrough() {
+        let temp = tempdir().expect("tempdir should create");
+        let output = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git init should run");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let alias_output = Command::new("git")
+            .args(["config", "alias.st", "status --short"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git config alias should run");
+        assert!(
+            alias_output.status.success(),
+            "git config alias failed: {}",
+            String::from_utf8_lossy(&alias_output.stderr)
+        );
+
+        let repo = find_repository_in_path(&temp.path().to_string_lossy())
+            .expect("repository should be discovered");
+        let parsed = parse_git_cli_args(&["st".to_string()]);
+        let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
+
+        assert_eq!(resolved.command.as_deref(), Some("status"));
+        assert!(resolved.command_args.iter().any(|arg| arg == "--short"));
+        assert!(should_passthrough_read_only_command(&resolved));
+    }
+
+    #[test]
+    fn wrapper_resolves_mutating_alias_before_passthrough() {
+        let temp = tempdir().expect("tempdir should create");
+        let output = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git init should run");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let alias_output = Command::new("git")
+            .args(["config", "alias.ci", "commit"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git config alias should run");
+        assert!(
+            alias_output.status.success(),
+            "git config alias failed: {}",
+            String::from_utf8_lossy(&alias_output.stderr)
+        );
+
+        let repo = find_repository_in_path(&temp.path().to_string_lossy())
+            .expect("repository should be discovered");
+        let parsed = parse_git_cli_args(&["ci".to_string(), "-m".to_string(), "msg".to_string()]);
+        let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
+
+        assert_eq!(resolved.command.as_deref(), Some("commit"));
+        assert!(!should_passthrough_read_only_command(&resolved));
     }
 
     #[cfg(unix)]

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -120,6 +120,23 @@ pub fn handle_git(args: &[String]) {
         exit_with_status(exit_status);
     }
 
+    // Repo-creating commands (clone, init) have no meaningful pre/post
+    // repo state — the target repo doesn't exist yet. The wrapper would
+    // either capture nothing (clone from outside a repo) or the wrong
+    // repo (clone from inside a different repo). Skip the invocation_id
+    // so the daemon doesn't wait for wrapper state that never arrives or
+    // is misleading; trace2 events still flow normally (trace2 suppression
+    // requires *both* no invocation_id and a read-only command).
+    if parsed_args
+        .command
+        .as_deref()
+        .is_some_and(|cmd| matches!(cmd, "clone" | "init"))
+        && !parsed_args.is_help
+    {
+        let exit_status = proxy_to_git(&parsed_args.to_invocation_vec(), false, None, None);
+        exit_with_status(exit_status);
+    }
+
     // Async mode: wrapper should behave as a pure passthrough to git,
     // but capture and send authoritative pre/post state to the daemon.
     if config::Config::get().feature_flags().async_mode {

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -112,14 +112,6 @@ pub fn handle_git(args: &[String]) {
 
     let mut parsed_args = parse_git_cli_args(args);
 
-    // Direct read-only commands never participate in git-ai hooks, so avoid the
-    // wrapper's repository/config preflight entirely and behave like a pure
-    // passthrough. This keeps commands like `git status` fast on Windows.
-    if should_passthrough_read_only_command(&parsed_args) {
-        let exit_status = proxy_to_git(args, false, None, None);
-        exit_with_status(exit_status);
-    }
-
     let mut repository_option = find_repository(&parsed_args.global_args).ok();
     parsed_args = resolve_wrapper_invocation(&parsed_args, repository_option.as_ref());
 
@@ -1220,6 +1212,41 @@ mod tests {
         let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
 
         assert_eq!(resolved.command.as_deref(), Some("commit"));
+        assert!(!should_passthrough_read_only_command(&resolved));
+    }
+
+    #[test]
+    fn wrapper_does_not_passthrough_builtin_name_shadowed_by_mutating_alias() {
+        let temp = tempdir().expect("tempdir should create");
+        let output = Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git init should run");
+        assert!(
+            output.status.success(),
+            "git init failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let alias_output = Command::new("git")
+            .args(["config", "alias.status", "branch aliased HEAD"])
+            .current_dir(temp.path())
+            .output()
+            .expect("git config alias should run");
+        assert!(
+            alias_output.status.success(),
+            "git config alias failed: {}",
+            String::from_utf8_lossy(&alias_output.stderr)
+        );
+
+        let repo = find_repository_in_path(&temp.path().to_string_lossy())
+            .expect("repository should be discovered");
+        let parsed = parse_git_cli_args(&["status".to_string()]);
+
+        let resolved = resolve_wrapper_invocation(&parsed, Some(&repo));
+        assert_eq!(resolved.command.as_deref(), Some("branch"));
+        assert!(resolved.command_args.iter().any(|arg| arg == "aliased"));
         assert!(!should_passthrough_read_only_command(&resolved));
     }
 

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -273,7 +273,6 @@ pub fn handle_git(args: &[String]) {
     exit_with_status(exit_status);
 }
 
-
 /// Handle alias invocations
 #[cfg(feature = "test-support")]
 pub fn resolve_alias_invocation(
@@ -993,7 +992,9 @@ fn in_shell_completion_context() -> bool {
 #[cfg(test)]
 mod tests {
     use super::parse_alias_tokens;
-    use super::{parse_git_cli_args, resolve_alias_invocation, resolve_child_git_hooks_path_override};
+    use super::{
+        parse_git_cli_args, resolve_alias_invocation, resolve_child_git_hooks_path_override,
+    };
     use crate::git::command_classification::is_read_only_invocation;
     use crate::git::find_repository_in_path;
     use std::process::Command;

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,6 +209,10 @@ impl Config {
     }
 
     pub fn is_allowed_repository(&self, repository: &Option<Repository>) -> bool {
+        if self.allow_repositories.is_empty() && self.exclude_repositories.is_empty() {
+            return true;
+        }
+
         // Fetch remotes once and reuse for both exclude and allow checks
         let remotes = repository
             .as_ref()

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -97,29 +97,29 @@ fn is_read_only_branch_invocation(parsed: &ParsedGitInvocation) -> bool {
         return false;
     }
 
-    let read_only_listing_flags = [
+    // Flags that *trigger* list mode — their presence alone means read-only.
+    let list_mode_triggers = [
         "--all",
         "--contains",
         "--format",
-        "--ignore-case",
         "--list",
         "--merged",
-        "--no-color",
-        "--no-column",
         "--no-contains",
         "--no-merged",
         "--points-at",
         "--remotes",
         "--show-current",
         "--sort",
-        "--verbose",
         "-a",
         "-l",
         "-r",
-        "-v",
     ];
 
-    command_args_contain_any(&parsed.command_args, &read_only_listing_flags)
+    // Flags that only *modify* list output (e.g. -v, --no-color) but do NOT
+    // trigger list mode on their own. `git branch -v feature` creates a branch
+    // named "feature" — -v only means "verbose" in list mode, it does not
+    // activate list mode.
+    command_args_contain_any(&parsed.command_args, &list_mode_triggers)
         || parsed.pos_command(0).is_none()
 }
 
@@ -290,6 +290,18 @@ mod tests {
     #[test]
     fn read_only_invocation_rejects_branch_creation() {
         let parsed = parse_git_cli_args(&["branch".to_string(), "feature".to_string()]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_branch_create_with_verbose_flag() {
+        // `git branch -v feature` creates a branch; -v is a list-output modifier,
+        // not a list-mode trigger.
+        let parsed = parse_git_cli_args(&[
+            "branch".to_string(),
+            "-v".to_string(),
+            "feature".to_string(),
+        ]);
         assert!(!is_read_only_invocation(&parsed));
     }
 

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -38,8 +38,8 @@ pub fn is_definitely_read_only_command(command: &str) -> bool {
 }
 
 pub fn is_read_only_invocation(parsed: &ParsedGitInvocation) -> bool {
-    if parsed.is_help {
-        return false;
+    if parsed.is_help || parsed.command.is_none() {
+        return true;
     }
 
     if parsed
@@ -54,6 +54,10 @@ pub fn is_read_only_invocation(parsed: &ParsedGitInvocation) -> bool {
         Some("branch") => is_read_only_branch_invocation(parsed),
         Some("stash") => is_read_only_stash_invocation(parsed),
         Some("tag") => is_read_only_tag_invocation(parsed),
+        Some("remote") => is_read_only_remote_invocation(parsed),
+        Some("config") => is_read_only_config_invocation(parsed),
+        Some("worktree") => is_read_only_worktree_invocation(parsed),
+        Some("submodule") => is_read_only_submodule_invocation(parsed),
         _ => false,
     }
 }
@@ -172,6 +176,77 @@ fn is_read_only_tag_invocation(parsed: &ParsedGitInvocation) -> bool {
         || parsed.pos_command(0).is_none()
 }
 
+fn is_read_only_remote_invocation(parsed: &ParsedGitInvocation) -> bool {
+    let mutating_subcommands = [
+        "add",
+        "rename",
+        "remove",
+        "rm",
+        "set-head",
+        "set-branches",
+        "set-url",
+        "prune",
+        "update",
+    ];
+
+    match parsed.pos_command(0).as_deref() {
+        None => true,
+        Some(subcommand) if mutating_subcommands.contains(&subcommand) => false,
+        Some("show" | "get-url") => true,
+        Some(_) => false,
+    }
+}
+
+fn is_read_only_config_invocation(parsed: &ParsedGitInvocation) -> bool {
+    let mutating_flags = [
+        "--add",
+        "--replace-all",
+        "--unset",
+        "--unset-all",
+        "--rename-section",
+        "--remove-section",
+        "--edit",
+    ];
+    if command_args_contain_any(&parsed.command_args, &mutating_flags) {
+        return false;
+    }
+
+    let read_only_flags = [
+        "--blob",
+        "--default",
+        "--get",
+        "--get-all",
+        "--get-regexp",
+        "--get-urlmatch",
+        "--includes",
+        "--list",
+        "--name-only",
+        "--no-includes",
+        "--null",
+        "--show-origin",
+        "--show-scope",
+        "--type",
+        "-l",
+        "-z",
+    ];
+
+    command_args_contain_any(&parsed.command_args, &read_only_flags)
+}
+
+fn is_read_only_worktree_invocation(parsed: &ParsedGitInvocation) -> bool {
+    matches!(
+        parsed.command_args.first().map(String::as_str),
+        Some("list")
+    )
+}
+
+fn is_read_only_submodule_invocation(parsed: &ParsedGitInvocation) -> bool {
+    matches!(
+        parsed.command_args.first().map(String::as_str),
+        Some("status" | "summary")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,5 +316,55 @@ mod tests {
     fn read_only_invocation_detects_stash_list() {
         let parsed = parse_git_cli_args(&["stash".to_string(), "list".to_string()]);
         assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_top_level_version() {
+        let parsed = parse_git_cli_args(&["--version".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_commit_help() {
+        let parsed = parse_git_cli_args(&["commit".to_string(), "--help".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_remote_listing() {
+        let parsed = parse_git_cli_args(&["remote".to_string(), "-v".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_remote_add() {
+        let parsed = parse_git_cli_args(&[
+            "remote".to_string(),
+            "add".to_string(),
+            "origin".to_string(),
+            "https://example.com/repo".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_config_list() {
+        let parsed = parse_git_cli_args(&[
+            "config".to_string(),
+            "--list".to_string(),
+            "--show-origin".to_string(),
+        ]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_config_set() {
+        let parsed = parse_git_cli_args(&[
+            "config".to_string(),
+            "--add".to_string(),
+            "demo.key".to_string(),
+            "value".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
     }
 }

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -211,26 +211,19 @@ fn is_read_only_config_invocation(parsed: &ParsedGitInvocation) -> bool {
         return false;
     }
 
-    let read_only_flags = [
+    // Only explicit query actions are safe to fast-path. Other config flags like
+    // --type or --show-origin are modifiers and can still participate in writes.
+    let read_only_actions = [
         "--blob",
-        "--default",
         "--get",
         "--get-all",
         "--get-regexp",
         "--get-urlmatch",
-        "--includes",
         "--list",
-        "--name-only",
-        "--no-includes",
-        "--null",
-        "--show-origin",
-        "--show-scope",
-        "--type",
         "-l",
-        "-z",
     ];
 
-    command_args_contain_any(&parsed.command_args, &read_only_flags)
+    command_args_contain_any(&parsed.command_args, &read_only_actions)
 }
 
 fn is_read_only_worktree_invocation(parsed: &ParsedGitInvocation) -> bool {
@@ -366,5 +359,28 @@ mod tests {
             "value".to_string(),
         ]);
         assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_config_write_with_type_modifier() {
+        let parsed = parse_git_cli_args(&[
+            "config".to_string(),
+            "--type=bool".to_string(),
+            "demo.enabled".to_string(),
+            "true".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_accepts_config_get_with_modifiers() {
+        let parsed = parse_git_cli_args(&[
+            "config".to_string(),
+            "--show-origin".to_string(),
+            "--type=bool".to_string(),
+            "--get".to_string(),
+            "demo.enabled".to_string(),
+        ]);
+        assert!(is_read_only_invocation(&parsed));
     }
 }

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -291,11 +291,10 @@ fn is_read_only_reflog_invocation(parsed: &ParsedGitInvocation) -> bool {
 /// `git notes add/append/copy/edit/merge/prune/remove` are mutating.
 /// Bare `git notes` defaults to `list`.
 fn is_read_only_notes_invocation(parsed: &ParsedGitInvocation) -> bool {
-    match parsed.command_args.first().map(String::as_str) {
-        None => true,
-        Some("list" | "show" | "get-ref") => true,
-        _ => false,
-    }
+    matches!(
+        parsed.command_args.first().map(String::as_str),
+        None | Some("list" | "show" | "get-ref")
+    )
 }
 
 #[cfg(test)]

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -3,37 +3,59 @@ use crate::git::cli_parser::ParsedGitInvocation;
 /// Returns true if the given git subcommand is guaranteed to never mutate
 /// repository state (refs, objects, config, worktree). Used to skip expensive
 /// trace2 ingestion work and suppress trace2 emission for read-only commands.
+///
+/// This list covers both porcelain and plumbing commands that IDEs (VS Code,
+/// JetBrains), git clients (GitLens, Graphite CLI), and other tools call at
+/// high frequency. Only commands that are unconditionally read-only regardless
+/// of arguments belong here; commands with mixed read/write modes (symbolic-ref,
+/// reflog, notes, etc.) are handled by `is_read_only_invocation` instead.
 pub fn is_definitely_read_only_command(command: &str) -> bool {
     matches!(
         command,
+        // Porcelain read-only
         "blame"
-            | "cat-file"
-            | "check-attr"
-            | "check-ignore"
-            | "check-mailmap"
-            | "count-objects"
+            | "cherry"
             | "describe"
             | "diff"
+            | "grep"
+            | "help"
+            | "log"
+            | "shortlog"
+            | "show"
+            | "show-branch"
+            | "status"
+            | "version"
+            | "whatchanged"
+            // Plumbing — object/ref inspection
+            | "cat-file"
             | "diff-files"
             | "diff-index"
             | "diff-tree"
             | "for-each-ref"
-            | "grep"
-            | "help"
-            | "log"
             | "ls-files"
+            | "ls-remote"
             | "ls-tree"
             | "merge-base"
             | "name-rev"
             | "rev-list"
             | "rev-parse"
-            | "shortlog"
-            | "show"
-            | "status"
+            | "show-ref"
             | "var"
             | "verify-commit"
+            | "verify-pack"
             | "verify-tag"
-            | "version"
+            // Plumbing — query/validation helpers
+            | "check-attr"
+            | "check-ignore"
+            | "check-mailmap"
+            | "check-ref-format"
+            | "column"
+            | "count-objects"
+            | "fmt-merge-msg"
+            | "fsck"
+            | "get-tar-commit-id"
+            | "patch-id"
+            | "stripspace"
     )
 }
 
@@ -58,6 +80,9 @@ pub fn is_read_only_invocation(parsed: &ParsedGitInvocation) -> bool {
         Some("config") => is_read_only_config_invocation(parsed),
         Some("worktree") => is_read_only_worktree_invocation(parsed),
         Some("submodule") => is_read_only_submodule_invocation(parsed),
+        Some("symbolic-ref") => is_read_only_symbolic_ref_invocation(parsed),
+        Some("reflog") => is_read_only_reflog_invocation(parsed),
+        Some("notes") => is_read_only_notes_invocation(parsed),
         _ => false,
     }
 }
@@ -240,6 +265,39 @@ fn is_read_only_submodule_invocation(parsed: &ParsedGitInvocation) -> bool {
     )
 }
 
+/// `git symbolic-ref HEAD` reads; `git symbolic-ref HEAD refs/heads/main` writes.
+/// -d/--delete and -m (reason) with a target are also mutating.
+fn is_read_only_symbolic_ref_invocation(parsed: &ParsedGitInvocation) -> bool {
+    if command_args_contain_any(&parsed.command_args, &["-d", "--delete"]) {
+        return false;
+    }
+    // Read mode: exactly one positional (the ref name to read).
+    // Write mode: two positionals (ref name + target).
+    parsed.pos_command(1).is_none()
+}
+
+/// Only `git reflog expire` and `git reflog delete` are mutating.
+/// Everything else — bare `git reflog`, `git reflog show`, `git reflog HEAD`,
+/// `git reflog --all`, `git reflog exists` — is read-only (bare reflog and
+/// unrecognized first args are interpreted by git as `reflog show`).
+fn is_read_only_reflog_invocation(parsed: &ParsedGitInvocation) -> bool {
+    !matches!(
+        parsed.command_args.first().map(String::as_str),
+        Some("expire" | "delete")
+    )
+}
+
+/// `git notes list`, `git notes show` are read-only.
+/// `git notes add/append/copy/edit/merge/prune/remove` are mutating.
+/// Bare `git notes` defaults to `list`.
+fn is_read_only_notes_invocation(parsed: &ParsedGitInvocation) -> bool {
+    match parsed.command_args.first().map(String::as_str) {
+        None => true,
+        Some("list" | "show" | "get-ref") => true,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,6 +312,16 @@ mod tests {
         assert!(is_definitely_read_only_command("log"));
         assert!(is_definitely_read_only_command("cat-file"));
         assert!(is_definitely_read_only_command("ls-files"));
+        // High-volume plumbing used by IDEs and git clients
+        assert!(is_definitely_read_only_command("ls-remote"));
+        assert!(is_definitely_read_only_command("show-ref"));
+        assert!(is_definitely_read_only_command("cherry"));
+        assert!(is_definitely_read_only_command("show-branch"));
+        assert!(is_definitely_read_only_command("for-each-ref"));
+        assert!(is_definitely_read_only_command("verify-pack"));
+        assert!(is_definitely_read_only_command("check-ref-format"));
+        assert!(is_definitely_read_only_command("fsck"));
+        assert!(is_definitely_read_only_command("whatchanged"));
     }
 
     #[test]
@@ -393,6 +461,159 @@ mod tests {
             "--get".to_string(),
             "demo.enabled".to_string(),
         ]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    // symbolic-ref classifier
+    #[test]
+    fn read_only_invocation_detects_symbolic_ref_read() {
+        let parsed = parse_git_cli_args(&["symbolic-ref".to_string(), "HEAD".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_symbolic_ref_read_with_short() {
+        let parsed = parse_git_cli_args(&[
+            "symbolic-ref".to_string(),
+            "--short".to_string(),
+            "HEAD".to_string(),
+        ]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_symbolic_ref_write() {
+        let parsed = parse_git_cli_args(&[
+            "symbolic-ref".to_string(),
+            "HEAD".to_string(),
+            "refs/heads/main".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_symbolic_ref_delete() {
+        let parsed = parse_git_cli_args(&[
+            "symbolic-ref".to_string(),
+            "--delete".to_string(),
+            "HEAD".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    // reflog classifier
+    #[test]
+    fn read_only_invocation_detects_bare_reflog() {
+        let parsed = parse_git_cli_args(&["reflog".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_reflog_show() {
+        let parsed =
+            parse_git_cli_args(&["reflog".to_string(), "show".to_string(), "HEAD".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_reflog_implicit_show_with_ref() {
+        // `git reflog HEAD` is `git reflog show HEAD`
+        let parsed = parse_git_cli_args(&["reflog".to_string(), "HEAD".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_reflog_implicit_show_with_flags() {
+        // `git reflog --all` is `git reflog show --all`
+        let parsed = parse_git_cli_args(&["reflog".to_string(), "--all".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_reflog_exists() {
+        let parsed = parse_git_cli_args(&[
+            "reflog".to_string(),
+            "exists".to_string(),
+            "HEAD".to_string(),
+        ]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_reflog_expire() {
+        let parsed = parse_git_cli_args(&[
+            "reflog".to_string(),
+            "expire".to_string(),
+            "--all".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_reflog_delete() {
+        let parsed = parse_git_cli_args(&[
+            "reflog".to_string(),
+            "delete".to_string(),
+            "HEAD@{0}".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    // notes classifier
+    #[test]
+    fn read_only_invocation_detects_bare_notes() {
+        let parsed = parse_git_cli_args(&["notes".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_notes_list() {
+        let parsed = parse_git_cli_args(&["notes".to_string(), "list".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_notes_show() {
+        let parsed =
+            parse_git_cli_args(&["notes".to_string(), "show".to_string(), "HEAD".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_notes_add() {
+        let parsed = parse_git_cli_args(&[
+            "notes".to_string(),
+            "add".to_string(),
+            "-m".to_string(),
+            "note".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_notes_remove() {
+        let parsed = parse_git_cli_args(&[
+            "notes".to_string(),
+            "remove".to_string(),
+            "HEAD".to_string(),
+        ]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    // ls-remote and show-ref as invocations
+    #[test]
+    fn read_only_invocation_detects_ls_remote() {
+        let parsed = parse_git_cli_args(&[
+            "ls-remote".to_string(),
+            "--heads".to_string(),
+            "origin".to_string(),
+        ]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_show_ref() {
+        let parsed = parse_git_cli_args(&["show-ref".to_string(), "--heads".to_string()]);
         assert!(is_read_only_invocation(&parsed));
     }
 }

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -1,3 +1,5 @@
+use crate::git::cli_parser::ParsedGitInvocation;
+
 /// Returns true if the given git subcommand is guaranteed to never mutate
 /// repository state (refs, objects, config, worktree). Used to skip expensive
 /// trace2 ingestion work and suppress trace2 emission for read-only commands.
@@ -35,9 +37,145 @@ pub fn is_definitely_read_only_command(command: &str) -> bool {
     )
 }
 
+pub fn is_read_only_invocation(parsed: &ParsedGitInvocation) -> bool {
+    if parsed.is_help {
+        return false;
+    }
+
+    if parsed
+        .command
+        .as_deref()
+        .is_some_and(is_definitely_read_only_command)
+    {
+        return true;
+    }
+
+    match parsed.command.as_deref() {
+        Some("branch") => is_read_only_branch_invocation(parsed),
+        Some("stash") => is_read_only_stash_invocation(parsed),
+        Some("tag") => is_read_only_tag_invocation(parsed),
+        _ => false,
+    }
+}
+
+fn command_args_contain_any(command_args: &[String], flags: &[&str]) -> bool {
+    command_args.iter().any(|arg| {
+        flags
+            .iter()
+            .any(|flag| arg == flag || arg.starts_with(&format!("{flag}=")))
+    })
+}
+
+fn is_read_only_branch_invocation(parsed: &ParsedGitInvocation) -> bool {
+    let mutating_flags = [
+        "-c",
+        "-C",
+        "-d",
+        "-D",
+        "-f",
+        "-m",
+        "-M",
+        "-u",
+        "--copy",
+        "--create-reflog",
+        "--delete",
+        "--delete-force",
+        "--edit-description",
+        "--force",
+        "--move",
+        "--no-track",
+        "--recurse-submodules",
+        "--set-upstream-to",
+        "--track",
+        "--unset-upstream",
+    ];
+    if command_args_contain_any(&parsed.command_args, &mutating_flags) {
+        return false;
+    }
+
+    let read_only_listing_flags = [
+        "--all",
+        "--contains",
+        "--format",
+        "--ignore-case",
+        "--list",
+        "--merged",
+        "--no-color",
+        "--no-column",
+        "--no-contains",
+        "--no-merged",
+        "--points-at",
+        "--remotes",
+        "--show-current",
+        "--sort",
+        "--verbose",
+        "-a",
+        "-l",
+        "-r",
+        "-v",
+    ];
+
+    command_args_contain_any(&parsed.command_args, &read_only_listing_flags)
+        || parsed.pos_command(0).is_none()
+}
+
+fn is_read_only_stash_invocation(parsed: &ParsedGitInvocation) -> bool {
+    matches!(
+        parsed.command_args.first().map(String::as_str),
+        Some("list" | "show")
+    )
+}
+
+fn is_read_only_tag_invocation(parsed: &ParsedGitInvocation) -> bool {
+    let mutating_flags = [
+        "-a",
+        "-d",
+        "-e",
+        "-f",
+        "-F",
+        "-m",
+        "-s",
+        "-u",
+        "--annotate",
+        "--cleanup",
+        "--create-reflog",
+        "--delete",
+        "--edit",
+        "--file",
+        "--force",
+        "--local-user",
+        "--message",
+        "--no-sign",
+        "--sign",
+        "--trailer",
+    ];
+    if command_args_contain_any(&parsed.command_args, &mutating_flags) {
+        return false;
+    }
+
+    let read_only_listing_flags = [
+        "--column",
+        "--contains",
+        "--format",
+        "--ignore-case",
+        "--list",
+        "--merged",
+        "--no-column",
+        "--no-contains",
+        "--no-merged",
+        "--points-at",
+        "--sort",
+        "-l",
+    ];
+
+    command_args_contain_any(&parsed.command_args, &read_only_listing_flags)
+        || parsed.pos_command(0).is_none()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git::cli_parser::parse_git_cli_args;
 
     #[test]
     fn read_only_commands_detected() {
@@ -67,5 +205,41 @@ mod tests {
     fn unknown_commands_not_read_only() {
         assert!(!is_definitely_read_only_command("my-custom-alias"));
         assert!(!is_definitely_read_only_command(""));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_branch_show_current() {
+        let parsed = parse_git_cli_args(&["branch".to_string(), "--show-current".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_branch_listing_without_positionals() {
+        let parsed = parse_git_cli_args(&["branch".to_string(), "-v".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_branch_creation() {
+        let parsed = parse_git_cli_args(&["branch".to_string(), "feature".to_string()]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_tag_listing() {
+        let parsed = parse_git_cli_args(&["tag".to_string(), "--list".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_tag_creation() {
+        let parsed = parse_git_cli_args(&["tag".to_string(), "v1.2.3".to_string()]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_detects_stash_list() {
+        let parsed = parse_git_cli_args(&["stash".to_string(), "list".to_string()]);
+        assert!(is_read_only_invocation(&parsed));
     }
 }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2502,6 +2502,16 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
 fn try_find_repository_no_git_exec(
     global_args: &[String],
 ) -> Result<Option<Repository>, GitAiError> {
+    // When GIT_DIR, GIT_WORK_TREE, or GIT_CEILING_DIRECTORIES are set, the
+    // filesystem walk may disagree with git's own discovery logic. Fall back
+    // to the git-exec path so those env vars are honoured.
+    if std::env::var_os("GIT_DIR").is_some()
+        || std::env::var_os("GIT_WORK_TREE").is_some()
+        || std::env::var_os("GIT_CEILING_DIRECTORIES").is_some()
+    {
+        return Ok(None);
+    }
+
     let Some(base_dir) = resolve_fast_discovery_base_dir(global_args)? else {
         return Ok(None);
     };
@@ -3986,6 +3996,32 @@ index 0000000..abc1234 100644
         let args = vec!["--git-dir".to_string(), ".git".to_string()];
         let resolved = resolve_fast_discovery_base_dir(&args).expect("resolve fast discovery dir");
         assert_eq!(resolved, None);
+    }
+
+    #[test]
+    #[serial]
+    fn fast_discovery_skipped_when_git_dir_env_set() {
+        struct EnvGuard(&'static str, Option<std::ffi::OsString>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    match &self.1 {
+                        Some(val) => std::env::set_var(self.0, val),
+                        None => std::env::remove_var(self.0),
+                    }
+                }
+            }
+        }
+
+        let prev = std::env::var_os("GIT_DIR");
+        let _guard = EnvGuard("GIT_DIR", prev);
+        unsafe { std::env::set_var("GIT_DIR", "/tmp/other-repo/.git") };
+
+        let result = try_find_repository_no_git_exec(&[]).expect("should not error");
+        assert!(
+            result.is_none(),
+            "fast path must be skipped when GIT_DIR is set"
+        );
     }
 
     #[test]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2592,6 +2592,10 @@ fn is_fast_discovery_safe_global_flag(arg: &str) -> bool {
 }
 
 fn normalize_global_args_for_repo_root(global_args: &[String], command_root: &str) -> Vec<String> {
+    if !global_args_are_safe_to_rebase(global_args) {
+        return global_args.to_vec();
+    }
+
     let mut normalized = vec!["-C".to_string(), command_root.to_string()];
     let mut idx = 0usize;
 
@@ -2613,6 +2617,33 @@ fn normalize_global_args_for_repo_root(global_args: &[String], command_root: &st
     }
 
     normalized
+}
+
+fn global_args_are_safe_to_rebase(global_args: &[String]) -> bool {
+    let mut idx = 0usize;
+
+    while idx < global_args.len() {
+        let arg = &global_args[idx];
+
+        if arg == "-C" {
+            idx += 2;
+            continue;
+        }
+
+        if arg.starts_with("-C") && arg.len() > 2 {
+            idx += 1;
+            continue;
+        }
+
+        if is_fast_discovery_safe_global_flag(arg) {
+            idx += 1;
+            continue;
+        }
+
+        return false;
+    }
+
+    true
 }
 
 fn resolve_command_base_dir(global_args: &[String]) -> Result<PathBuf, GitAiError> {
@@ -3496,6 +3527,7 @@ fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -3970,6 +4002,55 @@ index 0000000..abc1234 100644
                 "--literal-pathspecs".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn normalize_global_args_for_repo_root_preserves_relative_git_dir_and_work_tree() {
+        let args = vec![
+            "--git-dir".to_string(),
+            "sub/repo/.git".to_string(),
+            "--work-tree".to_string(),
+            "sub/repo".to_string(),
+        ];
+
+        let normalized = normalize_global_args_for_repo_root(&args, "/repo/root");
+        assert_eq!(normalized, args);
+    }
+
+    #[test]
+    #[serial]
+    fn find_repository_preserves_relative_git_dir_and_work_tree_for_internal_commands() {
+        struct CurrentDirGuard(PathBuf);
+
+        impl Drop for CurrentDirGuard {
+            fn drop(&mut self) {
+                std::env::set_current_dir(&self.0).expect("restore current dir");
+            }
+        }
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let outer = temp.path().join("outer");
+        let repo_dir = outer.join("sub").join("repo");
+        fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+        run_git(&repo_dir, &["init"]);
+
+        let previous_dir = std::env::current_dir().expect("current dir");
+        let _guard = CurrentDirGuard(previous_dir);
+        std::env::set_current_dir(&outer).expect("set current dir");
+
+        let args = vec![
+            "--git-dir".to_string(),
+            "sub/repo/.git".to_string(),
+            "--work-tree".to_string(),
+            "sub/repo".to_string(),
+        ];
+        let repo = find_repository(&args).expect("find repository");
+        let output = repo
+            .git(&["config", "--get", "core.repositoryformatversion"])
+            .expect("internal git command should preserve relative repo args");
+
+        assert_eq!(output.trim(), "0");
     }
 
     #[test]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2606,25 +2606,31 @@ fn is_fast_discovery_safe_global_flag(arg: &str) -> bool {
     )
 }
 
+/// Replace any `-C` arguments with a single `-C <command_root>`, keeping other
+/// global flags intact. When the args contain flags that aren't safe to rebase
+/// (e.g. relative `--git-dir`/`--work-tree`), the original args are returned
+/// unchanged so their meaning is preserved.
 fn normalize_global_args_for_repo_root(global_args: &[String], command_root: &str) -> Vec<String> {
-    if !global_args_are_safe_to_rebase(global_args) {
-        return global_args.to_vec();
-    }
-
     let mut normalized = vec!["-C".to_string(), command_root.to_string()];
     let mut idx = 0usize;
 
     while idx < global_args.len() {
         let arg = &global_args[idx];
 
+        // Strip existing -C args (we prepended the canonical root above).
         if arg == "-C" {
             idx += 2;
             continue;
         }
-
         if arg.starts_with("-C") && arg.len() > 2 {
             idx += 1;
             continue;
+        }
+
+        // If the arg isn't a harmless global flag, we can't safely rebase.
+        // Return the original args unchanged.
+        if !is_fast_discovery_safe_global_flag(arg) {
+            return global_args.to_vec();
         }
 
         normalized.push(arg.clone());
@@ -2632,33 +2638,6 @@ fn normalize_global_args_for_repo_root(global_args: &[String], command_root: &st
     }
 
     normalized
-}
-
-fn global_args_are_safe_to_rebase(global_args: &[String]) -> bool {
-    let mut idx = 0usize;
-
-    while idx < global_args.len() {
-        let arg = &global_args[idx];
-
-        if arg == "-C" {
-            idx += 2;
-            continue;
-        }
-
-        if arg.starts_with("-C") && arg.len() > 2 {
-            idx += 1;
-            continue;
-        }
-
-        if is_fast_discovery_safe_global_flag(arg) {
-            idx += 1;
-            continue;
-        }
-
-        return false;
-    }
-
-    true
 }
 
 fn resolve_command_base_dir(global_args: &[String]) -> Result<PathBuf, GitAiError> {
@@ -2670,17 +2649,7 @@ fn resolve_command_base_dir(global_args: &[String]) -> Result<PathBuf, GitAiErro
             let path_arg = global_args.get(idx + 1).ok_or_else(|| {
                 GitAiError::Generic("Missing path after -C in global git args".to_string())
             })?;
-
-            let next_base = PathBuf::from(path_arg);
-            base = Some(if next_base.is_absolute() {
-                next_base
-            } else {
-                let current = match &base {
-                    Some(existing) => existing.clone(),
-                    None => std::env::current_dir().map_err(GitAiError::IoError)?,
-                };
-                current.join(next_base)
-            });
+            base = Some(apply_global_c_arg(base.as_ref(), path_arg)?);
             idx += 2;
             continue;
         }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -95,6 +95,19 @@ fn args_with_disabled_hooks_if_needed(args: &[String]) -> Vec<String> {
     out
 }
 
+fn apply_internal_git_command_env(cmd: &mut Command) {
+    cmd.env_remove("GIT_EXTERNAL_DIFF");
+    cmd.env_remove("GIT_DIFF_OPTS");
+
+    // Internal helper git invocations never need trace2 output. Disabling every
+    // trace2 stream here avoids extra named-pipe/process overhead on Windows when
+    // users have global trace2 targets configured for the wrapper daemon.
+    cmd.env("GIT_TRACE2", "0");
+    cmd.env("GIT_TRACE2_EVENT", "0");
+    cmd.env("GIT_TRACE2_PERF", "0");
+    cmd.env("GIT_TRACE2_BRIEF", "0");
+}
+
 fn first_git_subcommand_index(args: &[String]) -> Option<usize> {
     let mut index = 0usize;
 
@@ -2354,6 +2367,10 @@ impl Repository {
 }
 
 pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError> {
+    if let Some(repository) = try_find_repository_no_git_exec(global_args)? {
+        return Ok(repository);
+    }
+
     let mut rev_parse_args = global_args.to_owned();
     rev_parse_args.push("rev-parse".to_string());
     // Use --git-dir instead of --absolute-git-dir for compatibility with Git < 2.13
@@ -2440,21 +2457,12 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
     }
 
     // Ensure all internal git commands use a stable repository root consistently.
-    let mut normalized_global_args = global_args.to_owned();
     let command_root = if is_bare {
         git_dir.display().to_string()
     } else {
         workdir.display().to_string()
     };
-
-    if normalized_global_args.is_empty() {
-        normalized_global_args = vec!["-C".to_string(), command_root];
-    } else if normalized_global_args.len() == 2
-        && normalized_global_args[0] == "-C"
-        && normalized_global_args[1] != command_root
-    {
-        normalized_global_args[1] = command_root;
-    }
+    let normalized_global_args = normalize_global_args_for_repo_root(global_args, &command_root);
 
     // Canonicalize workdir for reliable path comparisons (especially on Windows)
     // On Windows, canonical paths use the \\?\ UNC prefix, which makes path.starts_with()
@@ -2489,6 +2497,122 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
         canonical_workdir,
         cached_author_identity: std::sync::OnceLock::new(),
     })
+}
+
+fn try_find_repository_no_git_exec(
+    global_args: &[String],
+) -> Result<Option<Repository>, GitAiError> {
+    let Some(base_dir) = resolve_fast_discovery_base_dir(global_args)? else {
+        return Ok(None);
+    };
+
+    let paths = match discover_repository_paths_no_git_exec(&base_dir) {
+        Ok(paths) => paths,
+        Err(_) => return Ok(None),
+    };
+
+    let normalized_global_args =
+        normalize_global_args_for_repo_root(global_args, &paths.command_root.to_string_lossy());
+
+    repository_from_discovered_paths(
+        normalized_global_args,
+        &paths.workdir,
+        &paths.git_dir,
+        &paths.git_common_dir,
+    )
+    .map(Some)
+}
+
+fn resolve_fast_discovery_base_dir(global_args: &[String]) -> Result<Option<PathBuf>, GitAiError> {
+    let mut base: Option<PathBuf> = None;
+    let mut idx = 0usize;
+
+    while idx < global_args.len() {
+        let arg = &global_args[idx];
+
+        if arg == "-C" {
+            let path_arg = global_args.get(idx + 1).ok_or_else(|| {
+                GitAiError::Generic("Missing path after -C in global git args".to_string())
+            })?;
+            base = Some(apply_global_c_arg(base.as_ref(), path_arg)?);
+            idx += 2;
+            continue;
+        }
+
+        if let Some(path_arg) = arg.strip_prefix("-C")
+            && !path_arg.is_empty()
+        {
+            base = Some(apply_global_c_arg(base.as_ref(), path_arg)?);
+            idx += 1;
+            continue;
+        }
+
+        if is_fast_discovery_safe_global_flag(arg) {
+            idx += 1;
+            continue;
+        }
+
+        return Ok(None);
+    }
+
+    Ok(Some(match base {
+        Some(base) => base,
+        None => std::env::current_dir().map_err(GitAiError::IoError)?,
+    }))
+}
+
+fn apply_global_c_arg(base: Option<&PathBuf>, path_arg: &str) -> Result<PathBuf, GitAiError> {
+    let next_base = PathBuf::from(path_arg);
+    Ok(if next_base.is_absolute() {
+        next_base
+    } else {
+        let current = match base {
+            Some(existing) => existing.clone(),
+            None => std::env::current_dir().map_err(GitAiError::IoError)?,
+        };
+        current.join(next_base)
+    })
+}
+
+fn is_fast_discovery_safe_global_flag(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-p" | "--paginate"
+            | "-P"
+            | "--no-pager"
+            | "--no-replace-objects"
+            | "--no-lazy-fetch"
+            | "--no-optional-locks"
+            | "--no-advice"
+            | "--literal-pathspecs"
+            | "--glob-pathspecs"
+            | "--noglob-pathspecs"
+            | "--icase-pathspecs"
+    )
+}
+
+fn normalize_global_args_for_repo_root(global_args: &[String], command_root: &str) -> Vec<String> {
+    let mut normalized = vec!["-C".to_string(), command_root.to_string()];
+    let mut idx = 0usize;
+
+    while idx < global_args.len() {
+        let arg = &global_args[idx];
+
+        if arg == "-C" {
+            idx += 2;
+            continue;
+        }
+
+        if arg.starts_with("-C") && arg.len() > 2 {
+            idx += 1;
+            continue;
+        }
+
+        normalized.push(arg.clone());
+        idx += 1;
+    }
+
+    normalized
 }
 
 fn resolve_command_base_dir(global_args: &[String]) -> Result<PathBuf, GitAiError> {
@@ -2807,7 +2931,7 @@ pub fn from_bare_repository(git_dir: &Path) -> Result<Repository, GitAiError> {
 }
 
 fn repository_from_discovered_paths(
-    command_root: &Path,
+    global_args: Vec<String>,
     workdir: &Path,
     git_dir: &Path,
     git_common_dir: &Path,
@@ -2847,7 +2971,7 @@ fn repository_from_discovered_paths(
     };
 
     Ok(Repository {
-        global_args: vec!["-C".to_string(), command_root.to_string_lossy().to_string()],
+        global_args,
         storage,
         git_dir: git_dir.to_path_buf(),
         git_common_dir: git_common_dir.to_path_buf(),
@@ -2865,8 +2989,10 @@ fn repository_from_discovered_paths(
 
 pub fn discover_repository_in_path_no_git_exec(path: &Path) -> Result<Repository, GitAiError> {
     let paths = discover_repository_paths_no_git_exec(path)?;
+    let global_args =
+        normalize_global_args_for_repo_root(&[], &paths.command_root.to_string_lossy());
     repository_from_discovered_paths(
-        &paths.command_root,
+        global_args,
         &paths.workdir,
         &paths.git_dir,
         &paths.git_common_dir,
@@ -3028,8 +3154,7 @@ pub fn exec_git_allow_nonzero_with_profile(
         args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
     let mut cmd = Command::new(config::Config::get().git_cmd());
     cmd.args(&effective_args);
-    cmd.env_remove("GIT_EXTERNAL_DIFF");
-    cmd.env_remove("GIT_DIFF_OPTS");
+    apply_internal_git_command_env(&mut cmd);
 
     #[cfg(windows)]
     {
@@ -3082,8 +3207,7 @@ pub fn exec_git_stdin_with_profile(
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    cmd.env_remove("GIT_EXTERNAL_DIFF");
-    cmd.env_remove("GIT_DIFF_OPTS");
+    apply_internal_git_command_env(&mut cmd);
 
     #[cfg(windows)]
     {
@@ -3147,8 +3271,7 @@ pub fn exec_git_stdin_with_env_with_profile(
     for (k, v) in env.iter() {
         cmd.env(k, v);
     }
-    cmd.env_remove("GIT_EXTERNAL_DIFF");
-    cmd.env_remove("GIT_DIFF_OPTS");
+    apply_internal_git_command_env(&mut cmd);
 
     #[cfg(windows)]
     {
@@ -3804,6 +3927,49 @@ index 0000000..abc1234 100644
 
         let resolved = resolve_command_base_dir(&args).expect("resolve base dir");
         assert_eq!(resolved, base.join("nested").join("..").join("repo"));
+    }
+
+    #[test]
+    fn resolve_fast_discovery_base_dir_supports_common_global_flags() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let base = temp.path().join("root");
+        let args = vec![
+            "--no-pager".to_string(),
+            "-C".to_string(),
+            base.to_string_lossy().to_string(),
+            "--literal-pathspecs".to_string(),
+        ];
+
+        let resolved = resolve_fast_discovery_base_dir(&args).expect("resolve fast discovery dir");
+        assert_eq!(resolved, Some(base));
+    }
+
+    #[test]
+    fn resolve_fast_discovery_base_dir_rejects_git_dir_override() {
+        let args = vec!["--git-dir".to_string(), ".git".to_string()];
+        let resolved = resolve_fast_discovery_base_dir(&args).expect("resolve fast discovery dir");
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn normalize_global_args_for_repo_root_collapses_chained_c_args() {
+        let args = vec![
+            "--no-pager".to_string(),
+            "-C".to_string(),
+            "nested".to_string(),
+            "--literal-pathspecs".to_string(),
+        ];
+
+        let normalized = normalize_global_args_for_repo_root(&args, "/repo/root");
+        assert_eq!(
+            normalized,
+            vec![
+                "-C".to_string(),
+                "/repo/root".to_string(),
+                "--no-pager".to_string(),
+                "--literal-pathspecs".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2514,13 +2514,18 @@ fn try_find_repository_no_git_exec(
     let normalized_global_args =
         normalize_global_args_for_repo_root(global_args, &paths.command_root.to_string_lossy());
 
-    repository_from_discovered_paths(
+    // If construction fails (e.g. canonicalize fails due to permissions/symlinks,
+    // or core.worktree config makes the assumed workdir incorrect), fall back to
+    // the git-exec discovery path rather than propagating the error.
+    match repository_from_discovered_paths(
         normalized_global_args,
         &paths.workdir,
         &paths.git_dir,
         &paths.git_common_dir,
-    )
-    .map(Some)
+    ) {
+        Ok(repo) => Ok(Some(repo)),
+        Err(_) => Ok(None),
+    }
 }
 
 fn resolve_fast_discovery_base_dir(global_args: &[String]) -> Result<Option<PathBuf>, GitAiError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,15 @@
+use clap::Parser;
 use git_ai::commands;
+
+#[derive(Parser)]
+#[command(name = "git-ai")]
+#[command(about = "git proxy with AI authorship tracking", long_about = None)]
+#[command(disable_help_flag = true, disable_version_flag = true)]
+struct Cli {
+    /// Git command and arguments
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    args: Vec<String>,
+}
 
 fn main() {
     // Get the binary name that was called
@@ -19,20 +30,21 @@ fn main() {
             commands::git_hook_handlers::handle_git_hook_invocation(&binary_name, &hook_args);
         std::process::exit(exit_code);
     }
-    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let cli = Cli::parse();
 
     #[cfg(debug_assertions)]
     {
         if std::env::var("GIT_AI").as_deref() == Ok("git") {
-            commands::git_handlers::handle_git(&args);
+            commands::git_handlers::handle_git(&cli.args);
             return;
         }
     }
 
     if binary_name == "git-ai" || binary_name == "git-ai.exe" {
-        commands::git_ai_handlers::handle_git_ai(&args);
+        commands::git_ai_handlers::handle_git_ai(&cli.args);
         std::process::exit(0);
     }
 
-    commands::git_handlers::handle_git(&args);
+    commands::git_handlers::handle_git(&cli.args);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,4 @@
-use clap::Parser;
 use git_ai::commands;
-
-#[derive(Parser)]
-#[command(name = "git-ai")]
-#[command(about = "git proxy with AI authorship tracking", long_about = None)]
-#[command(disable_help_flag = true, disable_version_flag = true)]
-struct Cli {
-    /// Git command and arguments
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    args: Vec<String>,
-}
 
 fn main() {
     // Get the binary name that was called
@@ -30,21 +19,20 @@ fn main() {
             commands::git_hook_handlers::handle_git_hook_invocation(&binary_name, &hook_args);
         std::process::exit(exit_code);
     }
-
-    let cli = Cli::parse();
+    let args: Vec<String> = std::env::args().skip(1).collect();
 
     #[cfg(debug_assertions)]
     {
         if std::env::var("GIT_AI").as_deref() == Ok("git") {
-            commands::git_handlers::handle_git(&cli.args);
+            commands::git_handlers::handle_git(&args);
             return;
         }
     }
 
     if binary_name == "git-ai" || binary_name == "git-ai.exe" {
-        commands::git_ai_handlers::handle_git_ai(&cli.args);
+        commands::git_ai_handlers::handle_git_ai(&args);
         std::process::exit(0);
     }
 
-    commands::git_handlers::handle_git(&cli.args);
+    commands::git_handlers::handle_git(&args);
 }

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -716,6 +716,40 @@ fn async_mode_post_commit_still_processing_when_no_daemon() {
 }
 
 #[test]
+fn async_mode_post_commit_shows_stats_with_commit_alias() {
+    let repo = TestRepo::new_with_mode(GitTestMode::WrapperDaemon);
+
+    // Configure a git alias: cm = commit (mimics common user setup)
+    repo.git(&["config", "alias.cm", "commit"]).unwrap();
+
+    // Base commit (human only).
+    let mut file = repo.filename("alias_test.txt");
+    file.set_contents(crate::lines!["Base line 1", "Base line 2"]);
+    repo.stage_all_and_commit("Base commit").unwrap();
+
+    // Add AI-attributed lines.
+    file.insert_at(2, crate::lines!["AI line 1".ai(), "AI line 2".ai()]);
+
+    repo.git(&["add", "-A"]).expect("add should succeed");
+
+    // Commit using the alias instead of "commit" directly.
+    let output = repo
+        .git_with_env(
+            &["cm", "-m", "AI additions via alias"],
+            &[("GIT_AI_TEST_FORCE_TTY", "1")],
+            None,
+        )
+        .expect("aliased commit should succeed");
+
+    // The wrapper should resolve the alias and still show the stats bar.
+    assert!(
+        output.contains("you") && output.contains("ai"),
+        "expected stats output when committing via alias, got:\n{}",
+        output
+    );
+}
+
+#[test]
 fn async_mode_post_commit_skips_stats_for_large_commit() {
     let repo = TestRepo::new_with_mode(GitTestMode::WrapperDaemon);
 


### PR DESCRIPTION
## Summary
- Fast-path unconditionally read-only commands (`status`, `log`, `diff`, `show`, `rev-parse`, `ls-files`, `blame`, `grep`, `help`, `version`, etc.) and help/version invocations so they skip all hooks and daemon state
- Resolve git aliases **before** the wrapper's passthrough/read-only decision so aliases like `st = status --short` use the fast path and aliases to mutating commands do not
- Alias resolution now happens once, early, before the async/sync branch point — this also fixes post-commit stats not showing when committing via alias (e.g. `alias.cm = commit`), subsuming #801
- Switch common-case wrapper repository discovery from extra `git rev-parse` subprocesses to the existing filesystem-based fast path
- Suppress trace2 for git-ai's own internal helper git subprocesses so global trace2 config does not add Windows pipe overhead to wrapper internals
- Preserve the original global git args whenever rebasing them to the repo root could change semantics, such as relative `--git-dir` / `--work-tree`
- `init` passthroughs unconditionally (no post-hooks); `clone` passthroughs only in async mode so `post_clone_hook` still runs in non-async mode
- The read-only classification is intentionally **narrow**: only commands in `is_definitely_read_only_command` (unconditionally read-only regardless of args) get the fast path. Mixed-mode commands like `branch`, `tag`, `stash`, `remote`, `config` are NOT fast-pathed — they always go through the full wrapper. A broader `is_read_only_invocation` classifier exists in `command_classification.rs` with per-command arg inspection but is **not wired into the critical dispatch path** to keep risk low.

## Root cause
The Windows slowdown was mostly wrapper preflight overhead, not the proxied git command itself.

Before these changes, a wrapper invocation could do several expensive things before the real git command even ran:
- spawn multiple internal git subprocesses for repository discovery
- spawn additional git subprocesses for repo-policy checks
- emit trace2 from those internal helper git subprocesses when trace2 was globally configured
- pay extra wrapper startup work even for simple passthrough-style invocations
- miss read-only fast paths for aliases because alias expansion happened later than the passthrough decision

That architecture is especially expensive on Windows, where each extra child process has noticeable startup cost.

## What changed
This PR attacks the problem in three narrow ways:

1. **Read-only passthrough classification** — commands that are unconditionally read-only (the `is_definitely_read_only_command` list), plus `--help` and no-command invocations, skip all hooks and daemon state. The list only includes commands that are read-only regardless of their arguments. Mixed-mode commands (`branch`, `tag`, `stash`, `remote`, `config`, etc.) are not included.

2. **Alias-aware passthrough** — wrapper alias expansion now happens once before the async/sync branch point and the passthrough/read-only decision. Read-only aliases (e.g. `alias.st = status --short`) get the fast path; mutating aliases still go through the full wrapper path. This also fixes the bug where commit aliases (e.g. `alias.cm = commit`) didn't trigger post-commit stats display in async mode.

3. **Shared wrapper preflight** — `find_repository()` now uses the existing filesystem-based discovery fast path for common global-arg shapes instead of immediately shelling out to `git rev-parse`. Falls back to git-exec discovery when `GIT_DIR`, `GIT_WORK_TREE`, or `GIT_CEILING_DIRECTORIES` env vars are set. Internal helper git subprocesses now force all trace2 streams off. Repo-root normalization preserves original args when they contain flags that aren't safe to rebase (e.g. relative `--git-dir`/`--work-tree`).

## Benchmarks
All numbers below are from the same Windows machine/repo style, using stopwatch timing around the wrapper binary.

### `git status` (forced sync wrapper path)
- pre-fix wrapper: 1043ms, 1556ms, 1090ms, 1123ms, 1049ms (avg 1172ms)
- patched wrapper: 244ms, 161ms, 146ms, 151ms, 135ms (avg 167ms)

### `git branch --show-current`
Pre-broader-fix wrapper warm runs:
- 407ms, 402ms, 386ms, 313ms

Patched wrapper warm runs:
- 110ms, 112ms, 149ms, 103ms, 133ms, 141ms, 140ms, 120ms, 231ms, 166ms

Plain git reference:
- 103ms, 190ms, 133ms, 279ms, 103ms

### `git branch <name> HEAD`
Pre-broader-fix wrapper:
- 346ms, 368ms, 411ms, 415ms, 387ms

Patched wrapper warm runs:
- 206ms, 276ms, 186ms, 194ms, 136ms, 166ms, 189ms, 163ms, 165ms, 138ms

Plain git reference:
- 196ms, 140ms, 115ms, 113ms, 167ms

### Additional passthrough cases
Warm wrapper runs after the latest startup/pass-through changes:
- `git --version`: 116ms, 163ms, 153ms, 126ms
- `git remote -v`: 150ms, 167ms, 170ms, 201ms, 229ms
- `git config --list --show-origin`: 216ms, 376ms, 275ms, 232ms, 253ms

Plain git reference:
- `git --version`: 82ms, 102ms, 94ms, 115ms
- `git remote -v`: 123ms, 165ms, 175ms, 165ms
- `git config --list --show-origin`: 166ms, 244ms, 95ms, 136ms, 147ms

## Notes
This does not produce a literal 10x win for every command. After these changes, the remaining floor is mostly actual git work plus Windows process startup for launching the wrapper binary itself. Hitting another step-function improvement across all commands will likely require a bigger architectural move, like a thinner launcher or persistent proxy process.

## Updates since last revision
- **Reverted Clap removal** from `main.rs` — the startup trim wasn't worth changing help/usage behavior
- **Ported alias commit test** from #801 (`async_mode_post_commit_shows_stats_with_commit_alias`) — this PR's early alias resolution subsumes #801 entirely
- **Fixed clippy `match_like_matches_macro` warning** in `is_read_only_notes_invocation`
- **Simplified wrapper dispatch** — inlined `should_passthrough_read_only_command()` and `resolve_wrapper_invocation()` which were single-line wrappers; alias resolution and read-only checks are now inline in `handle_git()`
- **Consolidated `normalize_global_args_for_repo_root`** — merged the separate `global_args_are_safe_to_rebase()` guard into the normalization loop itself (single pass: normalize `-C` args and bail if an unsafe flag is encountered). DRY'd `resolve_command_base_dir` to reuse `apply_global_c_arg`.
- **Fixed clone passthrough bypassing `post_clone_hook`** — the clone/init early-exit was unconditional, which made `post_clone_hook` unreachable in non-async mode. Now `init` passthroughs unconditionally (it has no post-hooks) and `clone` passthroughs only inside the `async_mode` block so the non-async clone handler with `post_clone_hook` is still reached.
- **Narrowed read-only fast path to `is_definitely_read_only_command` only** — removed `is_read_only_invocation` (the broader arg-inspecting classifier) from the wrapper dispatch path. The fast path now only catches commands that are unconditionally read-only by name. Mixed-mode commands (`branch`, `tag`, `config`, `stash`, etc.) always go through the full wrapper. This trades a small amount of fast-path coverage for significantly less risk and complexity in the critical dispatch path.

## Validation
- `cargo test --package git-ai passthrough_read_only_command -- --nocapture`
- `cargo test --package git-ai wrapper_resolves_ -- --nocapture`
- `cargo test --package git-ai resolve_fast_discovery_base_dir -- --nocapture`
- `cargo test --package git-ai normalize_global_args_for_repo_root -- --nocapture`
- `cargo test --package git-ai find_repository_preserves_relative_git_dir_and_work_tree_for_internal_commands -- --nocapture`
- `cargo test --package git-ai find_repository_in_path_supports_bare_repositories -- --nocapture`
- `cargo test --package git-ai find_repository_in_path_worktree_uses_common_dir_for_isolated_storage -- --nocapture`
- `cargo test --package git-ai test_empty_allowlist_allows_everything -- --nocapture`
- `cargo test --package git-ai --test async_mode async_mode_post_commit_shows_stats_with_commit_alias -- --nocapture`
- `cargo test --package git-ai --test notes_sync_regression notes_sync_clone_fetches_authorship_notes_from_origin -- --nocapture`
- `cargo clippy --package git-ai -- -D warnings`
- `cargo build --release`

## Review & Testing Checklist for Human
This PR touches the wrapper's main dispatch path — every git invocation goes through it. 4 items to verify:

- [ ] **Clone passthrough split correctness**: `init` exits unconditionally, `clone` exits only in async mode. Verify `git clone <url>` in non-async mode still runs `post_clone_hook` (fetches authorship notes from origin). Verify async-mode clone still skips daemon telemetry. The non-async clone handler also checks `skip_hooks`, which the async early-exit does not — confirm this difference is acceptable.
- [ ] **Alias resolution for commit in async mode**: Run `git config alias.cm commit`, then `git cm -m "test"` with AI content and verify post-commit stats appear. The ported test covers this but manual verification on a real repo is worthwhile.
- [ ] **Windows performance**: Re-run benchmarks on a Windows machine to confirm the numbers hold with the latest simplification changes (Clap revert, narrower read-only classification).
- [ ] **`normalize_global_args_for_repo_root` single-pass safety**: The function normalizes and bails mid-loop if an unsafe flag is encountered, returning the original args. Verify that bailing mid-loop is equivalent to the previous two-pass behavior in all edge cases — particularly when `-C` args appear before and after an unsafe flag.

### Notes
- This PR subsumes #801 — that PR has been closed.
- `proxy_to_git` still re-parses args for trace2 suppression (minor redundancy, not a correctness issue).
- The broader `is_read_only_invocation` classifier and its per-command sub-classifiers (`is_read_only_branch_invocation`, `is_read_only_tag_invocation`, etc.) remain in `command_classification.rs` as tested library code but are **not used in the critical wrapper dispatch path**. They can be wired in later if desired after more validation.

Link to Devin session: https://app.devin.ai/sessions/7bcaf7c2296b4a4699df61a164ed5986
Requested by: @svarlamov