### PR TITLE
ci: skip Rust CI suites when no Rust files changed

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,26 @@ name: Coverage
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/coverage.yml'
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/coverage.yml'
   merge_group:
     branches: [main]
 

--- a/.github/workflows/git-core-compat.yml
+++ b/.github/workflows/git-core-compat.yml
@@ -3,8 +3,26 @@ name: Git Core Compatibility
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/git-core-compat.yml'
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/git-core-compat.yml'
   merge_group:
     branches: [main]
 

--- a/.github/workflows/install-scripts-local.yml
+++ b/.github/workflows/install-scripts-local.yml
@@ -7,6 +7,14 @@ on:
     types: [labeled]
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'install.sh'
+      - 'install.ps1'
+      - 'scripts/**'
+      - '.github/workflows/install-scripts-local.yml'
   merge_group:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -3,8 +3,26 @@ name: Lint & Format
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/lint-format.yml'
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/lint-format.yml'
   merge_group:
     branches: [main]
 

--- a/.github/workflows/performance-benchmarks.yml
+++ b/.github/workflows/performance-benchmarks.yml
@@ -3,6 +3,16 @@ name: Performance Benchmarks
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'scripts/benchmarks/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/performance-benchmarks.yml'
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,26 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/test.yml'
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Taskfile.yml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/test.yml'
   merge_group:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Adds `paths` filters to 6 Rust-related GitHub Actions workflows so they only trigger when Rust-relevant files are modified. Non-Rust changes (docs, agent-support plugins, install scripts, etc.) will no longer spin up the full Rust test/lint/fmt/coverage/benchmark matrix.

**Affected workflows:**
- `test.yml` — cargo test (3 OS × 3 modes)
- `lint-format.yml` — clippy, rustfmt, rustdoc
- `coverage.yml` — cargo-llvm-cov
- `git-core-compat.yml` — git core compatibility tests
- `performance-benchmarks.yml` — PR smoke benchmarks
- `install-scripts-local.yml` — E2E install tests (push-to-main only)

**Path filter set** (per workflow): `src/**`, `tests/**`, `Cargo.toml`, `Cargo.lock`, `Taskfile.yml`, `flake.nix`, `flake.lock`, and the workflow file itself. `install-scripts-local.yml` additionally includes `install.sh`, `install.ps1`, and `scripts/**`. `performance-benchmarks.yml` additionally includes `scripts/benchmarks/**`.

**Not changed:** `merge_group` triggers have no path filter (GitHub doesn't support it for this event type, and merge queue should always run full CI). `workflow_dispatch` and `schedule` triggers are also unfiltered. Non-Rust workflows (`intellij-build`, `test-vscode-extension`, `opencode-type-check`) already had their own path filters.

## Review & Testing Checklist for Human

- [ ] **Required status checks**: If any of these workflows (`Test`, `Lint & Format`, `Coverage`, etc.) are configured as required checks on the repo, they will never report a status on non-Rust PRs — which will **block merging**. You may need to either (a) remove them as required checks, or (b) add a lightweight "skip" job that always passes when paths don't match, or (c) use the `paths-ignore` approach instead. **This is the most important thing to verify before merging.**
- [ ] **Path completeness**: Verify no Rust-affecting files are missing from the filter list. Candidates to consider: `.cargo/config.toml`, `rust-toolchain.toml` (if added in the future), any `build.rs` outside `src/`.
- [ ] **End-to-end validation**: Open a test PR that only touches a non-Rust file (e.g. a README edit) and confirm the Rust workflows are correctly skipped, and that the PR is still mergeable.

### Notes
- `merge_group` does not support `paths` filtering in GitHub Actions, so those triggers remain unfiltered — this acts as a safety net ensuring merge queue always runs the full suite.
- `install-scripts-local.yml`'s `pull_request` trigger uses `types: [labeled]` (manual gating), so no path filter was added there.

Link to Devin session: https://app.devin.ai/sessions/ad0f73c2d8f24017914ed6edc90c60dc
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
