### PR TITLE
Add regression tests for `git commit --amend --no-edit` tracking

### DIFF
--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1957,6 +1957,64 @@ fn daemon_pure_trace_socket_write_mode_applies_amend_rewrite() {
     );
 }
 
+/// Regression test: `git commit --amend --no-edit` should emit a commit_amend
+/// rewrite event in daemon pure-trace mode, just like `--amend -m "..."`.
+#[test]
+#[serial]
+fn daemon_pure_trace_socket_amend_no_edit_emits_rewrite_event() {
+    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let _daemon = DaemonGuard::start(&repo);
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let env = git_trace_env(&trace_socket);
+    let env_refs = [(env[0].0, env[0].1.as_str()), (env[1].0, env[1].1.as_str())];
+    let completion_baseline = repo.daemon_total_completion_count();
+    let mut expected_top_level_completions = 0u64;
+
+    fs::write(repo.path().join("no-edit.txt"), "line 1\n").expect("failed to write file");
+    traced_git_with_env(
+        &repo,
+        &["add", "no-edit.txt"],
+        &env_refs,
+        &mut expected_top_level_completions,
+    )
+    .expect("add should succeed");
+    traced_git_with_env(
+        &repo,
+        &["commit", "-m", "initial"],
+        &env_refs,
+        &mut expected_top_level_completions,
+    )
+    .expect("commit should succeed");
+
+    fs::write(repo.path().join("no-edit.txt"), "line 1\nline 2\n").expect("failed to update file");
+    traced_git_with_env(
+        &repo,
+        &["add", "no-edit.txt"],
+        &env_refs,
+        &mut expected_top_level_completions,
+    )
+    .expect("add before amend should succeed");
+    traced_git_with_env(
+        &repo,
+        &["commit", "--amend", "--no-edit"],
+        &env_refs,
+        &mut expected_top_level_completions,
+    )
+    .expect("amend --no-edit should succeed");
+
+    wait_for_expected_top_level_completions(
+        &repo,
+        completion_baseline,
+        expected_top_level_completions,
+    );
+
+    let amend_events = wait_for_rewrite_event_count(&repo, "\"commit_amend\"", 1);
+    assert_eq!(
+        amend_events, 1,
+        "pure trace socket mode should emit exactly one commit_amend rewrite event for --amend --no-edit"
+    );
+}
+
 #[test]
 #[serial]
 fn daemon_pure_trace_socket_rebase_abort_emits_abort_event() {

--- a/tests/integration/amend.rs
+++ b/tests/integration/amend.rs
@@ -572,6 +572,119 @@ fn test_amend_preserves_custom_attributes_from_config() {
     ]);
 }
 
