### PR TITLE
chore: change dependabot schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
 
@@ -12,7 +12,7 @@ updates:
     directory: "/agent-support/vscode"
     target-branch: "main"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(vscode-plugin)"
 
@@ -20,7 +20,7 @@ updates:
     directory: "/agent-support/opencode"
     target-branch: "main"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(opencode-plugin)"
 
@@ -28,7 +28,7 @@ updates:
     directory: "/agent-support/intellij"
     target-branch: "main"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore(intellij-plugin)"
 


### PR DESCRIPTION
## Summary

Changes the Dependabot update schedule from `daily` to `weekly` for the four ecosystems that were still on daily: cargo, npm (vscode plugin), npm (opencode plugin), and gradle (intellij plugin). The `github-actions` ecosystem was already on `weekly` and is unchanged.

## Review & Testing Checklist for Human

- [ ] Confirm weekly cadence is desired for **all** ecosystems (cargo, both npm, gradle) — not just some of them

### Notes

No code changes; config-only. Takes effect on next Dependabot scheduling cycle.

Link to Devin session: https://app.devin.ai/sessions/85341e13c58e41479db3227e56272420
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
