### PR TITLE
perf: use spawn_blocking instead of OS threads for per-connection handling

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -184,6 +184,10 @@ fn handle_run(args: &[String]) -> Result<(), String> {
         .block_on(async move { crate::daemon::run_daemon(config).await })
         .map_err(|e| e.to_string())?;
 
+    // Give in-flight spawn_blocking handlers a bounded window to finish,
+    // then force-terminate so the process doesn't hang on slow connections.
+    runtime.shutdown_timeout(std::time::Duration::from_secs(5));
+
     // Daemon is fully dead (lock released, sockets removed, threads joined).
     // Now safe to self-update — install.sh can start a fresh daemon.
     crate::daemon::daemon_run_pending_self_update();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6559,17 +6559,11 @@ fn control_listener_loop_actor(
             };
             let coord = coordinator.clone();
             let handle = runtime_handle.clone();
-            if std::thread::Builder::new()
-                .spawn(move || {
-                    if let Err(e) = handle_control_connection_actor(stream, coord, handle) {
-                        debug_log(&format!("daemon control connection error: {}", e));
-                    }
-                })
-                .is_err()
-            {
-                debug_log("daemon control listener: failed to spawn handler thread");
-                break;
-            }
+            drop(runtime_handle.spawn_blocking(move || {
+                if let Err(e) = handle_control_connection_actor(stream, coord, handle) {
+                    debug_log(&format!("daemon control connection error: {}", e));
+                }
+            }));
         }
         Ok(())
     }
@@ -6737,6 +6731,7 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
 fn trace_listener_loop_actor(
     trace_socket_path: PathBuf,
     coordinator: Arc<ActorDaemonCoordinator>,
+    runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), GitAiError> {
     #[cfg(not(windows))]
     {
@@ -6754,17 +6749,11 @@ fn trace_listener_loop_actor(
                 continue;
             };
             let coord = coordinator.clone();
-            if std::thread::Builder::new()
-                .spawn(move || {
-                    if let Err(e) = handle_trace_connection_actor(stream, coord) {
-                        debug_log(&format!("daemon trace connection error: {}", e));
-                    }
-                })
-                .is_err()
-            {
-                debug_log("daemon trace listener: failed to spawn handler thread");
-                break;
-            }
+            drop(runtime_handle.spawn_blocking(move || {
+                if let Err(e) = handle_trace_connection_actor(stream, coord) {
+                    debug_log(&format!("daemon trace connection error: {}", e));
+                }
+            }));
         }
         Ok(())
     }
@@ -7077,9 +7066,10 @@ pub async fn run_daemon(config: DaemonConfig) -> Result<(), GitAiError> {
 
     let trace_coord = coordinator.clone();
     let trace_shutdown_coord = coordinator.clone();
+    let trace_handle = rt_handle.clone();
     let trace_thread = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            trace_listener_loop_actor(trace_socket_path, trace_coord)
+            trace_listener_loop_actor(trace_socket_path, trace_coord, trace_handle)
         }));
         match result {
             Ok(Ok(())) => {}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6728,6 +6728,7 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
     Ok(())
 }
 
+#[allow(unused_variables)]
 fn trace_listener_loop_actor(
     trace_socket_path: PathBuf,
     coordinator: Arc<ActorDaemonCoordinator>,


### PR DESCRIPTION
## Summary

- **Use `spawn_blocking` for per-connection handling**: Replaces `std::thread::spawn` with `tokio::spawn_blocking` in both control and trace listener loops (Unix path). This reuses tokio's bounded blocking thread pool instead of creating unbounded OS threads per git invocation.
- **Bounded shutdown**: Adds `runtime.shutdown_timeout(5s)` after `run_daemon` returns so in-flight `spawn_blocking` handlers don't stall process exit indefinitely.

## Test plan

- [x] All 50 daemon integration tests pass
- [x] `cargo clippy` clean on all platforms (including Windows unused variable fix)
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)