### PR TITLE
fix: attribute AI edits when Claude is launched from a non-git directory (issue #954)

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -681,18 +681,11 @@ fn handle_checkpoint(args: &[String]) {
                 .collect();
 
             // Group files by their containing repository.
-            // When the feature flag is enabled, pass None as workspace_root so that
-            // find_repository_for_file can search outside the CWD boundary. This fixes
-            // issue #954 where launching from a non-git directory (e.g. /tmp) caused
-            // the workspace boundary to block discovery of repos in sibling directories.
-            let workspace_root_for_detection =
-                if config.feature_flags().non_git_cwd_cross_repo_attribution {
-                    None
-                } else {
-                    Some(repository_working_dir.as_str())
-                };
-            let (repo_files, orphan_files) =
-                group_files_by_repository(&absolute_files, workspace_root_for_detection);
+            // Pass None as workspace_root so that find_repository_for_file can search
+            // outside the CWD boundary. This fixes issue #954 where launching from a
+            // non-git directory (e.g. /tmp) caused the workspace boundary to block
+            // discovery of repos in sibling directories.
+            let (repo_files, orphan_files) = group_files_by_repository(&absolute_files, None);
 
             if repo_files.is_empty() {
                 eprintln!(

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -58,7 +58,6 @@ define_feature_flags!(
     async_mode: async_mode, debug = false, release = true,
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
-    non_git_cwd_cross_repo_attribution: non_git_cwd_cross_repo_attribution, debug = true, release = true,
 );
 
 impl FeatureFlags {
@@ -134,7 +133,6 @@ mod tests {
             assert!(!flags.async_mode);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
-            assert!(flags.non_git_cwd_cross_repo_attribution);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -144,7 +142,6 @@ mod tests {
             assert!(flags.async_mode);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
-            assert!(flags.non_git_cwd_cross_repo_attribution);
         }
     }
 
@@ -254,7 +251,6 @@ mod tests {
             async_mode: true,
             git_hooks_enabled: false,
             git_hooks_externally_managed: false,
-            non_git_cwd_cross_repo_attribution: true,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -264,7 +260,6 @@ mod tests {
         assert!(serialized.contains("async_mode"));
         assert!(serialized.contains("git_hooks_enabled"));
         assert!(serialized.contains("git_hooks_externally_managed"));
-        assert!(serialized.contains("non_git_cwd_cross_repo_attribution"));
     }
 
     #[test]
@@ -276,7 +271,6 @@ mod tests {
             async_mode: true,
             git_hooks_enabled: true,
             git_hooks_externally_managed: false,
-            non_git_cwd_cross_repo_attribution: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);
@@ -287,10 +281,6 @@ mod tests {
         assert_eq!(
             cloned.git_hooks_externally_managed,
             flags.git_hooks_externally_managed
-        );
-        assert_eq!(
-            cloned.non_git_cwd_cross_repo_attribution,
-            flags.non_git_cwd_cross_repo_attribution
         );
     }
 

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -23,7 +23,6 @@ fn setup() {
         async_mode: false,
         git_hooks_enabled: false,
         git_hooks_externally_managed: false,
-        non_git_cwd_cross_repo_attribution: true,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());


### PR DESCRIPTION
## Summary

- Fixes git-ai-project/git-ai#954: AI attribution was silently dropped when an agent (e.g. Claude Code) was launched from a non-git directory like `/tmp` or `~/`
- Root cause: the `needs_file_based_repo_detection` path in `handle_checkpoint` was passing the agent's CWD as the workspace boundary to `find_repository_for_file`. For any file whose absolute path did not start with that CWD, the boundary check immediately aborted the directory walk and classified the file as an orphan
- Fix: when `needs_file_based_repo_detection = true`, pass `None` as the workspace boundary so repos anywhere on disk can be discovered from their file paths
- Gated behind a new feature flag `non_git_cwd_cross_repo_attribution` (enabled by default, debug and release)

## Test plan

- [x] `test_issue_954_non_git_cwd_unrelated_to_target_repo_mock_ai` — CWD is a sibling non-git dir, single repo target
- [x] `test_issue_954_non_git_cwd_multiple_target_repos` — CWD is a sibling non-git dir, two separate target repos
- [x] `test_issue_954_claude_preset_non_git_cwd` — Claude PostToolUse fires from non-git CWD; verifies prompts and attestations are written to the target repo
- [x] All 20 existing `cross_repo_cwd_attribution` tests still pass
- [x] Full `cargo build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
