### PR TITLE
ci: set GIT_AI_ASYNC_MODE=false in e2e and nightly workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,11 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+env:
+  # Force wrapper mode (not async/daemon) so post-commit hooks fire
+  # synchronously and attribution notes are written in-process.
+  GIT_AI_ASYNC_MODE: "false"
+
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/install-scripts-local.yml
+++ b/.github/workflows/install-scripts-local.yml
@@ -19,6 +19,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Force wrapper mode (not async/daemon) so post-commit hooks fire
+  # synchronously and attribution notes are written in-process.
+  GIT_AI_ASYNC_MODE: "false"
+
 jobs:
   install-local-unix:
     name: E2E ${{ matrix.agent.name }} on ${{ matrix.os }}

--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -20,6 +20,9 @@ on:
 env:
   GIT_AI_DEBUG: "1"
   CARGO_INCREMENTAL: "0"
+  # Force wrapper mode (not async/daemon) so post-commit hooks fire
+  # synchronously and attribution notes are written in-process.
+  GIT_AI_ASYNC_MODE: "false"
 
 jobs:
   # ── Version Resolution ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Explicitly sets `GIT_AI_ASYNC_MODE=false` as a workflow-level environment variable in three CI workflow files to force the synchronous wrapper code path. This fixes the `"No authorship note on HEAD — post-commit hook did not fire"` failures in e2e tests (e.g. [this run](https://github.com/git-ai-project/git-ai/actions/runs/23662424998/job/68935850173)), where async mode was causing checkpoints to be queued to a daemon that doesn't exist in CI.

**Affected workflows:**
- `install-scripts-local.yml` — the main e2e test suite (the one currently failing)
- `nightly-agent-integration.yml` — nightly agent CLI integration tests
- `e2e-tests.yml` — BATS-based e2e tests

## Review & Testing Checklist for Human

- [ ] Verify `GIT_AI_ASYNC_MODE` is the correct env var name for the `async_mode` feature flag (should be resolved by `envy::prefixed("GIT_AI_")` in `feature_flags.rs`)
- [ ] Confirm no other workflows (e.g. `install-scripts-nightly.yml`, `nightly-upgrade.yml`) also need this flag
- [ ] Trigger the `install-scripts-local.yml` workflow (via `workflow_dispatch` or the `integration` label on a PR) and verify the Windows e2e jobs now pass

### Notes
- The `async_mode` flag already defaults to `false` in both debug and release builds, so this is a defensive override. Worth investigating what's causing async mode to activate in CI (config file pickup, recent default change, etc.).

Link to Devin session: https://app.devin.ai/sessions/a11477ff6fbd494895204c6e090a97c4
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
