### PR TITLE
perf: parallelize notes blob creation and optimize attribution reconstruction

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -709,10 +709,14 @@ fn try_reconstruct_attributions_from_notes_cached(
 
     // Get file contents at original_head for all pathspecs in one batch call.
     // We need all pathspec contents to build line-to-author maps from note attestations.
-    let file_contents = batch_read_file_contents_at_commit(repo, original_head, pathspecs).ok()?;
+    let file_contents =
+        batch_read_file_contents_at_commit_parallel(repo, original_head, pathspecs).ok()?;
 
     let pathspec_set: HashSet<&str> = pathspecs.iter().map(String::as_str).collect();
-    let mut file_line_authors: HashMap<String, HashMap<String, String>> = HashMap::new();
+    // Line-index-based map for head-note path (fast: no String allocations per line)
+    let mut file_line_authors_indexed: HashMap<String, Vec<Option<String>>> = HashMap::new();
+    // Content-based map for full-scan path (needed for cross-commit matching)
+    let mut file_line_authors_content: HashMap<String, HashMap<String, String>> = HashMap::new();
     let mut prompts: BTreeMap<
         String,
         BTreeMap<String, crate::authorship::authorship_log::PromptRecord>,
@@ -732,7 +736,9 @@ fn try_reconstruct_attributions_from_notes_cached(
             }
             let head_content = file_contents.get(file_path).cloned().unwrap_or_default();
             let lines: Vec<&str> = head_content.lines().collect();
-            let line_map = file_line_authors.entry(file_path.clone()).or_default();
+            let line_vec = file_line_authors_indexed
+                .entry(file_path.clone())
+                .or_insert_with(|| vec![None; lines.len()]);
             for entry in &file_attestation.entries {
                 for range in &entry.line_ranges {
                     let (start, end) = match range {
@@ -740,8 +746,8 @@ fn try_reconstruct_attributions_from_notes_cached(
                         crate::authorship::authorship_log::LineRange::Range(s, e) => (*s, *e),
                     };
                     for line_num in start..=end {
-                        if let Some(line_content) = lines.get(line_num.saturating_sub(1) as usize) {
-                            line_map.insert(line_content.to_string(), entry.hash.clone());
+                        if let Some(slot) = line_vec.get_mut(line_num.saturating_sub(1) as usize) {
+                            *slot = Some(entry.hash.clone());
                         }
                     }
                 }
@@ -755,13 +761,22 @@ fn try_reconstruct_attributions_from_notes_cached(
         }
     }
 
-    let head_covered_files: HashSet<&str> = file_line_authors.keys().map(String::as_str).collect();
-    let need_full_scan = head_log.is_none()
-        || is_squash_rebase
-        || pathspecs.iter().any(|p| {
-            let has_content = file_contents.get(p).map(|c| !c.is_empty()).unwrap_or(false);
+    let head_covered_files: HashSet<&str> = file_line_authors_indexed
+        .keys()
+        .map(String::as_str)
+        .collect();
+    let uncovered: Vec<&str> = pathspecs
+        .iter()
+        .filter(|p| {
+            let has_content = file_contents
+                .get(*p)
+                .map(|c| !c.is_empty())
+                .unwrap_or(false);
             has_content && !head_covered_files.contains(p.as_str())
-        });
+        })
+        .map(String::as_str)
+        .collect();
+    let need_full_scan = head_log.is_none() || is_squash_rebase || !uncovered.is_empty();
 
     if need_full_scan {
         // Use cached note contents instead of loading again
@@ -787,102 +802,10 @@ fn try_reconstruct_attributions_from_notes_cached(
         }
 
         if !parsed_logs.is_empty() {
-            // Batch read file contents for commits with notes
-            let mut all_refs: Vec<(String, String)> = Vec::new();
-            for commit in &commits_with_notes {
-                for path in pathspecs {
-                    all_refs.push((commit.clone(), path.clone()));
-                }
-            }
+            let uncovered_set: HashSet<&str> = uncovered.iter().copied().collect();
 
-            let mut commit_file_contents: HashMap<String, HashMap<String, String>> = HashMap::new();
-            if !all_refs.is_empty() {
-                let mut args = repo.global_args_for_exec();
-                args.push("cat-file".to_string());
-                args.push("--batch".to_string());
-                let stdin_data: String = all_refs
-                    .iter()
-                    .map(|(commit, path)| format!("{}:{}", commit, path))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-                    + "\n";
-                if let Ok(output) = exec_git_stdin(&args, stdin_data.as_bytes()) {
-                    let data = &output.stdout;
-                    let mut pos = 0usize;
-                    let mut ref_idx = 0usize;
-                    while pos < data.len() && ref_idx < all_refs.len() {
-                        let header_end = match data[pos..].iter().position(|&b| b == b'\n') {
-                            Some(idx) => pos + idx,
-                            None => break,
-                        };
-                        let header = std::str::from_utf8(&data[pos..header_end]).unwrap_or("");
-                        let parts: Vec<&str> = header.split_whitespace().collect();
-                        let (commit, path) = &all_refs[ref_idx];
-                        if parts.len() >= 2 && parts[1] == "missing" {
-                            commit_file_contents
-                                .entry(commit.clone())
-                                .or_default()
-                                .insert(path.clone(), String::new());
-                            pos = header_end + 1;
-                            ref_idx += 1;
-                            continue;
-                        }
-                        if parts.len() < 3 {
-                            pos = header_end + 1;
-                            ref_idx += 1;
-                            continue;
-                        }
-                        let size: usize = parts[2].parse().unwrap_or(0);
-                        let content_start = header_end + 1;
-                        let content_end = content_start + size;
-                        if content_end <= data.len() {
-                            let content =
-                                String::from_utf8_lossy(&data[content_start..content_end])
-                                    .to_string();
-                            commit_file_contents
-                                .entry(commit.clone())
-                                .or_default()
-                                .insert(path.clone(), content);
-                        }
-                        pos = content_end;
-                        if pos < data.len() && data[pos] == b'\n' {
-                            pos += 1;
-                        }
-                        ref_idx += 1;
-                    }
-                }
-            }
-
+            // Collect prompts from all parsed logs (needed regardless of file coverage)
             for (commit, authorship_log) in &parsed_logs {
-                let empty_contents = HashMap::new();
-                let commit_contents = commit_file_contents.get(commit).unwrap_or(&empty_contents);
-                for file_attestation in &authorship_log.attestations {
-                    let file_path = &file_attestation.file_path;
-                    if !pathspec_set.contains(file_path.as_str()) {
-                        continue;
-                    }
-                    let commit_content =
-                        commit_contents.get(file_path).cloned().unwrap_or_default();
-                    let lines: Vec<&str> = commit_content.lines().collect();
-                    let line_map = file_line_authors.entry(file_path.clone()).or_default();
-                    for entry in &file_attestation.entries {
-                        for range in &entry.line_ranges {
-                            let (start, end) = match range {
-                                crate::authorship::authorship_log::LineRange::Single(l) => (*l, *l),
-                                crate::authorship::authorship_log::LineRange::Range(s, e) => {
-                                    (*s, *e)
-                                }
-                            };
-                            for line_num in start..=end {
-                                if let Some(line_content) =
-                                    lines.get(line_num.saturating_sub(1) as usize)
-                                {
-                                    line_map.insert(line_content.to_string(), entry.hash.clone());
-                                }
-                            }
-                        }
-                    }
-                }
                 for (prompt_id, prompt_record) in &authorship_log.metadata.prompts {
                     prompts
                         .entry(prompt_id.clone())
@@ -890,34 +813,178 @@ fn try_reconstruct_attributions_from_notes_cached(
                         .insert(commit.clone(), prompt_record.clone());
                 }
             }
+
+            if is_squash_rebase {
+                // Squash rebases need all commits × all pathspecs because lines
+                // at HEAD may have been authored across multiple commits.
+                let mut all_refs: Vec<(String, String)> = Vec::new();
+                for commit in &commits_with_notes {
+                    for path in pathspecs {
+                        all_refs.push((commit.clone(), path.clone()));
+                    }
+                }
+
+                let commit_file_contents = batch_read_refs_parallel(repo, &all_refs);
+
+                for (commit, authorship_log) in &parsed_logs {
+                    let empty_contents = HashMap::new();
+                    let commit_contents =
+                        commit_file_contents.get(commit).unwrap_or(&empty_contents);
+                    for file_attestation in &authorship_log.attestations {
+                        let file_path = &file_attestation.file_path;
+                        if !pathspec_set.contains(file_path.as_str()) {
+                            continue;
+                        }
+                        let commit_content =
+                            commit_contents.get(file_path).cloned().unwrap_or_default();
+                        let lines: Vec<&str> = commit_content.lines().collect();
+                        let line_map = file_line_authors_content
+                            .entry(file_path.clone())
+                            .or_default();
+                        for entry in &file_attestation.entries {
+                            for range in &entry.line_ranges {
+                                let (start, end) = match range {
+                                    crate::authorship::authorship_log::LineRange::Single(l) => {
+                                        (*l, *l)
+                                    }
+                                    crate::authorship::authorship_log::LineRange::Range(s, e) => {
+                                        (*s, *e)
+                                    }
+                                };
+                                for line_num in start..=end {
+                                    if let Some(line_content) =
+                                        lines.get(line_num.saturating_sub(1) as usize)
+                                    {
+                                        line_map
+                                            .insert(line_content.to_string(), entry.hash.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Non-squash: only read uncovered files (not all pathspecs) at each
+                // commit that mentions them. We still scan all commits for each
+                // uncovered file to accumulate content-based mappings across the full
+                // history — a line may have been AI-attributed in an older commit,
+                // removed later, but still exist at HEAD.
+                //
+                // Build the set of (commit, file) pairs we actually need to read.
+                let mut needed_refs: Vec<(String, String)> = Vec::new();
+                for (commit, authorship_log) in &parsed_logs {
+                    for file_attestation in &authorship_log.attestations {
+                        if uncovered_set.contains(file_attestation.file_path.as_str()) {
+                            needed_refs.push((commit.clone(), file_attestation.file_path.clone()));
+                        }
+                    }
+                }
+
+                let commit_file_contents = if !needed_refs.is_empty() {
+                    batch_read_refs_parallel(repo, &needed_refs)
+                } else {
+                    HashMap::new()
+                };
+
+                for (commit, authorship_log) in &parsed_logs {
+                    let empty_contents = HashMap::new();
+                    let commit_contents = commit_file_contents
+                        .get(commit.as_str())
+                        .unwrap_or(&empty_contents);
+                    for file_attestation in &authorship_log.attestations {
+                        let file_path = &file_attestation.file_path;
+                        if !uncovered_set.contains(file_path.as_str()) {
+                            continue;
+                        }
+                        let commit_content =
+                            commit_contents.get(file_path).cloned().unwrap_or_default();
+                        let lines: Vec<&str> = commit_content.lines().collect();
+                        let line_map = file_line_authors_content
+                            .entry(file_path.clone())
+                            .or_default();
+                        for entry in &file_attestation.entries {
+                            for range in &entry.line_ranges {
+                                let (start, end) = match range {
+                                    crate::authorship::authorship_log::LineRange::Single(l) => {
+                                        (*l, *l)
+                                    }
+                                    crate::authorship::authorship_log::LineRange::Range(s, e) => {
+                                        (*s, *e)
+                                    }
+                                };
+                                for line_num in start..=end {
+                                    if let Some(line_content) =
+                                        lines.get(line_num.saturating_sub(1) as usize)
+                                    {
+                                        line_map
+                                            .insert(line_content.to_string(), entry.hash.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
-    if file_line_authors.is_empty() {
+    if file_line_authors_indexed.is_empty() && file_line_authors_content.is_empty() {
         return None;
     }
 
-    // Build attributions at original_head using the line content -> author map
+    // Build attributions at original_head using line-index map (head-note) with
+    // content-based map fallback (full-scan)
     let mut attributions = HashMap::new();
     for file_path in pathspecs {
-        let line_map = match file_line_authors.get(file_path) {
-            Some(m) => m,
-            None => continue,
-        };
         let content = file_contents.get(file_path).cloned().unwrap_or_default();
         let lines: Vec<&str> = content.lines().collect();
-
         let mut line_attrs: Vec<LineAttribution> = Vec::new();
-        for (line_idx, line_content) in lines.iter().enumerate() {
-            if let Some(author_id) = line_map.get(*line_content) {
-                let line_num = (line_idx + 1) as u32;
-                line_attrs.push(LineAttribution {
-                    start_line: line_num,
-                    end_line: line_num,
-                    author_id: author_id.clone(),
-                    overrode: None,
-                });
+
+        if let Some(line_vec) = file_line_authors_indexed.get(file_path) {
+            // Fast path: line-index-based lookup from head-note
+            for (line_idx, author_opt) in line_vec.iter().enumerate() {
+                if let Some(author_id) = author_opt {
+                    let line_num = (line_idx + 1) as u32;
+                    line_attrs.push(LineAttribution {
+                        start_line: line_num,
+                        end_line: line_num,
+                        author_id: author_id.clone(),
+                        overrode: None,
+                    });
+                }
             }
+            // Also check content-based map for any additional lines from full-scan
+            if let Some(content_map) = file_line_authors_content.get(file_path) {
+                for (line_idx, line_content) in lines.iter().enumerate() {
+                    // Only add if not already covered by indexed map
+                    let already_covered =
+                        line_vec.get(line_idx).map(|o| o.is_some()).unwrap_or(false);
+                    if !already_covered && let Some(author_id) = content_map.get(*line_content) {
+                        let line_num = (line_idx + 1) as u32;
+                        line_attrs.push(LineAttribution {
+                            start_line: line_num,
+                            end_line: line_num,
+                            author_id: author_id.clone(),
+                            overrode: None,
+                        });
+                    }
+                }
+            }
+        } else if let Some(content_map) = file_line_authors_content.get(file_path) {
+            // Fallback: content-based lookup for full-scan-only files
+            for (line_idx, line_content) in lines.iter().enumerate() {
+                if let Some(author_id) = content_map.get(*line_content) {
+                    let line_num = (line_idx + 1) as u32;
+                    line_attrs.push(LineAttribution {
+                        start_line: line_num,
+                        end_line: line_num,
+                        author_id: author_id.clone(),
+                        overrode: None,
+                    });
+                }
+            }
+        } else {
+            continue;
         }
 
         if !line_attrs.is_empty() {
@@ -928,6 +995,229 @@ fn try_reconstruct_attributions_from_notes_cached(
     }
 
     Some((attributions, file_contents, prompts))
+}
+
+/// Read file contents at a commit in parallel using multiple `git cat-file --batch` processes.
+/// Falls back to a single call for small batches.
+const MAX_PARALLEL_FILE_READS: usize = 4;
+const FILE_READ_CHUNK_SIZE: usize = 20;
+
+fn batch_read_file_contents_at_commit_parallel(
+    repo: &Repository,
+    commit_sha: &str,
+    file_paths: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    if file_paths.is_empty() {
+        return Ok(HashMap::new());
+    }
+    if file_paths.len() <= FILE_READ_CHUNK_SIZE {
+        return batch_read_file_contents_at_commit(repo, commit_sha, file_paths);
+    }
+
+    let global_args = repo.global_args_for_exec();
+    let commit = commit_sha.to_string();
+    let chunks: Vec<Vec<String>> = file_paths
+        .chunks(FILE_READ_CHUNK_SIZE)
+        .map(|c| c.to_vec())
+        .collect();
+
+    let results = smol::block_on(async {
+        let semaphore = std::sync::Arc::new(smol::lock::Semaphore::new(MAX_PARALLEL_FILE_READS));
+        let mut tasks = Vec::new();
+
+        for chunk in chunks {
+            let args = global_args.clone();
+            let sem = std::sync::Arc::clone(&semaphore);
+            let commit = commit.clone();
+
+            let task = smol::spawn(async move {
+                let _permit = sem.acquire().await;
+                smol::unblock(move || {
+                    let mut cat_args = args;
+                    cat_args.push("cat-file".to_string());
+                    cat_args.push("--batch".to_string());
+                    let stdin_data: String = chunk
+                        .iter()
+                        .map(|path| format!("{}:{}", commit, path))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                        + "\n";
+                    let output = exec_git_stdin(&cat_args, stdin_data.as_bytes())?;
+                    parse_cat_file_batch_output_with_paths(&output.stdout, &chunk)
+                })
+                .await
+            });
+
+            tasks.push(task);
+        }
+
+        futures::future::join_all(tasks).await
+    });
+
+    let mut merged = HashMap::new();
+    for result in results {
+        merged.extend(result?);
+    }
+    Ok(merged)
+}
+
+/// Read file contents for multiple (commit, path) pairs in parallel.
+/// Used by the full-scan path where we need files at different commits.
+fn batch_read_refs_parallel(
+    repo: &Repository,
+    all_refs: &[(String, String)],
+) -> HashMap<String, HashMap<String, String>> {
+    if all_refs.is_empty() {
+        return HashMap::new();
+    }
+
+    let global_args = repo.global_args_for_exec();
+    let chunks: Vec<Vec<(String, String)>> = all_refs
+        .chunks(FILE_READ_CHUNK_SIZE)
+        .map(|c| c.to_vec())
+        .collect();
+
+    let results = smol::block_on(async {
+        let semaphore = std::sync::Arc::new(smol::lock::Semaphore::new(MAX_PARALLEL_FILE_READS));
+        let mut tasks = Vec::new();
+
+        for chunk in chunks {
+            let args = global_args.clone();
+            let sem = std::sync::Arc::clone(&semaphore);
+
+            let task = smol::spawn(async move {
+                let _permit = sem.acquire().await;
+                smol::unblock(move || {
+                    let mut cat_args = args;
+                    cat_args.push("cat-file".to_string());
+                    cat_args.push("--batch".to_string());
+                    let stdin_data: String = chunk
+                        .iter()
+                        .map(|(commit, path)| format!("{}:{}", commit, path))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                        + "\n";
+                    let output = exec_git_stdin(&cat_args, stdin_data.as_bytes());
+                    match output {
+                        Ok(output) => {
+                            let mut result: HashMap<String, HashMap<String, String>> =
+                                HashMap::new();
+                            let data = &output.stdout;
+                            let mut pos = 0usize;
+                            let mut ref_idx = 0usize;
+                            while pos < data.len() && ref_idx < chunk.len() {
+                                let header_end = match data[pos..].iter().position(|&b| b == b'\n')
+                                {
+                                    Some(idx) => pos + idx,
+                                    None => break,
+                                };
+                                let header =
+                                    std::str::from_utf8(&data[pos..header_end]).unwrap_or("");
+                                let parts: Vec<&str> = header.split_whitespace().collect();
+                                let (commit, path) = &chunk[ref_idx];
+                                if parts.len() >= 2 && parts[1] == "missing" {
+                                    result
+                                        .entry(commit.clone())
+                                        .or_default()
+                                        .insert(path.clone(), String::new());
+                                    pos = header_end + 1;
+                                    ref_idx += 1;
+                                    continue;
+                                }
+                                if parts.len() < 3 {
+                                    pos = header_end + 1;
+                                    ref_idx += 1;
+                                    continue;
+                                }
+                                let size: usize = parts[2].parse().unwrap_or(0);
+                                let content_start = header_end + 1;
+                                let content_end = content_start + size;
+                                if content_end <= data.len() {
+                                    let content =
+                                        String::from_utf8_lossy(&data[content_start..content_end])
+                                            .to_string();
+                                    result
+                                        .entry(commit.clone())
+                                        .or_default()
+                                        .insert(path.clone(), content);
+                                }
+                                pos = content_end;
+                                if pos < data.len() && data[pos] == b'\n' {
+                                    pos += 1;
+                                }
+                                ref_idx += 1;
+                            }
+                            result
+                        }
+                        Err(_) => HashMap::new(),
+                    }
+                })
+                .await
+            });
+
+            tasks.push(task);
+        }
+
+        futures::future::join_all(tasks).await
+    });
+
+    let mut merged: HashMap<String, HashMap<String, String>> = HashMap::new();
+    for chunk_result in results {
+        for (commit, files) in chunk_result {
+            merged.entry(commit).or_default().extend(files);
+        }
+    }
+    merged
+}
+
+/// Parse cat-file --batch output where we know the file paths in order.
+fn parse_cat_file_batch_output_with_paths(
+    data: &[u8],
+    file_paths: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    let mut results = HashMap::new();
+    let mut pos = 0usize;
+    let mut path_idx = 0usize;
+
+    while pos < data.len() && path_idx < file_paths.len() {
+        let header_end = match data[pos..].iter().position(|&b| b == b'\n') {
+            Some(idx) => pos + idx,
+            None => break,
+        };
+
+        let header = std::str::from_utf8(&data[pos..header_end]).unwrap_or("");
+        let parts: Vec<&str> = header.split_whitespace().collect();
+
+        if parts.len() >= 2 && parts[1] == "missing" {
+            results.insert(file_paths[path_idx].clone(), String::new());
+            pos = header_end + 1;
+            path_idx += 1;
+            continue;
+        }
+
+        if parts.len() < 3 {
+            pos = header_end + 1;
+            path_idx += 1;
+            continue;
+        }
+
+        let size: usize = parts[2].parse().unwrap_or(0);
+        let content_start = header_end + 1;
+        let content_end = content_start + size;
+
+        if content_end <= data.len() {
+            let content = String::from_utf8_lossy(&data[content_start..content_end]).to_string();
+            results.insert(file_paths[path_idx].clone(), content);
+        }
+
+        pos = content_end;
+        if pos < data.len() && data[pos] == b'\n' {
+            pos += 1;
+        }
+        path_idx += 1;
+    }
+
+    Ok(results)
 }
 
 /// Batch read file contents at a specific commit for multiple file paths.
@@ -1321,6 +1611,8 @@ pub fn rewrite_authorship_after_rebase_v2(
     let mut loop_transform_ms = 0u128;
     let mut loop_serialize_ms = 0u128;
     let mut loop_metrics_ms = 0u128;
+    // Reusable buffer for diff_based_line_attribution_transfer to avoid per-file allocation.
+    let mut diff_buffer: Vec<Option<usize>> = Vec::new();
     for (idx, new_commit) in commits_to_process.iter().enumerate() {
         debug_log(&format!(
             "Processing commit {}/{}: {}",
@@ -1349,11 +1641,9 @@ pub fn rewrite_authorship_after_rebase_v2(
             // Falls back to content-matching for files with no previous content.
             let t0 = std::time::Instant::now();
             for (file_path, new_content) in &new_content_for_changed_files {
-                // Subtract old metrics before modifying attributions
-                let previous_line_attrs = current_attributions
-                    .get(file_path)
-                    .map(|(_, la)| la.clone());
-                if let Some(ref prev_la) = previous_line_attrs {
+                // Take ownership of old entry via remove() to avoid cloning line_attrs.
+                let old_entry = current_attributions.remove(file_path);
+                if let Some((_, ref prev_la)) = old_entry {
                     subtract_prompt_line_metrics_for_line_attributions(
                         &mut prompt_line_metrics,
                         prev_la,
@@ -1365,11 +1655,15 @@ pub fn rewrite_authorship_after_rebase_v2(
                     // positional transfer from the pre-deletion state. Re-add the
                     // subtracted metrics to preserve balance (the file won't appear
                     // in the serialized note since existing_files excludes it).
-                    if let Some(ref prev_la) = previous_line_attrs {
+                    if let Some((_, ref prev_la)) = old_entry {
                         add_prompt_line_metrics_for_line_attributions(
                             &mut prompt_line_metrics,
                             prev_la,
                         );
+                    }
+                    // Re-insert old entry so later commits can inherit from it
+                    if let Some(entry) = old_entry {
+                        current_attributions.insert(file_path.clone(), entry);
                     }
                     cached_file_attestation_text.remove(file_path);
                     continue;
@@ -1377,10 +1671,9 @@ pub fn rewrite_authorship_after_rebase_v2(
                 let line_attrs = compute_line_attrs_for_changed_file(
                     new_content,
                     current_file_contents.get(file_path),
-                    current_attributions
-                        .get(file_path)
-                        .map(|(_, la)| la.as_slice()),
+                    old_entry.as_ref().map(|(_, la)| la.as_slice()),
                     original_head_line_to_author.get(file_path),
+                    &mut diff_buffer,
                 );
                 add_prompt_line_metrics_for_line_attributions(
                     &mut prompt_line_metrics,
@@ -3339,9 +3632,10 @@ fn compute_line_attrs_for_changed_file(
     old_content: Option<&String>,
     old_attrs: Option<&[crate::authorship::attribution_tracker::LineAttribution]>,
     original_head_line_map: Option<&HashMap<String, String>>,
+    diff_buffer: &mut Vec<Option<usize>>,
 ) -> Vec<crate::authorship::attribution_tracker::LineAttribution> {
     if let (Some(old_c), Some(old_a)) = (old_content, old_attrs) {
-        diff_based_line_attribution_transfer(old_c, new_content, old_a)
+        diff_based_line_attribution_transfer(old_c, new_content, old_a, diff_buffer)
     } else {
         // No previous content — fall back to content-matching from original_head
         let mut attrs = Vec::new();
@@ -3360,6 +3654,15 @@ fn compute_line_attrs_for_changed_file(
     }
 }
 
+#[cfg(test)]
+fn diff_based_line_attribution_transfer_test(
+    old_content: &str,
+    new_content: &str,
+    old_line_attrs: &[crate::authorship::attribution_tracker::LineAttribution],
+) -> Vec<crate::authorship::attribution_tracker::LineAttribution> {
+    diff_based_line_attribution_transfer(old_content, new_content, old_line_attrs, &mut Vec::new())
+}
+
 /// Transfer line attributions from old file content to new file content using line-level diffing.
 /// This replaces the blame-based slow path by using imara-diff to compute how lines moved
 /// between the old and new versions, then carrying attributions forward positionally.
@@ -3372,19 +3675,22 @@ fn diff_based_line_attribution_transfer(
     old_content: &str,
     new_content: &str,
     old_line_attrs: &[crate::authorship::attribution_tracker::LineAttribution],
+    diff_buffer: &mut Vec<Option<usize>>,
 ) -> Vec<crate::authorship::attribution_tracker::LineAttribution> {
     use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
 
     let old_lines: Vec<&str> = old_content.lines().collect();
     let new_lines: Vec<&str> = new_content.lines().collect();
 
-    // Build a lookup from 0-indexed line index → author_id for old content
-    let mut old_line_author: Vec<Option<&str>> = vec![None; old_lines.len()];
-    for attr in old_line_attrs {
+    // Reuse the caller-provided buffer for old_line → attr_index mapping.
+    // Using usize index into old_line_attrs avoids per-line &str references.
+    diff_buffer.clear();
+    diff_buffer.resize(old_lines.len(), None);
+    for (attr_idx, attr) in old_line_attrs.iter().enumerate() {
         for line_num in attr.start_line..=attr.end_line {
             let idx = (line_num as usize).saturating_sub(1);
-            if idx < old_line_author.len() {
-                old_line_author[idx] = Some(&attr.author_id);
+            if idx < diff_buffer.len() {
+                diff_buffer[idx] = Some(attr_idx);
             }
         }
     }
@@ -3405,12 +3711,13 @@ fn diff_based_line_attribution_transfer(
                 for i in 0..*len {
                     let old_idx = old_index + i;
                     let new_line_num = (new_index + i + 1) as u32;
-                    if let Some(Some(author_id)) = old_line_author.get(old_idx) {
+                    if let Some(Some(attr_idx)) = diff_buffer.get(old_idx) {
+                        let attr = &old_line_attrs[*attr_idx];
                         new_line_attrs.push(
                             crate::authorship::attribution_tracker::LineAttribution {
                                 start_line: new_line_num,
                                 end_line: new_line_num,
-                                author_id: author_id.to_string(),
+                                author_id: attr.author_id.clone(),
                                 overrode: None,
                             },
                         );
@@ -5247,7 +5554,7 @@ mod tests {
                 let new_content = &commit_contents[file_idx];
                 let old_content = &current_contents[file_idx];
                 let old_attrs = &current_line_attrs[file_idx];
-                let new_attrs = super::diff_based_line_attribution_transfer(
+                let new_attrs = super::diff_based_line_attribution_transfer_test(
                     old_content,
                     new_content,
                     old_attrs,
@@ -5340,7 +5647,7 @@ mod tests {
                 let old_attrs = &full_fast_line_attrs[file_idx];
 
                 // Step 1: diff-based transfer
-                let new_attrs = super::diff_based_line_attribution_transfer(
+                let new_attrs = super::diff_based_line_attribution_transfer_test(
                     old_content,
                     new_content,
                     old_attrs,
@@ -5479,7 +5786,7 @@ mod tests {
             let mut cur_c = file_contents.clone();
             for commit_contents in &all_new {
                 for fi in 0..num_files {
-                    let na = super::diff_based_line_attribution_transfer(
+                    let na = super::diff_based_line_attribution_transfer_test(
                         &cur_c[fi],
                         &commit_contents[fi],
                         &cur_la[fi],
@@ -5550,7 +5857,7 @@ mod tests {
                 overrode: None,
             },
         ];
-        let result = super::diff_based_line_attribution_transfer(old, new, &attrs);
+        let result = super::diff_based_line_attribution_transfer_test(old, new, &attrs);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].author_id, "ai-a");
         assert_eq!(result[1].author_id, "ai-b");
@@ -5581,7 +5888,7 @@ mod tests {
                 overrode: None,
             },
         ];
-        let result = super::diff_based_line_attribution_transfer(old, new, &attrs);
+        let result = super::diff_based_line_attribution_transfer_test(old, new, &attrs);
         // line1 kept (line 1), new_line inserted (line 2, no attr), line2 kept (line 3), line3 kept (line 4)
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].start_line, 1);
@@ -5616,7 +5923,7 @@ mod tests {
                 overrode: None,
             },
         ];
-        let result = super::diff_based_line_attribution_transfer(old, new, &attrs);
+        let result = super::diff_based_line_attribution_transfer_test(old, new, &attrs);
         // line1 kept (line 1), line2 deleted, line3 kept (line 2)
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].start_line, 1);
@@ -5649,7 +5956,7 @@ mod tests {
                 overrode: None,
             },
         ];
-        let result = super::diff_based_line_attribution_transfer(old, new, &attrs);
+        let result = super::diff_based_line_attribution_transfer_test(old, new, &attrs);
         // line1 kept (line 1), line2 replaced by "modified" (line 2, no attr), line3 kept (line 3)
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].start_line, 1);
@@ -5684,7 +5991,7 @@ mod tests {
                 overrode: None,
             },
         ];
-        let result = super::diff_based_line_attribution_transfer(old, new, &attrs);
+        let result = super::diff_based_line_attribution_transfer_test(old, new, &attrs);
         // line "let x = 42;" (1) kept as line 1 (ai-a)
         // "let z = 1;" inserted (line 2, no attr)
         // "let y = 0;" kept (line 3, ai-b)

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -5,6 +5,7 @@ use crate::git::repository::{Repository, exec_git, exec_git_stdin};
 use crate::utils::debug_log;
 use serde_json;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 // Modern refspecs without force to enable proper merging
 pub const AI_AUTHORSHIP_REFNAME: &str = "ai";
@@ -178,11 +179,48 @@ pub fn note_blob_oids_for_commits(
     Ok(result)
 }
 
+const PARALLEL_BLOB_THRESHOLD: usize = 50;
+const MAX_PARALLEL_BLOB_CREATES: usize = 4;
+
 pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Result<(), GitAiError> {
     if entries.is_empty() {
         return Ok(());
     }
 
+    let mut deduped_entries: Vec<(String, String)> = Vec::new();
+    let mut seen = HashSet::new();
+    for (commit_sha, note_content) in entries.iter().rev() {
+        if seen.insert(commit_sha.as_str()) {
+            deduped_entries.push((commit_sha.clone(), note_content.clone()));
+        }
+    }
+    deduped_entries.reverse();
+
+    if deduped_entries.len() <= PARALLEL_BLOB_THRESHOLD {
+        return notes_add_batch_single_pass(repo, &deduped_entries);
+    }
+
+    // Phase A: Create blobs in parallel
+    let blob_pairs = notes_create_blobs_parallel(repo, &deduped_entries)?;
+
+    // Phase C: Tree-only commit using pre-existing blob OIDs
+    notes_add_blob_batch(repo, &blob_pairs)?;
+
+    // The hook is called inside notes_add_blob_batch, but it resolves blob contents
+    // only when post_notes_updated hooks are configured. For the parallel path we
+    // already have the note contents, so fire the hook directly here to avoid the
+    // extra blob-read round-trip. notes_add_blob_batch already handles this, so
+    // we're done.
+
+    Ok(())
+}
+
+/// Single-pass fast-import that creates inline blobs + tree commit in one script.
+/// Used for small batches (<= PARALLEL_BLOB_THRESHOLD entries).
+fn notes_add_batch_single_pass(
+    repo: &Repository,
+    deduped_entries: &[(String, String)],
+) -> Result<(), GitAiError> {
     let mut args = repo.global_args_for_exec();
     args.push("rev-parse".to_string());
     args.push("--verify".to_string());
@@ -195,15 +233,6 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
         | Err(GitAiError::GitCliError { code: Some(1), .. }) => None,
         Err(e) => return Err(e),
     };
-
-    let mut deduped_entries: Vec<(String, String)> = Vec::new();
-    let mut seen = HashSet::new();
-    for (commit_sha, note_content) in entries.iter().rev() {
-        if seen.insert(commit_sha.as_str()) {
-            deduped_entries.push((commit_sha.clone(), note_content.clone()));
-        }
-    }
-    deduped_entries.reverse();
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -242,15 +271,118 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
     fast_import_args.push("fast-import".to_string());
     fast_import_args.push("--quiet".to_string());
     exec_git_stdin(&fast_import_args, &script)?;
-    crate::authorship::git_ai_hooks::post_notes_updated(repo, &deduped_entries);
+    crate::authorship::git_ai_hooks::post_notes_updated(repo, deduped_entries);
 
     Ok(())
+}
+
+/// Create blobs in parallel using multiple `git fast-import` processes, each
+/// writing an export-marks file. Returns `(commit_sha, blob_oid)` pairs.
+fn notes_create_blobs_parallel(
+    repo: &Repository,
+    deduped_entries: &[(String, String)],
+) -> Result<Vec<(String, String)>, GitAiError> {
+    let num_chunks = MAX_PARALLEL_BLOB_CREATES;
+    let chunk_size = deduped_entries.len().div_ceil(num_chunks);
+    let chunks: Vec<Vec<(String, String)>> = deduped_entries
+        .chunks(chunk_size)
+        .map(|c| c.to_vec())
+        .collect();
+
+    let global_args = repo.global_args_for_exec();
+    let tmp_dir = std::env::temp_dir();
+
+    let results = smol::block_on(async {
+        let semaphore = Arc::new(smol::lock::Semaphore::new(MAX_PARALLEL_BLOB_CREATES));
+        let mut tasks = Vec::new();
+
+        for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
+            let sem = Arc::clone(&semaphore);
+            let args = global_args.clone();
+            let marks_path = tmp_dir.join(format!(
+                "git-ai-marks-{}-{}-{}",
+                std::process::id(),
+                chunk_idx,
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            ));
+
+            let task = smol::spawn(async move {
+                let _permit = sem.acquire().await;
+                smol::unblock(move || {
+                    // Phase A: build blob-only fast-import script
+                    let mut script = Vec::<u8>::new();
+                    for (mark_idx, (_commit_sha, note_content)) in chunk.iter().enumerate() {
+                        script.extend_from_slice(b"blob\n");
+                        script.extend_from_slice(format!("mark :{}\n", mark_idx + 1).as_bytes());
+                        script
+                            .extend_from_slice(format!("data {}\n", note_content.len()).as_bytes());
+                        script.extend_from_slice(note_content.as_bytes());
+                        script.extend_from_slice(b"\n");
+                    }
+
+                    let mut fast_import_args = args;
+                    fast_import_args.push("fast-import".to_string());
+                    fast_import_args.push("--quiet".to_string());
+                    fast_import_args.push(format!("--export-marks={}", marks_path.display()));
+                    exec_git_stdin(&fast_import_args, &script)?;
+
+                    // Phase B: parse export-marks file
+                    let marks_content = std::fs::read_to_string(&marks_path).map_err(|e| {
+                        GitAiError::Generic(format!(
+                            "Failed to read export-marks file {}: {}",
+                            marks_path.display(),
+                            e
+                        ))
+                    })?;
+                    let _ = std::fs::remove_file(&marks_path);
+
+                    let mut mark_to_oid: HashMap<usize, String> = HashMap::new();
+                    for line in marks_content.lines() {
+                        // Format: ":1 abc123def..."
+                        if let Some((mark_str, oid)) = line.split_once(' ')
+                            && let Some(mark_num) = mark_str.strip_prefix(':')
+                            && let Ok(num) = mark_num.parse::<usize>()
+                        {
+                            mark_to_oid.insert(num, oid.to_string());
+                        }
+                    }
+
+                    let mut pairs: Vec<(String, String)> = Vec::with_capacity(chunk.len());
+                    for (mark_idx, (commit_sha, _note_content)) in chunk.iter().enumerate() {
+                        let oid = mark_to_oid.get(&(mark_idx + 1)).ok_or_else(|| {
+                            GitAiError::Generic(format!(
+                                "Missing blob OID for mark :{} (commit {})",
+                                mark_idx + 1,
+                                commit_sha
+                            ))
+                        })?;
+                        pairs.push((commit_sha.clone(), oid.clone()));
+                    }
+
+                    Ok::<Vec<(String, String)>, GitAiError>(pairs)
+                })
+                .await
+            });
+
+            tasks.push(task);
+        }
+
+        futures::future::join_all(tasks).await
+    });
+
+    let mut all_pairs: Vec<(String, String)> = Vec::with_capacity(deduped_entries.len());
+    for result in results {
+        all_pairs.extend(result?);
+    }
+    Ok(all_pairs)
 }
 
 /// Batch-attach existing note blobs to commits without rewriting blob contents.
 ///
 /// Each entry is (commit_sha, existing_note_blob_oid).
-#[allow(dead_code)]
 pub fn notes_add_blob_batch(
     repo: &Repository,
     entries: &[(String, String)],

--- a/tests/integration/rebase_benchmark.rs
+++ b/tests/integration/rebase_benchmark.rs
@@ -1018,3 +1018,448 @@ fn benchmark_large_scale_mixed() {
         }
     }
 }
+
+/// Brutal stress-test benchmark: hundreds of commits, dozens of files per commit,
+/// hundreds to thousands of lines per file, 100% AI-attributed, varied edit patterns.
+///
+/// Each commit does a mix of:
+/// - Multi-line insertions (5-20 lines) at random positions
+/// - Line replacements (modify existing AI lines)
+/// - Block deletions + re-additions
+/// - New function/struct additions
+///
+/// Main branch also modifies AI-tracked files to force the diff-based path.
+///
+/// Run with: cargo test --test integration benchmark_brutal -- --ignored --nocapture
+#[test]
+#[ignore]
+fn benchmark_brutal() {
+    use crate::repos::test_repo::TestRepo;
+
+    let num_files: usize = std::env::var("BRUTAL_FILES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(60);
+    let num_feature_commits: usize = std::env::var("BRUTAL_COMMITS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200);
+    let num_main_commits: usize = std::env::var("BRUTAL_MAIN_COMMITS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(15);
+    let files_per_commit: usize = std::env::var("BRUTAL_FILES_PER_COMMIT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30);
+
+    // File sizes: 20 files × 2000 lines, 25 files × 500 lines, 15 files × 5000 lines
+    let file_sizes: Vec<usize> = (0..num_files)
+        .map(|i| {
+            if i < 20 {
+                2000
+            } else if i < 45 {
+                500
+            } else {
+                5000
+            }
+        })
+        .collect();
+    let total_initial_lines: usize = file_sizes.iter().sum();
+
+    println!("\n╔══════════════════════════════════════════════════════════╗");
+    println!("║              BRUTAL REBASE BENCHMARK                    ║");
+    println!("╠══════════════════════════════════════════════════════════╣");
+    println!("║  Files: {} (20×2000L + 25×500L + 15×5000L)", num_files);
+    println!("║  Total initial lines: {}", total_initial_lines);
+    println!("║  Feature commits: {}", num_feature_commits);
+    println!("║  Files modified per commit: {}", files_per_commit);
+    println!("║  Main commits: {}", num_main_commits);
+    println!("║  All files 100% AI-attributed");
+    println!("║  Varied edit patterns: insert, replace, delete, add");
+    println!("╚══════════════════════════════════════════════════════════╝\n");
+
+    let repo = TestRepo::new();
+    let setup_start = Instant::now();
+
+    // Create initial commit: all files fully AI-attributed
+    {
+        for (file_idx, &line_count) in file_sizes.iter().enumerate() {
+            let dir = match file_idx % 5 {
+                0 => "src/api",
+                1 => "src/models",
+                2 => "src/services",
+                3 => "src/utils",
+                _ => "src/handlers",
+            };
+            let filename = format!("{}/module_{}.rs", dir, file_idx);
+            let mut file = repo.filename(&filename);
+            let mut lines: Vec<crate::repos::test_file::ExpectedLine> = Vec::new();
+
+            // Realistic file structure
+            lines.push(format!("// Module {} - auto-generated", file_idx).ai());
+            lines.push("use std::collections::HashMap;".to_string().ai());
+            lines.push("use serde::{{Serialize, Deserialize}};".to_string().ai());
+            lines.push("// MAIN_MARKER".to_string().into());
+            lines.push(format!("pub struct Module{} {{", file_idx).ai());
+
+            for field_idx in 0..(line_count / 20).max(5) {
+                lines.push(format!("    pub field_{}: String,", field_idx).ai());
+            }
+            lines.push("}".to_string().ai());
+            lines.push(String::new().ai());
+
+            // Fill rest with AI-authored functions
+            let remaining = line_count.saturating_sub(lines.len());
+            let funcs = remaining / 8;
+            for func_idx in 0..funcs {
+                lines.push(
+                    format!(
+                        "pub fn func_{}_{}(input: &str) -> String {{",
+                        file_idx, func_idx
+                    )
+                    .ai(),
+                );
+                lines.push("    let result = input.to_uppercase();".to_string().ai());
+                lines.push(
+                    format!(
+                        "    let processed = result.replace(\"old_{}\", \"new_{}\");",
+                        func_idx, func_idx
+                    )
+                    .ai(),
+                );
+                lines.push(
+                    format!(
+                        "    // AI-generated logic for module {} func {}",
+                        file_idx, func_idx
+                    )
+                    .ai(),
+                );
+                lines.push(
+                    format!(
+                        "    let output = format!(\"{{}}_{{}}\", processed, {});",
+                        func_idx
+                    )
+                    .ai(),
+                );
+                lines.push(
+                    format!(
+                        "    log::debug!(\"func_{}_{}: {{}}\", &output);",
+                        file_idx, func_idx
+                    )
+                    .ai(),
+                );
+                lines.push("    output".to_string().ai());
+                lines.push("}".to_string().ai());
+            }
+
+            while lines.len() < line_count {
+                lines.push(format!("// padding line {}", lines.len()).ai());
+            }
+
+            file.set_contents(lines);
+        }
+        repo.stage_all_and_commit("Initial: all AI-attributed files")
+            .unwrap();
+    }
+    println!(
+        "Initial commit: {:.1}s",
+        setup_start.elapsed().as_secs_f64()
+    );
+
+    let default_branch = repo.current_branch();
+
+    // Create feature branch with varied AI edits
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let feature_start = Instant::now();
+
+    for commit_idx in 0..num_feature_commits {
+        let stride = 3 + (commit_idx % 5);
+        let start = (commit_idx * stride) % num_files;
+
+        for i in 0..files_per_commit {
+            let file_idx = (start + i * 2) % num_files;
+            let dir = match file_idx % 5 {
+                0 => "src/api",
+                1 => "src/models",
+                2 => "src/services",
+                3 => "src/utils",
+                _ => "src/handlers",
+            };
+            let filename = format!("{}/module_{}.rs", dir, file_idx);
+            let path = repo.path().join(&filename);
+            let current = fs::read_to_string(&path).unwrap_or_default();
+            let mut file_lines: Vec<&str> = current.lines().collect();
+
+            let edit_type = (commit_idx * 7 + file_idx * 3) % 4;
+            match edit_type {
+                0 => {
+                    // Multi-line insertion at varied position
+                    let insert_pos = (file_lines.len() / 3)
+                        + (commit_idx * 17 + file_idx * 11) % (file_lines.len() / 3).max(1);
+                    let insert_pos = insert_pos.min(file_lines.len());
+                    let num_insert = 5 + (commit_idx + file_idx) % 16;
+                    let mut new_lines: Vec<String> = Vec::new();
+                    for l in 0..num_insert {
+                        new_lines.push(format!(
+                            "    // AI insert c{} f{} line{}: processing batch {}",
+                            commit_idx,
+                            file_idx,
+                            l,
+                            commit_idx * 100 + l
+                        ));
+                    }
+                    let new_refs: Vec<&str> = new_lines.iter().map(|s| s.as_str()).collect();
+                    file_lines.splice(insert_pos..insert_pos, new_refs);
+                    let joined = file_lines.join("\n");
+                    fs::write(&path, &joined).unwrap();
+                }
+                1 => {
+                    // Replace existing lines in middle third
+                    let start_replace =
+                        file_lines.len() / 4 + (commit_idx * 13) % (file_lines.len() / 4).max(1);
+                    let num_replace = (3 + (commit_idx + file_idx) % 8)
+                        .min(file_lines.len().saturating_sub(start_replace));
+                    let mut new_lines: Vec<String> = Vec::new();
+                    for l in 0..num_replace {
+                        new_lines.push(format!(
+                            "    let v{}_c{} = transform(input, {});",
+                            l,
+                            commit_idx,
+                            commit_idx * 1000 + l
+                        ));
+                    }
+                    let new_refs: Vec<&str> = new_lines.iter().map(|s| s.as_str()).collect();
+                    let end = (start_replace + num_replace).min(file_lines.len());
+                    file_lines.splice(start_replace..end, new_refs);
+                    let joined = file_lines.join("\n");
+                    fs::write(&path, &joined).unwrap();
+                }
+                2 => {
+                    // Delete block + add new function at end
+                    let del_start =
+                        file_lines.len() / 2 + (commit_idx * 11) % (file_lines.len() / 6).max(1);
+                    let del_count =
+                        (2 + commit_idx % 5).min(file_lines.len().saturating_sub(del_start));
+                    let end = (del_start + del_count).min(file_lines.len());
+                    file_lines.drain(del_start..end);
+                    let new_func = format!(
+                        "\npub fn generated_{}_{}(x: i32) -> i32 {{\n    let a = x * {};\n    let b = a + {};\n    // AI logic c{} f{}\n    b\n}}",
+                        commit_idx,
+                        file_idx,
+                        commit_idx + 1,
+                        file_idx,
+                        commit_idx,
+                        file_idx
+                    );
+                    let joined = file_lines.join("\n") + &new_func;
+                    fs::write(&path, &joined).unwrap();
+                }
+                _ => {
+                    // Append struct + impl block
+                    let block = format!(
+                        "\n#[derive(Debug)]\nstruct Batch{}_{} {{\n    data: Vec<u8>,\n    count: usize,\n    tag: String,\n}}\n\nimpl Batch{}_{} {{\n    fn new() -> Self {{\n        Self {{ data: vec![], count: {}, tag: \"{}\".into() }}\n    }}\n    fn process(&self) -> usize {{ self.data.len() + self.count }}\n}}",
+                        commit_idx, file_idx, commit_idx, file_idx, commit_idx, file_idx
+                    );
+                    let joined = file_lines.join("\n") + &block;
+                    fs::write(&path, &joined).unwrap();
+                }
+            }
+
+            repo.git_ai(&["checkpoint", "mock_ai", &filename]).unwrap();
+        }
+        repo.git(&["add", "-A"]).unwrap();
+        repo.stage_all_and_commit(&format!("Feature {}", commit_idx))
+            .unwrap();
+
+        if (commit_idx + 1) % 50 == 0 {
+            println!(
+                "  Feature commit {}/{} ({:.1}s)",
+                commit_idx + 1,
+                num_feature_commits,
+                feature_start.elapsed().as_secs_f64()
+            );
+        }
+    }
+    println!(
+        "Feature branch: {:.1}s ({} commits × {} files/commit)",
+        feature_start.elapsed().as_secs_f64(),
+        num_feature_commits,
+        files_per_commit
+    );
+
+    // Advance main: modify AI-tracked files to force diff-based path
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let main_start = Instant::now();
+    for main_idx in 0..num_main_commits {
+        let files_per_main = 40.min(num_files);
+        let start_file = (main_idx * 11) % num_files;
+        for i in 0..files_per_main {
+            let file_idx = (start_file + i) % num_files;
+            let dir = match file_idx % 5 {
+                0 => "src/api",
+                1 => "src/models",
+                2 => "src/services",
+                3 => "src/utils",
+                _ => "src/handlers",
+            };
+            let filename = format!("{}/module_{}.rs", dir, file_idx);
+            let path = repo.path().join(&filename);
+            let current = fs::read_to_string(&path).unwrap_or_default();
+            let new_content = current.replacen(
+                "// MAIN_MARKER",
+                &format!(
+                    "use crate::main_dep_{}::*;\n// Main integration {} for module {}\n// MAIN_MARKER",
+                    main_idx, main_idx, file_idx
+                ),
+                1,
+            );
+            fs::write(&path, &new_content).unwrap();
+        }
+        repo.git(&["add", "-A"]).unwrap();
+        repo.stage_all_and_commit(&format!("Main {}", main_idx))
+            .unwrap();
+    }
+    for i in 0..5 {
+        let mut f = repo.filename(&format!("main_only/f_{}.txt", i));
+        f.set_contents(crate::lines![format!("main only {}", i)]);
+        repo.stage_all_and_commit(&format!("Main unrelated {}", i))
+            .unwrap();
+    }
+    println!(
+        "Main branch: {:.1}s ({} commits × {} files + 5 unrelated)",
+        main_start.elapsed().as_secs_f64(),
+        num_main_commits,
+        40.min(num_files)
+    );
+    println!("Total setup: {:.1}s\n", setup_start.elapsed().as_secs_f64());
+
+    // Rebase
+    repo.git(&["checkout", "feature"]).unwrap();
+
+    let timing_file = repo.path().join("..").join("brutal_timing.txt");
+    let timing_path = timing_file.to_str().unwrap().to_string();
+
+    println!(
+        "--- Starting brutal rebase ({} commits onto {}) ---",
+        num_feature_commits, &default_branch
+    );
+    let wall_start = Instant::now();
+    let output = repo.git_with_env(
+        &["rebase", &default_branch],
+        &[
+            ("GIT_AI_DEBUG_PERFORMANCE", "2"),
+            ("GIT_AI_REBASE_TIMING_FILE", &timing_path),
+        ],
+        None,
+    );
+    let wall_duration = wall_start.elapsed();
+
+    let timing_data = fs::read_to_string(&timing_file).unwrap_or_default();
+
+    match &output {
+        Ok(out) => {
+            // Parse perf-json from output
+            let bench = TestRepo::parse_benchmark_result(out);
+            match bench {
+                Ok(bench) => {
+                    let git_ms = bench.git_duration.as_millis();
+                    let total_ms = bench.total_duration.as_millis();
+                    let pre_ms = bench.pre_command_duration.as_millis();
+                    let post_ms = bench.post_command_duration.as_millis();
+                    let overhead_ms = total_ms.saturating_sub(git_ms);
+                    let overhead_pct = if git_ms > 0 {
+                        overhead_ms as f64 / git_ms as f64 * 100.0
+                    } else {
+                        0.0
+                    };
+
+                    println!("\n╔══════════════════════════════════════════════════════════════╗");
+                    println!("║              BRUTAL BENCHMARK RESULTS                        ║");
+                    println!("╠══════════════════════════════════════════════════════════════╣");
+                    println!("║  Scale:");
+                    println!("║    {} files (20×2000L + 25×500L + 15×5000L)", num_files);
+                    println!(
+                        "║    {} initial lines of AI-attributed code",
+                        total_initial_lines
+                    );
+                    println!(
+                        "║    {} feature commits × {} files/commit",
+                        num_feature_commits, files_per_commit
+                    );
+                    println!(
+                        "║    {} main commits (forces diff-based path)",
+                        num_main_commits
+                    );
+                    println!("╠══════════════════════════════════════════════════════════════╣");
+                    println!("║  TIMING:");
+                    println!(
+                        "║    Wall clock:           {:.2}s",
+                        wall_duration.as_secs_f64()
+                    );
+                    println!(
+                        "║    git rebase (alone):   {}ms ({:.2}s)",
+                        git_ms,
+                        git_ms as f64 / 1000.0
+                    );
+                    println!(
+                        "║    git-ai total:         {}ms ({:.2}s)",
+                        total_ms,
+                        total_ms as f64 / 1000.0
+                    );
+                    println!("║    ├─ pre-command:       {}ms", pre_ms);
+                    println!(
+                        "║    └─ post-command:      {}ms ({:.2}s)",
+                        post_ms,
+                        post_ms as f64 / 1000.0
+                    );
+                    println!("║");
+                    println!("║  OVERHEAD:");
+                    println!(
+                        "║    git-ai overhead:      {}ms ({:.2}s)",
+                        overhead_ms,
+                        overhead_ms as f64 / 1000.0
+                    );
+                    println!("║    overhead / git time:  {:.1}%", overhead_pct);
+                    println!(
+                        "║    per-commit total:     {:.1}ms",
+                        total_ms as f64 / num_feature_commits as f64
+                    );
+                    println!(
+                        "║    per-commit git:       {:.1}ms",
+                        git_ms as f64 / num_feature_commits as f64
+                    );
+                    println!(
+                        "║    per-commit overhead:  {:.1}ms",
+                        overhead_ms as f64 / num_feature_commits as f64
+                    );
+                    println!("╚══════════════════════════════════════════════════════════════╝");
+                }
+                Err(e) => {
+                    println!(
+                        "\nWall time: {:.2}s ({}ms) — perf-json parse failed: {}",
+                        wall_duration.as_secs_f64(),
+                        wall_duration.as_millis(),
+                        e
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            println!(
+                "\nRebase FAILED after {:.2}s: {}",
+                wall_duration.as_secs_f64(),
+                e
+            );
+        }
+    }
+    output.unwrap();
+
+    if !timing_data.is_empty() {
+        println!("\n--- Internal phase timing ---");
+        print!("{}", timing_data);
+        println!("-----------------------------");
+    }
+
+    println!("\nDone.");
+}

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -2089,7 +2089,7 @@ impl TestRepo {
         Self::parse_benchmark_result(&output)
     }
 
-    fn parse_benchmark_result(output: &str) -> Result<BenchmarkResult, String> {
+    pub fn parse_benchmark_result(output: &str) -> Result<BenchmarkResult, String> {
         // Find the JSON performance line
         for line in output.lines() {
             if line.contains("[git-ai (perf-json)]") {


### PR DESCRIPTION
## Summary

- Parallelize notes blob creation for large batches (>50 entries) using 4 concurrent `git fast-import` processes, then a lightweight tree-only commit via the existing `notes_add_blob_batch` path
- Optimize full-scan attribution reconstruction to only read uncovered files at historical commits instead of all pathspecs, cutting IO proportionally
- Add line-index-based author lookup for head-note path (Vec vs HashMap), eliminate clone in transform loop via remove+reinsert, reuse diff buffer across files
- Add `benchmark_brutal` test (200 commits, 60 files, 127,500 lines) for measuring large-scale rebase performance

**Brutal benchmark results** (opt-level=2):
| Phase | Before | After |
|-------|--------|-------|
| attribution_reconstruction | 3,725ms | 1,255ms |
| notes_add_batch | 3,232ms | 2,093ms |
| loop:transform | 1,562ms | 1,407ms |
| **Total overhead** | **9,382ms** | **5,693ms (1.65x)** |

## Test plan
- [x] All 3056 integration tests pass
- [x] Autosquash tests specifically verified (squash path uses original full-scan behavior)
- [x] `cargo clippy` and `cargo fmt` clean
- [x] Brutal benchmark confirms performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
