### PR TITLE
Enable async mode by default for release builds

### DIFF
--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -55,7 +55,7 @@ define_feature_flags!(
     rewrite_stash: rewrite_stash, debug = true, release = false,
     inter_commit_move: checkpoint_inter_commit_move, debug = false, release = false,
     auth_keyring: auth_keyring, debug = false, release = false,
-    async_mode: async_mode, debug = false, release = false,
+    async_mode: async_mode, debug = false, release = true,
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
 );
@@ -139,7 +139,7 @@ mod tests {
             assert!(!flags.rewrite_stash);
             assert!(!flags.inter_commit_move);
             assert!(!flags.auth_keyring);
-            assert!(!flags.async_mode);
+            assert!(flags.async_mode);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
         }


### PR DESCRIPTION
## Summary
- Sets `async_mode` release default from `false` to `true` in `feature_flags.rs`
- Updates the corresponding release-mode test assertion to expect `async_mode = true`

## Test plan
- [ ] Run `cargo test` to verify all feature flag tests pass
- [ ] Verify release builds have async mode enabled by default
- [ ] Confirm async mode can still be overridden via env var (`GIT_AI_ASYNC_MODE=false`) or file config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
