### PR TITLE
fix: preserve AI attribution through git revert and revert-of-revert (ISSUE-004, 015)

### DIFF
--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -11,6 +11,7 @@ use crate::commands::hooks::merge_hooks;
 use crate::commands::hooks::push_hooks;
 use crate::commands::hooks::rebase_hooks;
 use crate::commands::hooks::reset_hooks;
+use crate::commands::hooks::revert_hooks;
 use crate::commands::hooks::stash_hooks;
 use crate::commands::hooks::switch_hooks;
 use crate::commands::hooks::update_ref_hooks;
@@ -98,6 +99,8 @@ pub struct CommandHooksContext {
     /// VirtualAttributions captured before a pull --rebase --autostash operation.
     /// Used to preserve uncommitted AI attributions that git's internal stash would lose.
     pub stashed_va: Option<VirtualAttributions>,
+    /// HEAD SHA captured before a revert operation, used by post_revert_hook.
+    pub revert_original_head: Option<String>,
 }
 
 pub fn handle_git(args: &[String]) {
@@ -231,6 +234,7 @@ pub fn handle_git(args: &[String]) {
             stash_sha: None,
             push_authorship_handle: None,
             stashed_va: None,
+            revert_original_head: None,
         };
 
         let repository = repository_option.as_mut().unwrap();
@@ -440,6 +444,9 @@ fn run_pre_command_hooks(
                     command_hooks_context,
                 );
             }
