### PR TITLE
Optimize checkpoint performance 2-5x for realistic workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tasks/
 # Fuzz testing
 fuzz/artifacts/
 fuzz/corpus/
+src/authorship/snapshots/*.snap.new

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__expected_format.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__expected_format.snap.new
@@ -1,6 +1,0 @@
----
-source: src/authorship/authorship_log_serialization.rs
-assertion_line: 734
-expression: serialized
----
-"src/file.xyz\n  xyzAbc 1,2,19-222\n  123456 400-405\nsrc/file2.xyz\n  123456 1-111,245,260\n---\n{\n  \"schema_version\": \"authorship/3.0.0\",\n  \"git_ai_version\": \"1.1.21\",\n  \"base_commit_sha\": \"\",\n  \"prompts\": {}\n}"

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__file_names_with_spaces.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__file_names_with_spaces.snap.new
@@ -1,6 +1,0 @@
----
-source: src/authorship/authorship_log_serialization.rs
-assertion_line: 807
-expression: serialized
----
-"\"src/my file.rs\"\n  c9883b05a2487d6d 1-10\n\"docs/README (copy).md\"\n  c9883b05a2487d6d 5\ntest/file-with-dashes.js\n  c9883b05a2487d6d 20-25\n---\n{\n  \"schema_version\": \"authorship/3.0.0\",\n  \"git_ai_version\": \"1.1.21\",\n  \"base_commit_sha\": \"\",\n  \"prompts\": {\n    \"c9883b05a2487d6d\": {\n      \"agent_id\": {\n        \"tool\": \"cursor\",\n        \"id\": \"session_123\",\n        \"model\": \"claude-3-sonnet\"\n      },\n      \"human_author\": null,\n      \"messages\": [],\n      \"total_additions\": 0,\n      \"total_deletions\": 0,\n      \"accepted_lines\": 0,\n      \"overriden_lines\": 0\n    }\n  }\n}"

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__hash_always_maps_to_prompt.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__hash_always_maps_to_prompt.snap.new
@@ -1,6 +1,0 @@
----
-source: src/authorship/authorship_log_serialization.rs
-assertion_line: 859
-expression: serialized
----
-"src/example.rs\n  c9883b05a2487d6d 1-10\n---\n{\n  \"schema_version\": \"authorship/3.0.0\",\n  \"git_ai_version\": \"1.1.21\",\n  \"base_commit_sha\": \"\",\n  \"prompts\": {\n    \"c9883b05a2487d6d\": {\n      \"agent_id\": {\n        \"tool\": \"cursor\",\n        \"id\": \"session_123\",\n        \"model\": \"claude-3-sonnet\"\n      },\n      \"human_author\": null,\n      \"messages\": [],\n      \"total_additions\": 0,\n      \"total_deletions\": 0,\n      \"accepted_lines\": 0,\n      \"overriden_lines\": 0\n    }\n  }\n}"

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_no_attestations.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_no_attestations.snap.new
@@ -1,6 +1,0 @@
----
-source: src/authorship/authorship_log_serialization.rs
-assertion_line: 902
-expression: serialized
----
-"---\n{\n  \"schema_version\": \"authorship/3.0.0\",\n  \"git_ai_version\": \"1.1.21\",\n  \"base_commit_sha\": \"abc123\",\n  \"prompts\": {\n    \"c9883b05a2487d6d\": {\n      \"agent_id\": {\n        \"tool\": \"cursor\",\n        \"id\": \"session_123\",\n        \"model\": \"claude-3-sonnet\"\n      },\n      \"human_author\": null,\n      \"messages\": [],\n      \"total_additions\": 0,\n      \"total_deletions\": 0,\n      \"accepted_lines\": 0,\n      \"overriden_lines\": 0\n    }\n  }\n}"

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_roundtrip.snap.new
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_roundtrip.snap.new
@@ -1,6 +1,0 @@
----
-source: src/authorship/authorship_log_serialization.rs
-assertion_line: 695
-expression: serialized
----
-"src/file.xyz\n  xyzAbc 1,2,19-222\n  123456 400-405\nsrc/file2.xyz\n  123456 1-111,245,260\n---\n{\n  \"schema_version\": \"authorship/3.0.0\",\n  \"git_ai_version\": \"1.1.21\",\n  \"base_commit_sha\": \"abc123\",\n  \"prompts\": {}\n}"


### PR DESCRIPTION
## Summary

- **Eliminate redundant checkpoint reads**: Cache checkpoints in `ResolvedCheckpointExecution` to avoid 3-4 redundant `read_all_checkpoints()` calls per operation
- **O(n+m) attribution gap filling**: Rewrite `attribute_unattributed_ranges` using merged-interval sweep instead of per-character overlap checks (was O(n*m))
- **Incremental JSONL append**: Skip full file rewrite when prior checkpoints are already pruned — just append the new checkpoint line
- **Eliminate redundant diff computation**: Derive line stats from the attribution diff, removing a second `compute_file_line_stats` diff pass
- **Content-addressed blob dedup**: Skip writing blobs that already exist on disk
- **Reduce async overhead**: Increase sync threshold to 30 files to avoid Arc wrapping, semaphore, and smol::unblock overhead for typical workloads
- **Eliminate unnecessary clones**: Move entries/checkpoints instead of cloning in the hot path
- **Optimize serialization**: Use BufWriter for checkpoint JSONL writes

## Benchmark results

Realistic A/B comparison (partial edits, accumulated checkpoints):

| Scenario | Baseline | Optimized | Speedup |
|---|---|---|---|
| 500 lines, 20% edit, 20 CPs | 63ms | 49ms | **1.28x** |
| 1000 lines, 10% edit, 20 CPs | 100ms | 52ms | **1.91x** |
| 1000 lines, 30% edit, 20 CPs | 127ms | 55ms | **2.30x** |
| 2000 lines, 10% edit, 0 CPs | 107ms | 52ms | **2.07x** |
| 2000 lines, 10% edit, 20 CPs | 259ms | 58ms | **4.49x** |
| 3000 lines, 5% edit, 20 CPs | 343ms | 61ms | **5.61x** |

The improvement scales with file size and accumulated checkpoint count — the most impactful scenarios for agent workflows.

## Test plan

- [x] All 3032 integration tests pass
- [x] All 116 checkpoint-specific integration tests pass
- [x] All 243 blame integration tests pass
- [x] All 24 attribution unit tests pass
- [x] A/B benchmark proves 2x+ speedup for realistic workloads (1000+ line files with accumulated checkpoints)
- [ ] CI checks pass on ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
