### PR TITLE
fix: recognize --no-literal-pathspecs and other negated pathspec globals

### DIFF
--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -327,9 +327,13 @@ pub fn parse_git_cli_args(args: &[String]) -> ParsedGitInvocation {
             | "--no-advice"
             | "--bare"
             | "--literal-pathspecs"
+            | "--no-literal-pathspecs"
             | "--glob-pathspecs"
+            | "--no-glob-pathspecs"
             | "--noglob-pathspecs"
-            | "--icase-pathspecs" => return GlobalNoValue,
+            | "--no-noglob-pathspecs"
+            | "--icase-pathspecs"
+            | "--no-icase-pathspecs" => return GlobalNoValue,
             _ => {}
         }
 

--- a/tests/integration/git_cli_arg_parsing.rs
+++ b/tests/integration/git_cli_arg_parsing.rs
@@ -202,6 +202,60 @@ fn pathspec_toggles_as_globals() {
 }
 
 #[test]
+fn negated_pathspec_toggles_as_globals() {
+    let args = s(&[
+        "--no-literal-pathspecs",
+        "--no-glob-pathspecs",
+        "--no-noglob-pathspecs",
+        "--no-icase-pathspecs",
+        "ls-files",
+        "-z",
+    ]);
+    let got = parse_git_cli_args(&args);
+    assert_eq!(
+        got.global_args,
+        s(&[
+            "--no-literal-pathspecs",
+            "--no-glob-pathspecs",
+            "--no-noglob-pathspecs",
+            "--no-icase-pathspecs"
+        ])
+    );
+    assert_eq!(got.command, Some("ls-files".into()));
+    assert_eq!(got.command_args, s(&["-z"]));
+}
+
+#[test]
+fn fugitive_commit_with_no_literal_pathspecs() {
+    // vim-fugitive passes --no-literal-pathspecs between -c flags when committing
+    let args = s(&[
+        "-c",
+        "color.advice=false",
+        "-c",
+        "color.ui=false",
+        "--no-literal-pathspecs",
+        "-c",
+        "advice.waitingForEditor=false",
+        "commit",
+    ]);
+    let got = parse_git_cli_args(&args);
+    assert_eq!(
+        got.global_args,
+        s(&[
+            "-c",
+            "color.advice=false",
+            "-c",
+            "color.ui=false",
+            "--no-literal-pathspecs",
+            "-c",
+            "advice.waitingForEditor=false"
+        ])
+    );
+    assert_eq!(got.command, Some("commit".into()));
+    assert!(got.command_args.is_empty());
+}
+
+#[test]
 fn paginate_and_no_pager_both_present_kept_as_globals() {
     let args = s(&["--paginate", "--no-pager", "log"]);
     let got = parse_git_cli_args(&args);


### PR DESCRIPTION
vim-fugitive passes --no-literal-pathspecs between -c flags when committing. The CLI parser didn't recognize this flag, treated it as an unknown top-level option, and set command = None — silently skipping all pre/post commit hooks and losing AI attributions.

Add --no-literal-pathspecs, --no-glob-pathspecs, --no-noglob-pathspecs, and --no-icase-pathspecs to the GlobalNoValue match arm.

This is for issue https://github.com/git-ai-project/git-ai/issues/440
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