+            Some("revert") => {
+                revert_hooks::pre_revert_hook(parsed_args, repository, command_hooks_context);
+            }
             Some("push") => {
                 command_hooks_context.push_authorship_handle =
                     push_hooks::push_pre_command_hook(parsed_args, repository);
@@ -534,6 +541,12 @@ fn run_post_command_hooks(
                 exit_status,
                 repository,
             ),
+            Some("revert") => revert_hooks::post_revert_hook(
+                command_hooks_context,
+                parsed_args,
+                exit_status,
+                repository,
+            ),
             Some("stash") => {
                 let config = config::Config::get();
 
@@ -614,6 +627,7 @@ fn command_uses_managed_hooks(command: Option<&str>) -> bool {
             "commit"
                 | "rebase"
                 | "cherry-pick"
+                | "revert"
                 | "reset"
                 | "stash"
                 | "merge"

--- a/src/commands/hooks/mod.rs
+++ b/src/commands/hooks/mod.rs
@@ -8,6 +8,7 @@ pub mod plumbing_rewrite_hooks;
 pub mod push_hooks;
 pub mod rebase_hooks;
 pub mod reset_hooks;
+pub mod revert_hooks;
 pub mod stash_hooks;
 pub mod switch_hooks;
 pub mod update_ref_hooks;

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -266,7 +266,10 @@ fn is_revert_commit(repository: &Repository, commit_sha: &str) -> bool {
                 "Commit {} is_revert_commit: {} (summary: {:?})",
                 commit_sha,
                 is_revert,
-                &summary[..summary.len().min(40)]
+                &summary[..summary
+                    .char_indices()
+                    .nth(40)
+                    .map_or(summary.len(), |(i, _)| i)]
             ));
             is_revert
         }

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -1,0 +1,313 @@
+use crate::commands::git_handlers::CommandHooksContext;
+use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
+use crate::git::refs::{get_reference_as_authorship_log_v3, notes_add};
+use crate::git::repository::Repository;
+use crate::git::rewrite_log::{RevertMixedEvent, RewriteLogEvent};
+use crate::utils::debug_log;
+
+/// Pre-revert hook: capture the commit being reverted and store it for the post-hook.
+pub fn pre_revert_hook(
+    _parsed_args: &ParsedGitInvocation,
+    repository: &mut Repository,
+    command_hooks_context: &mut CommandHooksContext,
+) {
+    debug_log("=== REVERT PRE-COMMAND HOOK ===");
+
+    // Capture the current HEAD before the revert
+    if let Ok(head) = repository.head() {
+        if let Ok(target) = head.target() {
+            debug_log(&format!("Pre-revert HEAD: {}", target));
+            command_hooks_context.revert_original_head = Some(target);
+        }
+    }
+}
+
+/// Post-revert hook: copy attribution from the source commit chain to the new revert commit.
+pub fn post_revert_hook(
+    command_hooks_context: &mut CommandHooksContext,
+    parsed_args: &ParsedGitInvocation,
+    exit_status: std::process::ExitStatus,
+    repository: &mut Repository,
+) {
+    debug_log("=== REVERT POST-COMMAND HOOK ===");
+    debug_log(&format!("Exit status: {}", exit_status));
+
+    if !exit_status.success() {
+        debug_log("Revert failed or was aborted, skipping attribution");
+        return;
+    }
+
+    if is_dry_run(&parsed_args.command_args) {
+        debug_log("Skipping revert post-hook for dry-run");
+        return;
+    }
+
+    let original_head = match &command_hooks_context.revert_original_head {
+        Some(head) => head.clone(),
+        None => {
+            debug_log("No original head captured in pre-revert hook");
+            return;
+        }
+    };
+
+    // Get the new HEAD (the revert commit)
+    let new_head = match repository.head() {
+        Ok(head) => match head.target() {
+            Ok(target) => target,
+            Err(e) => {
+                debug_log(&format!("Failed to get HEAD target: {}", e));
+                return;
+            }
+        },
+        Err(e) => {
+            debug_log(&format!("Failed to get HEAD: {}", e));
+            return;
+        }
+    };
+
+    if original_head == new_head {
+        debug_log("HEAD did not change, nothing to do");
+        return;
+    }
+
+    debug_log(&format!(
+        "Revert created new commit: {} (was: {})",
+        new_head, original_head
+    ));
+
+    // The reverted commit is the parent of the new commit that is NOT the original head.
+    // For `git revert <sha>`, the new commit's parent is original_head, and <sha> is what
+    // was reverted. We need to find <sha>.
+    // The reverted commit SHA can be found by looking at the new commit's parent and
+    // working backwards, or by reading REVERT_HEAD (which is gone after successful revert).
+    // The most reliable approach: the reverted commit is original_head's successor if this
+    // was a simple revert. Actually, let's parse from the commit message or args.
+    let reverted_commit = find_reverted_commit(repository, parsed_args, &original_head);
+
+    let reverted_commit = match reverted_commit {
+        Some(sha) => {
+            debug_log(&format!("Reverted commit: {}", sha));
+            sha
+        }
+        None => {
+            debug_log("Could not determine which commit was reverted");
+            return;
+        }
+    };
+
+    // Try to find AI attribution to copy to the new commit.
+    // Strategy:
+    // 1. Check if the reverted commit has an AI note with ai_additions > 0
+    // 2. If not (e.g., it was a revert commit itself with no AI), check its parent
+    //    (one level of chain traversal for revert-of-revert)
+    let source_sha = find_attribution_source(repository, &reverted_commit);
+
+    let source_sha = match source_sha {
+        Some(sha) => {
+            debug_log(&format!("Attribution source commit: {}", sha));
+            sha
+        }
+        None => {
+            debug_log("No AI attribution found in revert chain, skipping");
+            // Still emit the RevertMixed event for logging
+            emit_revert_event(repository, &reverted_commit, &new_head);
+            return;
+        }
+    };
+
+    // Copy the attribution note from source to the new commit
+    copy_attribution_note(repository, &source_sha, &new_head);
+
+    // Emit the RevertMixed event
+    emit_revert_event(repository, &reverted_commit, &new_head);
+
+    debug_log("Revert attribution handling complete");
+}
+
+/// Find the commit that was reverted by parsing args or commit message.
+fn find_reverted_commit(
+    repository: &Repository,
+    parsed_args: &ParsedGitInvocation,
+    _original_head: &str,
+) -> Option<String> {
+    // First, try to find the reverted commit from the command args
+    // `git revert <commit>` — the commit ref is in the args
+    for arg in &parsed_args.command_args {
+        // Skip flags and options
+        if arg.starts_with('-') {
+            continue;
+        }
+        // Skip special keywords
+        if arg == "continue" || arg == "abort" || arg == "quit" || arg == "skip" {
+            continue;
+        }
+
+        // Try to resolve this as a commit SHA
+        let mut args = repository.global_args_for_exec();
+        args.push("rev-parse".to_string());
+        args.push(arg.clone());
+
+        if let Ok(output) = crate::git::repository::exec_git(&args) {
+            let sha = String::from_utf8(output.stdout).ok()?.trim().to_string();
+            if !sha.is_empty() {
+                return Some(sha);
+            }
+        }
+    }
+
+    None
+}
+
+/// Find the commit whose attribution should be used for a revert.
+///
+/// Key insight: reverting an AI commit (which adds AI lines) creates a deletion commit —
+/// no AI attribution should be copied. But reverting a revert (which restores AI lines)
+/// should copy the original AI attribution.
+///
+/// Strategy:
+/// - If the reverted commit HAS AI attribution, this revert is undoing AI work (deletion).
+///   Do NOT copy attribution — the revert removes those lines.
+/// - If the reverted commit has NO AI attribution, it might be a revert commit itself.
+///   Check its parent (one level of chain traversal) for AI attribution to restore.
+fn find_attribution_source(repository: &Repository, reverted_commit: &str) -> Option<String> {
+    if has_ai_attribution(repository, reverted_commit) {
+        // The reverted commit has AI attribution. This means we're undoing AI work
+        // (the revert deletes AI-authored lines). Don't copy any attribution.
+        debug_log(&format!(
+            "Reverted commit {} has AI attribution — this revert undoes AI work, no attribution to copy",
+            reverted_commit
+        ));
+        return None;
+    }
+
+    // The reverted commit has no AI attribution. This might be because:
+    // - It was a revert commit itself (pure deletion → ai_additions=0)
+    // - It was a human-only commit
+    //
+    // For revert-of-revert: check the reverted commit's first parent.
+    // History: ... → A(ai) → B(revert of A, no ai) → C(revert of B, restores A's content)
+    // B's parent is A. If A has AI attribution, copy it to C.
+
+    debug_log(&format!(
+        "Reverted commit {} has no AI attribution, checking parent (revert-of-revert case)",
+        reverted_commit
+    ));
+
+    let parent_sha = get_first_parent(repository, reverted_commit)?;
+
+    debug_log(&format!("Parent of reverted commit: {}", parent_sha));
+
+    if has_ai_attribution(repository, &parent_sha) {
+        return Some(parent_sha);
+    }
+
+    None
+}
+
+/// Check if a commit has an authorship note with ai_additions > 0.
+fn has_ai_attribution(repository: &Repository, commit_sha: &str) -> bool {
+    match get_reference_as_authorship_log_v3(repository, commit_sha) {
+        Ok(log) => {
+            // Check if any prompt record has accepted_lines > 0
+            let has_ai = log.metadata.prompts.values().any(|p| p.accepted_lines > 0);
+            debug_log(&format!(
+                "Commit {} has_ai_attribution: {} (prompts: {})",
+                commit_sha,
+                has_ai,
+                log.metadata.prompts.len()
+            ));
+            has_ai
+        }
+        Err(_) => {
+            debug_log(&format!(
+                "Commit {} has no parseable authorship note",
+                commit_sha
+            ));
+            false
+        }
+    }
+}
+
+/// Get the first parent of a commit.
+fn get_first_parent(repository: &Repository, commit_sha: &str) -> Option<String> {
+    match repository.find_commit(commit_sha.to_string()) {
+        Ok(commit) => {
+            let mut parents = commit.parents();
+            parents.next().map(|p| p.id().to_string())
+        }
+        Err(e) => {
+            debug_log(&format!("Failed to find commit {}: {}", commit_sha, e));
+            None
+        }
+    }
+}
+
+/// Copy an attribution note from one commit to another, updating the base_commit_sha.
+fn copy_attribution_note(repository: &Repository, source_sha: &str, target_sha: &str) {
+    match get_reference_as_authorship_log_v3(repository, source_sha) {
+        Ok(mut log) => {
+            // Update the base_commit_sha to point to the new commit
+            log.metadata.base_commit_sha = target_sha.to_string();
+
+            match log.serialize_to_string() {
+                Ok(serialized) => match notes_add(repository, target_sha, &serialized) {
+                    Ok(_) => {
+                        debug_log(&format!(
+                            "Copied attribution from {} to {}",
+                            source_sha, target_sha
+                        ));
+                    }
+                    Err(e) => {
+                        debug_log(&format!("Failed to add note to {}: {}", target_sha, e));
+                    }
+                },
+                Err(e) => {
+                    debug_log(&format!("Failed to serialize authorship log: {}", e));
+                }
+            }
+        }
+        Err(e) => {
+            debug_log(&format!(
+                "Failed to read authorship log from {}: {}",
+                source_sha, e
+            ));
+        }
+    }
+}
+
+/// Emit a RevertMixed event to the rewrite log.
+fn emit_revert_event(repository: &mut Repository, reverted_commit: &str, new_head: &str) {
+    // Get the list of affected files from the new commit
+    let affected_files = get_affected_files(repository, new_head);
+
+    let event = RewriteLogEvent::revert_mixed(RevertMixedEvent::new(
+        reverted_commit.to_string(),
+        true,
+        affected_files,
+    ));
+
+    match repository.storage.append_rewrite_event(event) {
+        Ok(_) => debug_log("Logged RevertMixed event"),
+        Err(e) => debug_log(&format!("Failed to log RevertMixed event: {}", e)),
+    }
+}
+
+/// Get the list of files affected by a commit.
+fn get_affected_files(repository: &Repository, commit_sha: &str) -> Vec<String> {
+    let mut args = repository.global_args_for_exec();
+    args.push("diff-tree".to_string());
+    args.push("--no-commit-id".to_string());
+    args.push("-r".to_string());
+    args.push("--name-only".to_string());
+    args.push(commit_sha.to_string());
+
+    match crate::git::repository::exec_git(&args) {
+        Ok(output) => String::from_utf8(output.stdout)
+            .unwrap_or_default()
+            .lines()
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -3,7 +3,6 @@ use crate::git::cli_parser::{ParsedGitInvocation, is_dry_run};
 use crate::git::refs::{get_reference_as_authorship_log_v3, notes_add};
 use crate::git::repository::Repository;
 use crate::git::rewrite_log::{RevertMixedEvent, RewriteLogEvent};
-use crate::utils::debug_log;
 
 /// Pre-revert hook: capture the commit being reverted and store it for the post-hook.
 pub fn pre_revert_hook(
@@ -11,13 +10,13 @@ pub fn pre_revert_hook(
     repository: &mut Repository,
     command_hooks_context: &mut CommandHooksContext,
 ) {
-    debug_log("=== REVERT PRE-COMMAND HOOK ===");
+    tracing::debug!("=== REVERT PRE-COMMAND HOOK ===");
 
     // Capture the current HEAD before the revert
     if let Ok(head) = repository.head()
         && let Ok(target) = head.target()
     {
-        debug_log(&format!("Pre-revert HEAD: {}", target));
+        tracing::debug!("Pre-revert HEAD: {}", target);
         command_hooks_context.revert_original_head = Some(target);
     }
 }
@@ -29,23 +28,23 @@ pub fn post_revert_hook(
     exit_status: std::process::ExitStatus,
     repository: &mut Repository,
 ) {
-    debug_log("=== REVERT POST-COMMAND HOOK ===");
-    debug_log(&format!("Exit status: {}", exit_status));
+    tracing::debug!("=== REVERT POST-COMMAND HOOK ===");
+    tracing::debug!("Exit status: {}", exit_status);
 
     if !exit_status.success() {
-        debug_log("Revert failed or was aborted, skipping attribution");
+        tracing::debug!("Revert failed or was aborted, skipping attribution");
         return;
     }
 
     if is_dry_run(&parsed_args.command_args) {
-        debug_log("Skipping revert post-hook for dry-run");
+        tracing::debug!("Skipping revert post-hook for dry-run");
         return;
     }
 
     let original_head = match &command_hooks_context.revert_original_head {
         Some(head) => head.clone(),
         None => {
-            debug_log("No original head captured in pre-revert hook");
+            tracing::debug!("No original head captured in pre-revert hook");
             return;
         }
     };
@@ -55,25 +54,25 @@ pub fn post_revert_hook(
         Ok(head) => match head.target() {
             Ok(target) => target,
             Err(e) => {
-                debug_log(&format!("Failed to get HEAD target: {}", e));
+                tracing::debug!("Failed to get HEAD target: {}", e);
                 return;
             }
         },
         Err(e) => {
-            debug_log(&format!("Failed to get HEAD: {}", e));
+            tracing::debug!("Failed to get HEAD: {}", e);
             return;
         }
     };
 
     if original_head == new_head {
-        debug_log("HEAD did not change, nothing to do");
+        tracing::debug!("HEAD did not change, nothing to do");
         return;
     }
 
-    debug_log(&format!(
+    tracing::debug!(
         "Revert created new commit: {} (was: {})",
         new_head, original_head
-    ));
+    );
 
     // The reverted commit is the parent of the new commit that is NOT the original head.
     // For `git revert <sha>`, the new commit's parent is original_head, and <sha> is what
@@ -86,11 +85,11 @@ pub fn post_revert_hook(
 
     let reverted_commit = match reverted_commit {
         Some(sha) => {
-            debug_log(&format!("Reverted commit: {}", sha));
+            tracing::debug!("Reverted commit: {}", sha);
             sha
         }
         None => {
-            debug_log("Could not determine which commit was reverted");
+            tracing::debug!("Could not determine which commit was reverted");
             return;
         }
     };
@@ -104,11 +103,11 @@ pub fn post_revert_hook(
 
     let source_sha = match source_sha {
         Some(sha) => {
-            debug_log(&format!("Attribution source commit: {}", sha));
+            tracing::debug!("Attribution source commit: {}", sha);
             sha
         }
         None => {
-            debug_log("No AI attribution found in revert chain, skipping");
+            tracing::debug!("No AI attribution found in revert chain, skipping");
             // Still emit the RevertMixed event for logging
             emit_revert_event(repository, &reverted_commit, &new_head);
             return;
@@ -121,7 +120,7 @@ pub fn post_revert_hook(
     // Emit the RevertMixed event
     emit_revert_event(repository, &reverted_commit, &new_head);
 
-    debug_log("Revert attribution handling complete");
+    tracing::debug!("Revert attribution handling complete");
 }
 
 /// Find the commit that was reverted by parsing args or commit message.
@@ -193,10 +192,10 @@ fn find_attribution_source(repository: &Repository, reverted_commit: &str) -> Op
     if has_ai_attribution(repository, reverted_commit) {
         // The reverted commit has AI attribution. This means we're undoing AI work
         // (the revert deletes AI-authored lines). Don't copy any attribution.
-        debug_log(&format!(
+        tracing::debug!(
             "Reverted commit {} has AI attribution — this revert undoes AI work, no attribution to copy",
             reverted_commit
-        ));
+        );
         return None;
     }
 
@@ -210,21 +209,21 @@ fn find_attribution_source(repository: &Repository, reverted_commit: &str) -> Op
     // B's parent is A. If A has AI attribution, copy it to C.
 
     if !is_revert_commit(repository, reverted_commit) {
-        debug_log(&format!(
+        tracing::debug!(
             "Reverted commit {} is not itself a revert commit, skipping parent check",
             reverted_commit
-        ));
+        );
         return None;
     }
 
-    debug_log(&format!(
+    tracing::debug!(
         "Reverted commit {} is a revert commit with no AI attribution, checking parent",
         reverted_commit
-    ));
+    );
 
     let parent_sha = get_first_parent(repository, reverted_commit)?;
 
-    debug_log(&format!("Parent of reverted commit: {}", parent_sha));
+    tracing::debug!("Parent of reverted commit: {}", parent_sha);
 
     if has_ai_attribution(repository, &parent_sha) {
         return Some(parent_sha);
@@ -239,19 +238,19 @@ fn has_ai_attribution(repository: &Repository, commit_sha: &str) -> bool {
         Ok(log) => {
             // Check if any prompt record has accepted_lines > 0
             let has_ai = log.metadata.prompts.values().any(|p| p.accepted_lines > 0);
-            debug_log(&format!(
+            tracing::debug!(
                 "Commit {} has_ai_attribution: {} (prompts: {})",
                 commit_sha,
                 has_ai,
                 log.metadata.prompts.len()
-            ));
+            );
             has_ai
         }
         Err(_) => {
-            debug_log(&format!(
+            tracing::debug!(
                 "Commit {} has no parseable authorship note",
                 commit_sha
-            ));
+            );
             false
         }
     }
@@ -264,7 +263,7 @@ fn is_revert_commit(repository: &Repository, commit_sha: &str) -> bool {
         Ok(commit) => {
             let summary = commit.summary().unwrap_or_default();
             let is_revert = summary.starts_with("Revert ");
-            debug_log(&format!(
+            tracing::debug!(
                 "Commit {} is_revert_commit: {} (summary: {:?})",
                 commit_sha,
                 is_revert,
@@ -272,14 +271,14 @@ fn is_revert_commit(repository: &Repository, commit_sha: &str) -> bool {
                     .char_indices()
                     .nth(40)
                     .map_or(summary.len(), |(i, _)| i)]
-            ));
+            );
             is_revert
         }
         Err(e) => {
-            debug_log(&format!(
+            tracing::debug!(
                 "Failed to read commit message for {}: {}",
                 commit_sha, e
-            ));
+            );
             false
         }
     }
@@ -293,7 +292,7 @@ fn get_first_parent(repository: &Repository, commit_sha: &str) -> Option<String>
             parents.next().map(|p| p.id().to_string())
         }
         Err(e) => {
-            debug_log(&format!("Failed to find commit {}: {}", commit_sha, e));
+            tracing::debug!("Failed to find commit {}: {}", commit_sha, e);
             None
         }
     }
@@ -309,25 +308,25 @@ fn copy_attribution_note(repository: &Repository, source_sha: &str, target_sha: 
             match log.serialize_to_string() {
                 Ok(serialized) => match notes_add(repository, target_sha, &serialized) {
                     Ok(_) => {
-                        debug_log(&format!(
+                        tracing::debug!(
                             "Copied attribution from {} to {}",
                             source_sha, target_sha
-                        ));
+                        );
                     }
                     Err(e) => {
-                        debug_log(&format!("Failed to add note to {}: {}", target_sha, e));
+                        tracing::debug!("Failed to add note to {}: {}", target_sha, e);
                     }
                 },
                 Err(e) => {
-                    debug_log(&format!("Failed to serialize authorship log: {}", e));
+                    tracing::debug!("Failed to serialize authorship log: {}", e);
                 }
             }
         }
         Err(e) => {
-            debug_log(&format!(
+            tracing::debug!(
                 "Failed to read authorship log from {}: {}",
                 source_sha, e
-            ));
+            );
         }
     }
 }
@@ -344,8 +343,8 @@ fn emit_revert_event(repository: &mut Repository, reverted_commit: &str, new_hea
     ));
 
     match repository.storage.append_rewrite_event(event) {
-        Ok(_) => debug_log("Logged RevertMixed event"),
-        Err(e) => debug_log(&format!("Failed to log RevertMixed event: {}", e)),
+        Ok(_) => tracing::debug!("Logged RevertMixed event"),
+        Err(e) => tracing::debug!("Failed to log RevertMixed event: {}", e),
     }
 }
 

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -139,7 +139,7 @@ fn find_reverted_commit(
         if arg.starts_with('-') {
             if matches!(
                 arg.as_str(),
-                "-m" | "--mainline" | "-s" | "--strategy" | "-X" | "--strategy-option"
+                "-m" | "--mainline" | "--strategy" | "-X" | "--strategy-option"
             ) {
                 i += 2; // Skip flag and its value
                 continue;

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -132,13 +132,24 @@ fn find_reverted_commit(
 ) -> Option<String> {
     // First, try to find the reverted commit from the command args
     // `git revert <commit>` — the commit ref is in the args
-    for arg in &parsed_args.command_args {
-        // Skip flags and options
+    let mut i = 0;
+    while i < parsed_args.command_args.len() {
+        let arg = &parsed_args.command_args[i];
+        // Skip flags and their value arguments
         if arg.starts_with('-') {
+            if matches!(
+                arg.as_str(),
+                "-m" | "--mainline" | "-s" | "--strategy" | "-X" | "--strategy-option"
+            ) {
+                i += 2; // Skip flag and its value
+                continue;
+            }
+            i += 1;
             continue;
         }
         // Skip special keywords
         if arg == "continue" || arg == "abort" || arg == "quit" || arg == "skip" {
+            i += 1;
             continue;
         }
 
@@ -148,11 +159,18 @@ fn find_reverted_commit(
         args.push(arg.clone());
 
         if let Ok(output) = crate::git::repository::exec_git(&args) {
-            let sha = String::from_utf8(output.stdout).ok()?.trim().to_string();
+            let sha = match String::from_utf8(output.stdout) {
+                Ok(s) => s.trim().to_string(),
+                Err(_) => {
+                    i += 1;
+                    continue;
+                }
+            };
             if !sha.is_empty() {
                 return Some(sha);
             }
         }
+        i += 1;
     }
 
     None
@@ -167,8 +185,8 @@ fn find_reverted_commit(
 /// Strategy:
 /// - If the reverted commit HAS AI attribution, this revert is undoing AI work (deletion).
 ///   Do NOT copy attribution — the revert removes those lines.
-/// - If the reverted commit has NO AI attribution, it might be a revert commit itself.
-///   Check its parent (one level of chain traversal) for AI attribution to restore.
+/// - If the reverted commit has NO AI attribution AND its commit message indicates it is
+///   itself a revert commit, check its parent for AI attribution to restore.
 fn find_attribution_source(repository: &Repository, reverted_commit: &str) -> Option<String> {
     if has_ai_attribution(repository, reverted_commit) {
         // The reverted commit has AI attribution. This means we're undoing AI work
@@ -180,16 +198,25 @@ fn find_attribution_source(repository: &Repository, reverted_commit: &str) -> Op
         return None;
     }
 
-    // The reverted commit has no AI attribution. This might be because:
-    // - It was a revert commit itself (pure deletion → ai_additions=0)
-    // - It was a human-only commit
+    // The reverted commit has no AI attribution. Only proceed with parent chain
+    // traversal if the reverted commit is itself a revert (checked via commit message).
+    // This prevents false attribution when reverting a normal human commit whose parent
+    // happens to be an AI commit.
     //
     // For revert-of-revert: check the reverted commit's first parent.
     // History: ... → A(ai) → B(revert of A, no ai) → C(revert of B, restores A's content)
     // B's parent is A. If A has AI attribution, copy it to C.
 
+    if !is_revert_commit(repository, reverted_commit) {
+        debug_log(&format!(
+            "Reverted commit {} is not itself a revert commit, skipping parent check",
+            reverted_commit
+        ));
+        return None;
+    }
+
     debug_log(&format!(
-        "Reverted commit {} has no AI attribution, checking parent (revert-of-revert case)",
+        "Reverted commit {} is a revert commit with no AI attribution, checking parent",
         reverted_commit
     ));
 
@@ -222,6 +249,31 @@ fn has_ai_attribution(repository: &Repository, commit_sha: &str) -> bool {
             debug_log(&format!(
                 "Commit {} has no parseable authorship note",
                 commit_sha
+            ));
+            false
+        }
+    }
+}
+
+/// Check if a commit is itself a revert commit by examining its commit message.
+/// `git revert` generates messages starting with "Revert " by default.
+fn is_revert_commit(repository: &Repository, commit_sha: &str) -> bool {
+    match repository.find_commit(commit_sha.to_string()) {
+        Ok(commit) => {
+            let summary = commit.summary().unwrap_or_default();
+            let is_revert = summary.starts_with("Revert ");
+            debug_log(&format!(
+                "Commit {} is_revert_commit: {} (summary: {:?})",
+                commit_sha,
+                is_revert,
+                &summary[..summary.len().min(40)]
+            ));
+            is_revert
+        }
+        Err(e) => {
+            debug_log(&format!(
+                "Failed to read commit message for {}: {}",
+                commit_sha, e
             ));
             false
         }

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -147,10 +147,12 @@ fn find_reverted_commit(
             i += 1;
             continue;
         }
-        // Skip special keywords
-        if arg == "continue" || arg == "abort" || arg == "quit" || arg == "skip" {
-            i += 1;
-            continue;
+        // Control-mode subcommands: git revert --continue/--abort/--quit/--skip
+        // These are already caught by arg.starts_with('-') above, but if somehow
+        // a bare keyword reaches here, treat it as control mode (no commit to find).
+        // Use --prefix to match how git actually accepts these.
+        if arg == "--continue" || arg == "--abort" || arg == "--quit" || arg == "--skip" {
+            return None;
         }
 
         // Try to resolve this as a commit SHA

--- a/src/commands/hooks/revert_hooks.rs
+++ b/src/commands/hooks/revert_hooks.rs
@@ -14,11 +14,11 @@ pub fn pre_revert_hook(
     debug_log("=== REVERT PRE-COMMAND HOOK ===");
 
     // Capture the current HEAD before the revert
-    if let Ok(head) = repository.head() {
-        if let Ok(target) = head.target() {
-            debug_log(&format!("Pre-revert HEAD: {}", target));
-            command_hooks_context.revert_original_head = Some(target);
-        }
+    if let Ok(head) = repository.head()
+        && let Ok(target) = head.target()
+    {
+        debug_log(&format!("Pre-revert HEAD: {}", target));
+        command_hooks_context.revert_original_head = Some(target);
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6663,6 +6663,10 @@ impl ActorDaemonCoordinator {
                         )));
                     }
                 }
+                crate::daemon::domain::SemanticEvent::RevertAbort { .. } => {
+                    // Revert abort restores working tree to pre-revert state.
+                    // No attribution or rewrite log action needed.
+                }
                 crate::daemon::domain::SemanticEvent::MergeSquash {
                     base_branch,
                     base_head,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1240,7 +1240,16 @@ fn tracked_reflog_refs_for_command(
     }
     if matches!(
         command,
-        Some("reset" | "merge" | "pull" | "rebase" | "cherry-pick" | "revert" | "checkout" | "switch")
+        Some(
+            "reset"
+                | "merge"
+                | "pull"
+                | "rebase"
+                | "cherry-pick"
+                | "revert"
+                | "checkout"
+                | "switch"
+        )
     ) {
         refs.push("ORIG_HEAD".to_string());
     }
@@ -1492,11 +1501,9 @@ fn apply_revert_attribution_side_effect(
                 reverted_ref, err
             ))
         })?;
-        let oid = obj
-            .peel_to_commit()
+        obj.peel_to_commit()
             .map(|c| c.id())
-            .unwrap_or_else(|_| obj.id());
-        oid
+            .unwrap_or_else(|_| obj.id())
     };
 
     if reverted_commit.is_empty() || is_zero_oid(&reverted_commit) {
@@ -1549,14 +1556,12 @@ fn apply_revert_attribution_side_effect(
     };
 
     let source_sha = match parent_sha {
-        Some(ref parent) => {
-            match get_reference_as_authorship_log_v3(&repo, parent) {
-                Ok(log) if log.metadata.prompts.values().any(|p| p.accepted_lines > 0) => {
-                    Some(parent.clone())
-                }
-                _ => None,
+        Some(ref parent) => match get_reference_as_authorship_log_v3(&repo, parent) {
+            Ok(log) if log.metadata.prompts.values().any(|p| p.accepted_lines > 0) => {
+                Some(parent.clone())
             }
-        }
+            _ => None,
+        },
         None => None,
     };
 
@@ -1574,13 +1579,13 @@ fn apply_revert_attribution_side_effect(
     match get_reference_as_authorship_log_v3(&repo, &source_sha) {
         Ok(mut log) => {
             log.metadata.base_commit_sha = new_head.to_string();
-            if let Ok(serialized) = log.serialize_to_string() {
-                if let Err(e) = notes_add(&repo, new_head, &serialized) {
-                    debug_log(&format!(
-                        "daemon revert: failed to add note to {}: {}",
-                        new_head, e
-                    ));
-                }
+            if let Ok(serialized) = log.serialize_to_string()
+                && let Err(e) = notes_add(&repo, new_head, &serialized)
+            {
+                debug_log(&format!(
+                    "daemon revert: failed to add note to {}: {}",
+                    new_head, e
+                ));
             }
         }
         Err(e) => {
@@ -7124,11 +7129,9 @@ impl ActorDaemonCoordinator {
                         original_head: _,
                         new_head,
                     } => {
-                        if let Err(e) = apply_revert_attribution_side_effect(
-                            &worktree,
-                            cmd,
-                            new_head,
-                        ) {
+                        if let Err(e) =
+                            apply_revert_attribution_side_effect(&worktree, cmd, new_head)
+                        {
                             debug_log(&format!(
                                 "daemon revert attribution side effect failed for {}: {}",
                                 worktree, e

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3296,10 +3296,10 @@ fn revert_source_ref_from_command(
         if matches!(
             arg.as_str(),
             "-m" | "--mainline" | "-X" | "--strategy-option" | "--strategy"
-        ) || arg == "--gpg-sign"
-        {
+        ) {
             skip_next = true;
             continue;
+        }
         }
         if arg.starts_with('-') {
             continue;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,7 +18,8 @@ use crate::git::repo_state::{
 use crate::git::repository::{Repository, discover_repository_in_path_no_git_exec, exec_git};
 use crate::git::rewrite_log::{
     CherryPickAbortEvent, CherryPickCompleteEvent, MergeSquashEvent, RebaseAbortEvent,
-    RebaseCompleteEvent, ResetEvent, ResetKind, RewriteLogEvent, StashEvent, StashOperation,
+    RebaseCompleteEvent, ResetEvent, ResetKind, RevertMixedEvent, RewriteLogEvent, StashEvent,
+    StashOperation,
 };
 use crate::git::sync_authorship::{fetch_authorship_notes, fetch_remote_from_args};
 use crate::utils::LockFile;
@@ -684,6 +685,7 @@ fn trace_command_may_mutate_refs(primary_command: Option<&str>) -> bool {
                 | "push"
                 | "rebase"
                 | "reset"
+                | "revert"
                 | "stash"
                 | "switch"
         )
@@ -1238,7 +1240,7 @@ fn tracked_reflog_refs_for_command(
     }
     if matches!(
         command,
-        Some("reset" | "merge" | "pull" | "rebase" | "cherry-pick" | "checkout" | "switch")
+        Some("reset" | "merge" | "pull" | "rebase" | "cherry-pick" | "revert" | "checkout" | "switch")
     ) {
         refs.push("ORIG_HEAD".to_string());
     }
@@ -1456,6 +1458,125 @@ fn parsed_invocation_for_normalized_command(
         saw_end_of_opts: false,
         is_help: false,
     }
+}
+
+/// Daemon-mode side effect for `git revert`: copy AI attribution notes when
+/// a revert-of-revert restores AI-authored content.
+///
+/// This mirrors the logic in `revert_hooks::post_revert_hook` but operates from
+/// the daemon context where we have the normalized command and semantic event
+/// data instead of `CommandHooksContext`.
+fn apply_revert_attribution_side_effect(
+    worktree: &str,
+    cmd: &crate::daemon::domain::NormalizedCommand,
+    new_head: &str,
+) -> Result<(), GitAiError> {
+    use crate::git::refs::{get_reference_as_authorship_log_v3, notes_add};
+
+    let repo = find_repository_in_path(worktree)?;
+
+    // Resolve the reverted commit from command args
+    let reverted_ref = match revert_source_ref_from_command(cmd) {
+        Some(r) => r,
+        None => {
+            debug_log("daemon revert: no source ref found in command args");
+            return Ok(());
+        }
+    };
+
+    // Resolve the ref to a full OID
+    let reverted_commit = {
+        let obj = repo.revparse_single(&reverted_ref).map_err(|err| {
+            GitAiError::Generic(format!(
+                "daemon revert: failed to resolve reverted ref '{}': {}",
+                reverted_ref, err
+            ))
+        })?;
+        let oid = obj
+            .peel_to_commit()
+            .map(|c| c.id())
+            .unwrap_or_else(|_| obj.id());
+        oid
+    };
+
+    if reverted_commit.is_empty() || is_zero_oid(&reverted_commit) {
+        debug_log("daemon revert: reverted commit resolved to empty/zero OID");
+        return Ok(());
+    }
+
+    debug_log(&format!(
+        "daemon revert: reverted_commit={} new_head={}",
+        reverted_commit, new_head
+    ));
+
+    // Check if the reverted commit has AI attribution
+    let reverted_has_ai = match get_reference_as_authorship_log_v3(&repo, &reverted_commit) {
+        Ok(log) => log.metadata.prompts.values().any(|p| p.accepted_lines > 0),
+        Err(_) => false,
+    };
+
+    if reverted_has_ai {
+        // Reverting an AI commit → undoing AI work → no attribution to copy
+        debug_log(&format!(
+            "daemon revert: reverted commit {} has AI attribution, this revert undoes AI work",
+            reverted_commit
+        ));
+        return Ok(());
+    }
+
+    // The reverted commit has no AI attribution. Check its parent for
+    // revert-of-revert chain traversal.
+    let parent_sha = {
+        match repo.find_commit(reverted_commit.clone()) {
+            Ok(commit) => commit.parents().next().map(|p| p.id().to_string()),
+            Err(_) => None,
+        }
+    };
+
+    let source_sha = match parent_sha {
+        Some(ref parent) => {
+            match get_reference_as_authorship_log_v3(&repo, parent) {
+                Ok(log) if log.metadata.prompts.values().any(|p| p.accepted_lines > 0) => {
+                    Some(parent.clone())
+                }
+                _ => None,
+            }
+        }
+        None => None,
+    };
+
+    let Some(source_sha) = source_sha else {
+        debug_log("daemon revert: no AI attribution found in revert chain");
+        return Ok(());
+    };
+
+    debug_log(&format!(
+        "daemon revert: copying attribution from {} to {}",
+        source_sha, new_head
+    ));
+
+    // Copy the attribution note from source to the new commit
+    match get_reference_as_authorship_log_v3(&repo, &source_sha) {
+        Ok(mut log) => {
+            log.metadata.base_commit_sha = new_head.to_string();
+            if let Ok(serialized) = log.serialize_to_string() {
+                if let Err(e) = notes_add(&repo, new_head, &serialized) {
+                    debug_log(&format!(
+                        "daemon revert: failed to add note to {}: {}",
+                        new_head, e
+                    ));
+                }
+            }
+        }
+        Err(e) => {
+            debug_log(&format!(
+                "daemon revert: failed to read authorship log from {}: {}",
+                source_sha, e
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn apply_push_side_effect(
@@ -3136,6 +3257,38 @@ fn resolve_cherry_pick_source_refs(
         }
     }
     Ok(resolved)
+}
+
+/// Extract the single positional argument from a `git revert <commit>` invocation.
+/// Returns the first positional (non-flag) argument, skipping control-mode keywords.
+fn revert_source_ref_from_command(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> Option<String> {
+    let mut skip_next = false;
+    for arg in &cmd.invoked_args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg == "--abort" || arg == "--continue" || arg == "--quit" || arg == "--skip" {
+            return None;
+        }
+        if matches!(
+            arg.as_str(),
+            "-m" | "--mainline" | "-X" | "--strategy-option" | "--strategy"
+        ) || arg == "--gpg-sign"
+        {
+            skip_next = true;
+            continue;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        if !arg.is_empty() {
+            return Some(arg.clone());
+        }
+    }
+    None
 }
 
 fn rebase_is_control_mode(cmd: &crate::daemon::domain::NormalizedCommand) -> bool {
@@ -6477,6 +6630,20 @@ impl ActorDaemonCoordinator {
                         self.clear_pending_cherry_pick_sources_for_worktree(worktree)?;
                     }
                 }
+                crate::daemon::domain::SemanticEvent::RevertComplete {
+                    original_head: _,
+                    new_head,
+                } => {
+                    if !new_head.is_empty() {
+                        // Find the reverted commit from command args
+                        let reverted_commit = revert_source_ref_from_command(cmd);
+                        out.push(RewriteLogEvent::revert_mixed(RevertMixedEvent::new(
+                            reverted_commit.unwrap_or_default(),
+                            true,
+                            Vec::new(),
+                        )));
+                    }
+                }
                 crate::daemon::domain::SemanticEvent::MergeSquash {
                     base_branch,
                     base_head,
@@ -6937,6 +7104,21 @@ impl ActorDaemonCoordinator {
                             cmd.invoked_command.as_deref(),
                             &cmd.invoked_args,
                         );
+                    }
+                    crate::daemon::domain::SemanticEvent::RevertComplete {
+                        original_head: _,
+                        new_head,
+                    } => {
+                        if let Err(e) = apply_revert_attribution_side_effect(
+                            &worktree,
+                            cmd,
+                            new_head,
+                        ) {
+                            debug_log(&format!(
+                                "daemon revert attribution side effect failed for {}: {}",
+                                worktree, e
+                            ));
+                        }
                     }
                     _ => {}
                 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3300,7 +3300,6 @@ fn revert_source_ref_from_command(
             skip_next = true;
             continue;
         }
-        }
         if arg.starts_with('-') {
             continue;
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1488,7 +1488,7 @@ fn apply_revert_attribution_side_effect(
     let reverted_ref = match revert_source_ref_from_command(cmd) {
         Some(r) => r,
         None => {
-            debug_log("daemon revert: no source ref found in command args");
+            tracing::debug!("daemon revert: no source ref found in command args");
             return Ok(());
         }
     };
@@ -1507,14 +1507,14 @@ fn apply_revert_attribution_side_effect(
     };
 
     if reverted_commit.is_empty() || is_zero_oid(&reverted_commit) {
-        debug_log("daemon revert: reverted commit resolved to empty/zero OID");
+        tracing::debug!("daemon revert: reverted commit resolved to empty/zero OID");
         return Ok(());
     }
 
-    debug_log(&format!(
+    tracing::debug!(
         "daemon revert: reverted_commit={} new_head={}",
         reverted_commit, new_head
-    ));
+    );
 
     // Check if the reverted commit has AI attribution
     let reverted_has_ai = match get_reference_as_authorship_log_v3(&repo, &reverted_commit) {
@@ -1524,10 +1524,10 @@ fn apply_revert_attribution_side_effect(
 
     if reverted_has_ai {
         // Reverting an AI commit → undoing AI work → no attribution to copy
-        debug_log(&format!(
+        tracing::debug!(
             "daemon revert: reverted commit {} has AI attribution, this revert undoes AI work",
             reverted_commit
-        ));
+        );
         return Ok(());
     }
 
@@ -1539,10 +1539,10 @@ fn apply_revert_attribution_side_effect(
         Err(_) => false,
     };
     if !is_revert {
-        debug_log(&format!(
+        tracing::debug!(
             "daemon revert: reverted commit {} is not itself a revert, skipping parent check",
             reverted_commit
-        ));
+        );
         return Ok(());
     }
 
@@ -1566,14 +1566,14 @@ fn apply_revert_attribution_side_effect(
     };
 
     let Some(source_sha) = source_sha else {
-        debug_log("daemon revert: no AI attribution found in revert chain");
+        tracing::debug!("daemon revert: no AI attribution found in revert chain");
         return Ok(());
     };
 
-    debug_log(&format!(
+    tracing::debug!(
         "daemon revert: copying attribution from {} to {}",
         source_sha, new_head
-    ));
+    );
 
     // Copy the attribution note from source to the new commit
     match get_reference_as_authorship_log_v3(&repo, &source_sha) {
@@ -1582,17 +1582,17 @@ fn apply_revert_attribution_side_effect(
             if let Ok(serialized) = log.serialize_to_string()
                 && let Err(e) = notes_add(&repo, new_head, &serialized)
             {
-                debug_log(&format!(
+                tracing::debug!(
                     "daemon revert: failed to add note to {}: {}",
                     new_head, e
-                ));
+                );
             }
         }
         Err(e) => {
-            debug_log(&format!(
+            tracing::debug!(
                 "daemon revert: failed to read authorship log from {}: {}",
                 source_sha, e
-            ));
+            );
         }
     }
 
@@ -7135,10 +7135,10 @@ impl ActorDaemonCoordinator {
                         if let Err(e) =
                             apply_revert_attribution_side_effect(&worktree, cmd, new_head)
                         {
-                            debug_log(&format!(
+                            tracing::debug!(
                                 "daemon revert attribution side effect failed for {}: {}",
                                 worktree, e
-                            ));
+                            );
                         }
                     }
                     _ => {}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1524,8 +1524,23 @@ fn apply_revert_attribution_side_effect(
         return Ok(());
     }
 
-    // The reverted commit has no AI attribution. Check its parent for
-    // revert-of-revert chain traversal.
+    // Only proceed with parent chain traversal if the reverted commit is itself
+    // a revert commit (by commit message convention). This prevents false attribution
+    // when reverting a normal human commit whose parent happens to be an AI commit.
+    let is_revert = match repo.find_commit(reverted_commit.clone()) {
+        Ok(commit) => commit.summary().unwrap_or_default().starts_with("Revert "),
+        Err(_) => false,
+    };
+    if !is_revert {
+        debug_log(&format!(
+            "daemon revert: reverted commit {} is not itself a revert, skipping parent check",
+            reverted_commit
+        ));
+        return Ok(());
+    }
+
+    // The reverted commit has no AI attribution and is itself a revert.
+    // Check its parent for revert-of-revert chain traversal.
     let parent_sha = {
         match repo.find_commit(reverted_commit.clone()) {
             Ok(commit) => commit.parents().next().map(|p| p.id().to_string()),

--- a/src/daemon/analyzers/history.rs
+++ b/src/daemon/analyzers/history.rs
@@ -110,7 +110,15 @@ impl CommandAnalyzer for HistoryAnalyzer {
                 }
             }
             "revert" => {
-                if let Some((old_head, new_head)) = head_change(cmd, state.refs) {
+                if args.iter().any(|arg| arg == "--abort") {
+                    events.push(SemanticEvent::RevertAbort {
+                        head: cmd
+                            .post_repo
+                            .as_ref()
+                            .and_then(|repo| repo.head.clone())
+                            .unwrap_or_default(),
+                    });
+                } else if let Some((old_head, new_head)) = head_change(cmd, state.refs) {
                     events.push(SemanticEvent::RevertComplete {
                         original_head: old_head,
                         new_head,

--- a/src/daemon/analyzers/history.rs
+++ b/src/daemon/analyzers/history.rs
@@ -109,6 +109,14 @@ impl CommandAnalyzer for HistoryAnalyzer {
                     });
                 }
             }
+            "revert" => {
+                if let Some((old_head, new_head)) = head_change(cmd, state.refs) {
+                    events.push(SemanticEvent::RevertComplete {
+                        original_head: old_head,
+                        new_head,
+                    });
+                }
+            }
             "merge" => {
                 if args.iter().any(|arg| arg == "--squash") {
                     let source_ref = merge_source_ref(&args).ok_or_else(|| {

--- a/src/daemon/analyzers/mod.rs
+++ b/src/daemon/analyzers/mod.rs
@@ -47,6 +47,7 @@ impl AnalyzerRegistry {
             "reset",
             "rebase",
             "cherry-pick",
+            "revert",
             "merge",
             "update-ref",
         ] {

--- a/src/daemon/domain.rs
+++ b/src/daemon/domain.rs
@@ -146,6 +146,9 @@ pub enum SemanticEvent {
         original_head: String,
         new_head: String,
     },
+    RevertAbort {
+        head: String,
+    },
     MergeSquash {
         base_branch: Option<String>,
         base_head: String,

--- a/src/daemon/domain.rs
+++ b/src/daemon/domain.rs
@@ -142,6 +142,10 @@ pub enum SemanticEvent {
     CherryPickAbort {
         head: String,
     },
+    RevertComplete {
+        original_head: String,
+        new_head: String,
+    },
     MergeSquash {
         base_branch: Option<String>,
         base_head: String,

--- a/src/daemon/reducer.rs
+++ b/src/daemon/reducer.rs
@@ -112,6 +112,7 @@ fn should_apply_post_repo_refs(cmd: &NormalizedCommand, analysis: &AnalysisResul
                 | crate::daemon::domain::SemanticEvent::RebaseAbort { .. }
                 | crate::daemon::domain::SemanticEvent::CherryPickComplete { .. }
                 | crate::daemon::domain::SemanticEvent::CherryPickAbort { .. }
+                | crate::daemon::domain::SemanticEvent::RevertComplete { .. }
                 | crate::daemon::domain::SemanticEvent::PullCompleted { .. }
                 | crate::daemon::domain::SemanticEvent::RefUpdated { .. }
                 | crate::daemon::domain::SemanticEvent::BranchCreated { .. }

--- a/src/daemon/reducer.rs
+++ b/src/daemon/reducer.rs
@@ -113,6 +113,7 @@ fn should_apply_post_repo_refs(cmd: &NormalizedCommand, analysis: &AnalysisResul
                 | crate::daemon::domain::SemanticEvent::CherryPickComplete { .. }
                 | crate::daemon::domain::SemanticEvent::CherryPickAbort { .. }
                 | crate::daemon::domain::SemanticEvent::RevertComplete { .. }
+                | crate::daemon::domain::SemanticEvent::RevertAbort { .. }
                 | crate::daemon::domain::SemanticEvent::PullCompleted { .. }
                 | crate::daemon::domain::SemanticEvent::RefUpdated { .. }
                 | crate::daemon::domain::SemanticEvent::BranchCreated { .. }

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -1406,6 +1406,7 @@ fn command_may_mutate_refs(primary_command: Option<&str>) -> bool {
                 | "push"
                 | "rebase"
                 | "reset"
+                | "revert"
                 | "stash"
                 | "switch"
         )

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -86,6 +86,7 @@ mod rebase_merge_commit_note_leak;
 mod rebase_note_integrity;
 mod rebase_realworld;
 mod reset;
+mod revert_attribution;
 mod search;
 mod secrets_benchmark;
 mod share_tui_comprehensive;

--- a/tests/integration/revert_attribution.rs
+++ b/tests/integration/revert_attribution.rs
@@ -1,0 +1,127 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+
+/// ISSUE-015: revert-of-revert should restore original AI attribution
+#[test]
+fn test_revert_of_revert_restores_ai_attribution() {
+    let repo = TestRepo::new();
+
+    // Create initial commit with a base file
+    let mut file = repo.filename("module.py");
+    file.set_contents(crate::lines!["base line"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // Commit A: AI creates content
+    file.insert_at(1, crate::lines!["ai line 1".ai(), "ai line 2".ai()]);
+    let commit_a = repo.stage_all_and_commit("Add AI module").unwrap();
+
+    // Verify commit A has AI attribution
+    let stats_a = repo.stats().unwrap();
+    assert!(
+        stats_a.ai_additions > 0,
+        "Commit A should have ai_additions > 0, got {}",
+        stats_a.ai_additions
+    );
+    let ai_additions_a = stats_a.ai_additions;
+
+    // Commit B: Revert commit A (deletes the AI content)
+    repo.git(&["revert", "--no-edit", &commit_a.commit_sha])
+        .unwrap();
+
+    // Commit C: Revert the revert (restores the AI content)
+    let revert_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    repo.git(&["revert", "--no-edit", &revert_sha]).unwrap();
+
+    // Verify commit C has AI attribution matching commit A
+    let stats_c = repo.stats().unwrap();
+    assert!(
+        stats_c.ai_additions > 0,
+        "Commit C (revert-of-revert) should have ai_additions > 0, got {}. Expected {} (matching commit A)",
+        stats_c.ai_additions,
+        ai_additions_a
+    );
+}
+
+/// ISSUE-004: reverting an AI commit (deletion) should show ai=0 (correct behavior to preserve)
+#[test]
+fn test_revert_of_ai_commit_is_attribution_neutral() {
+    let repo = TestRepo::new();
+
+    // Create initial commit
+    let mut file = repo.filename("module.py");
+    file.set_contents(crate::lines!["base line"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // AI creates file content -> commit A (ai > 0)
+    file.insert_at(1, crate::lines!["ai content".ai()]);
+    let commit_a = repo.stage_all_and_commit("Add AI content").unwrap();
+
+    let stats_a = repo.stats().unwrap();
+    assert!(
+        stats_a.ai_additions > 0,
+        "Commit A should have ai_additions > 0"
+    );
+
+    // Revert commit A -> commit B (pure deletion, should have ai=0)
+    repo.git(&["revert", "--no-edit", &commit_a.commit_sha])
+        .unwrap();
+
+    let stats_b = repo.stats().unwrap();
+    assert_eq!(
+        stats_b.ai_additions, 0,
+        "Commit B (revert of AI commit) should have ai_additions=0 since it only deletes lines"
+    );
+
+    // Verify commit A's note is unchanged
+    let note_a = repo
+        .read_authorship_note(&commit_a.commit_sha)
+        .expect("Commit A should still have its authorship note");
+    assert!(
+        !note_a.is_empty(),
+        "Commit A's authorship note should not be empty"
+    );
+}
+
+/// The original AI commit's note must not be modified by a revert
+#[test]
+fn test_revert_preserves_original_commit_note() {
+    let repo = TestRepo::new();
+
+    // Create initial commit
+    let mut file = repo.filename("module.py");
+    file.set_contents(crate::lines!["base line"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // AI creates content
+    file.insert_at(1, crate::lines!["ai feature".ai()]);
+    let commit_a = repo.stage_all_and_commit("Add AI feature").unwrap();
+
+    // Read commit A's note before revert
+    let note_before = repo
+        .read_authorship_note(&commit_a.commit_sha)
+        .expect("Commit A should have authorship note");
+
+    // Revert commit A
+    repo.git(&["revert", "--no-edit", &commit_a.commit_sha])
+        .unwrap();
+
+    // Revert the revert
+    let revert_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    repo.git(&["revert", "--no-edit", &revert_sha]).unwrap();
+
+    // Read commit A's note after both reverts
+    let note_after = repo
+        .read_authorship_note(&commit_a.commit_sha)
+        .expect("Commit A should still have authorship note after reverts");
+
+    assert_eq!(
+        note_before, note_after,
+        "Commit A's authorship note should not be modified by reverts"
+    );
+}
+
+crate::reuse_tests_in_worktree!(
+    test_revert_of_revert_restores_ai_attribution,
+    test_revert_of_ai_commit_is_attribution_neutral,
+    test_revert_preserves_original_commit_note,
+);


### PR DESCRIPTION
## Summary
- Adds `pre_revert_hook` and `post_revert_hook` to intercept `git revert` operations in **wrapper mode**
- Post-revert handler traverses the reverted commit's note chain to restore AI attribution
- Handles revert-of-revert case: when a revert commit is reverted, attribution is sourced from the original AI commit (one level of chain traversal)
- Simple reverts of AI commits remain attribution-neutral (ai_additions=0) since they only delete lines
- Emits `RevertMixed` event to the rewrite log (was previously defined but never emitted)
- **Daemon mode**: adds `SemanticEvent::RevertComplete` and `RevertAbort`, registers `"revert"` in `AnalyzerRegistry`, implements `apply_revert_attribution_side_effect` and `revert_source_ref_from_command` for full daemon-mode parity

## Updates since last revision
- **Fixed `find_reverted_commit` bare keyword check**: changed `continue`/`abort`/`quit`/`skip` to `--continue`/`--abort`/`--quit`/`--skip` and returns `None` (control mode, no commit to find), matching how git actually accepts these and consistent with daemon-side `revert_source_ref_from_command`
- **Added `RevertAbort` handling in daemon mode**: `HistoryAnalyzer` now checks for `--abort` before emitting `RevertComplete` (previously a `git revert --abort` that changed HEAD would emit a spurious `RevertComplete`). Added `SemanticEvent::RevertAbort` variant, wired through reducer and daemon event handler (no-op — abort needs no attribution or rewrite log entry)
- All Devin Review comments resolved (18/18)

## Test plan
- [x] `test_revert_of_revert_restores_ai_attribution` passes
- [x] `test_revert_of_ai_commit_is_attribution_neutral` passes
- [x] `test_revert_preserves_original_commit_note` passes
- [x] All existing cherry-pick tests pass (49/49)
- [x] Format, Lint (all platforms), Ubuntu wrapper/daemon/wrapper-daemon tests green
- [x] `cargo clippy` with `-D warnings` clean

## Review & Testing Checklist for Human
- [ ] **Daemon-mode revert attribution is untested in CI** — integration tests use `TestRepo` (wrapper mode). Manually verify `apply_revert_attribution_side_effect` works by running a revert with daemon mode enabled and checking `git notes --ref=ai show HEAD`
- [ ] **`is_revert_commit` heuristic**: relies on commit message starting with `"Revert "`. Will fail if user passes `--edit` to customize the message or uses a non-English git locale — verify this is acceptable
- [ ] **Single-level chain traversal only**: revert-of-revert-of-revert (3+ levels deep) won't preserve attribution. Confirm this is acceptable scope
- [ ] **`revert_source_ref_from_command` arg parsing**: verify edge cases like `git revert -m 1 --gpg-sign abc123` and `git revert --strategy=recursive abc123` (equals-sign form) — the daemon-side parser does not handle `--flag=value` syntax for `-m`/`--strategy`/`-X`, which could cause the flag value to be mistaken for the commit ref
- [ ] **`RevertMixedEvent` fallback**: in the daemon event handler, if `revert_source_ref_from_command` returns `None`, the event is emitted with an empty `reverted_commit` string — verify downstream consumers handle this gracefully

### Notes
- CI failures are pre-existing flaky tests unrelated to this PR:
  - `utf8_filenames::test_arabic_filename` (ubuntu daemon) — daemon completion log timeout
  - `daemon_restart_brings_up_new_process` (windows wrapper) — PID file race condition
- `license/cla` check is pending for the bot commit; expected and not blocking

Link to Devin session: https://app.devin.ai/sessions/64198314ca39403db3aa3ac6f342e34f
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
