### PR TITLE
Refactor CheckpointKind API and improve attribution/storage performance

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d9de4835-cf67-48a6-b7e6-220de1a704b0","pid":41489,"acquiredAt":1776317094708}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d9de4835-cf67-48a6-b7e6-220de1a704b0","pid":41489,"acquiredAt":1776317094708}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ fuzz/corpus/
 .worktrees/
 .claude/worktrees/
 
+# Claude lock files
+.claude/*.lock
+

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -543,6 +543,9 @@ impl PersistedWorkingLog {
     {
         let mut checkpoints = self.read_all_checkpoints()?;
         mutator(&mut checkpoints)?;
+        // Prune char-level attributions from older checkpoints to prevent
+        // unbounded growth of the checkpoints.jsonl file.
+        self.prune_old_char_attributions(&mut checkpoints);
         self.write_all_checkpoints(&checkpoints)?;
         Ok(checkpoints)
     }


### PR DESCRIPTION
API cleanup:
- Rename CheckpointKind::to_str() -> as_str() returning &'static str
  instead of allocating a new String on each call
- Default unknown checkpoint kinds to Human instead of panicking

Performance:
- Use sweep-line algorithm for attribute_unattributed_ranges: O(n log n)
  sort + O(n) scan instead of O(n*m) per-character coverage check
- Compute line metadata once and pass through to compute_diffs and
  detect_moves instead of redundant recomputation
- Use true JSONL append for checkpoints instead of read-modify-write
- Skip hash migration on already-migrated working logs via marker file
- Unify canonical_workdir handling across platforms
- Read checkpoints once to derive both tracked files and
  has_ai_checkpoints flag
- Use HashSet for O(1) ref-change dedup instead of linear scans
- Single-scan get_or_create_file in AuthorshipLog
- Defer args allocation to the error path in exec_git_with_profile

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>