### PR TITLE
feat: warn loudly when git version < 2.22.0 at end of install-hooks

### DIFF
--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -823,16 +823,24 @@ fn warn_if_git_version_too_old() {
         if v < (maj, min, patch) {
             let (vmaj, vmin, vpatch) = v;
             eprintln!();
-            eprintln!("\x1b[1;31m╔══════════════════════════════════════════════════════════════╗\x1b[0m");
-            eprintln!("\x1b[1;31m║  WARNING: git version too old — git-ai will not work          ║\x1b[0m");
-            eprintln!("\x1b[1;31m╚══════════════════════════════════════════════════════════════╝\x1b[0m");
+            eprintln!(
+                "\x1b[1;31m╔══════════════════════════════════════════════════════════════╗\x1b[0m"
+            );
+            eprintln!(
+                "\x1b[1;31m║  WARNING: git version too old — git-ai will not work         ║\x1b[0m"
+            );
+            eprintln!(
+                "\x1b[1;31m╚══════════════════════════════════════════════════════════════╝\x1b[0m"
+            );
             eprintln!(
                 "\x1b[1;31mDetected git {}.{}.{} — git-ai requires git >= {}.{}.{}\x1b[0m",
                 vmaj, vmin, vpatch, maj, min, patch
             );
             eprintln!("\x1b[33mPlease upgrade git before using git-ai:\x1b[0m");
             eprintln!("  macOS:   brew install git");
-            eprintln!("  Ubuntu:  sudo add-apt-repository ppa:git-core/ppa && sudo apt-get update && sudo apt-get install git");
+            eprintln!(
+                "  Ubuntu:  sudo add-apt-repository ppa:git-core/ppa && sudo apt-get update && sudo apt-get install git"
+            );
             eprintln!("  Windows: https://git-scm.com/download/win");
             eprintln!();
         }
@@ -1253,10 +1261,7 @@ mod tests {
 
     #[test]
     fn parse_git_version_standard() {
-        assert_eq!(
-            parse_git_version("git version 2.39.1"),
-            Some((2, 39, 1))
-        );
+        assert_eq!(parse_git_version("git version 2.39.1"), Some((2, 39, 1)));
     }
 
     #[test]
@@ -1269,27 +1274,18 @@ mod tests {
 
     #[test]
     fn parse_git_version_no_patch() {
-        assert_eq!(
-            parse_git_version("git version 2.22"),
-            Some((2, 22, 0))
-        );
+        assert_eq!(parse_git_version("git version 2.22"), Some((2, 22, 0)));
     }
 
     #[test]
     fn parse_git_version_old() {
-        assert_eq!(
-            parse_git_version("git version 2.17.1"),
-            Some((2, 17, 1))
-        );
+        assert_eq!(parse_git_version("git version 2.17.1"), Some((2, 17, 1)));
         assert!(parse_git_version("git version 2.17.1").unwrap() < MIN_GIT_VERSION);
     }
 
     #[test]
     fn parse_git_version_at_minimum() {
-        assert_eq!(
-            parse_git_version("git version 2.22.0"),
-            Some((2, 22, 0))
-        );
+        assert_eq!(parse_git_version("git version 2.22.0"), Some((2, 22, 0)));
         assert!(parse_git_version("git version 2.22.0").unwrap() >= MIN_GIT_VERSION);
     }
 

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -779,7 +779,64 @@ async fn async_run_install(
         emit_install_hooks_metrics(&detailed_results);
     }
 
+    // Warn if git version is below the minimum required for full functionality
+    warn_if_git_version_too_old();
+
     Ok(statuses)
+}
+
+/// Minimum git version required for git-ai to function correctly.
+/// git 2.22.0 introduced `git worktree list --porcelain` output format improvements
+/// and trace2 event logging used by git-ai for attribution.
+const MIN_GIT_VERSION: (u32, u32, u32) = (2, 22, 0);
+
+/// Parse a git version string like "git version 2.39.1" into (major, minor, patch).
+fn parse_git_version(output: &str) -> Option<(u32, u32, u32)> {
+    // Strip the "git version " prefix and any platform suffix (e.g. "(Apple Git-140)")
+    let version_str = output.trim().strip_prefix("git version ")?;
+    let version_str = version_str.split_whitespace().next()?;
+    let mut parts = version_str.split('.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor: u32 = parts.next()?.parse().ok()?;
+    let patch: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    Some((major, minor, patch))
+}
+
+/// Print a loud warning if the installed git version is older than MIN_GIT_VERSION.
+fn warn_if_git_version_too_old() {
+    let output = Command::new("git")
+        .args(["--version"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output();
+
+    let version = match output {
+        Ok(o) => {
+            let text = String::from_utf8_lossy(&o.stdout).into_owned();
+            parse_git_version(&text)
+        }
+        Err(_) => None,
+    };
+
+    if let Some(v) = version {
+        let (maj, min, patch) = MIN_GIT_VERSION;
+        if v < (maj, min, patch) {
+            let (vmaj, vmin, vpatch) = v;
+            eprintln!();
+            eprintln!("\x1b[1;31m╔══════════════════════════════════════════════════════════════╗\x1b[0m");
+            eprintln!("\x1b[1;31m║  WARNING: git version too old — git-ai will not work          ║\x1b[0m");
+            eprintln!("\x1b[1;31m╚══════════════════════════════════════════════════════════════╝\x1b[0m");
+            eprintln!(
+                "\x1b[1;31mDetected git {}.{}.{} — git-ai requires git >= {}.{}.{}\x1b[0m",
+                vmaj, vmin, vpatch, maj, min, patch
+            );
+            eprintln!("\x1b[33mPlease upgrade git before using git-ai:\x1b[0m");
+            eprintln!("  macOS:   brew install git");
+            eprintln!("  Ubuntu:  sudo add-apt-repository ppa:git-core/ppa && sudo apt-get update && sudo apt-get install git");
+            eprintln!("  Windows: https://git-scm.com/download/win");
+            eprintln!();
+        }
+    }
 }
 
 /// Emit metrics events for install-hooks results
@@ -1192,5 +1249,53 @@ mod tests {
             parse_git_og_cmd_path("@echo off\r\n\"C:\\Program Files\\Git\\bin\\git.exe\" %*\r\n"),
             Some("C:\\Program Files\\Git\\bin\\git.exe".to_string())
         );
+    }
+
+    #[test]
+    fn parse_git_version_standard() {
+        assert_eq!(
+            parse_git_version("git version 2.39.1"),
+            Some((2, 39, 1))
+        );
+    }
+
+    #[test]
+    fn parse_git_version_apple_suffix() {
+        assert_eq!(
+            parse_git_version("git version 2.39.3 (Apple Git-146)"),
+            Some((2, 39, 3))
+        );
+    }
+
+    #[test]
+    fn parse_git_version_no_patch() {
+        assert_eq!(
+            parse_git_version("git version 2.22"),
+            Some((2, 22, 0))
+        );
+    }
+
+    #[test]
+    fn parse_git_version_old() {
+        assert_eq!(
+            parse_git_version("git version 2.17.1"),
+            Some((2, 17, 1))
+        );
+        assert!(parse_git_version("git version 2.17.1").unwrap() < MIN_GIT_VERSION);
+    }
+
+    #[test]
+    fn parse_git_version_at_minimum() {
+        assert_eq!(
+            parse_git_version("git version 2.22.0"),
+            Some((2, 22, 0))
+        );
+        assert!(parse_git_version("git version 2.22.0").unwrap() >= MIN_GIT_VERSION);
+    }
+
+    #[test]
+    fn parse_git_version_invalid() {
+        assert_eq!(parse_git_version("not a git version"), None);
+        assert_eq!(parse_git_version(""), None);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a loud red-box terminal warning at the end of `git-ai install-hooks` when the detected git version is below 2.22.0
- Includes upgrade instructions for macOS, Ubuntu, and Windows
- Adds 6 unit tests covering `parse_git_version` for standard, Apple-suffix, no-patch, old, at-minimum, and invalid inputs

## Why 2.22.0

git-ai relies on trace2 event logging, which was introduced in git 2.22.0. Running on an older git silently breaks attribution with no obvious error message.

## Test plan

- [ ] Run `git-ai install-hooks` on a machine with git >= 2.22.0 — no warning should appear
- [ ] Run `git-ai install-hooks` on a machine with git < 2.22.0 — red warning box with upgrade instructions should appear at the end
- [ ] `cargo test parse_git_version` passes (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
