### PR TITLE
Fix security: credential permissions, CAS validation, token redaction

### DIFF
--- a/src/api/cas.rs
+++ b/src/api/cas.rs
@@ -69,6 +69,17 @@ impl ApiClient {
         &self,
         hashes: &[&str],
     ) -> Result<CAPromptStoreReadResponse, GitAiError> {
+        // Validate all hashes are hex-only before building the URL to prevent
+        // injection via crafted hash values in the query string.
+        for hash in hashes {
+            if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(GitAiError::Generic(format!(
+                    "CAS hash contains non-hex characters: {}",
+                    hash
+                )));
+            }
+        }
+
         let query = hashes.join(",");
         let endpoint = format!("/worker/cas/?hashes={}", query);
         let response = self.context().get(&endpoint)?;

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -80,7 +80,7 @@ fn resolve_git_identity() -> Option<String> {
 }
 
 /// API client context with optional authentication
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ApiContext {
     /// Base URL for the API (e.g., `https://app.com`)
     pub base_url: String,
@@ -92,6 +92,21 @@ pub struct ApiContext {
     pub author_identity: Option<String>,
     /// Request timeout in seconds
     pub timeout_secs: Option<u64>,
+}
+
+impl std::fmt::Debug for ApiContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiContext")
+            .field("base_url", &self.base_url)
+            .field(
+                "auth_token",
+                &self.auth_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .field("author_identity", &self.author_identity)
+            .field("timeout_secs", &self.timeout_secs)
+            .finish()
+    }
 }
 
 impl ApiContext {

--- a/src/auth/credential_backend.rs
+++ b/src/auth/credential_backend.rs
@@ -136,14 +136,27 @@ impl CredentialBackend for FileBackend {
             fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
         }
 
-        fs::write(&self.path, value)
-            .map_err(|e| format!("Failed to write credentials file: {}", e))?;
-
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&self.path, fs::Permissions::from_mode(0o600))
-                .map_err(|e| format!("Failed to set file permissions: {}", e))?;
+            // Create (or truncate) the file with mode 0o600 atomically so there
+            // is no window where it exists with default (world-readable) permissions.
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&self.path)
+                .map_err(|e| format!("Failed to write credentials file: {}", e))?;
+            file.write_all(value.as_bytes())
+                .map_err(|e| format!("Failed to write credentials file: {}", e))?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            fs::write(&self.path, value)
+                .map_err(|e| format!("Failed to write credentials file: {}", e))?;
         }
 
         #[cfg(windows)]
@@ -183,7 +196,7 @@ pub use mock::*;
 #[cfg(test)]
 mod mock {
     use super::CredentialBackend;
-    use std::cell::RefCell;
+    use std::sync::Mutex;
 
     /// Configurable failure modes for MockBackend
     #[derive(Clone, Debug)]
@@ -193,46 +206,48 @@ mod mock {
         Clear(String),
     }
 
-    /// Mock backend for testing - stores in memory, can simulate failures
+    /// Mock backend for testing - stores in memory, can simulate failures.
+    /// Uses `std::sync::Mutex` instead of `RefCell` so that `Send + Sync`
+    /// is derived automatically without `unsafe impl`.
     pub struct MockBackend {
-        storage: RefCell<Option<String>>,
-        failure: RefCell<Option<MockFailure>>,
+        storage: Mutex<Option<String>>,
+        failure: Mutex<Option<MockFailure>>,
     }
 
     impl MockBackend {
         pub fn new() -> Self {
             Self {
-                storage: RefCell::new(None),
-                failure: RefCell::new(None),
+                storage: Mutex::new(None),
+                failure: Mutex::new(None),
             }
         }
 
         /// Configure to fail on store with given error message
         pub fn fail_store(self, msg: &str) -> Self {
-            *self.failure.borrow_mut() = Some(MockFailure::Store(msg.to_string()));
+            *self.failure.lock().unwrap() = Some(MockFailure::Store(msg.to_string()));
             self
         }
 
         /// Configure to fail on load with given error message
         pub fn fail_load(self, msg: &str) -> Self {
-            *self.failure.borrow_mut() = Some(MockFailure::Load(msg.to_string()));
+            *self.failure.lock().unwrap() = Some(MockFailure::Load(msg.to_string()));
             self
         }
 
         /// Configure to fail on clear with given error message
         pub fn fail_clear(self, msg: &str) -> Self {
-            *self.failure.borrow_mut() = Some(MockFailure::Clear(msg.to_string()));
+            *self.failure.lock().unwrap() = Some(MockFailure::Clear(msg.to_string()));
             self
         }
 
         /// Check if storage contains a value
         pub fn has_value(&self) -> bool {
-            self.storage.borrow().is_some()
+            self.storage.lock().unwrap().is_some()
         }
 
         /// Get the stored value (for test assertions)
         pub fn get_value(&self) -> Option<String> {
-            self.storage.borrow().clone()
+            self.storage.lock().unwrap().clone()
         }
     }
 
@@ -242,32 +257,27 @@ mod mock {
         }
     }
 
-    // MockBackend is not Send+Sync due to RefCell, but that's fine for single-threaded tests
-    // We implement the trait without the Send+Sync bounds for the mock
-    unsafe impl Send for MockBackend {}
-    unsafe impl Sync for MockBackend {}
-
     impl CredentialBackend for MockBackend {
         fn store(&self, value: &str) -> Result<(), String> {
-            if let Some(MockFailure::Store(msg)) = self.failure.borrow().as_ref() {
+            if let Some(MockFailure::Store(msg)) = self.failure.lock().unwrap().as_ref() {
                 return Err(msg.clone());
             }
-            *self.storage.borrow_mut() = Some(value.to_string());
+            *self.storage.lock().unwrap() = Some(value.to_string());
             Ok(())
         }
 
         fn load(&self) -> Result<Option<String>, String> {
-            if let Some(MockFailure::Load(msg)) = self.failure.borrow().as_ref() {
+            if let Some(MockFailure::Load(msg)) = self.failure.lock().unwrap().as_ref() {
                 return Err(msg.clone());
             }
-            Ok(self.storage.borrow().clone())
+            Ok(self.storage.lock().unwrap().clone())
         }
 
         fn clear(&self) -> Result<(), String> {
-            if let Some(MockFailure::Clear(msg)) = self.failure.borrow().as_ref() {
+            if let Some(MockFailure::Clear(msg)) = self.failure.lock().unwrap().as_ref() {
                 return Err(msg.clone());
             }
-            *self.storage.borrow_mut() = None;
+            *self.storage.lock().unwrap() = None;
             Ok(())
         }
 


### PR DESCRIPTION
- Create credential files atomically with mode 0600 on Unix to prevent
  a window where they exist with default permissions
- Validate CAS hashes are hex-only before building query URLs
- Implement custom Debug for ApiContext to redact auth_token and api_key
- Replace RefCell with Mutex in MockBackend to derive Send+Sync safely
  instead of using unsafe impl

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>