### PR TITLE
fix: filter Sentry events to only capture plugin errors in JetBrains plugin

### DIFF
--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -8,9 +8,11 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.extensions.PluginId
 import com.posthog.java.PostHog as PostHogClient
+import io.sentry.Hint
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
+import io.sentry.SentryOptions
 import io.sentry.protocol.Message
 import java.io.File
 
@@ -32,6 +34,19 @@ class TelemetryService : Disposable {
         private const val POSTHOG_HOST = "https://us.i.posthog.com"
         private const val SENTRY_DSN = "https://8316e787580a70ad21e7158027caf849@o4510273204649984.ingest.us.sentry.io/4510812879060992"
         private const val PLUGIN_ID = "com.usegitai.plugins.jetbrains"
+
+        /**
+         * Package prefixes used to identify events originating from our plugin.
+         * Events with stack frames matching these prefixes are sent to Sentry;
+         * all other JVM exceptions (e.g. JetBrains internal errors) are dropped.
+         */
+        private val PLUGIN_PACKAGE_PREFIXES = listOf(
+            "org.jetbrains.plugins.template",
+            "com.usegitai"
+        )
+
+        /** Tag key set on events we create directly (not from uncaught exceptions). */
+        private const val PLUGIN_EVENT_TAG = "git_ai_plugin_event"
 
         fun getInstance(): TelemetryService = service()
     }
@@ -68,11 +83,36 @@ class TelemetryService : Disposable {
                 options.tracesSampleRate = 0.3
                 options.setTag("ide", "intellij")
                 options.setTag("ide_version", ApplicationInfo.getInstance().fullVersion)
+
+                // Filter out events that don't originate from our plugin.
+                // Since the plugin runs in the same JVM as the IDE, Sentry would
+                // otherwise capture JetBrains internal errors as well.
+                options.beforeSend = SentryOptions.BeforeSendCallback { event: SentryEvent, _: Hint ->
+                    if (isPluginEvent(event)) event else null
+                }
             }
             sentryInitialized = true
             logger.info("Sentry initialized")
         } catch (e: Exception) {
             logger.warn("Failed to initialize Sentry: ${e.message}")
+        }
+    }
+
+    /**
+     * Returns true if the event was explicitly sent by our plugin (tagged) or if
+     * any exception in the event has a stack frame from our plugin packages.
+     */
+    private fun isPluginEvent(event: SentryEvent): Boolean {
+        // Events we send ourselves are tagged
+        if (event.getTag(PLUGIN_EVENT_TAG) != null) return true
+
+        // Check exception stack traces for our package prefixes
+        val exceptions = event.exceptions ?: return false
+        return exceptions.any { exception ->
+            exception.stacktrace?.frames?.any { frame ->
+                val module = frame.module ?: return@any false
+                PLUGIN_PACKAGE_PREFIXES.any { prefix -> module.startsWith(prefix) }
+            } ?: false
         }
     }
 
@@ -213,6 +253,7 @@ class TelemetryService : Disposable {
         if (sentryInitialized) {
             try {
                 Sentry.captureException(throwable) { scope ->
+                    scope.setTag(PLUGIN_EVENT_TAG, "true")
                     context.forEach { (key, value) ->
                         scope.setExtra(key, value)
                     }
@@ -241,6 +282,7 @@ class TelemetryService : Disposable {
             val event = SentryEvent().apply {
                 this.message = Message().apply { this.message = message }
                 this.level = level
+                setTag(PLUGIN_EVENT_TAG, "true")
                 context.forEach { (key, value) ->
                     setExtra(key, value)
                 }


### PR DESCRIPTION
## Summary

Since the JetBrains plugin runs in the same JVM as the IDE, our Sentry instance was capturing all uncaught JVM exceptions — including JetBrains internal errors. This adds a `beforeSend` filter to drop events that don't originate from our plugin.

**How the filter works:**
- Events we send explicitly (`captureError`, `captureSentryMessage`) are tagged with `git_ai_plugin_event` and always pass through.
- For uncaught exceptions, the filter checks whether any exception stack frame has a `module` matching our plugin package prefixes (`org.jetbrains.plugins.template`, `com.usegitai`). If not, the event is dropped.

## Review & Testing Checklist for Human

- [ ] **Verify `frame.module` behavior**: Confirm that the Sentry Java SDK populates `SentryStackFrame.module` with the Java package/class name for JVM stack traces. If it uses a different field (e.g., `filename`, `absPath`), the filter would silently drop all uncaught exceptions including our own.
- [ ] **Events with no exceptions and no tag are dropped**: `isPluginEvent` returns `false` if there are no exceptions and no tag. Verify this won't accidentally filter out Sentry performance transactions or other non-error event types we care about. (`beforeSend` should only apply to error events, not transactions, per the Sentry SDK docs — but worth confirming.)
- [ ] **Test plan**: Install the plugin in a JetBrains IDE, trigger a known plugin error (e.g., point to a bad `git-ai` binary path), and confirm it appears in Sentry. Then cause an unrelated IDE exception and confirm it does *not* appear. Monitor Sentry for a day after deploy to verify legitimate errors still come through and noise has dropped.

### Notes
- The plugin package is still `org.jetbrains.plugins.template` (from the IntelliJ plugin template). If this ever gets renamed, `PLUGIN_PACKAGE_PREFIXES` will need updating.

Link to Devin session: https://app.devin.ai/sessions/f9e14cd498a843fa87644b4862e9c139
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
