### PR TITLE
Fix Devin review findings: repo fallback + branch classification

### DIFF
--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -97,29 +97,29 @@ fn is_read_only_branch_invocation(parsed: &ParsedGitInvocation) -> bool {
         return false;
     }
 
-    let read_only_listing_flags = [
+    // Flags that *trigger* list mode — their presence alone means read-only.
+    let list_mode_triggers = [
         "--all",
         "--contains",
         "--format",
-        "--ignore-case",
         "--list",
         "--merged",
-        "--no-color",
-        "--no-column",
         "--no-contains",
         "--no-merged",
         "--points-at",
         "--remotes",
         "--show-current",
         "--sort",
-        "--verbose",
         "-a",
         "-l",
         "-r",
-        "-v",
     ];
 
-    command_args_contain_any(&parsed.command_args, &read_only_listing_flags)
+    // Flags that only *modify* list output (e.g. -v, --no-color) but do NOT
+    // trigger list mode on their own. `git branch -v feature` creates a branch
+    // named "feature" — -v only means "verbose" in list mode, it does not
+    // activate list mode.
+    command_args_contain_any(&parsed.command_args, &list_mode_triggers)
         || parsed.pos_command(0).is_none()
 }
 
@@ -290,6 +290,18 @@ mod tests {
     #[test]
     fn read_only_invocation_rejects_branch_creation() {
         let parsed = parse_git_cli_args(&["branch".to_string(), "feature".to_string()]);
+        assert!(!is_read_only_invocation(&parsed));
+    }
+
+    #[test]
+    fn read_only_invocation_rejects_branch_create_with_verbose_flag() {
+        // `git branch -v feature` creates a branch; -v is a list-output modifier,
+        // not a list-mode trigger.
+        let parsed = parse_git_cli_args(&[
+            "branch".to_string(),
+            "-v".to_string(),
+            "feature".to_string(),
+        ]);
         assert!(!is_read_only_invocation(&parsed));
     }
 

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2514,13 +2514,18 @@ fn try_find_repository_no_git_exec(
     let normalized_global_args =
         normalize_global_args_for_repo_root(global_args, &paths.command_root.to_string_lossy());
 
-    repository_from_discovered_paths(
+    // If construction fails (e.g. canonicalize fails due to permissions/symlinks,
+    // or core.worktree config makes the assumed workdir incorrect), fall back to
+    // the git-exec discovery path rather than propagating the error.
+    match repository_from_discovered_paths(
         normalized_global_args,
         &paths.workdir,
         &paths.git_dir,
         &paths.git_common_dir,
-    )
-    .map(Some)
+    ) {
+        Ok(repo) => Ok(Some(repo)),
+        Err(_) => Ok(None),
+    }
 }
 
 fn resolve_fast_discovery_base_dir(global_args: &[String]) -> Result<Option<PathBuf>, GitAiError> {


### PR DESCRIPTION
## Summary
- **Fix 1 — `try_find_repository_no_git_exec` fallback regression**: Construction errors from `repository_from_discovered_paths` (e.g. `canonicalize()` failures, bad `core.worktree` config) now return `Ok(None)` so `find_repository` falls back to the git-exec discovery path. Previously these errors propagated via `?`, causing `find_repository(...).ok()` to return `None` and silently skip hooks.
- **Fix 2 — `is_read_only_branch_invocation` false positive**: Split `read_only_listing_flags` into list-mode *triggers* (e.g. `--list`, `--merged`, `-a`, `-r`) and list-output *modifiers* (e.g. `-v`, `--verbose`, `--no-color`). Only triggers classify the command as read-only. This prevents `git branch -v feature` (a branch *create*) from being incorrectly classified as read-only and passthrough'd.
- Added test: `read_only_invocation_rejects_branch_create_with_verbose_flag`

## Test plan
- [x] All 18 `command_classification` tests pass (including new test)
- [x] All 34 `repository::tests` pass
- [x] All 25 `git_handlers::tests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
