### PR TITLE
fix: recover from stale daemon by killing unresponsive process

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -107,10 +107,15 @@ fn ensure_daemon_running_attached(timeout: Duration) -> Result<DaemonConfig, Str
     }
 
     if daemon_startup_is_blocked(&config) {
-        return Err(format!(
-            "daemon startup blocked: lock held at {}",
-            config.lock_path.display()
-        ));
+        // Daemon holds the lock but its sockets are unreachable — it is stale.
+        // Try to kill it so we can start a fresh one.
+        if !crate::daemon::try_kill_stale_daemon(&config) {
+            return Err(format!(
+                "daemon startup blocked: lock held at {}",
+                config.lock_path.display()
+            ));
+        }
+        // Lock may now be free — fall through to spawn below.
     }
 
     let mut child = spawn_daemon_run_with_piped_stderr(&config)?;
@@ -192,10 +197,15 @@ pub(crate) fn ensure_daemon_running(timeout: Duration) -> Result<DaemonConfig, S
     }
 
     if daemon_startup_is_blocked(&config) {
-        return Err(format!(
-            "daemon startup blocked: lock held at {}",
-            config.lock_path.display()
-        ));
+        // Daemon holds the lock but its sockets are unreachable — it is stale.
+        // Try to kill it so we can start a fresh one.
+        if !crate::daemon::try_kill_stale_daemon(&config) {
+            return Err(format!(
+                "daemon startup blocked: lock held at {}",
+                config.lock_path.display()
+            ));
+        }
+        // Lock may now be free — fall through to spawn below.
     }
 
     spawn_daemon_run_detached(&config)?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -291,6 +291,48 @@ struct TestCompletionLogEntry {
     error: Option<String>,
 }
 
+/// Attempt to kill a stale daemon whose lock is held but whose sockets are
+/// unreachable.  Returns `true` if the process was signalled (or already
+/// dead) and the caller should retry acquiring the lock.
+#[cfg(unix)]
+pub(crate) fn try_kill_stale_daemon(config: &DaemonConfig) -> bool {
+    let meta_path = pid_metadata_path(config);
+    let contents = match fs::read_to_string(&meta_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let meta: DaemonPidMeta = match serde_json::from_str(&contents) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    let pid = meta.pid as libc::pid_t;
+    // Send SIGTERM so the daemon can clean up.  If it's already dead, the
+    // flock should have been released automatically — but we still return
+    // true so the caller retries the lock.
+    if unsafe { libc::kill(pid, 0) } != 0 {
+        // Process is already gone — lock file is stale.
+        return true;
+    }
+    unsafe { libc::kill(pid, libc::SIGTERM) };
+    // Give the daemon a moment to release the lock.
+    for _ in 0..20 {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        if LockFile::try_acquire(&config.lock_path).is_some() {
+            // Lock is free — daemon exited.
+            return true;
+        }
+    }
+    // Last resort: SIGKILL.
+    unsafe { libc::kill(pid, libc::SIGKILL) };
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    true
+}
+
+#[cfg(windows)]
+pub(crate) fn try_kill_stale_daemon(_config: &DaemonConfig) -> bool {
+    false
+}
+
 pub struct DaemonLock {
     _lock: LockFile,
 }


### PR DESCRIPTION
## Summary
- When the daemon holds its lock but sockets are unreachable (stale/zombie state), every git command floods stderr with 3 error lines
- Instead of failing immediately, the wrapper now reads the daemon PID from metadata, sends SIGTERM (escalating to SIGKILL after 1s), waits for the lock to release, and restarts a fresh daemon
- Applied to both `ensure_daemon_running` and `ensure_daemon_running_attached` code paths

## Test plan
- [ ] Build a debug binary, start the daemon, delete its sockets manually, run a git command — should recover and restart the daemon instead of flooding errors
- [ ] Normal daemon operation (healthy daemon) is unaffected — the recovery path is only entered when `daemon_is_up()` is false AND lock is held
- [ ] If PID metadata is missing/corrupt, falls back to the existing error behavior
- [ ] On Windows, the new function is a no-op — existing behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
