### PR TITLE
fix: handle Windows backslash paths in implicit clone target resolution

### DIFF
--- a/src/daemon/git_backend.rs
+++ b/src/daemon/git_backend.rs
@@ -627,9 +627,16 @@ fn takes_value(arg: &str) -> bool {
 }
 
 fn default_clone_target_from_source(source: &str) -> Option<PathBuf> {
-    let source = source.trim_end_matches('/');
+    let source = source.trim_end_matches(&['/', '\\'] as &[char]);
     let source = source.strip_suffix(".git").unwrap_or(source);
-    let name = source.rsplit('/').next()?.rsplit(':').next()?.to_string();
+    // Split on both / and \ to handle Windows paths
+    let after_last_sep = source.rsplit(&['/', '\\'] as &[char]).next()?;
+    // Handle SCP-like syntax (user@host:path), but skip Windows drive letters (C:)
+    let name = if after_last_sep.contains(':') && after_last_sep.len() > 2 {
+        after_last_sep.rsplit(':').next()?
+    } else {
+        after_last_sep
+    };
     if name.is_empty() {
         return None;
     }
@@ -711,7 +718,7 @@ fn parse_alias_tokens(value: &str) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{GitBackend, SystemGitBackend};
+    use super::{GitBackend, SystemGitBackend, default_clone_target_from_source};
     use std::path::PathBuf;
 
     #[test]
@@ -725,6 +732,38 @@ mod tests {
             .expect("builtin commands should not require repository discovery");
 
         assert_eq!(resolved.as_deref(), Some("commit"));
+    }
+
+    #[test]
+    fn default_clone_target_from_url() {
+        assert_eq!(
+            default_clone_target_from_source("https://github.com/user/repo.git"),
+            Some(PathBuf::from("repo"))
+        );
+        assert_eq!(
+            default_clone_target_from_source("git@github.com:user/repo.git"),
+            Some(PathBuf::from("repo"))
+        );
+        assert_eq!(
+            default_clone_target_from_source("/local/path/repo"),
+            Some(PathBuf::from("repo"))
+        );
+    }
+
+    #[test]
+    fn default_clone_target_from_windows_path() {
+        assert_eq!(
+            default_clone_target_from_source(r"C:\Users\runner\Temp\repo"),
+            Some(PathBuf::from("repo"))
+        );
+        assert_eq!(
+            default_clone_target_from_source(r"C:\Users\runner\Temp\repo.git"),
+            Some(PathBuf::from("repo"))
+        );
+        assert_eq!(
+            default_clone_target_from_source(r"\\?\C:\Temp\bare-repo"),
+            Some(PathBuf::from("bare-repo"))
+        );
     }
 
     #[test]

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -685,11 +685,12 @@ pub fn extract_clone_target_directory(args: &[String]) -> Option<String> {
 /// Derive the target directory name from a repository URL.
 /// Mimics git's behavior of using the last path component, stripping .git suffix.
 fn derive_directory_from_url(url: &str) -> Option<String> {
-    // Remove trailing slashes
-    let url = url.trim_end_matches('/');
+    // Remove trailing slashes and backslashes (Windows)
+    let url = url.trim_end_matches(&['/', '\\'] as &[char]);
 
-    // Extract the last path component
-    let last_component = if let Some(pos) = url.rfind('/') {
+    // Extract the last path component (consider both / and \ for Windows paths)
+    let last_sep = url.rfind(&['/', '\\'] as &[char]);
+    let last_component = if let Some(pos) = last_sep {
         &url[pos + 1..]
     } else if let Some(pos) = url.rfind(':') {
         // Handle SCP-like syntax: user@host:path
@@ -807,6 +808,19 @@ mod tests {
         assert_eq!(
             derive_directory_from_url("/local/path/repo.git"),
             Some("repo".to_string())
+        );
+        // Windows backslash paths
+        assert_eq!(
+            derive_directory_from_url(r"C:\Users\runner\AppData\Local\Temp\repo"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_directory_from_url(r"C:\Users\runner\AppData\Local\Temp\repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_directory_from_url(r"\\?\C:\Temp\bare-repo"),
+            Some("bare-repo".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- `derive_directory_from_url` (cli_parser.rs) and `default_clone_target_from_source` (git_backend.rs) only split on `/` to extract the clone target basename. On Windows, local paths use `\`, so the entire path was returned instead of just the directory name, breaking post-clone authorship notes fetch for implicit targets.
- Both functions now split on both `/` and `\`, fixing the 4 `test_notes_sync_clone_implicit_target_from_non_repo_cwd` test failures on all 3 Windows CI jobs.
- Regression introduced by #835 / #838.

## Test plan
- [x] Added unit tests for Windows backslash paths in both `derive_directory_from_url` and `default_clone_target_from_source`
- [x] All 1296 lib tests pass locally
- [x] Windows CI jobs should now pass (all 3 modes: wrapper, daemon, wrapper-daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
