### PR TITLE
fix: disable PowerShell progress bar during download to fix extreme slowness

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -419,7 +419,15 @@ function Try-Download {
         [Parameter(Mandatory = $true)][string]$Url
     )
     try {
-        Invoke-WebRequest -Uri $Url -OutFile $tmpFile -UseBasicParsing -ErrorAction Stop
+        # Disable progress bar to avoid extreme slowdown caused by PowerShell's
+        # progress-stream rendering (can make downloads 10-50x slower).
+        $oldProgressPreference = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest -Uri $Url -OutFile $tmpFile -UseBasicParsing -ErrorAction Stop
+        } finally {
+            $ProgressPreference = $oldProgressPreference
+        }
         return $true
     } catch {
         return $false


### PR DESCRIPTION
## Summary

Fixes extremely slow Windows binary downloads (~45s for ~16MB) caused by PowerShell's `Invoke-WebRequest` progress bar rendering. Linux downloads the same binary in ~2s using `curl`.

The root cause is that `Invoke-WebRequest` renders a progress stream by default ("Writing web request / Writing request stream..."), and each progress update involves expensive UI rendering that slows downloads by 10-50x. The fix sets `$ProgressPreference = 'SilentlyContinue'` around the download call, with a `try/finally` to restore the original value.

## Review & Testing Checklist for Human

- [ ] **Test on Windows**: Run the install script on a Windows machine (ideally the same AWS environment where the 45s download was observed) and verify download completes in a few seconds instead of ~45s
- [ ] Verify that if the download fails (e.g., bad URL), the `$ProgressPreference` is still correctly restored to its original value (the `finally` block handles this)

### Notes
- This is a [well-documented PowerShell issue](https://github.com/PowerShell/PowerShell/issues/2138) — disabling the progress bar is the standard fix
- The Linux installer uses `curl` which doesn't have this problem, explaining the platform discrepancy

Link to Devin session: https://app.devin.ai/sessions/26061e719c09420ba1b522f533a5e482
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