+/// Regression test: `git commit --amend --no-edit` should be tracked the same as
+/// `git commit --amend -m "..."`. The `--no-edit` flag tells git to reuse the
+/// existing commit message without opening an editor, but git-ai must still
+/// detect the amend, run the rewrite pipeline, and preserve AI authorship.
+#[test]
+fn test_amend_no_edit_preserves_ai_attribution() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("test.txt");
+
+    // Initial file with human content
+    file.set_contents(crate::lines![
+        "line 1", "line 2", "line 3", "line 4", "line 5"
+    ]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // AI adds lines in the middle
+    file.insert_at(
+        2,
+        crate::lines!["// AI inserted line 1".ai(), "// AI inserted line 2".ai()],
+    );
+
+    // Amend with --no-edit (should behave identically to -m)
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"])
+        .expect("amend --no-edit should succeed");
+
+    // Verify AI authorship is preserved after amend --no-edit
+    file.assert_lines_and_blame(crate::lines![
+        "line 1".human(),
+        "line 2".human(),
+        "// AI inserted line 1".ai(),
+        "// AI inserted line 2".ai(),
+        "line 3".human(),
+        "line 4".human(),
+        "line 5".human()
+    ]);
+}
+
+/// Regression test: `git commit --amend --no-edit` with only AI content should
+/// produce an authorship note on the amended commit.
+#[test]
+fn test_amend_no_edit_creates_authorship_note() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("code.txt");
+
+    // Initial commit with AI content
+    file.set_contents(crate::lines!["fn main() {}".ai()]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let original_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(
+        repo.read_authorship_note(&original_sha).is_some(),
+        "original commit should have authorship note"
+    );
+
+    // Add more AI content and amend with --no-edit
+    file.insert_at(1, crate::lines!["fn helper() {}".ai()]);
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"])
+        .expect("amend --no-edit should succeed");
+
+    let amended_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(original_sha, amended_sha, "amend should create new SHA");
+    assert!(
+        repo.read_authorship_note(&amended_sha).is_some(),
+        "amended commit (--no-edit) should have authorship note"
+    );
+
+    // Verify the content and attribution
+    file.assert_lines_and_blame(crate::lines!["fn main() {}".ai(), "fn helper() {}".ai()]);
+}
+
+/// Regression test: repeated amend --no-edit cycles should preserve attribution
+/// exactly the same as amend with -m.
+#[test]
+fn test_amend_no_edit_repeated_round_trips() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("code.js");
+
+    file.set_contents(crate::lines![
+        "function example() {".ai(),
+        "  return 42;".ai(),
+        "}".ai()
+    ]);
+    repo.stage_all_and_commit("Add example function").unwrap();
+
+    // First amend with --no-edit
+    file.insert_at(0, crate::lines!["// Header comment".ai()]);
+    file.insert_at(2, crate::lines!["  // Added documentation".ai()]);
+    file.insert_at(5, crate::lines!["// Footer".ai()]);
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"])
+        .expect("first amend --no-edit should succeed");
+
+    // Second amend with --no-edit
+    file.insert_at(0, crate::lines!["// Human TODO".human()]);
+    file.insert_at(7, crate::lines!["// AI trailing note".ai()]);
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"])
+        .expect("second amend --no-edit should succeed");
+
+    file.assert_lines_and_blame(crate::lines![
+        "// Human TODO".human(),
+        "// Header comment".ai(),
+        "function example() {".ai(),
+        "  // Added documentation".ai(),
+        "  return 42;".ai(),
+        "}".ai(),
+        "// Footer".ai(),
+        "// AI trailing note".ai()
+    ]);
+}
+
 crate::reuse_tests_in_worktree!(
     test_amend_add_lines_at_top,
     test_amend_add_lines_in_middle,
@@ -584,4 +697,7 @@ crate::reuse_tests_in_worktree!(
     test_amend_with_partially_staged_mixed_content,
     test_amend_with_unstaged_middle_section,
     test_amend_repeated_round_trips_preserve_exact_line_authorship,
+    test_amend_no_edit_preserves_ai_attribution,
+    test_amend_no_edit_creates_authorship_note,
+    test_amend_no_edit_repeated_round_trips,
 );


### PR DESCRIPTION
## Summary

Adds regression tests for a user-reported issue where `git commit --amend --no-edit` was not properly tracked by git-ai. Tests cover both the sync wrapper mode (integration tests) and daemon pure-trace mode.

**Integration tests** (`tests/integration/amend.rs`):
- `test_amend_no_edit_preserves_ai_attribution` — mirrors `test_amend_add_lines_in_middle` but uses `--no-edit` instead of `-m`; verifies human/AI line attribution survives the amend
- `test_amend_no_edit_creates_authorship_note` — verifies the authorship note is copied to the new amended commit SHA
- `test_amend_no_edit_repeated_round_trips` — two successive `--amend --no-edit` cycles with mixed human/AI insertions
- All three are included in `reuse_tests_in_worktree!` for worktree variant coverage (6 tests total)

**Daemon mode test** (`tests/daemon_mode.rs`):
- `daemon_pure_trace_socket_amend_no_edit_emits_rewrite_event` — verifies the daemon emits a `commit_amend` rewrite event when observing `--amend --no-edit` via trace2

**Note:** All tests pass on current `main`. No production code fix is included because the sync wrapper and daemon trace2 paths both handle `--no-edit` correctly today.

## Review & Testing Checklist for Human

- [ ] **Determine if additional investigation is needed**: all tests pass, meaning the user-reported bug may involve a scenario not covered here (e.g., specific git version, async-mode wrapper path end-to-end with authorship, or environment-specific behavior). Consider whether the user can provide a repro or more details.
- [ ] **Verify daemon test covers enough**: the daemon test only asserts that a `commit_amend` rewrite event is emitted — it does **not** verify end-to-end authorship rewriting in daemon mode. The existing `daemon_pure_trace_socket_write_mode_applies_amend_rewrite` test for `-m` has the same scope, so this is consistent, but worth noting.
- [ ] **Spot-check `test_amend_no_edit_repeated_round_trips` index math**: multiple `insert_at` calls shift line indices; confirm the expected blame output on lines 679–688 matches the actual file state after all insertions.

### Notes
- The three integration tests are structurally identical to existing `--amend -m` tests but substituting `--no-edit`. This ensures `--no-edit` can never regress independently of `-m` in the future.

Link to Devin session: https://app.devin.ai/sessions/a1b2ff33104d4a409dde9499dbe82452
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
