### PR TITLE
feat(eclipse): add known_human checkpoint plugin

### DIFF
--- a/agent-support/eclipse/plugin/META-INF/MANIFEST.MF
+++ b/agent-support/eclipse/plugin/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: io.gitai.eclipse;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: io.gitai.eclipse.Activator
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.0.0",
- org.eclipse.core.runtime;bundle-version="3.0.0"
+ org.eclipse.core.runtime;bundle-version="3.0.0",
+ org.eclipse.ui;bundle-version="3.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/agent-support/eclipse/plugin/META-INF/MANIFEST.MF
+++ b/agent-support/eclipse/plugin/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: git-ai Eclipse Plugin
+Bundle-SymbolicName: io.gitai.eclipse;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Activator: io.gitai.eclipse.Activator
+Require-Bundle: org.eclipse.core.resources;bundle-version="3.0.0",
+ org.eclipse.core.runtime;bundle-version="3.0.0"
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/agent-support/eclipse/plugin/plugin.xml
+++ b/agent-support/eclipse/plugin/plugin.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+  <extension point="org.eclipse.ui.startup">
+    <startup class="io.gitai.eclipse.Startup"/>
+  </extension>
+</plugin>

--- a/agent-support/eclipse/plugin/pom.xml
+++ b/agent-support/eclipse/plugin/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.gitai</groupId>
+    <artifactId>eclipse-plugin-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>io.gitai.eclipse</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>4.0.6</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/agent-support/eclipse/plugin/src/io/gitai/eclipse/Activator.java
+++ b/agent-support/eclipse/plugin/src/io/gitai/eclipse/Activator.java
@@ -7,6 +7,8 @@ public class Activator extends Plugin {
     public static final String PLUGIN_ID = "io.gitai.eclipse";
     private static Activator instance;
 
+    private volatile GitAiSaveListener listener;
+
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
@@ -15,8 +17,16 @@ public class Activator extends Plugin {
 
     @Override
     public void stop(BundleContext context) throws Exception {
+        if (listener != null) {
+            listener.shutdown();
+            listener = null;
+        }
         instance = null;
         super.stop(context);
+    }
+
+    public void setListener(GitAiSaveListener listener) {
+        this.listener = listener;
     }
 
     public static Activator getDefault() { return instance; }

--- a/agent-support/eclipse/plugin/src/io/gitai/eclipse/Activator.java
+++ b/agent-support/eclipse/plugin/src/io/gitai/eclipse/Activator.java
@@ -1,0 +1,23 @@
+package io.gitai.eclipse;
+
+import org.eclipse.core.runtime.Plugin;
+import org.osgi.framework.BundleContext;
+
+public class Activator extends Plugin {
+    public static final String PLUGIN_ID = "io.gitai.eclipse";
+    private static Activator instance;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        super.start(context);
+        instance = this;
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        instance = null;
+        super.stop(context);
+    }
+
+    public static Activator getDefault() { return instance; }
+}

--- a/agent-support/eclipse/plugin/src/io/gitai/eclipse/GitAiSaveListener.java
+++ b/agent-support/eclipse/plugin/src/io/gitai/eclipse/GitAiSaveListener.java
@@ -1,0 +1,153 @@
+package io.gitai.eclipse;
+
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.CoreException;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class GitAiSaveListener implements IResourceChangeListener {
+
+    private static final long DEBOUNCE_MS = 500;
+    private static final String GIT_AI_BIN = resolveGitAiBin();
+
+    private final ScheduledExecutorService scheduler =
+            Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "git-ai-debounce");
+                t.setDaemon(true);
+                return t;
+            });
+
+    // per repo root -> debounce future
+    private final ConcurrentHashMap<String, ScheduledFuture<?>> futures = new ConcurrentHashMap<>();
+    // per repo root -> accumulated files {path -> content}
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> pending =
+            new ConcurrentHashMap<>();
+
+    private static String resolveGitAiBin() {
+        String home = System.getProperty("user.home");
+        String bin = home + "/.git-ai/bin/git-ai";
+        if (new File(bin).exists()) return bin;
+        // Windows
+        bin = home + "\\.git-ai\\bin\\git-ai.exe";
+        if (new File(bin).exists()) return bin;
+        return "git-ai"; // fallback to PATH
+    }
+
+    @Override
+    public void resourceChanged(IResourceChangeEvent event) {
+        if (event.getDelta() == null) return;
+        Set<String> repoRoots = new HashSet<>();
+        collectChanges(event.getDelta(), repoRoots);
+        for (String root : repoRoots) {
+            scheduleCheckpoint(root);
+        }
+    }
+
+    private void collectChanges(IResourceDelta delta, Set<String> repoRoots) {
+        IResource resource = delta.getResource();
+        if (resource instanceof IFile) {
+            IFile file = (IFile) resource;
+            if ((delta.getFlags() & IResourceDelta.CONTENT) != 0 &&
+                    (delta.getKind() & IResourceDelta.CHANGED) != 0) {
+                String path = file.getLocation().toOSString();
+                if (path.contains("/.git/") || path.contains("\\.git\\")) return;
+                String root = findRepoRoot(file.getParent());
+                if (root == null) return;
+                pending.computeIfAbsent(root, k -> new ConcurrentHashMap<>())
+                        .put(path, readFileContent(file));
+                repoRoots.add(root);
+            }
+        }
+        for (IResourceDelta child : delta.getAffectedChildren()) {
+            collectChanges(child, repoRoots);
+        }
+    }
+
+    private String readFileContent(IFile file) {
+        try (InputStream is = file.getContents()) {
+            return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String findRepoRoot(IContainer container) {
+        if (container == null) return null;
+        if (container.findMember(".git") != null) {
+            return container.getLocation().toOSString();
+        }
+        return findRepoRoot(container.getParent());
+    }
+
+    private void scheduleCheckpoint(String repoRoot) {
+        ScheduledFuture<?> existing = futures.get(repoRoot);
+        if (existing != null) existing.cancel(false);
+        ScheduledFuture<?> future = scheduler.schedule(
+                () -> fireCheckpoint(repoRoot), DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+        futures.put(repoRoot, future);
+    }
+
+    private void fireCheckpoint(String repoRoot) {
+        futures.remove(repoRoot);
+        Map<String, String> files = pending.remove(repoRoot);
+        if (files == null || files.isEmpty()) return;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("editor", "eclipse");
+        payload.put("editor_version", System.getProperty("eclipse.buildId", "unknown"));
+        payload.put("extension_version", "1.0.0");
+        payload.put("cwd", repoRoot);
+        payload.put("edited_filepaths", new ArrayList<>(files.keySet()));
+        payload.put("dirty_files", files);
+
+        String json = toJson(payload);
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                    GIT_AI_BIN, "checkpoint", "known_human", "--hook-input", "stdin");
+            pb.directory(new File(repoRoot));
+            pb.redirectErrorStream(true);
+            Process proc = pb.start();
+            try (OutputStream stdin = proc.getOutputStream()) {
+                stdin.write(json.getBytes(StandardCharsets.UTF_8));
+            }
+            proc.waitFor(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            // Best-effort; don't surface errors to the user
+        }
+    }
+
+    // Simple JSON builder — no external deps needed
+    private static String toJson(Map<String, Object> map) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> e : map.entrySet()) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("\"").append(e.getKey()).append("\":");
+            appendValue(sb, e.getValue());
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void appendValue(StringBuilder sb, Object v) {
+        if (v instanceof String) {
+            sb.append("\"").append(((String) v)
+                .replace("\\", "\\\\").replace("\"", "\\\"")
+                .replace("\n", "\\n").replace("\r", "\\r")).append("\"");
+        } else if (v instanceof List) {
+            sb.append("[");
+            boolean f = true;
+            for (Object item : (List<?>) v) { if (!f) sb.append(","); f = false; appendValue(sb, item); }
+            sb.append("]");
+        } else if (v instanceof Map) {
+            sb.append(toJson((Map<String, Object>) v));
+        } else {
+            sb.append(v);
+        }
+    }
+}

