### PR TITLE
feat(windsurf): auto-install VS Code extension for known_human checkpoint

### DIFF
--- a/src/mdm/agents/windsurf.rs
+++ b/src/mdm/agents/windsurf.rs
@@ -1,8 +1,13 @@
 use crate::error::GitAiError;
-use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
-use crate::mdm::utils::{
-    binary_exists, generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic,
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
+use crate::mdm::utils::{
+    binary_exists, generate_diff, home_dir, install_vsc_editor_extension,
+    is_git_ai_checkpoint_command, is_github_codespaces, is_vsc_editor_extension_installed,
+    resolve_editor_cli, write_atomic,
+};
+use crate::utils::debug_log;
 use serde_json::{Value, json};
 use std::fs;
 use std::path::PathBuf;
@@ -204,15 +209,38 @@ impl HookInstaller for WindsurfInstaller {
     }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let resolved_cli = resolve_editor_cli("windsurf");
+        let has_cli = resolved_cli.is_some();
         let has_binary = binary_exists("windsurf");
         let has_dotfiles = home_dir().join(".codeium").join("windsurf").exists();
 
-        if !has_binary && !has_dotfiles {
+        if !has_cli && !has_binary && !has_dotfiles {
             return Ok(HookCheckResult {
                 tool_installed: false,
                 hooks_installed: false,
                 hooks_up_to_date: false,
             });
+        }
+
+        // Check if VS Code extension is installed
+        if let Some(cli) = &resolved_cli {
+            match is_vsc_editor_extension_installed(cli, "git-ai.git-ai-vscode") {
+                Ok(true) => {
+                    return Ok(HookCheckResult {
+                        tool_installed: true,
+                        hooks_installed: true,
+                        hooks_up_to_date: true,
+                    });
+                }
+                Ok(false) => {
+                    return Ok(HookCheckResult {
+                        tool_installed: true,
+                        hooks_installed: false,
+                        hooks_up_to_date: false,
+                    });
+                }
+                Err(_) => {}
+            }
         }
 
         // Check all hook locations
@@ -301,5 +329,97 @@ impl HookInstaller for WindsurfInstaller {
         } else {
             Ok(Some(all_diffs.join("\n")))
         }
+    }
+
+    fn install_extras(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        let mut results = Vec::new();
+
+        // Skip extension installation in GitHub Codespaces
+        // Extensions must be configured via devcontainer.json in Codespaces
+        if is_github_codespaces() {
+            results.push(InstallResult {
+                changed: false,
+                diff: None,
+                message: "Windsurf: Unable to install extension in GitHub Codespaces. Add to your devcontainer.json: \"customizations\": { \"vscode\": { \"extensions\": [\"git-ai.git-ai-vscode\"] } }".to_string(),
+            });
+            return Ok(results);
+        }
+
+        // Install VS Code extension
+        if let Some(cli) = resolve_editor_cli("windsurf") {
+            match is_vsc_editor_extension_installed(&cli, "git-ai.git-ai-vscode") {
+                Ok(true) => {
+                    results.push(InstallResult {
+                        changed: false,
+                        diff: None,
+                        message: "Windsurf: Extension already installed".to_string(),
+                    });
+                }
+                Ok(false) => {
+                    if dry_run {
+                        results.push(InstallResult {
+                            changed: true,
+                            diff: None,
+                            message: "Windsurf: Pending extension install".to_string(),
+                        });
+                    } else {
+                        println!("Installing extensions...");
+                        println!("\tInstalling extension 'git-ai.git-ai-vscode'...");
+                        match install_vsc_editor_extension(&cli, "git-ai.git-ai-vscode") {
+                            Ok(()) => {
+                                results.push(InstallResult {
+                                    changed: true,
+                                    diff: None,
+                                    message: "\tExtension 'git-ai.git-ai-vscode' was successfully installed.".to_string(),
+                                });
+                            }
+                            Err(e) => {
+                                debug_log(&format!(
+                                    "Windsurf: Error automatically installing extension: {}",
+                                    e
+                                ));
+                                results.push(InstallResult {
+                                    changed: false,
+                                    diff: None,
+                                    message: "Windsurf: Unable to automatically install extension. Please cmd+click on the following link to install: windsurf:extension/git-ai.git-ai-vscode (or search for 'git-ai-vscode' in the Windsurf extensions tab)".to_string(),
+                                });
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    results.push(InstallResult {
+                        changed: false,
+                        diff: None,
+                        message: format!("Windsurf: Failed to check extension: {}", e),
+                    });
+                }
+            }
+        } else {
+            results.push(InstallResult {
+                changed: false,
+                diff: None,
+                message: "Windsurf: Unable to automatically install extension. Please cmd+click on the following link to install: windsurf:extension/git-ai.git-ai-vscode (or search for 'git-ai-vscode' in the Windsurf extensions tab)".to_string(),
+            });
+        }
+
+        Ok(results)
+    }
+
+    fn uninstall_extras(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<UninstallResult>, GitAiError> {
+        Ok(vec![UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Windsurf: Extension must be uninstalled manually through the editor"
+                .to_string(),
+        }])
     }
 }

--- a/src/mdm/agents/windsurf.rs
+++ b/src/mdm/agents/windsurf.rs
@@ -3,9 +3,8 @@ use crate::mdm::hook_installer::{
     HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
 use crate::mdm::utils::{
-    binary_exists, generate_diff, home_dir, install_vsc_editor_extension,
-    is_git_ai_checkpoint_command, is_github_codespaces, is_vsc_editor_extension_installed,
-    resolve_editor_cli, write_atomic,
+    generate_diff, home_dir, install_vsc_editor_extension, is_git_ai_checkpoint_command,
+    is_github_codespaces, is_vsc_editor_extension_installed, resolve_editor_cli, write_atomic,
 };
 use crate::utils::debug_log;
 use serde_json::{Value, json};
@@ -209,38 +208,15 @@ impl HookInstaller for WindsurfInstaller {
     }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
-        let resolved_cli = resolve_editor_cli("windsurf");
-        let has_cli = resolved_cli.is_some();
-        let has_binary = binary_exists("windsurf");
+        let has_cli = resolve_editor_cli("windsurf").is_some();
         let has_dotfiles = home_dir().join(".codeium").join("windsurf").exists();
 
-        if !has_cli && !has_binary && !has_dotfiles {
+        if !has_cli && !has_dotfiles {
             return Ok(HookCheckResult {
                 tool_installed: false,
                 hooks_installed: false,
                 hooks_up_to_date: false,
             });
-        }
-
-        // Check if VS Code extension is installed
-        if let Some(cli) = &resolved_cli {
-            match is_vsc_editor_extension_installed(cli, "git-ai.git-ai-vscode") {
-                Ok(true) => {
-                    return Ok(HookCheckResult {
-                        tool_installed: true,
-                        hooks_installed: true,
-                        hooks_up_to_date: true,
-                    });
-                }
-                Ok(false) => {
-                    return Ok(HookCheckResult {
-                        tool_installed: true,
-                        hooks_installed: false,
-                        hooks_up_to_date: false,
-                    });
-                }
-                Err(_) => {}
-            }
         }
 
         // Check all hook locations

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -261,6 +261,51 @@ fn get_editor_cli_candidates(cli_name: &str) -> Vec<(PathBuf, PathBuf)> {
                 }
             }
         }
+        "windsurf" => {
+            #[cfg(target_os = "macos")]
+            {
+                for apps_dir in [PathBuf::from("/Applications"), home.join("Applications")] {
+                    let app = apps_dir.join("Windsurf.app");
+                    candidates.push((
+                        app.join("Contents").join("MacOS").join("Windsurf"),
+                        app.join("Contents")
+                            .join("Resources")
+                            .join("app")
+                            .join("out")
+                            .join("cli.js"),
+                    ));
+                }
+            }
+            #[cfg(all(unix, not(target_os = "macos")))]
+            {
+                for base in [
+                    PathBuf::from("/opt/Windsurf"),
+                    home.join(".local").join("share").join("windsurf"),
+                    home.join(".local").join("share").join("Windsurf"),
+                ] {
+                    candidates.push((
+                        base.join("windsurf"),
+                        base.join("resources")
+                            .join("app")
+                            .join("out")
+                            .join("cli.js"),
+                    ));
+                }
+            }
+            #[cfg(windows)]
+            {
+                if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+                    let base = PathBuf::from(local_app_data).join("Programs").join("Windsurf");
+                    candidates.push((
+                        base.join("Windsurf.exe"),
+                        base.join("resources")
+                            .join("app")
+                            .join("out")
+                            .join("cli.js"),
+                    ));
+                }
+            }
+        }
         "code" => {
             #[cfg(target_os = "macos")]
             {

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -295,7 +295,9 @@ fn get_editor_cli_candidates(cli_name: &str) -> Vec<(PathBuf, PathBuf)> {
             #[cfg(windows)]
             {
                 if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
-                    let base = PathBuf::from(local_app_data).join("Programs").join("Windsurf");
+                    let base = PathBuf::from(local_app_data)
+                        .join("Programs")
+                        .join("Windsurf");
                     candidates.push((
                         base.join("Windsurf.exe"),
                         base.join("resources")


### PR DESCRIPTION
## Summary
- Adds Windsurf path candidates to `get_editor_cli_candidates()` (macOS, Linux, Windows) so `resolve_editor_cli("windsurf")` works
- Updates `WindsurfInstaller` to also install/check the `git-ai.git-ai-vscode` VS Code extension, mirroring the existing `CursorInstaller` pattern exactly
- No new extension code needed — Windsurf is VS Code-based and the existing extension already detects Windsurf via `host-kind.ts`

## How it works
When a user runs `git-ai install-hooks`, the Windsurf installer now calls `windsurf --install-extension git-ai.git-ai-vscode`. The VS Code extension then fires `git-ai checkpoint known_human --hook-input stdin` on every file save (500ms debounce), identical to the VS Code and Cursor flows.

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
