### PR TITLE
feat: sharded notes refs for reduced push contention

### DIFF
--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -58,6 +58,7 @@ define_feature_flags!(
     async_mode: async_mode, debug = false, release = false,
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
+    sharded_notes: sharded_notes, debug = false, release = false,
 );
 
 impl FeatureFlags {
@@ -127,6 +128,7 @@ mod tests {
             assert!(!flags.async_mode);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
+            assert!(!flags.sharded_notes);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -136,6 +138,7 @@ mod tests {
             assert!(!flags.async_mode);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
+            assert!(!flags.sharded_notes);
         }
     }
 
@@ -245,6 +248,7 @@ mod tests {
             async_mode: true,
             git_hooks_enabled: false,
             git_hooks_externally_managed: false,
+            sharded_notes: false,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -254,6 +258,7 @@ mod tests {
         assert!(serialized.contains("async_mode"));
         assert!(serialized.contains("git_hooks_enabled"));
         assert!(serialized.contains("git_hooks_externally_managed"));
+        assert!(serialized.contains("sharded_notes"));
     }
 
     #[test]
@@ -265,6 +270,7 @@ mod tests {
             async_mode: true,
             git_hooks_enabled: true,
             git_hooks_externally_managed: false,
+            sharded_notes: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);
@@ -276,6 +282,7 @@ mod tests {
             cloned.git_hooks_externally_managed,
             flags.git_hooks_externally_managed
         );
+        assert_eq!(cloned.sharded_notes, flags.sharded_notes);
     }
 
     #[test]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -58,7 +58,7 @@ define_feature_flags!(
     async_mode: async_mode, debug = false, release = false,
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
-    sharded_notes: sharded_notes, debug = false, release = false,
+    sharded_notes: sharded_notes, debug = false, release = false, // gated behind config
 );
 
 impl FeatureFlags {

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -685,11 +685,12 @@ pub fn extract_clone_target_directory(args: &[String]) -> Option<String> {
 /// Derive the target directory name from a repository URL.
 /// Mimics git's behavior of using the last path component, stripping .git suffix.
 fn derive_directory_from_url(url: &str) -> Option<String> {
-    // Remove trailing slashes
-    let url = url.trim_end_matches('/');
+    // Remove trailing slashes (both forward and backslash for Windows paths)
+    let url = url.trim_end_matches('/').trim_end_matches('\\');
 
-    // Extract the last path component
-    let last_component = if let Some(pos) = url.rfind('/') {
+    // Extract the last path component.
+    // Check both '/' and '\\' to handle Windows local paths (e.g. C:\path\to\repo.git).
+    let last_component = if let Some(pos) = url.rfind(['/', '\\']) {
         &url[pos + 1..]
     } else if let Some(pos) = url.rfind(':') {
         // Handle SCP-like syntax: user@host:path
@@ -806,6 +807,20 @@ mod tests {
         );
         assert_eq!(
             derive_directory_from_url("/local/path/repo.git"),
+            Some("repo".to_string())
+        );
+        // Windows-style local paths with backslashes
+        assert_eq!(
+            derive_directory_from_url("C:\\Users\\user\\repos\\repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_directory_from_url("C:\\Users\\user\\repos\\my-project"),
+            Some("my-project".to_string())
+        );
+        // Trailing backslash
+        assert_eq!(
+            derive_directory_from_url("C:\\Users\\user\\repos\\repo.git\\"),
             Some("repo".to_string())
         );
     }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -10,22 +10,69 @@ use std::collections::{HashMap, HashSet};
 pub const AI_AUTHORSHIP_REFNAME: &str = "ai";
 pub const AI_AUTHORSHIP_PUSH_REFSPEC: &str = "refs/notes/ai:refs/notes/ai";
 
+// Sharded notes: 256 independent refs keyed by first 2 hex chars of the annotated
+// commit SHA. This dramatically reduces push contention on busy monorepos.
+// Uses "ai-s" prefix (not "ai/" which conflicts with "ai" as a loose ref file).
+pub const AI_SHARDED_NOTES_PREFIX: &str = "refs/notes/ai-s/";
+
+/// Return the shard suffix (first 2 hex chars) for a given commit SHA.
+pub fn shard_for_commit(commit_sha: &str) -> &str {
+    &commit_sha[..2]
+}
+
+/// Return the full sharded ref (e.g. "refs/notes/ai-s/ab") for a commit.
+fn sharded_ref_for_commit(commit_sha: &str) -> String {
+    format!(
+        "{}{}",
+        AI_SHARDED_NOTES_PREFIX,
+        shard_for_commit(commit_sha)
+    )
+}
+
+/// Return the --ref= argument value for the shard of a commit (e.g. "ai-s/ab").
+fn sharded_refname_for_commit(commit_sha: &str) -> String {
+    format!("ai-s/{}", shard_for_commit(commit_sha))
+}
+
+fn sharded_notes_enabled() -> bool {
+    crate::config::Config::get()
+        .get_feature_flags()
+        .sharded_notes
+}
+
 pub fn notes_add(
     repo: &Repository,
     commit_sha: &str,
     note_content: &str,
 ) -> Result<(), GitAiError> {
+    // Always write to the legacy ref (backward compat for old clients)
     let mut args = repo.global_args_for_exec();
     args.push("notes".to_string());
     args.push("--ref=ai".to_string());
     args.push("add".to_string());
-    args.push("-f".to_string()); // Always force overwrite
+    args.push("-f".to_string());
     args.push("-F".to_string());
-    args.push("-".to_string()); // Read note content from stdin
+    args.push("-".to_string());
     args.push(commit_sha.to_string());
-
-    // Use stdin to provide the note content to avoid command line length limits
     exec_git_stdin(&args, note_content.as_bytes())?;
+
+    // Dual-write to shard ref when sharded notes are enabled
+    if sharded_notes_enabled() {
+        let shard_ref = sharded_refname_for_commit(commit_sha);
+        let mut args = repo.global_args_for_exec();
+        args.push("notes".to_string());
+        args.push(format!("--ref={}", shard_ref));
+        args.push("add".to_string());
+        args.push("-f".to_string());
+        args.push("-F".to_string());
+        args.push("-".to_string());
+        args.push(commit_sha.to_string());
+        // Best-effort: shard write failure should not block the operation
+        if let Err(e) = exec_git_stdin(&args, note_content.as_bytes()) {
+            debug_log(&format!("shard notes_add failed for {}: {}", shard_ref, e));
+        }
+    }
+
     crate::authorship::git_ai_hooks::post_notes_updated_single(repo, commit_sha, note_content);
     Ok(())
 }
@@ -44,6 +91,18 @@ fn flat_note_pathspec_for_commit(commit_sha: &str) -> String {
 
 fn fanout_note_pathspec_for_commit(commit_sha: &str) -> String {
     format!("refs/notes/ai:{}", notes_path_for_object(commit_sha))
+}
+
+fn sharded_flat_note_pathspec_for_commit(commit_sha: &str) -> String {
+    format!("{}:{}", sharded_ref_for_commit(commit_sha), commit_sha)
+}
+
+fn sharded_fanout_note_pathspec_for_commit(commit_sha: &str) -> String {
+    format!(
+        "{}:{}",
+        sharded_ref_for_commit(commit_sha),
+        notes_path_for_object(commit_sha)
+    )
 }
 
 fn parse_batch_check_blob_oid(line: &str) -> Option<String> {
@@ -135,6 +194,7 @@ fn batch_read_blob_contents(
 /// Resolve authorship note blob OIDs for a set of commits using one batched cat-file call.
 ///
 /// Returns a map of commit SHA -> note blob SHA for commits that currently have notes.
+/// When sharded notes are enabled, checks shard refs first and falls back to the legacy ref.
 pub fn note_blob_oids_for_commits(
     repo: &Repository,
     commit_shas: &[String],
@@ -143,14 +203,22 @@ pub fn note_blob_oids_for_commits(
         return Ok(HashMap::new());
     }
 
+    let sharded = sharded_notes_enabled();
+
     let mut args = repo.global_args_for_exec();
     args.push("cat-file".to_string());
     args.push("--batch-check".to_string());
 
+    // When sharded: 4 lines per commit (shard flat, shard fanout, legacy flat, legacy fanout)
+    // When not sharded: 2 lines per commit (legacy flat, legacy fanout)
     let mut stdin_data = String::new();
     for commit_sha in commit_shas {
-        // Notes can be stored with either flat paths (<sha>) or fanout paths (<aa>/<bb...>).
-        // Query both forms so this works regardless of repository note fanout state.
+        if sharded {
+            stdin_data.push_str(&sharded_flat_note_pathspec_for_commit(commit_sha));
+            stdin_data.push('\n');
+            stdin_data.push_str(&sharded_fanout_note_pathspec_for_commit(commit_sha));
+            stdin_data.push('\n');
+        }
         stdin_data.push_str(&flat_note_pathspec_for_commit(commit_sha));
         stdin_data.push('\n');
         stdin_data.push_str(&fanout_note_pathspec_for_commit(commit_sha));
@@ -163,6 +231,20 @@ pub fn note_blob_oids_for_commits(
     let mut result = HashMap::new();
 
     for commit_sha in commit_shas {
+        if sharded {
+            let shard_flat = lines.next().unwrap_or_default();
+            let shard_fanout = lines.next().unwrap_or_default();
+            if let Some(oid) = parse_batch_check_blob_oid(shard_flat)
+                .or_else(|| parse_batch_check_blob_oid(shard_fanout))
+            {
+                // Consume legacy lines but don't use them
+                let _ = lines.next();
+                let _ = lines.next();
+                result.insert(commit_sha.clone(), oid);
+                continue;
+            }
+        }
+
         let Some(flat_line) = lines.next() else {
             break;
         };
@@ -178,23 +260,56 @@ pub fn note_blob_oids_for_commits(
     Ok(result)
 }
 
+/// Resolve the current tip of a notes ref, returning None if the ref doesn't exist.
+fn resolve_notes_tip(repo: &Repository, notes_ref: &str) -> Result<Option<String>, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.push("rev-parse".to_string());
+    args.push("--verify".to_string());
+    args.push(notes_ref.to_string());
+    match exec_git(&args) {
+        Ok(output) => Ok(Some(String::from_utf8(output.stdout)?.trim().to_string())),
+        Err(GitAiError::GitCliError {
+            code: Some(128), ..
+        })
+        | Err(GitAiError::GitCliError { code: Some(1), .. }) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Append a fast-import commit block for a notes ref to `script`.
+/// `entries` are (mark_index, commit_sha) pairs — marks must already be defined as blobs.
+fn append_notes_commit_block(
+    script: &mut Vec<u8>,
+    notes_ref: &str,
+    existing_tip: Option<&str>,
+    entries: &[(usize, &str)],
+    now: u64,
+) {
+    script.extend_from_slice(format!("commit {}\n", notes_ref).as_bytes());
+    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
+    script.extend_from_slice(b"data 0\n");
+    if let Some(tip) = existing_tip {
+        script.extend_from_slice(format!("from {}\n", tip).as_bytes());
+    }
+
+    for (mark_idx, commit_sha) in entries {
+        let fanout_path = notes_path_for_object(commit_sha);
+        let flat_path = *commit_sha;
+        if flat_path != fanout_path {
+            script.extend_from_slice(format!("D {}\n", flat_path).as_bytes());
+        }
+        script.extend_from_slice(format!("D {}\n", fanout_path).as_bytes());
+        script.extend_from_slice(format!("M 100644 :{} {}\n", mark_idx, fanout_path).as_bytes());
+    }
+    script.extend_from_slice(b"\n");
+}
+
 pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Result<(), GitAiError> {
     if entries.is_empty() {
         return Ok(());
     }
 
-    let mut args = repo.global_args_for_exec();
-    args.push("rev-parse".to_string());
-    args.push("--verify".to_string());
-    args.push("refs/notes/ai".to_string());
-    let existing_notes_tip = match exec_git(&args) {
-        Ok(output) => Some(String::from_utf8(output.stdout)?.trim().to_string()),
-        Err(GitAiError::GitCliError {
-            code: Some(128), ..
-        })
-        | Err(GitAiError::GitCliError { code: Some(1), .. }) => None,
-        Err(e) => return Err(e),
-    };
+    let existing_notes_tip = resolve_notes_tip(repo, "refs/notes/ai")?;
 
     let mut deduped_entries: Vec<(String, String)> = Vec::new();
     let mut seen = HashSet::new();
@@ -210,8 +325,25 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
         .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
         .as_secs();
 
+    let sharded = sharded_notes_enabled();
+
+    // Resolve shard tips upfront if sharding is enabled
+    let shard_tips: HashMap<String, Option<String>> = if sharded {
+        let mut tips = HashMap::new();
+        for (commit_sha, _) in &deduped_entries {
+            let shard_ref = sharded_ref_for_commit(commit_sha);
+            if !tips.contains_key(&shard_ref) {
+                tips.insert(shard_ref.clone(), resolve_notes_tip(repo, &shard_ref)?);
+            }
+        }
+        tips
+    } else {
+        HashMap::new()
+    };
+
     let mut script = Vec::<u8>::new();
 
+    // Emit blob definitions with marks
     for (idx, (_commit_sha, note_content)) in deduped_entries.iter().enumerate() {
         script.extend_from_slice(b"blob\n");
         script.extend_from_slice(format!("mark :{}\n", idx + 1).as_bytes());
@@ -220,23 +352,42 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
         script.extend_from_slice(b"\n");
     }
 
-    script.extend_from_slice(b"commit refs/notes/ai\n");
-    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
-    script.extend_from_slice(b"data 0\n");
-    if let Some(existing_tip) = existing_notes_tip {
-        script.extend_from_slice(format!("from {}\n", existing_tip).as_bytes());
-    }
+    // Legacy commit block (always written)
+    let legacy_entries: Vec<(usize, &str)> = deduped_entries
+        .iter()
+        .enumerate()
+        .map(|(idx, (sha, _))| (idx + 1, sha.as_str()))
+        .collect();
+    append_notes_commit_block(
+        &mut script,
+        "refs/notes/ai",
+        existing_notes_tip.as_deref(),
+        &legacy_entries,
+        now,
+    );
 
-    for (idx, (commit_sha, _note_content)) in deduped_entries.iter().enumerate() {
-        let fanout_path = notes_path_for_object(commit_sha);
-        let flat_path = commit_sha.clone();
-        if flat_path != fanout_path {
-            script.extend_from_slice(format!("D {}\n", flat_path).as_bytes());
+    // Shard commit blocks (one per unique shard, when enabled)
+    if sharded {
+        // Group entries by shard
+        let mut shard_entries: HashMap<String, Vec<(usize, &str)>> = HashMap::new();
+        for (idx, (commit_sha, _)) in deduped_entries.iter().enumerate() {
+            let shard_ref = sharded_ref_for_commit(commit_sha);
+            shard_entries
+                .entry(shard_ref)
+                .or_default()
+                .push((idx + 1, commit_sha.as_str()));
         }
-        script.extend_from_slice(format!("D {}\n", fanout_path).as_bytes());
-        script.extend_from_slice(format!("M 100644 :{} {}\n", idx + 1, fanout_path).as_bytes());
+
+        // Sort shard keys for deterministic output
+        let mut shard_keys: Vec<&String> = shard_entries.keys().collect();
+        shard_keys.sort();
+
+        for shard_ref in shard_keys {
+            let entries = &shard_entries[shard_ref];
+            let tip = shard_tips.get(shard_ref).and_then(|t| t.as_deref());
+            append_notes_commit_block(&mut script, shard_ref, tip, entries, now);
+        }
     }
-    script.extend_from_slice(b"\n");
 
     let mut fast_import_args = repo.global_args_for_exec();
     fast_import_args.push("fast-import".to_string());
@@ -245,6 +396,32 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
     crate::authorship::git_ai_hooks::post_notes_updated(repo, &deduped_entries);
 
     Ok(())
+}
+
+/// Append a fast-import commit block that references existing blob OIDs (no marks needed).
+fn append_notes_blob_commit_block(
+    script: &mut Vec<u8>,
+    notes_ref: &str,
+    existing_tip: Option<&str>,
+    entries: &[(&str, &str)], // (commit_sha, blob_oid)
+    now: u64,
+) {
+    script.extend_from_slice(format!("commit {}\n", notes_ref).as_bytes());
+    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
+    script.extend_from_slice(b"data 0\n");
+    if let Some(tip) = existing_tip {
+        script.extend_from_slice(format!("from {}\n", tip).as_bytes());
+    }
+
+    for (commit_sha, blob_oid) in entries {
+        let fanout_path = notes_path_for_object(commit_sha);
+        if *commit_sha != fanout_path {
+            script.extend_from_slice(format!("D {}\n", commit_sha).as_bytes());
+        }
+        script.extend_from_slice(format!("D {}\n", fanout_path).as_bytes());
+        script.extend_from_slice(format!("M 100644 {} {}\n", blob_oid, fanout_path).as_bytes());
+    }
+    script.extend_from_slice(b"\n");
 }
 
 /// Batch-attach existing note blobs to commits without rewriting blob contents.
@@ -259,18 +436,7 @@ pub fn notes_add_blob_batch(
         return Ok(());
     }
 
-    let mut args = repo.global_args_for_exec();
-    args.push("rev-parse".to_string());
-    args.push("--verify".to_string());
-    args.push("refs/notes/ai".to_string());
-    let existing_notes_tip = match exec_git(&args) {
-        Ok(output) => Some(String::from_utf8(output.stdout)?.trim().to_string()),
-        Err(GitAiError::GitCliError {
-            code: Some(128), ..
-        })
-        | Err(GitAiError::GitCliError { code: Some(1), .. }) => None,
-        Err(e) => return Err(e),
-    };
+    let existing_notes_tip = resolve_notes_tip(repo, "refs/notes/ai")?;
 
     let mut deduped_entries: Vec<(String, String)> = Vec::new();
     let mut seen = HashSet::new();
@@ -286,24 +452,57 @@ pub fn notes_add_blob_batch(
         .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
         .as_secs();
 
-    let mut script = Vec::<u8>::new();
-    script.extend_from_slice(b"commit refs/notes/ai\n");
-    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
-    script.extend_from_slice(b"data 0\n");
-    if let Some(existing_tip) = existing_notes_tip {
-        script.extend_from_slice(format!("from {}\n", existing_tip).as_bytes());
-    }
+    let sharded = sharded_notes_enabled();
 
-    for (commit_sha, blob_oid) in &deduped_entries {
-        let fanout_path = notes_path_for_object(commit_sha);
-        let flat_path = commit_sha.clone();
-        if flat_path != fanout_path {
-            script.extend_from_slice(format!("D {}\n", flat_path).as_bytes());
+    // Resolve shard tips upfront
+    let shard_tips: HashMap<String, Option<String>> = if sharded {
+        let mut tips = HashMap::new();
+        for (commit_sha, _) in &deduped_entries {
+            let shard_ref = sharded_ref_for_commit(commit_sha);
+            if !tips.contains_key(&shard_ref) {
+                tips.insert(shard_ref.clone(), resolve_notes_tip(repo, &shard_ref)?);
+            }
         }
-        script.extend_from_slice(format!("D {}\n", fanout_path).as_bytes());
-        script.extend_from_slice(format!("M 100644 {} {}\n", blob_oid, fanout_path).as_bytes());
+        tips
+    } else {
+        HashMap::new()
+    };
+
+    let mut script = Vec::<u8>::new();
+
+    // Legacy commit block
+    let legacy_entries: Vec<(&str, &str)> = deduped_entries
+        .iter()
+        .map(|(sha, oid)| (sha.as_str(), oid.as_str()))
+        .collect();
+    append_notes_blob_commit_block(
+        &mut script,
+        "refs/notes/ai",
+        existing_notes_tip.as_deref(),
+        &legacy_entries,
+        now,
+    );
+
+    // Shard commit blocks
+    if sharded {
+        let mut shard_entries: HashMap<String, Vec<(&str, &str)>> = HashMap::new();
+        for (commit_sha, blob_oid) in &deduped_entries {
+            let shard_ref = sharded_ref_for_commit(commit_sha);
+            shard_entries
+                .entry(shard_ref)
+                .or_default()
+                .push((commit_sha.as_str(), blob_oid.as_str()));
+        }
+
+        let mut shard_keys: Vec<&String> = shard_entries.keys().collect();
+        shard_keys.sort();
+
+        for shard_ref in shard_keys {
+            let entries = &shard_entries[shard_ref];
+            let tip = shard_tips.get(shard_ref).and_then(|t| t.as_deref());
+            append_notes_blob_commit_block(&mut script, shard_ref, tip, entries, now);
+        }
     }
-    script.extend_from_slice(b"\n");
 
     let mut fast_import_args = repo.global_args_for_exec();
     fast_import_args.push("fast-import".to_string());
@@ -436,7 +635,28 @@ pub fn get_commits_with_notes_from_list(
 }
 
 // Show an authorship note and return its JSON content if found, or None if it doesn't exist.
+// When sharded notes are enabled, checks the shard ref first, then falls back to legacy.
 pub fn show_authorship_note(repo: &Repository, commit_sha: &str) -> Option<String> {
+    if sharded_notes_enabled() {
+        let shard_ref = sharded_refname_for_commit(commit_sha);
+        let mut args = repo.global_args_for_exec();
+        args.push("notes".to_string());
+        args.push(format!("--ref={}", shard_ref));
+        args.push("show".to_string());
+        args.push(commit_sha.to_string());
+
+        if let Ok(output) = exec_git(&args) {
+            let result = String::from_utf8(output.stdout)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            if result.is_some() {
+                return result;
+            }
+        }
+    }
+
+    // Fall back to legacy ref
     let mut args = repo.global_args_for_exec();
     args.push("notes".to_string());
     args.push("--ref=ai".to_string());

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -586,10 +586,7 @@ pub fn merge_notes_from_ref(repo: &Repository, source_ref: &str) -> Result<(), G
 ///
 /// This is O(1) git process invocations regardless of note count, which matters on
 /// large monorepos with thousands of notes.
-pub fn fallback_merge_notes_ours(
-    repo: &Repository,
-    source_ref: &str,
-) -> Result<(), GitAiError> {
+pub fn fallback_merge_notes_ours(repo: &Repository, source_ref: &str) -> Result<(), GitAiError> {
     let local_ref = format!("refs/notes/{}", AI_AUTHORSHIP_REFNAME);
 
     // 1. List notes from both refs
@@ -639,9 +636,7 @@ fn list_all_notes(repo: &Repository, notes_ref: &str) -> Result<Vec<(String, Str
     // `git notes list` uses --ref to specify which notes ref.
     // The --ref option prepends "refs/notes/" automatically, so for full refs
     // like "refs/notes/ai-remote/origin" we need to strip the prefix.
-    let ref_arg = notes_ref
-        .strip_prefix("refs/notes/")
-        .unwrap_or(notes_ref);
+    let ref_arg = notes_ref.strip_prefix("refs/notes/").unwrap_or(notes_ref);
 
     let mut args = repo.global_args_for_exec();
     args.extend_from_slice(&[

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -44,9 +44,14 @@ fn sharded_refname_for_commit(commit_sha: &str) -> String {
 }
 
 fn sharded_notes_enabled() -> bool {
-    crate::config::Config::get()
-        .get_feature_flags()
-        .sharded_notes
+    if crate::daemon::daemon_process_active() {
+        let config = crate::config::Config::fresh();
+        config.get_feature_flags().sharded_notes
+    } else {
+        crate::config::Config::get()
+            .get_feature_flags()
+            .sharded_notes
+    }
 }
 
 pub fn notes_add(

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -16,7 +16,16 @@ pub const AI_AUTHORSHIP_PUSH_REFSPEC: &str = "refs/notes/ai:refs/notes/ai";
 pub const AI_SHARDED_NOTES_PREFIX: &str = "refs/notes/ai-s/";
 
 /// Return the shard suffix (first 2 hex chars) for a given commit SHA.
+/// Panics if commit_sha is shorter than 2 characters (should never happen with real SHAs).
 pub fn shard_for_commit(commit_sha: &str) -> &str {
+    debug_assert!(
+        commit_sha.len() >= 2,
+        "shard_for_commit called with SHA shorter than 2 chars: {:?}",
+        commit_sha
+    );
+    if commit_sha.len() < 2 {
+        return "00";
+    }
     &commit_sha[..2]
 }
 

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -991,8 +991,10 @@ mod tests {
     }
 
     fn set_test_sharded_notes(enabled: bool) {
-        let mut flags = FeatureFlags::default();
-        flags.sharded_notes = enabled;
+        let flags = FeatureFlags {
+            sharded_notes: enabled,
+            ..FeatureFlags::default()
+        };
         crate::config::Config::set_test_feature_flags(flags);
     }
 

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -576,6 +576,107 @@ pub fn merge_notes_from_ref(repo: &Repository, source_ref: &str) -> Result<(), G
     Ok(())
 }
 
+/// Fallback merge when `git notes merge -s ours` fails (e.g., due to git assertion
+/// failures on corrupted/mixed-fanout notes trees). Implements the "ours" strategy
+/// using a single `git fast-import` invocation that:
+///   1. Creates a merge commit with both local and source as parents
+///   2. Emits all notes via `N <blob> <object>` commands (source first, then local —
+///      last writer wins, so local takes precedence on conflicts = "ours" strategy)
+///   3. Produces a clean notes tree with correct fanout regardless of input tree format
+///
+/// This is O(1) git process invocations regardless of note count, which matters on
+/// large monorepos with thousands of notes.
+pub fn fallback_merge_notes_ours(
+    repo: &Repository,
+    source_ref: &str,
+) -> Result<(), GitAiError> {
+    let local_ref = format!("refs/notes/{}", AI_AUTHORSHIP_REFNAME);
+
+    // 1. List notes from both refs
+    let source_notes = list_all_notes(repo, source_ref)?;
+    let local_notes = list_all_notes(repo, &local_ref)?;
+
+    // 2. Resolve parent commit SHAs for the merge commit
+    let local_commit = rev_parse(repo, &local_ref)?;
+    let source_commit = rev_parse(repo, source_ref)?;
+
+    // 3. Build the fast-import stream.
+    //    Emit source (remote) notes first, then local notes. fast-import uses
+    //    last-writer-wins for duplicate annotated objects, so local notes take
+    //    precedence — this implements the "ours" merge strategy.
+    let mut stream = String::new();
+    stream.push_str(&format!("commit {}\n", local_ref));
+    stream.push_str("committer git-ai <git-ai@noreply> 0 +0000\n");
+    stream.push_str("data 23\nMerge notes (fallback)\n");
+    stream.push_str(&format!("from {}\n", local_commit));
+    stream.push_str(&format!("merge {}\n", source_commit));
+
+    // Source notes first (will be overwritten by local on conflict)
+    for (blob, object) in &source_notes {
+        stream.push_str(&format!("N {} {}\n", blob, object));
+    }
+    // Local notes second (wins on conflict)
+    for (blob, object) in &local_notes {
+        stream.push_str(&format!("N {} {}\n", blob, object));
+    }
+    stream.push_str("done\n");
+
+    // 4. Run fast-import
+    let mut args = repo.global_args_for_exec();
+    args.extend_from_slice(&[
+        "fast-import".to_string(),
+        "--quiet".to_string(),
+        "--done".to_string(),
+    ]);
+    exec_git_stdin(&args, stream.as_bytes())?;
+
+    debug_log("fallback merge via fast-import completed successfully");
+    Ok(())
+}
+
+/// List all notes on a given ref. Returns Vec<(note_blob_sha, annotated_object_sha)>.
+fn list_all_notes(repo: &Repository, notes_ref: &str) -> Result<Vec<(String, String)>, GitAiError> {
+    // `git notes list` uses --ref to specify which notes ref.
+    // The --ref option prepends "refs/notes/" automatically, so for full refs
+    // like "refs/notes/ai-remote/origin" we need to strip the prefix.
+    let ref_arg = notes_ref
+        .strip_prefix("refs/notes/")
+        .unwrap_or(notes_ref);
+
+    let mut args = repo.global_args_for_exec();
+    args.extend_from_slice(&[
+        "notes".to_string(),
+        format!("--ref={}", ref_arg),
+        "list".to_string(),
+    ]);
+
+    let output = exec_git(&args)?;
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|_| GitAiError::Generic("Failed to parse notes list output".to_string()))?;
+
+    Ok(stdout
+        .lines()
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() == 2 {
+                Some((parts[0].to_string(), parts[1].to_string()))
+            } else {
+                None
+            }
+        })
+        .collect())
+}
+
+/// Parse a revision to its SHA
+fn rev_parse(repo: &Repository, rev: &str) -> Result<String, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend_from_slice(&["rev-parse".to_string(), rev.to_string()]);
+    let output = exec_git(&args)?;
+    String::from_utf8(output.stdout)
+        .map_err(|_| GitAiError::Generic("Failed to parse rev-parse output".to_string()))
+        .map(|s| s.trim().to_string())
+}
+
 /// Copy a ref to another location (used for initial setup of local notes from tracking ref)
 pub fn copy_ref(repo: &Repository, source_ref: &str, dest_ref: &str) -> Result<(), GitAiError> {
     let mut args = repo.global_args_for_exec();

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -971,7 +971,53 @@ pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::feature_flags::FeatureFlags;
     use crate::git::test_utils::TmpRepo;
+    use serial_test::serial;
+
+    struct TestFeatureFlagsGuard;
+
+    impl TestFeatureFlagsGuard {
+        fn new() -> Self {
+            crate::config::Config::clear_test_feature_flags();
+            Self
+        }
+    }
+
+    impl Drop for TestFeatureFlagsGuard {
+        fn drop(&mut self) {
+            crate::config::Config::clear_test_feature_flags();
+        }
+    }
+
+    fn set_test_sharded_notes(enabled: bool) {
+        let mut flags = FeatureFlags::default();
+        flags.sharded_notes = enabled;
+        crate::config::Config::set_test_feature_flags(flags);
+    }
+
+    fn create_commit_without_authorship_note(
+        tmp_repo: &TmpRepo,
+        filename: &str,
+        contents: &str,
+        message: &str,
+    ) -> String {
+        tmp_repo
+            .write_file(filename, contents, true)
+            .expect("write file for manual commit");
+
+        let mut args = tmp_repo.gitai_repo().global_args_for_exec();
+        args.extend_from_slice(&["add".to_string(), ".".to_string()]);
+        exec_git(&args).expect("stage files");
+
+        let mut args = tmp_repo.gitai_repo().global_args_for_exec();
+        args.extend_from_slice(&["commit".to_string(), "-m".to_string(), message.to_string()]);
+        exec_git(&args).expect("create manual commit");
+
+        tmp_repo
+            .get_head_commit_sha()
+            .expect("get manual commit sha")
+    }
 
     #[test]
     fn test_parse_batch_check_blob_oid_accepts_sha1_and_sha256() {
@@ -1025,6 +1071,118 @@ mod tests {
             "0000000000000000000000000000000000000000",
         );
         assert!(non_existent_content.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_notes_add_respects_sharded_notes_flag_for_writes() {
+        let _guard = TestFeatureFlagsGuard::new();
+        let tmp_repo = TmpRepo::new().expect("Failed to create tmp repo");
+        set_test_sharded_notes(false);
+
+        tmp_repo
+            .commit_with_message("Initial commit")
+            .expect("Failed to create initial commit");
+        let commit_a = tmp_repo
+            .get_head_commit_sha()
+            .expect("Failed to get first commit SHA");
+
+        set_test_sharded_notes(false);
+        notes_add(
+            tmp_repo.gitai_repo(),
+            &commit_a,
+            "{\"mode\":\"legacy-only\"}",
+        )
+        .expect("add non-sharded note");
+
+        let shard_ref_a = format!("refs/notes/ai-s/{}", &commit_a[..2]);
+        assert!(
+            !ref_exists(tmp_repo.gitai_repo(), &shard_ref_a),
+            "default-off write should not create shard refs"
+        );
+
+        tmp_repo
+            .write_file("second.txt", "second\n", true)
+            .expect("write second file");
+        tmp_repo
+            .commit_with_message("Second commit")
+            .expect("create second commit");
+        let commit_b = tmp_repo
+            .get_head_commit_sha()
+            .expect("Failed to get second commit SHA");
+
+        set_test_sharded_notes(true);
+        notes_add(tmp_repo.gitai_repo(), &commit_b, "{\"mode\":\"sharded\"}")
+            .expect("add sharded note");
+
+        let shard_ref_b = format!("refs/notes/ai-s/{}", &commit_b[..2]);
+        assert!(
+            ref_exists(tmp_repo.gitai_repo(), &shard_ref_b),
+            "enabling the flag should create the shard ref"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_shard_reads_are_ignored_when_flag_is_disabled() {
+        let _guard = TestFeatureFlagsGuard::new();
+        let tmp_repo = TmpRepo::new().expect("Failed to create tmp repo");
+        set_test_sharded_notes(false);
+        let commit_sha = create_commit_without_authorship_note(
+            &tmp_repo,
+            "shard-only.txt",
+            "shard only\n",
+            "Manual commit without authorship note",
+        );
+        let shard_ref = format!("ai-s/{}", &commit_sha[..2]);
+
+        let mut args = tmp_repo.gitai_repo().global_args_for_exec();
+        args.extend_from_slice(&[
+            "notes".to_string(),
+            format!("--ref={}", shard_ref),
+            "add".to_string(),
+            "-f".to_string(),
+            "-m".to_string(),
+            "{\"note\":\"shard-only\"}".to_string(),
+            commit_sha.clone(),
+        ]);
+        exec_git(&args).expect("add shard-only note");
+
+        set_test_sharded_notes(false);
+        assert!(
+            show_authorship_note(tmp_repo.gitai_repo(), &commit_sha).is_none(),
+            "default-off reads should ignore shard-only notes"
+        );
+        assert!(
+            note_blob_oids_for_commits(tmp_repo.gitai_repo(), std::slice::from_ref(&commit_sha))
+                .expect("resolve note blob oids")
+                .is_empty(),
+            "default-off blob lookup should ignore shard-only notes"
+        );
+        assert!(
+            commits_with_authorship_notes(tmp_repo.gitai_repo(), std::slice::from_ref(&commit_sha))
+                .expect("resolve commit note presence")
+                .is_empty(),
+            "default-off note existence checks should ignore shard-only notes"
+        );
+
+        set_test_sharded_notes(true);
+        assert_eq!(
+            show_authorship_note(tmp_repo.gitai_repo(), &commit_sha).as_deref(),
+            Some("{\"note\":\"shard-only\"}")
+        );
+        assert!(
+            note_blob_oids_for_commits(tmp_repo.gitai_repo(), std::slice::from_ref(&commit_sha))
+                .expect("resolve note blob oids with sharding")
+                .contains_key(&commit_sha),
+            "enabled shard reads should discover shard-only notes"
+        );
+        assert!(
+            commits_with_authorship_notes(tmp_repo.gitai_repo(), std::slice::from_ref(&commit_sha))
+                .expect("resolve commit note presence with sharding")
+                .contains(&commit_sha),
+            "enabled note existence checks should discover shard-only notes"
+        );
     }
 
     #[test]

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -1,5 +1,6 @@
 use crate::git::refs::{
-    AI_AUTHORSHIP_PUSH_REFSPEC, copy_ref, merge_notes_from_ref, ref_exists, tracking_ref_for_remote,
+    AI_AUTHORSHIP_PUSH_REFSPEC, copy_ref, fallback_merge_notes_ours, merge_notes_from_ref,
+    ref_exists, tracking_ref_for_remote,
 };
 use crate::{
     error::GitAiError,
@@ -133,7 +134,10 @@ pub fn fetch_authorship_notes(
             ));
             if let Err(e) = merge_notes_from_ref(repository, &tracking_ref) {
                 debug_log(&format!("notes merge failed: {}", e));
-                // Don't fail on merge errors, just log and continue
+                // Fallback: manually merge notes when git notes merge crashes
+                if let Err(e2) = fallback_merge_notes_ours(repository, &tracking_ref) {
+                    debug_log(&format!("fallback merge also failed: {}", e2));
+                }
             }
         } else {
             // Only tracking ref exists - copy it to local
@@ -168,67 +172,115 @@ fn is_missing_remote_notes_ref_error(error: &GitAiError) -> bool {
             || stderr_lower.contains("remote ref does not exist")
             || stderr_lower.contains("not our ref"))
 }
+/// Maximum number of fetch-merge-push attempts before giving up.
+/// On busy monorepos, concurrent pushers can cause non-fast-forward rejections
+/// even after a successful merge, so we retry the full cycle.
+const PUSH_NOTES_MAX_ATTEMPTS: usize = 3;
+
 // for use with post-push hook
-pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Result<(), GitAiError> {
-    // STEP 1: Fetch remote notes into tracking ref and merge before pushing
-    // This ensures we don't lose notes from other branches/clones
+pub fn push_authorship_notes(
+    repository: &Repository,
+    remote_name: &str,
+) -> Result<(), GitAiError> {
+    let mut last_error = None;
+
+    for attempt in 0..PUSH_NOTES_MAX_ATTEMPTS {
+        if attempt > 0 {
+            debug_log(&format!(
+                "retrying notes push (attempt {}/{})",
+                attempt + 1,
+                PUSH_NOTES_MAX_ATTEMPTS
+            ));
+        }
+
+        fetch_and_merge_tracking_notes(repository, remote_name);
+
+        // Push notes without force (requires fast-forward)
+        let push_args =
+            build_authorship_push_args(repository.global_args_for_exec(), remote_name);
+
+        debug_log(&format!(
+            "pushing authorship refs (no force): {:?}",
+            &push_args
+        ));
+
+        match exec_git(&push_args) {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                debug_log(&format!("authorship push failed: {}", e));
+                if is_non_fast_forward_error(&e) && attempt + 1 < PUSH_NOTES_MAX_ATTEMPTS {
+                    // Another pusher updated remote notes between our merge and push.
+                    // Retry the full fetch-merge-push cycle.
+                    last_error = Some(e);
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        GitAiError::Generic("notes push exhausted retries".to_string())
+    }))
+}
+
+/// Fetch remote notes into a tracking ref and merge into local refs/notes/ai.
+fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
     let tracking_ref = tracking_ref_for_remote(remote_name);
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
 
-    let fetch_before_push = build_authorship_fetch_args(
+    let fetch_args = build_authorship_fetch_args(
         repository.global_args_for_exec(),
         remote_name,
         &fetch_refspec,
     );
 
-    debug_log(&format!(
-        "pre-push authorship fetch: {:?}",
-        &fetch_before_push
-    ));
+    debug_log(&format!("pre-push authorship fetch: {:?}", &fetch_args));
 
     // Fetch is best-effort; if it fails (e.g., no remote notes yet), continue
-    if exec_git(&fetch_before_push).is_ok() {
-        // Merge fetched notes into local refs/notes/ai
-        let local_notes_ref = "refs/notes/ai";
+    if exec_git(&fetch_args).is_err() {
+        return;
+    }
 
-        if ref_exists(repository, &tracking_ref) {
-            if ref_exists(repository, local_notes_ref) {
-                // Both exist - merge them
-                debug_log(&format!(
-                    "pre-push: merging {} into {}",
-                    tracking_ref, local_notes_ref
-                ));
-                if let Err(e) = merge_notes_from_ref(repository, &tracking_ref) {
-                    debug_log(&format!("pre-push notes merge failed: {}", e));
-                }
-            } else {
-                // Only tracking ref exists - copy it to local
-                debug_log(&format!(
-                    "pre-push: initializing {} from {}",
-                    local_notes_ref, tracking_ref
-                ));
-                if let Err(e) = copy_ref(repository, &tracking_ref, local_notes_ref) {
-                    debug_log(&format!("pre-push notes copy failed: {}", e));
-                }
-            }
+    let local_notes_ref = "refs/notes/ai";
+
+    if !ref_exists(repository, &tracking_ref) {
+        return;
+    }
+
+    if !ref_exists(repository, local_notes_ref) {
+        // Only tracking ref exists - copy it to local
+        debug_log(&format!(
+            "pre-push: initializing {} from {}",
+            local_notes_ref, tracking_ref
+        ));
+        if let Err(e) = copy_ref(repository, &tracking_ref, local_notes_ref) {
+            debug_log(&format!("pre-push notes copy failed: {}", e));
+        }
+        return;
+    }
+
+    // Both exist - merge them
+    debug_log(&format!(
+        "pre-push: merging {} into {}",
+        tracking_ref, local_notes_ref
+    ));
+    if let Err(e) = merge_notes_from_ref(repository, &tracking_ref) {
+        debug_log(&format!("pre-push notes merge failed: {}", e));
+        // Fallback: manually merge notes when git notes merge crashes
+        // (e.g., due to corrupted/mixed-fanout notes trees, or git bugs
+        // with fanout-level mismatches on older git versions like macOS)
+        if let Err(e2) = fallback_merge_notes_ours(repository, &tracking_ref) {
+            debug_log(&format!("pre-push fallback merge also failed: {}", e2));
         }
     }
+}
 
-    // STEP 2: Push notes without force (requires fast-forward)
-    let push_authorship =
-        build_authorship_push_args(repository.global_args_for_exec(), remote_name);
-
-    debug_log(&format!(
-        "pushing authorship refs (no force): {:?}",
-        &push_authorship
-    ));
-    if let Err(e) = exec_git(&push_authorship) {
-        // Best-effort; don't fail user operation due to authorship sync issues
-        debug_log(&format!("authorship push skipped due to error: {}", e));
-        return Err(e);
-    }
-
-    Ok(())
+fn is_non_fast_forward_error(error: &GitAiError) -> bool {
+    let GitAiError::GitCliError { stderr, .. } = error else {
+        return false;
+    };
+    stderr.contains("non-fast-forward")
 }
 
 fn extract_remote_from_fetch_args(args: &[String]) -> Option<String> {

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -292,31 +292,25 @@ pub fn fetch_authorship_notes(
     repository: &Repository,
     remote_name: &str,
 ) -> Result<NotesExistence, GitAiError> {
-    // Generate tracking ref for this remote
     let tracking_ref = tracking_ref_for_remote(remote_name);
+    let sharded = sharded_notes_enabled();
 
     debug_log(&format!(
         "fetching authorship notes for remote '{}' to tracking ref '{}'",
         remote_name, tracking_ref
     ));
 
-    // Build refspecs: legacy + shard wildcard (when enabled)
+    // Fetch legacy ref
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
-    let mut refspecs = vec![fetch_refspec.as_str()];
-
-    let shard_prefix = shard_tracking_ref_prefix(remote_name);
-    let shard_refspec = format!("+{}*:{}*", AI_SHARDED_NOTES_PREFIX, shard_prefix);
-    let sharded = sharded_notes_enabled();
-    if sharded {
-        refspecs.push(&shard_refspec);
-    }
-
-    let fetch_authorship =
-        build_authorship_fetch_args(repository.global_args_for_exec(), remote_name, &refspecs);
+    let fetch_authorship = build_authorship_fetch_args(
+        repository.global_args_for_exec(),
+        remote_name,
+        &[fetch_refspec.as_str()],
+    );
 
     debug_log(&format!("fetch command: {:?}", fetch_authorship));
 
-    match exec_git(&fetch_authorship) {
+    let legacy_found = match exec_git(&fetch_authorship) {
         Ok(output) => {
             debug_log(&format!(
                 "fetch stdout: '{}'",
@@ -326,21 +320,51 @@ pub fn fetch_authorship_notes(
                 "fetch stderr: '{}'",
                 String::from_utf8_lossy(&output.stderr)
             ));
+            true
         }
         Err(e) => {
             if is_missing_remote_notes_ref_error(&e) {
                 debug_log(&format!(
-                    "no authorship notes found on remote '{}', nothing to sync",
+                    "no legacy authorship notes found on remote '{}'",
                     remote_name
                 ));
-                return Ok(NotesExistence::NotFound);
+                false
+            } else {
+                debug_log(&format!("authorship fetch failed: {}", e));
+                return Err(e);
             }
-            debug_log(&format!("authorship fetch failed: {}", e));
-            return Err(e);
+        }
+    };
+
+    // Fetch shard refs separately so a missing legacy ref doesn't block shard fetching
+    let mut shards_found = false;
+    if sharded {
+        let shard_prefix = shard_tracking_ref_prefix(remote_name);
+        let shard_refspec = format!("+{}*:{}*", AI_SHARDED_NOTES_PREFIX, shard_prefix);
+        let shard_fetch = build_authorship_fetch_args(
+            repository.global_args_for_exec(),
+            remote_name,
+            &[shard_refspec.as_str()],
+        );
+
+        debug_log(&format!("shard fetch command: {:?}", shard_fetch));
+
+        match exec_git(&shard_fetch) {
+            Ok(_) => {
+                shards_found = true;
+            }
+            Err(e) => {
+                // Wildcard refspecs that match nothing don't error, so this is a real failure
+                debug_log(&format!("shard fetch failed: {}", e));
+            }
         }
     }
 
-    // After successful fetch, merge the tracking ref into refs/notes/ai
+    if !legacy_found && !shards_found {
+        return Ok(NotesExistence::NotFound);
+    }
+
+    // Merge the legacy tracking ref into refs/notes/ai
     let local_notes_ref = "refs/notes/ai";
 
     if crate::git::refs::ref_exists(repository, &tracking_ref) {
@@ -372,7 +396,7 @@ pub fn fetch_authorship_notes(
         ));
     }
 
-    // Merge shard tracking refs when sharding is enabled
+    // Merge shard tracking refs
     if sharded {
         merge_shard_tracking_refs(repository, remote_name);
     }
@@ -452,64 +476,64 @@ pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Resu
 }
 
 /// Fetch remote notes into a tracking ref and merge into local refs/notes/ai.
+/// Fetches legacy and shard refs separately so a missing ref doesn't block the other.
 fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
     let sharded = sharded_notes_enabled();
     let tracking_ref = tracking_ref_for_remote(remote_name);
+
+    // Fetch legacy ref (best-effort)
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
-    let mut refspecs = vec![fetch_refspec.as_str()];
+    let legacy_fetch = build_authorship_fetch_args(
+        repository.global_args_for_exec(),
+        remote_name,
+        &[fetch_refspec.as_str()],
+    );
 
-    let shard_prefix = shard_tracking_ref_prefix(remote_name);
-    let shard_fetch_refspec = format!("+{}*:{}*", AI_SHARDED_NOTES_PREFIX, shard_prefix);
-    if sharded {
-        refspecs.push(&shard_fetch_refspec);
-    }
+    debug_log(&format!("pre-push authorship fetch: {:?}", &legacy_fetch));
 
-    let fetch_args =
-        build_authorship_fetch_args(repository.global_args_for_exec(), remote_name, &refspecs);
+    if exec_git(&legacy_fetch).is_ok() {
+        let local_notes_ref = "refs/notes/ai";
 
-    debug_log(&format!("pre-push authorship fetch: {:?}", &fetch_args));
-
-    // Fetch is best-effort; if it fails (e.g., no remote notes yet), continue
-    if exec_git(&fetch_args).is_err() {
-        return;
-    }
-
-    let local_notes_ref = "refs/notes/ai";
-
-    if !ref_exists(repository, &tracking_ref) {
-        return;
-    }
-
-    if !ref_exists(repository, local_notes_ref) {
-        // Only tracking ref exists - copy it to local
-        debug_log(&format!(
-            "pre-push: initializing {} from {}",
-            local_notes_ref, tracking_ref
-        ));
-        if let Err(e) = copy_ref(repository, &tracking_ref, local_notes_ref) {
-            debug_log(&format!("pre-push notes copy failed: {}", e));
-        }
-        return;
-    }
-
-    // Both exist - merge them
-    debug_log(&format!(
-        "pre-push: merging {} into {}",
-        tracking_ref, local_notes_ref
-    ));
-    if let Err(e) = merge_notes_from_ref(repository, &tracking_ref) {
-        debug_log(&format!("pre-push notes merge failed: {}", e));
-        // Fallback: manually merge notes when git notes merge crashes
-        // (e.g., due to corrupted/mixed-fanout notes trees, or git bugs
-        // with fanout-level mismatches on older git versions like macOS)
-        if let Err(e2) = fallback_merge_notes_ours(repository, &tracking_ref) {
-            debug_log(&format!("pre-push fallback merge also failed: {}", e2));
+        if ref_exists(repository, &tracking_ref) {
+            if ref_exists(repository, local_notes_ref) {
+                debug_log(&format!(
+                    "pre-push: merging {} into {}",
+                    tracking_ref, local_notes_ref
+                ));
+                if let Err(e) = merge_notes_from_ref(repository, &tracking_ref) {
+                    debug_log(&format!("pre-push notes merge failed: {}", e));
+                    // Fallback: manually merge notes when git notes merge crashes
+                    if let Err(e2) = fallback_merge_notes_ours(repository, &tracking_ref) {
+                        debug_log(&format!("pre-push fallback merge also failed: {}", e2));
+                    }
+                }
+            } else {
+                debug_log(&format!(
+                    "pre-push: initializing {} from {}",
+                    local_notes_ref, tracking_ref
+                ));
+                if let Err(e) = copy_ref(repository, &tracking_ref, local_notes_ref) {
+                    debug_log(&format!("pre-push notes copy failed: {}", e));
+                }
+            }
         }
     }
 
-    // Merge shard tracking refs
+    // Fetch shard refs separately (best-effort)
     if sharded {
-        merge_shard_tracking_refs(repository, remote_name);
+        let shard_prefix = shard_tracking_ref_prefix(remote_name);
+        let shard_fetch_refspec = format!("+{}*:{}*", AI_SHARDED_NOTES_PREFIX, shard_prefix);
+        let shard_fetch = build_authorship_fetch_args(
+            repository.global_args_for_exec(),
+            remote_name,
+            &[shard_fetch_refspec.as_str()],
+        );
+
+        debug_log(&format!("pre-push shard fetch: {:?}", &shard_fetch));
+
+        if exec_git(&shard_fetch).is_ok() {
+            merge_shard_tracking_refs(repository, remote_name);
+        }
     }
 }
 

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -1,6 +1,6 @@
 use crate::git::refs::{
-    AI_AUTHORSHIP_PUSH_REFSPEC, copy_ref, fallback_merge_notes_ours, merge_notes_from_ref,
-    ref_exists, tracking_ref_for_remote,
+    AI_AUTHORSHIP_PUSH_REFSPEC, AI_SHARDED_NOTES_PREFIX, copy_ref, fallback_merge_notes_ours,
+    merge_notes_from_ref, ref_exists, tracking_ref_for_remote,
 };
 use crate::{
     error::GitAiError,
@@ -18,6 +18,112 @@ fn disabled_hooks_config() -> &'static str {
 #[cfg(not(windows))]
 fn disabled_hooks_config() -> &'static str {
     "core.hooksPath=/dev/null"
+}
+
+fn sharded_notes_enabled() -> bool {
+    crate::config::Config::get()
+        .get_feature_flags()
+        .sharded_notes
+}
+
+/// Tracking ref prefix for sharded notes from a specific remote.
+/// e.g. "refs/notes/ai-s-remote/origin/ab"
+fn shard_tracking_ref_prefix(remote_name: &str) -> String {
+    format!(
+        "refs/notes/ai-s-remote/{}/",
+        sanitize_remote_name_for_ref(remote_name)
+    )
+}
+
+/// Sanitize a remote name for use in a ref path (same logic as refs.rs).
+fn sanitize_remote_name_for_ref(remote: &str) -> String {
+    remote
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// List all shard tracking refs for a remote (refs/notes/ai-s-remote/<remote>/*).
+fn list_shard_tracking_refs(
+    repository: &Repository,
+    remote_name: &str,
+) -> Result<Vec<(String, String)>, GitAiError> {
+    let prefix = shard_tracking_ref_prefix(remote_name);
+    let mut args = repository.global_args_for_exec();
+    args.push("for-each-ref".to_string());
+    args.push("--format=%(refname)".to_string());
+    args.push(prefix.clone());
+
+    match exec_git(&args) {
+        Ok(output) => {
+            let stdout = String::from_utf8(output.stdout)
+                .map_err(|_| GitAiError::Generic("bad utf8".to_string()))?;
+            Ok(stdout
+                .lines()
+                .filter(|l| !l.is_empty())
+                .filter_map(|tracking_ref| {
+                    // Extract shard suffix (e.g. "ab") from tracking ref
+                    let shard = tracking_ref.strip_prefix(&prefix)?;
+                    let local_shard_ref = format!("{}{}", AI_SHARDED_NOTES_PREFIX, shard);
+                    Some((tracking_ref.to_string(), local_shard_ref))
+                })
+                .collect())
+        }
+        Err(_) => Ok(Vec::new()),
+    }
+}
+
+/// Merge all shard tracking refs into their corresponding local shard refs.
+fn merge_shard_tracking_refs(repository: &Repository, remote_name: &str) {
+    let shard_refs = match list_shard_tracking_refs(repository, remote_name) {
+        Ok(refs) => refs,
+        Err(e) => {
+            debug_log(&format!("failed to list shard tracking refs: {}", e));
+            return;
+        }
+    };
+
+    for (tracking_ref, local_shard_ref) in &shard_refs {
+        if !ref_exists(repository, tracking_ref) {
+            continue;
+        }
+
+        if ref_exists(repository, local_shard_ref) {
+            // Both exist — merge using notes merge -s ours on the shard ref
+            let shard_name = local_shard_ref
+                .strip_prefix("refs/notes/")
+                .unwrap_or(local_shard_ref);
+            let mut args = repository.global_args_for_exec();
+            args.push("notes".to_string());
+            args.push(format!("--ref={}", shard_name));
+            args.push("merge".to_string());
+            args.push("-s".to_string());
+            args.push("ours".to_string());
+            args.push("--quiet".to_string());
+            args.push(tracking_ref.to_string());
+
+            if let Err(e) = exec_git(&args) {
+                debug_log(&format!(
+                    "shard merge failed for {} <- {}: {}",
+                    local_shard_ref, tracking_ref, e
+                ));
+            }
+        } else {
+            // Only tracking ref exists — copy it to local
+            if let Err(e) = copy_ref(repository, tracking_ref, local_shard_ref) {
+                debug_log(&format!(
+                    "shard copy failed for {} <- {}: {}",
+                    local_shard_ref, tracking_ref, e
+                ));
+            }
+        }
+    }
 }
 
 /// Result of checking for authorship notes on a remote
@@ -84,17 +190,19 @@ pub fn fetch_authorship_notes(
         remote_name, tracking_ref
     ));
 
-    // Fetch notes to tracking ref with explicit refspec.
-    // If the remote does not have refs/notes/ai yet, treat that as NotFound.
+    // Build refspecs: legacy + shard wildcard (when enabled)
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
+    let mut refspecs = vec![fetch_refspec.as_str()];
 
-    // Build the internal authorship fetch with explicit flags and disabled hooks.
-    // IMPORTANT: use repository.global_args_for_exec() to ensure -C flag is present for bare repos.
-    let fetch_authorship = build_authorship_fetch_args(
-        repository.global_args_for_exec(),
-        remote_name,
-        &fetch_refspec,
-    );
+    let shard_prefix = shard_tracking_ref_prefix(remote_name);
+    let shard_refspec = format!("+{}*:{}*", AI_SHARDED_NOTES_PREFIX, shard_prefix);
+    let sharded = sharded_notes_enabled();
+    if sharded {
+        refspecs.push(&shard_refspec);
+    }
+
+    let fetch_authorship =
+        build_authorship_fetch_args(repository.global_args_for_exec(), remote_name, &refspecs);
 
     debug_log(&format!("fetch command: {:?}", fetch_authorship));
 
@@ -127,7 +235,6 @@ pub fn fetch_authorship_notes(
 
     if crate::git::refs::ref_exists(repository, &tracking_ref) {
         if crate::git::refs::ref_exists(repository, local_notes_ref) {
-            // Both exist - merge them
             debug_log(&format!(
                 "merging authorship notes from {} into {}",
                 tracking_ref, local_notes_ref
@@ -140,14 +247,12 @@ pub fn fetch_authorship_notes(
                 }
             }
         } else {
-            // Only tracking ref exists - copy it to local
             debug_log(&format!(
                 "initializing {} from tracking ref {}",
                 local_notes_ref, tracking_ref
             ));
             if let Err(e) = copy_ref(repository, &tracking_ref, local_notes_ref) {
                 debug_log(&format!("notes copy failed: {}", e));
-                // Don't fail on copy errors, just log and continue
             }
         }
     } else {
@@ -155,6 +260,11 @@ pub fn fetch_authorship_notes(
             "tracking ref {} was not created after fetch",
             tracking_ref
         ));
+    }
+
+    // Merge shard tracking refs when sharding is enabled
+    if sharded {
+        merge_shard_tracking_refs(repository, remote_name);
     }
 
     Ok(NotesExistence::Found)
@@ -193,7 +303,19 @@ pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Resu
         fetch_and_merge_tracking_notes(repository, remote_name);
 
         // Push notes without force (requires fast-forward)
-        let push_args = build_authorship_push_args(repository.global_args_for_exec(), remote_name);
+        let sharded = sharded_notes_enabled();
+        let shard_push_refspec =
+            format!("{}*:{}*", AI_SHARDED_NOTES_PREFIX, AI_SHARDED_NOTES_PREFIX);
+        let mut push_refspecs: Vec<&str> = vec![AI_AUTHORSHIP_PUSH_REFSPEC];
+        if sharded {
+            push_refspecs.push(&shard_push_refspec);
+        }
+
+        let push_args = build_authorship_push_args(
+            repository.global_args_for_exec(),
+            remote_name,
+            &push_refspecs,
+        );
 
         debug_log(&format!(
             "pushing authorship refs (no force): {:?}",
@@ -221,14 +343,19 @@ pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Resu
 
 /// Fetch remote notes into a tracking ref and merge into local refs/notes/ai.
 fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
+    let sharded = sharded_notes_enabled();
     let tracking_ref = tracking_ref_for_remote(remote_name);
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
+    let mut refspecs = vec![fetch_refspec.as_str()];
 
-    let fetch_args = build_authorship_fetch_args(
-        repository.global_args_for_exec(),
-        remote_name,
-        &fetch_refspec,
-    );
+    let shard_prefix = shard_tracking_ref_prefix(remote_name);
+    let shard_fetch_refspec = format!("+{}*:{}*", AI_SHARDED_NOTES_PREFIX, shard_prefix);
+    if sharded {
+        refspecs.push(&shard_fetch_refspec);
+    }
+
+    let fetch_args =
+        build_authorship_fetch_args(repository.global_args_for_exec(), remote_name, &refspecs);
 
     debug_log(&format!("pre-push authorship fetch: {:?}", &fetch_args));
 
@@ -268,6 +395,11 @@ fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
         if let Err(e2) = fallback_merge_notes_ours(repository, &tracking_ref) {
             debug_log(&format!("pre-push fallback merge also failed: {}", e2));
         }
+    }
+
+    // Merge shard tracking refs
+    if sharded {
+        merge_shard_tracking_refs(repository, remote_name);
     }
 }
 
@@ -338,7 +470,7 @@ fn with_disabled_hooks(mut args: Vec<String>) -> Vec<String> {
 fn build_authorship_fetch_args(
     global_args: Vec<String>,
     remote_name: &str,
-    fetch_refspec: &str,
+    fetch_refspecs: &[&str],
 ) -> Vec<String> {
     let mut args = with_disabled_hooks(global_args);
     args.push("fetch".to_string());
@@ -348,11 +480,17 @@ fn build_authorship_fetch_args(
     args.push("--no-write-commit-graph".to_string());
     args.push("--no-auto-maintenance".to_string());
     args.push(remote_name.to_string());
-    args.push(fetch_refspec.to_string());
+    for refspec in fetch_refspecs {
+        args.push(refspec.to_string());
+    }
     args
 }
 
-fn build_authorship_push_args(global_args: Vec<String>, remote_name: &str) -> Vec<String> {
+fn build_authorship_push_args(
+    global_args: Vec<String>,
+    remote_name: &str,
+    push_refspecs: &[&str],
+) -> Vec<String> {
     let mut args = with_disabled_hooks(global_args);
     args.push("push".to_string());
     args.push("--quiet".to_string());
@@ -360,7 +498,9 @@ fn build_authorship_push_args(global_args: Vec<String>, remote_name: &str) -> Ve
     args.push("--no-verify".to_string());
     args.push("--no-signed".to_string());
     args.push(remote_name.to_string());
-    args.push(AI_AUTHORSHIP_PUSH_REFSPEC.to_string());
+    for refspec in push_refspecs {
+        args.push(refspec.to_string());
+    }
     args
 }
 
@@ -374,7 +514,7 @@ mod tests {
         let args = build_authorship_fetch_args(
             vec!["-C".to_string(), "/tmp/repo".to_string()],
             "origin",
-            "+refs/notes/ai:refs/notes/ai-remote/origin",
+            &["+refs/notes/ai:refs/notes/ai-remote/origin"],
         );
 
         assert!(
@@ -387,8 +527,11 @@ mod tests {
     #[test]
     fn authorship_push_args_always_disable_hooks() {
         let disabled_hooks = disabled_hooks_config();
-        let args =
-            build_authorship_push_args(vec!["-C".to_string(), "/tmp/repo".to_string()], "origin");
+        let args = build_authorship_push_args(
+            vec!["-C".to_string(), "/tmp/repo".to_string()],
+            "origin",
+            &[AI_AUTHORSHIP_PUSH_REFSPEC],
+        );
 
         assert!(
             args.windows(2)

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -202,14 +202,13 @@ fn merge_shard_tracking_refs(repository: &Repository, remote_name: &str) {
             debug_log(&format!("batch shard copy failed: {}", e));
             // Fall back to individual copies
             for (local_ref, _tracking_oid) in &copies {
-                // Find the matching pair to get the tracking ref name
-                if let Some(pair) = pairs.iter().find(|p| p.local_shard_ref == **local_ref) {
-                    if let Err(e) = copy_ref(repository, &pair.tracking_ref, local_ref) {
-                        debug_log(&format!(
-                            "shard copy failed for {} <- {}: {}",
-                            local_ref, pair.tracking_ref, e
-                        ));
-                    }
+                if let Some(pair) = pairs.iter().find(|p| p.local_shard_ref == **local_ref)
+                    && let Err(e) = copy_ref(repository, &pair.tracking_ref, local_ref)
+                {
+                    debug_log(&format!(
+                        "shard copy failed for {} <- {}: {}",
+                        local_ref, pair.tracking_ref, e
+                    ));
                 }
             }
         }

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -4,7 +4,10 @@ use crate::git::refs::{
 };
 use crate::{
     error::GitAiError,
-    git::{cli_parser::ParsedGitInvocation, repository::exec_git},
+    git::{
+        cli_parser::ParsedGitInvocation,
+        repository::{exec_git, exec_git_stdin},
+    },
     utils::debug_log,
 };
 
@@ -49,79 +52,187 @@ fn sanitize_remote_name_for_ref(remote: &str) -> String {
         .collect()
 }
 
-/// List all shard tracking refs for a remote (refs/notes/ai-s-remote/<remote>/*).
-fn list_shard_tracking_refs(
+/// Resolved shard ref pair: tracking ref name, local ref name, and their resolved OIDs.
+struct ShardRefPair {
+    tracking_ref: String,
+    tracking_oid: String,
+    local_shard_ref: String,
+    local_oid: Option<String>, // None means local doesn't exist yet
+}
+
+/// Discover shard tracking refs and resolve both tracking and local OIDs in a single
+/// `for-each-ref` + `cat-file --batch-check` round-trip pair (2 git processes total,
+/// regardless of shard count).
+fn resolve_shard_ref_pairs(
     repository: &Repository,
     remote_name: &str,
-) -> Result<Vec<(String, String)>, GitAiError> {
+) -> Result<Vec<ShardRefPair>, GitAiError> {
     let prefix = shard_tracking_ref_prefix(remote_name);
+
+    // 1. List tracking refs with their OIDs in one call
     let mut args = repository.global_args_for_exec();
     args.push("for-each-ref".to_string());
-    args.push("--format=%(refname)".to_string());
+    args.push("--format=%(objectname) %(refname)".to_string());
     args.push(prefix.clone());
 
-    match exec_git(&args) {
-        Ok(output) => {
-            let stdout = String::from_utf8(output.stdout)
-                .map_err(|_| GitAiError::Generic("bad utf8".to_string()))?;
-            Ok(stdout
-                .lines()
-                .filter(|l| !l.is_empty())
-                .filter_map(|tracking_ref| {
-                    // Extract shard suffix (e.g. "ab") from tracking ref
-                    let shard = tracking_ref.strip_prefix(&prefix)?;
-                    let local_shard_ref = format!("{}{}", AI_SHARDED_NOTES_PREFIX, shard);
-                    Some((tracking_ref.to_string(), local_shard_ref))
-                })
-                .collect())
-        }
-        Err(_) => Ok(Vec::new()),
+    let output = match exec_git(&args) {
+        Ok(o) => o,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|_| GitAiError::Generic("bad utf8".to_string()))?;
+
+    // Each entry: (tracking_oid, tracking_refname, local_shard_ref)
+    let tracking_refs: Vec<(String, String, String)> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .filter_map(|line| {
+            let (oid, refname) = line.split_once(' ')?;
+            let shard = refname.strip_prefix(&prefix)?;
+            let local_ref = format!("{}{}", AI_SHARDED_NOTES_PREFIX, shard);
+            Some((oid.to_string(), refname.to_string(), local_ref))
+        })
+        .collect();
+
+    if tracking_refs.is_empty() {
+        return Ok(Vec::new());
     }
+
+    // 2. Batch-resolve all local shard ref OIDs in one cat-file call
+    let mut batch_args = repository.global_args_for_exec();
+    batch_args.push("cat-file".to_string());
+    batch_args.push("--batch-check".to_string());
+
+    let stdin_data: String = tracking_refs
+        .iter()
+        .map(|(_, _, local_ref)| local_ref.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+
+    let batch_output = exec_git_stdin(&batch_args, stdin_data.as_bytes())?;
+    let batch_stdout = String::from_utf8(batch_output.stdout)
+        .map_err(|_| GitAiError::Generic("bad utf8".to_string()))?;
+
+    let pairs: Vec<ShardRefPair> = tracking_refs
+        .into_iter()
+        .zip(batch_stdout.lines())
+        .map(
+            |((tracking_oid, tracking_ref, local_shard_ref), batch_line)| {
+                // cat-file --batch-check output: "<oid> commit <size>" or "<ref> missing"
+                let local_oid = if batch_line.contains("missing") {
+                    None
+                } else {
+                    batch_line.split_whitespace().next().map(|s| s.to_string())
+                };
+                ShardRefPair {
+                    tracking_ref,
+                    tracking_oid,
+                    local_shard_ref,
+                    local_oid,
+                }
+            },
+        )
+        .collect();
+
+    Ok(pairs)
 }
 
 /// Merge all shard tracking refs into their corresponding local shard refs.
+///
+/// Optimized to minimize git process invocations:
+/// - 2 processes to discover and resolve all shard pairs (for-each-ref + cat-file)
+/// - Skips shards where tracking == local (no change) — zero cost
+/// - Batches all "copy" operations (local doesn't exist) into one update-ref --stdin call
+/// - Only runs `git notes merge` for genuinely diverged shards (typically 1-2 per fetch)
 fn merge_shard_tracking_refs(repository: &Repository, remote_name: &str) {
-    let shard_refs = match list_shard_tracking_refs(repository, remote_name) {
-        Ok(refs) => refs,
+    let pairs = match resolve_shard_ref_pairs(repository, remote_name) {
+        Ok(p) => p,
         Err(e) => {
-            debug_log(&format!("failed to list shard tracking refs: {}", e));
+            debug_log(&format!("failed to resolve shard ref pairs: {}", e));
             return;
         }
     };
 
-    for (tracking_ref, local_shard_ref) in &shard_refs {
-        if !ref_exists(repository, tracking_ref) {
-            continue;
+    if pairs.is_empty() {
+        return;
+    }
+
+    // Partition into: copies (local doesn't exist) and merges (both exist, different OIDs)
+    let mut copies: Vec<(&str, &str)> = Vec::new(); // (local_ref, tracking_oid)
+    let mut merges: Vec<(&str, &str)> = Vec::new(); // (local_ref, tracking_ref)
+
+    for pair in &pairs {
+        match &pair.local_oid {
+            None => {
+                // Local doesn't exist — copy tracking OID
+                copies.push((&pair.local_shard_ref, &pair.tracking_oid));
+            }
+            Some(local_oid) if local_oid == &pair.tracking_oid => {
+                // Already in sync — skip
+            }
+            Some(_) => {
+                // Both exist, different — need merge
+                merges.push((&pair.local_shard_ref, &pair.tracking_ref));
+            }
+        }
+    }
+
+    debug_log(&format!(
+        "shard merge: {} unchanged, {} copies, {} merges",
+        pairs.len() - copies.len() - merges.len(),
+        copies.len(),
+        merges.len(),
+    ));
+
+    // Batch all copies into one update-ref --stdin call
+    if !copies.is_empty() {
+        let mut args = repository.global_args_for_exec();
+        args.push("update-ref".to_string());
+        args.push("--stdin".to_string());
+
+        let mut stdin_data = String::new();
+        for (local_ref, tracking_oid) in &copies {
+            // "create <ref> <oid>\n" — sets ref to oid, fails if ref already exists
+            // (safe here because we confirmed local doesn't exist)
+            stdin_data.push_str(&format!("create {} {}\n", local_ref, tracking_oid));
         }
 
-        if ref_exists(repository, local_shard_ref) {
-            // Both exist — merge using notes merge -s ours on the shard ref
-            let shard_name = local_shard_ref
-                .strip_prefix("refs/notes/")
-                .unwrap_or(local_shard_ref);
-            let mut args = repository.global_args_for_exec();
-            args.push("notes".to_string());
-            args.push(format!("--ref={}", shard_name));
-            args.push("merge".to_string());
-            args.push("-s".to_string());
-            args.push("ours".to_string());
-            args.push("--quiet".to_string());
-            args.push(tracking_ref.to_string());
+        if let Err(e) = exec_git_stdin(&args, stdin_data.as_bytes()) {
+            debug_log(&format!("batch shard copy failed: {}", e));
+            // Fall back to individual copies
+            for (local_ref, _tracking_oid) in &copies {
+                // Find the matching pair to get the tracking ref name
+                if let Some(pair) = pairs.iter().find(|p| p.local_shard_ref == **local_ref) {
+                    if let Err(e) = copy_ref(repository, &pair.tracking_ref, local_ref) {
+                        debug_log(&format!(
+                            "shard copy failed for {} <- {}: {}",
+                            local_ref, pair.tracking_ref, e
+                        ));
+                    }
+                }
+            }
+        }
+    }
 
-            if let Err(e) = exec_git(&args) {
-                debug_log(&format!(
-                    "shard merge failed for {} <- {}: {}",
-                    local_shard_ref, tracking_ref, e
-                ));
-            }
-        } else {
-            // Only tracking ref exists — copy it to local
-            if let Err(e) = copy_ref(repository, tracking_ref, local_shard_ref) {
-                debug_log(&format!(
-                    "shard copy failed for {} <- {}: {}",
-                    local_shard_ref, tracking_ref, e
-                ));
-            }
+    // Merges: these are genuinely diverged shards — run notes merge per shard.
+    // Typically only 1-2 shards per fetch, so this is acceptable.
+    for (local_ref, tracking_ref) in &merges {
+        let shard_name = local_ref.strip_prefix("refs/notes/").unwrap_or(local_ref);
+        let mut args = repository.global_args_for_exec();
+        args.push("notes".to_string());
+        args.push(format!("--ref={}", shard_name));
+        args.push("merge".to_string());
+        args.push("-s".to_string());
+        args.push("ours".to_string());
+        args.push("--quiet".to_string());
+        args.push(tracking_ref.to_string());
+
+        if let Err(e) = exec_git(&args) {
+            debug_log(&format!(
+                "shard merge failed for {} <- {}: {}",
+                local_ref, tracking_ref, e
+            ));
         }
     }
 }

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -24,9 +24,14 @@ fn disabled_hooks_config() -> &'static str {
 }
 
 fn sharded_notes_enabled() -> bool {
-    crate::config::Config::get()
-        .get_feature_flags()
-        .sharded_notes
+    if crate::daemon::daemon_process_active() {
+        let config = crate::config::Config::fresh();
+        config.get_feature_flags().sharded_notes
+    } else {
+        crate::config::Config::get()
+            .get_feature_flags()
+            .sharded_notes
+    }
 }
 
 /// Tracking ref prefix for sharded notes from a specific remote.

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -178,10 +178,7 @@ fn is_missing_remote_notes_ref_error(error: &GitAiError) -> bool {
 const PUSH_NOTES_MAX_ATTEMPTS: usize = 3;
 
 // for use with post-push hook
-pub fn push_authorship_notes(
-    repository: &Repository,
-    remote_name: &str,
-) -> Result<(), GitAiError> {
+pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Result<(), GitAiError> {
     let mut last_error = None;
 
     for attempt in 0..PUSH_NOTES_MAX_ATTEMPTS {
@@ -196,8 +193,7 @@ pub fn push_authorship_notes(
         fetch_and_merge_tracking_notes(repository, remote_name);
 
         // Push notes without force (requires fast-forward)
-        let push_args =
-            build_authorship_push_args(repository.global_args_for_exec(), remote_name);
+        let push_args = build_authorship_push_args(repository.global_args_for_exec(), remote_name);
 
         debug_log(&format!(
             "pushing authorship refs (no force): {:?}",
@@ -219,9 +215,8 @@ pub fn push_authorship_notes(
         }
     }
 
-    Err(last_error.unwrap_or_else(|| {
-        GitAiError::Generic("notes push exhausted retries".to_string())
-    }))
+    Err(last_error
+        .unwrap_or_else(|| GitAiError::Generic("notes push exhausted retries".to_string())))
 }
 
 /// Fetch remote notes into a tracking ref and merge into local refs/notes/ai.

--- a/tests/integration/internal_machine_commands.rs
+++ b/tests/integration/internal_machine_commands.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-fn enable_sharded_notes(repo: &mut TestRepo) {
+fn set_sharded_notes(repo: &mut TestRepo, enabled: bool) {
     repo.patch_git_ai_config(|patch| {
         let mut flags = match patch.feature_flags.take() {
             Some(existing) if existing.is_object() => existing,
@@ -14,9 +14,26 @@ fn enable_sharded_notes(repo: &mut TestRepo) {
         let flags_obj = flags
             .as_object_mut()
             .expect("feature_flags value should be an object");
-        flags_obj.insert("sharded_notes".to_string(), json!(true));
+        flags_obj.insert("sharded_notes".to_string(), json!(enabled));
         patch.feature_flags = Some(flags);
     });
+}
+
+fn enable_sharded_notes(repo: &mut TestRepo) {
+    set_sharded_notes(repo, true);
+}
+
+fn disable_sharded_notes(repo: &mut TestRepo) {
+    set_sharded_notes(repo, false);
+}
+
+fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
+    Command::new("git")
+        .args(["-C", repo_path.to_str().unwrap()])
+        .args(["show-ref", "--verify", "--quiet", ref_name])
+        .status()
+        .expect("git should run")
+        .success()
 }
 
 #[test]
@@ -163,33 +180,6 @@ fn test_fetch_and_push_authorship_notes_internal_commands_json() {
     let fetch_after_json: serde_json::Value =
         serde_json::from_str(fetch_after.trim()).expect("fetch output should be JSON");
     assert_eq!(fetch_after_json["notes_existence"], "found");
-}
-
-fn set_sharded_notes(repo: &mut TestRepo, enabled: bool) {
-    repo.patch_git_ai_config(|patch| {
-        let mut flags = match patch.feature_flags.take() {
-            Some(existing) if existing.is_object() => existing,
-            _ => json!({}),
-        };
-        let flags_obj = flags
-            .as_object_mut()
-            .expect("feature_flags value should be an object");
-        flags_obj.insert("sharded_notes".to_string(), json!(enabled));
-        patch.feature_flags = Some(flags);
-    });
-}
-
-fn enable_sharded_notes(repo: &mut TestRepo) {
-    set_sharded_notes(repo, true);
-}
-
-fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
-    Command::new("git")
-        .args(["-C", repo_path.to_str().unwrap()])
-        .args(["show-ref", "--verify", "--quiet", ref_name])
-        .status()
-        .expect("git should run")
-        .success()
 }
 
 /// Helper to run a raw git command with stdin piped, returning trimmed stdout.
@@ -600,7 +590,7 @@ fn test_sharded_notes_mixed_team_interop() {
         .stage_all_and_commit("sharded client commit")
         .expect("commit should succeed");
     mirror
-        .git(&["push", "origin", "HEAD"])
+        .git_og(&["push", "origin", "HEAD"])
         .expect("push code should succeed");
 
     let request = json!({ "remote_name": "origin" }).to_string();
@@ -634,5 +624,125 @@ fn test_sharded_notes_mixed_team_interop() {
     );
 
     // Clean up
+    let _ = fs::remove_dir_all(&clone2_path);
+}
+
+#[test]
+fn test_non_sharded_push_does_not_push_existing_shard_refs() {
+    let (mut mirror, upstream) = TestRepo::new_with_remote();
+    enable_sharded_notes(&mut mirror);
+
+    fs::write(
+        mirror.path().join("local-shard-only.txt"),
+        "local shard should stay local when flag is off\n",
+    )
+    .expect("should write file");
+    let commit = mirror
+        .stage_all_and_commit("create local shard ref")
+        .expect("commit should succeed");
+    mirror
+        .git_og(&["push", "origin", "HEAD"])
+        .expect("push code should succeed");
+
+    let shard_ref_full = format!("refs/notes/ai-s/{}", &commit.commit_sha[..2]);
+    assert!(
+        git_ref_exists(mirror.path(), &shard_ref_full),
+        "local shard ref should exist before disabling the flag"
+    );
+    assert!(
+        !git_ref_exists(upstream.path(), &shard_ref_full),
+        "upstream should not have the shard ref before notes are pushed"
+    );
+
+    disable_sharded_notes(&mut mirror);
+
+    let request = json!({ "remote_name": "origin" }).to_string();
+    let push_output = mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("legacy-only push should succeed");
+    let push_json: serde_json::Value =
+        serde_json::from_str(push_output.trim()).expect("valid JSON");
+    assert_eq!(push_json["ok"], true);
+
+    let legacy_note = git_plumbing(
+        upstream.path(),
+        &["notes", "--ref=ai", "show", &commit.commit_sha],
+        None,
+    );
+    assert!(
+        !legacy_note.trim().is_empty(),
+        "legacy note should still be pushed with the flag disabled"
+    );
+    assert!(
+        !git_ref_exists(upstream.path(), &shard_ref_full),
+        "default-off push should not propagate shard refs that already exist locally"
+    );
+}
+
+#[test]
+fn test_non_sharded_fetch_does_not_fetch_shards_from_upstream() {
+    let (mut mirror, upstream) = TestRepo::new_with_remote();
+    enable_sharded_notes(&mut mirror);
+
+    fs::write(
+        mirror.path().join("remote-shard.txt"),
+        "remote shard should stay remote when flag is off\n",
+    )
+    .expect("should write file");
+    let commit = mirror
+        .stage_all_and_commit("create upstream shard ref")
+        .expect("commit should succeed");
+    mirror
+        .git_og(&["push", "origin", "HEAD"])
+        .expect("push code should succeed");
+
+    let request = json!({ "remote_name": "origin" }).to_string();
+    mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("sharded push should succeed");
+
+    let shard_ref_full = format!("refs/notes/ai-s/{}", &commit.commit_sha[..2]);
+    assert!(
+        git_ref_exists(upstream.path(), &shard_ref_full),
+        "upstream should have the shard ref before the non-sharded fetch"
+    );
+
+    let base = std::env::temp_dir();
+    let clone2_path = base.join(format!("non-sharded-fetch-clone-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&clone2_path);
+
+    let clone_output = Command::new("git")
+        .args([
+            "clone",
+            upstream.path().to_str().unwrap(),
+            clone2_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("clone should succeed");
+    assert!(clone_output.status.success(), "clone2 should succeed");
+
+    let clone2 = TestRepo::new_at_path_with_mode(&clone2_path, mirror.mode());
+    let fetch_output = clone2
+        .git_ai(&["fetch-authorship-notes", "--json", &request])
+        .expect("legacy-only fetch should succeed");
+    let fetch_json: serde_json::Value =
+        serde_json::from_str(fetch_output.trim()).expect("valid JSON");
+    assert_eq!(fetch_json["notes_existence"], "found");
+
+    let legacy_note = git_plumbing(
+        clone2.path(),
+        &["notes", "--ref=ai", "show", &commit.commit_sha],
+        None,
+    );
+    assert!(
+        !legacy_note.trim().is_empty(),
+        "legacy note should still be fetched with the flag disabled"
+    );
+    assert!(
+        !git_ref_exists(clone2.path(), &shard_ref_full),
+        "default-off fetch should not materialize shard refs locally"
+    );
+
+    drop(clone2);
     let _ = fs::remove_dir_all(&clone2_path);
 }

--- a/tests/integration/internal_machine_commands.rs
+++ b/tests/integration/internal_machine_commands.rs
@@ -2,6 +2,7 @@ use crate::repos::test_repo::{TestRepo, real_git_executable};
 use serde_json::json;
 use std::fs;
 use std::io::Write;
+use std::path::Path;
 use std::process::{Command, Stdio};
 
 #[test]
@@ -148,6 +149,33 @@ fn test_fetch_and_push_authorship_notes_internal_commands_json() {
     let fetch_after_json: serde_json::Value =
         serde_json::from_str(fetch_after.trim()).expect("fetch output should be JSON");
     assert_eq!(fetch_after_json["notes_existence"], "found");
+}
+
+fn set_sharded_notes(repo: &mut TestRepo, enabled: bool) {
+    repo.patch_git_ai_config(|patch| {
+        let mut flags = match patch.feature_flags.take() {
+            Some(existing) if existing.is_object() => existing,
+            _ => json!({}),
+        };
+        let flags_obj = flags
+            .as_object_mut()
+            .expect("feature_flags value should be an object");
+        flags_obj.insert("sharded_notes".to_string(), json!(enabled));
+        patch.feature_flags = Some(flags);
+    });
+}
+
+fn enable_sharded_notes(repo: &mut TestRepo) {
+    set_sharded_notes(repo, true);
+}
+
+fn git_ref_exists(repo_path: &Path, ref_name: &str) -> bool {
+    Command::new("git")
+        .args(["-C", repo_path.to_str().unwrap()])
+        .args(["show-ref", "--verify", "--quiet", ref_name])
+        .status()
+        .expect("git should run")
+        .success()
 }
 
 /// Helper to run a raw git command with stdin piped, returning trimmed stdout.
@@ -407,4 +435,192 @@ fn test_push_authorship_notes_retries_on_concurrent_push() {
         notes_list.contains(&other_sha),
         "upstream should have note from concurrent pusher"
     );
+}
+
+/// With sharded_notes enabled, push-authorship-notes writes both legacy refs/notes/ai
+/// AND shard refs (refs/notes/ai-s/XX) to the upstream.
+#[test]
+fn test_sharded_notes_dual_write_on_push() {
+    let (mut mirror, upstream) = TestRepo::new_with_remote();
+    enable_sharded_notes(&mut mirror);
+
+    fs::write(mirror.path().join("shard_test.txt"), "sharded notes test\n")
+        .expect("should write file");
+    // Commit WITH sharding enabled so the note gets dual-written
+    let commit = mirror
+        .stage_all_and_commit("add shard test file")
+        .expect("commit should succeed");
+
+    let request = json!({ "remote_name": "origin" }).to_string();
+
+    // Push with sharded_notes enabled
+    let push_output = mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("push should succeed with sharded notes");
+    let push_json: serde_json::Value =
+        serde_json::from_str(push_output.trim()).expect("valid JSON");
+    assert_eq!(push_json["ok"], true);
+
+    // Verify legacy ref exists on upstream
+    let legacy_note = git_plumbing(
+        upstream.path(),
+        &["notes", "--ref=ai", "show", &commit.commit_sha],
+        None,
+    );
+    assert!(
+        !legacy_note.trim().is_empty(),
+        "legacy notes ref should have the note on upstream"
+    );
+
+    // Verify shard ref exists on upstream
+    let shard_suffix = &commit.commit_sha[..2];
+    let shard_ref = format!("ai-s/{}", shard_suffix);
+    let shard_note = git_plumbing(
+        upstream.path(),
+        &[
+            "notes",
+            &format!("--ref={}", shard_ref),
+            "show",
+            &commit.commit_sha,
+        ],
+        None,
+    );
+    assert!(
+        !shard_note.trim().is_empty(),
+        "shard ref {} should have the note on upstream",
+        shard_ref
+    );
+
+    // Both should have identical content
+    assert_eq!(legacy_note.trim(), shard_note.trim());
+}
+
+/// A non-sharded client writes notes. A sharded client can read them via union-read
+/// (falls back to legacy ref when shard ref doesn't exist).
+#[test]
+fn test_sharded_notes_union_read_legacy_fallback() {
+    let (mut mirror, _upstream) = TestRepo::new_with_remote();
+
+    fs::write(mirror.path().join("legacy.txt"), "legacy only write\n").expect("should write file");
+    let commit = mirror
+        .stage_all_and_commit("legacy commit")
+        .expect("commit should succeed");
+
+    // Push WITHOUT sharded notes (legacy-only write)
+    let request = json!({ "remote_name": "origin" }).to_string();
+    mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("legacy push should succeed");
+
+    // Verify legacy note exists locally
+    let legacy_note = git_plumbing(
+        mirror.path(),
+        &["notes", "--ref=ai", "show", &commit.commit_sha],
+        None,
+    );
+    assert!(!legacy_note.trim().is_empty(), "legacy note should exist");
+
+    // Verify NO shard ref exists
+    let shard_suffix = &commit.commit_sha[..2];
+    let shard_ref_full = format!("refs/notes/ai-s/{}", shard_suffix);
+    assert!(
+        !git_ref_exists(mirror.path(), &shard_ref_full),
+        "shard ref should NOT exist after legacy-only write"
+    );
+
+    // Now do a blame-analysis with sharded notes enabled — it should still find the note
+    // via legacy fallback
+    let blame_request = json!({
+        "file_path": "legacy.txt",
+        "options": {
+            "line_ranges": [[1, 1]],
+            "return_human_authors_as_human": true,
+            "split_hunks_by_ai_author": false
+        }
+    })
+    .to_string();
+
+    enable_sharded_notes(&mut mirror);
+    let blame_output = mirror
+        .git_ai(&["blame-analysis", "--json", &blame_request])
+        .expect("blame with sharded notes should succeed");
+    let blame_json: serde_json::Value =
+        serde_json::from_str(blame_output.trim()).expect("valid blame JSON");
+
+    // The blame should find the note (via legacy fallback) and report line authors
+    let line_authors = blame_json["line_authors"]
+        .as_object()
+        .expect("line_authors should be present");
+    assert!(
+        !line_authors.is_empty(),
+        "blame should find authorship via legacy fallback"
+    );
+}
+
+/// Mixed-team scenario: one clone pushes with sharding, another without.
+/// Both should be able to read each other's notes after fetch.
+#[test]
+fn test_sharded_notes_mixed_team_interop() {
+    let (mut mirror, upstream) = TestRepo::new_with_remote();
+    enable_sharded_notes(&mut mirror);
+
+    // Create a second clone of the same upstream
+    let base = std::env::temp_dir();
+    let clone2_path = base.join(format!("sharded-clone2-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&clone2_path);
+    let clone_output = Command::new("git")
+        .args([
+            "clone",
+            upstream.path().to_str().unwrap(),
+            clone2_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("clone should succeed");
+    assert!(clone_output.status.success(), "clone2 should succeed");
+
+    // Mirror (sharded client) creates a commit and pushes notes
+    fs::write(
+        mirror.path().join("from_sharded.txt"),
+        "from sharded client\n",
+    )
+    .expect("write file");
+    let sharded_commit = mirror
+        .stage_all_and_commit("sharded client commit")
+        .expect("commit should succeed");
+    mirror
+        .git(&["push", "origin", "HEAD"])
+        .expect("push code should succeed");
+
+    let request = json!({ "remote_name": "origin" }).to_string();
+    mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("sharded push should succeed");
+
+    // Clone2 (non-sharded client) fetches and reads the note via legacy ref
+    let _ = Command::new("git")
+        .args([
+            "-C",
+            clone2_path.to_str().unwrap(),
+            "pull",
+            "origin",
+            "main",
+        ])
+        .output();
+    let _ = git_plumbing(
+        &clone2_path,
+        &["fetch", "origin", "+refs/notes/ai:refs/notes/ai"],
+        None,
+    );
+    let note_content = git_plumbing(
+        &clone2_path,
+        &["notes", "--ref=ai", "show", &sharded_commit.commit_sha],
+        None,
+    );
+    assert!(
+        !note_content.trim().is_empty(),
+        "non-sharded client should read notes via legacy ref"
+    );
+
+    // Clean up
+    let _ = fs::remove_dir_all(&clone2_path);
 }

--- a/tests/integration/internal_machine_commands.rs
+++ b/tests/integration/internal_machine_commands.rs
@@ -158,12 +158,15 @@ fn git_plumbing(repo_path: &std::path::Path, args: &[&str], stdin_data: Option<&
         .arg(repo_path)
         .arg("-c")
         .arg("core.hooksPath=/dev/null")
+        .arg("-c")
+        .arg("user.name=Test")
+        .arg("-c")
+        .arg("user.email=test@test.com")
         .args(args);
     if stdin_data.is_some() {
         cmd.stdin(Stdio::piped());
     }
-    cmd.stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let mut child = cmd.spawn().expect("failed to spawn git plumbing command");
 
@@ -281,17 +284,14 @@ fn test_push_authorship_notes_survives_corrupted_remote_notes_tree() {
     let push_json: serde_json::Value =
         serde_json::from_str(push_output.trim()).expect("push output should be JSON");
     assert_eq!(
-        push_json["ok"], true,
+        push_json["ok"],
+        true,
         "push should succeed via fallback merge, got: {}",
         push_output.trim()
     );
 
     // 6. Verify both notes are present on upstream after push
-    let notes_list = git_plumbing(
-        upstream.path(),
-        &["notes", "--ref=ai", "list"],
-        None,
-    );
+    let notes_list = git_plumbing(upstream.path(), &["notes", "--ref=ai", "list"], None);
     assert!(
         notes_list.contains(&commit_sha),
         "upstream should have note for first commit"
@@ -315,9 +315,7 @@ fn test_push_authorship_notes_retries_on_concurrent_push() {
     let commit1 = mirror
         .stage_all_and_commit("first commit")
         .expect("commit1");
-    mirror
-        .git(&["push", "origin", "main"])
-        .expect("push main");
+    mirror.git(&["push", "origin", "main"]).expect("push main");
 
     // 2. Push mirror's initial notes to upstream
     mirror
@@ -325,14 +323,15 @@ fn test_push_authorship_notes_retries_on_concurrent_push() {
         .expect("push initial notes");
 
     // 3. Create a second clone that simulates the concurrent pusher
-    let clone2_path = std::env::temp_dir().join(format!(
-        "concurrent-clone-{}",
-        std::process::id()
-    ));
+    let clone2_path = std::env::temp_dir().join(format!("concurrent-clone-{}", std::process::id()));
     let _ = fs::remove_dir_all(&clone2_path);
     git_plumbing(
         mirror.path(),
-        &["clone", upstream.path().to_str().unwrap(), clone2_path.to_str().unwrap()],
+        &[
+            "clone",
+            upstream.path().to_str().unwrap(),
+            clone2_path.to_str().unwrap(),
+        ],
         None,
     );
     // Configure clone2 and fetch notes
@@ -341,11 +340,7 @@ fn test_push_authorship_notes_retries_on_concurrent_push() {
         &["config", "user.email", "other@test.com"],
         None,
     );
-    git_plumbing(
-        &clone2_path,
-        &["config", "user.name", "Other"],
-        None,
-    );
+    git_plumbing(&clone2_path, &["config", "user.name", "Other"], None);
     git_plumbing(
         &clone2_path,
         &["fetch", "origin", "+refs/notes/ai:refs/notes/ai"],
@@ -396,17 +391,14 @@ fn test_push_authorship_notes_retries_on_concurrent_push() {
     let push_json: serde_json::Value =
         serde_json::from_str(push_output.trim()).expect("push output should be JSON");
     assert_eq!(
-        push_json["ok"], true,
+        push_json["ok"],
+        true,
         "push should eventually succeed, got: {}",
         push_output.trim()
     );
 
     // 7. Verify all notes are present on upstream
-    let notes_list = git_plumbing(
-        upstream.path(),
-        &["notes", "--ref=ai", "list"],
-        None,
-    );
+    let notes_list = git_plumbing(upstream.path(), &["notes", "--ref=ai", "list"], None);
     assert!(
         notes_list.contains(&commit1.commit_sha),
         "upstream should have note for mirror's first commit"

--- a/tests/integration/internal_machine_commands.rs
+++ b/tests/integration/internal_machine_commands.rs
@@ -1,6 +1,8 @@
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{TestRepo, real_git_executable};
 use serde_json::json;
 use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
 
 #[test]
 fn test_effective_ignore_patterns_internal_command_json() {
@@ -146,4 +148,271 @@ fn test_fetch_and_push_authorship_notes_internal_commands_json() {
     let fetch_after_json: serde_json::Value =
         serde_json::from_str(fetch_after.trim()).expect("fetch output should be JSON");
     assert_eq!(fetch_after_json["notes_existence"], "found");
+}
+
+/// Helper to run a raw git command with stdin piped, returning trimmed stdout.
+fn git_plumbing(repo_path: &std::path::Path, args: &[&str], stdin_data: Option<&[u8]>) -> String {
+    let git = real_git_executable();
+    let mut cmd = Command::new(git);
+    cmd.arg("-C")
+        .arg(repo_path)
+        .arg("-c")
+        .arg("core.hooksPath=/dev/null")
+        .args(args);
+    if stdin_data.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
+    cmd.stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn git plumbing command");
+
+    if let Some(data) = stdin_data {
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(data)
+            .expect("failed to write stdin");
+    }
+
+    let output = child.wait_with_output().expect("failed to wait for git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("non-utf8 git output")
+        .trim()
+        .to_string()
+}
+
+/// Reproduces a bug where `git notes merge -s ours` crashes with:
+///   Assertion failed: (is_null_oid(&mp->remote)), function diff_tree_remote,
+///   file notes-merge.c, line 170.
+///
+/// This happens when the remote notes tree has mixed fanout — both a flat blob
+/// entry (e.g. `aabbccdd…`) AND a subtree entry (e.g. `aa/bbccdd…`) for the
+/// same annotated object. The fallback merge should handle this gracefully and
+/// the push should succeed.
+#[test]
+fn test_push_authorship_notes_survives_corrupted_remote_notes_tree() {
+    let (mirror, upstream) = TestRepo::new_with_remote();
+
+    // 1. Create a commit on mirror and push it
+    fs::write(mirror.path().join("test.txt"), "hello\n").expect("write file");
+    let commit = mirror
+        .stage_all_and_commit("initial commit")
+        .expect("commit should succeed");
+    mirror
+        .git(&["push", "origin", "main"])
+        .expect("push should succeed");
+    let commit_sha = commit.commit_sha;
+
+    // 2. Create a corrupted notes tree on upstream with NO common merge base
+    //    relative to the mirror's local notes ref. This is the key condition that
+    //    triggers the assertion in git's notes-merge.c: when there's no merge base,
+    //    git uses an empty tree as the base, and the diff against the corrupted remote
+    //    tree encounters the same annotated object twice (once flat, once fanout).
+    let prefix = &commit_sha[..2];
+    let rest = &commit_sha[2..];
+
+    // Create a note blob on upstream (independent of mirror's notes)
+    let note_blob = git_plumbing(
+        upstream.path(),
+        &["hash-object", "-w", "--stdin"],
+        Some(br#"{"author":"remote"}"#),
+    );
+
+    // Build inner tree (fanout: prefix/rest -> blob)
+    let inner_tree_input = format!("100644 blob {}\t{}\n", note_blob, rest);
+    let inner_tree = git_plumbing(
+        upstream.path(),
+        &["mktree"],
+        Some(inner_tree_input.as_bytes()),
+    );
+
+    // Build mixed tree: flat entry + subtree entry for same commit
+    let mixed_tree_input = format!(
+        "100644 blob {}\t{}\n040000 tree {}\t{}\n",
+        note_blob, commit_sha, inner_tree, prefix
+    );
+    let mixed_tree = git_plumbing(
+        upstream.path(),
+        &["mktree"],
+        Some(mixed_tree_input.as_bytes()),
+    );
+
+    // Create a root commit (NO parent) — this ensures no common merge base
+    // with the mirror's notes ref, which is what triggers the assertion.
+    let corrupted_commit = git_plumbing(
+        upstream.path(),
+        &[
+            "commit-tree",
+            &mixed_tree,
+            "-m",
+            "corrupted notes tree (orphan)",
+        ],
+        None,
+    );
+    git_plumbing(
+        upstream.path(),
+        &["update-ref", "refs/notes/ai", &corrupted_commit],
+        None,
+    );
+
+    // 4. Add a new local note on mirror (so local and remote have diverged).
+    //    The git-ai commit hook automatically creates notes, so just making
+    //    a new commit is sufficient.
+    fs::write(mirror.path().join("test2.txt"), "world\n").expect("write file2");
+    let commit2 = mirror
+        .stage_all_and_commit("second commit")
+        .expect("second commit should succeed");
+
+    // 5. Push authorship notes — this triggers fetch + merge + push.
+    //    Without the fallback fix, the merge crashes and the push fails
+    //    with "non-fast-forward".
+    let request = json!({"remote_name": "origin"}).to_string();
+    let push_output = mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("push-authorship-notes should succeed despite corrupted remote tree");
+    let push_json: serde_json::Value =
+        serde_json::from_str(push_output.trim()).expect("push output should be JSON");
+    assert_eq!(
+        push_json["ok"], true,
+        "push should succeed via fallback merge, got: {}",
+        push_output.trim()
+    );
+
+    // 6. Verify both notes are present on upstream after push
+    let notes_list = git_plumbing(
+        upstream.path(),
+        &["notes", "--ref=ai", "list"],
+        None,
+    );
+    assert!(
+        notes_list.contains(&commit_sha),
+        "upstream should have note for first commit"
+    );
+    assert!(
+        notes_list.contains(&commit2.commit_sha),
+        "upstream should have note for second commit"
+    );
+}
+
+/// Simulates the race condition on busy monorepos where another developer
+/// pushes notes between our fetch-merge and push steps, causing a
+/// non-fast-forward rejection. The retry loop should re-fetch, re-merge,
+/// and push successfully.
+#[test]
+fn test_push_authorship_notes_retries_on_concurrent_push() {
+    let (mirror, upstream) = TestRepo::new_with_remote();
+
+    // 1. Create initial commit and push
+    fs::write(mirror.path().join("a.txt"), "a\n").expect("write a");
+    let commit1 = mirror
+        .stage_all_and_commit("first commit")
+        .expect("commit1");
+    mirror
+        .git(&["push", "origin", "main"])
+        .expect("push main");
+
+    // 2. Push mirror's initial notes to upstream
+    mirror
+        .git_og(&["push", "origin", "refs/notes/ai:refs/notes/ai"])
+        .expect("push initial notes");
+
+    // 3. Create a second clone that simulates the concurrent pusher
+    let clone2_path = std::env::temp_dir().join(format!(
+        "concurrent-clone-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&clone2_path);
+    git_plumbing(
+        mirror.path(),
+        &["clone", upstream.path().to_str().unwrap(), clone2_path.to_str().unwrap()],
+        None,
+    );
+    // Configure clone2 and fetch notes
+    git_plumbing(
+        &clone2_path,
+        &["config", "user.email", "other@test.com"],
+        None,
+    );
+    git_plumbing(
+        &clone2_path,
+        &["config", "user.name", "Other"],
+        None,
+    );
+    git_plumbing(
+        &clone2_path,
+        &["fetch", "origin", "+refs/notes/ai:refs/notes/ai"],
+        None,
+    );
+
+    // 4. Other clone makes a commit with a note and pushes notes to upstream.
+    //    This advances remote refs/notes/ai beyond what mirror has fetched.
+    fs::write(clone2_path.join("b.txt"), "b\n").expect("write b");
+    git_plumbing(&clone2_path, &["add", "b.txt"], None);
+    git_plumbing(&clone2_path, &["commit", "-m", "other commit"], None);
+    let other_sha = git_plumbing(&clone2_path, &["rev-parse", "HEAD"], None);
+    git_plumbing(
+        &clone2_path,
+        &[
+            "notes",
+            "--ref=ai",
+            "add",
+            "-m",
+            r#"{"author":"other"}"#,
+            &other_sha,
+        ],
+        None,
+    );
+    git_plumbing(
+        &clone2_path,
+        &["push", "origin", "refs/notes/ai:refs/notes/ai"],
+        None,
+    );
+
+    // 5. Mirror makes another commit (notes auto-created by hook).
+    //    Mirror's local refs/notes/ai is now behind remote.
+    fs::write(mirror.path().join("c.txt"), "c\n").expect("write c");
+    let _commit3 = mirror
+        .stage_all_and_commit("mirror commit")
+        .expect("commit3");
+
+    // 6. Push authorship notes. The retry loop should:
+    //    - Attempt 1: fetch, merge, push → fails (non-fast-forward if
+    //      remote was updated between merge and push, or succeeds on first try)
+    //    - Attempt 2+: re-fetch, re-merge, push → succeeds
+    //    In this test, the remote is already ahead, so the first attempt's
+    //    fetch+merge will incorporate the other clone's notes, and push succeeds.
+    let request = json!({"remote_name": "origin"}).to_string();
+    let push_output = mirror
+        .git_ai(&["push-authorship-notes", "--json", &request])
+        .expect("push-authorship-notes should succeed after retry");
+    let push_json: serde_json::Value =
+        serde_json::from_str(push_output.trim()).expect("push output should be JSON");
+    assert_eq!(
+        push_json["ok"], true,
+        "push should eventually succeed, got: {}",
+        push_output.trim()
+    );
+
+    // 7. Verify all notes are present on upstream
+    let notes_list = git_plumbing(
+        upstream.path(),
+        &["notes", "--ref=ai", "list"],
+        None,
+    );
+    assert!(
+        notes_list.contains(&commit1.commit_sha),
+        "upstream should have note for mirror's first commit"
+    );
+    assert!(
+        notes_list.contains(&other_sha),
+        "upstream should have note from concurrent pusher"
+    );
 }

--- a/tests/integration/internal_machine_commands.rs
+++ b/tests/integration/internal_machine_commands.rs
@@ -5,6 +5,20 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+fn enable_sharded_notes(repo: &mut TestRepo) {
+    repo.patch_git_ai_config(|patch| {
+        let mut flags = match patch.feature_flags.take() {
+            Some(existing) if existing.is_object() => existing,
+            _ => json!({}),
+        };
+        let flags_obj = flags
+            .as_object_mut()
+            .expect("feature_flags value should be an object");
+        flags_obj.insert("sharded_notes".to_string(), json!(true));
+        patch.feature_flags = Some(flags);
+    });
+}
+
 #[test]
 fn test_effective_ignore_patterns_internal_command_json() {
     let repo = TestRepo::new();
@@ -446,14 +460,12 @@ fn test_sharded_notes_dual_write_on_push() {
 
     fs::write(mirror.path().join("shard_test.txt"), "sharded notes test\n")
         .expect("should write file");
-    // Commit WITH sharding enabled so the note gets dual-written
     let commit = mirror
         .stage_all_and_commit("add shard test file")
         .expect("commit should succeed");
 
     let request = json!({ "remote_name": "origin" }).to_string();
 
-    // Push with sharded_notes enabled
     let push_output = mirror
         .git_ai(&["push-authorship-notes", "--json", &request])
         .expect("push should succeed with sharded notes");

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -23,6 +23,7 @@ fn setup() {
         async_mode: false,
         git_hooks_enabled: false,
         git_hooks_externally_managed: false,
+        sharded_notes: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());


### PR DESCRIPTION
## Summary
- Introduces opt-in sharded notes architecture splitting `refs/notes/ai` into 256 independent shard refs (`refs/notes/ai-s/XX`), keyed by first 2 hex chars of annotated commit SHA
- Dual-write (legacy + shard), union-read (shard first, legacy fallback), shard-aware fetch/push with wildcard refspecs
- Fully backward-compatible: old clients continue reading/writing the legacy ref; gated behind `sharded_notes` feature flag (default off)

## Test plan
- [x] `test_sharded_notes_dual_write_on_push` — verifies both legacy and shard refs reach upstream with identical content
- [x] `test_sharded_notes_union_read_legacy_fallback` — verifies blame works via legacy fallback when no shard refs exist
- [x] `test_sharded_notes_mixed_team_interop` — verifies non-sharded clone can read notes pushed by sharded clone
- [x] All existing unit and integration tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
