### PR TITLE
Security: Harden generated CI workflows with version pinning and integrity checks

### DIFF
--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -115,7 +115,8 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
 }
 
 /// Install or update the GitHub Actions workflow in the current repository
-/// Writes the embedded template to .github/workflows/git-ai.yaml at the repo root
+/// Writes the embedded template to .github/workflows/git-ai.yaml at the repo root,
+/// pinned to the current git-ai version for supply chain security.
 pub fn install_github_ci_workflow() -> Result<PathBuf, GitAiError> {
     // Discover repository at current working directory
     let repo = find_repository_in_path(".")?;
@@ -126,10 +127,82 @@ pub fn install_github_ci_workflow() -> Result<PathBuf, GitAiError> {
     fs::create_dir_all(&workflows_dir)
         .map_err(|e| GitAiError::Generic(format!("Failed to create workflows dir: {}", e)))?;
 
+    // Pin template to current git-ai version
+    let version = format!("v{}", env!("CARGO_PKG_VERSION"));
+    let workflow_content = GITHUB_CI_TEMPLATE_YAML.replace("__GIT_AI_VERSION__", &version);
+
     // Write template
     let dest_path = workflows_dir.join("git-ai.yaml");
-    fs::write(&dest_path, GITHUB_CI_TEMPLATE_YAML)
+    fs::write(&dest_path, workflow_content)
         .map_err(|e| GitAiError::Generic(format!("Failed to write workflow file: {}", e)))?;
 
     Ok(dest_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_github_ci_template_yaml_not_empty() {
+        assert!(
+            !GITHUB_CI_TEMPLATE_YAML.is_empty(),
+            "GitHub CI template YAML should not be empty"
+        );
+    }
+
+    #[test]
+    fn test_github_ci_template_contains_version_placeholder() {
+        assert!(
+            GITHUB_CI_TEMPLATE_YAML.contains("__GIT_AI_VERSION__"),
+            "GitHub CI template should contain __GIT_AI_VERSION__ placeholder"
+        );
+    }
+
+    #[test]
+    fn test_github_ci_template_no_curl_pipe_bash() {
+        // Ensure the template doesn't use the insecure `curl | bash` pattern
+        assert!(
+            !GITHUB_CI_TEMPLATE_YAML.contains("| bash"),
+            "GitHub CI template should not pipe curl directly to bash"
+        );
+        assert!(
+            !GITHUB_CI_TEMPLATE_YAML.contains("| sh"),
+            "GitHub CI template should not pipe curl directly to sh"
+        );
+    }
+
+    #[test]
+    fn test_github_ci_template_uses_release_url() {
+        assert!(
+            GITHUB_CI_TEMPLATE_YAML.contains("github.com/git-ai-project/git-ai/releases/download"),
+            "GitHub CI template should download install script from GitHub releases"
+        );
+    }
+
+    #[test]
+    fn test_github_ci_template_has_version_verification() {
+        assert!(
+            GITHUB_CI_TEMPLATE_YAML.contains("version mismatch"),
+            "GitHub CI template should verify installed version"
+        );
+    }
+
+    #[test]
+    fn test_github_ci_template_version_replacement() {
+        let version = format!("v{}", env!("CARGO_PKG_VERSION"));
+        let rendered = GITHUB_CI_TEMPLATE_YAML.replace("__GIT_AI_VERSION__", &version);
+
+        // Placeholder should be gone
+        assert!(
+            !rendered.contains("__GIT_AI_VERSION__"),
+            "Rendered template should not contain placeholder"
+        );
+
+        // Version should appear
+        assert!(
+            rendered.contains(&version),
+            "Rendered template should contain the pinned version"
+        );
+    }
 }

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -275,11 +275,14 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
     }))
 }
 
-/// Print the GitLab CI YAML snippet to stdout for users to copy into their .gitlab-ci.yml
+/// Print the GitLab CI YAML snippet to stdout for users to copy into their .gitlab-ci.yml,
+/// pinned to the current git-ai version for supply chain security.
 pub fn print_gitlab_ci_yaml() {
+    let version = format!("v{}", env!("CARGO_PKG_VERSION"));
+    let yaml = GITLAB_CI_TEMPLATE_YAML.replace("__GIT_AI_VERSION__", &version);
     println!("Add the following to your .gitlab-ci.yml:");
     println!();
-    println!("{}", GITLAB_CI_TEMPLATE_YAML);
+    println!("{}", yaml);
 }
 
 #[cfg(test)]
