### PR TITLE
prompt-event: add tool/model/timing/text fields

### DIFF
--- a/src/commands/prompt_event.rs
+++ b/src/commands/prompt_event.rs
@@ -19,6 +19,48 @@ pub mod prompt_event_kind {
     pub const THINKING_MESSAGE: &str = "ThinkingMessage";
     pub const TOOL_CALL: &str = "ToolCall";
     pub const FILE_WRITE: &str = "FileWrite";
+    pub const SKILL_INVOCATION: &str = "SkillInvocation";
+    pub const MCP_CALL: &str = "McpCall";
+}
+
+/// Maximum length for `input_text` payloads (HumanMessage/AiMessage only).
+const INPUT_TEXT_MAX_BYTES: usize = 1024;
+
+/// Compute the 16-char content hash always stored on a PromptEvent.
+fn compute_input_hash(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let digest = hasher.finalize();
+    format!("{:x}", digest)[..16].to_string()
+}
+
+/// Truncate text on a UTF-8 boundary, used only for `input_text` payloads.
+fn truncate_for_text(s: &str) -> String {
+    if s.len() <= INPUT_TEXT_MAX_BYTES {
+        return s.to_string();
+    }
+    let safe_end = s.floor_char_boundary(INPUT_TEXT_MAX_BYTES);
+    s[..safe_end].to_string()
+}
+
+/// Parse an ISO-8601 timestamp string into unix milliseconds.
+fn parse_iso_to_unix_ms(ts: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|dt| dt.timestamp_millis() as u64)
+}
+
+/// Classify a Claude tool_use into the right PromptEvent kind.
+fn kind_for_tool(tool_name: &str) -> &'static str {
+    if tool_name.starts_with("mcp__") {
+        prompt_event_kind::MCP_CALL
+    } else if matches!(tool_name, "Write" | "Edit" | "MultiEdit") {
+        prompt_event_kind::FILE_WRITE
+    } else if tool_name == "Skill" || tool_name == "SlashCommand" {
+        prompt_event_kind::SKILL_INVOCATION
+    } else {
+        prompt_event_kind::TOOL_CALL
+    }
 }
 
 /// Apply parent_id and parent_id_estimated to a PromptEventValues builder.
@@ -40,9 +82,16 @@ struct TranscriptEvent {
     kind: String,
     /// Content used for stable ID generation.
     content_hash_input: String,
-    /// Timestamp of the event, if available.
-    #[allow(dead_code)]
+    /// Wall-clock timestamp of the event, if available.
     timestamp: Option<String>,
+    /// Tool/skill/mcp server name (for tool_use kinds).
+    tool_call_name: Option<String>,
+    /// Model id (for AiMessage/ThinkingMessage).
+    model: Option<String>,
+    /// SHA256[..16] of the normalized payload — always populated.
+    input_hash: String,
+    /// Truncated message text — only set for HumanMessage/AiMessage.
+    input_text: Option<String>,
 }
 
 /// State file for tracking emitted events per session.
@@ -133,10 +182,15 @@ fn parse_claude_transcript(transcript_path: &str) -> Result<Vec<TranscriptEvent>
                         kind: prompt_event_kind::HUMAN_MESSAGE.to_string(),
                         content_hash_input: truncate_for_hash(&text),
                         timestamp,
+                        tool_call_name: None,
+                        model: None,
+                        input_hash: compute_input_hash(&text),
+                        input_text: Some(truncate_for_text(&text)),
                     });
                 }
             }
             Some("assistant") => {
+                let model = entry["message"]["model"].as_str().map(|s| s.to_string());
                 if let Some(content_array) = entry["message"]["content"].as_array() {
                     for item in content_array {
                         match item["type"].as_str() {
@@ -148,6 +202,10 @@ fn parse_claude_transcript(transcript_path: &str) -> Result<Vec<TranscriptEvent>
                                         kind: prompt_event_kind::THINKING_MESSAGE.to_string(),
                                         content_hash_input: truncate_for_hash(thinking),
                                         timestamp: timestamp.clone(),
+                                        tool_call_name: None,
+                                        model: model.clone(),
+                                        input_hash: compute_input_hash(thinking),
+                                        input_text: None,
                                     });
                                 }
                             }
