### PR TITLE
Rename `git-ai d` to `git-ai bg`, keep `d` as hidden alias

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -51,7 +51,7 @@ pub fn handle_daemon(args: &[String]) {
         }
         "tail" => {
             if let Err(e) = handle_tail(&args[1..]) {
-                eprintln!("Failed to tail daemon log: {}", e);
+                eprintln!("Failed to tail log: {}", e);
                 std::process::exit(1);
             }
         }
@@ -272,7 +272,7 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
     #[cfg(windows)]
     {
         let script = format!(
-            "Start-Process -FilePath {} -ArgumentList @('d','run') -WorkingDirectory {} -WindowStyle Hidden",
+            "Start-Process -FilePath {} -ArgumentList @('bg','run') -WorkingDirectory {} -WindowStyle Hidden",
             powershell_single_quote_literal(exe.as_os_str()),
             powershell_single_quote_literal(Path::new(&runtime_dir).as_os_str())
         );
@@ -313,7 +313,7 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
     {
         let mut child = Command::new(exe);
         child
-            .arg("d")
+            .arg("bg")
             .arg("run")
             .current_dir(&runtime_dir)
             .stdin(Stdio::null())
@@ -331,7 +331,7 @@ fn spawn_daemon_run_with_piped_stderr(
     let runtime_dir = daemon_runtime_dir(config)?;
     let mut child = Command::new(exe);
     child
-        .arg("d")
+        .arg("bg")
         .arg("run")
         .current_dir(&runtime_dir)
         .stdin(Stdio::null())
@@ -382,13 +382,13 @@ fn handle_status(repo_working_dir: String) -> Result<(), String> {
 fn handle_tail(args: &[String]) -> Result<(), String> {
     let config = daemon_config_from_env_or_default_paths()?;
     if !daemon_is_up(&config) {
-        return Err("daemon is not running".to_string());
+        return Err("background service is not running".to_string());
     }
 
     let log_path =
-        daemon_log_file_path(&config).map_err(|e| format!("cannot locate daemon log: {}", e))?;
+        daemon_log_file_path(&config).map_err(|e| format!("cannot locate log: {}", e))?;
     if !log_path.exists() {
-        return Err(format!("daemon log file not found: {}", log_path.display()));
+        return Err(format!("log file not found: {}", log_path.display()));
     }
 
     let full = has_flag(args, "--full") || has_flag(args, "-f");
@@ -508,12 +508,12 @@ fn is_help(value: &str) -> bool {
 }
 
 fn print_help() {
-    eprintln!("git-ai d - run and control git-ai background service");
+    eprintln!("git-ai bg - run and control git-ai background service");
     eprintln!();
     eprintln!("Usage:");
-    eprintln!("  git-ai d start");
-    eprintln!("  git-ai d run");
-    eprintln!("  git-ai d status [--repo <path>]");
-    eprintln!("  git-ai d shutdown");
-    eprintln!("  git-ai d tail [-n <lines>] [--full]");
+    eprintln!("  git-ai bg start");
+    eprintln!("  git-ai bg run");
+    eprintln!("  git-ai bg status [--repo <path>]");
+    eprintln!("  git-ai bg shutdown");
+    eprintln!("  git-ai bg tail [-n <lines>] [--full]");
 }

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -54,6 +54,7 @@ pub fn handle_git_ai(args: &[String]) {
                 | "--version"
                 | "-v"
                 | "config"
+                | "bg"
                 | "d"
                 | "daemon"
                 | "debug"
@@ -110,7 +111,7 @@ pub fn handle_git_ai(args: &[String]) {
         "debug" => {
             commands::debug::handle_debug(&args[1..]);
         }
-        "d" | "daemon" => {
+        "bg" | "d" | "daemon" => {
             commands::daemon::handle_daemon(&args[1..]);
         }
         "stats" => {
@@ -295,7 +296,7 @@ fn print_help() {
     eprintln!("    --add <key> <value>   Add to array or upsert into object");
     eprintln!("    unset <key>           Remove config value (reverts to default)");
     eprintln!("  debug              Print support/debug diagnostics");
-    eprintln!("  d                  Run and control git-ai background service");
+    eprintln!("  bg                 Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");
     eprintln!("  git-hooks ensure   Ensure repo-local git-ai hooks are installed/healed");

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -174,7 +174,7 @@ fn daemon_status_response(home_repo: &TestRepo, target_repo: &TestRepo) -> Value
     let output = daemon_command_output(
         home_repo,
         &[
-            "d",
+            "bg",
             "status",
             "--repo",
             target_repo.canonical_path().to_string_lossy().as_ref(),
@@ -200,7 +200,7 @@ fn assert_daemon_status_ok_after_launch_repo_removed(home_repo: &TestRepo, targe
 }
 
 fn shutdown_daemon(home_repo: &TestRepo) {
-    let output = daemon_command_output(home_repo, &["d", "shutdown"], home_repo.test_home_path());
+    let output = daemon_command_output(home_repo, &["bg", "shutdown"], home_repo.test_home_path());
     assert!(
         output.status.success(),
         "daemon shutdown command should succeed: stdout={} stderr={}",
@@ -291,7 +291,7 @@ fn install_hooks_async_mode_trace2_target_routes_real_git_trace_to_daemon() {
     git_ai_with_async_daemon_env(&repo, &["install-hooks", "--dry-run=false"])
         .expect("install-hooks should succeed in async mode");
 
-    let start_output = daemon_command_output(&repo, &["d", "start"], repo.path());
+    let start_output = daemon_command_output(&repo, &["bg", "start"], repo.path());
     assert!(
         start_output.status.success(),
         "daemon start should succeed: stdout={} stderr={}",
@@ -385,7 +385,7 @@ fn daemon_status_does_not_self_emit_trace2_events() {
 
     let mut daemon_cmd = Command::new(repos::test_repo::get_binary_path());
     daemon_cmd
-        .arg("d")
+        .arg("bg")
         .arg("run")
         .current_dir(repo.path())
         .stdout(Stdio::null())
@@ -436,7 +436,7 @@ fn daemon_run_survives_deleted_launch_repo_cwd() {
 
     let mut daemon_cmd = Command::new(get_binary_path());
     daemon_cmd
-        .arg("d")
+        .arg("bg")
         .arg("run")
         .current_dir(launch_repo.path())
         .stdout(Stdio::null())
@@ -459,7 +459,7 @@ fn daemon_start_survives_deleted_launch_repo_cwd() {
     let launch_repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
     let target_repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
 
-    let output = daemon_command_output(&launch_repo, &["d", "start"], launch_repo.path());
+    let output = daemon_command_output(&launch_repo, &["bg", "start"], launch_repo.path());
     assert!(
         output.status.success(),
         "daemon start should succeed: stdout={} stderr={}",
@@ -507,7 +507,7 @@ fn daemon_telemetry_and_cas_over_persistent_connection() {
     let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
 
     // Start the daemon
-    let start_output = daemon_command_output(&repo, &["d", "start"], repo.path());
+    let start_output = daemon_command_output(&repo, &["bg", "start"], repo.path());
     assert!(
         start_output.status.success(),
         "daemon start should succeed: stdout={} stderr={}",

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -150,7 +150,7 @@ impl DaemonGuard {
         let trace_socket_path = daemon_trace_socket_path(repo);
         let mut command = Command::new(get_binary_path());
         command
-            .arg("d")
+            .arg("bg")
             .arg("run")
             .current_dir(repo.path())
             .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
@@ -591,7 +591,7 @@ fn daemon_start_spawns_detached_run_process() {
 
     let mut command = Command::new(get_binary_path());
     command
-        .arg("d")
+        .arg("bg")
         .arg("start")
         .current_dir(repo.path())
         .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
@@ -3571,7 +3571,7 @@ fn spawn_daemon_with_env(repo: &TestRepo, extra_env: &[(&str, String)]) -> Child
 
     let mut command = Command::new(get_binary_path());
     command
-        .arg("d")
+        .arg("bg")
         .arg("run")
         .current_dir(repo.path())
         .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -127,7 +127,7 @@ impl DaemonProcess {
 
         let mut command = Command::new(get_binary_path());
         command
-            .arg("d")
+            .arg("bg")
             .arg("run")
             .current_dir(test_home)
             .env("GIT_AI_TEST_DB_PATH", test_db_path)


### PR DESCRIPTION
## Summary
- Changes the primary shortcut from `git-ai d` to `git-ai bg` in help text, error messages, and subprocess spawns
- Keeps both `d` and `daemon` as hidden aliases for backward compatibility
- Removes remaining "daemon" wording from user-facing `tail` subcommand error messages

## Test plan
- [x] `cargo fmt` + `cargo clippy` — clean
- [x] Integration tests (wrapper mode) — 3032 passed
- [x] Daemon mode tests — 45 passed
- [x] Async mode tests — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
