### PR TITLE
Fix GitHub Copilot apply_patch hook handling

### DIFF
--- a/src/commands/checkpoint_agent/agent_presets.rs
+++ b/src/commands/checkpoint_agent/agent_presets.rs
@@ -2500,6 +2500,7 @@ impl GithubCopilotPreset {
             "edit",
             "multiedit",
             "applypatch",
+            "apply_patch",
             "copilot_insertedit",
             "copilot_replacestring",
             "vscode_editfile_internal",
@@ -2515,6 +2516,24 @@ impl GithubCopilotPreset {
         }
 
         lower.contains("edit") || lower.contains("write") || lower.contains("replace")
+    }
+
+    fn collect_apply_patch_paths_from_text(raw: &str, out: &mut Vec<String>) {
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            let maybe_path = trimmed
+                .strip_prefix("*** Update File: ")
+                .or_else(|| trimmed.strip_prefix("*** Add File: "))
+                .or_else(|| trimmed.strip_prefix("*** Delete File: "))
+                .or_else(|| trimmed.strip_prefix("*** Move to: "));
+
+            if let Some(path) = maybe_path {
+                let path = path.trim();
+                if !path.is_empty() && !out.iter().any(|existing| existing == path) {
+                    out.push(path.to_string());
+                }
+            }
+        }
     }
 
     fn extract_filepaths_from_vscode_hook_payload(
@@ -2584,6 +2603,7 @@ impl GithubCopilotPreset {
                 if s.starts_with("file://") {
                     out.push(s.to_string());
                 }
+                Self::collect_apply_patch_paths_from_text(s, out);
             }
             _ => {}
         }
@@ -3443,6 +3463,9 @@ impl GithubCopilotPreset {
                 for item in arr {
                     Self::collect_copilot_filepaths(item, out);
                 }
+            }
+            serde_json::Value::String(s) => {
+                Self::collect_apply_patch_paths_from_text(s, out);
             }
             _ => {}
         }

--- a/tests/integration/github_copilot.rs
+++ b/tests/integration/github_copilot.rs
@@ -1192,6 +1192,38 @@ fn test_copilot_preset_vscode_create_file_tool_is_supported() {
 }
 
 #[test]
+fn test_copilot_preset_vscode_apply_patch_tool_is_supported() {
+    use git_ai::commands::checkpoint_agent::agent_presets::{
+        AgentCheckpointFlags, AgentCheckpointPreset,
+    };
+
+    let hook_input = json!({
+        "hookEventName": "PreToolUse",
+        "cwd": "/Users/test/project",
+        "toolName": "apply_patch",
+        "transcript_path": "/Users/test/Library/Application Support/Code/User/workspaceStorage/workspace-id/GitHub.copilot-chat/transcripts/copilot-session-apply-patch.jsonl",
+        "toolInput": "*** Begin Patch\n*** Update File: src/main.ts\n@@\n-old\n+new\n*** End Patch",
+        "sessionId": "copilot-session-apply-patch"
+    });
+
+    let flags = AgentCheckpointFlags {
+        hook_input: Some(hook_input.to_string()),
+    };
+
+    let preset = GithubCopilotPreset;
+    let result = preset.run(flags).expect("Expected human checkpoint");
+
+    assert_eq!(
+        result.checkpoint_kind,
+        git_ai::authorship::working_log::CheckpointKind::Human
+    );
+    assert_eq!(
+        result.will_edit_filepaths,
+        Some(vec!["/Users/test/project/src/main.ts".to_string()])
+    );
+}
+
+#[test]
 fn test_copilot_preset_vscode_editfiles_files_array_is_supported() {
     use git_ai::commands::checkpoint_agent::agent_presets::{
         AgentCheckpointFlags, AgentCheckpointPreset,
@@ -1270,6 +1302,52 @@ fn test_copilot_preset_vscode_posttooluse_ai_checkpoint() {
     );
     assert_eq!(result.agent_id.tool, "github-copilot");
     assert_eq!(result.agent_id.id, "copilot-session-post");
+    assert_eq!(
+        result.edited_filepaths,
+        Some(vec!["/Users/test/project/src/main.ts".to_string()])
+    );
+}
+
+#[test]
+fn test_copilot_preset_vscode_apply_patch_posttooluse_ai_checkpoint() {
+    use git_ai::commands::checkpoint_agent::agent_presets::{
+        AgentCheckpointFlags, AgentCheckpointPreset,
+    };
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let transcripts_dir = temp_dir
+        .path()
+        .join("workspaceStorage")
+        .join("workspace-id")
+        .join("GitHub.copilot-chat")
+        .join("transcripts");
+    fs::create_dir_all(&transcripts_dir).unwrap();
+    let transcript_path = transcripts_dir.join("copilot-session-apply-patch-post.jsonl");
+    fs::write(&transcript_path, r#"{"requests": []}"#).unwrap();
+    let session_path = transcript_path.to_string_lossy().to_string();
+
+    let hook_input = json!({
+        "hookEventName": "PostToolUse",
+        "cwd": "/Users/test/project",
+        "toolName": "apply_patch",
+        "toolInput": "*** Begin Patch\n*** Update File: src/main.ts\n@@\n-old\n+new\n*** End Patch",
+        "sessionId": "copilot-session-apply-patch-post",
+        "transcript_path": session_path
+    });
+
+    let flags = AgentCheckpointFlags {
+        hook_input: Some(hook_input.to_string()),
+    };
+
+    let preset = GithubCopilotPreset;
+    let result = preset.run(flags).expect("Expected AI checkpoint");
+
+    assert_eq!(
+        result.checkpoint_kind,
+        git_ai::authorship::working_log::CheckpointKind::AiAgent
+    );
+    assert_eq!(result.agent_id.tool, "github-copilot");
+    assert_eq!(result.agent_id.id, "copilot-session-apply-patch-post");
     assert_eq!(
         result.edited_filepaths,
         Some(vec!["/Users/test/project/src/main.ts".to_string()])


### PR DESCRIPTION
Fixes #814.

## Summary
- treat VS Code Copilot's apply_patch tool name as a supported edit tool
- extract edited file paths from raw apply-patch text payloads used in Copilot pre/post hook events
- add focused Copilot integration tests for apply_patch pre and post hooks

## Testing
- cargo test --test integration copilot_preset_vscode -- --nocapture