@@ -159,6 +217,10 @@ fn parse_claude_transcript(transcript_path: &str) -> Result<Vec<TranscriptEvent>
                                         kind: prompt_event_kind::AI_MESSAGE.to_string(),
                                         content_hash_input: truncate_for_hash(text),
                                         timestamp: timestamp.clone(),
+                                        tool_call_name: None,
+                                        model: model.clone(),
+                                        input_hash: compute_input_hash(text),
+                                        input_text: Some(truncate_for_text(text)),
                                     });
                                 }
                             }
@@ -166,16 +228,16 @@ fn parse_claude_transcript(transcript_path: &str) -> Result<Vec<TranscriptEvent>
                                 let tool_name =
                                     item["name"].as_str().unwrap_or("unknown").to_string();
                                 let tool_id = item["id"].as_str().unwrap_or("").to_string();
-                                let is_file_write =
-                                    matches!(tool_name.as_str(), "Write" | "Edit" | "MultiEdit");
+                                let kind = kind_for_tool(&tool_name).to_string();
+                                let hash_input = format!("{}:{}", tool_name, tool_id);
                                 events.push(TranscriptEvent {
-                                    kind: if is_file_write {
-                                        prompt_event_kind::FILE_WRITE.to_string()
-                                    } else {
-                                        prompt_event_kind::TOOL_CALL.to_string()
-                                    },
-                                    content_hash_input: format!("{}:{}", tool_name, tool_id),
+                                    kind,
+                                    content_hash_input: hash_input.clone(),
                                     timestamp: timestamp.clone(),
+                                    tool_call_name: Some(tool_name),
+                                    model: model.clone(),
+                                    input_hash: compute_input_hash(&hash_input),
+                                    input_text: None,
                                 });
                             }
                             _ => {}
