### PR TITLE
Filter mock_ai-related metrics events from telemetry

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -21,6 +21,33 @@ pub use types::{EventValues, METRICS_API_VERSION, MetricEvent, MetricsBatch};
 /// filtered out of telemetry to avoid polluting real metrics data.
 pub const MOCK_AI_TOOL: &str = "mock_ai";
 
+/// Returns `true` when the event originates from the `mock_ai` test preset.
+///
+/// Checks both the tool attribute (position 20, set for AgentUsage /
+/// Checkpoint / InstallHooks events) and the `tool_model_pairs` committed
+/// value (position 3, keys like `"mock_ai::unknown"`).
+pub(crate) fn is_mock_ai(event: &MetricEvent) -> bool {
+    use serde_json::Value;
+
+    let tool_pos = attrs::attr_pos::TOOL.to_string();
+    if let Some(Value::String(tool)) = event.attrs.get(&tool_pos)
+        && tool == MOCK_AI_TOOL
+    {
+        return true;
+    }
+
+    let pairs_pos = events::committed_pos::TOOL_MODEL_PAIRS.to_string();
+    if let Some(Value::Array(pairs)) = event.values.get(&pairs_pos)
+        && pairs
+            .iter()
+            .any(|p| matches!(p, Value::String(s) if s.starts_with(MOCK_AI_TOOL)))
+    {
+        return true;
+    }
+
+    false
+}
+
 /// Record an event with values and attributes.
 ///
 /// Events are sent to the daemon telemetry worker which batches
