### PR TITLE
prompt analysis powered by CaS

### DIFF
--- a/src/commands/prompts_db.rs
+++ b/src/commands/prompts_db.rs
@@ -974,13 +974,12 @@ fn resolve_cas_messages(conn: &Connection, deferred: &[DeferredPrompt]) {
         && let Ok(db_guard) = db_mutex.lock()
     {
         for hash in hash_to_indices.keys() {
-            if let Ok(Some(cached_json)) = db_guard.get_cas_cache(hash) {
-                if let Ok(cas_obj) = serde_json::from_str::<CasMessagesObject>(&cached_json) {
-                    if let Ok(messages_json) = serde_json::to_string(&cas_obj.messages) {
-                        resolved_messages.insert(hash.clone(), messages_json);
-                        continue;
-                    }
-                }
+            if let Ok(Some(cached_json)) = db_guard.get_cas_cache(hash)
+                && let Ok(cas_obj) = serde_json::from_str::<CasMessagesObject>(&cached_json)
+                && let Ok(messages_json) = serde_json::to_string(&cas_obj.messages)
+            {
+                resolved_messages.insert(hash.clone(), messages_json);
+                continue;
             }
             hashes_needing_fetch.push(hash.clone());
         }
@@ -1017,25 +1016,24 @@ fn resolve_cas_messages(conn: &Connection, deferred: &[DeferredPrompt]) {
                 match client.read_ca_prompt_store(&hash_refs) {
                     Ok(response) => {
                         for result in &response.results {
-                            if result.status == "ok" {
-                                if let Some(content) = &result.content {
-                                    let json_str =
-                                        serde_json::to_string(content).unwrap_or_default();
-                                    if let Ok(cas_obj) =
-                                        serde_json::from_value::<CasMessagesObject>(content.clone())
+                            if result.status == "ok"
+                                && let Some(content) = &result.content
+                            {
+                                let json_str = serde_json::to_string(content).unwrap_or_default();
+                                if let Ok(cas_obj) =
+                                    serde_json::from_value::<CasMessagesObject>(content.clone())
+                                {
+                                    if let Ok(messages_json) =
+                                        serde_json::to_string(&cas_obj.messages)
                                     {
-                                        if let Ok(messages_json) =
-                                            serde_json::to_string(&cas_obj.messages)
-                                        {
-                                            resolved_messages
-                                                .insert(result.hash.clone(), messages_json);
-                                        }
-                                        // Cache for future runs
-                                        if let Ok(db_mutex) = InternalDatabase::global()
-                                            && let Ok(mut db_guard) = db_mutex.lock()
-                                        {
-                                            let _ = db_guard.set_cas_cache(&result.hash, &json_str);
-                                        }
+                                        resolved_messages
+                                            .insert(result.hash.clone(), messages_json);
+                                    }
+                                    // Cache for future runs
+                                    if let Ok(db_mutex) = InternalDatabase::global()
+                                        && let Ok(mut db_guard) = db_mutex.lock()
+                                    {
+                                        let _ = db_guard.set_cas_cache(&result.hash, &json_str);
                                     }
                                 }
                             }


### PR DESCRIPTION
Follow-up to https://github.com/git-ai-project/git-ai/pull/770 to enable better x-device x-repo use of prompt analysis when logged in to a Team or Enterprise org
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
