### PR TITLE
feat: enable async_mode feature flag for new installations

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -509,7 +509,10 @@ try {
     if (-not (Test-Path -LiteralPath $configJsonPath)) {
         $cfg = @{
             git_path = $stdGitPath
-        } | ConvertTo-Json -Compress
+            feature_flags = @{
+                async_mode = $true
+            }
+        } | ConvertTo-Json -Depth 3 -Compress
         $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
         [System.IO.File]::WriteAllText($configJsonPath, $cfg, $utf8NoBom)
     }

--- a/install.sh
+++ b/install.sh
@@ -357,7 +357,10 @@ if [ ! -f "$CONFIG_JSON_PATH" ]; then
     TMP_CFG="$CONFIG_JSON_PATH.tmp.$$"
     cat >"$TMP_CFG" <<EOF
 {
-  "git_path": "${STD_GIT_PATH}"
+  "git_path": "${STD_GIT_PATH}",
+  "feature_flags": {
+    "async_mode": true
+  }
 }
 EOF
     mv -f "$TMP_CFG" "$CONFIG_JSON_PATH"


### PR DESCRIPTION
## Summary
- Enables `async_mode` feature flag by default for **new installations only**
- Embeds `feature_flags.async_mode: true` directly in the initial `config.json` written by both `install.sh` and `install.ps1`
- Existing users are unaffected — config is only written when `config.json` does not already exist
- Added `-Depth 3` to `ConvertTo-Json` in `install.ps1` to correctly serialize the nested `feature_flags` object

## Test plan
- [ ] Verify Ubuntu CI tests pass (install-scripts-local workflow)
- [ ] Verify macOS CI tests pass
- [ ] Verify Windows CI tests pass
- [ ] Fresh install creates config.json with `feature_flags.async_mode: true`
- [ ] Re-running installer on existing install preserves existing config (no overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
