### PR TITLE
perf: hunk-based rebase attribution transfer (3.5x faster)

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -1398,7 +1398,7 @@ pub fn rewrite_authorship_after_rebase_v2(
                         prev_la,
                     );
                 }
-                loop_metrics_subtract_ms += tsub.elapsed().as_micros() as u128;
+                loop_metrics_subtract_ms += tsub.elapsed().as_micros();
 
                 // Check if blob content is available and non-empty (file not deleted)
                 let new_content = new_content_for_changed_files.get(file_path);
@@ -1436,7 +1436,7 @@ pub fn rewrite_authorship_after_rebase_v2(
                         .unwrap_or(&[]);
                     let result = apply_hunks_to_line_attributions(old_attrs, hunks);
                     total_files_hunk_transferred += 1;
-                    loop_hunk_ms += thunk.elapsed().as_micros() as u128;
+                    loop_hunk_ms += thunk.elapsed().as_micros();
                     result
                 } else if let Some(new_content) = new_content {
                     // SLOW PATH: Content-diff based attribution transfer
@@ -1452,7 +1452,7 @@ pub fn rewrite_authorship_after_rebase_v2(
                             .map(|(_, la)| la.as_slice()),
                         original_head_line_to_author.get(file_path),
                     );
-                    loop_diff_ms += tdiff.elapsed().as_micros() as u128;
+                    loop_diff_ms += tdiff.elapsed().as_micros();
                     files_with_synced_state.insert(file_path.clone());
                     result
                 } else {
@@ -1472,22 +1472,20 @@ pub fn rewrite_authorship_after_rebase_v2(
                     &mut prompt_line_metrics,
                     &line_attrs,
                 );
-                loop_metrics_add_ms += tadd.elapsed().as_micros() as u128;
+                loop_metrics_add_ms += tadd.elapsed().as_micros();
                 let tatt = std::time::Instant::now();
                 if let Some(text) = serialize_attestation_from_line_attrs(file_path, &line_attrs) {
                     cached_file_attestation_text.insert(file_path.clone(), text);
                 } else {
                     cached_file_attestation_text.remove(file_path);
                 }
-                loop_attestation_ms += tatt.elapsed().as_micros() as u128;
+                loop_attestation_ms += tatt.elapsed().as_micros();
                 let tclone = std::time::Instant::now();
                 current_attributions.insert(file_path.clone(), (Vec::new(), line_attrs));
-                if !use_hunk_based {
-                    if let Some(content) = new_content {
-                        current_file_contents.insert(file_path.clone(), content.clone());
-                    }
+                if !use_hunk_based && let Some(content) = new_content {
+                    current_file_contents.insert(file_path.clone(), content.clone());
                 }
-                loop_content_clone_ms += tclone.elapsed().as_micros() as u128;
+                loop_content_clone_ms += tclone.elapsed().as_micros();
             }
             loop_transform_ms += t0.elapsed().as_millis();
 

--- a/tests/integration/rebase_benchmark.rs
+++ b/tests/integration/rebase_benchmark.rs
@@ -801,7 +801,6 @@ fn benchmark_rebase_heavy() {
     repo.git(&["checkout", "feature"]).unwrap();
 
     let timing_file = repo.path().join("..").join("heavy_rebase_timing.txt");
-    let timing_path = timing_file.to_str().unwrap().to_string();
 
     println!(
         "\n━━━ Starting HEAVY rebase ({} commits onto {}) ━━━",


### PR DESCRIPTION
## Summary

- Replace per-file content diffing (imara_diff Myers) with hunk-based attribution transfer using `git diff-tree -p -U0` hunk headers
- For commits after first appearance, adjusts attribution line numbers via O(attrs+hunks) arithmetic instead of O(file_length) Myers diff
- Only read blob contents for first-seen files (99% reduction in blob I/O)

### Benchmark (100 commits × 30 files × 200 lines)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Authorship overhead | 1450ms | 413ms | **3.5x faster** |
| Commit processing loop | 1247ms | 28ms | **44x faster** |
| Blob reads | 3000 | 30 | **-99%** |
| Total rebase time | 2716ms | 1666ms | **-39%** |

### Heavy benchmark (200 commits × 50 files × 300 lines)

| Metric | After |
|--------|-------|
| Authorship overhead | 1399ms |
| Hunk transfers | 9,950 files in 3ms |
| Commit processing loop | 83ms (estimated baseline: ~5,500ms) |

## How it works

`git diff-tree --stdin -p -U0` outputs minimal unified diff hunk headers (`@@ -old,count +new,count @@`). For a linear rebase sequence, each commit's parent is the previous rebased commit — so hunk headers give us exactly the line-level change information needed for attribution transfer without reading file content or running any diff algorithm.

1. **First commit**: Uses content-diff (Myers) to sync accumulated state
2. **All subsequent commits**: Uses hunk-based arithmetic to adjust line numbers

## Test plan

- [x] All 76 rebase integration tests pass
- [x] All 21 cherry-pick integration tests pass
- [x] Full integration suite: 3056 passed, 0 failed
- [x] Heavy benchmark (200×50×300) completes correctly
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/853" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
