### PR TITLE
feat: return ok=true with git_repo=false when bg status is run outside a git repo

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -375,12 +375,17 @@ fn spawn_daemon_run_with_piped_stderr(
 }
 
 fn handle_status(repo_working_dir: String) -> Result<(), String> {
+    let config = daemon_config_from_env_or_default_paths()?;
+
     // Check if the path is inside a git repository before contacting the daemon.
-    // When run outside a git repo, return a successful response indicating so.
+    // When run outside a git repo, still check daemon health but skip the
+    // family-level status query which requires a valid repo.
     if crate::git::find_repository_in_path(&repo_working_dir).is_err() {
+        let daemon_running = daemon_is_up(&config);
         let response = serde_json::json!({
             "ok": true,
             "git_repo": false,
+            "daemon_running": daemon_running,
         });
         println!(
             "{}",
@@ -389,7 +394,6 @@ fn handle_status(repo_working_dir: String) -> Result<(), String> {
         return Ok(());
     }
 
-    let config = daemon_config_from_env_or_default_paths()?;
     let request = ControlRequest::StatusFamily { repo_working_dir };
     let response =
         send_control_request(&config.control_socket_path, &request).map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary

When `git ai bg status` is run outside a git repository, it previously returned `ok: false` with a `git rev-parse` error from the daemon. This change adds an early check in the client-side `handle_status` function: before contacting the daemon, it verifies the path is inside a git repo using `find_repository_in_path`. If not, it skips the family-level status query but still checks daemon health via `daemon_is_up`, returning:

```json
{
  "ok": true,
  "git_repo": false,
  "daemon_running": true
}
```

Normal in-repo behavior is unchanged.

## Review & Testing Checklist for Human

- [ ] **Response shape consistency**: The early-return response (`{ "ok": true, "git_repo": false, "daemon_running": bool }`) is a different shape than the normal `ControlResponse` (`{ "ok", "seq", "data", "error" }`). Verify that all consumers of `bg status` output can handle this divergent schema, or decide if `git_repo`/`daemon_running` should be nested inside the standard `ControlResponse` structure instead.
- [ ] **Error conflation**: `find_repository_in_path(...).is_err()` treats _any_ error (permissions, git binary missing, corrupt repo, etc.) as "not a git repo." Consider whether some errors should still surface as failures rather than being silently mapped to `git_repo: false`.
- [ ] **Manual test**: Run `git ai bg status` from `/` or `/tmp` (outside any repo) and confirm the new JSON output includes `daemon_running`. Then run it inside a repo and confirm normal behavior is unchanged.

### Notes
- `daemon_is_up` checks socket connectivity (control + trace sockets respond within 100ms); it does not issue a full control request.
- No new tests were added for this path. The daemon integration tests don't cover the client-side early return.

Link to Devin session: https://app.devin.ai/sessions/37f5a9c05ad346f587f3cf512e4e58f5
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
