### PR TITLE
feat: Known Human attribution (h_<hash>) for IDE-verified edits

### DIFF
--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
@@ -48,9 +48,10 @@ class DocumentSaveListener(
 
             val workspaceRoot = findWorkspaceRoot(event.path) ?: continue
 
-            pendingPaths
-                .computeIfAbsent(workspaceRoot) { ConcurrentHashMap.newKeySet() }
-                .add(event.path)
+            val paths = pendingPaths.computeIfAbsent(workspaceRoot) { ConcurrentHashMap.newKeySet() }
+            synchronized(paths) {
+                paths.add(event.path)
+            }
             workspaceRoots.add(workspaceRoot)
 
             logger.warn("[SAVE] Document saved: ${event.path}")
@@ -72,8 +73,12 @@ class DocumentSaveListener(
     private fun executeCheckpoint(workspaceRoot: String) {
         pendingFutures.remove(workspaceRoot)
 
-        val paths = pendingPaths.remove(workspaceRoot) ?: return
-        val snapshot = paths.toList()
+        val paths = pendingPaths[workspaceRoot] ?: return
+        val snapshot = synchronized(paths) {
+            val snap = paths.toList()
+            paths.clear()
+            snap
+        }
         if (snapshot.isEmpty()) return
 
         val dirtyFiles = mutableMapOf<String, String>()

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 /**
  * Listens for IDE-initiated document saves (isFromRefresh=false) and fires a
- * known_human checkpoint after a 300ms debounce window.
+ * known_human checkpoint after a 500ms debounce window.
  *
  * Filters out JetBrains-internal paths (e.g. .idea/, .sandbox/) to avoid noise.
  */
@@ -27,7 +27,7 @@ class DocumentSaveListener(
 
     private val logger = Logger.getInstance(DocumentSaveListener::class.java)
 
-    private val debounceMs = 300L
+    private val debounceMs = 500L
 
     // Per workspace root: debounce future
     private val pendingFutures = ConcurrentHashMap<String, ScheduledFuture<*>>()

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
@@ -72,9 +72,8 @@ class DocumentSaveListener(
     private fun executeCheckpoint(workspaceRoot: String) {
         pendingFutures.remove(workspaceRoot)
 
-        val paths = pendingPaths[workspaceRoot] ?: return
+        val paths = pendingPaths.remove(workspaceRoot) ?: return
         val snapshot = paths.toList()
-        snapshot.forEach { paths.remove(it) }
         if (snapshot.isEmpty()) return
 
         val dirtyFiles = mutableMapOf<String, String>()

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
@@ -83,8 +83,7 @@ class DocumentSaveListener(
                 val content = LocalFileSystem.getInstance().findFileByPath(absolutePath)
                     ?.let { String(it.contentsToByteArray(), Charsets.UTF_8) }
                 if (content != null) {
-                    val relativePath = toRelativePath(absolutePath, workspaceRoot)
-                    dirtyFiles[relativePath] = content
+                    dirtyFiles[absolutePath] = content
                 }
             }
         }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt
@@ -1,0 +1,123 @@
+package org.jetbrains.plugins.template.listener
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import org.jetbrains.plugins.template.model.KnownHumanInput
+import org.jetbrains.plugins.template.services.GitAiService
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Listens for IDE-initiated document saves (isFromRefresh=false) and fires a
+ * known_human checkpoint after a 300ms debounce window.
+ *
+ * Filters out JetBrains-internal paths (e.g. .idea/, .sandbox/) to avoid noise.
+ */
+class DocumentSaveListener(
+    private val scheduler: ScheduledExecutorService,
+    private val editorVersion: String,
+    private val extensionVersion: String,
+) : BulkFileListener {
+
+    private val logger = Logger.getInstance(DocumentSaveListener::class.java)
+
+    private val debounceMs = 300L
+
+    // Per workspace root: debounce future
+    private val pendingFutures = ConcurrentHashMap<String, ScheduledFuture<*>>()
+
+    // Per workspace root: set of absolute paths pending in the current debounce window
+    private val pendingPaths = ConcurrentHashMap<String, MutableSet<String>>()
+
+    override fun after(events: List<VFileEvent>) {
+        val workspaceRoots = mutableSetOf<String>()
+
+        for (event in events) {
+            if (event !is VFileContentChangeEvent) continue
+            if (event.isFromRefresh) continue  // external writes handled by VfsRefreshListener
+            if (isInternalJetBrainsPath(event.path)) {
+                logger.debug("[SAVE] Ignoring internal JetBrains file: ${event.path}")
+                continue
+            }
+
+            val workspaceRoot = findWorkspaceRoot(event.path) ?: continue
+
+            pendingPaths
+                .computeIfAbsent(workspaceRoot) { ConcurrentHashMap.newKeySet() }
+                .add(event.path)
+            workspaceRoots.add(workspaceRoot)
+
+            logger.warn("[SAVE] Document saved: ${event.path}")
+        }
+
+        for (root in workspaceRoots) {
+            scheduleCheckpoint(root)
+        }
+    }
+
+    private fun scheduleCheckpoint(workspaceRoot: String) {
+        pendingFutures[workspaceRoot]?.cancel(false)
+        val future = scheduler.schedule({
+            executeCheckpoint(workspaceRoot)
+        }, debounceMs, TimeUnit.MILLISECONDS)
+        pendingFutures[workspaceRoot] = future
+    }
+
+    private fun executeCheckpoint(workspaceRoot: String) {
+        pendingFutures.remove(workspaceRoot)
+
+        val paths = pendingPaths[workspaceRoot] ?: return
+        val snapshot = paths.toList()
+        snapshot.forEach { paths.remove(it) }
+        if (snapshot.isEmpty()) return
+
+        val dirtyFiles = mutableMapOf<String, String>()
+        ApplicationManager.getApplication().runReadAction {
+            for (absolutePath in snapshot) {
+                val content = LocalFileSystem.getInstance().findFileByPath(absolutePath)
+                    ?.let { String(it.contentsToByteArray(), Charsets.UTF_8) }
+                if (content != null) {
+                    val relativePath = toRelativePath(absolutePath, workspaceRoot)
+                    dirtyFiles[relativePath] = content
+                }
+            }
+        }
+
+        if (dirtyFiles.isEmpty()) return
+
+        val input = KnownHumanInput(
+            editor = "jetbrains",
+            editorVersion = editorVersion,
+            extensionVersion = extensionVersion,
+            cwd = workspaceRoot,
+            editedFilepaths = dirtyFiles.keys.toList(),
+            dirtyFiles = dirtyFiles
+        )
+
+        logger.warn("[SAVE] Firing known_human checkpoint for ${dirtyFiles.keys}")
+        GitAiService.getInstance().checkpointKnownHuman(input, workspaceRoot)
+    }
+
+    private fun isInternalJetBrainsPath(path: String): Boolean {
+        return path.contains("/.idea/") ||
+               path.contains("/.sandbox/") ||
+               path.contains("/system/projects/")
+    }
+
+    private fun findWorkspaceRoot(absolutePath: String): String? {
+        var current = LocalFileSystem.getInstance().findFileByPath(absolutePath)?.parent
+        while (current != null) {
+            if (current.findChild(".git") != null) {
+                return current.path
+            }
+            current = current.parent
+        }
+        return null
+    }
+}

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/model/CheckpointModels.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/model/CheckpointModels.kt
@@ -4,6 +4,36 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 
 /**
+ * Input data for git-ai checkpoint known_human command sent via stdin.
+ */
+data class KnownHumanInput(
+    val editor: String,
+    val editorVersion: String,
+    val extensionVersion: String,
+    val cwd: String?,
+    val editedFilepaths: List<String>,
+    val dirtyFiles: Map<String, String>
+) {
+    fun toJson(): String {
+        val json = JsonObject()
+        json.addProperty("editor", editor)
+        json.addProperty("editor_version", editorVersion)
+        json.addProperty("extension_version", extensionVersion)
+        cwd?.let { json.addProperty("cwd", it) }
+
+        val pathsArray = com.google.gson.JsonArray()
+        editedFilepaths.forEach { pathsArray.add(it) }
+        json.add("edited_filepaths", pathsArray)
+
+        val filesObj = JsonObject()
+        dirtyFiles.forEach { (path, content) -> filesObj.addProperty(path, content) }
+        json.add("dirty_files", filesObj)
+
+        return GsonBuilder().create().toJson(json)
+    }
+}
+
+/**
  * Input data for git-ai checkpoint agent-v1 command sent via stdin.
  * Uses a sealed class to represent the two types: human (before edit) and ai_agent (after edit).
  */

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.editor.EditorFactory
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.vfs.VirtualFileManager
 import org.jetbrains.plugins.template.listener.DocumentChangeListener
 import org.jetbrains.plugins.template.listener.DocumentSaveListener
@@ -45,9 +44,8 @@ class DocumentChangeTrackerService : Disposable {
             .subscribe(VirtualFileManager.VFS_CHANGES, vfsListener)
 
         val editorVersion = ApplicationInfo.getInstance().fullVersion
-        val extensionVersion = com.intellij.ide.plugins.PluginManagerCore
-            .getPlugin(PluginId.findId("com.usegitai.plugins.jetbrains"))
-            ?.version ?: "unknown"
+        // TODO: Get plugin version dynamically when IntelliJ platform API stabilizes
+        val extensionVersion = "0.1.6"
         val saveListener = DocumentSaveListener(scheduler, editorVersion, extensionVersion)
         ApplicationManager.getApplication().messageBus.connect(this)
             .subscribe(VirtualFileManager.VFS_CHANGES, saveListener)

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
@@ -40,17 +40,17 @@ class DocumentChangeTrackerService : Disposable {
         val docListener = DocumentChangeListener(agentTouchedFiles, scheduler)
         EditorFactory.getInstance().eventMulticaster.addDocumentListener(docListener, this)
 
-        val bus = ApplicationManager.getApplication().messageBus.connect(this)
-
         val vfsListener = VfsRefreshListener(agentTouchedFiles, scheduler)
-        bus.subscribe(VirtualFileManager.VFS_CHANGES, vfsListener)
+        ApplicationManager.getApplication().messageBus.connect(this)
+            .subscribe(VirtualFileManager.VFS_CHANGES, vfsListener)
 
         val editorVersion = ApplicationInfo.getInstance().fullVersion
         val extensionVersion = com.intellij.ide.plugins.PluginManagerCore
             .getPlugin(PluginId.getId("com.usegitai.plugins.jetbrains"))
             ?.version ?: "unknown"
         val saveListener = DocumentSaveListener(scheduler, editorVersion, extensionVersion)
-        bus.subscribe(VirtualFileManager.VFS_CHANGES, saveListener)
+        ApplicationManager.getApplication().messageBus.connect(this)
+            .subscribe(VirtualFileManager.VFS_CHANGES, saveListener)
 
         // Periodic eviction of stale tracking entries
         scheduler.scheduleAtFixedRate(

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
@@ -1,12 +1,15 @@
 package org.jetbrains.plugins.template.services
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.vfs.VirtualFileManager
 import org.jetbrains.plugins.template.listener.DocumentChangeListener
+import org.jetbrains.plugins.template.listener.DocumentSaveListener
 import org.jetbrains.plugins.template.listener.TrackedAgent
 import org.jetbrains.plugins.template.listener.VfsRefreshListener
 import java.util.concurrent.ConcurrentHashMap
@@ -37,9 +40,17 @@ class DocumentChangeTrackerService : Disposable {
         val docListener = DocumentChangeListener(agentTouchedFiles, scheduler)
         EditorFactory.getInstance().eventMulticaster.addDocumentListener(docListener, this)
 
+        val bus = ApplicationManager.getApplication().messageBus.connect(this)
+
         val vfsListener = VfsRefreshListener(agentTouchedFiles, scheduler)
-        ApplicationManager.getApplication().messageBus.connect(this)
-            .subscribe(VirtualFileManager.VFS_CHANGES, vfsListener)
+        bus.subscribe(VirtualFileManager.VFS_CHANGES, vfsListener)
+
+        val editorVersion = ApplicationInfo.getInstance().fullVersion
+        val extensionVersion = com.intellij.ide.plugins.PluginManagerCore
+            .getPlugin(PluginId.getId("com.usegitai.plugins.jetbrains"))
+            ?.version ?: "unknown"
+        val saveListener = DocumentSaveListener(scheduler, editorVersion, extensionVersion)
+        bus.subscribe(VirtualFileManager.VFS_CHANGES, saveListener)
 
         // Periodic eviction of stale tracking entries
         scheduler.scheduleAtFixedRate(

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/DocumentChangeTrackerService.kt
@@ -46,7 +46,7 @@ class DocumentChangeTrackerService : Disposable {
 
         val editorVersion = ApplicationInfo.getInstance().fullVersion
         val extensionVersion = com.intellij.ide.plugins.PluginManagerCore
-            .getPlugin(PluginId.getId("com.usegitai.plugins.jetbrains"))
+            .getPlugin(PluginId.findId("com.usegitai.plugins.jetbrains"))
             ?.version ?: "unknown"
         val saveListener = DocumentSaveListener(scheduler, editorVersion, extensionVersion)
         ApplicationManager.getApplication().messageBus.connect(this)

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/GitAiService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/GitAiService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import org.jetbrains.plugins.template.model.AgentV1Input
+import org.jetbrains.plugins.template.model.KnownHumanInput
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -343,6 +344,71 @@ class GitAiService {
         } catch (e: Exception) {
             logger.warn("Failed to create checkpoint: ${e.message}", e)
             TelemetryService.getInstance().captureError(e, mapOf("context" to "checkpoint_creation"))
+            false
+        }
+    }
+
+    /**
+     * Creates a known_human checkpoint by calling git-ai checkpoint known_human command.
+     *
+     * @param input The checkpoint data to send via stdin
+     * @param workingDirectory The working directory (git repo root) for the command
+     * @return true if checkpoint was created successfully
+     */
+    fun checkpointKnownHuman(input: KnownHumanInput, workingDirectory: String): Boolean {
+        if (!checkAvailable()) {
+            logger.warn("Skipping known_human checkpoint - git-ai not available")
+            return false
+        }
+
+        val gitAiPath = resolvedGitAiPath
+        if (gitAiPath == null) {
+            logger.warn("Skipping known_human checkpoint - git-ai path not resolved")
+            return false
+        }
+
+        return try {
+            val jsonInput = input.toJson()
+            logger.info("Creating known_human checkpoint for ${input.editedFilepaths}")
+            logger.info("known_human checkpoint input: $jsonInput")
+
+            val command = listOf(gitAiPath, "checkpoint", "known_human", "--hook-input", "stdin")
+            val process = ProcessBuilder(command)
+                .directory(File(workingDirectory))
+                .redirectErrorStream(false)
+                .start()
+
+            process.outputStream.bufferedWriter().use { writer ->
+                writer.write(jsonInput)
+            }
+
+            val completed = process.waitFor(30, TimeUnit.SECONDS)
+            if (!completed) {
+                process.destroyForcibly()
+                logger.warn("git-ai known_human checkpoint timed out")
+                return false
+            }
+
+            val output = process.inputStream.bufferedReader().readText().trim()
+            val errorOutput = process.errorStream.bufferedReader().readText().trim()
+            val exitCode = process.exitValue()
+
+            if (exitCode != 0) {
+                logger.warn("""
+                    git-ai known_human checkpoint failed
+                    Command: ${command.joinToString(" ")}
+                    Exit code: $exitCode
+                    Stdout: $output
+                    Stderr: $errorOutput
+                """.trimIndent())
+                return false
+            }
+
+            logger.info("known_human checkpoint created successfully")
+            if (output.isNotEmpty()) logger.info("git-ai output: $output")
+            true
+        } catch (e: Exception) {
+            logger.warn("Failed to create known_human checkpoint: ${e.message}", e)
             false
         }
     }

--- a/agent-support/vscode/src/extension.ts
+++ b/agent-support/vscode/src/extension.ts
@@ -9,6 +9,7 @@ import { AITabEditManager } from "./ai-tab-edit-manager";
 import { Config } from "./utils/config";
 import { BlameLensManager, registerBlameLensCommands } from "./blame-lens-manager";
 import { initBinaryResolver } from "./utils/binary-path";
+import { KnownHumanCheckpointManager } from "./known-human-checkpoint-manager";
 
 function getDistinctId(): string {
   try {
@@ -43,6 +44,17 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const aiEditManager = new AIEditManager(context);
+
+  const knownHumanManager = new KnownHumanCheckpointManager(
+    vscode.version,
+    context.extension.packageJSON.version,
+  );
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      knownHumanManager.handleSaveEvent(doc);
+    }),
+    { dispose: () => knownHumanManager.dispose() },
+  );
 
   // Initialize and activate blame lens manager
   registerBlameLensCommands(context);

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -58,7 +58,9 @@ export class KnownHumanCheckpointManager {
     }
 
     const timer = setTimeout(() => {
-      this.executeCheckpoint(repoRoot);
+      this.executeCheckpoint(repoRoot).catch((err) =>
+        console.error("[git-ai] KnownHumanCheckpointManager: Checkpoint error:", err)
+      );
     }, this.debounceMs);
 
     this.pendingTimers.set(repoRoot, timer);

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -6,13 +6,13 @@ import { getGitRepoRoot } from "./utils/git-api";
 
 /**
  * Fires a `git-ai checkpoint known_human --hook-input stdin` whenever a
- * document is saved. Debounces per repo root over a 300ms window so that
+ * document is saved. Debounces per repo root over a 500ms window so that
  * bulk saves (e.g. "Save All") are batched into one checkpoint call.
  *
  * Skips non-file-scheme documents and .vscode/ internal files.
  */
 export class KnownHumanCheckpointManager {
-  private readonly debounceMs = 300;
+  private readonly debounceMs = 500;
 
   // per repo root: pending debounce timer
   private pendingTimers = new Map<string, NodeJS.Timeout>();

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -1,0 +1,148 @@
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { spawn } from "child_process";
+import { getGitAiBinary } from "./utils/binary-path";
+import { getGitRepoRoot } from "./utils/git-api";
+
+/**
+ * Fires a `git-ai checkpoint known_human --hook-input stdin` whenever a
+ * document is saved. Debounces per repo root over a 300ms window so that
+ * bulk saves (e.g. "Save All") are batched into one checkpoint call.
+ *
+ * Skips non-file-scheme documents and .vscode/ internal files.
+ */
+export class KnownHumanCheckpointManager {
+  private readonly debounceMs = 300;
+
+  // per repo root: pending debounce timer
+  private pendingTimers = new Map<string, NodeJS.Timeout>();
+
+  // per repo root: set of absolute file paths queued in current debounce window
+  private pendingPaths = new Map<string, Set<string>>();
+
+  constructor(
+    private readonly editorVersion: string,
+    private readonly extensionVersion: string,
+  ) {}
+
+  public handleSaveEvent(doc: vscode.TextDocument): void {
+    if (doc.uri.scheme !== "file") {
+      return;
+    }
+
+    const filePath = doc.uri.fsPath;
+
+    if (this.isInternalVSCodePath(filePath)) {
+      console.log("[git-ai] KnownHumanCheckpointManager: Ignoring internal VSCode file:", filePath);
+      return;
+    }
+
+    const repoRoot = getGitRepoRoot(doc.uri);
+    if (!repoRoot) {
+      console.log("[git-ai] KnownHumanCheckpointManager: No git repo found for", filePath, "- skipping");
+      return;
+    }
+
+    // Accumulate file into pending set for this repo root
+    let pending = this.pendingPaths.get(repoRoot);
+    if (!pending) {
+      pending = new Set();
+      this.pendingPaths.set(repoRoot, pending);
+    }
+    pending.add(filePath);
+
+    // Reset debounce timer
+    const existing = this.pendingTimers.get(repoRoot);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.executeCheckpoint(repoRoot);
+    }, this.debounceMs);
+
+    this.pendingTimers.set(repoRoot, timer);
+    console.log("[git-ai] KnownHumanCheckpointManager: Save queued for", filePath);
+  }
+
+  private executeCheckpoint(repoRoot: string): void {
+    this.pendingTimers.delete(repoRoot);
+
+    const paths = this.pendingPaths.get(repoRoot);
+    if (!paths || paths.size === 0) {
+      return;
+    }
+    const snapshot = [...paths];
+    paths.clear();
+
+    // Build dirty_files as repo-relative path → current content
+    const dirtyFiles: Record<string, string> = {};
+    for (const absolutePath of snapshot) {
+      const relativePath = path.relative(repoRoot, absolutePath);
+      const doc = vscode.workspace.textDocuments.find(
+        (d) => d.uri.fsPath === absolutePath && d.uri.scheme === "file"
+      );
+      // Use open document buffer if available (handles codespaces/remote lag);
+      // fall back to reading from the saved document directly.
+      const content = doc ? doc.getText() : null;
+      if (content !== null) {
+        dirtyFiles[relativePath] = content;
+      }
+    }
+
+    if (Object.keys(dirtyFiles).length === 0) {
+      return;
+    }
+
+    const editedFilepaths = Object.keys(dirtyFiles);
+
+    const hookInput = JSON.stringify({
+      editor: "vscode",
+      editor_version: this.editorVersion,
+      extension_version: this.extensionVersion,
+      cwd: repoRoot,
+      edited_filepaths: editedFilepaths,
+      dirty_files: dirtyFiles,
+    });
+
+    console.log("[git-ai] KnownHumanCheckpointManager: Firing known_human checkpoint for", editedFilepaths);
+
+    const proc = spawn(getGitAiBinary(), ["checkpoint", "known_human", "--hook-input", "stdin"], {
+      cwd: repoRoot,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data) => { stdout += data.toString(); });
+    proc.stderr.on("data", (data) => { stderr += data.toString(); });
+
+    proc.on("error", (err) => {
+      console.error("[git-ai] KnownHumanCheckpointManager: Spawn error:", err.message);
+    });
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        console.error("[git-ai] KnownHumanCheckpointManager: Checkpoint exited with code", code, stdout, stderr);
+      } else {
+        console.log("[git-ai] KnownHumanCheckpointManager: Checkpoint succeeded", stdout.trim());
+      }
+    });
+
+    proc.stdin.write(hookInput);
+    proc.stdin.end();
+  }
+
+  private isInternalVSCodePath(filePath: string): boolean {
+    const normalized = filePath.replace(/\\/g, "/");
+    return normalized.includes("/.vscode/");
+  }
+
+  public dispose(): void {
+    for (const timer of this.pendingTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingTimers.clear();
+    this.pendingPaths.clear();
+  }
+}

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -75,10 +75,9 @@ export class KnownHumanCheckpointManager {
     const snapshot = [...paths];
     paths.clear();
 
-    // Build dirty_files as repo-relative path → current content
+    // Build dirty_files as absolute path → current content
     const dirtyFiles: Record<string, string> = {};
     for (const absolutePath of snapshot) {
-      const relativePath = path.relative(repoRoot, absolutePath);
       const doc = vscode.workspace.textDocuments.find(
         (d) => d.uri.fsPath === absolutePath && d.uri.scheme === "file"
       );
@@ -86,7 +85,7 @@ export class KnownHumanCheckpointManager {
       // fall back to reading from the saved document directly.
       const content = doc ? doc.getText() : null;
       if (content !== null) {
-        dirtyFiles[relativePath] = content;
+        dirtyFiles[absolutePath] = content;
       }
     }
 

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -65,7 +65,7 @@ export class KnownHumanCheckpointManager {
     console.log("[git-ai] KnownHumanCheckpointManager: Save queued for", filePath);
   }
 
-  private executeCheckpoint(repoRoot: string): void {
+  private async executeCheckpoint(repoRoot: string): Promise<void> {
     this.pendingTimers.delete(repoRoot);
 
     const paths = this.pendingPaths.get(repoRoot);
@@ -81,9 +81,21 @@ export class KnownHumanCheckpointManager {
       const doc = vscode.workspace.textDocuments.find(
         (d) => d.uri.fsPath === absolutePath && d.uri.scheme === "file"
       );
-      // Use open document buffer if available (handles codespaces/remote lag);
-      // fall back to reading from the saved document directly.
-      const content = doc ? doc.getText() : null;
+
+      let content: string | null = null;
+      if (doc) {
+        // Use open document buffer if available (handles codespaces/remote lag)
+        content = doc.getText();
+      } else {
+        // Fall back to reading from disk if document was closed within debounce window
+        try {
+          const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(absolutePath));
+          content = Buffer.from(bytes).toString("utf-8");
+        } catch (err) {
+          console.error("[git-ai] KnownHumanCheckpointManager: Failed to read file", absolutePath, err);
+        }
+      }
+
       if (content !== null) {
         dirtyFiles[absolutePath] = content;
       }

--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -2148,9 +2148,7 @@ fn find_dominant_author_for_line_candidates(
     let mut last_human_edit: Option<&Attribution> = None;
     for attr in &candidate_attrs {
         // Both legacy "human" and KnownHuman h_<hash> IDs are human edits.
-        if attr.author_id == CheckpointKind::Human.to_str()
-            || attr.author_id.starts_with("h_")
-        {
+        if attr.author_id == CheckpointKind::Human.to_str() || attr.author_id.starts_with("h_") {
             last_human_edit = Some(attr);
         } else {
             last_ai_edit = Some(attr);

--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -2118,7 +2118,11 @@ fn find_dominant_author_for_line_candidates(
         // Zero-length attributions are deletion markers - they indicate the author
         // deleted content at this position, so they should influence line attribution
         let is_deletion_marker = attribution.start == attribution.end;
-        let is_ai_author = attribution.author_id != CheckpointKind::Human.to_str();
+        // h_<hash> IDs are known-human attestations; treat them like "human" for
+        // whitespace-inclusion purposes so their newline ranges don't bleed into
+        // adjacent lines during an AI checkpoint.
+        let is_ai_author = attribution.author_id != CheckpointKind::Human.to_str()
+            && !attribution.author_id.starts_with("h_");
         let include_ai_whitespace = is_ai_checkpoint && is_ai_author;
         if has_non_whitespace || is_line_empty || is_deletion_marker || include_ai_whitespace {
             candidate_attrs.push(attribution);
@@ -2143,7 +2147,10 @@ fn find_dominant_author_for_line_candidates(
     let mut last_ai_edit: Option<&Attribution> = None;
     let mut last_human_edit: Option<&Attribution> = None;
     for attr in &candidate_attrs {
-        if attr.author_id == CheckpointKind::Human.to_str() {
+        // Both legacy "human" and KnownHuman h_<hash> IDs are human edits.
+        if attr.author_id == CheckpointKind::Human.to_str()
+            || attr.author_id.starts_with("h_")
+        {
             last_human_edit = Some(attr);
         } else {
             last_ai_edit = Some(attr);

--- a/src/authorship/authorship_log.rs
+++ b/src/authorship/authorship_log.rs
@@ -187,6 +187,13 @@ impl fmt::Display for LineRange {
     }
 }
 
+/// Identity record for a known human author attested by an IDE extension
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HumanRecord {
+    /// Git committer identity: "Alice Smith <alice@example.com>"
+    pub author: String,
+}
+
 /// Prompt session details stored in the top-level prompts map keyed by short hash (agent_id + tool)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PromptRecord {

--- a/src/authorship/authorship_log_serialization.rs
+++ b/src/authorship/authorship_log_serialization.rs
@@ -52,7 +52,7 @@ impl Default for AuthorshipMetadata {
 /// This system only tracks AI-generated content, not human-authored content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttestationEntry {
-    /// Short hash (7 chars) that maps to an entry in the prompts section of the metadata
+    /// Short hash (16 chars) that maps to an entry in the prompts section of the metadata
     pub hash: String,
     /// Line ranges that this prompt is responsible for
     pub line_ranges: Vec<LineRange>,
@@ -625,14 +625,24 @@ fn needs_quoting(path: &str) -> bool {
     path.contains(' ') || path.contains('\t') || path.contains('\n')
 }
 
-/// Generate a short hash (7 characters) from agent_id and tool
+/// Generate a short hash (16 characters) from agent_id and tool
 pub fn generate_short_hash(agent_id: &str, tool: &str) -> String {
     let combined = format!("{}:{}", tool, agent_id);
     let mut hasher = Sha256::new();
     hasher.update(combined.as_bytes());
     let result = hasher.finalize();
-    // Take first 7 characters of the hex representation
+    // Take first 16 characters of the hex representation
     format!("{:x}", result)[..16].to_string()
+}
+
+/// Generate a short hash identifying a known human author from their git committer identity.
+/// Returns "h_" + first 14 hex chars of SHA256(author_identity) = 16 chars total.
+/// The "h_" prefix distinguishes human hashes from AI session hashes throughout the system.
+pub fn generate_human_short_hash(author_identity: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(author_identity.as_bytes());
+    let hex = format!("{:x}", hasher.finalize());
+    format!("h_{}", &hex[..14])
 }
 
 #[cfg(test)]
@@ -1349,5 +1359,21 @@ mod tests {
             .map(|attr| attr.end_line - attr.start_line + 1)
             .sum();
         assert_eq!(lines_session2, 20);
+    }
+
+    #[test]
+    fn test_generate_human_short_hash() {
+        let hash = generate_human_short_hash("Alice Smith <alice@example.com>");
+        // Must be exactly 16 chars: "h_" + 14 hex chars
+        assert_eq!(hash.len(), 16);
+        assert!(hash.starts_with("h_"));
+        assert_eq!(hash, "h_31dce776f88375");
+        // Must be deterministic
+        assert_eq!(
+            hash,
+            generate_human_short_hash("Alice Smith <alice@example.com>")
+        );
+        // Different identities → different hashes
+        assert_ne!(hash, generate_human_short_hash("Bob Jones <bob@example.com>"));
     }
 }

--- a/src/authorship/authorship_log_serialization.rs
+++ b/src/authorship/authorship_log_serialization.rs
@@ -1,4 +1,4 @@
-use crate::authorship::authorship_log::{Author, LineRange, PromptRecord};
+use crate::authorship::authorship_log::{Author, HumanRecord, LineRange, PromptRecord};
 use crate::authorship::working_log::CheckpointKind;
 use crate::git::repository::Repository;
 use serde::{Deserialize, Serialize};
@@ -27,6 +27,8 @@ pub struct AuthorshipMetadata {
     pub git_ai_version: Option<String>,
     pub base_commit_sha: String,
     pub prompts: BTreeMap<String, PromptRecord>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub humans: BTreeMap<String, HumanRecord>,
 }
 
 impl AuthorshipMetadata {
@@ -36,6 +38,7 @@ impl AuthorshipMetadata {
             git_ai_version: Some(GIT_AI_VERSION.to_string()),
             base_commit_sha: String::new(),
             prompts: BTreeMap::new(),
+            humans: BTreeMap::new(),
         }
     }
 }

--- a/src/authorship/authorship_log_serialization.rs
+++ b/src/authorship/authorship_log_serialization.rs
@@ -1404,7 +1404,10 @@ mod tests {
             generate_human_short_hash("Alice Smith <alice@example.com>")
         );
         // Different identities → different hashes
-        assert_ne!(hash, generate_human_short_hash("Bob Jones <bob@example.com>"));
+        assert_ne!(
+            hash,
+            generate_human_short_hash("Bob Jones <bob@example.com>")
+        );
     }
 
     /// Test that `convert_to_checkpoints_for_squash` correctly skips h_ attestation entries

--- a/src/authorship/authorship_log_serialization.rs
+++ b/src/authorship/authorship_log_serialization.rs
@@ -49,10 +49,13 @@ impl Default for AuthorshipMetadata {
     }
 }
 
-/// Attestation entry: short hash followed by line ranges
+/// Attestation entry: a short hash followed by line ranges.
 ///
-/// IMPORTANT: The hash ALWAYS corresponds to a prompt in the prompts section.
-/// This system only tracks AI-generated content, not human-authored content.
+/// The hash maps to either:
+/// - An AI session entry in `metadata.prompts` (16 hex chars, no prefix), or
+/// - A known-human author entry in `metadata.humans` (prefixed with `h_`)
+///
+/// Lines with no attestation entry are "unknown" — not tracked by git-ai.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttestationEntry {
     /// Short hash (16 chars) that maps to an entry in the prompts section of the metadata
@@ -247,6 +250,22 @@ impl AuthorshipLog {
             // Check if this line is covered by any of the line ranges
             let contains = entry.line_ranges.iter().any(|range| range.contains(line));
             if contains {
+                // h_-prefixed hashes are known-human attestations — route to humans map
+                if entry.hash.starts_with("h_") {
+                    if let Some(human_record) = self.metadata.humans.get(&entry.hash) {
+                        return Some((
+                            Author {
+                                username: human_record.author.clone(),
+                                email: String::new(),
+                            },
+                            Some(entry.hash.clone()),
+                            None, // No PromptRecord for known-human lines
+                        ));
+                    }
+                    // h_ hash not found locally (foreign cherry-pick) — skip this entry
+                    continue;
+                }
+
                 // The hash corresponds to a prompt session short hash
                 if let Some(prompt_record) = self.metadata.prompts.get(&entry.hash) {
                     // Create author info from the prompt record
@@ -375,6 +394,11 @@ impl AuthorshipLog {
             let mut session_prompt_records: Vec<PromptRecord> = Vec::new();
 
             for (session_hash, ranges) in &session_entries {
+                // Skip known-human attestations — they don't have prompt records
+                if session_hash.starts_with("h_") {
+                    continue;
+                }
+
                 let prompt_record = self
                     .metadata
                     .prompts
@@ -871,14 +895,17 @@ mod tests {
         let serialized = log.serialize_to_string().unwrap();
         assert_debug_snapshot!(serialized);
 
-        // Verify that every hash in attestations has a corresponding prompt
+        // Verify that every non-h_ hash in attestations has a corresponding prompt.
+        // Only non-h_ hashes must map to prompts; h_ hashes map to humans instead.
         for file_attestation in &log.attestations {
             for entry in &file_attestation.entries {
-                assert!(
-                    log.metadata.prompts.contains_key(&entry.hash),
-                    "Hash '{}' should have a corresponding prompt in metadata",
-                    entry.hash
-                );
+                if !entry.hash.starts_with("h_") {
+                    assert!(
+                        log.metadata.prompts.contains_key(&entry.hash),
+                        "Hash '{}' should have a corresponding prompt in metadata",
+                        entry.hash
+                    );
+                }
             }
         }
     }
@@ -1379,4 +1406,84 @@ mod tests {
         // Different identities → different hashes
         assert_ne!(hash, generate_human_short_hash("Bob Jones <bob@example.com>"));
     }
+
+    /// Test that `convert_to_checkpoints_for_squash` correctly skips h_ attestation entries
+    /// rather than failing with "Missing prompt record".
+    #[test]
+    fn test_convert_to_checkpoints_skips_h_entries() {
+        use crate::authorship::transcript::{AiTranscript, Message};
+        use crate::authorship::working_log::AgentId;
+        use std::collections::HashMap;
+
+        let mut log = AuthorshipLog::new();
+        log.metadata.base_commit_sha = "base123".to_string();
+
+        // AI session
+        let agent_id = AgentId {
+            tool: "cursor".to_string(),
+            id: "session_abc".to_string(),
+            model: "claude-3-sonnet".to_string(),
+        };
+        let mut transcript = AiTranscript::new();
+        transcript.add_message(Message::user("Write a helper".to_string(), None));
+        transcript.add_message(Message::assistant("Here it is".to_string(), None));
+        let ai_hash = generate_short_hash(&agent_id.id, &agent_id.tool);
+        log.metadata.prompts.insert(
+            ai_hash.clone(),
+            crate::authorship::authorship_log::PromptRecord {
+                agent_id,
+                human_author: None,
+                messages: transcript.messages().to_vec(),
+                total_additions: 5,
+                total_deletions: 0,
+                accepted_lines: 5,
+                overriden_lines: 0,
+                messages_url: None,
+                custom_attributes: None,
+            },
+        );
+
+        // Known-human attestation — h_ hash present in attestations but NOT in prompts.
+        let human_hash = generate_human_short_hash("Alice <alice@example.com>");
+        log.metadata.humans.insert(
+            human_hash.clone(),
+            crate::authorship::authorship_log::HumanRecord {
+                author: "Alice".to_string(),
+            },
+        );
+
+        // File: AI owns lines 1-5, human owns lines 6-10
+        let mut file1 = FileAttestation::new("src/lib.rs".to_string());
+        file1.add_entry(AttestationEntry::new(
+            ai_hash.clone(),
+            vec![LineRange::Range(1, 5)],
+        ));
+        file1.add_entry(AttestationEntry::new(
+            human_hash.clone(),
+            vec![LineRange::Range(6, 10)],
+        ));
+        log.attestations.push(file1);
+
+        let mut file_contents = HashMap::new();
+        let content: String = (1..=10).map(|i| format!("line{}\n", i)).collect();
+        file_contents.insert("src/lib.rs".to_string(), content);
+
+        // Must succeed — h_ entry must be silently skipped
+        let result = log.convert_to_checkpoints_for_squash(&file_contents);
+        assert!(
+            result.is_ok(),
+            "convert_to_checkpoints_for_squash should not fail on h_ entries: {:?}",
+            result.err()
+        );
+        let checkpoints = result.unwrap();
+
+        // Only 1 AI checkpoint — the human entry has no corresponding prompt record
+        assert_eq!(checkpoints.len(), 1);
+        assert_eq!(checkpoints[0].author, "ai");
+    }
+
+    // TODO: `get_line_attribution` routing for h_ hashes requires a live `Repository` instance
+    // and cannot be unit-tested here without significant mocking infrastructure.
+    // The h_-routing path (returning HumanRecord data instead of PromptRecord) is covered by
+    // integration tests in the authorship integration test suite.
 }

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -291,6 +291,7 @@ pub fn post_commit_with_final_state(
         new_working_log.write_initial_attributions_with_contents(
             initial_attributions.files,
             initial_attributions.prompts,
+            initial_attributions.humans,
             initial_file_contents,
         )?;
     }

--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -207,12 +207,8 @@ fn create_authorship_log_for_range(
             crate::authorship::authorship_log_serialization::AuthorshipLog {
                 attestations: Vec::new(),
                 metadata: crate::authorship::authorship_log_serialization::AuthorshipMetadata {
-                    schema_version: "3".to_string(),
-                    git_ai_version: Some(
-                        crate::authorship::authorship_log_serialization::GIT_AI_VERSION.to_string(),
-                    ),
                     base_commit_sha: end_sha.to_string(),
-                    prompts: std::collections::BTreeMap::new(),
+                    ..crate::authorship::authorship_log_serialization::AuthorshipMetadata::new()
                 },
             },
         );

--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -424,6 +424,7 @@ fn calculate_range_stats_direct(
         git_diff_added_lines,
         git_diff_deleted_lines,
         diff_ai_stats.total_ai_accepted,
+        0,
         &diff_ai_stats.per_tool_model,
     );
 
@@ -666,7 +667,9 @@ mod tests {
         // Range authorship merges attributions from start to end, filtering to commits in range
         // The exact AI/human split depends on the merge attribution logic
         assert_eq!(stats.range_stats.ai_additions, 2);
-        assert_eq!(stats.range_stats.human_additions, 1);
+        // range_authorship passes known_human_accepted=0, so human lines appear as unknown_additions
+        assert_eq!(stats.range_stats.human_additions, 0);
+        assert_eq!(stats.range_stats.unknown_additions, 1);
         assert_eq!(stats.range_stats.git_diff_added_lines, 3);
     }
 
@@ -874,9 +877,10 @@ mod tests {
         assert_eq!(stats.range_stats.git_diff_added_lines, 3); // Only lib.rs, package-lock.json excluded
         // Verify the total is much less than 3003 (if lockfile was included)
         assert!(stats.range_stats.git_diff_added_lines < 100);
-        // Verify that some AI and human work is detected
+        // Verify that some AI work is detected and unattested lines exist
         assert!(stats.range_stats.ai_additions > 0);
-        assert!(stats.range_stats.human_additions > 0);
+        // range_authorship passes known_human_accepted=0, so human lines show as unknown_additions
+        assert!(stats.range_stats.unknown_additions > 0);
     }
 
     #[test]

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -3712,7 +3712,7 @@ fn build_metadata_template_parts(
 /// that `total_additions` / `total_deletions` reflect *this* commit, not an unrelated one
 /// that happens to sort first by SHA).
 ///
-/// `delta_humans` overrides `metadata.humans` with per-commit-delta humans (only h_<hash>
+/// `delta_humans` overrides `metadata.humans` with per-commit-delta humans (only `h_<hash>`
 /// entries that appear in this commit's changed files). Passing `None` leaves metadata.humans
 /// unchanged (used for the initial/non-per-commit path).
 fn build_metadata_template_parts_filtered(

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -1257,8 +1257,14 @@ pub fn rewrite_authorship_after_rebase_v2(
     // Only load file contents for files that actually change — skip unchanged files.
     let va_phase_start = std::time::Instant::now();
 
-    let (mut current_attributions, mut current_file_contents, initial_prompts, initial_humans, _rebase_ts) =
-        if let Some((attrs, contents, prompts, humans)) = try_reconstruct_attributions_from_notes_cached(
+    let (
+        mut current_attributions,
+        mut current_file_contents,
+        initial_prompts,
+        initial_humans,
+        _rebase_ts,
+    ) = if let Some((attrs, contents, prompts, humans)) =
+        try_reconstruct_attributions_from_notes_cached(
             repo,
             original_head,
             original_commits,
@@ -1267,58 +1273,58 @@ pub fn rewrite_authorship_after_rebase_v2(
             &note_cache,
             &original_hunks_by_commit,
         ) {
-            debug_log("Using fast note-based attribution reconstruction (skipping blame)");
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis();
-            (attrs, contents, prompts, humans, ts)
-        } else {
-            debug_log("Falling back to VirtualAttributions (blame-based reconstruction)");
-            let new_head = new_commits.last().unwrap();
-            let merge_base = repo
-                .merge_base(original_head.to_string(), new_head.to_string())
-                .ok();
+        debug_log("Using fast note-based attribution reconstruction (skipping blame)");
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        (attrs, contents, prompts, humans, ts)
+    } else {
+        debug_log("Falling back to VirtualAttributions (blame-based reconstruction)");
+        let new_head = new_commits.last().unwrap();
+        let merge_base = repo
+            .merge_base(original_head.to_string(), new_head.to_string())
+            .ok();
 
-            let repo_clone = repo.clone();
-            let original_head_clone = original_head.to_string();
-            let pathspecs_clone = pathspecs.clone();
+        let repo_clone = repo.clone();
+        let original_head_clone = original_head.to_string();
+        let pathspecs_clone = pathspecs.clone();
 
-            let current_va = smol::block_on(async {
-                crate::authorship::virtual_attribution::VirtualAttributions::new_for_base_commit(
-                    repo_clone,
-                    original_head_clone,
-                    &pathspecs_clone,
-                    merge_base,
-                )
-                .await
-            })?;
+        let current_va = smol::block_on(async {
+            crate::authorship::virtual_attribution::VirtualAttributions::new_for_base_commit(
+                repo_clone,
+                original_head_clone,
+                &pathspecs_clone,
+                merge_base,
+            )
+            .await
+        })?;
 
-            let mut attrs = HashMap::new();
-            let mut contents = HashMap::new();
-            for file in current_va.files() {
-                if let Some(char_attrs) = current_va.get_char_attributions(&file)
-                    && let Some(line_attrs) = current_va.get_line_attributions(&file)
-                {
-                    attrs.insert(file.clone(), (char_attrs.clone(), line_attrs.clone()));
-                }
-                if let Some(content) = current_va.get_file_content(&file) {
-                    contents.insert(file, content.clone());
-                }
+        let mut attrs = HashMap::new();
+        let mut contents = HashMap::new();
+        for file in current_va.files() {
+            if let Some(char_attrs) = current_va.get_char_attributions(&file)
+                && let Some(line_attrs) = current_va.get_line_attributions(&file)
+            {
+                attrs.insert(file.clone(), (char_attrs.clone(), line_attrs.clone()));
             }
-
-            let mut prompts: BTreeMap<
-                String,
-                BTreeMap<String, crate::authorship::authorship_log::PromptRecord>,
-            > = BTreeMap::new();
-            for (prompt_id, commit_map) in current_va.prompts() {
-                prompts.insert(prompt_id.clone(), commit_map.clone());
+            if let Some(content) = current_va.get_file_content(&file) {
+                contents.insert(file, content.clone());
             }
+        }
 
-            let humans = current_va.humans.clone();
-            let ts = current_va.timestamp();
-            (attrs, contents, prompts, humans, ts)
-        };
+        let mut prompts: BTreeMap<
+            String,
+            BTreeMap<String, crate::authorship::authorship_log::PromptRecord>,
+        > = BTreeMap::new();
+        for (prompt_id, commit_map) in current_va.prompts() {
+            prompts.insert(prompt_id.clone(), commit_map.clone());
+        }
+
+        let humans = current_va.humans.clone();
+        let ts = current_va.timestamp();
+        (attrs, contents, prompts, humans, ts)
+    };
 
     timing_phases.push((
         format!("attribution_reconstruction ({} pathspecs)", pathspecs.len()),
@@ -4064,10 +4070,9 @@ fn build_note_from_conflict_wl(
         // the attribution state is accumulated across checkpoints), so there is no need to
         // process the KnownHuman checkpoint's entries separately.
         if checkpoint.kind == CheckpointKind::KnownHuman {
-            let hash =
-                crate::authorship::authorship_log_serialization::generate_human_short_hash(
-                    &checkpoint.author,
-                );
+            let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                &checkpoint.author,
+            );
             authorship_log
                 .metadata
                 .humans

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -678,6 +678,9 @@ pub fn rewrite_authorship_after_squash_or_rebase(
                 entry.0 = entry.0.saturating_add(record.total_additions);
                 entry.1 = entry.1.saturating_add(record.total_deletions);
             }
+            for (hash, record) in log.metadata.humans {
+                authorship_log.metadata.humans.entry(hash).or_insert(record);
+            }
         }
     }
 
@@ -713,7 +716,7 @@ pub fn rewrite_authorship_after_squash_or_rebase(
 /// expensive git blame operations. This reads notes from ALL original commits in batch
 /// and merges their attributions to get the full state at original_head.
 /// Cached version: uses pre-loaded note contents from RebaseNoteCache.
-/// Returns: (attributions, file_contents, prompts) or None if reconstruction fails.
+/// Returns: (attributions, file_contents, prompts, humans) or None if reconstruction fails.
 #[allow(clippy::type_complexity)]
 fn try_reconstruct_attributions_from_notes_cached(
     repo: &Repository,
@@ -733,8 +736,10 @@ fn try_reconstruct_attributions_from_notes_cached(
     >,
     HashMap<String, String>,
     BTreeMap<String, BTreeMap<String, crate::authorship::authorship_log::PromptRecord>>,
+    BTreeMap<String, crate::authorship::authorship_log::HumanRecord>,
 )> {
     use crate::authorship::attribution_tracker::LineAttribution;
+    use crate::authorship::authorship_log::HumanRecord;
     use crate::authorship::authorship_log_serialization::AuthorshipLog;
 
     let pathspec_set: HashSet<&str> = pathspecs.iter().map(String::as_str).collect();
@@ -742,6 +747,7 @@ fn try_reconstruct_attributions_from_notes_cached(
         String,
         BTreeMap<String, crate::authorship::authorship_log::PromptRecord>,
     > = BTreeMap::new();
+    let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
 
     // Parse all notes and check if any exist.
     let mut parsed_logs: HashMap<String, AuthorshipLog> = HashMap::new();
@@ -821,6 +827,10 @@ fn try_reconstruct_attributions_from_notes_cached(
                     .or_default()
                     .insert(commit.to_string(), prompt_record.clone());
             }
+            // Collect humans (union-merge: first writer wins).
+            for (hash, record) in &log.metadata.humans {
+                humans.entry(hash.clone()).or_insert_with(|| record.clone());
+            }
         }
     }
 
@@ -840,7 +850,7 @@ fn try_reconstruct_attributions_from_notes_cached(
         }
     }
 
-    Some((attributions, file_contents, prompts))
+    Some((attributions, file_contents, prompts, humans))
 }
 
 /// Overlay a new attribution range onto an existing sorted attribution list.
@@ -1244,8 +1254,8 @@ pub fn rewrite_authorship_after_rebase_v2(
     // Only load file contents for files that actually change — skip unchanged files.
     let va_phase_start = std::time::Instant::now();
 
-    let (mut current_attributions, mut current_file_contents, initial_prompts, _rebase_ts) =
-        if let Some((attrs, contents, prompts)) = try_reconstruct_attributions_from_notes_cached(
+    let (mut current_attributions, mut current_file_contents, initial_prompts, initial_humans, _rebase_ts) =
+        if let Some((attrs, contents, prompts, humans)) = try_reconstruct_attributions_from_notes_cached(
             repo,
             original_head,
             original_commits,
@@ -1259,7 +1269,7 @@ pub fn rewrite_authorship_after_rebase_v2(
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis();
-            (attrs, contents, prompts, ts)
+            (attrs, contents, prompts, humans, ts)
         } else {
             debug_log("Falling back to VirtualAttributions (blame-based reconstruction)");
             let new_head = new_commits.last().unwrap();
@@ -1302,8 +1312,9 @@ pub fn rewrite_authorship_after_rebase_v2(
                 prompts.insert(prompt_id.clone(), commit_map.clone());
             }
 
+            let humans = current_va.humans.clone();
             let ts = current_va.timestamp();
-            (attrs, contents, prompts, ts)
+            (attrs, contents, prompts, humans, ts)
         };
 
     timing_phases.push((
@@ -1397,6 +1408,7 @@ pub fn rewrite_authorship_after_rebase_v2(
     let current_authorship_log = build_authorship_log_from_state(
         original_head,
         &current_prompts,
+        &initial_humans,
         &current_attributions,
         &existing_files,
     );
@@ -2739,11 +2751,11 @@ pub fn rewrite_authorship_after_commit_amend_with_snapshot(
     let touched_files = working_log.all_touched_files()?;
     pathspecs.extend(touched_files);
 
-    // Check if original commit has an authorship log with prompts
+    // Check if original commit has an authorship log with prompts or humans
     let has_existing_log = get_reference_as_authorship_log_v3(repo, original_commit).is_ok();
-    let has_existing_prompts = if has_existing_log {
+    let has_existing_data = if has_existing_log {
         let original_log = get_reference_as_authorship_log_v3(repo, original_commit).unwrap();
-        !original_log.metadata.prompts.is_empty()
+        !original_log.metadata.prompts.is_empty() || !original_log.metadata.humans.is_empty()
     } else {
         false
     };
@@ -2757,7 +2769,7 @@ pub fn rewrite_authorship_after_commit_amend_with_snapshot(
                 repo_clone,
                 original_commit.to_string(),
                 &pathspecs_vec,
-                if has_existing_prompts {
+                if has_existing_data {
                     None
                 } else {
                     Some(human_author.clone())
@@ -2773,7 +2785,7 @@ pub fn rewrite_authorship_after_commit_amend_with_snapshot(
                 repo_clone,
                 original_commit.to_string(),
                 &pathspecs_vec,
-                if has_existing_prompts {
+                if has_existing_data {
                     None
                 } else {
                     Some(human_author.clone())
@@ -3292,8 +3304,11 @@ fn build_metadata_only_authorship_log_from_source_notes(
     source_commits: &[String],
     target_commit_sha: &str,
 ) -> Result<Option<AuthorshipLog>, GitAiError> {
+    use crate::authorship::authorship_log::HumanRecord;
+
     let mut merged_prompts = BTreeMap::new();
     let mut prompt_totals: HashMap<String, (u32, u32)> = HashMap::new();
+    let mut merged_humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
     let mut saw_any_note = false;
 
     for commit_sha in source_commits {
@@ -3307,6 +3322,9 @@ fn build_metadata_only_authorship_log_from_source_notes(
             entry.0 = entry.0.saturating_add(prompt_record.total_additions);
             entry.1 = entry.1.saturating_add(prompt_record.total_deletions);
             merged_prompts.insert(prompt_id, prompt_record);
+        }
+        for (hash, record) in log.metadata.humans {
+            merged_humans.entry(hash).or_insert(record);
         }
     }
 
@@ -3324,6 +3342,7 @@ fn build_metadata_only_authorship_log_from_source_notes(
     let mut authorship_log = AuthorshipLog::new();
     authorship_log.metadata.base_commit_sha = target_commit_sha.to_string();
     authorship_log.metadata.prompts = merged_prompts;
+    authorship_log.metadata.humans = merged_humans;
     Ok(Some(authorship_log))
 }
 
@@ -4056,6 +4075,7 @@ fn build_note_from_conflict_wl(
 fn build_authorship_log_from_state(
     base_commit_sha: &str,
     prompts: &BTreeMap<String, BTreeMap<String, crate::authorship::authorship_log::PromptRecord>>,
+    humans: &BTreeMap<String, crate::authorship::authorship_log::HumanRecord>,
     attributions: &HashMap<
         String,
         (
@@ -4068,6 +4088,7 @@ fn build_authorship_log_from_state(
     let mut authorship_log = AuthorshipLog::new();
     authorship_log.metadata.base_commit_sha = base_commit_sha.to_string();
     authorship_log.metadata.prompts = flatten_prompts_for_metadata(prompts);
+    authorship_log.metadata.humans = humans.clone();
 
     for (file_path, (_, line_attrs)) in attributions {
         if !existing_files.contains(file_path) {

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -1474,6 +1474,10 @@ pub fn rewrite_authorship_after_rebase_v2(
     // per-commit fields (total_additions, total_deletions) are always taken from the correct
     // original commit's PromptRecord even when accepted_lines happen to be equal across commits.
     let mut prev_original_commit: Option<String> = None;
+    // Per-commit-delta humans: only h_<hash> entries that appear in the current commit's
+    // changed files, mirroring the same scoping applied to prompts/accepted_lines.
+    let mut prev_delta_humans: BTreeMap<String, crate::authorship::authorship_log::HumanRecord> =
+        BTreeMap::new();
 
     for (idx, new_commit) in commits_to_process.iter().enumerate() {
         debug_log(&format!(
@@ -1626,15 +1630,53 @@ pub fn rewrite_authorship_after_rebase_v2(
                 .filter(|(_, m)| m.accepted_lines > 0)
                 .map(|(pid, m)| (pid.clone(), m.accepted_lines))
                 .collect();
+            // Per-commit-delta humans: h_<hash> entries for KnownHuman-attributed lines in
+            // this commit's changed files.  `current_attributions` only tracks AI-attributed
+            // lines (from note attestations), so we read KnownHuman checkpoints from the
+            // working log stored under this commit's parent SHA instead.  For non-conflict
+            // commits the working log is absent or has no KnownHuman entries → empty map.
+            let delta_humans: BTreeMap<String, crate::authorship::authorship_log::HumanRecord> = {
+                let mut map = BTreeMap::new();
+                if let Some(parent_sha) = commit_parent_shas.get(new_commit) {
+                    if let Ok(wl) = repo.storage.working_log_for_base_commit(parent_sha) {
+                        if let Ok(checkpoints) = wl.read_all_checkpoints() {
+                            for cp in &checkpoints {
+                                if cp.kind
+                                    != crate::authorship::working_log::CheckpointKind::KnownHuman
+                                {
+                                    continue;
+                                }
+                                // Only include if any entry covers a changed file in this commit.
+                                if !cp
+                                    .entries
+                                    .iter()
+                                    .any(|e| changed_files_in_commit.contains(&e.file))
+                                {
+                                    continue;
+                                }
+                                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                                    &cp.author,
+                                );
+                                map.entry(hash.clone()).or_insert_with(|| {
+                                    initial_humans.get(&hash).cloned().unwrap_or_else(|| {
+                                        crate::authorship::authorship_log::HumanRecord {
+                                            author: cp.author.clone(),
+                                        }
+                                    })
+                                });
+                            }
+                        }
+                    }
+                }
+                map
+            };
             // Only rebuild the (expensive) serde_json metadata template when the active-prompt
-            // set OR accepted_lines values changed, OR when the original commit changed.
-            // Consecutive same-session commits share the same prompt IDs but differ in
-            // accepted_lines, so the key includes both.  We also track the original commit
-            // because per-commit fields (total_additions, total_deletions) are keyed by the
-            // original SHA and must be refreshed whenever it changes.
+            // set OR accepted_lines values changed, OR when the original commit changed, OR
+            // when per-commit humans changed.
             let current_original_commit = new_to_original.get(new_commit).map(String::as_str);
             if active_prompt_key != prev_active_prompt_key
                 || current_original_commit != prev_original_commit.as_deref()
+                || delta_humans != prev_delta_humans
             {
                 let active_ids: HashSet<String> = active_prompt_key.keys().cloned().collect();
                 metadata_json_template_parts = build_metadata_template_parts_filtered(
@@ -1642,9 +1684,11 @@ pub fn rewrite_authorship_after_rebase_v2(
                     &current_prompts,
                     Some(&active_ids),
                     current_original_commit,
+                    Some(&delta_humans),
                 );
                 prev_active_prompt_key = active_prompt_key;
                 prev_original_commit = current_original_commit.map(str::to_string);
+                prev_delta_humans = delta_humans;
             }
             loop_metrics_ms += tmetrics.elapsed().as_micros();
         }
@@ -3649,7 +3693,7 @@ fn build_metadata_template_parts(
     metadata: &crate::authorship::authorship_log_serialization::AuthorshipMetadata,
     prompts: &BTreeMap<String, BTreeMap<String, crate::authorship::authorship_log::PromptRecord>>,
 ) -> Option<(String, String)> {
-    build_metadata_template_parts_filtered(metadata, prompts, None, None)
+    build_metadata_template_parts_filtered(metadata, prompts, None, None, None)
 }
 
 /// Like `build_metadata_template_parts` but only includes prompts whose IDs are in
@@ -3661,16 +3705,26 @@ fn build_metadata_template_parts(
 /// being serialized. When provided, it is used to select the per-commit `PromptRecord` (so
 /// that `total_additions` / `total_deletions` reflect *this* commit, not an unrelated one
 /// that happens to sort first by SHA).
+///
+/// `delta_humans` overrides `metadata.humans` with per-commit-delta humans (only h_<hash>
+/// entries that appear in this commit's changed files). Passing `None` leaves metadata.humans
+/// unchanged (used for the initial/non-per-commit path).
 fn build_metadata_template_parts_filtered(
     metadata: &crate::authorship::authorship_log_serialization::AuthorshipMetadata,
     prompts: &BTreeMap<String, BTreeMap<String, crate::authorship::authorship_log::PromptRecord>>,
     active_ids: Option<&HashSet<String>>,
     original_commit: Option<&str>,
+    delta_humans: Option<&BTreeMap<String, crate::authorship::authorship_log::HumanRecord>>,
 ) -> Option<(String, String)> {
     let mut template_meta = metadata.clone();
     template_meta.base_commit_sha = "BASE_COMMIT_SHA_PLACEHOLDER".to_string();
     template_meta.prompts =
         flatten_prompts_for_metadata_filtered(prompts, active_ids, original_commit);
+    // Per-commit-delta: scope humans to only those appearing in this commit's changed files.
+    // An empty map serializes to nothing (humans field is skip_serializing_if = is_empty).
+    if let Some(humans) = delta_humans {
+        template_meta.humans = humans.clone();
+    }
     serde_json::to_string_pretty(&template_meta)
         .ok()
         .map(|template| {
@@ -4001,6 +4055,26 @@ fn build_note_from_conflict_wl(
 
     for checkpoint in &checkpoints {
         if checkpoint.kind == CheckpointKind::Human {
+            continue;
+        }
+
+        // KnownHuman checkpoints: record the human identity in metadata.humans and skip
+        // AI-prompt processing.  The AI checkpoint that follows a KnownHuman checkpoint
+        // already carries the h_-attributed line_attributions in its own entries (because
+        // the attribution state is accumulated across checkpoints), so there is no need to
+        // process the KnownHuman checkpoint's entries separately.
+        if checkpoint.kind == CheckpointKind::KnownHuman {
+            let hash =
+                crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                    &checkpoint.author,
+                );
+            authorship_log
+                .metadata
+                .humans
+                .entry(hash)
+                .or_insert_with(|| crate::authorship::authorship_log::HumanRecord {
+                    author: checkpoint.author.clone(),
+                });
             continue;
         }
 

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -829,7 +829,7 @@ fn try_reconstruct_attributions_from_notes_cached(
             }
             // Collect humans (union-merge: first writer wins).
             for (hash, record) in &log.metadata.humans {
-                humans.entry(hash.clone()).or_insert_with(|| record.clone());
+                humans.entry(hash.clone()).or_insert(record.clone());
             }
         }
     }

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -384,6 +384,7 @@ pub fn prepare_working_log_after_squash(
         working_log.write_initial_attributions_with_contents(
             initial_attributions.files,
             initial_attributions.prompts,
+            initial_attributions.humans,
             initial_file_contents,
         )?;
     }
@@ -459,6 +460,7 @@ pub fn prepare_working_log_after_squash_from_final_state(
         working_log.write_initial_attributions_with_contents(
             initial_attributions.files,
             initial_attributions.prompts,
+            initial_attributions.humans,
             initial_file_contents,
         )?;
     }
@@ -530,6 +532,7 @@ pub fn restore_virtual_attribution_carryover(
     working_log.write_initial_attributions_with_contents(
         initial_attributions.files,
         initial_attributions.prompts,
+        initial_attributions.humans,
         final_state,
     )?;
     Ok(())
@@ -2842,6 +2845,7 @@ pub fn rewrite_authorship_after_commit_amend_with_snapshot(
         new_working_log.write_initial_attributions_with_contents(
             initial_attributions.files,
             initial_attributions.prompts,
+            initial_attributions.humans,
             initial_file_contents,
         )?;
     }
@@ -3098,6 +3102,7 @@ pub fn reconstruct_working_log_after_reset(
         new_working_log.write_initial_attributions_with_contents(
             initial_attributions.files,
             initial_attributions.prompts,
+            initial_attributions.humans,
             final_state,
         )?;
     }

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -1643,35 +1643,32 @@ pub fn rewrite_authorship_after_rebase_v2(
             // commits the working log is absent or has no KnownHuman entries → empty map.
             let delta_humans: BTreeMap<String, crate::authorship::authorship_log::HumanRecord> = {
                 let mut map = BTreeMap::new();
-                if let Some(parent_sha) = commit_parent_shas.get(new_commit) {
-                    if let Ok(wl) = repo.storage.working_log_for_base_commit(parent_sha) {
-                        if let Ok(checkpoints) = wl.read_all_checkpoints() {
-                            for cp in &checkpoints {
-                                if cp.kind
-                                    != crate::authorship::working_log::CheckpointKind::KnownHuman
-                                {
-                                    continue;
-                                }
-                                // Only include if any entry covers a changed file in this commit.
-                                if !cp
-                                    .entries
-                                    .iter()
-                                    .any(|e| changed_files_in_commit.contains(&e.file))
-                                {
-                                    continue;
-                                }
-                                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
-                                    &cp.author,
-                                );
-                                map.entry(hash.clone()).or_insert_with(|| {
-                                    initial_humans.get(&hash).cloned().unwrap_or_else(|| {
-                                        crate::authorship::authorship_log::HumanRecord {
-                                            author: cp.author.clone(),
-                                        }
-                                    })
-                                });
-                            }
+                if let Some(parent_sha) = commit_parent_shas.get(new_commit)
+                    && let Ok(wl) = repo.storage.working_log_for_base_commit(parent_sha)
+                    && let Ok(checkpoints) = wl.read_all_checkpoints()
+                {
+                    for cp in &checkpoints {
+                        if cp.kind != crate::authorship::working_log::CheckpointKind::KnownHuman {
+                            continue;
                         }
+                        // Only include if any entry covers a changed file in this commit.
+                        if !cp
+                            .entries
+                            .iter()
+                            .any(|e| changed_files_in_commit.contains(&e.file))
+                        {
+                            continue;
+                        }
+                        let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                            &cp.author,
+                        );
+                        map.entry(hash.clone()).or_insert_with(|| {
+                            initial_humans.get(&hash).cloned().unwrap_or_else(|| {
+                                crate::authorship::authorship_log::HumanRecord {
+                                    author: cp.author.clone(),
+                                }
+                            })
+                        });
                     }
                 }
                 map

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__file_names_with_spaces-2.snap
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__file_names_with_spaces-2.snap
@@ -69,5 +69,6 @@ AuthorshipLogV3 {
                 custom_attributes: None,
             },
         },
+        humans: {},
     },
 }

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_no_attestations-2.snap
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_no_attestations-2.snap
@@ -27,5 +27,6 @@ AuthorshipLogV3 {
                 custom_attributes: None,
             },
         },
+        humans: {},
     },
 }

--- a/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_roundtrip-2.snap
+++ b/src/authorship/snapshots/git_ai__authorship__authorship_log_serialization__tests__serialize_deserialize_roundtrip-2.snap
@@ -61,5 +61,6 @@ AuthorshipLogV3 {
         ),
         base_commit_sha: "abc123",
         prompts: {},
+        humans: {},
     },
 }

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -315,7 +315,7 @@ pub fn write_stats_to_markdown(stats: &CommitStats) -> String {
     }
 
     // Calculate total additions for the progress bar
-    // Total = pure human + mixed (AI-edited-by-human) + pure AI (accepted)
+    // Total = (known human + unknown) + mixed (AI-edited-by-human) + pure AI (accepted)
     let total_additions = stats.git_diff_added_lines;
 
     // Pure human additions: known-human attested + unattested (treated as human until full KnownHuman pipeline)
@@ -503,7 +503,9 @@ pub fn stats_from_authorship_log(
 
     // TODO: Mixed additions come from prompt overrides and can exceed the final diff when we
     // compute ai_accepted from diff/blame. Cap to remaining added lines until we improve mixed tracking.
-    let max_mixed = git_diff_added_lines.saturating_sub(commit_stats.ai_accepted);
+    let max_mixed = git_diff_added_lines
+        .saturating_sub(commit_stats.ai_accepted)
+        .saturating_sub(known_human_accepted);
     if commit_stats.mixed_additions > max_mixed {
         commit_stats.mixed_additions = max_mixed;
     }
@@ -618,11 +620,14 @@ fn accepted_lines_from_attestations(
         for entry in &file_attestation.entries {
             // KnownHuman entries (h_ prefix): count as known-human-attested lines.
             if entry.hash.starts_with("h_") {
-                known_human_accepted += entry
+                let accepted = entry
                     .line_ranges
                     .iter()
                     .map(|line_range| line_range_overlap_len(line_range, added_lines))
                     .sum::<u32>();
+                if accepted > 0 {
+                    known_human_accepted += accepted;
+                }
                 continue;
             }
 
@@ -1034,6 +1039,8 @@ mod tests {
         let stats = stats_for_commit_stats(tmp_repo.gitai_repo(), &head_sha, &[]).unwrap();
 
         // Verify the stats
+        // trigger_checkpoint_with_author produces KnownHuman checkpoints (post Task 9),
+        // so human-written lines have h_-prefixed attestation entries → human_additions.
         assert_eq!(stats.human_additions, 2, "Human added 2 lines");
         assert_eq!(stats.ai_additions, 2, "AI added 2 lines");
         assert_eq!(stats.ai_accepted, 2, "AI lines were accepted");

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -605,6 +605,12 @@ fn accepted_lines_from_attestations(
         };
 
         for entry in &file_attestation.entries {
+            // Skip KnownHuman entries (h_ prefix). These are human-attested lines that
+            // should count as human additions, not AI accepted.
+            if entry.hash.starts_with("h_") {
+                continue;
+            }
+
             let accepted = entry
                 .line_ranges
                 .iter()

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -29,6 +29,8 @@ pub struct CommitStats {
     #[serde(default)]
     pub human_additions: u32, // Number of lines committed with human attribution (full and/or mixed)
     #[serde(default)]
+    pub unknown_additions: u32, // Number of lines with no attestation at all
+    #[serde(default)]
     pub mixed_additions: u32, // Number of AI-generated lines that were edited by humans before being committed
     #[serde(default)]
     pub ai_additions: u32, // Number of lines committed with AI attribution (full and/or mixed)
@@ -452,10 +454,12 @@ pub fn stats_from_authorship_log(
     git_diff_added_lines: u32,
     git_diff_deleted_lines: u32,
     ai_accepted: u32,
+    known_human_accepted: u32,
     ai_accepted_by_tool: &BTreeMap<String, u32>,
 ) -> CommitStats {
     let mut commit_stats = CommitStats {
         human_additions: 0,
+        unknown_additions: 0,
         mixed_additions: 0,
         ai_additions: 0,
         ai_accepted,
@@ -518,12 +522,13 @@ pub fn stats_from_authorship_log(
         tool_stats.ai_additions = tool_stats.ai_accepted + tool_stats.mixed_additions;
     }
 
-    // Human additions are the difference between total git diff and AI accepted lines (ensure non-negative)
-    // This includes mixed lines (AI-generated but human-edited) as human additions
-    commit_stats.human_additions = std::cmp::max(
-        0,
-        git_diff_added_lines.saturating_sub(commit_stats.ai_accepted),
-    );
+    // KnownHuman-attested additions (positively identified as human-authored)
+    commit_stats.human_additions = known_human_accepted;
+
+    // Unknown additions: lines with no attestation at all (not AI-accepted, not KnownHuman)
+    commit_stats.unknown_additions = git_diff_added_lines
+        .saturating_sub(commit_stats.ai_accepted)
+        .saturating_sub(known_human_accepted);
 
     commit_stats
 }
@@ -567,7 +572,7 @@ pub fn stats_for_commit_stats(
     }
 
     // Step 4: derive accepted lines directly from note attestations for lines added in this commit.
-    let (ai_accepted, ai_accepted_by_tool) = accepted_lines_from_attestations(
+    let (ai_accepted, known_human_accepted, ai_accepted_by_tool) = accepted_lines_from_attestations(
         authorship_log.as_ref(),
         &added_lines_by_file,
         is_merge_commit,
@@ -579,6 +584,7 @@ pub fn stats_for_commit_stats(
         git_diff_added_lines,
         git_diff_deleted_lines,
         ai_accepted,
+        known_human_accepted,
         &ai_accepted_by_tool,
     ))
 }
@@ -587,16 +593,18 @@ fn accepted_lines_from_attestations(
     authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
     added_lines_by_file: &HashMap<String, Vec<u32>>,
     is_merge_commit: bool,
-) -> (u32, BTreeMap<String, u32>) {
+) -> (u32, u32, BTreeMap<String, u32>) {
+    // returns (ai_accepted, known_human_accepted, per_tool_model)
     if is_merge_commit {
-        return (0, BTreeMap::new());
+        return (0, 0, BTreeMap::new());
     }
 
     let mut total_ai_accepted = 0u32;
+    let mut known_human_accepted = 0u32;
     let mut per_tool_model = BTreeMap::new();
 
     let Some(log) = authorship_log else {
-        return (0, per_tool_model);
+        return (0, 0, per_tool_model);
     };
 
     for file_attestation in &log.attestations {
@@ -605,9 +613,13 @@ fn accepted_lines_from_attestations(
         };
 
         for entry in &file_attestation.entries {
-            // Skip KnownHuman entries (h_ prefix). These are human-attested lines that
-            // should count as human additions, not AI accepted.
+            // KnownHuman entries (h_ prefix): count as known-human-attested lines.
             if entry.hash.starts_with("h_") {
+                known_human_accepted += entry
+                    .line_ranges
+                    .iter()
+                    .map(|line_range| line_range_overlap_len(line_range, added_lines))
+                    .sum::<u32>();
                 continue;
             }
 
@@ -633,7 +645,7 @@ fn accepted_lines_from_attestations(
         }
     }
 
-    (total_ai_accepted, per_tool_model)
+    (total_ai_accepted, known_human_accepted, per_tool_model)
 }
 
 fn line_range_overlap_len(range: &LineRange, added_lines: &[u32]) -> u32 {
@@ -758,6 +770,7 @@ mod tests {
         // Test with mixed human/AI stats
         let stats = CommitStats {
             human_additions: 50,
+            unknown_additions: 0,
             mixed_additions: 40,
             ai_additions: 100,
             ai_accepted: 25,
@@ -775,6 +788,7 @@ mod tests {
         // Test with AI-only stats
         let ai_stats = CommitStats {
             human_additions: 0,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 100,
             ai_accepted: 95,
@@ -792,6 +806,7 @@ mod tests {
         // Test with human-only stats
         let human_stats = CommitStats {
             human_additions: 75,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 0,
             ai_accepted: 0,
@@ -809,6 +824,7 @@ mod tests {
         // Test with minimal human contribution (should get at least 2 blocks)
         let minimal_human_stats = CommitStats {
             human_additions: 2,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 100,
             ai_accepted: 95,
@@ -826,6 +842,7 @@ mod tests {
         // Test with deletion-only commit (no additions)
         let deletion_only_stats = CommitStats {
             human_additions: 0,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 0,
             ai_accepted: 0,
@@ -846,6 +863,7 @@ mod tests {
         // Test with mixed human/AI stats
         let stats = CommitStats {
             human_additions: 50,
+            unknown_additions: 0,
             mixed_additions: 40,
             ai_additions: 100,
             ai_accepted: 25,
@@ -863,6 +881,7 @@ mod tests {
         // Test with AI-only stats
         let ai_stats = CommitStats {
             human_additions: 0,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 100,
             ai_accepted: 95,
@@ -880,6 +899,7 @@ mod tests {
         // Test with human-only stats
         let human_stats = CommitStats {
             human_additions: 75,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 0,
             ai_accepted: 0,
@@ -897,6 +917,7 @@ mod tests {
         // Test with minimal human contribution (should get at least 2 blocks)
         let minimal_human_stats = CommitStats {
             human_additions: 2,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 100,
             ai_accepted: 95,
@@ -914,6 +935,7 @@ mod tests {
         // Test with deletion-only commit (no additions)
         let deletion_only_stats = CommitStats {
             human_additions: 0,
+            unknown_additions: 0,
             mixed_additions: 0,
             ai_additions: 0,
             ai_accepted: 0,
@@ -1039,10 +1061,15 @@ mod tests {
         let head_sha = tmp_repo.get_head_commit_sha().unwrap();
         let stats = stats_for_commit_stats(tmp_repo.gitai_repo(), &head_sha, &[]).unwrap();
 
-        // For initial commit, everything should be additions
+        // For initial commit, human lines have no h_-prefixed attestation entries yet
+        // (pure-human files bypass line-level attribution tracking), so they appear as unknown.
         assert_eq!(
-            stats.human_additions, 3,
-            "Human authored 3 lines in initial commit"
+            stats.human_additions, 0,
+            "No KnownHuman-attested additions in pure-human commit"
+        );
+        assert_eq!(
+            stats.unknown_additions, 3,
+            "All 3 lines are unattested (unknown) in a pure-human initial commit"
         );
         assert_eq!(stats.ai_additions, 0, "No AI additions in initial commit");
         assert_eq!(stats.ai_accepted, 0, "No AI lines to accept");
@@ -1142,7 +1169,9 @@ mod tests {
         let stats_filtered =
             stats_for_commit_stats(tmp_repo.gitai_repo(), &head_sha, &ignore_patterns).unwrap();
         assert_eq!(stats_filtered.git_diff_added_lines, 1);
-        assert_eq!(stats_filtered.human_additions, 1);
+        // Pure-human files have no h_-prefixed line attestation entries, so lines appear as unknown.
+        assert_eq!(stats_filtered.human_additions, 0);
+        assert_eq!(stats_filtered.unknown_additions, 1);
     }
 
     #[test]
@@ -1272,8 +1301,10 @@ mod tests {
     #[test]
     fn test_accepted_lines_no_authorship_log() {
         let added_lines: HashMap<String, Vec<u32>> = HashMap::new();
-        let (accepted, per_tool) = accepted_lines_from_attestations(None, &added_lines, false);
+        let (accepted, known_human, per_tool) =
+            accepted_lines_from_attestations(None, &added_lines, false);
         assert_eq!(accepted, 0);
+        assert_eq!(known_human, 0);
         assert!(per_tool.is_empty());
     }
 
@@ -1319,8 +1350,10 @@ mod tests {
         let mut added_lines: HashMap<String, Vec<u32>> = HashMap::new();
         added_lines.insert("foo.rs".to_string(), vec![1, 2, 3]);
 
-        let (accepted, per_tool) = accepted_lines_from_attestations(Some(&log), &added_lines, true);
+        let (accepted, known_human, per_tool) =
+            accepted_lines_from_attestations(Some(&log), &added_lines, true);
         assert_eq!(accepted, 0);
+        assert_eq!(known_human, 0);
         assert!(per_tool.is_empty());
     }
 
@@ -1366,9 +1399,10 @@ mod tests {
         let mut added_lines: HashMap<String, Vec<u32>> = HashMap::new();
         added_lines.insert("bar.rs".to_string(), vec![1, 2, 3]);
 
-        let (accepted, per_tool) =
+        let (accepted, known_human, per_tool) =
             accepted_lines_from_attestations(Some(&log), &added_lines, false);
         assert_eq!(accepted, 0);
+        assert_eq!(known_human, 0);
         assert!(per_tool.is_empty());
     }
 
@@ -1413,9 +1447,10 @@ mod tests {
         let mut added_lines: HashMap<String, Vec<u32>> = HashMap::new();
         added_lines.insert("foo.rs".to_string(), vec![1, 2, 3]);
 
-        let (accepted, per_tool) =
+        let (accepted, known_human, per_tool) =
             accepted_lines_from_attestations(Some(&log), &added_lines, false);
         assert_eq!(accepted, 3);
+        assert_eq!(known_human, 0);
 
         // Verify per-tool breakdown contains the right key
         let expected_key = "cursor::claude-3-sonnet".to_string();
@@ -1724,13 +1759,14 @@ mod tests {
 
     #[test]
     fn test_stats_from_authorship_log_no_log() {
-        let stats = stats_from_authorship_log(None, 10, 5, 3, &BTreeMap::new());
+        let stats = stats_from_authorship_log(None, 10, 5, 3, 0, &BTreeMap::new());
 
         assert_eq!(stats.git_diff_added_lines, 10);
         assert_eq!(stats.git_diff_deleted_lines, 5);
         assert_eq!(stats.ai_accepted, 3);
         assert_eq!(stats.ai_additions, 3); // ai_accepted when no mixed
-        assert_eq!(stats.human_additions, 7); // 10 - 3
+        assert_eq!(stats.human_additions, 0); // no known-human attestations passed
+        assert_eq!(stats.unknown_additions, 7); // 10 - 3 (unattested lines)
         assert_eq!(stats.mixed_additions, 0);
         assert_eq!(stats.total_ai_additions, 0);
         assert_eq!(stats.total_ai_deletions, 0);
@@ -1769,7 +1805,7 @@ mod tests {
         );
 
         // Only 10 lines added, 5 accepted by AI
-        let stats = stats_from_authorship_log(Some(&log), 10, 0, 5, &BTreeMap::new());
+        let stats = stats_from_authorship_log(Some(&log), 10, 0, 5, 0, &BTreeMap::new());
 
         // Mixed should be capped to max possible: 10 - 5 = 5
         assert_eq!(stats.mixed_additions, 5);

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -128,8 +128,11 @@ pub fn write_stats_to_terminal(stats: &CommitStats, print: bool) -> String {
     }
 
     // Calculate total additions for the progress bar
-    // Total = pure human + mixed (AI-edited-by-human) + pure AI
-    let total_additions = stats.human_additions + stats.ai_additions;
+    // Total = (known human + unknown) + mixed (AI-edited-by-human) + pure AI
+    // unknown_additions are unattested lines — treated as human for display until
+    // full KnownHuman attestation pipeline is in place.
+    let display_human = stats.human_additions + stats.unknown_additions;
+    let total_additions = display_human + stats.ai_additions;
 
     // Calculate AI acceptance percentage (capped at 100%)
     // It can go higher because AI can write on top of AI code. This feels reasonable for now
@@ -140,8 +143,8 @@ pub fn write_stats_to_terminal(stats: &CommitStats, print: bool) -> String {
     };
 
     // Create progress bar with three categories
-    // Pure human = human_additions - mixed_additions (overridden lines)
-    let pure_human = stats.human_additions.saturating_sub(stats.mixed_additions);
+    // Pure human = (human_additions + unknown_additions) - mixed_additions (overridden lines)
+    let pure_human = display_human.saturating_sub(stats.mixed_additions);
 
     let pure_human_bars = if total_additions > 0 {
         ((pure_human as f64 / total_additions as f64) * bar_width as f64) as usize
@@ -164,8 +167,8 @@ pub fn write_stats_to_terminal(stats: &CommitStats, print: bool) -> String {
     };
 
     // Ensure human contributions get at least 2 visible blocks if they have more than 1 line
-    let min_human_bars = if stats.human_additions > 1 { 2 } else { 0 };
-    let final_pure_human_bars = if stats.human_additions > 1 {
+    let min_human_bars = if display_human > 1 { 2 } else { 0 };
+    let final_pure_human_bars = if display_human > 1 {
         pure_human_bars.max(min_human_bars)
     } else {
         pure_human_bars
@@ -315,8 +318,8 @@ pub fn write_stats_to_markdown(stats: &CommitStats) -> String {
     // Total = pure human + mixed (AI-edited-by-human) + pure AI (accepted)
     let total_additions = stats.git_diff_added_lines;
 
-    // Pure human additions (not including mixed)
-    let pure_human = stats.human_additions;
+    // Pure human additions: known-human attested + unattested (treated as human until full KnownHuman pipeline)
+    let pure_human = stats.human_additions + stats.unknown_additions;
     // Mixed = AI lines that were edited by human
     let mixed = stats.mixed_additions;
     // Pure AI = AI lines accepted without changes

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -1071,15 +1071,15 @@ mod tests {
         let head_sha = tmp_repo.get_head_commit_sha().unwrap();
         let stats = stats_for_commit_stats(tmp_repo.gitai_repo(), &head_sha, &[]).unwrap();
 
-        // For initial commit, human lines have no h_-prefixed attestation entries yet
-        // (pure-human files bypass line-level attribution tracking), so they appear as unknown.
+        // KnownHuman checkpoints record h_<hash> attributions for all human-edited lines,
+        // so they appear as human_additions (not unknown) even on pure-human commits.
         assert_eq!(
-            stats.human_additions, 0,
-            "No KnownHuman-attested additions in pure-human commit"
+            stats.human_additions, 3,
+            "All 3 lines should be KnownHuman-attested human_additions"
         );
         assert_eq!(
-            stats.unknown_additions, 3,
-            "All 3 lines are unattested (unknown) in a pure-human initial commit"
+            stats.unknown_additions, 0,
+            "No unattested lines in a KnownHuman-checkpointed commit"
         );
         assert_eq!(stats.ai_additions, 0, "No AI additions in initial commit");
         assert_eq!(stats.ai_accepted, 0, "No AI lines to accept");
@@ -1179,9 +1179,9 @@ mod tests {
         let stats_filtered =
             stats_for_commit_stats(tmp_repo.gitai_repo(), &head_sha, &ignore_patterns).unwrap();
         assert_eq!(stats_filtered.git_diff_added_lines, 1);
-        // Pure-human files have no h_-prefixed line attestation entries, so lines appear as unknown.
-        assert_eq!(stats_filtered.human_additions, 0);
-        assert_eq!(stats_filtered.unknown_additions, 1);
+        // KnownHuman checkpoints record h_<hash> attributions, so the README line is human_additions.
+        assert_eq!(stats_filtered.human_additions, 1);
+        assert_eq!(stats_filtered.unknown_additions, 0);
     }
 
     #[test]

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -339,7 +339,9 @@ impl VirtualAttributions {
 
         // Load known human records from INITIAL attributions
         for (hash, human_record) in &initial_attributions.humans {
-            humans.entry(hash.clone()).or_insert_with(|| human_record.clone());
+            humans
+                .entry(hash.clone())
+                .or_insert_with(|| human_record.clone());
         }
 
         // Process INITIAL attributions
@@ -401,9 +403,10 @@ impl VirtualAttributions {
             }
 
             if checkpoint.kind == CheckpointKind::KnownHuman {
-                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
-                    &checkpoint.author,
-                );
+                let hash =
+                    crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                        &checkpoint.author,
+                    );
                 humans.entry(hash).or_insert_with(|| HumanRecord {
                     author: checkpoint.author.clone(),
                 });
@@ -504,7 +507,9 @@ impl VirtualAttributions {
 
         // Load known human records from INITIAL attributions
         for (hash, human_record) in &initial_attributions.humans {
-            humans.entry(hash.clone()).or_insert_with(|| human_record.clone());
+            humans
+                .entry(hash.clone())
+                .or_insert_with(|| human_record.clone());
         }
 
         for (file_path, line_attrs) in &initial_attributions.files {
@@ -556,9 +561,10 @@ impl VirtualAttributions {
             }
 
             if checkpoint.kind == CheckpointKind::KnownHuman {
-                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
-                    &checkpoint.author,
-                );
+                let hash =
+                    crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                        &checkpoint.author,
+                    );
                 humans.entry(hash).or_insert_with(|| HumanRecord {
                     author: checkpoint.author.clone(),
                 });
@@ -651,7 +657,9 @@ impl VirtualAttributions {
 
         // Load known human records from INITIAL attributions
         for (hash, human_record) in &initial_attributions.humans {
-            humans.entry(hash.clone()).or_insert_with(|| human_record.clone());
+            humans
+                .entry(hash.clone())
+                .or_insert_with(|| human_record.clone());
         }
 
         for (file_path, line_attrs) in &initial_attributions.files {
@@ -703,9 +711,10 @@ impl VirtualAttributions {
             }
 
             if checkpoint.kind == CheckpointKind::KnownHuman {
-                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
-                    &checkpoint.author,
-                );
+                let hash =
+                    crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                        &checkpoint.author,
+                    );
                 humans.entry(hash).or_insert_with(|| HumanRecord {
                     author: checkpoint.author.clone(),
                 });
@@ -1912,8 +1921,7 @@ pub fn merge_attributions_favoring_first(
         VirtualAttributions::merge_prompts_picking_newest(&[&primary.prompts, &secondary.prompts]);
 
     // Merge humans from both VAs
-    let merged_humans =
-        VirtualAttributions::merge_humans(&primary.humans, &secondary.humans);
+    let merged_humans = VirtualAttributions::merge_humans(&primary.humans, &secondary.humans);
 
     let mut merged = VirtualAttributions {
         repo,

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -74,11 +74,12 @@ impl VirtualAttributions {
             }
         }
 
-        // Find missing author_ids (not in prompts map)
-        // An author_id is missing if it doesn't exist as a key in the outer prompts map
+        // Find missing author_ids (not in prompts or humans maps)
+        // An author_id is missing if it doesn't exist in prompts or humans
+        // h_-prefixed KnownHuman IDs are stored in self.humans, not self.prompts
         let missing_ids: Vec<String> = all_author_ids
             .into_iter()
-            .filter(|id| !self.prompts.contains_key(id))
+            .filter(|id| !self.prompts.contains_key(id) && !self.humans.contains_key(id))
             .collect();
 
         if missing_ids.is_empty() {

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -2135,6 +2135,7 @@ pub fn restore_stashed_va(
         if let Err(e) = working_log.write_initial_attributions_with_contents(
             initial_attributions.files,
             initial_attributions.prompts,
+            initial_attributions.humans,
             initial_file_contents,
         ) {
             debug_log(&format!("Failed to write INITIAL attributions: {}", e));

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1700,10 +1700,10 @@ impl VirtualAttributions {
         // Collect h_ human records referenced by retained attributions
         let mut initial_humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         for author_id in &referenced_prompts {
-            if author_id.starts_with("h_") {
-                if let Some(record) = self.humans.get(author_id) {
-                    initial_humans.insert(author_id.clone(), record.clone());
-                }
+            if author_id.starts_with("h_")
+                && let Some(record) = self.humans.get(author_id)
+            {
+                initial_humans.insert(author_id.clone(), record.clone());
             }
         }
 

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1,7 +1,7 @@
 use crate::authorship::attribution_tracker::{
     Attribution, LineAttribution, line_attributions_to_attributions,
 };
-use crate::authorship::authorship_log::{LineRange, PromptRecord};
+use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord};
 use crate::authorship::working_log::CheckpointKind;
 use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
 use crate::error::GitAiError;
@@ -24,6 +24,7 @@ pub struct VirtualAttributions {
     // Timestamp to use for attributions
     ts: u128,
     pub blame_start_commit: Option<String>,
+    pub humans: BTreeMap<String, HumanRecord>,
 }
 
 impl VirtualAttributions {
@@ -47,6 +48,7 @@ impl VirtualAttributions {
             prompts: BTreeMap::new(),
             ts,
             blame_start_commit,
+            humans: BTreeMap::new(),
         };
 
         // Process all pathspecs concurrently
@@ -319,6 +321,7 @@ impl VirtualAttributions {
         let mut attributions: HashMap<String, (Vec<Attribution>, Vec<LineAttribution>)> =
             HashMap::new();
         let mut prompts = BTreeMap::new();
+        let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         let mut file_contents: HashMap<String, String> = HashMap::new();
 
         // Track additions and deletions per session_id for metrics
@@ -332,6 +335,11 @@ impl VirtualAttributions {
                 .entry(prompt_id.clone())
                 .or_insert_with(BTreeMap::new)
                 .insert(String::new(), prompt_record.clone());
+        }
+
+        // Load known human records from INITIAL attributions
+        for (hash, human_record) in &initial_attributions.humans {
+            humans.entry(hash.clone()).or_insert_with(|| human_record.clone());
         }
 
         // Process INITIAL attributions
@@ -390,6 +398,15 @@ impl VirtualAttributions {
                     checkpoint.line_stats.additions;
                 *session_deletions.entry(author_id.clone()).or_insert(0) +=
                     checkpoint.line_stats.deletions;
+            }
+
+            if checkpoint.kind == CheckpointKind::KnownHuman {
+                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                    &checkpoint.author,
+                );
+                humans.entry(hash).or_insert_with(|| HumanRecord {
+                    author: checkpoint.author.clone(),
+                });
             }
 
             // Collect attributions from checkpoint entries
@@ -453,6 +470,7 @@ impl VirtualAttributions {
             prompts,
             ts: 0,
             blame_start_commit: None,
+            humans,
         })
     }
 
@@ -471,6 +489,7 @@ impl VirtualAttributions {
         let mut attributions: HashMap<String, (Vec<Attribution>, Vec<LineAttribution>)> =
             HashMap::new();
         let mut prompts = BTreeMap::new();
+        let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         let mut file_contents: HashMap<String, String> = HashMap::new();
 
         let mut session_additions: HashMap<String, u32> = HashMap::new();
@@ -481,6 +500,11 @@ impl VirtualAttributions {
                 .entry(prompt_id.clone())
                 .or_insert_with(BTreeMap::new)
                 .insert(String::new(), prompt_record.clone());
+        }
+
+        // Load known human records from INITIAL attributions
+        for (hash, human_record) in &initial_attributions.humans {
+            humans.entry(hash.clone()).or_insert_with(|| human_record.clone());
         }
 
         for (file_path, line_attrs) in &initial_attributions.files {
@@ -529,6 +553,15 @@ impl VirtualAttributions {
                     checkpoint.line_stats.additions;
                 *session_deletions.entry(author_id.clone()).or_insert(0) +=
                     checkpoint.line_stats.deletions;
+            }
+
+            if checkpoint.kind == CheckpointKind::KnownHuman {
+                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                    &checkpoint.author,
+                );
+                humans.entry(hash).or_insert_with(|| HumanRecord {
+                    author: checkpoint.author.clone(),
+                });
             }
 
             for entry in &checkpoint.entries {
@@ -583,6 +616,7 @@ impl VirtualAttributions {
             prompts,
             ts: 0,
             blame_start_commit: None,
+            humans,
         })
     }
 
@@ -602,6 +636,7 @@ impl VirtualAttributions {
         let mut attributions: HashMap<String, (Vec<Attribution>, Vec<LineAttribution>)> =
             HashMap::new();
         let mut prompts = BTreeMap::new();
+        let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         let mut file_contents: HashMap<String, String> = HashMap::new();
 
         let mut session_additions: HashMap<String, u32> = HashMap::new();
@@ -612,6 +647,11 @@ impl VirtualAttributions {
                 .entry(prompt_id.clone())
                 .or_insert_with(BTreeMap::new)
                 .insert(String::new(), prompt_record.clone());
+        }
+
+        // Load known human records from INITIAL attributions
+        for (hash, human_record) in &initial_attributions.humans {
+            humans.entry(hash.clone()).or_insert_with(|| human_record.clone());
         }
 
         for (file_path, line_attrs) in &initial_attributions.files {
@@ -660,6 +700,15 @@ impl VirtualAttributions {
                     checkpoint.line_stats.additions;
                 *session_deletions.entry(author_id.clone()).or_insert(0) +=
                     checkpoint.line_stats.deletions;
+            }
+
+            if checkpoint.kind == CheckpointKind::KnownHuman {
+                let hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+                    &checkpoint.author,
+                );
+                humans.entry(hash).or_insert_with(|| HumanRecord {
+                    author: checkpoint.author.clone(),
+                });
             }
 
             for entry in &checkpoint.entries {
@@ -721,6 +770,7 @@ impl VirtualAttributions {
             prompts,
             ts: 0,
             blame_start_commit: None,
+            humans,
         })
     }
 
@@ -827,6 +877,7 @@ impl VirtualAttributions {
             prompts: BTreeMap::new(),
             ts,
             blame_start_commit: None,
+            humans: BTreeMap::new(),
         }
     }
 
@@ -846,6 +897,7 @@ impl VirtualAttributions {
             prompts,
             ts,
             blame_start_commit: None,
+            humans: BTreeMap::new(), // TODO(known-human): propagate humans from caller when rebase path is wired (Task 12)
         }
     }
 
@@ -869,6 +921,7 @@ impl VirtualAttributions {
                     .map(|record| (prompt_id.clone(), record.clone()))
             })
             .collect();
+        authorship_log.metadata.humans = self.humans.clone();
 
         // Process each file
         for (file_path, (_, line_attrs)) in &self.attributions {
@@ -880,7 +933,8 @@ impl VirtualAttributions {
             // This avoids expanding every range to individual line numbers.
             let mut author_ranges: HashMap<String, Vec<(u32, u32)>> = HashMap::new();
             for line_attr in line_attrs {
-                // Skip human attributions - we only track AI attributions
+                // Skip the legacy "human" sentinel (CheckpointKind::Human checkpoints that were
+                // never attested). KnownHuman lines use h_-prefixed author IDs and pass through.
                 if line_attr.author_id == CheckpointKind::Human.to_str() {
                     continue;
                 }
@@ -1185,9 +1239,11 @@ impl VirtualAttributions {
                     .map(|record| (prompt_id.clone(), record.clone()))
             })
             .collect();
+        authorship_log.metadata.humans = self.humans.clone();
 
         let mut initial_files: StdHashMap<String, Vec<LineAttribution>> = StdHashMap::new();
         let mut referenced_prompts: HashSet<String> = HashSet::new();
+        let mut initial_humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
 
         // Get committed hunks (in commit coordinates) and unstaged hunks (in working directory coordinates)
         let committed_hunks = collect_committed_hunks(repo, parent_sha, commit_sha, pathspecs)?;
@@ -1321,7 +1377,8 @@ impl VirtualAttributions {
             if !committed_lines_map.is_empty() {
                 // Create attestation entries from committed lines
                 for (author_id, mut lines) in committed_lines_map {
-                    // Skip human attributions - we only track AI attributions in the output
+                    // Skip the legacy "human" sentinel (CheckpointKind::Human checkpoints that were
+                    // never attested). KnownHuman lines use h_-prefixed author IDs and pass through.
                     if author_id == CheckpointKind::Human.to_str() {
                         continue;
                     }
@@ -1384,7 +1441,8 @@ impl VirtualAttributions {
                 // Convert the map into line attributions
                 let mut uncommitted_line_attrs = Vec::new();
                 for (author_id, mut lines) in uncommitted_lines_map {
-                    // Skip human attributions - we only track AI attributions in the output
+                    // Skip the legacy "human" sentinel (CheckpointKind::Human checkpoints that were
+                    // never attested). KnownHuman lines use h_-prefixed author IDs and pass through.
                     if author_id == CheckpointKind::Human.to_str() {
                         continue;
                     }
@@ -1394,6 +1452,15 @@ impl VirtualAttributions {
 
                     if lines.is_empty() {
                         continue;
+                    }
+
+                    // Track h_ hashes for INITIAL humans map
+                    if author_id.starts_with("h_") {
+                        // h_ hash absent from self.humans — foreign cherry-pick or pre-existing
+                        // INITIAL attribution. Intentionally skip: the record is not needed locally.
+                        if let Some(record) = self.humans.get(&author_id) {
+                            initial_humans.insert(author_id.clone(), record.clone());
+                        }
                     }
 
                     // Create ranges from individual lines
@@ -1444,6 +1511,7 @@ impl VirtualAttributions {
             files: initial_files,
             prompts: initial_prompts,
             file_blobs: HashMap::new(),
+            humans: initial_humans,
         };
 
         Ok((authorship_log, initial_attributions))
@@ -1484,6 +1552,7 @@ impl VirtualAttributions {
                     .map(|record| (prompt_id.clone(), record.clone()))
             })
             .collect();
+        authorship_log.metadata.humans = self.humans.clone();
 
         // Get committed hunks only (no need to check working copy)
         let committed_hunks = collect_committed_hunks(repo, parent_sha, commit_sha, pathspecs)?;
@@ -1527,7 +1596,8 @@ impl VirtualAttributions {
             if !committed_lines_map.is_empty() {
                 // Create attestation entries from committed lines
                 for (author_id, mut lines) in committed_lines_map {
-                    // Skip human attributions - we only track AI attributions in the output
+                    // Skip the legacy "human" sentinel (CheckpointKind::Human checkpoints that were
+                    // never attested). KnownHuman lines use h_-prefixed author IDs and pass through.
                     if author_id == CheckpointKind::Human.to_str() {
                         continue;
                     }
@@ -1610,11 +1680,21 @@ impl VirtualAttributions {
         }
 
         let mut initial_prompts = HashMap::new();
-        for prompt_id in referenced_prompts {
-            if let Some(commits) = self.prompts.get(&prompt_id)
+        for prompt_id in &referenced_prompts {
+            if let Some(commits) = self.prompts.get(prompt_id)
                 && let Some(prompt) = commits.values().next()
             {
-                initial_prompts.insert(prompt_id, prompt.clone());
+                initial_prompts.insert(prompt_id.clone(), prompt.clone());
+            }
+        }
+
+        // Collect h_ human records referenced by retained attributions
+        let mut initial_humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
+        for author_id in &referenced_prompts {
+            if author_id.starts_with("h_") {
+                if let Some(record) = self.humans.get(author_id) {
+                    initial_humans.insert(author_id.clone(), record.clone());
+                }
             }
         }
 
@@ -1622,6 +1702,7 @@ impl VirtualAttributions {
             files: initial_files,
             prompts: initial_prompts,
             file_blobs: HashMap::new(),
+            humans: initial_humans,
         }
     }
 
@@ -1688,6 +1769,18 @@ impl VirtualAttributions {
         }
 
         merged_prompts
+    }
+
+    /// Union-merge two human records maps.
+    /// Because records are keyed by content-hash of the author identity, any value
+    /// for a given key is semantically equivalent. Simple `b`-wins extension is safe.
+    fn merge_humans(
+        a: &BTreeMap<String, HumanRecord>,
+        b: &BTreeMap<String, HumanRecord>,
+    ) -> BTreeMap<String, HumanRecord> {
+        let mut result = a.clone();
+        result.extend(b.iter().map(|(k, v)| (k.clone(), v.clone())));
+        result
     }
 
     /// Calculate and update prompt metrics (accepted_lines, overridden_lines, total_additions, total_deletions)
@@ -1818,6 +1911,10 @@ pub fn merge_attributions_favoring_first(
     let merged_prompts =
         VirtualAttributions::merge_prompts_picking_newest(&[&primary.prompts, &secondary.prompts]);
 
+    // Merge humans from both VAs
+    let merged_humans =
+        VirtualAttributions::merge_humans(&primary.humans, &secondary.humans);
+
     let mut merged = VirtualAttributions {
         repo,
         base_commit,
@@ -1826,6 +1923,7 @@ pub fn merge_attributions_favoring_first(
         prompts: merged_prompts,
         ts,
         blame_start_commit: None,
+        humans: merged_humans,
     };
 
     // Get union of all files

--- a/src/authorship/working_log.rs
+++ b/src/authorship/working_log.rs
@@ -329,7 +329,10 @@ mod tests {
     fn test_checkpoint_kind_known_human_roundtrip() {
         let kind = CheckpointKind::KnownHuman;
         assert_eq!(kind.to_str(), "known_human");
-        assert_eq!(CheckpointKind::from_str("known_human"), CheckpointKind::KnownHuman);
+        assert_eq!(
+            CheckpointKind::from_str("known_human"),
+            CheckpointKind::KnownHuman
+        );
         // Serde round-trip
         let json = serde_json::to_string(&kind).unwrap();
         let back: CheckpointKind = serde_json::from_str(&json).unwrap();

--- a/src/authorship/working_log.rs
+++ b/src/authorship/working_log.rs
@@ -51,6 +51,7 @@ pub enum CheckpointKind {
     Human,
     AiAgent,
     AiTab,
+    KnownHuman,
 }
 
 impl fmt::Display for CheckpointKind {
@@ -67,6 +68,7 @@ impl CheckpointKind {
             "human" => CheckpointKind::Human,
             "ai_agent" => CheckpointKind::AiAgent,
             "ai_tab" => CheckpointKind::AiTab,
+            "known_human" => CheckpointKind::KnownHuman,
             _ => panic!("Invalid checkpoint kind: {}", s),
         }
     }
@@ -77,13 +79,27 @@ impl CheckpointKind {
             CheckpointKind::Human => "human".to_string(),
             CheckpointKind::AiAgent => "ai_agent".to_string(),
             CheckpointKind::AiTab => "ai_tab".to_string(),
+            CheckpointKind::KnownHuman => "known_human".to_string(),
         }
+    }
+
+    /// Returns true if this checkpoint kind represents AI-generated content.
+    pub fn is_ai(self) -> bool {
+        matches!(self, CheckpointKind::AiAgent | CheckpointKind::AiTab)
     }
 
     /// Default value to prevent crashes on old versions
     pub fn serde_default() -> Self {
         CheckpointKind::Human
     }
+}
+
+/// Metadata stored for KnownHuman checkpoints, identifying the IDE that fired the save event
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnownHumanMetadata {
+    pub editor: String,            // e.g. "vscode"
+    pub editor_version: String,    // e.g. "1.85.0"
+    pub extension_version: String, // e.g. "0.4.1"
 }
 
 /// Line-level statistics tracked per checkpoint kind
@@ -118,6 +134,8 @@ pub struct Checkpoint {
     pub api_version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_ai_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub known_human_metadata: Option<KnownHumanMetadata>,
 }
 
 impl Checkpoint {
@@ -144,6 +162,7 @@ impl Checkpoint {
             line_stats: CheckpointLineStats::default(),
             api_version: CHECKPOINT_API_VERSION.to_string(),
             git_ai_version: Some(GIT_AI_VERSION.to_string()),
+            known_human_metadata: None,
         }
     }
 }
@@ -304,5 +323,52 @@ mod tests {
         let deserialized_agent = deserialized.agent_id.as_ref().unwrap();
         assert_eq!(deserialized_agent.tool, "cursor");
         assert_eq!(deserialized_agent.id, "session-abc123");
+    }
+
+    #[test]
+    fn test_checkpoint_kind_known_human_roundtrip() {
+        let kind = CheckpointKind::KnownHuman;
+        assert_eq!(kind.to_str(), "known_human");
+        assert_eq!(CheckpointKind::from_str("known_human"), CheckpointKind::KnownHuman);
+        // Serde round-trip
+        let json = serde_json::to_string(&kind).unwrap();
+        let back: CheckpointKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, CheckpointKind::KnownHuman);
+    }
+
+    #[test]
+    fn test_is_ai_returns_false_for_human_kinds() {
+        assert!(!CheckpointKind::Human.is_ai());
+        assert!(!CheckpointKind::KnownHuman.is_ai());
+    }
+
+    #[test]
+    fn test_is_ai_returns_true_for_ai_kinds() {
+        assert!(CheckpointKind::AiAgent.is_ai());
+        assert!(CheckpointKind::AiTab.is_ai());
+    }
+
+    #[test]
+    fn test_checkpoint_with_known_human_metadata_roundtrip() {
+        use crate::authorship::working_log::{Checkpoint, KnownHumanMetadata};
+        let mut checkpoint = Checkpoint::new(
+            CheckpointKind::KnownHuman,
+            "diff".to_string(),
+            "Alice <alice@example.com>".to_string(),
+            vec![],
+        );
+        checkpoint.known_human_metadata = Some(KnownHumanMetadata {
+            editor: "vscode".to_string(),
+            editor_version: "1.85.0".to_string(),
+            extension_version: "0.4.1".to_string(),
+        });
+        // Serde round-trip
+        let json = serde_json::to_string(&checkpoint).unwrap();
+        let back: Checkpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, CheckpointKind::KnownHuman);
+        let meta = back.known_human_metadata.unwrap();
+        assert_eq!(meta.editor, "vscode");
+        assert_eq!(meta.editor_version, "1.85.0");
+        assert_eq!(meta.extension_version, "0.4.1");
     }
 }

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1096,8 +1096,10 @@ fn overlay_ai_authorship(
                         if options.use_prompt_hashes_as_names {
                             line_authors.insert(current_line_num, hash.clone());
                         } else if options.return_human_authors_as_human {
-                            line_authors
-                                .insert(current_line_num, CheckpointKind::Human.to_str().to_string());
+                            line_authors.insert(
+                                current_line_num,
+                                CheckpointKind::Human.to_str().to_string(),
+                            );
                         } else {
                             line_authors.insert(current_line_num, author.username.clone());
                         }

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1097,7 +1097,7 @@ fn overlay_ai_authorship(
                             line_authors.insert(current_line_num, hash.clone());
                         } else if options.return_human_authors_as_human {
                             line_authors
-                                .insert(current_line_num, CheckpointKind::Human.to_str());
+                                .insert(current_line_num, CheckpointKind::Human.to_str().to_string());
                         } else {
                             line_authors.insert(current_line_num, author.username.clone());
                         }

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1089,8 +1089,20 @@ fn overlay_ai_authorship(
                         }
 
                         prompt_records.insert(prompt_hash, prompt_record.clone());
+                    } else if let Some(ref hash) = prompt_hash
+                        && hash.starts_with("h_")
+                    {
+                        // Known human attestation (h_-prefixed hash from KnownHuman checkpoint)
+                        if options.use_prompt_hashes_as_names {
+                            line_authors.insert(current_line_num, hash.clone());
+                        } else if options.return_human_authors_as_human {
+                            line_authors
+                                .insert(current_line_num, CheckpointKind::Human.to_str());
+                        } else {
+                            line_authors.insert(current_line_num, author.username.clone());
+                        }
                     } else {
-                        // Has authorship log but line not AI = human-authored
+                        // Has authorship log but line not AI and not KnownHuman = unattested
                         if options.return_human_authors_as_human {
                             line_authors.insert(
                                 current_line_num,

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1113,7 +1113,7 @@ fn overlay_ai_authorship(
                         }
                     }
                 } else {
-                    // Has authorship log but no attribution found = human-authored
+                    // Has authorship log but no attribution found = unattested (unknown)
                     if options.return_human_authors_as_human {
                         line_authors
                             .insert(current_line_num, CheckpointKind::Human.to_str().to_string());

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -631,8 +631,7 @@ fn resolve_live_checkpoint_execution(
             .map(|files| files.is_empty())
             .unwrap_or(true);
         let has_initial_attributions = !working_log.read_initial_attributions().files.is_empty();
-        let has_explicit_ai_agent_context =
-            kind.is_ai() && agent_run_result.is_some();
+        let has_explicit_ai_agent_context = kind.is_ai() && agent_run_result.is_some();
 
         if has_no_ai_edits
             && !has_initial_attributions
@@ -803,12 +802,10 @@ fn execute_resolved_checkpoint(
                 && cp.entries.iter().any(|e| resolved.files.contains(&e.file))
         });
         if too_soon {
-            debug_log(
-                &format!(
-                    "[KnownHuman] Rejected: fired within {}s of an AI checkpoint on the same file",
-                    KNOWN_HUMAN_MIN_SECS_AFTER_AI
-                ),
-            );
+            debug_log(&format!(
+                "[KnownHuman] Rejected: fired within {}s of an AI checkpoint on the same file",
+                KNOWN_HUMAN_MIN_SECS_AFTER_AI
+            ));
             return Ok((0, 0, 0));
         }
     }
@@ -877,10 +874,11 @@ fn execute_resolved_checkpoint(
             if let Some(agent_run) = &agent_run_result {
                 if let Some(meta) = &agent_run.agent_metadata {
                     let editor = meta.get("kh_editor").cloned().unwrap_or_default();
-                    let editor_version =
-                        meta.get("kh_editor_version").cloned().unwrap_or_default();
-                    let extension_version =
-                        meta.get("kh_extension_version").cloned().unwrap_or_default();
+                    let editor_version = meta.get("kh_editor_version").cloned().unwrap_or_default();
+                    let extension_version = meta
+                        .get("kh_extension_version")
+                        .cloned()
+                        .unwrap_or_default();
                     if !editor.is_empty() {
                         use crate::authorship::working_log::KnownHumanMetadata;
                         checkpoint.known_human_metadata = Some(KnownHumanMetadata {
@@ -1600,9 +1598,7 @@ fn build_previous_file_state_maps(
                 },
             );
 
-            if checkpoint.kind.is_ai()
-                || working_log_entry_has_non_human_attribution(entry)
-            {
+            if checkpoint.kind.is_ai() || working_log_entry_has_non_human_attribution(entry) {
                 ai_touched_files.insert(entry.file.clone());
             }
         }
@@ -1643,11 +1639,7 @@ fn get_checkpoint_entry_for_file(
     // Pre-commit fast path:
     // If this file has no prior AI attribution and no INITIAL attribution,
     // we can skip it entirely. Human-only files do not affect AI authorship.
-    if is_pre_commit
-        && !kind.is_ai()
-        && !has_prior_ai_edits
-        && initial_attrs_for_file.is_empty()
-    {
+    if is_pre_commit && !kind.is_ai() && !has_prior_ai_edits && initial_attrs_for_file.is_empty() {
         return Ok(None);
     }
 

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -804,7 +804,10 @@ fn execute_resolved_checkpoint(
         });
         if too_soon {
             debug_log(
-                "[KnownHuman] Rejected: fired within 1s of an AI checkpoint on the same file",
+                &format!(
+                    "[KnownHuman] Rejected: fired within {}s of an AI checkpoint on the same file",
+                    KNOWN_HUMAN_MIN_SECS_AFTER_AI
+                ),
             );
             return Ok((0, 0, 0));
         }
@@ -1547,7 +1550,7 @@ fn get_previous_content_from_head(
 }
 
 fn is_ai_author_id(author_id: &str) -> bool {
-    author_id != CheckpointKind::Human.to_str() && !author_id.starts_with("h_")
+    author_id != "human" && !author_id.starts_with("h_")
 }
 
 fn working_log_entry_has_non_human_attribution(entry: &WorkingLogEntry) -> bool {

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -183,7 +183,7 @@ pub fn explicit_capture_target_paths(
     agent_run_result: Option<&AgentRunResult>,
 ) -> Option<(PreparedPathRole, Vec<String>)> {
     let result = agent_run_result?;
-    let (role, paths) = if kind == CheckpointKind::Human {
+    let (role, paths) = if kind == CheckpointKind::Human || kind == CheckpointKind::KnownHuman {
         (
             PreparedPathRole::WillEdit,
             result.will_edit_filepaths.as_ref()?,
@@ -2322,6 +2322,24 @@ mod tests {
         assert_eq!(
             explicit_capture_target_paths(CheckpointKind::AiAgent, Some(&agent_run_result)),
             None
+        );
+    }
+
+    #[test]
+    fn test_explicit_capture_target_paths_known_human_uses_will_edit_filepaths() {
+        // KnownHuman checkpoints carry will_edit_filepaths (like Human), not edited_filepaths.
+        // Regression: previously KnownHuman fell into the else branch and read
+        // edited_filepaths (None), silently disabling pathspec optimisation.
+        let agent_run_result = test_agent_run_result(
+            CheckpointKind::KnownHuman,
+            None,
+            Some(vec!["src/foo.rs"]),
+            None,
+        );
+
+        assert_eq!(
+            explicit_capture_target_paths(CheckpointKind::KnownHuman, Some(&agent_run_result)),
+            Some((PreparedPathRole::WillEdit, vec!["src/foo.rs".to_string()]))
         );
     }
 

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -873,6 +873,24 @@ fn execute_resolved_checkpoint(
                 checkpoint.agent_id = Some(agent_run.agent_id.clone());
                 checkpoint.agent_metadata = agent_run.agent_metadata.clone();
             }
+        } else if kind == CheckpointKind::KnownHuman {
+            if let Some(agent_run) = &agent_run_result {
+                if let Some(meta) = &agent_run.agent_metadata {
+                    let editor = meta.get("kh_editor").cloned().unwrap_or_default();
+                    let editor_version =
+                        meta.get("kh_editor_version").cloned().unwrap_or_default();
+                    let extension_version =
+                        meta.get("kh_extension_version").cloned().unwrap_or_default();
+                    if !editor.is_empty() {
+                        use crate::authorship::working_log::KnownHumanMetadata;
+                        checkpoint.known_human_metadata = Some(KnownHumanMetadata {
+                            editor,
+                            editor_version,
+                            extension_version,
+                        });
+                    }
+                }
+            }
         }
         debug_log(&format!(
             "[BENCHMARK] Checkpoint creation took {:?}",

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -870,24 +870,23 @@ fn execute_resolved_checkpoint(
                 checkpoint.agent_id = Some(agent_run.agent_id.clone());
                 checkpoint.agent_metadata = agent_run.agent_metadata.clone();
             }
-        } else if kind == CheckpointKind::KnownHuman {
-            if let Some(agent_run) = &agent_run_result {
-                if let Some(meta) = &agent_run.agent_metadata {
-                    let editor = meta.get("kh_editor").cloned().unwrap_or_default();
-                    let editor_version = meta.get("kh_editor_version").cloned().unwrap_or_default();
-                    let extension_version = meta
-                        .get("kh_extension_version")
-                        .cloned()
-                        .unwrap_or_default();
-                    if !editor.is_empty() {
-                        use crate::authorship::working_log::KnownHumanMetadata;
-                        checkpoint.known_human_metadata = Some(KnownHumanMetadata {
-                            editor,
-                            editor_version,
-                            extension_version,
-                        });
-                    }
-                }
+        } else if kind == CheckpointKind::KnownHuman
+            && let Some(agent_run) = &agent_run_result
+            && let Some(meta) = &agent_run.agent_metadata
+        {
+            let editor = meta.get("kh_editor").cloned().unwrap_or_default();
+            let editor_version = meta.get("kh_editor_version").cloned().unwrap_or_default();
+            let extension_version = meta
+                .get("kh_extension_version")
+                .cloned()
+                .unwrap_or_default();
+            if !editor.is_empty() {
+                use crate::authorship::working_log::KnownHumanMetadata;
+                checkpoint.known_human_metadata = Some(KnownHumanMetadata {
+                    editor,
+                    editor_version,
+                    extension_version,
+                });
             }
         }
         debug_log(&format!(

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -188,6 +188,16 @@ pub fn explicit_capture_target_paths(
             PreparedPathRole::WillEdit,
             result.will_edit_filepaths.as_ref()?,
         )
+    } else if kind == CheckpointKind::KnownHuman {
+        // KnownHuman can be pre-save (will_edit) or post-save (edited); prefer edited.
+        if let Some(paths) = result.edited_filepaths.as_ref() {
+            (PreparedPathRole::Edited, paths)
+        } else {
+            (
+                PreparedPathRole::WillEdit,
+                result.will_edit_filepaths.as_ref()?,
+            )
+        }
     } else {
         (PreparedPathRole::Edited, result.edited_filepaths.as_ref()?)
     };
@@ -2322,6 +2332,40 @@ mod tests {
         assert_eq!(
             explicit_capture_target_paths(CheckpointKind::AiAgent, Some(&agent_run_result)),
             None
+        );
+    }
+
+    #[test]
+    fn test_explicit_capture_target_paths_known_human_uses_edited_filepaths() {
+        // KnownHuman post-save: edit already happened, uses edited_filepaths.
+        let agent_run_result = test_agent_run_result(
+            CheckpointKind::KnownHuman,
+            Some(vec!["src/foo.rs"]),
+            None,
+            None,
+        );
+
+        assert_eq!(
+            explicit_capture_target_paths(CheckpointKind::KnownHuman, Some(&agent_run_result)),
+            Some((PreparedPathRole::Edited, vec!["src/foo.rs".to_string()]))
+        );
+    }
+
+    #[test]
+    fn test_explicit_capture_target_paths_known_human_uses_will_edit_filepaths() {
+        // KnownHuman pre-save: edit hasn't happened yet, uses will_edit_filepaths.
+        // Regression: KnownHuman fell into the else branch which only reads edited_filepaths,
+        // returning None and silently disabling pathspec scoping for pre-save KnownHuman.
+        let agent_run_result = test_agent_run_result(
+            CheckpointKind::KnownHuman,
+            None,
+            Some(vec!["src/foo.rs"]),
+            None,
+        );
+
+        assert_eq!(
+            explicit_capture_target_paths(CheckpointKind::KnownHuman, Some(&agent_run_result)),
+            Some((PreparedPathRole::WillEdit, vec!["src/foo.rs".to_string()]))
         );
     }
 

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -50,6 +50,11 @@ use crate::authorship::working_log::AgentId;
 #[cfg_attr(any(test, feature = "test-support"), allow(dead_code))]
 const AGENT_USAGE_MIN_INTERVAL_SECS: u64 = 150;
 
+#[cfg(not(test))]
+const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 1;
+#[cfg(test)]
+const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 0;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PreparedPathRole {
@@ -627,7 +632,7 @@ fn resolve_live_checkpoint_execution(
             .unwrap_or(true);
         let has_initial_attributions = !working_log.read_initial_attributions().files.is_empty();
         let has_explicit_ai_agent_context =
-            kind != CheckpointKind::Human && agent_run_result.is_some();
+            kind.is_ai() && agent_run_result.is_some();
 
         if has_no_ai_edits
             && !has_initial_attributions
@@ -784,6 +789,27 @@ fn execute_resolved_checkpoint(
         read_checkpoints_start.elapsed()
     ));
 
+    // Reject KnownHuman checkpoints that arrive within KNOWN_HUMAN_MIN_SECS_AFTER_AI
+    // seconds of an AI checkpoint on any of the same files. These are likely spurious
+    // IDE save events triggered by the AI completing its edit, not genuine human keystrokes.
+    if kind == CheckpointKind::KnownHuman && KNOWN_HUMAN_MIN_SECS_AFTER_AI > 0 {
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let too_soon = checkpoints.iter().rev().any(|cp| {
+            cp.kind.is_ai()
+                && now_secs.saturating_sub(cp.timestamp) < KNOWN_HUMAN_MIN_SECS_AFTER_AI
+                && cp.entries.iter().any(|e| resolved.files.contains(&e.file))
+        });
+        if too_soon {
+            debug_log(
+                "[KnownHuman] Rejected: fired within 1s of an AI checkpoint on the same file",
+            );
+            return Ok((0, 0, 0));
+        }
+    }
+
     let save_states_start = Instant::now();
     let file_content_hashes = save_current_file_states(&working_log, &resolved.files)?;
     debug_log(&format!(
@@ -810,6 +836,7 @@ fn execute_resolved_checkpoint(
     let entries_start = Instant::now();
     let (entries, file_stats) = smol::block_on(get_checkpoint_entries(
         kind,
+        author,
         repo,
         &working_log,
         &resolved.files,
@@ -837,19 +864,19 @@ fn execute_resolved_checkpoint(
         checkpoint.timestamp = (resolved.ts / 1000) as u64;
         checkpoint.line_stats = compute_line_stats(&file_stats)?;
 
-        if kind != CheckpointKind::Human
-            && let Some(agent_run) = &agent_run_result
-        {
-            checkpoint.transcript = Some(agent_run.transcript.clone().unwrap_or_default());
-            checkpoint.agent_id = Some(agent_run.agent_id.clone());
-            checkpoint.agent_metadata = agent_run.agent_metadata.clone();
+        if kind.is_ai() {
+            if let Some(agent_run) = &agent_run_result {
+                checkpoint.transcript = Some(agent_run.transcript.clone().unwrap_or_default());
+                checkpoint.agent_id = Some(agent_run.agent_id.clone());
+                checkpoint.agent_metadata = agent_run.agent_metadata.clone();
+            }
         }
         debug_log(&format!(
             "[BENCHMARK] Checkpoint creation took {:?}",
             checkpoint_create_start.elapsed()
         ));
 
-        if kind != CheckpointKind::Human
+        if kind.is_ai()
             && checkpoint.agent_id.is_some()
             && checkpoint.transcript.is_some()
             && let Err(e) = upsert_checkpoint_prompt_to_db(
@@ -882,7 +909,7 @@ fn execute_resolved_checkpoint(
         let attrs =
             build_checkpoint_attrs(repo, &resolved.base_commit, checkpoint.agent_id.as_ref());
 
-        if kind != CheckpointKind::Human
+        if kind.is_ai()
             && let Some(agent_id) = checkpoint.agent_id.as_ref()
             && should_emit_agent_usage(agent_id)
         {
@@ -904,7 +931,7 @@ fn execute_resolved_checkpoint(
         }
     }
 
-    let agent_tool = if kind != CheckpointKind::Human
+    let agent_tool = if kind.is_ai()
         && let Some(agent_run_result) = &agent_run_result
     {
         Some(agent_run_result.agent_id.tool.as_str())
@@ -1519,15 +1546,19 @@ fn get_previous_content_from_head(
     }
 }
 
+fn is_ai_author_id(author_id: &str) -> bool {
+    author_id != CheckpointKind::Human.to_str() && !author_id.starts_with("h_")
+}
+
 fn working_log_entry_has_non_human_attribution(entry: &WorkingLogEntry) -> bool {
     entry
         .line_attributions
         .iter()
-        .any(|attr| attr.author_id != CheckpointKind::Human.to_str())
+        .any(|attr| is_ai_author_id(&attr.author_id))
         || entry
             .attributions
             .iter()
-            .any(|attr| attr.author_id != CheckpointKind::Human.to_str())
+            .any(|attr| is_ai_author_id(&attr.author_id))
 }
 
 fn build_previous_file_state_maps(
@@ -1548,7 +1579,7 @@ fn build_previous_file_state_maps(
                 },
             );
 
-            if checkpoint.kind != CheckpointKind::Human
+            if checkpoint.kind.is_ai()
                 || working_log_entry_has_non_human_attribution(entry)
             {
                 ai_touched_files.insert(entry.file.clone());
@@ -1592,7 +1623,7 @@ fn get_checkpoint_entry_for_file(
     // If this file has no prior AI attribution and no INITIAL attribution,
     // we can skip it entirely. Human-only files do not affect AI authorship.
     if is_pre_commit
-        && kind == CheckpointKind::Human
+        && !kind.is_ai()
         && !has_prior_ai_edits
         && initial_attrs_for_file.is_empty()
     {
@@ -1606,7 +1637,7 @@ fn get_checkpoint_entry_for_file(
     // Non-pre-commit fast path:
     // Preserve existing `git-ai checkpoint` behavior for human-only files by writing an
     // attribution-empty entry while still capturing line stats.
-    if kind == CheckpointKind::Human && !has_prior_ai_edits && initial_attrs_for_file.is_empty() {
+    if !kind.is_ai() && !has_prior_ai_edits && initial_attrs_for_file.is_empty() {
         let previous_content = if let Some(state) = previous_state.as_ref() {
             working_log
                 .get_file_version(&state.blob_sha)
@@ -1714,7 +1745,7 @@ fn get_checkpoint_entry_for_file(
         }
 
         // For AI checkpoints, attribute any lines NOT in INITIAL and NOT returned by ai_blame
-        if kind != CheckpointKind::Human {
+        if kind.is_ai() {
             let total_lines = current_content.lines().count() as u32;
             for line_num in 1..=total_lines {
                 if !initial_covered_lines.contains(&line_num) && !blamed_lines.contains(&line_num) {
@@ -1769,7 +1800,7 @@ fn get_checkpoint_entry_for_file(
         file_path: &file_path,
         blob_sha: &file_content_hash,
         author_id: author_id.as_ref(),
-        is_ai_checkpoint: kind != CheckpointKind::Human,
+        is_ai_checkpoint: kind.is_ai(),
         previous_content: &previous_content,
         previous_attributions: &prev_attributions,
         content: &current_content,
@@ -1786,6 +1817,7 @@ fn get_checkpoint_entry_for_file(
 #[allow(clippy::too_many_arguments)]
 async fn get_checkpoint_entries(
     kind: CheckpointKind,
+    author: &str,
     repo: &Repository,
     working_log: &PersistedWorkingLog,
     files: &[String],
@@ -1825,19 +1857,22 @@ async fn get_checkpoint_entries(
     ));
 
     // Determine author_id based on checkpoint kind and agent_id
-    let author_id = if kind != CheckpointKind::Human {
-        // For AI checkpoints, use session hash
-        agent_run_result
-            .map(|result| {
-                crate::authorship::authorship_log_serialization::generate_short_hash(
-                    &result.agent_id.id,
-                    &result.agent_id.tool,
-                )
-            })
-            .unwrap_or_else(|| kind.to_str())
-    } else {
-        // For human checkpoints, use checkpoint kind string
-        kind.to_str()
+    let author_id = match kind {
+        CheckpointKind::Human => kind.to_str(), // "human" — stripped, never attested
+        CheckpointKind::KnownHuman => {
+            crate::authorship::authorship_log_serialization::generate_human_short_hash(author)
+        }
+        _ => {
+            // AI kinds: use session hash
+            agent_run_result
+                .map(|result| {
+                    crate::authorship::authorship_log_serialization::generate_short_hash(
+                        &result.agent_id.id,
+                        &result.agent_id.tool,
+                    )
+                })
+                .unwrap_or_else(|| kind.to_str())
+        }
     };
 
     // Get HEAD commit info for git operations

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -183,7 +183,7 @@ pub fn explicit_capture_target_paths(
     agent_run_result: Option<&AgentRunResult>,
 ) -> Option<(PreparedPathRole, Vec<String>)> {
     let result = agent_run_result?;
-    let (role, paths) = if kind == CheckpointKind::Human || kind == CheckpointKind::KnownHuman {
+    let (role, paths) = if kind == CheckpointKind::Human {
         (
             PreparedPathRole::WillEdit,
             result.will_edit_filepaths.as_ref()?,
@@ -2322,24 +2322,6 @@ mod tests {
         assert_eq!(
             explicit_capture_target_paths(CheckpointKind::AiAgent, Some(&agent_run_result)),
             None
-        );
-    }
-
-    #[test]
-    fn test_explicit_capture_target_paths_known_human_uses_will_edit_filepaths() {
-        // KnownHuman checkpoints carry will_edit_filepaths (like Human), not edited_filepaths.
-        // Regression: previously KnownHuman fell into the else branch and read
-        // edited_filepaths (None), silently disabling pathspec optimisation.
-        let agent_run_result = test_agent_run_result(
-            CheckpointKind::KnownHuman,
-            None,
-            Some(vec!["src/foo.rs"]),
-            None,
-        );
-
-        assert_eq!(
-            explicit_capture_target_paths(CheckpointKind::KnownHuman, Some(&agent_run_result)),
-            Some((PreparedPathRole::WillEdit, vec!["src/foo.rs".to_string()]))
         );
     }
 

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -52,8 +52,6 @@ const AGENT_USAGE_MIN_INTERVAL_SECS: u64 = 150;
 
 #[cfg(not(any(test, feature = "test-support")))]
 const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 1;
-#[cfg(any(test, feature = "test-support"))]
-const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -791,7 +789,10 @@ fn execute_resolved_checkpoint(
     // Reject KnownHuman checkpoints that arrive within KNOWN_HUMAN_MIN_SECS_AFTER_AI
     // seconds of an AI checkpoint on any of the same files. These are likely spurious
     // IDE save events triggered by the AI completing its edit, not genuine human keystrokes.
-    if kind == CheckpointKind::KnownHuman && KNOWN_HUMAN_MIN_SECS_AFTER_AI > 0 {
+    // Only compiled in non-test builds where the constant is non-zero; under --all-targets
+    // clippy would otherwise flag the comparisons as always-false for u64.
+    #[cfg(not(any(test, feature = "test-support")))]
+    if kind == CheckpointKind::KnownHuman {
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -50,9 +50,9 @@ use crate::authorship::working_log::AgentId;
 #[cfg_attr(any(test, feature = "test-support"), allow(dead_code))]
 const AGENT_USAGE_MIN_INTERVAL_SECS: u64 = 150;
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "test-support")))]
 const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 1;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1658,7 +1658,9 @@ fn get_checkpoint_entry_for_file(
     // Non-pre-commit fast path:
     // Preserve existing `git-ai checkpoint` behavior for human-only files by writing an
     // attribution-empty entry while still capturing line stats.
-    if !kind.is_ai() && !has_prior_ai_edits && initial_attrs_for_file.is_empty() {
+    // KnownHuman checkpoints must bypass this path so they record h_<hash> attributions
+    // that later AI checkpoints can use to identify human-written lines.
+    if kind == CheckpointKind::Human && !has_prior_ai_edits && initial_attrs_for_file.is_empty() {
         let previous_content = if let Some(state) = previous_state.as_ref() {
             working_log
                 .get_file_version(&state.blob_sha)
@@ -2910,7 +2912,7 @@ mod tests {
     }
 
     #[test]
-    fn test_human_checkpoint_without_ai_history_uses_empty_attributions() {
+    fn test_known_human_checkpoint_without_ai_history_records_h_hash_attributions() {
         let repo = TmpRepo::new().unwrap();
         let mut file = repo.write_file("simple.txt", "one\n", true).unwrap();
 
@@ -2940,17 +2942,22 @@ mod tests {
             .find(|entry| entry.file == "simple.txt")
             .unwrap();
 
+        // KnownHuman checkpoints always record h_<hash> line attributions, even with no AI history.
+        // This allows downstream stats to count these lines as human_additions.
         assert!(
-            entry.attributions.is_empty(),
-            "Human-only file should skip char-level attribution generation"
+            !entry.line_attributions.is_empty(),
+            "KnownHuman checkpoint should record line-level h_<hash> attributions"
         );
         assert!(
-            entry.line_attributions.is_empty(),
-            "Human-only file should skip line-level attribution generation"
+            entry
+                .line_attributions
+                .iter()
+                .all(|la| la.author_id.starts_with("h_")),
+            "All line attributions should be h_<hash> IDs"
         );
         assert!(
             latest.line_stats.additions > 0,
-            "Fast path should still record line stats"
+            "KnownHuman checkpoint should record line stats"
         );
     }
 
@@ -2997,13 +3004,18 @@ mod tests {
             .iter()
             .find(|entry| entry.file == "alphabet.md")
             .unwrap();
+        // KnownHuman checkpoints record h_<hash> attributions for all files, including
+        // files with no AI history. This ensures human lines are counted correctly in stats.
         assert!(
-            human_only_entry.attributions.is_empty(),
-            "Human-only file should use fast path with empty char attributions"
+            !human_only_entry.line_attributions.is_empty(),
+            "KnownHuman checkpoint should record line attributions for human-only files"
         );
         assert!(
-            human_only_entry.line_attributions.is_empty(),
-            "Human-only file should use fast path with empty line attributions"
+            human_only_entry
+                .line_attributions
+                .iter()
+                .all(|la| la.author_id.starts_with("h_")),
+            "Human-only file attributions should all be h_<hash> IDs"
         );
     }
 

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -972,8 +972,8 @@ fn apply_blame_for_side(
                 // Known human attestation (h_-prefixed hash from KnownHuman checkpoint)
                 Attribution::Human(author_marker.clone())
             } else {
-                // Other markers (e.g. legacy "human" marker)
-                Attribution::Human(author_marker.clone())
+                // Legacy or unrecognized marker (e.g. "human") — treat as unattested
+                Attribution::NoData
             };
             attributions.insert(key.clone(), attribution);
             line_details.insert(

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -968,7 +968,11 @@ fn apply_blame_for_side(
                     .or_default()
                     .push(*line);
                 Attribution::Ai(tool)
+            } else if author_marker.starts_with("h_") {
+                // Known human attestation (h_-prefixed hash from KnownHuman checkpoint)
+                Attribution::Human(author_marker.clone())
             } else {
+                // Other markers (e.g. legacy "human" marker)
                 Attribution::Human(author_marker.clone())
             };
             attributions.insert(key.clone(), attribution);

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -660,41 +660,68 @@ fn handle_checkpoint(args: &[String]) {
             }
             "known_human" => {
                 // Production preset: IDE extension attests human-authored lines.
-                // Usage: git ai checkpoint known_human [--editor <name>]
-                //        [--editor-version <ver>] [--extension-version <ver>] -- file...
-                let mut editor = "unknown".to_string();
-                let mut editor_version = "unknown".to_string();
-                let mut extension_version = "unknown".to_string();
-                let mut files: Vec<String> = Vec::new();
-                let mut i = 1usize; // skip "known_human"
-                while i < args.len() {
-                    match args[i].as_str() {
-                        "--editor" if i + 1 < args.len() => {
-                            editor = args[i + 1].clone();
-                            i += 2;
+                // Stdin mode (--hook-input stdin): all data passed as JSON on stdin:
+                //   { "editor": "...", "editor_version": "...", "extension_version": "...",
+                //     "cwd": "/abs/path", "edited_filepaths": [...], "dirty_files": {...} }
+                // CLI mode: git ai checkpoint known_human [--editor <name>]
+                //           [--editor-version <ver>] [--extension-version <ver>] -- file...
+                let (editor, editor_version, extension_version, repo_working_dir, edited_filepaths, dirty_files) =
+                    if let Some(ref json_str) = hook_input {
+                        let v: serde_json::Value = serde_json::from_str(json_str)
+                            .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                        let editor = v["editor"].as_str().unwrap_or("unknown").to_string();
+                        let editor_version = v["editor_version"].as_str().unwrap_or("unknown").to_string();
+                        let extension_version = v["extension_version"].as_str().unwrap_or("unknown").to_string();
+                        let cwd = v["cwd"].as_str().map(str::to_string);
+                        let edited_filepaths = v["edited_filepaths"]
+                            .as_array()
+                            .map(|arr| arr.iter().filter_map(|x| x.as_str().map(str::to_string)).collect::<Vec<_>>())
+                            .filter(|v| !v.is_empty());
+                        let dirty_files = v["dirty_files"]
+                            .as_object()
+                            .map(|obj| {
+                                obj.iter()
+                                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                                    .collect::<std::collections::HashMap<String, String>>()
+                            })
+                            .filter(|m| !m.is_empty());
+                        (editor, editor_version, extension_version, cwd, edited_filepaths, dirty_files)
+                    } else {
+                        let mut editor = "unknown".to_string();
+                        let mut editor_version = "unknown".to_string();
+                        let mut extension_version = "unknown".to_string();
+                        let mut files: Vec<String> = Vec::new();
+                        let mut i = 1usize; // skip "known_human"
+                        while i < args.len() {
+                            match args[i].as_str() {
+                                "--editor" if i + 1 < args.len() => {
+                                    editor = args[i + 1].clone();
+                                    i += 2;
+                                }
+                                "--editor-version" if i + 1 < args.len() => {
+                                    editor_version = args[i + 1].clone();
+                                    i += 2;
+                                }
+                                "--extension-version" if i + 1 < args.len() => {
+                                    extension_version = args[i + 1].clone();
+                                    i += 2;
+                                }
+                                "--" => {
+                                    files.extend(args[i + 1..].iter().cloned());
+                                    break;
+                                }
+                                arg if !arg.starts_with("--") => {
+                                    files.push(arg.to_string());
+                                    i += 1;
+                                }
+                                _ => {
+                                    i += 1;
+                                }
+                            }
                         }
-                        "--editor-version" if i + 1 < args.len() => {
-                            editor_version = args[i + 1].clone();
-                            i += 2;
-                        }
-                        "--extension-version" if i + 1 < args.len() => {
-                            extension_version = args[i + 1].clone();
-                            i += 2;
-                        }
-                        "--" => {
-                            files.extend(args[i + 1..].iter().cloned());
-                            break;
-                        }
-                        arg if !arg.starts_with("--") => {
-                            files.push(arg.to_string());
-                            i += 1;
-                        }
-                        _ => {
-                            i += 1;
-                        }
-                    }
-                }
-                let edited_filepaths = if files.is_empty() { None } else { Some(files) };
+                        let edited_filepaths = if files.is_empty() { None } else { Some(files) };
+                        (editor, editor_version, extension_version, None, edited_filepaths, None)
+                    };
 
                 let known_human_agent_metadata = {
                     let mut m = std::collections::HashMap::new();
@@ -713,10 +740,10 @@ fn handle_checkpoint(args: &[String]) {
                     agent_metadata: Some(known_human_agent_metadata),
                     checkpoint_kind: CheckpointKind::KnownHuman,
                     transcript: None,
-                    repo_working_dir: None,
+                    repo_working_dir,
                     edited_filepaths,
                     will_edit_filepaths: None,
-                    dirty_files: None,
+                    dirty_files,
                     captured_checkpoint_id: None,
                 });
             }

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -665,63 +665,93 @@ fn handle_checkpoint(args: &[String]) {
                 //     "cwd": "/abs/path", "edited_filepaths": [...], "dirty_files": {...} }
                 // CLI mode: git ai checkpoint known_human [--editor <name>]
                 //           [--editor-version <ver>] [--extension-version <ver>] -- file...
-                let (editor, editor_version, extension_version, repo_working_dir, edited_filepaths, dirty_files) =
-                    if let Some(ref json_str) = hook_input {
-                        let v: serde_json::Value = serde_json::from_str(json_str)
-                            .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-                        let editor = v["editor"].as_str().unwrap_or("unknown").to_string();
-                        let editor_version = v["editor_version"].as_str().unwrap_or("unknown").to_string();
-                        let extension_version = v["extension_version"].as_str().unwrap_or("unknown").to_string();
-                        let cwd = v["cwd"].as_str().map(str::to_string);
-                        let edited_filepaths = v["edited_filepaths"]
-                            .as_array()
-                            .map(|arr| arr.iter().filter_map(|x| x.as_str().map(str::to_string)).collect::<Vec<_>>())
-                            .filter(|v| !v.is_empty());
-                        let dirty_files = v["dirty_files"]
-                            .as_object()
-                            .map(|obj| {
-                                obj.iter()
-                                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                                    .collect::<std::collections::HashMap<String, String>>()
-                            })
-                            .filter(|m| !m.is_empty());
-                        (editor, editor_version, extension_version, cwd, edited_filepaths, dirty_files)
-                    } else {
-                        let mut editor = "unknown".to_string();
-                        let mut editor_version = "unknown".to_string();
-                        let mut extension_version = "unknown".to_string();
-                        let mut files: Vec<String> = Vec::new();
-                        let mut i = 1usize; // skip "known_human"
-                        while i < args.len() {
-                            match args[i].as_str() {
-                                "--editor" if i + 1 < args.len() => {
-                                    editor = args[i + 1].clone();
-                                    i += 2;
-                                }
-                                "--editor-version" if i + 1 < args.len() => {
-                                    editor_version = args[i + 1].clone();
-                                    i += 2;
-                                }
-                                "--extension-version" if i + 1 < args.len() => {
-                                    extension_version = args[i + 1].clone();
-                                    i += 2;
-                                }
-                                "--" => {
-                                    files.extend(args[i + 1..].iter().cloned());
-                                    break;
-                                }
-                                arg if !arg.starts_with("--") => {
-                                    files.push(arg.to_string());
-                                    i += 1;
-                                }
-                                _ => {
-                                    i += 1;
-                                }
+                let (
+                    editor,
+                    editor_version,
+                    extension_version,
+                    repo_working_dir,
+                    edited_filepaths,
+                    dirty_files,
+                ) = if let Some(ref json_str) = hook_input {
+                    let v: serde_json::Value = serde_json::from_str(json_str)
+                        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+                    let editor = v["editor"].as_str().unwrap_or("unknown").to_string();
+                    let editor_version = v["editor_version"]
+                        .as_str()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let extension_version = v["extension_version"]
+                        .as_str()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let cwd = v["cwd"].as_str().map(str::to_string);
+                    let edited_filepaths = v["edited_filepaths"]
+                        .as_array()
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|x| x.as_str().map(str::to_string))
+                                .collect::<Vec<_>>()
+                        })
+                        .filter(|v| !v.is_empty());
+                    let dirty_files = v["dirty_files"]
+                        .as_object()
+                        .map(|obj| {
+                            obj.iter()
+                                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                                .collect::<std::collections::HashMap<String, String>>()
+                        })
+                        .filter(|m| !m.is_empty());
+                    (
+                        editor,
+                        editor_version,
+                        extension_version,
+                        cwd,
+                        edited_filepaths,
+                        dirty_files,
+                    )
+                } else {
+                    let mut editor = "unknown".to_string();
+                    let mut editor_version = "unknown".to_string();
+                    let mut extension_version = "unknown".to_string();
+                    let mut files: Vec<String> = Vec::new();
+                    let mut i = 1usize; // skip "known_human"
+                    while i < args.len() {
+                        match args[i].as_str() {
+                            "--editor" if i + 1 < args.len() => {
+                                editor = args[i + 1].clone();
+                                i += 2;
+                            }
+                            "--editor-version" if i + 1 < args.len() => {
+                                editor_version = args[i + 1].clone();
+                                i += 2;
+                            }
+                            "--extension-version" if i + 1 < args.len() => {
+                                extension_version = args[i + 1].clone();
+                                i += 2;
+                            }
+                            "--" => {
+                                files.extend(args[i + 1..].iter().cloned());
+                                break;
+                            }
+                            arg if !arg.starts_with("--") => {
+                                files.push(arg.to_string());
+                                i += 1;
+                            }
+                            _ => {
+                                i += 1;
                             }
                         }
-                        let edited_filepaths = if files.is_empty() { None } else { Some(files) };
-                        (editor, editor_version, extension_version, None, edited_filepaths, None)
-                    };
+                    }
+                    let edited_filepaths = if files.is_empty() { None } else { Some(files) };
+                    (
+                        editor,
+                        editor_version,
+                        extension_version,
+                        None,
+                        edited_filepaths,
+                        None,
+                    )
+                };
 
                 let known_human_agent_metadata = {
                     let mut m = std::collections::HashMap::new();

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -260,12 +260,13 @@ fn print_help() {
     eprintln!("Commands:");
     eprintln!("  checkpoint         Checkpoint working changes and attribute author");
     eprintln!(
-        "    Presets: claude, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, ai_tab, firebender, mock_ai"
+        "    Presets: claude, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, ai_tab, firebender, mock_ai, mock_known_human, known_human"
     );
     eprintln!(
         "    --hook-input <json|stdin>   JSON payload required by presets, or 'stdin' to read from stdin"
     );
-    eprintln!("    mock_ai [pathspecs...]      Test preset accepting optional file pathspecs");
+    eprintln!("    mock_ai [pathspecs...]           Test preset accepting optional file pathspecs");
+    eprintln!("    mock_known_human [pathspecs...]  Test preset for KnownHuman checkpoints");
     eprintln!("  log [args...]      Show commit log with AI authorship notes");
     eprintln!(
         "                        Proxies git log --notes=ai with all standard git log options"
@@ -649,6 +650,36 @@ fn handle_checkpoint(args: &[String]) {
                     },
                     agent_metadata: None,
                     checkpoint_kind: CheckpointKind::AiAgent,
+                    transcript: None,
+                    repo_working_dir: None,
+                    edited_filepaths,
+                    will_edit_filepaths: None,
+                    dirty_files: None,
+                    captured_checkpoint_id: None,
+                });
+            }
+            "mock_known_human" => {
+                // Test preset: KnownHuman checkpoint for given paths (mirrors mock_ai behavior)
+                let edited_filepaths = if args.len() > 1 {
+                    let mut paths = Vec::new();
+                    for arg in &args[1..] {
+                        if !arg.starts_with("--") {
+                            paths.push(arg.clone());
+                        }
+                    }
+                    if paths.is_empty() { None } else { Some(paths) }
+                } else {
+                    None
+                };
+
+                agent_run_result = Some(AgentRunResult {
+                    agent_id: AgentId {
+                        tool: "mock_known_human".to_string(),
+                        id: "mock_known_human_session".to_string(),
+                        model: "unknown".to_string(),
+                    },
+                    agent_metadata: None,
+                    checkpoint_kind: CheckpointKind::KnownHuman,
                     transcript: None,
                     repo_working_dir: None,
                     edited_filepaths,

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -658,6 +658,62 @@ fn handle_checkpoint(args: &[String]) {
                     captured_checkpoint_id: None,
                 });
             }
+            "known_human" => {
+                // Production preset: IDE extension attests human-authored lines.
+                // Usage: git ai checkpoint known_human [--editor <name>]
+                //        [--editor-version <ver>] [--extension-version <ver>] -- file...
+                let mut editor = "unknown".to_string();
+                let mut editor_version = "unknown".to_string();
+                let mut extension_version = "unknown".to_string();
+                let mut files: Vec<String> = Vec::new();
+                let mut i = 1usize; // skip "known_human"
+                while i < args.len() {
+                    match args[i].as_str() {
+                        "--editor" if i + 1 < args.len() => {
+                            editor = args[i + 1].clone();
+                            i += 2;
+                        }
+                        "--editor-version" if i + 1 < args.len() => {
+                            editor_version = args[i + 1].clone();
+                            i += 2;
+                        }
+                        "--extension-version" if i + 1 < args.len() => {
+                            extension_version = args[i + 1].clone();
+                            i += 2;
+                        }
+                        "--" => {
+                            files.extend(args[i + 1..].iter().cloned());
+                            break;
+                        }
+                        arg if !arg.starts_with("--") => {
+                            files.push(arg.to_string());
+                            i += 1;
+                        }
+                        _ => {
+                            i += 1;
+                        }
+                    }
+                }
+                let _ = (editor, editor_version, extension_version); // metadata stored on Checkpoint by checkpoint.rs
+
+                let edited_filepaths = if files.is_empty() { None } else { Some(files) };
+
+                agent_run_result = Some(AgentRunResult {
+                    agent_id: AgentId {
+                        tool: "known_human".to_string(),
+                        id: "known_human_session".to_string(),
+                        model: "unknown".to_string(),
+                    },
+                    agent_metadata: None,
+                    checkpoint_kind: CheckpointKind::KnownHuman,
+                    transcript: None,
+                    repo_working_dir: None,
+                    edited_filepaths,
+                    will_edit_filepaths: None,
+                    dirty_files: None,
+                    captured_checkpoint_id: None,
+                });
+            }
             "mock_known_human" => {
                 // Test preset: KnownHuman checkpoint for given paths (mirrors mock_ai behavior)
                 let edited_filepaths = if args.len() > 1 {

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -1463,6 +1463,7 @@ fn checkpoint_kind_to_str(kind: CheckpointKind) -> &'static str {
         CheckpointKind::Human => "human",
         CheckpointKind::AiAgent => "ai_agent",
         CheckpointKind::AiTab => "ai_tab",
+        CheckpointKind::KnownHuman => "known_human",
     }
 }
 
@@ -1968,7 +1969,7 @@ fn emit_no_repo_agent_metrics(agent_run_result: Option<&AgentRunResult>) {
     let Some(result) = agent_run_result else {
         return;
     };
-    if result.checkpoint_kind == CheckpointKind::Human {
+    if !result.checkpoint_kind.is_ai() {
         return;
     }
 

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -694,9 +694,15 @@ fn handle_checkpoint(args: &[String]) {
                         }
                     }
                 }
-                let _ = (editor, editor_version, extension_version); // metadata stored on Checkpoint by checkpoint.rs
-
                 let edited_filepaths = if files.is_empty() { None } else { Some(files) };
+
+                let known_human_agent_metadata = {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("kh_editor".to_string(), editor);
+                    m.insert("kh_editor_version".to_string(), editor_version);
+                    m.insert("kh_extension_version".to_string(), extension_version);
+                    m
+                };
 
                 agent_run_result = Some(AgentRunResult {
                     agent_id: AgentId {
@@ -704,7 +710,7 @@ fn handle_checkpoint(args: &[String]) {
                         id: "known_human_session".to_string(),
                         model: "unknown".to_string(),
                     },
-                    agent_metadata: None,
+                    agent_metadata: Some(known_human_agent_metadata),
                     checkpoint_kind: CheckpointKind::KnownHuman,
                     transcript: None,
                     repo_working_dir: None,

--- a/src/commands/hooks/checkout_hooks.rs
+++ b/src/commands/hooks/checkout_hooks.rs
@@ -215,6 +215,7 @@ fn remove_attributions_for_pathspecs(repository: &Repository, head: &str, pathsp
             files: filtered_files,
             prompts: initial.prompts,
             file_blobs: filtered_blobs,
+            humans: initial.humans,
         });
     }
 

--- a/src/commands/hooks/stash_hooks.rs
+++ b/src/commands/hooks/stash_hooks.rs
@@ -305,6 +305,8 @@ pub(crate) fn restore_stash_attributions(
         .into_iter()
         .collect();
 
+    let initial_humans = authorship_log.metadata.humans.clone();
+
     // Write INITIAL attributions to working log
     if !initial_files.is_empty() || !initial_prompts.is_empty() {
         let working_log = repo.storage.working_log_for_base_commit(head_sha)?;
@@ -313,6 +315,7 @@ pub(crate) fn restore_stash_attributions(
         working_log.write_initial_attributions_with_contents(
             initial_files.clone(),
             initial_prompts.clone(),
+            initial_humans,
             initial_file_contents,
         )?;
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -151,6 +151,7 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
         total_additions,
         total_deletions,
         ai_accepted,
+        0,
         &BTreeMap::new(),
     );
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1776,6 +1776,7 @@ fn capture_recent_working_log_snapshot(
         file_contents: va.snapshot_contents_for_files(initial.files.keys()),
         files: initial.files,
         prompts: initial.prompts,
+        humans: initial.humans,
     }))
 }
 
@@ -1793,7 +1794,7 @@ fn restore_recent_working_log_snapshot(
         .write_initial_attributions_with_contents(
             snapshot.files.clone(),
             snapshot.prompts.clone(),
-            std::collections::BTreeMap::new(),
+            snapshot.humans.clone(),
             snapshot.file_contents.clone(),
         )?;
     Ok(working_log_has_tracked_state_for_base(repo, base_commit))
@@ -3548,6 +3549,7 @@ struct RecentWorkingLogSnapshot {
     files: HashMap<String, Vec<crate::authorship::attribution_tracker::LineAttribution>>,
     prompts: HashMap<String, crate::authorship::authorship_log::PromptRecord>,
     file_contents: HashMap<String, String>,
+    humans: std::collections::BTreeMap<String, crate::authorship::authorship_log::HumanRecord>,
 }
 
 impl RecentWorkingLogSnapshot {
@@ -8242,5 +8244,64 @@ mod tests {
             normalize_commit_carryover_snapshot(Some(&carryover), Some(&committed)).unwrap();
 
         assert_eq!(normalized.get("example.txt"), carryover.get("example.txt"));
+    }
+
+    #[test]
+    fn recent_working_log_snapshot_preserves_humans_on_restore() {
+        use crate::authorship::attribution_tracker::LineAttribution;
+        use crate::authorship::authorship_log::HumanRecord;
+        use crate::git::test_utils::TmpRepo;
+        use std::collections::BTreeMap;
+
+        let test_repo = TmpRepo::new().expect("Failed to create test repo");
+        let repo = test_repo.gitai_repo();
+
+        // Create a snapshot with KnownHuman attributions
+        let h_hash = "h_abc123";
+        let human_record = HumanRecord {
+            author: "Test User <test@example.com>".to_string(),
+        };
+
+        let file_path = "test.txt";
+        let line_attributions = vec![LineAttribution {
+            start_line: 1,
+            end_line: 1,
+            author_id: h_hash.to_string(),
+            overrode: None,
+        }];
+
+        let mut humans = BTreeMap::new();
+        humans.insert(h_hash.to_string(), human_record.clone());
+
+        let snapshot = RecentWorkingLogSnapshot {
+            files: HashMap::from([(file_path.to_string(), line_attributions.clone())]),
+            prompts: HashMap::new(),
+            file_contents: HashMap::from([(file_path.to_string(), "test line\n".to_string())]),
+            humans: humans.clone(),
+        };
+
+        // Restore the snapshot
+        let base_commit = "HEAD";
+        let restored = restore_recent_working_log_snapshot(repo, base_commit, &snapshot).unwrap();
+        assert!(restored, "Snapshot should be restored");
+
+        // Read back the INITIAL file and verify humans are present
+        let working_log = repo
+            .storage
+            .working_log_for_base_commit(base_commit)
+            .unwrap();
+        let initial = working_log.read_initial_attributions();
+
+        // Verify humans were restored
+        assert_eq!(
+            initial.humans.len(),
+            1,
+            "Should have one human record after restore"
+        );
+        assert_eq!(
+            initial.humans.get(h_hash),
+            Some(&human_record),
+            "Human record should match"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1793,6 +1793,7 @@ fn restore_recent_working_log_snapshot(
         .write_initial_attributions_with_contents(
             snapshot.files.clone(),
             snapshot.prompts.clone(),
+            std::collections::BTreeMap::new(),
             snapshot.file_contents.clone(),
         )?;
     Ok(working_log_has_tracked_state_for_base(repo, base_commit))

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1324,6 +1324,7 @@ fn parse_checkpoint_kind(value: &str) -> Option<CheckpointKind> {
         "human" => Some(CheckpointKind::Human),
         "ai_agent" => Some(CheckpointKind::AiAgent),
         "ai_tab" => Some(CheckpointKind::AiTab),
+        "known_human" => Some(CheckpointKind::KnownHuman),
         _ => None,
     }
 }
@@ -2643,11 +2644,11 @@ fn rewrite_event_needs_authorship_processing(
     if has_initial {
         return Ok(true);
     }
-    let has_ai_checkpoints = working_log
+    let has_processable_checkpoints = working_log
         .read_all_checkpoints()?
         .iter()
         .any(|checkpoint| checkpoint.kind != CheckpointKind::Human);
-    Ok(has_ai_checkpoints)
+    Ok(has_processable_checkpoints)
 }
 
 fn deferred_commit_carryover_context(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1444,6 +1444,7 @@ fn remove_working_log_attributions_for_pathspecs(
             files: filtered_files,
             prompts: initial.prompts,
             file_blobs: filtered_blobs,
+            humans: initial.humans,
         })?;
     }
 

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -22,7 +22,7 @@ pub struct InitialAttributions {
     /// Optional blob snapshot of the file content represented by INITIAL.
     #[serde(default)]
     pub file_blobs: HashMap<String, String>,
-    /// Known human records: h_<hash> -> HumanRecord
+    /// Known human records: `h_<hash>` -> HumanRecord
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub humans: std::collections::BTreeMap<String, HumanRecord>,
 }

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -613,7 +613,7 @@ impl PersistedWorkingLog {
                         touched_files.insert(entry.file);
                     }
                 }
-                CheckpointKind::Human => {
+                CheckpointKind::Human | CheckpointKind::KnownHuman => {
                     // Skip human checkpoints
                 }
             }

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -647,6 +647,7 @@ impl PersistedWorkingLog {
         &self,
         attributions: HashMap<String, Vec<LineAttribution>>,
         prompts: HashMap<String, PromptRecord>,
+        humans: std::collections::BTreeMap<String, HumanRecord>,
         file_contents: HashMap<String, String>,
     ) -> Result<(), GitAiError> {
         let filtered: HashMap<String, Vec<LineAttribution>> = attributions
@@ -665,7 +666,7 @@ impl PersistedWorkingLog {
             files: filtered,
             prompts,
             file_blobs,
-            humans: std::collections::BTreeMap::new(),
+            humans,
         })
     }
 
@@ -1151,7 +1152,12 @@ mod tests {
         contents.insert("src/test.rs".to_string(), "fn main() {}\n".to_string());
 
         working_log
-            .write_initial_attributions_with_contents(attributions, HashMap::new(), contents)
+            .write_initial_attributions_with_contents(
+                attributions,
+                HashMap::new(),
+                std::collections::BTreeMap::new(),
+                contents,
+            )
             .expect("write INITIAL with contents");
 
         let initial = working_log.read_initial_attributions();

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -1,5 +1,5 @@
 use crate::authorship::attribution_tracker::LineAttribution;
-use crate::authorship::authorship_log::PromptRecord;
+use crate::authorship::authorship_log::{HumanRecord, PromptRecord};
 use crate::authorship::authorship_log_serialization::generate_short_hash;
 use crate::authorship::working_log::{CHECKPOINT_API_VERSION, Checkpoint, CheckpointKind};
 use crate::error::GitAiError;
@@ -22,6 +22,9 @@ pub struct InitialAttributions {
     /// Optional blob snapshot of the file content represented by INITIAL.
     #[serde(default)]
     pub file_blobs: HashMap<String, String>,
+    /// Known human records: h_<hash> -> HumanRecord
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub humans: std::collections::BTreeMap<String, HumanRecord>,
 }
 
 #[derive(Debug, Clone)]
@@ -635,6 +638,7 @@ impl PersistedWorkingLog {
             files: attributions,
             prompts,
             file_blobs: HashMap::new(),
+            humans: std::collections::BTreeMap::new(),
         })
     }
 
@@ -661,6 +665,7 @@ impl PersistedWorkingLog {
             files: filtered,
             prompts,
             file_blobs,
+            humans: std::collections::BTreeMap::new(),
         })
     }
 
@@ -686,6 +691,7 @@ impl PersistedWorkingLog {
             files: filtered_files,
             prompts: initial.prompts,
             file_blobs,
+            humans: initial.humans,
         };
 
         let json = serde_json::to_string_pretty(&initial_data)?;

--- a/src/git/test_utils/mod.rs
+++ b/src/git/test_utils/mod.rs
@@ -504,7 +504,7 @@ impl TmpRepo {
         checkpoint(
             &self.repo_gitai,
             author,
-            CheckpointKind::Human,
+            CheckpointKind::KnownHuman,
             true,
             agent_run_result,
             false,

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -100,7 +100,6 @@ fn test_cherry_pick_preserves_human_only_commit_note_metadata() {
         .expect("source commit should have a metadata-only note");
     let source_log =
         AuthorshipLog::deserialize_from_string(&source_note).expect("parse source note");
-    assert!(source_log.attestations.is_empty());
     assert!(source_log.metadata.prompts.is_empty());
 
     repo.git(&["checkout", &main_branch]).unwrap();
@@ -112,7 +111,6 @@ fn test_cherry_pick_preserves_human_only_commit_note_metadata() {
         .read_authorship_note(&new_commit)
         .expect("cherry-picked commit should preserve metadata-only note");
     let new_log = AuthorshipLog::deserialize_from_string(&new_note).expect("parse new note");
-    assert!(new_log.attestations.is_empty());
     assert!(new_log.metadata.prompts.is_empty());
     assert_eq!(new_log.metadata.base_commit_sha, new_commit);
 }
@@ -139,12 +137,8 @@ fn test_cherry_pick_preserves_prompt_only_commit_note_metadata() {
     let mut source_log =
         AuthorshipLog::deserialize_from_string(&source_note).expect("parse source note");
     assert!(
-        source_log.attestations.is_empty(),
-        "precondition: source should start metadata-only"
-    );
-    assert!(
         source_log.metadata.prompts.is_empty(),
-        "precondition: source commit should not have prompts before test mutation"
+        "precondition: source commit should not have AI prompts before test mutation"
     );
 
     let mut test_attrs = HashMap::new();
@@ -192,7 +186,6 @@ fn test_cherry_pick_preserves_prompt_only_commit_note_metadata() {
         .read_authorship_note(&new_commit)
         .expect("cherry-picked commit should preserve prompt-only note");
     let new_log = AuthorshipLog::deserialize_from_string(&new_note).expect("parse new note");
-    assert!(new_log.attestations.is_empty());
     assert_eq!(new_log.metadata.prompts.len(), 1);
     assert_eq!(new_log.metadata.base_commit_sha, new_commit);
 

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -227,7 +227,10 @@ fn test_ci_squash_merge_mixed_content() {
         merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
         "squash note should carry h_9e95a89b42f1fb from human-attributed lines in mixed content"
     );
-    assert_eq!(merge_log.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        merge_log.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
 
     // Verify mixed authorship is preserved
     file.assert_lines_and_blame(crate::lines![
@@ -407,7 +410,10 @@ fn test_ci_squash_merge_with_manual_changes() {
         merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
         "squash note should carry h_9e95a89b42f1fb from human-attributed lines in config"
     );
-    assert_eq!(merge_log.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        merge_log.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
 
     // Verify AI authorship is preserved for AI lines, human for manual additions
     file.assert_lines_and_blame(crate::lines![
@@ -497,7 +503,10 @@ fn test_ci_rebase_merge_multiple_commits() {
         merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
         "squash note should carry h_9e95a89b42f1fb from human function lines"
     );
-    assert_eq!(merge_log.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        merge_log.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
 
     // Verify all authorship is correctly attributed
     file.assert_lines_and_blame(crate::lines![
@@ -1241,7 +1250,10 @@ fn test_ci_rebase_merge_multiple_commits_standard_human() {
     let mut file = repo.filename("app.js");
 
     // Create initial commit
-    file.set_contents(crate::lines!["// App v1".unattributed_human(), "".unattributed_human()]);
+    file.set_contents(crate::lines![
+        "// App v1".unattributed_human(),
+        "".unattributed_human()
+    ]);
     let _base_commit = repo.stage_all_and_commit("Initial commit").unwrap();
     repo.git(&["branch", "-M", "main"]).unwrap();
 

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -221,6 +221,14 @@ fn test_ci_squash_merge_mixed_content() {
     )
     .unwrap();
 
+    // Verify metadata.humans contains the known human attribution
+    let merge_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
+    assert!(
+        merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "squash note should carry h_9e95a89b42f1fb from human-attributed lines in mixed content"
+    );
+    assert_eq!(merge_log.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+
     // Verify mixed authorship is preserved
     file.assert_lines_and_blame(crate::lines![
         "// Base code".human(),
@@ -393,6 +401,14 @@ fn test_ci_squash_merge_with_manual_changes() {
     )
     .unwrap();
 
+    // Verify metadata.humans contains the known human attribution
+    let merge_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
+    assert!(
+        merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "squash note should carry h_9e95a89b42f1fb from human-attributed lines in config"
+    );
+    assert_eq!(merge_log.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+
     // Verify AI authorship is preserved for AI lines, human for manual additions
     file.assert_lines_and_blame(crate::lines![
         "const config = {".human(),
@@ -474,6 +490,14 @@ fn test_ci_rebase_merge_multiple_commits() {
         false,
     )
     .unwrap();
+
+    // Verify metadata.humans contains the known human attribution
+    let merge_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
+    assert!(
+        merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "squash note should carry h_9e95a89b42f1fb from human function lines"
+    );
+    assert_eq!(merge_log.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
 
     // Verify all authorship is correctly attributed
     file.assert_lines_and_blame(crate::lines![
@@ -977,6 +1001,324 @@ fn test_ci_local_rebase_merge_three_commits() {
     );
 }
 
+/// Standard-human variant of test_ci_squash_merge_basic.
+/// Uses unattributed (checkpoint --) human lines instead of known-human attribution.
+#[test]
+fn test_ci_squash_merge_basic_standard_human() {
+    let repo = direct_test_repo();
+    let mut file = repo.filename("feature.js");
+
+    // Create initial commit on main (rename default branch to main)
+    file.set_contents(crate::lines![
+        "// Original code".unattributed_human(),
+        "function original() {}".unattributed_human()
+    ]);
+    let _base_commit = repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    // Create feature branch with AI code
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.insert_at(
+        2,
+        crate::lines![
+            "// AI added function".ai(),
+            "function aiFeature() {".ai(),
+            "  return 'ai code';".ai(),
+            "}".ai()
+        ],
+    );
+    let feature_commit = repo.stage_all_and_commit("Add AI feature").unwrap();
+    let feature_sha = feature_commit.commit_sha;
+
+    // Simulate CI squash merge: checkout main, create merge commit
+    repo.git(&["checkout", "main"]).unwrap();
+
+    // Manually create the squashed state (as CI would do)
+    file.set_contents(crate::lines![
+        "// Original code".unattributed_human(),
+        "function original() {}".unattributed_human(),
+        "// AI added function".unattributed_human(),
+        "function aiFeature() {".unattributed_human(),
+        "  return 'ai code';".unattributed_human(),
+        "}".unattributed_human()
+    ]);
+    let merge_commit = repo
+        .stage_all_and_commit("Merge feature via squash")
+        .unwrap();
+    let merge_sha = merge_commit.commit_sha;
+
+    // Get the GitAi repository instance
+    let git_ai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    // Call the CI rewrite function
+    use git_ai::authorship::rebase_authorship::rewrite_authorship_after_squash_or_rebase;
+    rewrite_authorship_after_squash_or_rebase(
+        &git_ai_repo,
+        "feature",
+        "main",
+        &feature_sha,
+        &merge_sha,
+        false,
+    )
+    .unwrap();
+
+    // Verify AI authorship is preserved in the merge commit
+    file.assert_lines_and_blame(crate::lines![
+        "// Original code".unattributed_human(),
+        "function original() {}".ai(),
+        "// AI added function".ai(),
+        "function aiFeature() {".ai(),
+        "  return 'ai code';".ai(),
+        "}".ai()
+    ]);
+}
+
+/// Standard-human variant of test_ci_squash_merge_mixed_content.
+/// Uses unattributed (checkpoint --) human lines instead of known-human attribution.
+#[test]
+fn test_ci_squash_merge_mixed_content_standard_human() {
+    let repo = direct_test_repo();
+    let mut file = repo.filename("mixed.js");
+
+    // Create initial commit
+    file.set_contents(crate::lines![
+        "// Base code".unattributed_human(),
+        "const base = 1;".unattributed_human()
+    ]);
+    let _base_commit = repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    // Create feature branch with mixed AI and human changes
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+
+    // Simulate: human adds a comment, AI adds code, human adds more
+    file.insert_at(
+        2,
+        crate::lines![
+            "// Human comment".unattributed_human(),
+            "// AI generated function".ai(),
+            "function aiHelper() {".ai(),
+            "  return true;".ai(),
+            "}".ai(),
+            "// Another human comment".unattributed_human()
+        ],
+    );
+
+    let feature_commit = repo.stage_all_and_commit("Add mixed content").unwrap();
+    let feature_sha = feature_commit.commit_sha;
+
+    // Simulate CI squash merge
+    repo.git(&["checkout", "main"]).unwrap();
+
+    file.set_contents(crate::lines![
+        "// Base code".unattributed_human(),
+        "const base = 1;".unattributed_human(),
+        "// Human comment".unattributed_human(),
+        "// AI generated function".unattributed_human(),
+        "function aiHelper() {".unattributed_human(),
+        "  return true;".unattributed_human(),
+        "}".unattributed_human(),
+        "// Another human comment".unattributed_human()
+    ]);
+
+    let merge_commit = repo
+        .stage_all_and_commit("Merge feature via squash")
+        .unwrap();
+    let merge_sha = merge_commit.commit_sha;
+
+    // Get the GitAi repository instance
+    let git_ai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    // Call the CI rewrite function
+    use git_ai::authorship::rebase_authorship::rewrite_authorship_after_squash_or_rebase;
+    rewrite_authorship_after_squash_or_rebase(
+        &git_ai_repo,
+        "feature",
+        "main",
+        &feature_sha,
+        &merge_sha,
+        false,
+    )
+    .unwrap();
+
+    // Verify mixed authorship is preserved
+    file.assert_lines_and_blame(crate::lines![
+        "// Base code".unattributed_human(),
+        "const base = 1;".unattributed_human(),
+        "// Human comment".ai(),
+        "// AI generated function".ai(),
+        "function aiHelper() {".ai(),
+        "  return true;".ai(),
+        "}".ai(),
+        "// Another human comment".unattributed_human()
+    ]);
+}
+
+/// Standard-human variant of test_ci_squash_merge_with_manual_changes.
+/// Uses unattributed (checkpoint --) human lines instead of known-human attribution.
+#[test]
+fn test_ci_squash_merge_with_manual_changes_standard_human() {
+    let repo = direct_test_repo();
+    let mut file = repo.filename("config.js");
+
+    // Create initial commit
+    file.set_contents(crate::lines![
+        "const config = {".unattributed_human(),
+        "  version: 1".unattributed_human(),
+        "};".unattributed_human()
+    ]);
+    let _base_commit = repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    // Create feature branch with AI additions
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+
+    file.set_contents(crate::lines![
+        "const config = {".unattributed_human(),
+        "  version: 1,".unattributed_human(),
+        "  // AI added feature flag".ai(),
+        "  enableAI: true".ai(),
+        "};".unattributed_human()
+    ]);
+
+    let feature_commit = repo.stage_all_and_commit("Add AI config").unwrap();
+    let feature_sha = feature_commit.commit_sha;
+
+    // Simulate CI squash merge with manual adjustment during merge
+    // (e.g., developer manually tweaks formatting or adds extra config)
+    repo.git(&["checkout", "main"]).unwrap();
+
+    file.set_contents(crate::lines![
+        "const config = {".unattributed_human(),
+        "  version: 1,".unattributed_human(),
+        "  // AI added feature flag".unattributed_human(),
+        "  enableAI: true,".unattributed_human(),
+        "  // Manual addition during merge".unattributed_human(),
+        "  production: false".unattributed_human(),
+        "};".unattributed_human()
+    ]);
+
+    let merge_commit = repo
+        .stage_all_and_commit("Merge feature via squash with tweaks")
+        .unwrap();
+    let merge_sha = merge_commit.commit_sha;
+
+    // Get the GitAi repository instance
+    let git_ai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    // Call the CI rewrite function
+    use git_ai::authorship::rebase_authorship::rewrite_authorship_after_squash_or_rebase;
+    rewrite_authorship_after_squash_or_rebase(
+        &git_ai_repo,
+        "feature",
+        "main",
+        &feature_sha,
+        &merge_sha,
+        false,
+    )
+    .unwrap();
+
+    // Verify AI authorship is preserved for AI lines, human for manual additions
+    file.assert_lines_and_blame(crate::lines![
+        "const config = {".unattributed_human(),
+        "  version: 1,".unattributed_human(),
+        "  // AI added feature flag".ai(),
+        "  enableAI: true,".ai(),
+        "  // Manual addition during merge".unattributed_human(),
+        "  production: false".unattributed_human(),
+        "};".unattributed_human()
+    ]);
+}
+
+/// Standard-human variant of test_ci_rebase_merge_multiple_commits.
+/// Uses unattributed (checkpoint --) human lines instead of known-human attribution.
+#[test]
+fn test_ci_rebase_merge_multiple_commits_standard_human() {
+    let repo = direct_test_repo();
+    let mut file = repo.filename("app.js");
+
+    // Create initial commit
+    file.set_contents(crate::lines!["// App v1".unattributed_human(), "".unattributed_human()]);
+    let _base_commit = repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    // Create feature branch with multiple commits
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+
+    // First commit: AI adds function
+    file.insert_at(
+        1,
+        crate::lines!["// AI function 1".ai(), "function ai1() { }".ai()],
+    );
+    repo.stage_all_and_commit("Add AI function 1").unwrap();
+
+    // Second commit: AI adds another function
+    file.insert_at(
+        3,
+        crate::lines!["// AI function 2".ai(), "function ai2() { }".ai()],
+    );
+    repo.stage_all_and_commit("Add AI function 2").unwrap();
+
+    // Third commit: Human adds function
+    file.insert_at(
+        5,
+        crate::lines![
+            "// Human function".unattributed_human(),
+            "function human() { }".unattributed_human()
+        ],
+    );
+    let feature_commit = repo.stage_all_and_commit("Add human function").unwrap();
+    let feature_sha = feature_commit.commit_sha;
+
+    // Simulate CI rebase-style merge (all commits squashed into one)
+    repo.git(&["checkout", "main"]).unwrap();
+
+    file.set_contents(crate::lines![
+        "// App v1".unattributed_human(),
+        "// AI function 1".unattributed_human(),
+        "function ai1() { }".unattributed_human(),
+        "// AI function 2".unattributed_human(),
+        "function ai2() { }".unattributed_human(),
+        "// Human function".unattributed_human(),
+        "function human() { }".unattributed_human()
+    ]);
+
+    let merge_commit = repo
+        .stage_all_and_commit("Merge feature branch (squashed)")
+        .unwrap();
+    let merge_sha = merge_commit.commit_sha;
+
+    // Get the GitAi repository instance
+    let git_ai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    // Call the CI rewrite function
+    use git_ai::authorship::rebase_authorship::rewrite_authorship_after_squash_or_rebase;
+    rewrite_authorship_after_squash_or_rebase(
+        &git_ai_repo,
+        "feature",
+        "main",
+        &feature_sha,
+        &merge_sha,
+        false,
+    )
+    .unwrap();
+
+    // Verify all authorship is correctly attributed
+    file.assert_lines_and_blame(crate::lines![
+        "// App v1".unattributed_human(),
+        "// AI function 1".ai(),
+        "function ai1() { }".ai(),
+        "// AI function 2".ai(),
+        "function ai2() { }".ai(),
+        "// Human function".unattributed_human(),
+        "function human() { }".unattributed_human()
+    ]);
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -988,4 +1330,8 @@ crate::reuse_tests_in_worktree!(
     test_ci_rebase_merge_commit_order_pairing,
     test_ci_local_rebase_merge_two_commits,
     test_ci_local_rebase_merge_three_commits,
+    test_ci_squash_merge_basic_standard_human,
+    test_ci_squash_merge_mixed_content_standard_human,
+    test_ci_squash_merge_with_manual_changes_standard_human,
+    test_ci_rebase_merge_multiple_commits_standard_human,
 );

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -272,7 +272,7 @@ fn test_ci_squash_merge_empty_notes_preserved() {
 
     let authorship_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
     assert!(
-        authorship_log.attestations.is_empty(),
+        authorship_log.metadata.prompts.is_empty(),
         "Expected empty attestations for human-only squash merge"
     );
 }

--- a/tests/integration/codex.rs
+++ b/tests/integration/codex.rs
@@ -740,6 +740,93 @@ fn test_codex_read_only_bash_post_tool_use_before_edit_does_not_steal_commit_att
     ]);
 }
 
+/// Variant of test_codex_commit_inside_bash_inflight_repeated_append_keeps_file_ai using
+/// unattributed (legacy) human checkpoints. Assertions match origin/main behavior: with empty
+/// attribution, all lines (including "Project README") are attributed to AI because the codex
+/// session claims any unattributed content.
+#[test]
+fn test_codex_commit_inside_bash_inflight_repeated_append_keeps_file_ai_standard_human() {
+    use crate::repos::test_repo::TestRepo;
+
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+
+    let mut readme = repo.filename("README.md");
+    readme.set_contents(crate::lines!["Project README".unattributed_human()]);
+    repo.stage_all_and_commit("Initial README")
+        .expect("initial README commit should succeed");
+
+    let repo_root = repo.canonical_path();
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-bash-append-rollout-standard-human.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "codex-bash-append-session-sh",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "bash-use-append-commit-sh",
+        "tool_input": {
+            "command": "git add README.md && git commit -m 'Codex append proof'"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("pre-hook checkpoint should succeed");
+
+    readme.set_contents(crate::lines![
+        "Project README".unattributed_human(),
+        "Updated by Codex".unattributed_human()
+    ]);
+    repo.stage_all_and_commit("Codex append proof")
+        .expect("Codex append commit should succeed");
+
+    readme.assert_lines_and_blame(crate::lines![
+        "Project README".ai(),
+        "Updated by Codex".ai(),
+    ]);
+
+    let second_pre_hook_input = json!({
+        "session_id": "codex-bash-append-session-2-sh",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "bash-use-append-commit-2-sh",
+        "tool_input": {
+            "command": "git add README.md && git commit -m 'Codex append proof 2'"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&[
+        "checkpoint",
+        "codex",
+        "--hook-input",
+        &second_pre_hook_input,
+    ])
+    .expect("second pre-hook checkpoint should succeed");
+
+    readme.set_contents(crate::lines![
+        "Project README".unattributed_human(),
+        "Updated by Codex".unattributed_human(),
+        "Updated again by Codex".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("Codex append proof 2")
+        .expect("second Codex append commit should succeed");
+
+    readme.assert_lines_and_blame(crate::lines![
+        "Project README".ai(),
+        "Updated by Codex".ai(),
+        "Updated again by Codex".ai(),
+    ]);
+}
+
 crate::reuse_tests_in_worktree!(
     test_parse_codex_rollout_transcript,
     test_codex_preset_legacy_hook_input,
@@ -754,4 +841,5 @@ crate::reuse_tests_in_worktree!(
     test_codex_file_edit_then_bash_pretooluse_does_not_steal_ai_commit_attribution,
     test_codex_file_edit_then_camel_case_bash_pretooluse_does_not_steal_ai_commit_attribution,
     test_codex_read_only_bash_post_tool_use_before_edit_does_not_steal_commit_attribution,
+    test_codex_commit_inside_bash_inflight_repeated_append_keeps_file_ai_standard_human,
 );

--- a/tests/integration/codex.rs
+++ b/tests/integration/codex.rs
@@ -522,12 +522,12 @@ fn test_codex_commit_inside_bash_inflight_repeated_append_keeps_file_ai() {
     repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
         .expect("pre-hook checkpoint should succeed");
 
-    readme.set_contents(crate::lines!["Project README", "Updated by Codex"]);
+    readme.set_contents(crate::lines!["Project README", "Updated by Codex".ai()]);
     repo.stage_all_and_commit("Codex append proof")
         .expect("Codex append commit should succeed");
 
     readme.assert_lines_and_blame(crate::lines![
-        "Project README".ai(),
+        "Project README".human(),
         "Updated by Codex".ai(),
     ]);
 
@@ -554,14 +554,14 @@ fn test_codex_commit_inside_bash_inflight_repeated_append_keeps_file_ai() {
 
     readme.set_contents(crate::lines![
         "Project README",
-        "Updated by Codex",
-        "Updated again by Codex",
+        "Updated by Codex".ai(),
+        "Updated again by Codex".ai(),
     ]);
     repo.stage_all_and_commit("Codex append proof 2")
         .expect("second Codex append commit should succeed");
 
     readme.assert_lines_and_blame(crate::lines![
-        "Project README".ai(),
+        "Project README".human(),
         "Updated by Codex".ai(),
         "Updated again by Codex".ai(),
     ]);

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -357,6 +357,11 @@ fn checkpoint_human(repo: &TestRepo) {
         .expect("human checkpoint should succeed");
 }
 
+fn checkpoint_known_human(repo: &TestRepo, file_path: &str) {
+    repo.git_ai(&["checkpoint", "mock_known_human", file_path])
+        .expect("known human checkpoint should succeed");
+}
+
 fn commit_after_staging_all(repo: &TestRepo, message: &str) -> NewCommit {
     repo.git(&["add", "-A"]).expect("git add should succeed");
     repo.commit(message).expect("commit should succeed")
@@ -1347,7 +1352,7 @@ fn test_diff_json_include_stats_exact_multi_model_with_non_landing_prompt() {
             "codex-b2",
         ],
     );
-    checkpoint_human(&repo);
+    checkpoint_known_human(&repo, "multi_model_stats.txt");
 
     let commit = commit_after_staging_all(&repo, "multi model stats target");
     let diff = diff_json(
@@ -1428,7 +1433,7 @@ fn test_diff_json_include_stats_exact_human_landed_with_ai_generated() {
         "human_landed_stats.txt",
         &["base", "human-final-1", "human-final-2"],
     );
-    checkpoint_human(&repo);
+    checkpoint_known_human(&repo, "human_landed_stats.txt");
 
     let commit = commit_after_staging_all(&repo, "human landed target");
     let diff = diff_json(

--- a/tests/integration/github_copilot_tools.rs
+++ b/tests/integration/github_copilot_tools.rs
@@ -112,21 +112,19 @@ fn test_replace_string_in_file_basic() {
 fn test_run_in_terminal_bash_checkpoint() {
     let repo = TestRepo::new();
 
-    // Create initial file
-    let mut script = repo.filename("example.py");
-    script.set_contents(crate::lines![
-        "import argparse",
-        "",
-        "def main():",
-        "    parser = argparse.ArgumentParser(description=\"Test CLI\")",
-        "    parser.add_argument(\"--name\", default=\"World\")",
-        "    args = parser.parse_args()",
-        "    print(f\"Hello, {args.name}!\")",
-        "",
-        "if __name__ == \"__main__\":",
-        "    main()"
-    ]);
-    repo.stage_all_and_commit("Initial script").unwrap();
+    // Create initial file with raw I/O — do NOT use set_contents/filename helpers
+    // as they fire real checkpoints that corrupt the bash snapshot state.
+    std::fs::write(
+        repo.path().join("example.py"),
+        "import argparse\n\ndef main():\n    parser = argparse.ArgumentParser(description=\"Test CLI\")\n    parser.add_argument(\"--name\", default=\"World\")\n    args = parser.parse_args()\n    print(f\"Hello, {args.name}!\")\n\nif __name__ == \"__main__\":\n    main()\n",
+    )
+    .unwrap();
+    repo.git(&["add", "example.py"]).unwrap();
+    repo.git(&["commit", "-m", "Initial script"]).unwrap();
+
+    // Wait for the daemon's watermark grace window (2s) to expire so the
+    // pre-snapshot is not filtered to empty.
+    std::thread::sleep(std::time::Duration::from_secs(3));
 
     let session_id = "b4a517c6-b9f0-4787-af3a-7c002539b448";
 
@@ -155,9 +153,9 @@ fn test_run_in_terminal_bash_checkpoint() {
     ])
     .unwrap();
 
-    // Simulate the command creating/modifying a file (like creating output.txt)
-    let mut output = repo.filename("output.txt");
-    output.set_contents(crate::lines!["Hello, World!"]);
+    // Simulate the bash command writing a file directly to disk — raw I/O only,
+    // no set_contents/filename helpers between Pre and PostToolUse.
+    std::fs::write(repo.path().join("output.txt"), "Hello, World!").unwrap();
 
     // PostToolUse hook
     let post_hook_input = json!({
@@ -188,10 +186,14 @@ fn test_run_in_terminal_bash_checkpoint() {
     // Sync daemon before assertions
     repo.sync_daemon();
 
-    repo.stage_all_and_commit("Add output file from command")
+    repo.git(&["add", "output.txt"]).unwrap();
+    repo.git(&["commit", "-m", "Add output file from command"])
         .unwrap();
 
+    repo.sync_daemon();
+
     // File created by bash command should be attributed to AI
+    let mut output = repo.filename("output.txt");
     output.assert_lines_and_blame(crate::lines!["Hello, World!".ai()]);
 }
 
@@ -200,10 +202,10 @@ fn test_run_in_terminal_bash_checkpoint() {
 fn test_run_in_terminal_no_changes() {
     let repo = TestRepo::new();
 
-    // Create initial file
-    let mut script = repo.filename("test.py");
-    script.set_contents(crate::lines!["print('test')"]);
-    repo.stage_all_and_commit("Initial commit").unwrap();
+    // Create initial file with raw I/O
+    std::fs::write(repo.path().join("test.py"), "print('test')\n").unwrap();
+    repo.git(&["add", "test.py"]).unwrap();
+    repo.git(&["commit", "-m", "Initial commit"]).unwrap();
 
     let session_id = "c3f5a7b8-9d0e-1f2a-3b4c-5d6e7f8a9b0c";
 

--- a/tests/integration/prompt_across_commit.rs
+++ b/tests/integration/prompt_across_commit.rs
@@ -91,7 +91,10 @@ fn test_change_across_commits_standard_human() {
         .unwrap();
 
     file.replace_at(4, "    print(f\"Hello, {name.upper()}!\")".ai());
-    file.insert_at(4, crate::lines!["    name = name.upper()".unattributed_human()]);
+    file.insert_at(
+        4,
+        crate::lines!["    name = name.upper()".unattributed_human()],
+    );
 
     let commit = repo.stage_all_and_commit("add more AI").unwrap();
 
@@ -112,4 +115,7 @@ fn test_change_across_commits_standard_human() {
     assert_ne!(second_ai_entry.hash, initial_ai_entry.hash);
 }
 
-crate::reuse_tests_in_worktree!(test_change_across_commits, test_change_across_commits_standard_human,);
+crate::reuse_tests_in_worktree!(
+    test_change_across_commits,
+    test_change_across_commits_standard_human,
+);

--- a/tests/integration/prompt_across_commit.rs
+++ b/tests/integration/prompt_across_commit.rs
@@ -61,4 +61,55 @@ fn test_change_across_commits() {
     assert_ne!(second_ai_entry.hash, initial_ai_entry.hash);
 }
 
-crate::reuse_tests_in_worktree!(test_change_across_commits,);
+/// Variant of test_change_across_commits using unattributed (legacy) human checkpoints.
+/// Assertions match origin/main: with empty attribution, the file has only 1 attestation
+/// entry (the second AI commit's entry only) because the first commit's attribution is
+/// subsumed into the working log without creating a separate attestation entry.
+#[test]
+fn test_change_across_commits_standard_human() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("foo.py");
+
+    file.set_contents(crate::lines![
+        "def print_name(name: str) -> None:".ai(),
+        "    \"\"\"Print the given name.\"\"\"".ai(),
+        "    if name == 'foobar':".ai(),
+        "        print('name not allowed!')".ai(),
+        "    print(f\"Hello, {name}!\")".ai(),
+        "".ai(),
+        "print_name(\"Michael\")".ai(),
+    ]);
+
+    let commit = repo.stage_all_and_commit("Initial all AI").unwrap();
+    let initial_ai_entry = commit
+        .authorship_log
+        .attestations
+        .first()
+        .unwrap()
+        .entries
+        .first()
+        .unwrap();
+
+    file.replace_at(4, "    print(f\"Hello, {name.upper()}!\")".ai());
+    file.insert_at(4, crate::lines!["    name = name.upper()".unattributed_human()]);
+
+    let commit = repo.stage_all_and_commit("add more AI").unwrap();
+
+    let file_attestation = commit.authorship_log.attestations.first().unwrap();
+    assert_eq!(file_attestation.entries.len(), 1);
+
+    let second_ai_prompt_hash = commit
+        .authorship_log
+        .metadata
+        .prompts
+        .keys()
+        .next()
+        .unwrap();
+    assert_ne!(*second_ai_prompt_hash, initial_ai_entry.hash);
+
+    let second_ai_entry = file_attestation.entries.first().unwrap();
+    assert_eq!(second_ai_entry.line_ranges, vec![LineRange::Single(6)]);
+    assert_ne!(second_ai_entry.hash, initial_ai_entry.hash);
+}
+
+crate::reuse_tests_in_worktree!(test_change_across_commits, test_change_across_commits_standard_human,);

--- a/tests/integration/prompt_across_commit.rs
+++ b/tests/integration/prompt_across_commit.rs
@@ -41,7 +41,7 @@ fn test_change_across_commits() {
     let commit = repo.stage_all_and_commit("add more AI").unwrap();
 
     let file_attestation = commit.authorship_log.attestations.first().unwrap();
-    assert_eq!(file_attestation.entries.len(), 1);
+    assert_eq!(file_attestation.entries.len(), 2);
 
     let second_ai_prompt_hash = commit
         .authorship_log
@@ -52,7 +52,11 @@ fn test_change_across_commits() {
         .unwrap();
     assert_ne!(*second_ai_prompt_hash, initial_ai_entry.hash);
 
-    let second_ai_entry = file_attestation.entries.first().unwrap();
+    let second_ai_entry = file_attestation
+        .entries
+        .iter()
+        .find(|e| commit.authorship_log.metadata.prompts.contains_key(&e.hash))
+        .unwrap();
     assert_eq!(second_ai_entry.line_ranges, vec![LineRange::Single(6)]);
     assert_ne!(second_ai_entry.hash, initial_ai_entry.hash);
 }

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -298,7 +298,7 @@ fn test_rebase_preserves_human_only_commit_note_metadata() {
     let old_log =
         AuthorshipLog::deserialize_from_string(&old_note).expect("parse original authorship note");
     assert!(
-        old_log.attestations.is_empty(),
+        old_log.metadata.prompts.is_empty(),
         "precondition: human-only commit should have no attestations"
     );
     assert!(
@@ -317,7 +317,7 @@ fn test_rebase_preserves_human_only_commit_note_metadata() {
     let rebased_log = AuthorshipLog::deserialize_from_string(&rebased_note)
         .expect("parse rebased authorship note");
     assert!(
-        rebased_log.attestations.is_empty(),
+        rebased_log.metadata.prompts.is_empty(),
         "rebased human-only commit should still have no attestations"
     );
     assert!(
@@ -355,7 +355,7 @@ fn test_rebase_preserves_prompt_only_commit_note_metadata() {
     let mut original_log =
         AuthorshipLog::deserialize_from_string(&original_note).expect("parse source note");
     assert!(
-        original_log.attestations.is_empty(),
+        original_log.metadata.prompts.is_empty(),
         "precondition: should start metadata-only"
     );
     assert!(
@@ -402,7 +402,6 @@ fn test_rebase_preserves_prompt_only_commit_note_metadata() {
         .expect("rebased commit should preserve prompt-only note");
     let rebased_log =
         AuthorshipLog::deserialize_from_string(&rebased_note).expect("parse rebased note");
-    assert!(rebased_log.attestations.is_empty());
     assert_eq!(rebased_log.metadata.prompts.len(), 1);
     assert_eq!(rebased_log.metadata.base_commit_sha, rebased_sha);
 

--- a/tests/integration/rebase_realworld.rs
+++ b/tests/integration/rebase_realworld.rs
@@ -9704,16 +9704,23 @@ fn test_conflict_ai_resolves_timeout_constant() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 2 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -10139,16 +10146,23 @@ fn test_conflict_ai_resolves_preserving_human_context_lines() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 2 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -10330,16 +10344,23 @@ fn test_conflict_ai_resolves_on_first_commit() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[0]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c1' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 0 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -10529,16 +10550,23 @@ fn test_conflict_ai_resolves_on_last_commit() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[4]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c5' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 4 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -10748,16 +10776,23 @@ fn test_conflict_ai_resolves_multiple_files_in_same_commit() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 2 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -10942,16 +10977,23 @@ fn test_conflict_ai_resolves_then_more_ai_builds_on_result() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[1]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c2' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 1 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -11158,16 +11200,23 @@ fn test_conflict_ai_resolves_rust_struct_fields() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 2 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -11413,16 +11462,23 @@ fn test_conflict_ai_resolves_complex_function_with_error_handling() {
     // Verify per-commit-delta humans scoping (KnownHuman variant)
     let conflict_note = parse_note(&repo, &chain[3]); // X = conflict commit index
     assert!(
-        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        conflict_note
+            .metadata
+            .humans
+            .contains_key("h_9e95a89b42f1fb"),
         "c4' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
     );
-    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    assert_eq!(
+        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
+        "Test User"
+    );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
         if i != 3 {
             assert!(
                 parse_note(&repo, sha).metadata.humans.is_empty(),
-                "chain[{}] (pure AI commit) should have no humans entry", i
+                "chain[{}] (pure AI commit) should have no humans entry",
+                i
             );
         }
     }
@@ -12032,7 +12088,6 @@ fn test_conflict_ai_resolves_timeout_constant_standard_human() {
     // C5': payments.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["payments.py"]);
-
 }
 
 /// Test 3: processor.py — feature (C3) adds 5 AI lines to method2 body,
@@ -12237,7 +12292,6 @@ fn test_conflict_ai_resolves_preserving_human_context_lines_standard_human() {
     // C5': util_e.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["util_e.py"]);
-
 }
 
 /// Test 4: version.py — conflict is on C1 (the VERY FIRST feature commit).
@@ -12412,7 +12466,6 @@ fn test_conflict_ai_resolves_on_first_commit_standard_human() {
     // C5': migration_guide.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["migration_guide.py"]);
-
 }
 
 /// Test 5: schema.rs max_connections — conflict is on C5 (LAST feature commit).
@@ -12595,7 +12648,6 @@ fn test_conflict_ai_resolves_on_last_commit_standard_human() {
             ("SCHEMA_VERSION: u32 = 1", false),
         ],
     );
-
 }
 
 /// Test 6: config.py AND settings.py both conflict in C3.
@@ -12798,7 +12850,6 @@ fn test_conflict_ai_resolves_multiple_files_in_same_commit_standard_human() {
     // C5': serializers.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["serializers.py"]);
-
 }
 
 /// Test 7: dispatcher.py — conflict on C2.  C3 and C4 also modify dispatcher.py
@@ -12976,7 +13027,6 @@ fn test_conflict_ai_resolves_then_more_ai_builds_on_result_standard_human() {
     // C5': event_bus.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["event_bus.py"]);
-
 }
 
 /// Test 8: models.rs struct fields — feature (C3) AI adds 4 new fields,
@@ -13176,7 +13226,6 @@ fn test_conflict_ai_resolves_rust_struct_fields_standard_human() {
     // C5': utils.rs only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["src/utils.rs"]);
-
 }
 
 /// Test 9: service.py process_payment — feature (C4) AI implements a 20-line
@@ -13415,7 +13464,6 @@ fn test_conflict_ai_resolves_complex_function_with_error_handling_standard_human
     // C5': utils.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["utils.py"]);
-
 }
 
 crate::reuse_tests_in_worktree!(

--- a/tests/integration/rebase_realworld.rs
+++ b/tests/integration/rebase_realworld.rs
@@ -9700,6 +9700,23 @@ fn test_conflict_ai_resolves_timeout_constant() {
     // C5': payments.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["payments.py"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 2 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 2: compute.rs function body — feature (C2) implements a function with
@@ -10118,6 +10135,23 @@ fn test_conflict_ai_resolves_preserving_human_context_lines() {
     // C5': util_e.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["util_e.py"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 2 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 4: version.py — conflict is on C1 (the VERY FIRST feature commit).
@@ -10292,6 +10326,23 @@ fn test_conflict_ai_resolves_on_first_commit() {
     // C5': migration_guide.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["migration_guide.py"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[0]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c1' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 0 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 5: schema.rs max_connections — conflict is on C5 (LAST feature commit).
@@ -10474,6 +10525,23 @@ fn test_conflict_ai_resolves_on_last_commit() {
             ("SCHEMA_VERSION: u32 = 1", false),
         ],
     );
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[4]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c5' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 4 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 6: config.py AND settings.py both conflict in C3.
@@ -10676,6 +10744,23 @@ fn test_conflict_ai_resolves_multiple_files_in_same_commit() {
     // C5': serializers.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["serializers.py"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 2 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 7: dispatcher.py — conflict on C2.  C3 and C4 also modify dispatcher.py
@@ -10853,6 +10938,23 @@ fn test_conflict_ai_resolves_then_more_ai_builds_on_result() {
     // C5': event_bus.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["event_bus.py"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[1]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c2' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 1 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 8: models.rs struct fields — feature (C3) AI adds 4 new fields,
@@ -11052,6 +11154,23 @@ fn test_conflict_ai_resolves_rust_struct_fields() {
     // C5': utils.rs only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["src/utils.rs"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[2]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 2 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 9: service.py process_payment — feature (C4) AI implements a 20-line
@@ -11290,6 +11409,23 @@ fn test_conflict_ai_resolves_complex_function_with_error_handling() {
     // C5': utils.py only
     assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
     assert_note_files_exact(&repo, &chain[4], "c5_files", &["utils.py"]);
+
+    // Verify per-commit-delta humans scoping (KnownHuman variant)
+    let conflict_note = parse_note(&repo, &chain[3]); // X = conflict commit index
+    assert!(
+        conflict_note.metadata.humans.contains_key("h_9e95a89b42f1fb"),
+        "c4' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+    );
+    assert_eq!(conflict_note.metadata.humans["h_9e95a89b42f1fb"].author, "Test User");
+    // Other commits (pure AI) should have no humans entry
+    for (i, sha) in chain.iter().enumerate() {
+        if i != 3 {
+            assert!(
+                parse_note(&repo, sha).metadata.humans.is_empty(),
+                "chain[{}] (pure AI commit) should have no humans entry", i
+            );
+        }
+    }
 }
 
 /// Test 10: Two conflicts — C2 (AI resolved) and C4 (human resolved).
@@ -11705,6 +11841,1583 @@ fn test_conflict_content_diff_wins_over_working_log() {
 // END Category 5: Path-specific correctness tests
 // ============================================================================
 
+// ============================================================================
+// Standard-human variants: same as the KnownHuman tests above but use
+// .unattributed_human() instead of .human() in set_contents calls.
+// These do NOT assert metadata.humans (no KnownHuman attribution expected).
+// ============================================================================
+
+/// Test 1: config.py TIMEOUT constant — feature (C3) changes TIMEOUT to 60,
+/// main changes it to 120 → conflict.  AI resolves to TIMEOUT = 90.
+/// C1' has users.py, C2' adds products.py, C3' adds config.py (AI-resolved),
+/// C4' adds orders.py, C5' adds payments.py.
+#[test]
+fn test_conflict_ai_resolves_timeout_constant_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: config.py with a class and TIMEOUT constant (human)
+    write_raw_commit(
+        &repo,
+        "config.py",
+        "class Config:\n    TIMEOUT = 30\n    HOST = 'localhost'\n    PORT = 8080\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: changes TIMEOUT to 120 and adds 4 more commits
+    write_raw_commit(
+        &repo,
+        "config.py",
+        "class Config:\n    TIMEOUT = 120\n    HOST = 'localhost'\n    PORT = 8080\n",
+        "main: increase TIMEOUT to 120",
+    );
+    write_raw_commit(
+        &repo,
+        "logging_config.py",
+        "import logging\nlogging.basicConfig(level=logging.INFO)\n",
+        "main: add logging config",
+    );
+    write_raw_commit(
+        &repo,
+        "constants.py",
+        "MAX_CONNECTIONS = 100\nDEFAULT_PAGE_SIZE = 20\n",
+        "main: add constants",
+    );
+    write_raw_commit(
+        &repo,
+        "exceptions.py",
+        "class AppError(Exception): pass\nclass ValidationError(AppError): pass\n",
+        "main: add exceptions",
+    );
+    write_raw_commit(
+        &repo,
+        "utils.py",
+        "def flatten(lst): return [x for sub in lst for x in sub]\n",
+        "main: add utils",
+    );
+
+    // Feature branch from base (before main's TIMEOUT change)
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates users.py (8 AI lines)
+    let mut users = repo.filename("users.py");
+    users.set_contents(crate::lines![
+        "class UserService:".ai(),
+        "    def __init__(self, db):".ai(),
+        "        self.db = db".ai(),
+        "    def get_user(self, uid):".ai(),
+        "        return self.db.query('SELECT * FROM users WHERE id=?', uid)".ai(),
+        "    def create_user(self, name, email):".ai(),
+        "        return self.db.execute('INSERT INTO users VALUES (?, ?)', name, email)".ai(),
+        "    def delete_user(self, uid):".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add user service")
+        .unwrap();
+
+    // C2: AI creates products.py (8 AI lines)
+    let mut products = repo.filename("products.py");
+    products.set_contents(crate::lines![
+        "class ProductService:".ai(),
+        "    def __init__(self, db):".ai(),
+        "        self.db = db".ai(),
+        "    def get_product(self, pid):".ai(),
+        "        return self.db.query('SELECT * FROM products WHERE id=?', pid)".ai(),
+        "    def list_products(self):".ai(),
+        "        return self.db.query('SELECT * FROM products')".ai(),
+        "    def update_price(self, pid, price):".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 add product service")
+        .unwrap();
+
+    // C3: AI changes TIMEOUT to 60 in config.py — WILL CONFLICT with main's 120
+    let mut config = repo.filename("config.py");
+    config.set_contents(crate::lines![
+        "class Config:".unattributed_human(),
+        "    TIMEOUT = 60".ai(),
+        "    HOST = 'localhost'".unattributed_human(),
+        "    PORT = 8080".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 AI tunes TIMEOUT to 60")
+        .unwrap();
+
+    // C4: AI creates orders.py (8 AI lines)
+    let mut orders = repo.filename("orders.py");
+    orders.set_contents(crate::lines![
+        "class OrderService:".ai(),
+        "    def __init__(self, db):".ai(),
+        "        self.db = db".ai(),
+        "    def create_order(self, uid, items):".ai(),
+        "        total = sum(i['price'] for i in items)".ai(),
+        "        return self.db.execute('INSERT INTO orders VALUES (?, ?)', uid, total)".ai(),
+        "    def get_order(self, oid):".ai(),
+        "        return self.db.query('SELECT * FROM orders WHERE id=?', oid)".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 add order service")
+        .unwrap();
+
+    // C5: AI creates payments.py (8 AI lines)
+    let mut payments = repo.filename("payments.py");
+    payments.set_contents(crate::lines![
+        "class PaymentService:".ai(),
+        "    def __init__(self, db, stripe):".ai(),
+        "        self.db = db".ai(),
+        "        self.stripe = stripe".ai(),
+        "    def charge(self, oid, amount, token):".ai(),
+        "        r = self.stripe.charge(amount, token)".ai(),
+        "        self.db.execute('INSERT INTO payments VALUES (?, ?)', oid, r['id'])".ai(),
+        "    def refund(self, pid):".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 add payment service")
+        .unwrap();
+
+    // Rebase onto main — C3 will conflict on config.py
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on config.py at C3"
+    );
+
+    // AI resolves: sets TIMEOUT = 90 as .ai(), surrounding lines as .unattributed_human()
+    let mut conflict_config = repo.filename("config.py");
+    conflict_config.set_contents(crate::lines![
+        "class Config:".unattributed_human(),
+        "    TIMEOUT = 90".ai(),
+        "    HOST = 'localhost'".unattributed_human(),
+        "    PORT = 8080".unattributed_human(),
+    ]);
+    // set_contents already ran git add -A + checkpoint
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': users.py only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["users.py"]);
+
+    // C2': products.py only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["products.py"]);
+
+    // C3': config.py only (AI-resolved, TIMEOUT = 90 attributed as AI)
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["config.py"]);
+    // 1 AI line: TIMEOUT = 90 (working-log fallback path must set accepted_lines correctly)
+    assert_accepted_lines_exact(&repo, &chain[2], "c3_accepted_lines", 1);
+
+    // blame at chain[2] for config.py: the AI-resolved TIMEOUT line should be AI
+    assert_blame_at_commit(
+        &repo,
+        &chain[2],
+        "config.py",
+        "c3_blame_config",
+        &[
+            ("class Config:", false),
+            ("TIMEOUT = 90", true),
+            ("HOST = 'localhost'", false),
+            ("PORT = 8080", false),
+        ],
+    );
+
+    // C4': orders.py only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["orders.py"]);
+
+    // C5': payments.py only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["payments.py"]);
+
+}
+
+/// Test 3: processor.py — feature (C3) adds 5 AI lines to method2 body,
+/// main also changes method2.  AI resolution rewrites processor.py preserving
+/// 2 human context lines and writing 7 lines for the resolved method2 (marked
+/// `.ai()` in set_contents).  However, the content-diff path only carries
+/// attribution for lines whose content exactly matches the original feature commit:
+/// only `def method2(self):`, `result = []`, `for i in range(10):`, and
+/// `result.append(i * 2)` survive the content match — 4 lines.  The newly
+/// introduced lines (`# AI merged`, `label = `, `return result, label`) have no
+/// entry in `original_head_line_to_author` and therefore receive human attribution.
+#[test]
+fn test_conflict_ai_resolves_preserving_human_context_lines_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: processor.py with a class (6 human lines)
+    write_raw_commit(
+        &repo,
+        "processor.py",
+        "class Processor:\n    def method1(self): return 'method1'\n    def method2(self): pass\n    def method3(self): return 'method3'\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: human changes method2 differently → conflict
+    write_raw_commit(
+        &repo,
+        "processor.py",
+        "class Processor:\n    def method1(self): return 'method1'\n    def method2(self): return 'human-method2'\n    def method3(self): return 'method3'\n",
+        "main: implement method2",
+    );
+    write_raw_commit(
+        &repo,
+        "runner.py",
+        "from processor import Processor\np = Processor()\np.method1()\n",
+        "main: add runner",
+    );
+    write_raw_commit(
+        &repo,
+        "tests/test_processor.py",
+        "from processor import Processor\ndef test_method1(): assert Processor().method1() == 'method1'\n",
+        "main: add tests",
+    );
+    write_raw_commit(
+        &repo,
+        "setup.py",
+        "from setuptools import setup\nsetup(name='processor', version='0.1.0')\n",
+        "main: add setup.py",
+    );
+    write_raw_commit(
+        &repo,
+        "pyproject.toml",
+        "[build-system]\nrequires = ['setuptools']\n",
+        "main: add pyproject.toml",
+    );
+
+    // Feature branch from base
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates util_a.py (8 AI lines)
+    let mut util_a = repo.filename("util_a.py");
+    util_a.set_contents(crate::lines![
+        "def parse_int(s: str) -> int:".ai(),
+        "    try:".ai(),
+        "        return int(s)".ai(),
+        "    except ValueError:".ai(),
+        "        raise ValueError(f'Cannot parse {s!r} as int')".ai(),
+        "".ai(),
+        "def parse_float(s: str) -> float:".ai(),
+        "    return float(s)".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add util_a").unwrap();
+
+    // C2: AI creates util_b.py (8 AI lines)
+    let mut util_b = repo.filename("util_b.py");
+    util_b.set_contents(crate::lines![
+        "from typing import List, Optional".ai(),
+        "".ai(),
+        "def chunk(lst: List, size: int) -> List[List]:".ai(),
+        "    return [lst[i:i+size] for i in range(0, len(lst), size)]".ai(),
+        "".ai(),
+        "def flatten(lst: List[List]) -> List:".ai(),
+        "    return [x for sub in lst for x in sub]".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 add util_b").unwrap();
+
+    // C3: AI adds 5 lines to method2 in processor.py — WILL CONFLICT
+    let mut processor = repo.filename("processor.py");
+    processor.set_contents(crate::lines![
+        "class Processor:".unattributed_human(),
+        "    def method1(self): return 'method1'".unattributed_human(),
+        "    def method2(self):".ai(),
+        "        result = []".ai(),
+        "        for i in range(10):".ai(),
+        "            result.append(i * 2)".ai(),
+        "        return result".ai(),
+        "    def method3(self): return 'method3'".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 AI implements method2")
+        .unwrap();
+
+    // C4: AI creates util_d.py (8 AI lines)
+    let mut util_d = repo.filename("util_d.py");
+    util_d.set_contents(crate::lines![
+        "import hashlib".ai(),
+        "".ai(),
+        "def md5(s: str) -> str:".ai(),
+        "    return hashlib.md5(s.encode()).hexdigest()".ai(),
+        "".ai(),
+        "def sha256(s: str) -> str:".ai(),
+        "    return hashlib.sha256(s.encode()).hexdigest()".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 add util_d").unwrap();
+
+    // C5: AI creates util_e.py (8 AI lines)
+    let mut util_e = repo.filename("util_e.py");
+    util_e.set_contents(crate::lines![
+        "import json".ai(),
+        "".ai(),
+        "def to_json(obj) -> str:".ai(),
+        "    return json.dumps(obj, indent=2)".ai(),
+        "".ai(),
+        "def from_json(s: str):".ai(),
+        "    return json.loads(s)".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 add util_e").unwrap();
+
+    // Rebase — C3 will conflict on processor.py
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on processor.py at C3"
+    );
+
+    // AI resolves: 2 human context lines + 7 lines for resolved method2 (set_contents(.ai()))
+    // NOTE: content-diff only recovers lines matching original C3 content:
+    //   def method2, result = [], for i in range, result.append → 4 AI-attributed lines.
+    //   # AI merged, label = , return result/label → newly introduced, no original match → human.
+    let mut conflict_processor = repo.filename("processor.py");
+    conflict_processor.set_contents(crate::lines![
+        "class Processor:".unattributed_human(),
+        "    def method1(self): return 'method1'".unattributed_human(),
+        "    def method2(self):".ai(),
+        "        # AI merged: combines human's return with feature's loop".ai(),
+        "        result = []".ai(),
+        "        for i in range(10):".ai(),
+        "            result.append(i * 2)".ai(),
+        "        label = 'human-method2'".ai(),
+        "        return result, label".ai(),
+        "    def method3(self): return 'method3'".unattributed_human(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': util_a.py only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["util_a.py"]);
+
+    // C2': util_b.py only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["util_b.py"]);
+
+    // C3': processor.py only (AI-resolved: 4 AI lines via content-diff match)
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["processor.py"]);
+
+    // blame at chain[2] for processor.py: human lines not AI, AI lines are AI
+    assert_blame_at_commit(
+        &repo,
+        &chain[2],
+        "processor.py",
+        "c3_blame_processor",
+        &[
+            ("class Processor:", false),
+            ("def method1", false),
+            ("def method2", true),
+            ("AI merged", false),
+            ("result = []", true),
+            ("for i in range", true),
+            ("result.append", true),
+            ("label = ", false),
+            ("return result, label", false),
+            ("def method3", false),
+        ],
+    );
+
+    // C4': util_d.py only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["util_d.py"]);
+
+    // C5': util_e.py only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["util_e.py"]);
+
+}
+
+/// Test 4: version.py — conflict is on C1 (the VERY FIRST feature commit).
+/// Feature changes VERSION to "2.0", main changes it to "1.5".
+/// AI resolves to "2.1".  C2–C5 accumulate other files normally.
+#[test]
+fn test_conflict_ai_resolves_on_first_commit_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: version.py with VERSION = "1.0"
+    write_raw_commit(
+        &repo,
+        "version.py",
+        "VERSION = \"1.0\"\nCODENAME = \"alpha\"\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: changes VERSION to "1.5" — will conflict with feature's C1
+    write_raw_commit(
+        &repo,
+        "version.py",
+        "VERSION = \"1.5\"\nCODENAME = \"beta\"\n",
+        "main: bump version to 1.5",
+    );
+    write_raw_commit(
+        &repo,
+        "CHANGELOG.md",
+        "## 1.5\n- Performance improvements\n",
+        "main: add changelog",
+    );
+    write_raw_commit(
+        &repo,
+        "CONTRIBUTORS.md",
+        "# Contributors\n- Alice\n- Bob\n",
+        "main: add contributors",
+    );
+    write_raw_commit(
+        &repo,
+        "LICENSE",
+        "MIT License\nCopyright 2024\n",
+        "main: add license",
+    );
+    write_raw_commit(
+        &repo,
+        "docs/index.md",
+        "# Docs\nWelcome to the docs.\n",
+        "main: add docs",
+    );
+
+    // Feature branch from base
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI changes VERSION to "2.0" — WILL CONFLICT
+    let mut version = repo.filename("version.py");
+    version.set_contents(crate::lines![
+        "VERSION = \"2.0\"".ai(),
+        "CODENAME = \"alpha\"".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 bump version to 2.0")
+        .unwrap();
+
+    // C2: AI creates changelog.py (8 AI lines)
+    let mut changelog = repo.filename("changelog.py");
+    changelog.set_contents(crate::lines![
+        "import datetime".ai(),
+        "".ai(),
+        "class ChangelogEntry:".ai(),
+        "    def __init__(self, version: str, date: datetime.date, changes: list):".ai(),
+        "        self.version = version".ai(),
+        "        self.date = date".ai(),
+        "        self.changes = changes".ai(),
+        "    def render(self) -> str: return f'{self.version} ({self.date}): {len(self.changes)} changes'".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 add changelog model")
+        .unwrap();
+
+    // C3: AI creates release_notes.py (8 AI lines)
+    let mut release_notes = repo.filename("release_notes.py");
+    release_notes.set_contents(crate::lines![
+        "from typing import List".ai(),
+        "".ai(),
+        "def format_release_notes(entries: List[dict]) -> str:".ai(),
+        "    lines = []".ai(),
+        "    for e in entries:".ai(),
+        "        lines.append(f\"## {e['version']}\")".ai(),
+        "        for change in e.get('changes', []):".ai(),
+        "            lines.append(f'- {change}')".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 add release notes formatter")
+        .unwrap();
+
+    // C4: AI creates deprecations.py (8 AI lines)
+    let mut deprecations = repo.filename("deprecations.py");
+    deprecations.set_contents(crate::lines![
+        "import warnings".ai(),
+        "import functools".ai(),
+        "".ai(),
+        "def deprecated(reason: str):".ai(),
+        "    def decorator(func):".ai(),
+        "        @functools.wraps(func)".ai(),
+        "        def wrapper(*args, **kwargs):".ai(),
+        "            warnings.warn(f'{func.__name__} is deprecated: {reason}', DeprecationWarning, stacklevel=2)".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 add deprecation decorator")
+        .unwrap();
+
+    // C5: AI creates migration_guide.py (8 AI lines)
+    let mut migration_guide = repo.filename("migration_guide.py");
+    migration_guide.set_contents(crate::lines![
+        "MIGRATION_STEPS = [".ai(),
+        "    'Update config files to new schema',".ai(),
+        "    'Run database migration scripts',".ai(),
+        "    'Update API call signatures',".ai(),
+        "    'Test all integrations',".ai(),
+        "    'Deploy to staging first',".ai(),
+        "    'Monitor error rates after deployment',".ai(),
+        "]".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 add migration guide")
+        .unwrap();
+
+    // Rebase — C1 will conflict immediately on version.py
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on version.py at C1"
+    );
+
+    // AI resolves: VERSION = "2.1" as .ai(), CODENAME as .unattributed_human()
+    let mut conflict_version = repo.filename("version.py");
+    conflict_version.set_contents(crate::lines![
+        "VERSION = \"2.1\"".ai(),
+        "CODENAME = \"beta\"".unattributed_human(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': version.py only with AI-resolved VERSION line (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["version.py"]);
+
+    // blame at chain[0] for version.py: VERSION line is AI, CODENAME is human
+    assert_blame_at_commit(
+        &repo,
+        &chain[0],
+        "version.py",
+        "c1_blame_version",
+        &[("VERSION = \"2.1\"", true), ("CODENAME = \"beta\"", false)],
+    );
+
+    // C2': changelog.py only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["changelog.py"]);
+
+    // C3': release_notes.py only
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["release_notes.py"]);
+
+    // C4': deprecations.py only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["deprecations.py"]);
+
+    // C5': migration_guide.py only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["migration_guide.py"]);
+
+}
+
+/// Test 5: schema.rs max_connections — conflict is on C5 (LAST feature commit).
+/// C1–C4 accumulate model_*.rs files cleanly.  C5 modifies schema.rs
+/// max_connections constant; main also modifies same constant.  AI resolves.
+#[test]
+fn test_conflict_ai_resolves_on_last_commit_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: schema.rs with a constant (human)
+    write_raw_commit(
+        &repo,
+        "src/schema.rs",
+        "pub const MAX_CONNECTIONS: u32 = 10;\npub const SCHEMA_VERSION: u32 = 1;\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: changes max_connections → will conflict with feature's C5
+    write_raw_commit(
+        &repo,
+        "src/schema.rs",
+        "pub const MAX_CONNECTIONS: u32 = 50;\npub const SCHEMA_VERSION: u32 = 1;\n",
+        "main: increase max_connections to 50",
+    );
+    write_raw_commit(
+        &repo,
+        "src/migration.rs",
+        "pub fn run_migrations() {}\n",
+        "main: add migration runner",
+    );
+    write_raw_commit(
+        &repo,
+        "src/connection.rs",
+        "pub struct Connection { id: u32 }\n",
+        "main: add Connection type",
+    );
+    write_raw_commit(
+        &repo,
+        "src/pool.rs",
+        "pub struct Pool { size: u32 }\n",
+        "main: add Pool struct",
+    );
+    write_raw_commit(
+        &repo,
+        "Cargo.toml",
+        "[package]\nname = \"schema\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        "main: add Cargo.toml",
+    );
+
+    // Feature branch from base
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates model_a.rs (10 AI lines)
+    let mut model_a = repo.filename("src/model_a.rs");
+    model_a.set_contents(crate::lines![
+        "#[derive(Debug, Clone)]".ai(),
+        "pub struct ModelA {".ai(),
+        "    pub id: u64,".ai(),
+        "    pub name: String,".ai(),
+        "    pub active: bool,".ai(),
+        "}".ai(),
+        "".ai(),
+        "impl ModelA {".ai(),
+        "    pub fn new(id: u64, name: impl Into<String>) -> Self {".ai(),
+        "        Self { id, name: name.into(), active: true }".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add ModelA").unwrap();
+
+    // C2: AI creates model_b.rs (10 AI lines)
+    let mut model_b = repo.filename("src/model_b.rs");
+    model_b.set_contents(crate::lines![
+        "#[derive(Debug, Clone)]".ai(),
+        "pub struct ModelB {".ai(),
+        "    pub id: u64,".ai(),
+        "    pub value: f64,".ai(),
+        "    pub tags: Vec<String>,".ai(),
+        "}".ai(),
+        "".ai(),
+        "impl ModelB {".ai(),
+        "    pub fn new(id: u64, value: f64) -> Self {".ai(),
+        "        Self { id, value, tags: Vec::new() }".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 add ModelB").unwrap();
+
+    // C3: AI creates model_c.rs (10 AI lines)
+    let mut model_c = repo.filename("src/model_c.rs");
+    model_c.set_contents(crate::lines![
+        "#[derive(Debug, Clone, PartialEq)]".ai(),
+        "pub enum Status {".ai(),
+        "    Active,".ai(),
+        "    Inactive,".ai(),
+        "    Pending,".ai(),
+        "}".ai(),
+        "".ai(),
+        "impl Default for Status {".ai(),
+        "    fn default() -> Self { Status::Pending }".ai(),
+        "}".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 add Status enum")
+        .unwrap();
+
+    // C4: AI creates model_d.rs (10 AI lines)
+    let mut model_d = repo.filename("src/model_d.rs");
+    model_d.set_contents(crate::lines![
+        "use std::collections::HashMap;".ai(),
+        "".ai(),
+        "#[derive(Debug, Default)]".ai(),
+        "pub struct Registry {".ai(),
+        "    entries: HashMap<u64, String>,".ai(),
+        "}".ai(),
+        "".ai(),
+        "impl Registry {".ai(),
+        "    pub fn register(&mut self, id: u64, name: impl Into<String>) {".ai(),
+        "        self.entries.insert(id, name.into());".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 add Registry").unwrap();
+
+    // C5: AI changes max_connections to 100 — WILL CONFLICT
+    let mut schema = repo.filename("src/schema.rs");
+    schema.set_contents(crate::lines![
+        "pub const MAX_CONNECTIONS: u32 = 100;".ai(),
+        "pub const SCHEMA_VERSION: u32 = 1;".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 AI tunes MAX_CONNECTIONS to 100")
+        .unwrap();
+
+    // Rebase — C5 will conflict on src/schema.rs
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on src/schema.rs at C5"
+    );
+
+    // AI resolves: picks 75 as a compromise, as .ai()
+    let mut conflict_schema = repo.filename("src/schema.rs");
+    conflict_schema.set_contents(crate::lines![
+        "pub const MAX_CONNECTIONS: u32 = 75;".ai(),
+        "pub const SCHEMA_VERSION: u32 = 1;".unattributed_human(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': model_a.rs only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["src/model_a.rs"]);
+
+    // C2': model_b.rs only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["src/model_b.rs"]);
+
+    // C3': model_c.rs only
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["src/model_c.rs"]);
+
+    // C4': model_d.rs only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["src/model_d.rs"]);
+
+    // C5': schema.rs only (AI-resolved MAX_CONNECTIONS)
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["src/schema.rs"]);
+
+    // blame at chain[4] for schema.rs: MAX_CONNECTIONS line is AI, SCHEMA_VERSION is human
+    assert_blame_at_commit(
+        &repo,
+        &chain[4],
+        "src/schema.rs",
+        "c5_blame_schema",
+        &[
+            ("MAX_CONNECTIONS: u32 = 75", true),
+            ("SCHEMA_VERSION: u32 = 1", false),
+        ],
+    );
+
+}
+
+/// Test 6: config.py AND settings.py both conflict in C3.
+/// C3 AI changes a line in both files; main also changes same lines.
+/// AI resolves both conflicts.  Note for C3' has both files.
+#[test]
+fn test_conflict_ai_resolves_multiple_files_in_same_commit_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: BOTH files exist at the shared base so C3's edits will conflict with main
+    write_raw_commit(
+        &repo,
+        "config.py",
+        "DEBUG = False\nSECRET_KEY = 'changeme'\n",
+        "Initial: config",
+    );
+    write_raw_commit(
+        &repo,
+        "settings.py",
+        "DATABASE_URL = 'sqlite:///dev.db'\nCACHE_BACKEND = 'locmem'\n",
+        "Initial: settings",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: changes the same lines in both files → will conflict with feature's C3
+    write_raw_commit(
+        &repo,
+        "config.py",
+        "DEBUG = True\nSECRET_KEY = 'changeme'\n",
+        "main: enable DEBUG",
+    );
+    write_raw_commit(
+        &repo,
+        "settings.py",
+        "DATABASE_URL = 'postgres://localhost/main_db'\nCACHE_BACKEND = 'redis'\n",
+        "main: update settings",
+    );
+    write_raw_commit(
+        &repo,
+        "wsgi.py",
+        "from app import create_app\napplication = create_app()\n",
+        "main: add wsgi",
+    );
+    write_raw_commit(
+        &repo,
+        "asgi.py",
+        "from app import create_app\napplication = create_app()\n",
+        "main: add asgi",
+    );
+    write_raw_commit(
+        &repo,
+        "manage.py",
+        "#!/usr/bin/env python\nimport sys\nif __name__ == '__main__': pass\n",
+        "main: add manage.py",
+    );
+
+    // Feature branch from the shared base (HEAD~5 = after both initial commits)
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates auth.py (8 AI lines)
+    let mut auth = repo.filename("auth.py");
+    auth.set_contents(crate::lines![
+        "from typing import Optional".ai(),
+        "".ai(),
+        "def authenticate(token: str) -> Optional[str]:".ai(),
+        "    if not token: return None".ai(),
+        "    parts = token.split('.')".ai(),
+        "    if len(parts) != 3: return None".ai(),
+        "    return parts[1]".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add auth").unwrap();
+
+    // C2: AI creates middleware.py (8 AI lines)
+    let mut middleware = repo.filename("middleware.py");
+    middleware.set_contents(crate::lines![
+        "class CorsMiddleware:".ai(),
+        "    def __init__(self, app):".ai(),
+        "        self.app = app".ai(),
+        "    def __call__(self, environ, start_response):".ai(),
+        "        def custom_start(status, headers):".ai(),
+        "            headers.append(('Access-Control-Allow-Origin', '*'))".ai(),
+        "            return start_response(status, headers)".ai(),
+        "        return self.app(environ, custom_start)".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 add CORS middleware")
+        .unwrap();
+
+    // C3: AI changes config.py AND settings.py — BOTH WILL CONFLICT
+    let mut config = repo.filename("config.py");
+    config.set_contents(crate::lines![
+        "DEBUG = False".unattributed_human(),
+        "SECRET_KEY = 'ai-generated-secret-key-v2'".ai(),
+    ]);
+    let mut settings = repo.filename("settings.py");
+    settings.set_contents(crate::lines![
+        "DATABASE_URL = 'postgres://localhost/feature_db'".ai(),
+        "CACHE_BACKEND = 'locmem'".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 AI tunes config and settings")
+        .unwrap();
+
+    // C4: AI creates permissions.py (8 AI lines)
+    let mut permissions = repo.filename("permissions.py");
+    permissions.set_contents(crate::lines![
+        "class Permission:".ai(),
+        "    READ = 'read'".ai(),
+        "    WRITE = 'write'".ai(),
+        "    ADMIN = 'admin'".ai(),
+        "".ai(),
+        "def has_permission(user_perms: list, required: str) -> bool:".ai(),
+        "    return required in user_perms".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 add permissions")
+        .unwrap();
+
+    // C5: AI creates serializers.py (8 AI lines)
+    let mut serializers = repo.filename("serializers.py");
+    serializers.set_contents(crate::lines![
+        "import json".ai(),
+        "".ai(),
+        "class JsonSerializer:".ai(),
+        "    @staticmethod".ai(),
+        "    def dumps(obj) -> str: return json.dumps(obj)".ai(),
+        "    @staticmethod".ai(),
+        "    def loads(s: str): return json.loads(s)".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 add JSON serializer")
+        .unwrap();
+
+    // Rebase — C3 will conflict on config.py (and possibly settings.py)
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(rebase_result.is_err(), "rebase should conflict at C3");
+
+    // AI resolves config.py
+    let mut conflict_config = repo.filename("config.py");
+    conflict_config.set_contents(crate::lines![
+        "DEBUG = True".unattributed_human(),
+        "SECRET_KEY = 'ai-generated-secret-key-v2'".ai(),
+    ]);
+    // AI resolves settings.py
+    let mut conflict_settings = repo.filename("settings.py");
+    conflict_settings.set_contents(crate::lines![
+        "DATABASE_URL = 'postgres://localhost/feature_db'".ai(),
+        "CACHE_BACKEND = 'redis'".unattributed_human(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': auth.py only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["auth.py"]);
+
+    // C2': middleware.py only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["middleware.py"]);
+
+    // C3': config.py + settings.py (AI-resolved, both in same commit)
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["config.py", "settings.py"]);
+
+    // blame for config.py: DEBUG is human (unchanged), SECRET_KEY is AI
+    assert_blame_at_commit(
+        &repo,
+        &chain[2],
+        "config.py",
+        "c3_blame_config",
+        &[
+            ("DEBUG = True", false),
+            ("SECRET_KEY = 'ai-generated-secret-key-v2'", true),
+        ],
+    );
+
+    // blame for settings.py: DATABASE_URL is AI, CACHE_BACKEND is human
+    assert_blame_at_commit(
+        &repo,
+        &chain[2],
+        "settings.py",
+        "c3_blame_settings",
+        &[
+            ("DATABASE_URL = 'postgres://localhost/feature_db'", true),
+            ("CACHE_BACKEND = 'redis'", false),
+        ],
+    );
+
+    // C4': permissions.py only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["permissions.py"]);
+
+    // C5': serializers.py only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["serializers.py"]);
+
+}
+
+/// Test 7: dispatcher.py — conflict on C2.  C3 and C4 also modify dispatcher.py
+/// (no further conflicts).  AI resolves C2 with 12-line process() implementation.
+/// Subsequent commits append more methods to dispatcher.py.
+#[test]
+fn test_conflict_ai_resolves_then_more_ai_builds_on_result_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: dispatcher.py stub (human)
+    write_raw_commit(
+        &repo,
+        "dispatcher.py",
+        "class Dispatcher:\n    pass\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: human implements process() differently → will conflict with feature's C2
+    write_raw_commit(
+        &repo,
+        "dispatcher.py",
+        "class Dispatcher:\n    def process(self, msg): return msg.strip()\n",
+        "main: implement process() simply",
+    );
+    write_raw_commit(
+        &repo,
+        "config.py",
+        "WORKERS = 4\nQUEUE_SIZE = 100\n",
+        "main: add config",
+    );
+    write_raw_commit(
+        &repo,
+        "queue.py",
+        "import queue\nQ = queue.Queue()\n",
+        "main: add queue",
+    );
+    write_raw_commit(
+        &repo,
+        "worker.py",
+        "class Worker:\n    def __init__(self, q): self.q = q\n",
+        "main: add worker",
+    );
+    write_raw_commit(
+        &repo,
+        "monitor.py",
+        "class Monitor:\n    def check(self): return 'ok'\n",
+        "main: add monitor",
+    );
+
+    // Feature branch from base
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates base_handler.py (8 AI lines)
+    let mut base_handler = repo.filename("base_handler.py");
+    base_handler.set_contents(crate::lines![
+        "class BaseHandler:".ai(),
+        "    def __init__(self):".ai(),
+        "        self.middlewares = []".ai(),
+        "    def use(self, middleware):".ai(),
+        "        self.middlewares.append(middleware)".ai(),
+        "        return self".ai(),
+        "    def handle(self, msg): raise NotImplementedError".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add BaseHandler")
+        .unwrap();
+
+    // C2: AI adds process() to dispatcher.py — WILL CONFLICT
+    let mut dispatcher_c2 = repo.filename("dispatcher.py");
+    dispatcher_c2.set_contents(crate::lines![
+        "class Dispatcher:".unattributed_human(),
+        "    def process(self, msg):".ai(),
+        "        msg = msg.strip()".ai(),
+        "        if not msg: raise ValueError('empty')".ai(),
+        "        tokens = msg.split()".ai(),
+        "        return {'cmd': tokens[0], 'args': tokens[1:]}".ai(),
+        "    pass".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 AI adds process() to Dispatcher")
+        .unwrap();
+
+    // C3: AI creates router.py (does NOT touch dispatcher.py — no conflict)
+    let mut router = repo.filename("router.py");
+    router.set_contents(crate::lines![
+        "from dispatcher import Dispatcher".ai(),
+        "".ai(),
+        "class Router:".ai(),
+        "    def __init__(self):".ai(),
+        "        self.dispatcher = Dispatcher()".ai(),
+        "    def register(self, cmd, fn): self.dispatcher.route(cmd, fn)".ai(),
+        "    def run(self, msg): return self.dispatcher.dispatch(msg)".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 AI adds Router")
+        .unwrap();
+
+    // C4: AI creates middleware.py (new file, no conflict)
+    let mut mw = repo.filename("middleware.py");
+    mw.set_contents(crate::lines![
+        "class Middleware:".ai(),
+        "    def __init__(self): self.chain = []".ai(),
+        "    def use(self, fn): self.chain.append(fn); return self".ai(),
+        "    def run(self, msg):".ai(),
+        "        for fn in self.chain: msg = fn(msg)".ai(),
+        "        return msg".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 AI adds Middleware")
+        .unwrap();
+
+    // C5: AI creates event_bus.py (new file, no conflict)
+    let mut bus = repo.filename("event_bus.py");
+    bus.set_contents(crate::lines![
+        "class EventBus:".ai(),
+        "    def __init__(self): self.handlers = {}".ai(),
+        "    def on(self, event, fn): self.handlers.setdefault(event, []).append(fn)".ai(),
+        "    def emit(self, event, *args):".ai(),
+        "        for fn in self.handlers.get(event, []): fn(*args)".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 AI adds EventBus")
+        .unwrap();
+
+    // Rebase — C2 will conflict on dispatcher.py
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on dispatcher.py at C2"
+    );
+
+    // AI resolves C2: 12-line process() implementation (all .ai() except class line)
+    let mut conflict_dispatcher = repo.filename("dispatcher.py");
+    conflict_dispatcher.set_contents(crate::lines![
+        "class Dispatcher:".unattributed_human(),
+        "    def process(self, msg):".ai(),
+        "        # AI merge: validates and parses, as in feature branch".ai(),
+        "        msg = msg.strip()".ai(),
+        "        if not msg: raise ValueError('empty message')".ai(),
+        "        tokens = msg.split()".ai(),
+        "        cmd = tokens[0].lower()".ai(),
+        "        args = tokens[1:]".ai(),
+        "        return {'cmd': cmd, 'args': args, 'raw': msg}".ai(),
+        "    def _noop(self, args): return None".ai(),
+        "    def __repr__(self): return f'Dispatcher()'".ai(),
+        "    pass".unattributed_human(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': base_handler.py only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["base_handler.py"]);
+
+    // C2': dispatcher.py only (AI-resolved: ~10 AI lines)
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["dispatcher.py"]);
+
+    // C3': router.py only
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["router.py"]);
+
+    // C4': middleware.py only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["middleware.py"]);
+
+    // C5': event_bus.py only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["event_bus.py"]);
+
+}
+
+/// Test 8: models.rs struct fields — feature (C3) AI adds 4 new fields,
+/// main human adds 2 different fields.  AI resolution merges all 8 fields.
+/// The merged struct body is all .ai().
+#[test]
+fn test_conflict_ai_resolves_rust_struct_fields_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: models.rs with a struct (2 original fields, human)
+    write_raw_commit(
+        &repo,
+        "src/models.rs",
+        "pub struct User {\n    pub id: u64,\n    pub name: String,\n}\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: adds email and created_at fields → will conflict
+    write_raw_commit(
+        &repo,
+        "src/models.rs",
+        "pub struct User {\n    pub id: u64,\n    pub name: String,\n    pub email: String,\n    pub created_at: u64,\n}\n",
+        "main: add email and created_at to User",
+    );
+    write_raw_commit(
+        &repo,
+        "src/db.rs",
+        "pub struct Db { url: String }\n",
+        "main: add Db",
+    );
+    write_raw_commit(
+        &repo,
+        "src/repo.rs",
+        "use crate::models::User;\npub struct UserRepo;\n",
+        "main: add UserRepo",
+    );
+    write_raw_commit(
+        &repo,
+        "src/service.rs",
+        "pub struct UserService;\n",
+        "main: add UserService",
+    );
+    write_raw_commit(
+        &repo,
+        "Cargo.toml",
+        "[package]\nname = \"models\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        "main: add Cargo.toml",
+    );
+
+    // Feature branch from base
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates traits.rs (8 AI lines)
+    let mut traits = repo.filename("src/traits.rs");
+    traits.set_contents(crate::lines![
+        "pub trait Entity {".ai(),
+        "    fn id(&self) -> u64;".ai(),
+        "    fn name(&self) -> &str;".ai(),
+        "}".ai(),
+        "".ai(),
+        "pub trait Persistable: Entity {".ai(),
+        "    fn save(&self) -> Result<(), String>;".ai(),
+        "    fn delete(&self) -> Result<(), String>;".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add Entity and Persistable traits")
+        .unwrap();
+
+    // C2: AI creates impls.rs (8 AI lines)
+    let mut impls = repo.filename("src/impls.rs");
+    impls.set_contents(crate::lines![
+        "use crate::models::User;".ai(),
+        "use crate::traits::Entity;".ai(),
+        "".ai(),
+        "impl Entity for User {".ai(),
+        "    fn id(&self) -> u64 { self.id }".ai(),
+        "    fn name(&self) -> &str { &self.name }".ai(),
+        "}".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 impl Entity for User")
+        .unwrap();
+
+    // C3: AI adds 4 new fields to User struct — WILL CONFLICT with main's email/created_at
+    let mut models = repo.filename("src/models.rs");
+    models.set_contents(crate::lines![
+        "pub struct User {".unattributed_human(),
+        "    pub id: u64,".unattributed_human(),
+        "    pub name: String,".unattributed_human(),
+        "    pub active: bool,".ai(),
+        "    pub role: String,".ai(),
+        "    pub score: f64,".ai(),
+        "    pub metadata: std::collections::HashMap<String, String>,".ai(),
+        "}".unattributed_human(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 AI adds active/role/score/metadata fields")
+        .unwrap();
+
+    // C4: AI creates errors.rs (8 AI lines)
+    let mut errors = repo.filename("src/errors.rs");
+    errors.set_contents(crate::lines![
+        "#[derive(Debug)]".ai(),
+        "pub enum ModelError {".ai(),
+        "    NotFound(u64),".ai(),
+        "    InvalidField(String),".ai(),
+        "    DuplicateId(u64),".ai(),
+        "}".ai(),
+        "".ai(),
+        "impl std::fmt::Display for ModelError { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { write!(f, \"{:?}\", self) } }".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 add ModelError")
+        .unwrap();
+
+    // C5: AI creates utils.rs (8 AI lines)
+    let mut utils = repo.filename("src/utils.rs");
+    utils.set_contents(crate::lines![
+        "pub fn slugify(s: &str) -> String {".ai(),
+        "    s.to_lowercase()".ai(),
+        "        .chars()".ai(),
+        "        .map(|c| if c.is_alphanumeric() { c } else { '-' })".ai(),
+        "        .collect::<String>()".ai(),
+        "        .trim_matches('-')".ai(),
+        "        .to_string()".ai(),
+        "}".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 add slugify utility")
+        .unwrap();
+
+    // Rebase — C3 will conflict on src/models.rs
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on src/models.rs at C3"
+    );
+
+    // AI resolves: merges ALL fields — original 2 + 4 feature + 2 main = 8 fields (all .ai() in struct body)
+    let mut conflict_models = repo.filename("src/models.rs");
+    conflict_models.set_contents(crate::lines![
+        "pub struct User {".unattributed_human(),
+        "    pub id: u64,".ai(),
+        "    pub name: String,".ai(),
+        "    pub email: String,".ai(),
+        "    pub created_at: u64,".ai(),
+        "    pub active: bool,".ai(),
+        "    pub role: String,".ai(),
+        "    pub score: f64,".ai(),
+        "    pub metadata: std::collections::HashMap<String, String>,".ai(),
+        "}".unattributed_human(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': traits.rs only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["src/traits.rs"]);
+
+    // C2': impls.rs only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["src/impls.rs"]);
+
+    // C3': models.rs only (AI-resolved struct with merged fields)
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["src/models.rs"]);
+
+    // blame for models.rs: struct keyword is human, equal fields carry AI attribution, new fields are human
+    assert_blame_at_commit(
+        &repo,
+        &chain[2],
+        "src/models.rs",
+        "c3_blame_models",
+        &[
+            ("pub struct User {", false),
+            ("pub id: u64,", false),
+            ("pub name: String,", false),
+            ("pub email: String,", false),
+            ("pub created_at: u64,", false),
+            ("pub active: bool,", true),
+            ("pub role: String,", true),
+            ("pub score: f64,", true),
+            ("pub metadata:", true),
+            ("}", false),
+        ],
+    );
+
+    // C4': errors.rs only
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["src/errors.rs"]);
+
+    // C5': utils.rs only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["src/utils.rs"]);
+
+}
+
+/// Test 9: service.py process_payment — feature (C4) AI implements a 20-line
+/// function body; main also implements the same function (12 lines).
+/// AI resolution produces a 25-line merged implementation (all .ai()).
+/// Non-conflict commits: C1 models.py, C2 validators.py, C3 exceptions.py, C5 utils.py.
+#[test]
+fn test_conflict_ai_resolves_complex_function_with_error_handling_standard_human() {
+    let repo = TestRepo::new();
+
+    // Initial: service.py with a function stub (human)
+    write_raw_commit(
+        &repo,
+        "service.py",
+        "def process_payment(amount, card):\n    pass\n",
+        "Initial commit",
+    );
+    let main_branch = repo.current_branch();
+
+    // Main: human implements process_payment differently → will conflict
+    write_raw_commit(
+        &repo,
+        "service.py",
+        "def process_payment(amount, card):\n    if amount <= 0:\n        raise ValueError('amount must be positive')\n    return {'status': 'ok', 'amount': amount}\n",
+        "main: implement process_payment",
+    );
+    write_raw_commit(
+        &repo,
+        "tests/test_service.py",
+        "from service import process_payment\ndef test_basic(): assert process_payment(10, '4111')['status'] == 'ok'\n",
+        "main: add service tests",
+    );
+    write_raw_commit(
+        &repo,
+        "requirements.txt",
+        "stripe==5.0.0\nrequests==2.31.0\n",
+        "main: add requirements",
+    );
+    write_raw_commit(
+        &repo,
+        ".env.example",
+        "STRIPE_KEY=sk_test_xxx\nDATABASE_URL=sqlite:///dev.db\n",
+        "main: add .env.example",
+    );
+    write_raw_commit(
+        &repo,
+        "Makefile",
+        "test:\n\tpython -m pytest\nlint:\n\tflake8 .\n.PHONY: test lint\n",
+        "main: add Makefile",
+    );
+
+    // Feature branch from base
+    let base_sha = repo
+        .git(&["rev-parse", "HEAD~5"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "feature", &base_sha]).unwrap();
+
+    // C1: AI creates models.py (8 AI lines)
+    let mut models = repo.filename("models.py");
+    models.set_contents(crate::lines![
+        "from dataclasses import dataclass, field".ai(),
+        "".ai(),
+        "@dataclass".ai(),
+        "class PaymentResult:".ai(),
+        "    status: str".ai(),
+        "    transaction_id: str".ai(),
+        "    amount: float".ai(),
+        "    error: str = ''".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C1 add PaymentResult model")
+        .unwrap();
+
+    // C2: AI creates validators.py (8 AI lines)
+    let mut validators = repo.filename("validators.py");
+    validators.set_contents(crate::lines![
+        "import re".ai(),
+        "".ai(),
+        "def validate_card(card: str) -> bool:".ai(),
+        "    return bool(re.match(r'^[0-9]{13,19}$', card.replace(' ', '')))".ai(),
+        "".ai(),
+        "def validate_amount(amount: float) -> bool:".ai(),
+        "    return isinstance(amount, (int, float)) and 0 < amount <= 1_000_000".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C2 add payment validators")
+        .unwrap();
+
+    // C3: AI creates exceptions.py (8 AI lines)
+    let mut exceptions = repo.filename("exceptions.py");
+    exceptions.set_contents(crate::lines![
+        "class PaymentError(Exception):".ai(),
+        "    def __init__(self, msg: str, code: int = 400):".ai(),
+        "        super().__init__(msg)".ai(),
+        "        self.code = code".ai(),
+        "".ai(),
+        "class CardDeclinedError(PaymentError):".ai(),
+        "    def __init__(self): super().__init__('Card declined', 402)".ai(),
+        "".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C3 add payment exceptions")
+        .unwrap();
+
+    // C4: AI implements process_payment with 20 lines — WILL CONFLICT
+    let mut service = repo.filename("service.py");
+    service.set_contents(crate::lines![
+        "def process_payment(amount, card):".unattributed_human(),
+        "    from validators import validate_amount, validate_card".ai(),
+        "    from exceptions import PaymentError, CardDeclinedError".ai(),
+        "    import logging".ai(),
+        "    logger = logging.getLogger(__name__)".ai(),
+        "    logger.info(f'Processing payment: amount={amount}')".ai(),
+        "    if not validate_amount(amount):".ai(),
+        "        raise PaymentError(f'Invalid amount: {amount}')".ai(),
+        "    if not validate_card(card):".ai(),
+        "        raise PaymentError(f'Invalid card number')".ai(),
+        "    if str(card).startswith('0000'):".ai(),
+        "        raise CardDeclinedError()".ai(),
+        "    transaction_id = f'txn_{hash(card + str(amount)) % 10**9}'".ai(),
+        "    logger.info(f'Payment successful: {transaction_id}')".ai(),
+        "    return {'status': 'ok', 'transaction_id': transaction_id, 'amount': amount}".ai(),
+        "    # end process_payment".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C4 AI implements process_payment")
+        .unwrap();
+
+    // C5: AI creates utils.py (8 AI lines)
+    let mut utils = repo.filename("utils.py");
+    utils.set_contents(crate::lines![
+        "def mask_card(card: str) -> str:".ai(),
+        "    digits = card.replace(' ', '')".ai(),
+        "    return '*' * (len(digits) - 4) + digits[-4:]".ai(),
+        "".ai(),
+        "def format_amount(amount: float) -> str:".ai(),
+        "    return f'${amount:.2f}'".ai(),
+        "".ai(),
+        "def generate_receipt(result: dict) -> str: return f\"Receipt: {result['transaction_id']} {result['amount']}\"".ai(),
+    ]);
+    repo.stage_all_and_commit("feat: C5 add payment utils")
+        .unwrap();
+
+    // Rebase — C4 will conflict on service.py
+    repo.git(&["checkout", "feature"]).unwrap();
+    let rebase_result = repo.git(&["rebase", &main_branch]);
+    assert!(
+        rebase_result.is_err(),
+        "rebase should conflict on service.py at C4"
+    );
+
+    // AI resolves: 25-line merged implementation (all .ai() except function signature line)
+    let mut conflict_service = repo.filename("service.py");
+    conflict_service.set_contents(crate::lines![
+        "def process_payment(amount, card):".unattributed_human(),
+        "    from validators import validate_amount, validate_card".ai(),
+        "    from exceptions import PaymentError, CardDeclinedError".ai(),
+        "    from models import PaymentResult".ai(),
+        "    import logging".ai(),
+        "    logger = logging.getLogger(__name__)".ai(),
+        "    logger.info(f'Processing: amount={amount} card=***{str(card)[-4:]}')".ai(),
+        "    if amount <= 0:".ai(),
+        "        raise ValueError('amount must be positive')".ai(),
+        "    if not validate_amount(amount):".ai(),
+        "        raise PaymentError(f'Amount out of range: {amount}')".ai(),
+        "    if not validate_card(card):".ai(),
+        "        raise PaymentError('Invalid card number format')".ai(),
+        "    if str(card).startswith('0000'):".ai(),
+        "        raise CardDeclinedError()".ai(),
+        "    transaction_id = f'txn_{hash(str(card) + str(amount)) % 10**9}'".ai(),
+        "    logger.info(f'Payment OK: txn={transaction_id}')".ai(),
+        "    result = PaymentResult(".ai(),
+        "        status='ok',".ai(),
+        "        transaction_id=transaction_id,".ai(),
+        "        amount=amount,".ai(),
+        "    )".ai(),
+        "    return {'status': result.status, 'transaction_id': result.transaction_id, 'amount': result.amount}".ai(),
+        "    # AI merged: combined validation + result model".ai(),
+        "    # end process_payment".ai(),
+    ]);
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+
+    let chain = get_commit_chain(&repo, 5);
+
+    // C1': models.py only (per-commit-delta)
+    assert_note_base_commit_matches(&repo, &chain[0], "c1_base");
+    assert_note_files_exact(&repo, &chain[0], "c1_files", &["models.py"]);
+
+    // C2': validators.py only
+    assert_note_base_commit_matches(&repo, &chain[1], "c2_base");
+    assert_note_files_exact(&repo, &chain[1], "c2_files", &["validators.py"]);
+
+    // C3': exceptions.py only
+    assert_note_base_commit_matches(&repo, &chain[2], "c3_base");
+    assert_note_files_exact(&repo, &chain[2], "c3_files", &["exceptions.py"]);
+
+    // C4': service.py only (AI-resolved: 24 AI lines in function body)
+    assert_note_base_commit_matches(&repo, &chain[3], "c4_base");
+    assert_note_files_exact(&repo, &chain[3], "c4_files", &["service.py"]);
+
+    // blame at chain[3] for service.py: only Equal lines carry AI; new/changed lines get false
+    assert_blame_at_commit(
+        &repo,
+        &chain[3],
+        "service.py",
+        "c4_blame_service",
+        &[
+            ("def process_payment", false),
+            ("validate_amount, validate_card", true),
+            ("PaymentError, CardDeclinedError", true),
+            ("PaymentResult", false),
+            ("import logging", true),
+            ("logger = logging", true),
+            ("Processing:", false),
+            ("if amount <= 0:", false),
+            ("must be positive", false),
+            ("if not validate_amount", true),
+            ("Amount out of range", false),
+            ("if not validate_card", true),
+            ("Invalid card number", false),
+            ("startswith('0000')", true),
+            ("CardDeclinedError()", true),
+            ("transaction_id = ", false),
+            ("Payment OK:", false),
+            ("result = PaymentResult(", false),
+            ("status='ok',", false),
+            ("transaction_id=transaction_id,", false),
+            ("amount=amount,", false),
+            (")", false),
+            ("return {", false),
+            ("AI merged", false),
+            ("end process_payment", true),
+        ],
+    );
+
+    // C5': utils.py only
+    assert_note_base_commit_matches(&repo, &chain[4], "c5_base");
+    assert_note_files_exact(&repo, &chain[4], "c5_files", &["utils.py"]);
+
+}
+
 crate::reuse_tests_in_worktree!(
     // Category 1: Fast Path
     test_fast_path_python_microservice_5_endpoints,
@@ -11742,14 +13455,22 @@ crate::reuse_tests_in_worktree!(
     test_human_conflict_resolves_all_ai_lines_replaced,
     // Category 4: AI conflict resolution
     test_conflict_ai_resolves_timeout_constant,
+    test_conflict_ai_resolves_timeout_constant_standard_human,
     test_conflict_ai_resolves_with_added_extra_lines,
     test_conflict_ai_resolves_preserving_human_context_lines,
+    test_conflict_ai_resolves_preserving_human_context_lines_standard_human,
     test_conflict_ai_resolves_on_first_commit,
+    test_conflict_ai_resolves_on_first_commit_standard_human,
     test_conflict_ai_resolves_on_last_commit,
+    test_conflict_ai_resolves_on_last_commit_standard_human,
     test_conflict_ai_resolves_multiple_files_in_same_commit,
+    test_conflict_ai_resolves_multiple_files_in_same_commit_standard_human,
     test_conflict_ai_resolves_then_more_ai_builds_on_result,
+    test_conflict_ai_resolves_then_more_ai_builds_on_result_standard_human,
     test_conflict_ai_resolves_rust_struct_fields,
+    test_conflict_ai_resolves_rust_struct_fields_standard_human,
     test_conflict_ai_resolves_complex_function_with_error_handling,
+    test_conflict_ai_resolves_complex_function_with_error_handling_standard_human,
     test_conflict_mixed_ai_and_human_resolve_different_commits,
     // Category 5: Path-specific correctness
     test_conflict_working_log_is_sole_attribution_source,

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -696,7 +696,10 @@ impl<'a> TestFile<'a> {
             .collect::<Vec<String>>()
             .join("\n");
 
-        let human_kind = if lines.iter().any(|l| l.author_type == AuthorType::UnattributedHuman) {
+        let human_kind = if lines
+            .iter()
+            .any(|l| l.author_type == AuthorType::UnattributedHuman)
+        {
             &AuthorType::UnattributedHuman
         } else {
             &AuthorType::Human
@@ -733,7 +736,10 @@ impl<'a> TestFile<'a> {
             .collect::<Vec<String>>()
             .join("\n");
 
-        let human_kind = if lines.iter().any(|l| l.author_type == AuthorType::UnattributedHuman) {
+        let human_kind = if lines
+            .iter()
+            .any(|l| l.author_type == AuthorType::UnattributedHuman)
+        {
             &AuthorType::UnattributedHuman
         } else {
             &AuthorType::Human
@@ -774,12 +780,14 @@ impl<'a> TestFile<'a> {
             AuthorType::Ai => self
                 .repo
                 .git_ai(&["checkpoint", "mock_ai", relative_path.as_str()]),
-            AuthorType::Human => self
-                .repo
-                .git_ai(&["checkpoint", "mock_known_human", relative_path.as_str()]),
-            AuthorType::UnattributedHuman => self
-                .repo
-                .git_ai(&["checkpoint", "--", relative_path.as_str()]),
+            AuthorType::Human => {
+                self.repo
+                    .git_ai(&["checkpoint", "mock_known_human", relative_path.as_str()])
+            }
+            AuthorType::UnattributedHuman => {
+                self.repo
+                    .git_ai(&["checkpoint", "--", relative_path.as_str()])
+            }
         };
         result.unwrap();
     }

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -22,6 +22,7 @@ const AI_AUTHOR_NAMES: &[&str] = &[
 #[derive(Debug, Clone, PartialEq)]
 pub enum AuthorType {
     Human,
+    UnattributedHuman,
     Ai,
 }
 
@@ -46,10 +47,11 @@ impl ExpectedLine {
     }
 }
 
-/// Trait to add .ai() and .human() methods to string types
+/// Trait to add .ai(), .human(), and .unattributed_human() methods to string types
 pub trait ExpectedLineExt {
     fn ai(self) -> ExpectedLine;
     fn human(self) -> ExpectedLine;
+    fn unattributed_human(self) -> ExpectedLine;
 }
 
 impl ExpectedLineExt for &str {
@@ -59,6 +61,10 @@ impl ExpectedLineExt for &str {
 
     fn human(self) -> ExpectedLine {
         ExpectedLine::new(self.to_string(), AuthorType::Human)
+    }
+
+    fn unattributed_human(self) -> ExpectedLine {
+        ExpectedLine::new(self.to_string(), AuthorType::UnattributedHuman)
     }
 }
 
@@ -70,6 +76,10 @@ impl ExpectedLineExt for String {
     fn human(self) -> ExpectedLine {
         ExpectedLine::new(self, AuthorType::Human)
     }
+
+    fn unattributed_human(self) -> ExpectedLine {
+        ExpectedLine::new(self, AuthorType::UnattributedHuman)
+    }
 }
 
 impl ExpectedLineExt for ExpectedLine {
@@ -79,6 +89,10 @@ impl ExpectedLineExt for ExpectedLine {
 
     fn human(self) -> ExpectedLine {
         ExpectedLine::new(self.contents, AuthorType::Human)
+    }
+
+    fn unattributed_human(self) -> ExpectedLine {
+        ExpectedLine::new(self.contents, AuthorType::UnattributedHuman)
     }
 }
 
@@ -299,7 +313,7 @@ impl<'a> TestFile<'a> {
                         blame_output
                     );
                 }
-                AuthorType::Human => {
+                AuthorType::Human | AuthorType::UnattributedHuman => {
                     assert!(
                         !self.is_ai_author(actual_author),
                         "Line {}: Expected Human author but got AI author '{}'\nExpected: {:?}\nActual content: {:?}\nFull blame output:\n{}",
@@ -374,7 +388,7 @@ impl<'a> TestFile<'a> {
                         blame_output
                     );
                 }
-                AuthorType::Human => {
+                AuthorType::Human | AuthorType::UnattributedHuman => {
                     assert!(
                         !self.is_ai_author(actual_author),
                         "Line {}: Expected Human author but got AI author '{}'\nExpected: {:?}\nActual content: {:?}\nFull blame output:\n{}",
@@ -488,7 +502,7 @@ impl<'a> TestFile<'a> {
                         blame_output
                     );
                 }
-                AuthorType::Human => {
+                AuthorType::Human | AuthorType::UnattributedHuman => {
                     assert!(
                         !self.is_ai_author(actual_author),
                         "Line {}: Expected Human author but got AI author '{}'. Expected line: {:?}\n{}",
@@ -682,7 +696,12 @@ impl<'a> TestFile<'a> {
             .collect::<Vec<String>>()
             .join("\n");
 
-        self.write_and_checkpoint_with_contents(&line_contents, &AuthorType::Human);
+        let human_kind = if lines.iter().any(|l| l.author_type == AuthorType::UnattributedHuman) {
+            &AuthorType::UnattributedHuman
+        } else {
+            &AuthorType::Human
+        };
+        self.write_and_checkpoint_with_contents(&line_contents, human_kind);
 
         let line_contents_with_ai = lines
             .iter()
@@ -714,7 +733,12 @@ impl<'a> TestFile<'a> {
             .collect::<Vec<String>>()
             .join("\n");
 
-        self.write_and_checkpoint_no_stage(&line_contents, &AuthorType::Human);
+        let human_kind = if lines.iter().any(|l| l.author_type == AuthorType::UnattributedHuman) {
+            &AuthorType::UnattributedHuman
+        } else {
+            &AuthorType::Human
+        };
+        self.write_and_checkpoint_no_stage(&line_contents, human_kind);
 
         let line_contents_with_ai = lines
             .iter()
@@ -746,14 +770,17 @@ impl<'a> TestFile<'a> {
 
     fn run_checkpoint_for_author_type(&self, author_type: &AuthorType) {
         let relative_path = self.repo_relative_path();
-        let result = if author_type == &AuthorType::Ai {
-            self.repo
-                .git_ai(&["checkpoint", "mock_ai", relative_path.as_str()])
-        } else {
-            self.repo
-                .git_ai(&["checkpoint", "mock_known_human", relative_path.as_str()])
+        let result = match author_type {
+            AuthorType::Ai => self
+                .repo
+                .git_ai(&["checkpoint", "mock_ai", relative_path.as_str()]),
+            AuthorType::Human => self
+                .repo
+                .git_ai(&["checkpoint", "mock_known_human", relative_path.as_str()]),
+            AuthorType::UnattributedHuman => self
+                .repo
+                .git_ai(&["checkpoint", "--", relative_path.as_str()]),
         };
-
         result.unwrap();
     }
 

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -751,7 +751,7 @@ impl<'a> TestFile<'a> {
                 .git_ai(&["checkpoint", "mock_ai", relative_path.as_str()])
         } else {
             self.repo
-                .git_ai(&["checkpoint", "--", relative_path.as_str()])
+                .git_ai(&["checkpoint", "mock_known_human", relative_path.as_str()])
         };
 
         result.unwrap();

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -686,6 +686,8 @@ fn is_known_checkpoint_preset(arg: &str) -> bool {
             | "ai_tab"
             | "firebender"
             | "mock_ai"
+            | "mock_known_human"
+            | "known_human"
             | "droid"
             | "agent-v1"
     )

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1057,8 +1057,9 @@ fn test_ai_deletion_with_human_checkpoint_in_same_commit() {
     )
     .unwrap();
 
-    // Human checkpoint
-    repo.git_ai(&["checkpoint"]).unwrap();
+    // KnownHuman checkpoint for the human-added lines
+    repo.git_ai(&["checkpoint", "mock_known_human", "data.txt"])
+        .unwrap();
 
     // Step 2: AI deletes one of its own lines and adds 2 new lines
     fs::write(
@@ -1705,12 +1706,19 @@ fn test_ai_generated_file_then_human_full_rewrite() {
     let agent_author_id = "3bd30911a58cb074";
     // Determine the git dir and base commit for checkpoint storage.
     // In worktree mode .git is a gitlink file, so use rev-parse to resolve.
-    let git_dir = repo
+    // `--git-dir` may return a relative path; resolve it against the repo root
+    // so that fs::create_dir_all works regardless of the process CWD.
+    let git_dir_raw = repo
         .git(&["rev-parse", "--git-dir"])
         .unwrap()
         .trim()
         .to_string();
-    let git_dir = std::path::Path::new(&git_dir);
+    let git_dir_path = if std::path::Path::new(&git_dir_raw).is_absolute() {
+        std::path::PathBuf::from(&git_dir_raw)
+    } else {
+        repo.path().join(&git_dir_raw)
+    };
+    let git_dir = git_dir_path.as_path();
     let base_commit = repo
         .git(&["rev-parse", "HEAD"])
         .unwrap_or_else(|_| "initial".to_string())

--- a/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_daemon_mode.snap
+++ b/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_daemon_mode.snap
@@ -1,10 +1,10 @@
 ---
 source: tests/integration/worktrees.rs
-assertion_line: 468
 expression: stats
 ---
 CommitStats {
-    human_additions: 1,
+    human_additions: 0,
+    unknown_additions: 1,
     mixed_additions: 0,
     ai_additions: 2,
     ai_accepted: 2,

--- a/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_daemon_mode.snap
+++ b/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_daemon_mode.snap
@@ -1,10 +1,11 @@
 ---
 source: tests/integration/worktrees.rs
+assertion_line: 476
 expression: stats
 ---
 CommitStats {
-    human_additions: 0,
-    unknown_additions: 1,
+    human_additions: 1,
+    unknown_additions: 0,
     mixed_additions: 0,
     ai_additions: 2,
     ai_accepted: 2,

--- a/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_daemon_mode.snap
+++ b/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_daemon_mode.snap
@@ -1,10 +1,10 @@
 ---
 source: tests/integration/worktrees.rs
-assertion_line: 468
 expression: stats
 ---
 CommitStats {
-    human_additions: 1,
+    human_additions: 0,
+    unknown_additions: 1,
     mixed_additions: 0,
     ai_additions: 2,
     ai_accepted: 2,

--- a/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_daemon_mode.snap
+++ b/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_daemon_mode.snap
@@ -1,10 +1,11 @@
 ---
 source: tests/integration/worktrees.rs
+assertion_line: 476
 expression: stats
 ---
 CommitStats {
-    human_additions: 0,
-    unknown_additions: 1,
+    human_additions: 1,
+    unknown_additions: 0,
     mixed_additions: 0,
     ai_additions: 2,
     ai_accepted: 2,

--- a/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_mode.snap
+++ b/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_mode.snap
@@ -1,10 +1,10 @@
 ---
-source: tests/worktrees.rs
-assertion_line: 346
+source: tests/integration/worktrees.rs
 expression: stats
 ---
 CommitStats {
-    human_additions: 1,
+    human_additions: 0,
+    unknown_additions: 1,
     mixed_additions: 0,
     ai_additions: 2,
     ai_accepted: 2,

--- a/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_mode.snap
+++ b/tests/integration/snapshots/integration__worktrees__worktree_stats_snapshot_in_worktree_wrapper_mode.snap
@@ -1,10 +1,11 @@
 ---
 source: tests/integration/worktrees.rs
+assertion_line: 476
 expression: stats
 ---
 CommitStats {
-    human_additions: 0,
-    unknown_additions: 1,
+    human_additions: 1,
+    unknown_additions: 0,
     mixed_additions: 0,
     ai_additions: 2,
     ai_accepted: 2,

--- a/tests/integration/squash_merge.rs
+++ b/tests/integration/squash_merge.rs
@@ -176,7 +176,10 @@ fn test_prepare_working_log_squash_multiple_sessions() {
         "2 AI lines from feature branch (both sessions)"
     );
     assert_eq!(stats.ai_accepted, 2, "2 AI lines accepted without edits");
-    assert_eq!(stats.human_additions, 2, "2 human lines from feature branch (Human addition + footer)");
+    assert_eq!(
+        stats.human_additions, 2,
+        "2 human lines from feature branch (Human addition + footer)"
+    );
     assert_eq!(stats.mixed_additions, 0, "No mixed edits");
 }
 
@@ -498,7 +501,10 @@ fn test_prepare_working_log_squash_with_main_changes_standard_human() {
 
     // Re-initialize file after checkout to get current master state
     let mut file = repo.filename("document.txt");
-    file.insert_at(0, crate::lines!["// Master update at top".unattributed_human()]);
+    file.insert_at(
+        0,
+        crate::lines!["// Master update at top".unattributed_human()],
+    );
     repo.stage_all_and_commit("Out-of-band update on master")
         .unwrap();
 

--- a/tests/integration/squash_merge.rs
+++ b/tests/integration/squash_merge.rs
@@ -470,9 +470,142 @@ fn test_squash_rebase_preserves_interleaved_attribution() {
     ]);
 }
 
+/// Variant of test_prepare_working_log_squash_with_main_changes using unattributed (legacy)
+/// human checkpoints. Assertions match origin/main behavior: with empty attribution, "section 3"
+/// gains the AI-attributed trailing newline in the squash diff and is counted as AI.
+#[test]
+fn test_prepare_working_log_squash_with_main_changes_standard_human() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("document.txt");
+
+    // Create master branch with initial content
+    file.set_contents(crate::lines![
+        "section 1".unattributed_human(),
+        "section 2".unattributed_human(),
+        "section 3".unattributed_human()
+    ]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let default_branch = repo.current_branch();
+
+    // Create feature branch and add AI changes
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.insert_at(3, crate::lines!["// AI feature addition at end".ai()]);
+    repo.stage_all_and_commit("AI adds feature").unwrap();
+
+    // Switch back to master and make out-of-band changes
+    repo.git(&["checkout", &default_branch]).unwrap();
+
+    // Re-initialize file after checkout to get current master state
+    let mut file = repo.filename("document.txt");
+    file.insert_at(0, crate::lines!["// Master update at top".unattributed_human()]);
+    repo.stage_all_and_commit("Out-of-band update on master")
+        .unwrap();
+
+    // Squash merge feature into master
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    repo.stage_all_and_commit("Squashed feature with out-of-band")
+        .unwrap();
+
+    // Verify attribution — with empty attribution, "section 3" gains the AI-attributed
+    // trailing newline from the squash diff and is counted as AI (origin/main behavior).
+    file.assert_lines_and_blame(crate::lines![
+        "// Master update at top".human(),
+        "section 1".human(),
+        "section 2".human(),
+        "section 3".ai(),
+        "// AI feature addition at end".ai()
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.git_diff_added_lines, 2,
+        "Squash commit adds 2 lines from feature (includes newline)"
+    );
+    assert_eq!(stats.ai_additions, 2, "2 AI lines from feature branch");
+    assert_eq!(stats.ai_accepted, 2, "2 AI lines accepted without edits");
+    assert_eq!(
+        stats.human_additions, 0,
+        "0 human lines from feature branch"
+    );
+    assert_eq!(stats.mixed_additions, 0, "No mixed edits");
+}
+
+/// Variant of test_prepare_working_log_squash_multiple_sessions using unattributed (legacy)
+/// human checkpoints. Assertions match origin/main behavior: "footer" gains the AI-attributed
+/// trailing newline and is counted as AI.
+#[test]
+fn test_prepare_working_log_squash_multiple_sessions_standard_human() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("file.txt");
+
+    // Create master branch
+    file.set_contents(crate::lines![
+        "header".unattributed_human(),
+        "body".unattributed_human(),
+        "footer".unattributed_human()
+    ]);
+    repo.stage_all_and_commit("Initial").unwrap();
+
+    let default_branch = repo.current_branch();
+
+    // Create feature branch
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+
+    // First AI session
+    file.insert_at(1, crate::lines!["// AI session 1".ai()]);
+    repo.stage_all_and_commit("AI session 1").unwrap();
+
+    // Human edit
+    file.insert_at(3, crate::lines!["// Human addition".unattributed_human()]);
+    repo.stage_all_and_commit("Human edit").unwrap();
+
+    // Second AI session (different agent - simulated by new checkpoint)
+    file.insert_at(5, crate::lines!["// AI session 2".ai()]);
+    repo.stage_all_and_commit("AI session 2").unwrap();
+
+    // Squash merge into master
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    repo.commit("Squashed multiple sessions").unwrap();
+
+    // Verify attribution — "footer" gains the AI-attributed trailing newline and is counted
+    // as AI (origin/main behavior).
+    file.assert_lines_and_blame(crate::lines![
+        "header".human(),
+        "// AI session 1".ai(),
+        "body".human(),
+        "// Human addition".human(),
+        "footer".ai(),
+        "// AI session 2".ai()
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.git_diff_added_lines, 4,
+        "Squash commit adds 4 lines total (includes newline)"
+    );
+    assert_eq!(
+        stats.ai_additions, 3,
+        "3 AI lines from feature branch (both sessions plus reformatted footer)"
+    );
+    assert_eq!(stats.ai_accepted, 3, "3 AI lines accepted without edits");
+    assert_eq!(
+        stats.human_additions, 0,
+        "0 KnownHuman-attested lines (checkpoint -- produces empty attribution)"
+    );
+    assert_eq!(
+        stats.unknown_additions, 1,
+        "1 unattested human line (// Human addition, unattributed via checkpoint --)"
+    );
+    assert_eq!(stats.mixed_additions, 0, "No mixed edits");
+}
+
 crate::reuse_tests_in_worktree!(
     test_prepare_working_log_simple_squash,
     test_prepare_working_log_squash_with_main_changes,
     test_prepare_working_log_squash_multiple_sessions,
     test_prepare_working_log_squash_with_mixed_additions,
+    test_prepare_working_log_squash_with_main_changes_standard_human,
+    test_prepare_working_log_squash_multiple_sessions_standard_human,
 );

--- a/tests/integration/squash_merge.rs
+++ b/tests/integration/squash_merge.rs
@@ -104,7 +104,7 @@ fn test_prepare_working_log_squash_with_main_changes() {
         "// Master update at top".human(),
         "section 1".human(),
         "section 2".human(),
-        "section 3".ai(),
+        "section 3".human(),
         "// AI feature addition at end".ai()
     ]);
 
@@ -114,11 +114,11 @@ fn test_prepare_working_log_squash_with_main_changes() {
         stats.git_diff_added_lines, 2,
         "Squash commit adds 2 lines from feature (includes newline)"
     );
-    assert_eq!(stats.ai_additions, 2, "2 AI lines from feature branch");
-    assert_eq!(stats.ai_accepted, 2, "2 AI lines accepted without edits");
+    assert_eq!(stats.ai_additions, 1, "1 AI line from feature branch");
+    assert_eq!(stats.ai_accepted, 1, "1 AI line accepted without edits");
     assert_eq!(
-        stats.human_additions, 0,
-        "0 human lines from feature branch"
+        stats.human_additions, 1,
+        "1 human line from feature branch (section 3 included in squash diff)"
     );
     assert_eq!(stats.mixed_additions, 0, "No mixed edits");
 }
@@ -161,7 +161,7 @@ fn test_prepare_working_log_squash_multiple_sessions() {
         "// AI session 1".ai(),
         "body".human(),
         "// Human addition".human(),
-        "footer".ai(),
+        "footer".human(),
         "// AI session 2".ai()
     ]);
 
@@ -172,11 +172,11 @@ fn test_prepare_working_log_squash_multiple_sessions() {
         "Squash commit adds 4 lines total (includes newline)"
     );
     assert_eq!(
-        stats.ai_additions, 3,
-        "3 AI lines from feature branch (both sessions plus reformatted footer)"
+        stats.ai_additions, 2,
+        "2 AI lines from feature branch (both sessions)"
     );
-    assert_eq!(stats.ai_accepted, 3, "3 AI lines accepted without edits");
-    assert_eq!(stats.human_additions, 1, "1 human line from feature branch");
+    assert_eq!(stats.ai_accepted, 2, "2 AI lines accepted without edits");
+    assert_eq!(stats.human_additions, 2, "2 human lines from feature branch (Human addition + footer)");
     assert_eq!(stats.mixed_additions, 0, "No mixed edits");
 }
 

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -136,7 +136,11 @@ fn test_authorship_log_stats() {
     let raw = repo.git_ai(&["stats", "--json"]).unwrap();
     let json = extract_json_object(&raw);
     let stats: CommitStats = serde_json::from_str(&json).unwrap();
-    assert_eq!(stats.human_additions, 4);
+    // Integration harness uses legacy `checkpoint --` (CheckpointKind::Human), which does not
+    // produce h_-prefixed attestation entries. Until Task 16 updates the harness to use
+    // KnownHuman, human lines appear as unknown_additions.
+    assert_eq!(stats.human_additions, 0);
+    assert_eq!(stats.unknown_additions, 4);
     assert_eq!(stats.mixed_additions, 1);
     assert_eq!(stats.ai_additions, 6); // Includes the one mixed line (Neptune (override))
     assert_eq!(stats.ai_accepted, 5);
@@ -338,8 +342,10 @@ fn test_stats_cli_empty_tree_range() {
     assert_eq!(stats.authorship_stats.total_commits, 2);
     assert_eq!(stats.range_stats.git_diff_added_lines, 2);
     assert_eq!(stats.range_stats.ai_additions, 1);
-    // human_additions is computed as git_diff_added_lines - ai_accepted
-    assert_eq!(stats.range_stats.human_additions, 1);
+    // Range stats use legacy Human checkpoints and pass known_human_accepted=0,
+    // so human lines appear as unknown_additions (not human_additions).
+    assert_eq!(stats.range_stats.human_additions, 0);
+    assert_eq!(stats.range_stats.unknown_additions, 1);
 }
 
 #[test]
@@ -349,6 +355,7 @@ fn test_markdown_stats_deletion_only() {
 
     let stats = CommitStats {
         human_additions: 0,
+        unknown_additions: 0,
         mixed_additions: 0,
         ai_additions: 0,
         ai_accepted: 0,
@@ -372,6 +379,7 @@ fn test_markdown_stats_all_human() {
 
     let stats = CommitStats {
         human_additions: 10,
+        unknown_additions: 0,
         mixed_additions: 0,
         ai_additions: 0,
         ai_accepted: 0,
@@ -395,6 +403,7 @@ fn test_markdown_stats_all_ai() {
 
     let stats = CommitStats {
         human_additions: 0,
+        unknown_additions: 0,
         mixed_additions: 0,
         ai_additions: 15,
         ai_accepted: 15,
@@ -418,6 +427,7 @@ fn test_markdown_stats_mixed() {
 
     let stats = CommitStats {
         human_additions: 10,
+        unknown_additions: 0,
         mixed_additions: 5,
         ai_additions: 20,
         ai_accepted: 15,
@@ -441,6 +451,7 @@ fn test_markdown_stats_no_mixed() {
 
     let stats = CommitStats {
         human_additions: 8,
+        unknown_additions: 0,
         mixed_additions: 0,
         ai_additions: 12,
         ai_accepted: 12,
@@ -465,6 +476,7 @@ fn test_markdown_stats_minimal_human() {
     // Test that humans get at least 2 visible blocks if they have more than 1 line
     let stats = CommitStats {
         human_additions: 2,
+        unknown_additions: 0,
         mixed_additions: 0,
         ai_additions: 98,
         ai_accepted: 98,
@@ -501,6 +513,7 @@ fn test_markdown_stats_formatting() {
 
     let stats = CommitStats {
         human_additions: 5,
+        unknown_additions: 0,
         mixed_additions: 2,
         ai_additions: 8,
         ai_accepted: 6,

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -136,13 +136,17 @@ fn test_authorship_log_stats() {
     let raw = repo.git_ai(&["stats", "--json"]).unwrap();
     let json = extract_json_object(&raw);
     let stats: CommitStats = serde_json::from_str(&json).unwrap();
-    // Integration harness uses legacy `checkpoint --` (CheckpointKind::Human), which does not
-    // produce h_-prefixed attestation entries. Until Task 16 updates the harness to use
-    // KnownHuman, human lines appear as unknown_additions.
-    assert_eq!(stats.human_additions, 0);
-    assert_eq!(stats.unknown_additions, 4);
-    assert_eq!(stats.mixed_additions, 1);
-    assert_eq!(stats.ai_additions, 6); // Includes the one mixed line (Neptune (override))
+    // The integration harness now uses mock_known_human (CheckpointKind::KnownHuman), which
+    // produces h_-prefixed attestation entries for lines written under a human checkpoint.
+    // Neptune (override) — human-overrides-AI line — gets h_<hash> attestation.
+    // Mercury, Venus, Jupiter also get h_<hash> attestation from the KnownHuman checkpoint.
+    // All 4 human-written lines now count as human_additions; unknown_additions = 0.
+    // Neptune (override) is now h_<hash> attested, so it counts as human_additions only,
+    // not mixed. mixed_additions = 0.
+    assert_eq!(stats.human_additions, 4);
+    assert_eq!(stats.unknown_additions, 0);
+    assert_eq!(stats.mixed_additions, 0);
+    assert_eq!(stats.ai_additions, 5); // Neptune (override) no longer counted as mixed AI
     assert_eq!(stats.ai_accepted, 5);
     assert_eq!(stats.total_ai_additions, 11);
     assert_eq!(stats.total_ai_deletions, 11);

--- a/tests/integration/utf8_filenames.rs
+++ b/tests/integration/utf8_filenames.rs
@@ -344,7 +344,11 @@ fn test_utf8_filename_with_human_and_ai_lines() {
     );
     assert_eq!(
         stats.human_additions, 3,
-        "3 lines should be attributed to human"
+        "3 h_<hash>-attested lines from KnownHuman checkpoint on fresh file"
+    );
+    assert_eq!(
+        stats.unknown_additions, 0,
+        "No unattested human lines - all human lines now have h_<hash>-attestation"
     );
     assert_eq!(
         stats.git_diff_added_lines, 5,


### PR DESCRIPTION
## Summary

- Introduces `CheckpointKind::KnownHuman` — fired by IDE extensions when a user saves/edits a file. Attests lines with an `h_<hash>` author ID (SHA256 of git committer identity), distinct from AI session hashes.
- Changes the attribution tristate from `{AI, Human}` to `{AI, Known Human, Unknown}`: lines with no attestation are now `unknown_additions` rather than `human_additions`.
- Propagates `humans: BTreeMap<String, HumanRecord>` through the full note rewrite pipeline (rebase, squash, amend, post-commit, stash, checkout, CI paths).
- Scopes `metadata.humans` per-commit-delta during rebase (same semantics as prompts/accepted_lines): only h_ entries for the current commit's changed files.

## Key changes

- **Data model**: `HumanRecord`, `generate_human_short_hash`, `humans` field on `AuthorshipMetadata` and `InitialAttributions`, `VirtualAttributions.humans`
- **Checkpoint execution**: `KnownHuman` kind with `h_<hash>` author ID, 1-second timing-safety guard (0 in tests), `mock_known_human` test preset
- **Attribution routing**: `is_ai_author_id` excludes `h_` prefixes; `is_ai()` helper on `CheckpointKind`; `blame.rs`, `diff.rs`, `stats.rs` all route `h_` to human display
- **Stats**: `unknown_additions` added to `CommitStats`; `human_additions` now counts only positively-attested KnownHuman lines
- **Test harness**: `run_checkpoint_for_author_type` and `trigger_checkpoint_with_author` emit KnownHuman checkpoints for `.human()` lines; `set_contents` uses placeholders so AI and human checkpoint content differs
- **Rebase metadata.humans scoping**:
  - *Fallback path* (`build_note_from_conflict_wl`): AI-resolved conflicts where new content has no diff-match now correctly populate `metadata.humans` from KnownHuman checkpoints in the working log; the checkpoint is no longer misclassified as an AI prompt entry.
  - *Fast path* (metadata template): AI-resolved conflicts that keep/extend existing lines (some AI lines diff-match) now compute `delta_humans` by reading KnownHuman checkpoints from the working log stored under the commit's parent SHA, since `current_attributions` only carries AI-attributed lines from note attestations.
- **Compatibility with #1024**: `build_metadata_template_parts_filtered` now takes both `original_commit` (per-commit PromptRecord selection) and `delta_humans` (per-commit humans scoping); template cache invalidation checks all three conditions.

## Test plan

- [x] All 2920 integration tests pass (after rebase onto main including #1024)
- [ ] All unit tests pass
- [ ] `git ai checkpoint known_human --editor vscode --editor-version 1.0 --extension-version 0.1 -- <file>` records h_-prefixed attribution
- [ ] `git ai blame` shows git author username for KnownHuman lines, "mock_ai" for AI lines
- [ ] `git ai stats --json` shows `human_additions` for KnownHuman lines and `unknown_additions` for unattested lines
- [ ] Rebased commits with KnownHuman conflict resolution carry correct `metadata.humans` (verified by new rebase_realworld tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)