@@ -348,6 +351,57 @@ mod tests {
         assert!(
             !GITLAB_CI_TEMPLATE_YAML.is_empty(),
             "GitLab CI template YAML should not be empty"
+        );
+    }
+
+    #[test]
+    fn test_gitlab_ci_template_contains_version_placeholder() {
+        assert!(
+            GITLAB_CI_TEMPLATE_YAML.contains("__GIT_AI_VERSION__"),
+            "GitLab CI template should contain __GIT_AI_VERSION__ placeholder"
+        );
+    }
+
+    #[test]
+    fn test_gitlab_ci_template_no_curl_pipe_bash() {
+        assert!(
+            !GITLAB_CI_TEMPLATE_YAML.contains("| bash"),
+            "GitLab CI template should not pipe curl directly to bash"
+        );
+        assert!(
+            !GITLAB_CI_TEMPLATE_YAML.contains("| sh"),
+            "GitLab CI template should not pipe curl directly to sh"
+        );
+    }
+
+    #[test]
+    fn test_gitlab_ci_template_uses_release_url() {
+        assert!(
+            GITLAB_CI_TEMPLATE_YAML.contains("github.com/git-ai-project/git-ai/releases/download"),
+            "GitLab CI template should download install script from GitHub releases"
+        );
+    }
+
+    #[test]
+    fn test_gitlab_ci_template_has_version_verification() {
+        assert!(
+            GITLAB_CI_TEMPLATE_YAML.contains("version mismatch"),
+            "GitLab CI template should verify installed version"
+        );
+    }
+
+    #[test]
+    fn test_gitlab_ci_template_version_replacement() {
+        let version = format!("v{}", env!("CARGO_PKG_VERSION"));
+        let rendered = GITLAB_CI_TEMPLATE_YAML.replace("__GIT_AI_VERSION__", &version);
+
+        assert!(
+            !rendered.contains("__GIT_AI_VERSION__"),
+            "Rendered template should not contain placeholder"
+        );
+        assert!(
+            rendered.contains(&version),
+            "Rendered template should contain the pinned version"
         );
     }
 }

--- a/src/ci/workflow_templates/github.yaml
+++ b/src/ci/workflow_templates/github.yaml
@@ -11,11 +11,25 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      GIT_AI_VERSION: "__GIT_AI_VERSION__"
+
     steps:
       - name: Install git-ai
         run: |
-          curl -fsSL https://usegitai.com/install.sh | bash
+          curl -fsSL "https://github.com/git-ai-project/git-ai/releases/download/${GIT_AI_VERSION}/install.sh" -o /tmp/git-ai-install.sh
+          bash /tmp/git-ai-install.sh
           echo "$HOME/.git-ai/bin" >> $GITHUB_PATH
+
+      - name: Verify git-ai installation
+        run: |
+          INSTALLED=$(git-ai --version)
+          EXPECTED="${GIT_AI_VERSION#v}"
+          if [ "$INSTALLED" != "$EXPECTED" ]; then
+            echo "::error::git-ai version mismatch: expected $EXPECTED, got $INSTALLED"
+            exit 1
+          fi
+
       - name: Run git-ai
         id: run-git-ai
         env:

--- a/src/ci/workflow_templates/gitlab.yaml
+++ b/src/ci/workflow_templates/gitlab.yaml
@@ -17,13 +17,22 @@
 
 git-ai:
   stage: build
+  variables:
+    GIT_AI_VERSION: "__GIT_AI_VERSION__"
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_PIPELINE_SOURCE == "push"
       when: always
   script:
-    - curl -fsSL https://usegitai.com/install.sh | bash
+    - curl -fsSL "https://github.com/git-ai-project/git-ai/releases/download/${GIT_AI_VERSION}/install.sh" -o /tmp/git-ai-install.sh
+    - bash /tmp/git-ai-install.sh
     - export PATH="$HOME/.git-ai/bin:$PATH"
+    - |
+      INSTALLED=$(git-ai --version)
+      EXPECTED="${GIT_AI_VERSION#v}"
+      if [ "$INSTALLED" != "$EXPECTED" ]; then
+        echo "ERROR: git-ai version mismatch: expected $EXPECTED, got $INSTALLED"
+        exit 1
+      fi
     - git config --global user.name "gitlab-ci[bot]"
     - git config --global user.email "gitlab-ci[bot]@users.noreply.gitlab.com"
     - git-ai ci gitlab run
-


### PR DESCRIPTION
## Summary

Hardens the CI workflow templates generated by `git-ai ci github install` and `git-ai ci gitlab install` to address supply chain security risks identified in #920.

### Changes

**Workflow templates** (`github.yaml`, `gitlab.yaml`):
- Replace `curl -fsSL https://usegitai.com/install.sh | bash` with **download-then-execute** from version-pinned GitHub Release install scripts
- Add `GIT_AI_VERSION` environment variable for explicit version pinning
- Add **post-install version verification** step that fails the job on mismatch
- Checksum verification happens automatically via the release install script's embedded SHA-256 checksums

**Rust code** (`github.rs`, `gitlab.rs`):
- `install_github_ci_workflow()` now injects the current git-ai version into the template placeholder
- `print_gitlab_ci_yaml()` now injects the current git-ai version into the template placeholder
- Added 11 new tests covering: template integrity, no `curl | bash` pattern, release URL usage, version verification presence, and placeholder replacement

### Security improvements

| Concern from #920 | Resolution |
|---|---|
| Unpinned `curl \| bash` from remote URL | Now downloads version-pinned install script from GitHub Releases |
| No version pinning | `GIT_AI_VERSION` pinned to the version of git-ai that generated the workflow |
| No checksum verification | Release install scripts have embedded SHA-256 checksums (already implemented) |
| Download-then-execute | Install script saved to file before execution |

### What was already in place (no changes needed)

- `SHA256SUMS` published with each GitHub Release
- Build provenance attestation via `actions/attest-build-provenance`
- `install.sh` has `EMBEDDED_CHECKSUMS` and `verify_checksum()` logic
- `upgrade.rs` has full checksum chain verification

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 23 CI module tests pass (12 existing + 11 new)
- [ ] CI passes on this PR

Closes #920
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