--- a/agent-support/eclipse/plugin/src/io/gitai/eclipse/GitAiSaveListener.java
+++ b/agent-support/eclipse/plugin/src/io/gitai/eclipse/GitAiSaveListener.java
@@ -20,6 +20,12 @@ public class GitAiSaveListener implements IResourceChangeListener {
                 return t;
             });
 
+    private final ExecutorService ioExecutor = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "git-ai-checkpoint-io");
+        t.setDaemon(true);
+        return t;
+    });
+
     // per repo root -> debounce future
     private final ConcurrentHashMap<String, ScheduledFuture<?>> futures = new ConcurrentHashMap<>();
     // per repo root -> accumulated files {path -> content}
@@ -76,6 +82,7 @@ public class GitAiSaveListener implements IResourceChangeListener {
 
     private String findRepoRoot(IContainer container) {
         if (container == null) return null;
+        if (container instanceof IWorkspaceRoot) return null;
         if (container.findMember(".git") != null) {
             return container.getLocation().toOSString();
         }
@@ -83,11 +90,10 @@ public class GitAiSaveListener implements IResourceChangeListener {
     }
 
     private void scheduleCheckpoint(String repoRoot) {
-        ScheduledFuture<?> existing = futures.get(repoRoot);
-        if (existing != null) existing.cancel(false);
-        ScheduledFuture<?> future = scheduler.schedule(
-                () -> fireCheckpoint(repoRoot), DEBOUNCE_MS, TimeUnit.MILLISECONDS);
-        futures.put(repoRoot, future);
+        futures.compute(repoRoot, (key, existing) -> {
+            if (existing != null) existing.cancel(false);
+            return scheduler.schedule(() -> fireCheckpoint(repoRoot), DEBOUNCE_MS, TimeUnit.MILLISECONDS);
+        });
     }
 
     private void fireCheckpoint(String repoRoot) {
@@ -104,19 +110,27 @@ public class GitAiSaveListener implements IResourceChangeListener {
         payload.put("dirty_files", files);
 
         String json = toJson(payload);
-        try {
-            ProcessBuilder pb = new ProcessBuilder(
-                    GIT_AI_BIN, "checkpoint", "known_human", "--hook-input", "stdin");
-            pb.directory(new File(repoRoot));
-            pb.redirectErrorStream(true);
-            Process proc = pb.start();
-            try (OutputStream stdin = proc.getOutputStream()) {
-                stdin.write(json.getBytes(StandardCharsets.UTF_8));
+        ioExecutor.submit(() -> {
+            try {
+                ProcessBuilder pb = new ProcessBuilder(
+                        GIT_AI_BIN, "checkpoint", "known_human", "--hook-input", "stdin");
+                pb.directory(new File(repoRoot));
+                pb.redirectErrorStream(true);
+                Process proc = pb.start();
+                try (OutputStream stdin = proc.getOutputStream()) {
+                    stdin.write(json.getBytes(StandardCharsets.UTF_8));
+                }
+                proc.waitFor(10, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                // Best-effort; don't surface errors to the user
             }
-            proc.waitFor(10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            // Best-effort; don't surface errors to the user
-        }
+        });
+    }
+
+    public void shutdown() {
+        scheduler.shutdownNow();
+        ioExecutor.shutdownNow();
+        ResourcesPlugin.getWorkspace().removeResourceChangeListener(this);
     }
 
     // Simple JSON builder — no external deps needed
@@ -138,7 +152,8 @@ public class GitAiSaveListener implements IResourceChangeListener {
         if (v instanceof String) {
             sb.append("\"").append(((String) v)
                 .replace("\\", "\\\\").replace("\"", "\\\"")
-                .replace("\n", "\\n").replace("\r", "\\r")).append("\"");
+                .replace("\n", "\\n").replace("\r", "\\r")
+                .replace("\t", "\\t")).append("\"");
         } else if (v instanceof List) {
             sb.append("[");
             boolean f = true;

--- a/agent-support/eclipse/plugin/src/io/gitai/eclipse/Startup.java
+++ b/agent-support/eclipse/plugin/src/io/gitai/eclipse/Startup.java
@@ -10,5 +10,6 @@ public class Startup implements IStartup {
         GitAiSaveListener listener = new GitAiSaveListener();
         ResourcesPlugin.getWorkspace().addResourceChangeListener(
             listener, IResourceChangeEvent.POST_CHANGE);
+        Activator.getDefault().setListener(listener);
     }
 }

--- a/agent-support/eclipse/plugin/src/io/gitai/eclipse/Startup.java
+++ b/agent-support/eclipse/plugin/src/io/gitai/eclipse/Startup.java
@@ -1,0 +1,14 @@
+package io.gitai.eclipse;
+
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.ui.IStartup;
+
+public class Startup implements IStartup {
+    @Override
+    public void earlyStartup() {
+        GitAiSaveListener listener = new GitAiSaveListener();
+        ResourcesPlugin.getWorkspace().addResourceChangeListener(
+            listener, IResourceChangeEvent.POST_CHANGE);
+    }
+}

--- a/agent-support/eclipse/pom.xml
+++ b/agent-support/eclipse/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.gitai</groupId>
+  <artifactId>eclipse-plugin-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>plugin</module>
+  </modules>
+</project>

--- a/src/mdm/agents/eclipse.rs
+++ b/src/mdm/agents/eclipse.rs
@@ -7,9 +7,15 @@ use crate::mdm::utils::{binary_exists, home_dir};
 pub struct EclipseInstaller;
 
 impl HookInstaller for EclipseInstaller {
-    fn name(&self) -> &str { "Eclipse" }
-    fn id(&self) -> &str { "eclipse" }
-    fn uses_config_hooks(&self) -> bool { false }
+    fn name(&self) -> &str {
+        "Eclipse"
+    }
+    fn id(&self) -> &str {
+        "eclipse"
+    }
+    fn uses_config_hooks(&self) -> bool {
+        false
+    }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         // Detect Eclipse by binary or by presence of the Eclipse p2 provisioning metadata
@@ -18,9 +24,13 @@ impl HookInstaller for EclipseInstaller {
         // Check common Eclipse install locations
         let has_app = {
             #[cfg(target_os = "macos")]
-            { std::path::Path::new("/Applications/Eclipse.app").exists() }
+            {
+                std::path::Path::new("/Applications/Eclipse.app").exists()
+            }
             #[cfg(not(target_os = "macos"))]
-            { false }
+            {
+                false
+            }
         };
 
         let tool_installed = has_binary || has_p2 || has_app;
@@ -62,7 +72,8 @@ impl HookInstaller for EclipseInstaller {
                 "Install the plugin manually via Help → Install New Software → ",
                 "Add update site URL from https://github.com/git-ai-project/git-ai/releases, ",
                 "then restart Eclipse."
-            ).to_string(),
+            )
+            .to_string(),
         }])
     }
 }
@@ -86,6 +97,11 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        assert!(EclipseInstaller.install_hooks(&params, false).unwrap().is_none());
+        assert!(
+            EclipseInstaller
+                .install_hooks(&params, false)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/src/mdm/agents/eclipse.rs
+++ b/src/mdm/agents/eclipse.rs
@@ -1,0 +1,91 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult,
+};
+use crate::mdm::utils::{binary_exists, home_dir};
+
+pub struct EclipseInstaller;
+
+impl HookInstaller for EclipseInstaller {
+    fn name(&self) -> &str { "Eclipse" }
+    fn id(&self) -> &str { "eclipse" }
+    fn uses_config_hooks(&self) -> bool { false }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        // Detect Eclipse by binary or by presence of the Eclipse p2 provisioning metadata
+        let has_binary = binary_exists("eclipse");
+        let has_p2 = home_dir().join(".p2").join("pool").exists();
+        // Check common Eclipse install locations
+        let has_app = {
+            #[cfg(target_os = "macos")]
+            { std::path::Path::new("/Applications/Eclipse.app").exists() }
+            #[cfg(not(target_os = "macos"))]
+            { false }
+        };
+
+        let tool_installed = has_binary || has_p2 || has_app;
+        // Plugin install detection would require scanning the Eclipse plugins dir;
+        // for now we report not-installed and show manual instructions.
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed: false,
+            hooks_up_to_date: false,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: concat!(
+                "Eclipse: Automatic installation is not supported. ",
+                "Install the plugin manually via Help → Install New Software → ",
+                "Add update site URL from https://github.com/git-ai-project/git-ai/releases, ",
+                "then restart Eclipse."
+            ).to_string(),
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eclipse_installer_name() {
+        assert_eq!(EclipseInstaller.name(), "Eclipse");
+    }
+
+    #[test]
+    fn test_eclipse_installer_id() {
+        assert_eq!(EclipseInstaller.id(), "eclipse");
+    }
+
+    #[test]
+    fn test_eclipse_install_hooks_returns_none() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        assert!(EclipseInstaller.install_hooks(&params, false).unwrap().is_none());
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -3,6 +3,7 @@ mod claude_code;
 mod codex;
 mod cursor;
 mod droid;
+mod eclipse;
 mod firebender;
 mod gemini;
 mod github_copilot;
@@ -16,6 +17,7 @@ pub use claude_code::ClaudeCodeInstaller;
 pub use codex::CodexInstaller;
 pub use cursor::CursorInstaller;
 pub use droid::DroidInstaller;
+pub use eclipse::EclipseInstaller;
 pub use firebender::FirebenderInstaller;
 pub use gemini::GeminiInstaller;
 pub use github_copilot::GitHubCopilotInstaller;
@@ -38,6 +40,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(OpenCodeInstaller),
         Box::new(GeminiInstaller),
         Box::new(DroidInstaller),
+        Box::new(EclipseInstaller),
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
         Box::new(WindsurfInstaller),


### PR DESCRIPTION
## Summary
- New Java OSGi Eclipse plugin (`agent-support/eclipse/`) that fires `git-ai checkpoint known_human --hook-input stdin` on file save with 500ms debounce per git repo root
- Uses `IResourceChangeListener` (`POST_CHANGE` events) — the standard Eclipse API for file-save tracking
- No external dependencies — JSON is built with a small inline helper
- New `EclipseInstaller` Rust struct that detects Eclipse and surfaces manual install instructions

## Manual install steps (for docs site)
1. Open Eclipse
2. Go to **Help → Install New Software**
3. Click **Add…** and enter the update site URL: `https://github.com/git-ai-project/git-ai/releases` (update site TBD — add actual URL when published)
4. Select **git-ai Eclipse Plugin** and click **Install**
5. Restart Eclipse when prompted

Or build from source:
```bash
cd agent-support/eclipse
mvn package
# Install the resulting .jar into Eclipse's dropins/ folder
```

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