@@ -281,8 +343,23 @@ fn process_claude_prompt_events(hook_input: &str) -> Result<(), GitAiError> {
 
     for (i, eid, parent_id, parent_estimated) in &new_events {
         let evt = &all_events[*i];
-        let values = PromptEventValues::new().kind(&evt.kind).event_id(eid);
-        let values = apply_parent_id(values, parent_id.clone(), *parent_estimated);
+        let mut values = PromptEventValues::new()
+            .kind(&evt.kind)
+            .event_id(eid)
+            .input_hash(&evt.input_hash);
+        values = apply_parent_id(values, parent_id.clone(), *parent_estimated);
+        if let Some(name) = &evt.tool_call_name {
+            values = values.tool_call_name(name);
+        }
+        if let Some(model) = &evt.model {
+            values = values.model(model);
+        }
+        if let Some(text) = &evt.input_text {
+            values = values.input_text(text);
+        }
+        if let Some(ts) = evt.timestamp.as_deref().and_then(parse_iso_to_unix_ms) {
+            values = values.start_ts(ts);
+        }
 
         let event = MetricEvent::new(&values, attrs.to_sparse());
         metric_events.push(event);
@@ -353,8 +430,21 @@ fn emit_single_event_from_hook(
         (None, false)
     };
 
-    let values = PromptEventValues::new().kind(kind).event_id(&event_id);
-    let values = apply_parent_id(values, parent_id, parent_estimated);
+    let mut values = PromptEventValues::new()
+        .kind(kind)
+        .event_id(&event_id)
+        .input_hash(compute_input_hash(&content_hash_input));
+    values = apply_parent_id(values, parent_id, parent_estimated);
+    if hook_event_name == "UserPromptSubmit"
+        && let Some(prompt) = hook_data["prompt"].as_str()
+    {
+        values = values.input_text(truncate_for_text(prompt));
+    }
+    if matches!(hook_event_name, "PreToolUse" | "PostToolUse" | "AfterTool")
+        && let Some(tool_name) = hook_data["tool_name"].as_str()
+    {
+        values = values.tool_call_name(tool_name);
+    }
 
     let attrs = build_prompt_event_attrs(prompt_id, session_id);
     let metric_event = MetricEvent::new(&values, attrs.to_sparse());
@@ -453,8 +543,14 @@ fn process_generic_prompt_events(agent: &str, hook_input: &str) -> Result<(), Gi
         (None, false)
     };
 
-    let values = PromptEventValues::new().kind(kind).event_id(&event_id);
-    let values = apply_parent_id(values, parent_id, parent_estimated);
+    let mut values = PromptEventValues::new()
+        .kind(kind)
+        .event_id(&event_id)
+        .input_hash(compute_input_hash(&content_hash_input));
+    values = apply_parent_id(values, parent_id, parent_estimated);
+    if tool_name != "unknown" {
+        values = values.tool_call_name(tool_name);
+    }
 
     let attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
         .tool(agent)

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -668,10 +668,18 @@ impl EventValues for CheckpointValues {
 /// Value positions for "prompt_event" event.
 /// Tracks individual events within a prompt session (messages, tool calls, etc.).
 pub mod prompt_event_pos {
-    pub const KIND: usize = 0; // String - event kind (HumanMessage, AiMessage, ThinkingMessage, ToolCall, FileWrite, etc.)
+    pub const KIND: usize = 0; // String - event kind (HumanMessage, AiMessage, ThinkingMessage, ToolCall, FileWrite, SkillInvocation, McpCall)
     pub const EVENT_ID: usize = 1; // String - content-based stable ID, prefixed with prompt_id
     pub const PARENT_ID: usize = 2; // Option<String> - parent event ID (null for first events)
     pub const PARENT_ID_ESTIMATED: usize = 3; // bool - true if parent_id was estimated (fallback)
+    pub const TOOL_CALL_NAME: usize = 4; // String - tool/skill/mcp server name (null for messages)
+    pub const MODEL: usize = 5; // String - model id (set on AiMessage/ThinkingMessage)
+    pub const ERROR: usize = 6; // bool - true if tool call errored
+    pub const START_TS: usize = 7; // u64 - wall-clock start (unix ms)
+    pub const REPORTED_DURATION_MS: usize = 8; // u64 - agent-reported duration
+    pub const OBSERVED_DURATION_MS: usize = 9; // u64 - hook-observed wall-clock duration
+    pub const INPUT_HASH: usize = 10; // String - sha256[..16] of normalized content (always set)
+    pub const INPUT_TEXT: usize = 11; // String - truncated text, only on HumanMessage/AiMessage (≤1KB)
 }
 
 /// Values for Event ID 5: prompt_event
@@ -686,12 +694,28 @@ pub mod prompt_event_pos {
 /// | 1 | event_id | String |
 /// | 2 | parent_id | `Option<String>` |
 /// | 3 | parent_id_estimated | bool |
+/// | 4 | tool_call_name | String |
+/// | 5 | model | String |
+/// | 6 | error | bool |
+/// | 7 | start_ts | u64 |
+/// | 8 | reported_duration_ms | u64 |
+/// | 9 | observed_duration_ms | u64 |
+/// | 10 | input_hash | String |
+/// | 11 | input_text | String |
 #[derive(Debug, Clone, Default)]
 pub struct PromptEventValues {
     pub kind: PosField<String>,
     pub event_id: PosField<String>,
     pub parent_id: PosField<String>,
     pub parent_id_estimated: PosField<bool>,
+    pub tool_call_name: PosField<String>,
+    pub model: PosField<String>,
+    pub error: PosField<bool>,
+    pub start_ts: PosField<u64>,
+    pub reported_duration_ms: PosField<u64>,
+    pub observed_duration_ms: PosField<u64>,
+    pub input_hash: PosField<String>,
+    pub input_text: PosField<String>,
 }
 
 impl PromptEventValues {
@@ -741,6 +765,94 @@ impl PromptEventValues {
         self.parent_id_estimated = Some(None);
         self
     }
+
+    pub fn tool_call_name(mut self, value: impl Into<String>) -> Self {
+        self.tool_call_name = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn tool_call_name_null(mut self) -> Self {
+        self.tool_call_name = Some(None);
+        self
+    }
+
+    pub fn model(mut self, value: impl Into<String>) -> Self {
+        self.model = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn model_null(mut self) -> Self {
+        self.model = Some(None);
+        self
+    }
+
+    pub fn error(mut self, value: bool) -> Self {
+        self.error = Some(Some(value));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn error_null(mut self) -> Self {
+        self.error = Some(None);
+        self
+    }
+
+    pub fn start_ts(mut self, value: u64) -> Self {
+        self.start_ts = Some(Some(value));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn start_ts_null(mut self) -> Self {
+        self.start_ts = Some(None);
+        self
+    }
+
+    pub fn reported_duration_ms(mut self, value: u64) -> Self {
+        self.reported_duration_ms = Some(Some(value));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn reported_duration_ms_null(mut self) -> Self {
+        self.reported_duration_ms = Some(None);
+        self
+    }
+
+    pub fn observed_duration_ms(mut self, value: u64) -> Self {
+        self.observed_duration_ms = Some(Some(value));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn observed_duration_ms_null(mut self) -> Self {
+        self.observed_duration_ms = Some(None);
+        self
+    }
+
+    pub fn input_hash(mut self, value: impl Into<String>) -> Self {
+        self.input_hash = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn input_hash_null(mut self) -> Self {
+        self.input_hash = Some(None);
+        self
+    }
+
+    pub fn input_text(mut self, value: impl Into<String>) -> Self {
+        self.input_text = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn input_text_null(mut self) -> Self {
+        self.input_text = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for PromptEventValues {
@@ -763,6 +875,42 @@ impl PosEncoded for PromptEventValues {
             prompt_event_pos::PARENT_ID_ESTIMATED,
             bool_to_json(&self.parent_id_estimated),
         );
+        sparse_set(
+            &mut map,
+            prompt_event_pos::TOOL_CALL_NAME,
+            string_to_json(&self.tool_call_name),
+        );
+        sparse_set(
+            &mut map,
+            prompt_event_pos::MODEL,
+            string_to_json(&self.model),
+        );
+        sparse_set(&mut map, prompt_event_pos::ERROR, bool_to_json(&self.error));
+        sparse_set(
+            &mut map,
+            prompt_event_pos::START_TS,
+            u64_to_json(&self.start_ts),
+        );
+        sparse_set(
+            &mut map,
+            prompt_event_pos::REPORTED_DURATION_MS,
+            u64_to_json(&self.reported_duration_ms),
+        );
+        sparse_set(
+            &mut map,
+            prompt_event_pos::OBSERVED_DURATION_MS,
+            u64_to_json(&self.observed_duration_ms),
+        );
+        sparse_set(
+            &mut map,
+            prompt_event_pos::INPUT_HASH,
+            string_to_json(&self.input_hash),
+        );
+        sparse_set(
+            &mut map,
+            prompt_event_pos::INPUT_TEXT,
+            string_to_json(&self.input_text),
+        );
 
         map
     }
@@ -773,6 +921,14 @@ impl PosEncoded for PromptEventValues {
             event_id: sparse_get_string(arr, prompt_event_pos::EVENT_ID),
             parent_id: sparse_get_string(arr, prompt_event_pos::PARENT_ID),
             parent_id_estimated: sparse_get_bool(arr, prompt_event_pos::PARENT_ID_ESTIMATED),
+            tool_call_name: sparse_get_string(arr, prompt_event_pos::TOOL_CALL_NAME),
+            model: sparse_get_string(arr, prompt_event_pos::MODEL),
+            error: sparse_get_bool(arr, prompt_event_pos::ERROR),
+            start_ts: sparse_get_u64(arr, prompt_event_pos::START_TS),
+            reported_duration_ms: sparse_get_u64(arr, prompt_event_pos::REPORTED_DURATION_MS),
+            observed_duration_ms: sparse_get_u64(arr, prompt_event_pos::OBSERVED_DURATION_MS),
+            input_hash: sparse_get_string(arr, prompt_event_pos::INPUT_HASH),
+            input_text: sparse_get_string(arr, prompt_event_pos::INPUT_TEXT),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extends `PromptEventValues` with sparse positional fields needed for the Sessions UI: `tool_call_name`, `model`, `error`, `start_ts`, `reported_duration_ms`, `observed_duration_ms`, `input_hash`, `input_text`.
- Stacked on top of #852 (`feat/prompt-event-metric`) — targets that branch, not main.

## Why
The base PR introduces the `PromptEvent` metric (event id 5) but only carries the core identification fields (kind, event_id, parent). The downstream Sessions dashboard in the monorepo needs:
- `model` on AiMessage / ThinkingMessage to attribute turns
- `tool_call_name` + `error` on ToolCall for tool usage / friction analysis
- `start_ts` / `*_duration_ms` for session timing
- `input_text` (truncated) on HumanMessage / AiMessage for friction regex + session titles
- `input_hash` for dedupe across re-emits

## Test plan
- [ ] cargo check / cargo test on the git-ai crate
- [ ] napi build picks up the new fields and round-trips them through `parseMetricsBatch`
- [ ] End-to-end: emit a real prompt with claude-code, verify all new fields populate in the local ClickHouse `prompt_events` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
