### PR TITLE
Fix git ai diff to display human author names and include human_id in JSON

### DIFF
--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1,5 +1,5 @@
 use crate::auth::CredentialStore;
-use crate::authorship::authorship_log::PromptRecord;
+use crate::authorship::authorship_log::{HumanRecord, PromptRecord};
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::prompt_utils::enrich_prompt_messages;
 use crate::authorship::working_log::CheckpointKind;
@@ -11,7 +11,7 @@ use crate::git::repository::{exec_git, exec_git_stdin};
 use crate::utils::normalize_to_posix;
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::sync::LazyLock;
@@ -62,6 +62,8 @@ pub struct BlameAnalysisResult {
     pub line_authors: HashMap<u32, String>,
     pub prompt_records: HashMap<String, PromptRecord>,
     pub blame_hunks: Vec<BlameHunk>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub humans: BTreeMap<String, HumanRecord>,
 }
 
 struct PreparedBlameRequest {
@@ -405,14 +407,21 @@ impl Repository {
         let blame_hunks = self.blame_hunks_for_ranges(relative_file_path, line_ranges, options)?;
 
         // Step 2: Overlay AI authorship information.
-        let (line_authors, prompt_records, authorship_logs, prompt_commits, commits_with_notes) =
-            overlay_ai_authorship(self, &blame_hunks, relative_file_path, options)?;
+        let (
+            line_authors,
+            prompt_records,
+            humans,
+            authorship_logs,
+            prompt_commits,
+            commits_with_notes,
+        ) = overlay_ai_authorship(self, &blame_hunks, relative_file_path, options)?;
 
         Ok((
             BlameAnalysisResult {
                 line_authors,
                 prompt_records,
                 blame_hunks,
+                humans,
             },
             authorship_logs,
             prompt_commits,
@@ -541,6 +550,7 @@ impl Repository {
             line_authors,
             prompt_records,
             blame_hunks: _,
+            humans: _,
         } = analysis;
 
         if request.options.no_output {
@@ -1024,6 +1034,7 @@ fn overlay_ai_authorship(
     (
         HashMap<u32, String>,
         HashMap<String, PromptRecord>,
+        BTreeMap<String, HumanRecord>, // humans map
         Vec<AuthorshipLog>,
         HashMap<String, Vec<String>>,      // prompt_hash -> commit_shas
         std::collections::HashSet<String>, // commit SHAs with real authorship notes
@@ -1032,6 +1043,7 @@ fn overlay_ai_authorship(
 > {
     let mut line_authors: HashMap<u32, String> = HashMap::new();
     let mut prompt_records: HashMap<String, PromptRecord> = HashMap::new();
+    let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
     // Track which commits contain each prompt hash
     let mut prompt_commits: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
     // Track commit SHAs that have real (non-simulated) authorship notes
@@ -1058,8 +1070,16 @@ fn overlay_ai_authorship(
         };
 
         // If we have AI authorship data, look up the author for lines in this hunk
-        if let Some(authorship_log) = authorship_log {
+        if let Some(ref authorship_log) = authorship_log {
             commits_with_notes.insert(hunk.commit_sha.clone());
+
+            // Collect humans from this authorship log
+            for (human_id, human_record) in &authorship_log.metadata.humans {
+                humans
+                    .entry(human_id.clone())
+                    .or_insert_with(|| human_record.clone());
+            }
+
             // Check each line in this hunk for AI authorship using compact schema
             // IMPORTANT: Use the original line numbers from the commit, not the current line numbers
             let num_lines = hunk.range.1 - hunk.range.0 + 1;
@@ -1222,6 +1242,7 @@ fn overlay_ai_authorship(
     Ok((
         line_authors,
         prompt_records,
+        humans,
         authorship_logs,
         prompt_commits_vec,
         commits_with_notes,

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1,4 +1,4 @@
-use crate::authorship::authorship_log::{LineRange, PromptRecord};
+use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord};
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
@@ -149,6 +149,8 @@ pub struct DiffJsonHunk {
     pub file_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub human_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,6 +180,7 @@ pub enum Attribution {
 struct LineAttributionDetail {
     commit_sha: Option<String>,
     prompt_id: Option<String>,
+    human_id: Option<String>,
 }
 
 #[derive(Debug)]
@@ -185,6 +188,7 @@ struct DiffBuildArtifacts {
     attributions: HashMap<DiffLineKey, Attribution>,
     annotations_by_file: BTreeMap<String, BTreeMap<String, Vec<LineRange>>>,
     prompts: BTreeMap<String, PromptRecord>,
+    humans: BTreeMap<String, HumanRecord>,
     json_hunks: Vec<DiffJsonHunk>,
     commits: BTreeMap<String, DiffCommitMetadata>,
     included_files: HashSet<String>,
@@ -392,6 +396,7 @@ pub fn execute_diff(repo: &Repository, parsed: ParsedDiffArgs) -> Result<String,
             &from_commit,
             &to_commit,
             &artifacts.attributions,
+            &artifacts.humans,
             &artifacts.included_files,
         )?,
     };
@@ -739,7 +744,7 @@ pub fn overlay_diff_attributions(
     to_commit: &str,
     hunks: &[DiffHunk],
 ) -> Result<HashMap<DiffLineKey, Attribution>, GitAiError> {
-    let (_, attributions, _, _, _) = build_line_attribution_data(
+    let (_, attributions, _, _, _, _) = build_line_attribution_data(
         repo,
         from_commit,
         to_commit,
@@ -774,7 +779,7 @@ fn build_diff_artifacts(
     included_files.extend(hunks.iter().map(|h| h.file_path.clone()));
     let line_contents = build_line_content_map(&hunks);
 
-    let (annotations_by_file, attributions, line_details, prompts, mut commits) =
+    let (annotations_by_file, attributions, line_details, prompts, humans, mut commits) =
         build_line_attribution_data(repo, from_commit, to_commit, &hunks, options)?;
 
     let json_hunks = build_json_hunks(
@@ -790,6 +795,7 @@ fn build_diff_artifacts(
         attributions,
         annotations_by_file,
         prompts,
+        humans,
         json_hunks,
         commits,
         included_files,
@@ -809,6 +815,7 @@ fn build_line_attribution_data(
         HashMap<DiffLineKey, Attribution>,
         HashMap<DiffLineKey, LineAttributionDetail>,
         BTreeMap<String, PromptRecord>,
+        BTreeMap<String, HumanRecord>,
         BTreeMap<String, DiffCommitMetadata>,
     ),
     GitAiError,
@@ -818,6 +825,7 @@ fn build_line_attribution_data(
     let mut attributions: HashMap<DiffLineKey, Attribution> = HashMap::new();
     let mut line_details: HashMap<DiffLineKey, LineAttributionDetail> = HashMap::new();
     let mut prompts: BTreeMap<String, PromptRecord> = BTreeMap::new();
+    let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
     let mut commits: BTreeMap<String, DiffCommitMetadata> = BTreeMap::new();
 
     let added_lines_by_file = collect_lines_by_file(hunks, LineSide::New);
@@ -835,6 +843,7 @@ fn build_line_attribution_data(
             &mut attributions,
             &mut line_details,
             &mut prompts,
+            &mut humans,
             &mut commits,
         );
     }
@@ -855,6 +864,7 @@ fn build_line_attribution_data(
                 &mut attributions,
                 &mut line_details,
                 &mut prompts,
+                &mut humans,
                 &mut commits,
             );
         }
@@ -865,6 +875,7 @@ fn build_line_attribution_data(
         attributions,
         line_details,
         prompts,
+        humans,
         commits,
     ))
 }
@@ -883,6 +894,7 @@ fn apply_blame_for_side(
     attributions: &mut HashMap<DiffLineKey, Attribution>,
     line_details: &mut HashMap<DiffLineKey, LineAttributionDetail>,
     prompts: &mut BTreeMap<String, PromptRecord>,
+    humans: &mut BTreeMap<String, HumanRecord>,
     commits: &mut BTreeMap<String, DiffCommitMetadata>,
 ) {
     if lines.is_empty() {
@@ -933,6 +945,12 @@ fn apply_blame_for_side(
             .or_insert_with(|| prompt_record.clone());
     }
 
+    for (human_id, human_record) in &analysis.humans {
+        humans
+            .entry(human_id.clone())
+            .or_insert_with(|| human_record.clone());
+    }
+
     let mut line_to_commit: HashMap<u32, String> = HashMap::new();
     for blame_hunk in &analysis.blame_hunks {
         ensure_commit_metadata(repo, &blame_hunk.commit_sha, commits);
@@ -952,6 +970,12 @@ fn apply_blame_for_side(
 
         if let Some(author_marker) = analysis.line_authors.get(line) {
             let prompt_id = if analysis.prompt_records.contains_key(author_marker) {
+                Some(author_marker.clone())
+            } else {
+                None
+            };
+
+            let human_id = if author_marker.starts_with("h_") {
                 Some(author_marker.clone())
             } else {
                 None
@@ -981,6 +1005,7 @@ fn apply_blame_for_side(
                 LineAttributionDetail {
                     commit_sha: line_to_commit.get(line).cloned(),
                     prompt_id,
+                    human_id,
                 },
             );
         } else {
@@ -990,6 +1015,7 @@ fn apply_blame_for_side(
                 LineAttributionDetail {
                     commit_sha: None,
                     prompt_id: None,
+                    human_id: None,
                 },
             );
         }
@@ -1181,6 +1207,7 @@ fn build_json_hunk_segments(
     let mut current_start = 0u32;
     let mut current_end = 0u32;
     let mut current_prompt_id: Option<String> = None;
+    let mut current_human_id: Option<String> = None;
     let mut current_original_commit_sha: Option<String> = None;
     let mut current_commit_sha = String::new();
     let mut current_contents: Vec<String> = Vec::new();
@@ -1189,6 +1216,7 @@ fn build_json_hunk_segments(
                  current_start: &mut u32,
                  current_end: &mut u32,
                  current_prompt_id: &mut Option<String>,
+                 current_human_id: &mut Option<String>,
                  current_original_commit_sha: &mut Option<String>,
                  current_commit_sha: &mut String,
                  current_contents: &mut Vec<String>| {
@@ -1205,10 +1233,12 @@ fn build_json_hunk_segments(
             end_line: *current_end,
             file_path: diff_hunk.file_path.clone(),
             prompt_id: current_prompt_id.clone(),
+            human_id: current_human_id.clone(),
         });
         *current_start = 0;
         *current_end = 0;
         *current_prompt_id = None;
+        *current_human_id = None;
         *current_original_commit_sha = None;
         current_commit_sha.clear();
         current_contents.clear();
@@ -1222,6 +1252,7 @@ fn build_json_hunk_segments(
         };
         let detail = line_details.get(&key);
         let prompt_id = detail.and_then(|d| d.prompt_id.clone());
+        let human_id = detail.and_then(|d| d.human_id.clone());
         let original_commit_sha = if matches!(side, LineSide::Old) {
             detail.and_then(|d| d.commit_sha.clone())
         } else {
@@ -1243,6 +1274,7 @@ fn build_json_hunk_segments(
         let can_extend = current_start != 0
             && *line == current_end + 1
             && prompt_id == current_prompt_id
+            && human_id == current_human_id
             && original_commit_sha == current_original_commit_sha
             && commit_sha == current_commit_sha;
 
@@ -1252,6 +1284,7 @@ fn build_json_hunk_segments(
                 &mut current_start,
                 &mut current_end,
                 &mut current_prompt_id,
+                &mut current_human_id,
                 &mut current_original_commit_sha,
                 &mut current_commit_sha,
                 &mut current_contents,
@@ -1259,6 +1292,7 @@ fn build_json_hunk_segments(
             current_start = *line;
             current_end = *line;
             current_prompt_id = prompt_id.clone();
+            current_human_id = human_id.clone();
             current_original_commit_sha = original_commit_sha.clone();
             current_commit_sha = commit_sha;
         } else {
@@ -1273,6 +1307,7 @@ fn build_json_hunk_segments(
         &mut current_start,
         &mut current_end,
         &mut current_prompt_id,
+        &mut current_human_id,
         &mut current_original_commit_sha,
         &mut current_commit_sha,
         &mut current_contents,
@@ -1612,6 +1647,7 @@ pub fn format_annotated_diff(
     from_commit: &str,
     to_commit: &str,
     attributions: &HashMap<DiffLineKey, Attribution>,
+    humans: &BTreeMap<String, HumanRecord>,
     included_files: &HashSet<String>,
 ) -> Result<String, GitAiError> {
     let sections = get_diff_sections_by_file(repo, from_commit, to_commit)?;
@@ -1632,14 +1668,26 @@ pub fn format_annotated_diff(
                 if line.starts_with("diff --git") {
                     in_hunk = false;
                 }
-                result.push_str(&format_line(line, LineType::DiffHeader, use_color, None));
+                result.push_str(&format_line(
+                    line,
+                    LineType::DiffHeader,
+                    use_color,
+                    None,
+                    humans,
+                ));
             } else if line.starts_with("@@ ") {
                 in_hunk = true;
                 if let Some((old_start, new_start)) = parse_hunk_header_for_line_nums(line) {
                     old_line_num = old_start;
                     new_line_num = new_start;
                 }
-                result.push_str(&format_line(line, LineType::HunkHeader, use_color, None));
+                result.push_str(&format_line(
+                    line,
+                    LineType::HunkHeader,
+                    use_color,
+                    None,
+                    humans,
+                ));
             } else if in_hunk && line.starts_with('-') {
                 let key = DiffLineKey {
                     file: file_path.clone(),
@@ -1652,6 +1700,7 @@ pub fn format_annotated_diff(
                     LineType::Deletion,
                     use_color,
                     attribution,
+                    humans,
                 ));
                 old_line_num += 1;
             } else if in_hunk && line.starts_with('+') {
@@ -1666,16 +1715,35 @@ pub fn format_annotated_diff(
                     LineType::Addition,
                     use_color,
                     attribution,
+                    humans,
                 ));
                 new_line_num += 1;
             } else if in_hunk && line.starts_with(' ') {
-                result.push_str(&format_line(line, LineType::Context, use_color, None));
+                result.push_str(&format_line(
+                    line,
+                    LineType::Context,
+                    use_color,
+                    None,
+                    humans,
+                ));
                 old_line_num += 1;
                 new_line_num += 1;
             } else if line.starts_with("Binary files") {
-                result.push_str(&format_line(line, LineType::Binary, use_color, None));
+                result.push_str(&format_line(
+                    line,
+                    LineType::Binary,
+                    use_color,
+                    None,
+                    humans,
+                ));
             } else {
-                result.push_str(&format_line(line, LineType::Context, use_color, None));
+                result.push_str(&format_line(
+                    line,
+                    LineType::Context,
+                    use_color,
+                    None,
+                    humans,
+                ));
             }
         }
     }
@@ -1739,9 +1807,10 @@ fn format_line(
     line_type: LineType,
     use_color: bool,
     attribution: Option<&Attribution>,
+    humans: &BTreeMap<String, HumanRecord>,
 ) -> String {
     let annotation = if let Some(attr) = attribution {
-        format_attribution(attr)
+        format_attribution(attr, humans)
     } else {
         String::new()
     };
@@ -1782,10 +1851,18 @@ fn format_line(
     }
 }
 
-fn format_attribution(attribution: &Attribution) -> String {
+fn format_attribution(attribution: &Attribution, humans: &BTreeMap<String, HumanRecord>) -> String {
     match attribution {
         Attribution::Ai(tool) => format!("🤖{}", tool),
-        Attribution::Human(username) => format!("👤{}", username),
+        Attribution::Human(human_id) => {
+            // Resolve human_id (h_-prefixed hash) to actual author name
+            if let Some(human_record) = humans.get(human_id) {
+                format!("👤{}", human_record.author)
+            } else {
+                // Fallback to showing the ID if not found in humans map
+                format!("👤{}", human_id)
+            }
+        }
         Attribution::NoData => "[no-data]".to_string(),
     }
 }
@@ -2207,26 +2284,46 @@ mod tests {
 
     #[test]
     fn test_format_attribution_ai() {
+        let humans = BTreeMap::new();
         let attr = Attribution::Ai("cursor".to_string());
-        assert_eq!(format_attribution(&attr), "🤖cursor");
+        assert_eq!(format_attribution(&attr, &humans), "🤖cursor");
 
         let attr = Attribution::Ai("claude".to_string());
-        assert_eq!(format_attribution(&attr), "🤖claude");
+        assert_eq!(format_attribution(&attr, &humans), "🤖claude");
     }
 
     #[test]
     fn test_format_attribution_human() {
-        let attr = Attribution::Human("alice".to_string());
-        assert_eq!(format_attribution(&attr), "👤alice");
+        let mut humans = BTreeMap::new();
+        humans.insert(
+            "h_alice123".to_string(),
+            HumanRecord {
+                author: "alice".to_string(),
+            },
+        );
+        humans.insert(
+            "h_bob456".to_string(),
+            HumanRecord {
+                author: "bob@example.com".to_string(),
+            },
+        );
 
-        let attr = Attribution::Human("bob@example.com".to_string());
-        assert_eq!(format_attribution(&attr), "👤bob@example.com");
+        let attr = Attribution::Human("h_alice123".to_string());
+        assert_eq!(format_attribution(&attr, &humans), "👤alice");
+
+        let attr = Attribution::Human("h_bob456".to_string());
+        assert_eq!(format_attribution(&attr, &humans), "👤bob@example.com");
+
+        // Test fallback when human_id not in map
+        let attr = Attribution::Human("h_unknown".to_string());
+        assert_eq!(format_attribution(&attr, &humans), "👤h_unknown");
     }
 
     #[test]
     fn test_format_attribution_no_data() {
+        let humans = BTreeMap::new();
         let attr = Attribution::NoData;
-        assert_eq!(format_attribution(&attr), "[no-data]");
+        assert_eq!(format_attribution(&attr, &humans), "[no-data]");
     }
 
     #[test]
@@ -2496,6 +2593,7 @@ index abc123..def456 100644
             attributions,
             annotations_by_file,
             prompts: prompts.clone(),
+            humans: BTreeMap::new(),
             json_hunks: vec![DiffJsonHunk {
                 commit_sha: "abc".to_string(),
                 content_hash: "hash".to_string(),
@@ -2505,6 +2603,7 @@ index abc123..def456 100644
                 end_line: 6,
                 file_path: "f.rs".to_string(),
                 prompt_id: None,
+                human_id: None,
             }],
             commits: BTreeMap::new(),
             included_files: HashSet::new(),

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -83,6 +83,9 @@ pub struct DiffJson {
     pub files: BTreeMap<String, FileDiffJson>,
     /// Prompt records keyed by prompt hash
     pub prompts: BTreeMap<String, PromptRecord>,
+    /// Human records keyed by human hash (h_-prefixed)
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub humans: BTreeMap<String, HumanRecord>,
     /// Per-hunk records for machine consumption
     #[serde(default)]
     pub hunks: Vec<DiffJsonHunk>,
@@ -1531,6 +1534,7 @@ fn build_diff_json(
     Ok(DiffJson {
         files,
         prompts: prompts.clone(),
+        humans: artifacts.humans.clone(),
         hunks: artifacts.json_hunks.clone(),
         commits: artifacts.commits.clone(),
         commit_stats,

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -2863,10 +2863,12 @@ fn test_diff_json_output_includes_human_id_in_hunks() {
             );
 
             // Verify the human_id can be resolved via the humans map
-            let human_record = humans.get(human_id).expect(&format!(
-                "human_id '{}' from hunk should be resolvable in top-level humans map",
-                human_id
-            ));
+            let human_record = humans.get(human_id).unwrap_or_else(|| {
+                panic!(
+                    "human_id '{}' from hunk should be resolvable in top-level humans map",
+                    human_id
+                )
+            });
             let author = human_record["author"]
                 .as_str()
                 .expect("human record should have author field");

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -2878,6 +2878,83 @@ fn test_diff_json_output_includes_human_id_in_hunks() {
     }
 }
 
+#[test]
+fn test_diff_json_humans_map_complete_across_multiple_commits() {
+    let repo = TestRepo::new();
+
+    // Create base commit
+    write_lines(&repo, "multi_human.txt", &["line1"]);
+    checkpoint_human(&repo);
+    let _base = commit_after_staging_all(&repo, "base");
+
+    // Commit 1: First human author
+    write_lines(
+        &repo,
+        "multi_human.txt",
+        &["line1", "human_a_1", "human_a_2"],
+    );
+    checkpoint_known_human(&repo, "multi_human.txt");
+    let _commit1 = commit_after_staging_all(&repo, "first human");
+
+    // Commit 2: Second human author (creates a different h_ ID)
+    write_lines(
+        &repo,
+        "multi_human.txt",
+        &["line1", "human_a_1", "human_a_2", "human_b_1", "human_b_2"],
+    );
+    checkpoint_known_human(&repo, "multi_human.txt");
+    let commit2 = commit_after_staging_all(&repo, "second human");
+
+    // Get JSON diff for commit2 (which includes lines from both human checkpoints)
+    let diff = diff_json(&repo, &["diff", &commit2.commit_sha, "--json"]);
+
+    // Extract all human_ids from all hunks
+    let hunks = diff["hunks"].as_array().expect("hunks should be array");
+    let mut human_ids_in_hunks: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    for hunk in hunks {
+        if let Some(human_id) = hunk.get("human_id").and_then(|v| v.as_str()) {
+            human_ids_in_hunks.insert(human_id.to_string());
+        }
+    }
+
+    // Get the top-level humans map
+    let humans = diff["humans"].as_object().expect("should have humans map");
+
+    // Critical assertion: every human_id in hunks MUST be resolvable via the humans map
+    for human_id in &human_ids_in_hunks {
+        assert!(
+            humans.contains_key(human_id),
+            "human_id '{}' appears in hunks but is missing from top-level humans map. \
+             Hunks reference {} unique human_ids but humans map only contains {} entries: {:?}",
+            human_id,
+            human_ids_in_hunks.len(),
+            humans.len(),
+            humans.keys().collect::<Vec<_>>()
+        );
+
+        // Also verify the author field is present and non-empty
+        let author = humans[human_id]["author"]
+            .as_str()
+            .expect("author should be string");
+        assert!(!author.is_empty(), "author name should not be empty");
+    }
+
+    // We should have collected at least one human across the commits
+    assert!(
+        !human_ids_in_hunks.is_empty(),
+        "Should have at least one human_id across multiple commits"
+    );
+
+    // Verify humans map contains exactly the humans referenced by hunks (no orphans)
+    assert_eq!(
+        humans.len(),
+        human_ids_in_hunks.len(),
+        "humans map should contain exactly the humans referenced in hunks, no more, no less"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_diff_single_commit,
     test_diff_commit_range,
@@ -2920,4 +2997,5 @@ crate::reuse_tests_in_worktree!(
     test_diff_json_commit_author_is_full_ident,
     test_diff_visual_output_shows_human_author_name_not_id,
     test_diff_json_output_includes_human_id_in_hunks,
+    test_diff_json_humans_map_complete_across_multiple_commits,
 );

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -2839,7 +2839,17 @@ fn test_diff_json_output_includes_human_id_in_hunks() {
         human_hunks
     );
 
+    // Verify the top-level humans map is present and can resolve human_id values
+    let humans = diff["humans"]
+        .as_object()
+        .expect("JSON should have top-level humans object");
+    assert!(
+        !humans.is_empty(),
+        "humans map should not be empty when there are human-authored hunks"
+    );
+
     // If we get here, verify the human_id starts with "h_" and prompt_id is not set
+    // Also verify that each human_id can be resolved via the top-level humans map
     for hunk in &human_hunks {
         if let Some(human_id) = hunk.get("human_id").and_then(|v| v.as_str()) {
             assert!(
@@ -2850,6 +2860,19 @@ fn test_diff_json_output_includes_human_id_in_hunks() {
             assert!(
                 hunk["prompt_id"].is_null() || !hunk.as_object().unwrap().contains_key("prompt_id"),
                 "Human hunks should not have prompt_id when they have human_id"
+            );
+
+            // Verify the human_id can be resolved via the humans map
+            let human_record = humans.get(human_id).expect(&format!(
+                "human_id '{}' from hunk should be resolvable in top-level humans map",
+                human_id
+            ));
+            let author = human_record["author"]
+                .as_str()
+                .expect("human record should have author field");
+            assert!(
+                !author.is_empty(),
+                "Resolved author name should not be empty"
             );
         }
     }

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -2732,6 +2732,129 @@ fn test_diff_blame_uses_detect_copies_for_moved_ai_lines() {
     );
 }
 
+#[test]
+fn test_diff_visual_output_shows_human_author_name_not_id() {
+    let repo = TestRepo::new();
+
+    // Create a base commit
+    write_lines(&repo, "human_author.txt", &["line1", "line2"]);
+    checkpoint_human(&repo);
+    let _base = commit_after_staging_all(&repo, "base commit");
+
+    // Add lines and create a known human checkpoint with a specific author
+    write_lines(
+        &repo,
+        "human_author.txt",
+        &["line1", "line2", "line3", "line4"],
+    );
+    checkpoint_known_human(&repo, "human_author.txt");
+    let commit = commit_after_staging_all(&repo, "human changes");
+
+    // Get visual diff output (not JSON)
+    let output = repo
+        .git_ai(&["diff", &commit.commit_sha])
+        .expect("diff should succeed");
+
+    // Parse the diff to find the added lines
+    let lines = parse_diff_output(&output);
+    let line3 = lines
+        .iter()
+        .find(|l| l.prefix == "+" && l.content.contains("line3"))
+        .expect("should find +line3");
+    let line4 = lines
+        .iter()
+        .find(|l| l.prefix == "+" && l.content.contains("line4"))
+        .expect("should find +line4");
+
+    // The visual output should show the author name, not the h_-prefixed ID
+    assert!(line3.attribution.is_some(), "line3 should have attribution");
+    let attr = line3.attribution.as_ref().unwrap();
+    assert!(
+        attr.starts_with("human:"),
+        "line3 attribution should be human, got: {}",
+        attr
+    );
+
+    // Extract the displayed name from attribution (format is "human:<name>")
+    let displayed_name = attr.strip_prefix("human:").unwrap();
+
+    // Bug: Currently shows the h_-prefixed ID instead of the author name
+    // Expected behavior: should show a readable author name like "Test User <test@example.com>"
+    // Actual behavior: shows "h_9e95a89b42f1fb" (the hash ID)
+    // This assertion will fail until we fix it
+    assert!(
+        !displayed_name.starts_with("h_"),
+        "Visual output should show human author name, not human ID '{}'. Full output:\n{}",
+        displayed_name,
+        output
+    );
+
+    // Verify line4 has the same attribution
+    assert_eq!(
+        line4.attribution, line3.attribution,
+        "line4 should have same attribution as line3"
+    );
+}
+
+#[test]
+fn test_diff_json_output_includes_human_id_in_hunks() {
+    let repo = TestRepo::new();
+
+    // Create a base commit
+    write_lines(&repo, "human_json.txt", &["base1", "base2"]);
+    checkpoint_human(&repo);
+    let _base = commit_after_staging_all(&repo, "base commit");
+
+    // Add lines with known human checkpoint
+    write_lines(
+        &repo,
+        "human_json.txt",
+        &["base1", "base2", "human1", "human2"],
+    );
+    checkpoint_known_human(&repo, "human_json.txt");
+    let commit = commit_after_staging_all(&repo, "human additions");
+
+    // Get JSON diff output
+    let diff = diff_json(&repo, &["diff", &commit.commit_sha, "--json"]);
+
+    // Verify the hunks array contains human_id field
+    let hunks = diff["hunks"].as_array().expect("hunks should be an array");
+
+    // Find hunks for our file
+    let human_hunks: Vec<&Value> = hunks
+        .iter()
+        .filter(|h| h["file_path"] == "human_json.txt" && h["hunk_kind"] == "addition")
+        .collect();
+
+    assert!(!human_hunks.is_empty(), "should have addition hunks");
+
+    // Bug: Currently human_id field is missing from hunks
+    // Expected: hunks should have a "human_id" field set to the h_-prefixed hash
+    // Actual: only "prompt_id" field exists (for AI), no equivalent for humans
+    // This assertion will fail until we fix it
+    let has_human_id = human_hunks.iter().any(|h| h.get("human_id").is_some());
+    assert!(
+        has_human_id,
+        "At least one human hunk should have human_id field. Found hunks: {:?}",
+        human_hunks
+    );
+
+    // If we get here, verify the human_id starts with "h_" and prompt_id is not set
+    for hunk in &human_hunks {
+        if let Some(human_id) = hunk.get("human_id").and_then(|v| v.as_str()) {
+            assert!(
+                human_id.starts_with("h_"),
+                "human_id should start with h_ prefix, got: {}",
+                human_id
+            );
+            assert!(
+                hunk["prompt_id"].is_null() || !hunk.as_object().unwrap().contains_key("prompt_id"),
+                "Human hunks should not have prompt_id when they have human_id"
+            );
+        }
+    }
+}
+
 crate::reuse_tests_in_worktree!(
     test_diff_single_commit,
     test_diff_commit_range,
@@ -2772,4 +2895,6 @@ crate::reuse_tests_in_worktree!(
     test_diff_json_deleted_hunks_strict_mixed_origins_and_contiguous_segments,
     test_diff_json_deleted_hunks_same_content_but_different_origins,
     test_diff_json_commit_author_is_full_ident,
+    test_diff_visual_output_shows_human_author_name_not_id,
+    test_diff_json_output_includes_human_id_in_hunks,
 );


### PR DESCRIPTION
## Summary
Fixes two bugs in the `git ai diff` command related to human authorship display:

1. **Visual output bug**: Diff was showing the internal h_-prefixed ID (e.g., `👤h_9e95a89b42f1fb`) instead of the actual author name (e.g., `👤Sasha Varlamov <sasha@example.com>`) from the humans object in the authorship note.

2. **JSON output bug**: The JSON `hunks` array was missing the `human_id` field for human-authored lines. It only included `prompt_id` for AI-authored lines, making it inconsistent.

## Changes
- Added `humans: BTreeMap<String, HumanRecord>` to `BlameAnalysisResult` to propagate human records through the blame pipeline
- Updated `overlay_ai_authorship()` to collect and return the humans map from authorship logs
- Modified `format_attribution()` to resolve human IDs to actual author names by looking them up in the humans map
- Added `human_id` field to `DiffJsonHunk` and `LineAttributionDetail` structures
- Updated `build_json_hunks()` to populate `human_id` field for human-authored lines, mirroring how `prompt_id` works for AI lines
- Added comprehensive tests that verify both bugs are fixed

## Test plan
- [x] Added failing test `test_diff_visual_output_shows_human_author_name_not_id` proving visual bug
- [x] Added failing test `test_diff_json_output_includes_human_id_in_hunks` proving JSON bug
- [x] Both tests now pass with the fixes
- [x] All 84 diff integration tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with rustfmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
