### PR TITLE
Resolve SSH host aliases in git remote URLs

### DIFF
--- a/src/authorship/git_ai_hooks.rs
+++ b/src/authorship/git_ai_hooks.rs
@@ -217,6 +217,7 @@ fn build_repo_hook_context(repo: &Repository) -> RepoHookContext {
                     .map(|(_, url)| url)
             })
         })
+        .map(|url| crate::repo_url::normalize_repo_url(&url).unwrap_or(url))
         .unwrap_or_default();
 
     let repo_name = repo_url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,5 @@ pub mod mdm;
 pub mod metrics;
 pub mod observability;
 pub mod repo_url;
+pub mod ssh_config;
 pub mod utils;

--- a/src/repo_url.rs
+++ b/src/repo_url.rs
@@ -11,7 +11,8 @@ pub fn normalize_repo_url(url_str: &str) -> Result<String, String> {
         && let Some((user_host, path)) = url_str.split_once(':')
         && let Some((_, host)) = user_host.rsplit_once('@')
     {
-        return normalize_ssh_url(host, path);
+        let resolved = crate::ssh_config::resolve_ssh_hostname_default(host);
+        return normalize_ssh_url(resolved.as_deref().unwrap_or(host), path);
     }
 
     // Parse as URL
@@ -23,8 +24,14 @@ pub fn normalize_repo_url(url_str: &str) -> Result<String, String> {
         return Err(format!("Unsupported URL scheme: {}", scheme));
     }
 
-    // Extract host
-    let host = url.host_str().ok_or("URL must have a host")?;
+    // Extract host, resolving SSH aliases if applicable
+    let raw_host = url.host_str().ok_or("URL must have a host")?;
+    let resolved_host = if scheme == "ssh" {
+        crate::ssh_config::resolve_ssh_hostname_default(raw_host)
+    } else {
+        None
+    };
+    let host = resolved_host.as_deref().unwrap_or(raw_host);
 
     // Normalize path: remove .git suffix and trailing slash
     let path = url.path().trim_end_matches('/').trim_end_matches(".git");

--- a/src/ssh_config.rs
+++ b/src/ssh_config.rs
@@ -1,0 +1,223 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Parse an SSH config file and return a map of Host alias → HostName.
+/// Skips wildcard hosts (containing `*` or `?`).
+/// Returns an empty map on any I/O or parse error.
+pub fn parse_ssh_config(path: &Path) -> HashMap<String, String> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return HashMap::new(),
+    };
+
+    let mut map = HashMap::new();
+    let mut current_hosts: Vec<String> = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Skip empty lines and comments
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        // Split on first whitespace or '='
+        let (keyword, value) = match trimmed.split_once(|c: char| c.is_whitespace() || c == '=') {
+            Some((k, v)) => (k, v.trim().trim_start_matches('=')),
+            None => continue,
+        };
+
+        if keyword.eq_ignore_ascii_case("Host") {
+            // New Host block — collect all aliases, skip wildcards
+            current_hosts = value
+                .split_whitespace()
+                .filter(|h| !h.contains('*') && !h.contains('?'))
+                .map(String::from)
+                .collect();
+        } else if keyword.eq_ignore_ascii_case("HostName") && !current_hosts.is_empty() {
+            let hostname = value.trim().to_string();
+            if !hostname.is_empty() {
+                for alias in &current_hosts {
+                    map.insert(alias.clone(), hostname.clone());
+                }
+            }
+        } else if keyword.eq_ignore_ascii_case("Match") {
+            // Match blocks are complex; clear current hosts to avoid misattribution
+            current_hosts.clear();
+        }
+    }
+
+    map
+}
+
+/// Resolve an SSH host to its real hostname using a specific config file.
+/// Returns `None` if the file can't be read, the host isn't found, or
+/// the resolved hostname equals the input (no-op).
+pub fn resolve_ssh_hostname(host: &str, config_path: &Path) -> Option<String> {
+    let map = parse_ssh_config(config_path);
+    let resolved = map.get(host)?;
+    if resolved == host {
+        None
+    } else {
+        Some(resolved.clone())
+    }
+}
+
+/// Resolve an SSH host using the default `~/.ssh/config`.
+/// Returns `None` on any error or if the host is not found.
+pub fn resolve_ssh_hostname_default(host: &str) -> Option<String> {
+    let config_path = ssh_config_path()?;
+    resolve_ssh_hostname(host, &config_path)
+}
+
+fn ssh_config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".ssh").join("config"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_config(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_parse_basic_host_hostname() {
+        let f = write_config("Host github-work\n  HostName github.com\n  User git\n");
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("github-work").unwrap(), "github.com");
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_multiple_host_blocks() {
+        let f = write_config(
+            "Host github-work\n  HostName github.com\n\n\
+             Host gitlab-work\n  HostName gitlab.com\n",
+        );
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("github-work").unwrap(), "github.com");
+        assert_eq!(map.get("gitlab-work").unwrap(), "gitlab.com");
+    }
+
+    #[test]
+    fn test_parse_multiple_aliases_per_host_line() {
+        let f = write_config("Host gh ghub github-alias\n  HostName github.com\n");
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("gh").unwrap(), "github.com");
+        assert_eq!(map.get("ghub").unwrap(), "github.com");
+        assert_eq!(map.get("github-alias").unwrap(), "github.com");
+    }
+
+    #[test]
+    fn test_parse_wildcard_hosts_skipped() {
+        let f = write_config(
+            "Host *\n  HostName default.com\n\n\
+             Host *.example.com\n  HostName proxy.com\n\n\
+             Host real-alias\n  HostName real.com\n",
+        );
+        let map = parse_ssh_config(f.path());
+        assert!(!map.contains_key("*"));
+        assert!(!map.contains_key("*.example.com"));
+        assert_eq!(map.get("real-alias").unwrap(), "real.com");
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_case_insensitive_keywords() {
+        let f = write_config("host my-server\n  hostname myserver.example.com\n");
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("my-server").unwrap(), "myserver.example.com");
+    }
+
+    #[test]
+    fn test_parse_missing_file() {
+        let map = parse_ssh_config(Path::new("/nonexistent/path/ssh_config"));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_parse_comments_and_empty_lines() {
+        let f = write_config(
+            "# This is a comment\n\n\
+             Host my-host\n\
+             # Another comment\n\
+               HostName real-host.com\n\n",
+        );
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("my-host").unwrap(), "real-host.com");
+    }
+
+    #[test]
+    fn test_parse_equals_separator() {
+        let f = write_config("Host=my-server\n  HostName=server.example.com\n");
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("my-server").unwrap(), "server.example.com");
+    }
+
+    #[test]
+    fn test_parse_match_block_clears_hosts() {
+        let f = write_config(
+            "Host my-host\n  HostName real.com\n\n\
+             Match host *.internal\n  HostName internal.com\n\n\
+             Host another\n  HostName another.com\n",
+        );
+        let map = parse_ssh_config(f.path());
+        assert_eq!(map.get("my-host").unwrap(), "real.com");
+        assert_eq!(map.get("another").unwrap(), "another.com");
+        // Match block should not produce entries
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_ssh_hostname_found() {
+        let f = write_config("Host github-work\n  HostName github.com\n");
+        assert_eq!(
+            resolve_ssh_hostname("github-work", f.path()),
+            Some("github.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_ssh_hostname_not_found() {
+        let f = write_config("Host github-work\n  HostName github.com\n");
+        assert_eq!(resolve_ssh_hostname("other-host", f.path()), None);
+    }
+
+    #[test]
+    fn test_resolve_ssh_hostname_same_as_input() {
+        let f = write_config("Host github.com\n  HostName github.com\n");
+        // No-op resolution returns None
+        assert_eq!(resolve_ssh_hostname("github.com", f.path()), None);
+    }
+
+    #[test]
+    fn test_resolve_dotted_alias() {
+        let f = write_config("Host github.com\n  HostName internal-github.corp.example.com\n");
+        assert_eq!(
+            resolve_ssh_hostname("github.com", f.path()),
+            Some("internal-github.corp.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_missing_config_file() {
+        assert_eq!(
+            resolve_ssh_hostname("anything", Path::new("/nonexistent")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_host_without_hostname_not_mapped() {
+        let f = write_config("Host my-host\n  User git\n  Port 22\n");
+        let map = parse_ssh_config(f.path());
+        assert!(!map.contains_key("my-host"));
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -75,6 +75,8 @@ mod show_prompt;
 mod simple_additions;
 mod simple_benchmark;
 mod squash_merge;
+#[cfg(unix)]
+mod ssh_alias_resolution;
 mod stash_attribution;
 mod stats;
 mod status_ignore;

--- a/tests/integration/ssh_alias_resolution.rs
+++ b/tests/integration/ssh_alias_resolution.rs
@@ -1,0 +1,261 @@
+use crate::repos::test_repo::{GitTestMode, TestRepo};
+use serde_json::Value;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+fn sh_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn set_executable(path: &Path) {
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+fn write_capture_hook_script(repo: &TestRepo, name: &str, output_path: &Path) -> String {
+    let script_path = repo.path().join(format!("{name}.sh"));
+    let quoted_output = sh_single_quote(&output_path.to_string_lossy());
+
+    let script =
+        format!("#!/bin/sh\nset -eu\ncat >> {quoted_output}\nprintf '\\n' >> {quoted_output}\n");
+
+    fs::write(&script_path, script).unwrap();
+    set_executable(&script_path);
+
+    sh_single_quote(&script_path.to_string_lossy())
+}
+
+fn configure_post_notes_updated_hook(repo: &TestRepo, command: &str) {
+    repo.git_ai(&["config", "set", "git_ai_hooks.post_notes_updated", command])
+        .expect("failed to set post_notes_updated hook command");
+}
+
+fn wait_for_json_lines(path: &Path, expected_count: usize, timeout: Duration) -> Vec<Value> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(contents) = fs::read_to_string(path) {
+            let lines: Vec<&str> = contents
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .collect();
+            if lines.len() >= expected_count {
+                return lines
+                    .into_iter()
+                    .map(|l| serde_json::from_str::<Value>(l).unwrap())
+                    .collect();
+            }
+        }
+        if Instant::now() >= deadline {
+            let contents = fs::read_to_string(path).unwrap_or_default();
+            panic!(
+                "timed out waiting for {} JSON lines in {}. Contents:\n{}",
+                expected_count,
+                path.display(),
+                contents
+            );
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn write_ssh_config(repo: &TestRepo, content: &str) {
+    let ssh_dir = repo.test_home_path().join(".ssh");
+    fs::create_dir_all(&ssh_dir).unwrap();
+    fs::write(ssh_dir.join("config"), content).unwrap();
+}
+
+fn setup_ai_commit(repo: &TestRepo) -> String {
+    let file_path = repo.path().join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    repo.git(&["add", "main.rs"]).unwrap();
+    repo.commit("base commit").unwrap();
+
+    // Add an AI-authored line and commit
+    fs::write(&file_path, "fn main() {}\nfn ai_func() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "main.rs"]).unwrap();
+    repo.git(&["add", "main.rs"]).unwrap();
+    repo.commit("ai commit").unwrap().commit_sha
+}
+
+#[test]
+fn ssh_alias_resolves_in_hook_context() {
+    let repo = TestRepo::new_with_mode(GitTestMode::Hooks);
+
+    // Set up SSH config with alias
+    write_ssh_config(
+        &repo,
+        "Host github-work\n  HostName github.com\n  User git\n",
+    );
+
+    // Set remote to use the alias
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "git@github-work:my-org/my-repo.git",
+    ])
+    .unwrap();
+
+    // Configure hook to capture payload
+    let payload_log = repo.path().join("hook-output.ndjson");
+    let hook_cmd = write_capture_hook_script(&repo, "capture-hook", &payload_log);
+    configure_post_notes_updated_hook(&repo, &hook_cmd);
+
+    let _commit_sha = setup_ai_commit(&repo);
+
+    let hook_calls = wait_for_json_lines(&payload_log, 1, Duration::from_secs(6));
+    let payload = hook_calls[0].as_array().expect("payload should be array");
+    assert!(
+        !payload.is_empty(),
+        "payload should have at least one entry"
+    );
+
+    let entry = &payload[0];
+    let repo_url = entry
+        .get("repo_url")
+        .and_then(Value::as_str)
+        .expect("repo_url should be present");
+
+    assert_eq!(
+        repo_url, "https://github.com/my-org/my-repo",
+        "SSH alias 'github-work' should resolve to 'github.com'"
+    );
+
+    let repo_name = entry
+        .get("repo_name")
+        .and_then(Value::as_str)
+        .expect("repo_name should be present");
+    assert_eq!(
+        repo_name, "my-repo",
+        "repo_name should be derived from resolved URL"
+    );
+}
+
+#[test]
+fn ssh_alias_no_config_falls_back_to_literal() {
+    let repo = TestRepo::new_with_mode(GitTestMode::Hooks);
+
+    // Do NOT write SSH config — the alias should fall back to literal
+    repo.git(&["remote", "add", "origin", "git@my-alias:org/repo.git"])
+        .unwrap();
+
+    let payload_log = repo.path().join("hook-output.ndjson");
+    let hook_cmd = write_capture_hook_script(&repo, "capture-hook", &payload_log);
+    configure_post_notes_updated_hook(&repo, &hook_cmd);
+
+    let _commit_sha = setup_ai_commit(&repo);
+
+    let hook_calls = wait_for_json_lines(&payload_log, 1, Duration::from_secs(6));
+    let payload = hook_calls[0].as_array().expect("payload should be array");
+
+    let repo_url = payload[0]
+        .get("repo_url")
+        .and_then(Value::as_str)
+        .expect("repo_url should be present");
+
+    assert_eq!(
+        repo_url, "https://my-alias/org/repo",
+        "without SSH config, alias should be used literally"
+    );
+}
+
+#[test]
+fn ssh_alias_no_matching_host_falls_back() {
+    let repo = TestRepo::new_with_mode(GitTestMode::Hooks);
+
+    // SSH config with a different alias — no match for our remote
+    write_ssh_config(&repo, "Host other-alias\n  HostName gitlab.com\n");
+
+    repo.git(&["remote", "add", "origin", "git@github-work:org/repo.git"])
+        .unwrap();
+
+    let payload_log = repo.path().join("hook-output.ndjson");
+    let hook_cmd = write_capture_hook_script(&repo, "capture-hook", &payload_log);
+    configure_post_notes_updated_hook(&repo, &hook_cmd);
+
+    let _commit_sha = setup_ai_commit(&repo);
+
+    let hook_calls = wait_for_json_lines(&payload_log, 1, Duration::from_secs(6));
+    let payload = hook_calls[0].as_array().expect("payload should be array");
+
+    let repo_url = payload[0]
+        .get("repo_url")
+        .and_then(Value::as_str)
+        .expect("repo_url should be present");
+
+    assert_eq!(
+        repo_url, "https://github-work/org/repo",
+        "non-matching alias should fall back to literal hostname"
+    );
+}
+
+#[test]
+fn dotted_ssh_alias_resolves() {
+    let repo = TestRepo::new_with_mode(GitTestMode::Hooks);
+
+    // SSH config remapping a dotted hostname to another
+    write_ssh_config(
+        &repo,
+        "Host github.com\n  HostName internal-github.corp.example.com\n",
+    );
+
+    repo.git(&["remote", "add", "origin", "git@github.com:org/repo.git"])
+        .unwrap();
+
+    let payload_log = repo.path().join("hook-output.ndjson");
+    let hook_cmd = write_capture_hook_script(&repo, "capture-hook", &payload_log);
+    configure_post_notes_updated_hook(&repo, &hook_cmd);
+
+    let _commit_sha = setup_ai_commit(&repo);
+
+    let hook_calls = wait_for_json_lines(&payload_log, 1, Duration::from_secs(6));
+    let payload = hook_calls[0].as_array().expect("payload should be array");
+
+    let repo_url = payload[0]
+        .get("repo_url")
+        .and_then(Value::as_str)
+        .expect("repo_url should be present");
+
+    assert_eq!(
+        repo_url, "https://internal-github.corp.example.com/org/repo",
+        "dotted SSH alias should resolve to HostName from config"
+    );
+}
+
+#[test]
+fn ssh_alias_multiple_hosts_in_config() {
+    let repo = TestRepo::new_with_mode(GitTestMode::Hooks);
+
+    write_ssh_config(
+        &repo,
+        "Host github-work gh-work\n  HostName github.com\n  User git\n\n\
+         Host gitlab-work\n  HostName gitlab.com\n",
+    );
+
+    // Test with first alias from multi-alias Host line
+    repo.git(&["remote", "add", "origin", "git@gh-work:org/repo.git"])
+        .unwrap();
+
+    let payload_log = repo.path().join("hook-output.ndjson");
+    let hook_cmd = write_capture_hook_script(&repo, "capture-hook", &payload_log);
+    configure_post_notes_updated_hook(&repo, &hook_cmd);
+
+    let _commit_sha = setup_ai_commit(&repo);
+
+    let hook_calls = wait_for_json_lines(&payload_log, 1, Duration::from_secs(6));
+    let payload = hook_calls[0].as_array().expect("payload should be array");
+
+    let repo_url = payload[0]
+        .get("repo_url")
+        .and_then(Value::as_str)
+        .expect("repo_url should be present");
+
+    assert_eq!(
+        repo_url, "https://github.com/org/repo",
+        "multi-alias Host line should resolve each alias correctly"
+    );
+}


### PR DESCRIPTION
## Summary
- Parse `~/.ssh/config` to resolve SSH `Host` aliases to their `HostName` values when normalizing git remote URLs
- Fixes telemetry/metrics reporting incorrect domains when repos use SSH profiles (e.g., `git@github-work:org/repo` now correctly resolves to `github.com`)
- Always attempts resolution for any SSH-style URL — SSH aliases can be anything, including dotted hostnames

## Changes
- **New `src/ssh_config.rs`**: Lightweight SSH config parser (Host→HostName extraction, wildcard/Match block handling, case-insensitive keywords, `=` separator support)
- **`src/repo_url.rs`**: `normalize_repo_url()` resolves SSH hosts via config for both scp-like and `ssh://` URLs
- **`src/authorship/git_ai_hooks.rs`**: Hook context now normalizes remote URLs (resolving aliases + canonicalizing)
- **5 integration tests** using TestRepo with isolated `HOME`/SSH config per test

## Test plan
- [x] 15 unit tests for SSH config parser
- [x] 15 existing repo_url unit tests pass (no regression)
- [x] 5 new TestRepo-based e2e tests: alias resolution, no-config fallback, no-match fallback, dotted alias, multi-alias Host lines
- [x] 4 existing git_ai_hooks integration tests pass (no regression)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
