### PR TITLE
Add typed feature flag options to NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -378,9 +378,18 @@ GITOGEOF
             disable_auto_updates = cfg.settings.disableAutoUpdates;
             update_channel = cfg.settings.updateChannel;
             feature_flags =
-              if cfg.settings.featureFlags != { }
-              then cfg.settings.featureFlags
-              else null;
+              let
+                knownFlags = filterAttrs (n: v: v != null) {
+                  async_mode = cfg.settings.featureFlags.asyncMode;
+                  rewrite_stash = cfg.settings.featureFlags.rewriteStash;
+                  checkpoint_inter_commit_move = cfg.settings.featureFlags.interCommitMove;
+                  auth_keyring = cfg.settings.featureFlags.authKeyring;
+                  git_hooks_enabled = cfg.settings.featureFlags.gitHooksEnabled;
+                  git_hooks_externally_managed = cfg.settings.featureFlags.gitHooksExternallyManaged;
+                };
+                merged = cfg.settings.featureFlags.extraFlags // knownFlags;
+              in
+              if merged != { } then merged else null;
           };
 
           # Generate the config file in the Nix store
@@ -533,21 +542,81 @@ GITOGEOF
               };
 
               updateChannel = mkOption {
-                type = types.nullOr (types.enum [ "latest" "next" ]);
+                type = types.nullOr (types.enum [
+                  "latest" "next" "enterprise-latest" "enterprise-next"
+                ]);
                 default = null;
                 description = ''
-                  Update channel: "latest" for stable releases, "next" for pre-releases.
+                  Update channel: "latest" for stable releases, "next" for
+                  pre-releases, "enterprise-latest" and "enterprise-next" for
+                  enterprise deployments.
                 '';
               };
 
-              featureFlags = mkOption {
-                type = jsonFormat.type;
-                default = { };
-                example = { rewrite_stash = true; };
-                description = ''
-                  Feature flags as a JSON-compatible attribute set.
-                  See git-ai documentation for available flags.
-                '';
+              featureFlags = {
+                asyncMode = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable async daemon mode for background processing.
+                    When enabled, git operations are processed asynchronously
+                    through a background daemon, improving performance for IDE
+                    and agent workflows.
+                    Equivalent to: git ai config set feature_flags.async_mode true
+                  '';
+                };
+
+                rewriteStash = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable stash rewriting for improved AI tracking of stash
+                    operations.
+                  '';
+                };
+
+                interCommitMove = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable checkpoint inter-commit move tracking.
+                  '';
+                };
+
+                authKeyring = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable system keyring integration for authentication.
+                  '';
+                };
+
+                gitHooksEnabled = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable git hooks integration for git-ai tracking.
+                  '';
+                };
+
+                gitHooksExternallyManaged = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Indicate that git hooks are managed externally
+                    (e.g., by lefthook or husky). When enabled, git-ai will not
+                    attempt to install or manage git hooks itself.
+                  '';
+                };
+
+                extraFlags = mkOption {
+                  type = types.attrsOf types.bool;
+                  default = { };
+                  description = ''
+                    Additional feature flags not explicitly defined above.
+                    Keys should use snake_case to match the config.json format.
+                  '';
+                };
               };
             };
           };
@@ -617,9 +686,18 @@ GITOGEOF
             disable_auto_updates = cfg.settings.disableAutoUpdates;
             update_channel = cfg.settings.updateChannel;
             feature_flags =
-              if cfg.settings.featureFlags != { }
-              then cfg.settings.featureFlags
-              else null;
+              let
+                knownFlags = filterAttrs (n: v: v != null) {
+                  async_mode = cfg.settings.featureFlags.asyncMode;
+                  rewrite_stash = cfg.settings.featureFlags.rewriteStash;
+                  checkpoint_inter_commit_move = cfg.settings.featureFlags.interCommitMove;
+                  auth_keyring = cfg.settings.featureFlags.authKeyring;
+                  git_hooks_enabled = cfg.settings.featureFlags.gitHooksEnabled;
+                  git_hooks_externally_managed = cfg.settings.featureFlags.gitHooksExternallyManaged;
+                };
+                merged = cfg.settings.featureFlags.extraFlags // knownFlags;
+              in
+              if merged != { } then merged else null;
           };
         in
         {
@@ -759,21 +837,81 @@ GITOGEOF
               };
 
               updateChannel = mkOption {
-                type = types.nullOr (types.enum [ "latest" "next" ]);
+                type = types.nullOr (types.enum [
+                  "latest" "next" "enterprise-latest" "enterprise-next"
+                ]);
                 default = null;
                 description = ''
-                  Update channel: "latest" for stable releases, "next" for pre-releases.
+                  Update channel: "latest" for stable releases, "next" for
+                  pre-releases, "enterprise-latest" and "enterprise-next" for
+                  enterprise deployments.
                 '';
               };
 
-              featureFlags = mkOption {
-                type = jsonFormat.type;
-                default = { };
-                example = { rewrite_stash = true; };
-                description = ''
-                  Feature flags as a JSON-compatible attribute set.
-                  See git-ai documentation for available flags.
-                '';
+              featureFlags = {
+                asyncMode = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable async daemon mode for background processing.
+                    When enabled, git operations are processed asynchronously
+                    through a background daemon, improving performance for IDE
+                    and agent workflows.
+                    Equivalent to: git ai config set feature_flags.async_mode true
+                  '';
+                };
+
+                rewriteStash = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable stash rewriting for improved AI tracking of stash
+                    operations.
+                  '';
+                };
+
+                interCommitMove = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable checkpoint inter-commit move tracking.
+                  '';
+                };
+
+                authKeyring = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable system keyring integration for authentication.
+                  '';
+                };
+
+                gitHooksEnabled = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Enable git hooks integration for git-ai tracking.
+                  '';
+                };
+
+                gitHooksExternallyManaged = mkOption {
+                  type = types.nullOr types.bool;
+                  default = null;
+                  description = ''
+                    Indicate that git hooks are managed externally
+                    (e.g., by lefthook or husky). When enabled, git-ai will not
+                    attempt to install or manage git hooks itself.
+                  '';
+                };
+
+                extraFlags = mkOption {
+                  type = types.attrsOf types.bool;
+                  default = { };
+                  description = ''
+                    Additional feature flags not explicitly defined above.
+                    Keys should use snake_case to match the config.json format.
+                  '';
+                };
               };
             };
           };


### PR DESCRIPTION
## Summary
- Replace the freeform `featureFlags` JSON attrset with individually typed boolean options for each known feature flag (`asyncMode`, `rewriteStash`, `interCommitMove`, `authKeyring`, `gitHooksEnabled`, `gitHooksExternallyManaged`)
- Add `extraFlags` escape hatch for forward-compatible unknown flags
- Add missing `enterprise-latest` and `enterprise-next` values to `updateChannel` enum

## Motivation
Nix users cannot run `git ai config set feature_flags.async_mode true` because `config.json` lives in the Nix store (read-only). Typed options make async daemon mode and other feature flags accessible through the module system:

```nix
programs.git-ai = {
  enable = true;
  settings.featureFlags.asyncMode = true;
};
```

Applied to both the NixOS module and Home Manager module.

## Test plan
- [x] `nix flake check --no-build` passes
- [ ] Verify config.json output contains `"feature_flags": {"async_mode": true}` when `asyncMode = true`
- [ ] Verify omitted flags produce no `feature_flags` key in config.json
- [ ] Verify `extraFlags` values are included but overridden by typed options

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