@@ -54,12 +81,11 @@ pub fn record<V: EventValues>(values: V, attrs: EventAttributes) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use types::MetricEventId;
+    use serde_json::Value;
+    use types::{MetricEventId, SparseArray};
 
     #[test]
     fn test_record_creates_event() {
-        // This test verifies that record() creates a valid MetricEvent
-        // The actual write to the log file happens via observability::log_metrics()
         let values = CommittedValues::new()
             .human_additions(5)
             .git_diff_added_lines(10)
@@ -71,9 +97,78 @@ mod tests {
             .tool("test")
             .commit_sha("test-commit");
 
-        // Create the event manually to verify structure
         let event = MetricEvent::new(&values, attrs.to_sparse());
         assert_eq!(event.event_id, MetricEventId::Committed as u16);
         assert!(event.timestamp > 0);
+    }
+
+    fn event_with_tool_attr(tool: &str) -> MetricEvent {
+        let mut attrs = SparseArray::new();
+        attrs.insert(
+            attrs::attr_pos::TOOL.to_string(),
+            Value::String(tool.to_string()),
+        );
+        MetricEvent {
+            timestamp: 0,
+            event_id: MetricEventId::AgentUsage as u16,
+            values: SparseArray::new(),
+            attrs,
+        }
+    }
+
+    fn event_with_tool_model_pairs(pairs: Vec<&str>) -> MetricEvent {
+        let mut values = SparseArray::new();
+        values.insert(
+            events::committed_pos::TOOL_MODEL_PAIRS.to_string(),
+            Value::Array(
+                pairs
+                    .into_iter()
+                    .map(|s| Value::String(s.to_string()))
+                    .collect(),
+            ),
+        );
+        MetricEvent {
+            timestamp: 0,
+            event_id: MetricEventId::Committed as u16,
+            values,
+            attrs: SparseArray::new(),
+        }
+    }
+
+    #[test]
+    fn test_is_mock_ai_true_for_tool_attr() {
+        assert!(is_mock_ai(&event_with_tool_attr(MOCK_AI_TOOL)));
+    }
+
+    #[test]
+    fn test_is_mock_ai_false_for_other_tool_attr() {
+        assert!(!is_mock_ai(&event_with_tool_attr("claude-code")));
+    }
+
+    #[test]
+    fn test_is_mock_ai_true_for_committed_pairs() {
+        assert!(is_mock_ai(&event_with_tool_model_pairs(vec![
+            "all",
+            "mock_ai::unknown",
+        ])));
+    }
+
+    #[test]
+    fn test_is_mock_ai_false_for_other_committed_pairs() {
+        assert!(!is_mock_ai(&event_with_tool_model_pairs(vec![
+            "all",
+            "claude-code::claude-sonnet-4-20250514",
+        ])));
+    }
+
+    #[test]
+    fn test_is_mock_ai_false_for_empty_event() {
+        let event = MetricEvent {
+            timestamp: 0,
+            event_id: MetricEventId::Committed as u16,
+            values: SparseArray::new(),
+            attrs: SparseArray::new(),
+        };
+        assert!(!is_mock_ai(&event));
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -64,57 +64,29 @@ pub fn log_message(message: &str, level: &str, context: Option<serde_json::Value
 /// Events are batched into envelopes of up to 250 events each.
 /// Events originating from the `mock_ai` test preset are silently
 /// dropped so they never reach telemetry.
-pub fn log_metrics(
-    #[cfg_attr(any(test, feature = "test-support"), allow(unused))] events: Vec<MetricEvent>,
-) {
-    #[cfg(any(test, feature = "test-support"))]
-    return;
+pub fn log_metrics(events: Vec<MetricEvent>) {
+    let events: Vec<MetricEvent> = events
+        .into_iter()
+        .filter(|e| !crate::metrics::is_mock_ai(e))
+        .collect();
+    submit_metric_events(events);
+}
 
-    #[cfg(not(any(test, feature = "test-support")))]
-    {
-        let events: Vec<MetricEvent> = events.into_iter().filter(|e| !is_mock_ai(e)).collect();
-        if events.is_empty() {
-            return;
-        }
-
-        // Split into chunks of MAX_METRICS_PER_ENVELOPE
-        for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-            let envelope = crate::daemon::TelemetryEnvelope::Metrics {
-                events: chunk.to_vec(),
-            };
-            submit_telemetry_envelope(vec![envelope]);
-        }
+#[cfg(not(any(test, feature = "test-support")))]
+fn submit_metric_events(events: Vec<MetricEvent>) {
+    if events.is_empty() {
+        return;
+    }
+    for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
+        let envelope = crate::daemon::TelemetryEnvelope::Metrics {
+            events: chunk.to_vec(),
+        };
+        submit_telemetry_envelope(vec![envelope]);
     }
 }
 
-/// Returns `true` when the event originates from the `mock_ai` test preset.
-///
-/// Checks both the tool attribute (position 20, set for AgentUsage /
-/// Checkpoint / InstallHooks events) and the `tool_model_pairs` committed
-/// value (position 3, keys like `"mock_ai::unknown"`).
-#[cfg_attr(any(test, feature = "test-support"), allow(dead_code))]
-fn is_mock_ai(event: &MetricEvent) -> bool {
-    use crate::metrics::{MOCK_AI_TOOL, attrs::attr_pos, events::committed_pos};
-    use serde_json::Value;
-
-    let tool_pos = attr_pos::TOOL.to_string();
-    if let Some(Value::String(tool)) = event.attrs.get(&tool_pos)
-        && tool == MOCK_AI_TOOL
-    {
-        return true;
-    }
-
-    let pairs_pos = committed_pos::TOOL_MODEL_PAIRS.to_string();
-    if let Some(Value::Array(pairs)) = event.values.get(&pairs_pos)
-        && pairs
-            .iter()
-            .any(|p| matches!(p, Value::String(s) if s.starts_with(MOCK_AI_TOOL)))
-    {
-        return true;
-    }
-
-    false
-}
+#[cfg(any(test, feature = "test-support"))]
+fn submit_metric_events(_events: Vec<MetricEvent>) {}
 
 #[cfg(test)]
 mod tests {
@@ -188,78 +160,5 @@ mod tests {
     #[test]
     fn test_max_metrics_per_envelope() {
         assert_eq!(MAX_METRICS_PER_ENVELOPE, 250);
-    }
-
-    // is_mock_ai tests
-    use crate::metrics::{
-        MOCK_AI_TOOL, attrs::attr_pos, events::committed_pos, types::SparseArray,
-    };
-    use serde_json::Value;
-
-    fn event_with_tool_attr(tool: &str) -> MetricEvent {
-        let mut attrs: SparseArray = SparseArray::new();
-        attrs.insert(attr_pos::TOOL.to_string(), Value::String(tool.to_string()));
-        MetricEvent {
-            timestamp: 0,
-            event_id: 2,
-            values: SparseArray::new(),
-            attrs,
-        }
-    }
-
-    fn event_with_tool_model_pairs(pairs: Vec<&str>) -> MetricEvent {
-        let mut values: SparseArray = SparseArray::new();
-        values.insert(
-            committed_pos::TOOL_MODEL_PAIRS.to_string(),
-            Value::Array(
-                pairs
-                    .into_iter()
-                    .map(|s| Value::String(s.to_string()))
-                    .collect(),
-            ),
-        );
-        MetricEvent {
-            timestamp: 0,
-            event_id: 1,
-            values,
-            attrs: SparseArray::new(),
-        }
-    }
-
-    #[test]
-    fn test_is_mock_ai_true_for_tool_attr() {
-        assert!(super::is_mock_ai(&event_with_tool_attr(MOCK_AI_TOOL)));
-    }
-
-    #[test]
-    fn test_is_mock_ai_false_for_other_tool_attr() {
-        assert!(!super::is_mock_ai(&event_with_tool_attr("claude-code")));
-    }
-
-    #[test]
-    fn test_is_mock_ai_true_for_committed_pairs() {
-        assert!(super::is_mock_ai(&event_with_tool_model_pairs(vec![
-            "all",
-            "mock_ai::unknown",
-        ])));
-    }
-
-    #[test]
-    fn test_is_mock_ai_false_for_other_committed_pairs() {
-        assert!(!super::is_mock_ai(&event_with_tool_model_pairs(vec![
-            "all",
-            "claude-code::claude-sonnet-4-20250514",
-        ])));
-    }
-
-    #[test]
-    fn test_is_mock_ai_false_for_empty_event() {
-        let event = MetricEvent {
-            timestamp: 0,
-            event_id: 1,
-            values: SparseArray::new(),
-            attrs: SparseArray::new(),
-        };
-        assert!(!super::is_mock_ai(&event));
     }
 }


### PR DESCRIPTION
## Summary

Closes #976. Prevents `mock_ai` test preset events from reaching telemetry by filtering in `observability::log_metrics()` — the single lowest-level funnel for all metric events.

A `pub(crate) is_mock_ai()` helper in `src/metrics/mod.rs` inspects the serialized `MetricEvent` and checks two positions:

1. **Attr position 20 (`TOOL`)** — catches AgentUsage / Checkpoint / InstallHooks events where `attrs.tool = "mock_ai"`
2. **Value position 3 (`TOOL_MODEL_PAIRS`)** — catches Committed events whose `tool_model_breakdown` keys start with `"mock_ai"` (e.g. `"mock_ai::unknown"`)

A `MOCK_AI_TOOL` constant in `src/metrics/mod.rs` centralizes the string. `log_metrics()` always runs the filter, then delegates to `submit_metric_events()` — a no-op in test/test-support builds, real submission otherwise. This means `is_mock_ai()` is always compiled and exercised by tests with **zero `cfg` annotations** on the detection logic itself.

## Review & Testing Checklist for Human

- [ ] **`starts_with(MOCK_AI_TOOL)` matching on `tool_model_pairs`** — verify no real tool name could start with `"mock_ai"` and get falsely filtered.
- [ ] **Position constants** — the helper uses `attr_pos::TOOL` (20) and `committed_pos::TOOL_MODEL_PAIRS` (3). Confirm these match the current sparse array encoding.
- [ ] **Integration path not tested in CI** — `submit_metric_events` is a no-op in test builds, so the filter→submit→telemetry path is never exercised end-to-end in CI. Recommended manual test: run `git-ai` with the `mock_ai` preset, make a commit, and verify no events appear in the metrics DB or telemetry upload logs.

### Notes
- Two files touched: `src/metrics/mod.rs` (`MOCK_AI_TOOL` constant + `is_mock_ai()` helper + 5 unit tests) and `src/observability/mod.rs` (filter call in `log_metrics()` + `submit_metric_events` cfg split).
- All existing + new tests pass; lint and format checks clean.

Link to Devin session: https://app.devin.ai/sessions/9e5cb55142ff40b387b12c28ddf113cb
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
