### PR TITLE
fix: ensure parent dirs exist in write_atomic (#1039)

### DIFF
--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -1232,4 +1232,26 @@ mod tests {
             "Unix paths should be preserved unchanged"
         );
     }
+
+    /// Regression test for #1039: install_hooks_at should succeed even when
+    /// the parent directory does not yet exist.
+    #[test]
+    fn test_install_hooks_creates_missing_parent_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        // Point to a settings.json inside a directory that does NOT exist yet
+        let settings_path = temp_dir.path().join("missing_dir").join("settings.json");
+        assert!(!settings_path.parent().unwrap().exists());
+
+        let result =
+            ClaudeCodeInstaller::install_hooks_at(&settings_path, &params(), false).unwrap();
+
+        assert!(result.is_some(), "should report changes for fresh install");
+        assert!(settings_path.exists(), "settings.json should be created");
+
+        let content: Value =
+            serde_json::from_str(&fs::read_to_string(&settings_path).unwrap()).expect("valid JSON");
+        let hooks = content.get("hooks").expect("hooks key should exist");
+        assert!(hooks.get("PreToolUse").is_some());
+        assert!(hooks.get("PostToolUse").is_some());
+    }
 }

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -1214,4 +1214,38 @@ codex_hooks = true
             );
         });
     }
+
+    /// Regression test for #1039: install_hooks should succeed even when
+    /// ~/.codex/ directory does not yet exist.
+    #[test]
+    #[serial]
+    fn test_install_hooks_creates_missing_codex_dir() {
+        with_temp_home(|home| {
+            // Ensure ~/.codex/ does NOT exist
+            let codex_dir = home.join(".codex");
+            assert!(!codex_dir.exists());
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            let result = installer.install_hooks(&params, false).unwrap();
+            assert!(result.is_some(), "should report changes for fresh install");
+
+            // Both config.toml and hooks.json should be created
+            let config_path = codex_dir.join("config.toml");
+            let hooks_path = codex_dir.join("hooks.json");
+            assert!(config_path.exists(), "config.toml should be created");
+            assert!(hooks_path.exists(), "hooks.json should be created");
+
+            // Verify hooks.json has the expected structure
+            let hooks_json: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+            assert!(
+                CodexInstaller::hooks_have_codex_commands(&hooks_json, false),
+                "hooks.json should contain git-ai codex commands"
+            );
+        });
+    }
 }

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -386,26 +386,55 @@ pub fn claude_config_dir() -> PathBuf {
 /// If the path is a symlink, writes to the target file (preserving the symlink)
 pub fn write_atomic(path: &Path, data: &[u8]) -> Result<(), GitAiError> {
     let target_path = if path.is_symlink() {
-        fs::canonicalize(path)?
+        fs::canonicalize(path).map_err(|e| {
+            GitAiError::Generic(format!(
+                "Failed to resolve symlink {}: {}",
+                path.display(),
+                e
+            ))
+        })?
     } else {
         path.to_path_buf()
     };
 
+    // Ensure parent directory exists before writing. This guards against
+    // environments (e.g. nushell) where the parent may not yet exist when
+    // write_atomic is reached. See #1039.
+    ensure_parent_dir(&target_path)?;
+
     let tmp_path = target_path.with_extension("tmp");
     {
-        let mut file = fs::File::create(&tmp_path)?;
+        let mut file = fs::File::create(&tmp_path).map_err(|e| {
+            GitAiError::Generic(format!(
+                "Failed to create temp file {}: {}",
+                tmp_path.display(),
+                e
+            ))
+        })?;
         file.write_all(data)?;
         file.sync_all()?;
     }
-    fs::rename(&tmp_path, &target_path)?;
+    fs::rename(&tmp_path, &target_path).map_err(|e| {
+        GitAiError::Generic(format!(
+            "Failed to rename {} to {}: {}",
+            tmp_path.display(),
+            target_path.display(),
+            e
+        ))
+    })?;
     Ok(())
 }
 
 /// Ensure parent directory exists
-#[allow(dead_code)]
 pub fn ensure_parent_dir(path: &Path) -> Result<(), GitAiError> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent).map_err(|e| {
+            GitAiError::Generic(format!(
+                "Failed to create directory {}: {}",
+                parent.display(),
+                e
+            ))
+        })?;
     }
     Ok(())
 }
@@ -1504,5 +1533,50 @@ mod tests {
             std::env::remove_var("CLAUDE_CONFIG_DIR");
         }
         assert_eq!(dir, home_dir().join(".claude"));
+    }
+
+    /// Regression test for #1039: write_atomic should create parent directories
+    /// if they do not exist, preventing "No such file or directory" errors.
+    #[test]
+    fn test_write_atomic_creates_parent_dirs() {
+        let temp_dir = TempDir::new().unwrap();
+        // Path whose parent directory does NOT yet exist
+        let file_path = temp_dir
+            .path()
+            .join("nonexistent")
+            .join("subdir")
+            .join("test.json");
+        assert!(!file_path.parent().unwrap().exists());
+
+        write_atomic(&file_path, b"{\"key\": \"value\"}").unwrap();
+
+        assert!(file_path.exists());
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "{\"key\": \"value\"}");
+    }
+
+    /// Regression test for #1039: ensure_parent_dir handles nested missing dirs.
+    #[test]
+    fn test_ensure_parent_dir_creates_nested() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir
+            .path()
+            .join("a")
+            .join("b")
+            .join("c")
+            .join("file.txt");
+        assert!(!temp_dir.path().join("a").exists());
+
+        ensure_parent_dir(&file_path).unwrap();
+
+        assert!(file_path.parent().unwrap().exists());
+    }
+
+    /// Regression test for #1039: ensure_parent_dir is a no-op for root-level paths.
+    #[test]
+    fn test_ensure_parent_dir_no_parent() {
+        // A path with no parent component should not error
+        let path = Path::new("standalone_file.txt");
+        ensure_parent_dir(path).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Makes `write_atomic()` call `ensure_parent_dir()` before creating the temp file, preventing "No such file or directory (os error 2)" when hooks are installed in environments where the config directory hasn't been created yet (e.g. nushell)
- Wraps IO errors in `write_atomic` and `ensure_parent_dir` with path context for easier debugging
- Removes `#[allow(dead_code)]` from `ensure_parent_dir` since it is now used

## Test plan

- [x] New test `test_write_atomic_creates_parent_dirs` — verifies `write_atomic` succeeds when parent dirs are missing
- [x] New test `test_ensure_parent_dir_creates_nested` — verifies nested dir creation
- [x] New test `test_ensure_parent_dir_no_parent` — verifies no-op for root-level paths
- [x] New test `test_install_hooks_creates_missing_parent_dir` — verifies Claude Code hook install with missing `~/.claude/`
- [x] New test `test_install_hooks_creates_missing_codex_dir` — verifies Codex hook install with missing `~/.codex/`
- [x] All existing `write_atomic` tests still pass
- [x] `cargo clippy` clean, `cargo fmt` clean

Fixes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
