### PR TITLE
feat(hooks): add trigger and workdir fields to hook payload

### DIFF
--- a/src/authorship/git_ai_hooks.rs
+++ b/src/authorship/git_ai_hooks.rs
@@ -18,6 +18,7 @@ struct RepoHookContext {
     repo_name: String,
     branch: String,
     is_default_branch: bool,
+    workdir: String,
 }
 
 /// Dispatch configured `git_ai_hooks.post_notes_updated` shell commands.
@@ -25,7 +26,7 @@ struct RepoHookContext {
 /// The hook input is always passed through stdin as a JSON array of 1..N note entries.
 /// Commands are started in parallel, and we wait up to 3 seconds for completion before
 /// detaching and continuing so git-ai does not block.
-pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
+pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)], trigger: &str) {
     if notes.is_empty() {
         return;
     }
@@ -43,6 +44,8 @@ pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
     let repo_name = context.repo_name;
     let branch = context.branch;
     let is_default_branch = context.is_default_branch;
+    let workdir = context.workdir;
+    let trigger = trigger.to_string();
     let payload = notes
         .iter()
         .map(|(commit_sha, note_content)| {
@@ -53,6 +56,8 @@ pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
                 "branch": branch.as_str(),
                 "is_default_branch": is_default_branch,
                 "note_content": note_content,
+                "trigger": trigger.as_str(),
+                "workdir": workdir.as_str(),
             })
         })
         .collect::<Vec<_>>();
@@ -105,9 +110,9 @@ pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
     wait_for_hooks_or_detach(running_children);
 }
 
-pub fn post_notes_updated_single(repo: &Repository, commit_sha: &str, note_content: &str) {
+pub fn post_notes_updated_single(repo: &Repository, commit_sha: &str, note_content: &str, trigger: &str) {
     let note_batch = vec![(commit_sha.to_string(), note_content.to_string())];
-    post_notes_updated(repo, &note_batch);
+    post_notes_updated(repo, &note_batch, trigger);
 }
 
 fn wait_for_hooks_or_detach(mut children: Vec<(String, Child)>) {
@@ -250,5 +255,10 @@ fn build_repo_hook_context(repo: &Repository) -> RepoHookContext {
         repo_name,
         branch: branch.clone(),
         is_default_branch: branch == default_branch,
+        workdir: repo
+            .workdir()
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default(),
     }
 }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -26,7 +26,7 @@ pub fn notes_add(
 
     // Use stdin to provide the note content to avoid command line length limits
     exec_git_stdin(&args, note_content.as_bytes())?;
-    crate::authorship::git_ai_hooks::post_notes_updated_single(repo, commit_sha, note_content);
+    crate::authorship::git_ai_hooks::post_notes_updated_single(repo, commit_sha, note_content, "notes_add");
     Ok(())
 }
 
@@ -242,7 +242,7 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
     fast_import_args.push("fast-import".to_string());
     fast_import_args.push("--quiet".to_string());
     exec_git_stdin(&fast_import_args, &script)?;
-    crate::authorship::git_ai_hooks::post_notes_updated(repo, &deduped_entries);
+    crate::authorship::git_ai_hooks::post_notes_updated(repo, &deduped_entries, "notes_add_batch");
 
     Ok(())
 }
@@ -335,7 +335,7 @@ pub fn notes_add_blob_batch(
         })();
         match hook_entries {
             Ok(entries) if !entries.is_empty() => {
-                crate::authorship::git_ai_hooks::post_notes_updated(repo, &entries)
+                crate::authorship::git_ai_hooks::post_notes_updated(repo, &entries, "notes_add_blob_batch")
             }
             Ok(_) => {}
             Err(e) => debug_log(&format!(


### PR DESCRIPTION
 Summary                                                                                                                                                                                                  
                                                                                                                                                                                                           
  This PR extends the post_notes_updated hook mechanism to provide richer context to hook scripts.

  Changes

  - Added a trigger parameter to post_notes_updated and post_notes_updated_single, allowing callers to identify which code path fired the hook.
  - Added workdir to the RepoHookContext struct, populated from the repository's working directory via repo.workdir().
  - Both trigger and workdir are now included in each entry of the JSON payload sent to configured git_ai_hooks.post_notes_updated shell commands.
  - Updated all three call sites in refs.rs with descriptive trigger values: notes_add, notes_add_batch, and notes_add_blob_batch.

  Motivation

  Hook scripts previously had no way to distinguish which operation triggered the hook, nor did they receive the local repository path. This made it difficult to implement integrations that need to
  report events to external services with full context.

  Payload example

  {
    "commit_sha": "abc123",
    "repo_url": "git@github.com:org/repo.git",
    "repo_name": "repo",
    "branch": "main",
    "is_default_branch": true,
    "note_content": "...",
    "trigger": "notes_add",
    "workdir": "/home/user/projects/my-repo"
  }

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
