### PR TITLE
feat(xcode): add known_human checkpoint via FSEvents watcher

### DIFF
--- a/agent-support/xcode/Package.swift
+++ b/agent-support/xcode/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "git-ai-xcode-watcher",
+    platforms: [.macOS(.v12)],
+    targets: [
+        .executableTarget(
+            name: "git-ai-xcode-watcher",
+            path: "Sources/git-ai-xcode-watcher"
+        )
+    ]
+)

--- a/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
+++ b/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
@@ -1,0 +1,134 @@
+import Foundation
+import CoreServices
+
+// MARK: - Globals
+var watchedPaths: [String] = []
+var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [path: content]
+var debounceItems: [String: DispatchWorkItem] = []  // repoRoot -> work item
+let queue = DispatchQueue(label: "io.gitai.xcode-watcher", qos: .utility)
+let gitAiBin: String = {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let dev = "\(home)/.git-ai/bin/git-ai"
+    if FileManager.default.fileExists(atPath: dev) { return dev }
+    return "git-ai"
+}()
+
+// MARK: - Utilities
+func findRepoRoot(for path: String) -> String? {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = ["-C", path, "rev-parse", "--show-toplevel"]
+    let pipe = Pipe()
+    proc.standardOutput = pipe
+    proc.standardError = Pipe()
+    try? proc.run()
+    proc.waitUntilExit()
+    guard proc.terminationStatus == 0 else { return nil }
+    let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    return out?.isEmpty == false ? out : nil
+}
+
+func readFileContents(_ path: String) -> String? {
+    try? String(contentsOfFile: path, encoding: .utf8)
+}
+
+func shouldSkip(_ path: String) -> Bool {
+    let skip = ["/.git/", "/DerivedData/", "/xcuserdata/", "/.build/", ".DS_Store"]
+    return skip.contains { path.contains($0) }
+}
+
+func fireCheckpoint(repoRoot: String) {
+    queue.async {
+        guard let files = pendingFiles[repoRoot], !files.isEmpty else { return }
+        pendingFiles[repoRoot] = nil
+
+        let payload: [String: Any] = [
+            "editor": "xcode",
+            "editor_version": "unknown",
+            "extension_version": "1.0.0",
+            "cwd": repoRoot,
+            "edited_filepaths": Array(files.keys),
+            "dirty_files": files
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+              let jsonStr = String(data: jsonData, encoding: .utf8) else { return }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: gitAiBin)
+        proc.arguments = ["checkpoint", "known_human", "--hook-input", "stdin"]
+        proc.currentDirectoryURL = URL(fileURLWithPath: repoRoot)
+        let stdinPipe = Pipe()
+        proc.standardInput = stdinPipe
+        proc.standardOutput = Pipe()
+        proc.standardError = Pipe()
+        try? proc.run()
+        stdinPipe.fileHandleForWriting.write(jsonStr.data(using: .utf8)!)
+        stdinPipe.fileHandleForWriting.closeFile()
+        proc.waitUntilExit()
+    }
+}
+
+func scheduleDebounce(repoRoot: String) {
+    debounceItems[repoRoot]?.cancel()
+    let item = DispatchWorkItem { fireCheckpoint(repoRoot: repoRoot) }
+    debounceItems[repoRoot] = item
+    queue.asyncAfter(deadline: .now() + 0.5, execute: item)
+}
+
+// MARK: - FSEvents callback
+let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
+    let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as! [String]
+    var roots = Set<String>()
+    for path in paths {
+        guard !shouldSkip(path) else { continue }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir),
+              !isDir.boolValue else { continue }
+        let dir = (path as NSString).deletingLastPathComponent
+        guard let root = findRepoRoot(for: dir) else { continue }
+        guard let content = readFileContents(path) else { continue }
+        queue.sync {
+            if pendingFiles[root] == nil { pendingFiles[root] = [:] }
+            pendingFiles[root]![path] = content
+        }
+        roots.insert(root)
+    }
+    for root in roots { scheduleDebounce(repoRoot: root) }
+}
+
+// MARK: - Main
+var args = CommandLine.arguments.dropFirst()
+var paths: [String] = []
+var i = args.startIndex
+while i < args.endIndex {
+    if args[i] == "--path", args.index(after: i) < args.endIndex {
+        i = args.index(after: i)
+        paths.append(args[i])
+    }
+    i = args.index(after: i)
+}
+if paths.isEmpty { paths = [FileManager.default.currentDirectoryPath] }
+
+// Canonicalize paths
+let watchPaths = paths.map { ($0 as NSString).standardizingPath } as CFArray
+
+var context = FSEventStreamContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
+guard let stream = FSEventStreamCreate(
+    kCFAllocatorDefault,
+    callback,
+    &context,
+    watchPaths,
+    FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+    0.1,
+    FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer)
+) else {
+    fputs("git-ai-xcode-watcher: failed to create FSEvents stream\n", stderr)
+    exit(1)
+}
+
+FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
+FSEventStreamStart(stream)
+print("git-ai-xcode-watcher: watching \(paths.joined(separator: ", "))")
+CFRunLoopRun()

--- a/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
+++ b/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
@@ -5,6 +5,7 @@ import CoreServices
 var watchedPaths: [String] = []
 var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [path: content]
 var debounceItems: [String: DispatchWorkItem] = []  // repoRoot -> work item
+var repoRootCache: [String: String?] = [:]          // dir -> repoRoot (nil = not a repo)
 let queue = DispatchQueue(label: "io.gitai.xcode-watcher", qos: .utility)
 let gitAiBin: String = {
     let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -14,19 +15,29 @@ let gitAiBin: String = {
 }()
 
 // MARK: - Utilities
-func findRepoRoot(for path: String) -> String? {
+func findRepoRoot(for filePath: String) -> String? {
+    let dir = (filePath as NSString).deletingLastPathComponent
+    if let cached = repoRootCache[dir] {
+        return cached
+    }
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-    proc.arguments = ["-C", path, "rev-parse", "--show-toplevel"]
+    proc.arguments = ["-C", dir, "rev-parse", "--show-toplevel"]
     let pipe = Pipe()
     proc.standardOutput = pipe
     proc.standardError = Pipe()
     try? proc.run()
     proc.waitUntilExit()
-    guard proc.terminationStatus == 0 else { return nil }
-    let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-    return out?.isEmpty == false ? out : nil
+    let result: String?
+    if proc.terminationStatus == 0 {
+        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        result = out?.isEmpty == false ? out : nil
+    } else {
+        result = nil
+    }
+    repoRootCache[dir] = result
+    return result
 }
 
 func readFileContents(_ path: String) -> String? {
@@ -39,37 +50,36 @@ func shouldSkip(_ path: String) -> Bool {
 }
 
 func fireCheckpoint(repoRoot: String) {
-    queue.async {
-        guard let files = pendingFiles[repoRoot], !files.isEmpty else { return }
-        pendingFiles[repoRoot] = nil
+    guard let files = pendingFiles[repoRoot], !files.isEmpty else { return }
+    pendingFiles[repoRoot] = nil
 
-        let payload: [String: Any] = [
-            "editor": "xcode",
-            "editor_version": "unknown",
-            "extension_version": "1.0.0",
-            "cwd": repoRoot,
-            "edited_filepaths": Array(files.keys),
-            "dirty_files": files
-        ]
+    let payload: [String: Any] = [
+        "editor": "xcode",
+        "editor_version": "unknown",
+        "extension_version": "1.0.0",
+        "cwd": repoRoot,
+        "edited_filepaths": Array(files.keys),
+        "dirty_files": files
+    ]
 
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
-              let jsonStr = String(data: jsonData, encoding: .utf8) else { return }
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
+          let jsonStr = String(data: jsonData, encoding: .utf8) else { return }
 
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: gitAiBin)
-        proc.arguments = ["checkpoint", "known_human", "--hook-input", "stdin"]
-        proc.currentDirectoryURL = URL(fileURLWithPath: repoRoot)
-        let stdinPipe = Pipe()
-        proc.standardInput = stdinPipe
-        proc.standardOutput = Pipe()
-        proc.standardError = Pipe()
-        try? proc.run()
-        stdinPipe.fileHandleForWriting.write(jsonStr.data(using: .utf8)!)
-        stdinPipe.fileHandleForWriting.closeFile()
-        proc.waitUntilExit()
-    }
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: gitAiBin)
+    proc.arguments = ["checkpoint", "known_human", "--hook-input", "stdin"]
+    proc.currentDirectoryURL = URL(fileURLWithPath: repoRoot)
+    let stdinPipe = Pipe()
+    proc.standardInput = stdinPipe
+    proc.standardOutput = Pipe()
+    proc.standardError = Pipe()
+    try? proc.run()
+    stdinPipe.fileHandleForWriting.write(jsonStr.data(using: .utf8)!)
+    stdinPipe.fileHandleForWriting.closeFile()
+    proc.waitUntilExit()
 }
 
+// Must be called on `queue`.
 func scheduleDebounce(repoRoot: String) {
     debounceItems[repoRoot]?.cancel()
     let item = DispatchWorkItem { fireCheckpoint(repoRoot: repoRoot) }
@@ -79,23 +89,31 @@ func scheduleDebounce(repoRoot: String) {
 
 // MARK: - FSEvents callback
 let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
-    let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as! [String]
-    var roots = Set<String>()
+    guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String] else { return }
+    // Collect candidate file paths on the RunLoop thread (cheap checks only).
+    var candidates: [String] = []
     for path in paths {
         guard !shouldSkip(path) else { continue }
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir),
               !isDir.boolValue else { continue }
-        let dir = (path as NSString).deletingLastPathComponent
-        guard let root = findRepoRoot(for: dir) else { continue }
-        guard let content = readFileContents(path) else { continue }
-        queue.sync {
+        candidates.append(path)
+    }
+    guard !candidates.isEmpty else { return }
+    // Dispatch all heavy work (git subprocess, file reads, debounce scheduling) onto `queue`
+    // so that `pendingFiles`, `debounceItems`, and `repoRootCache` are only accessed from
+    // a single serial queue, eliminating data races.
+    queue.async {
+        var roots = Set<String>()
+        for path in candidates {
+            guard let root = findRepoRoot(for: path) else { continue }
+            guard let content = readFileContents(path) else { continue }
             if pendingFiles[root] == nil { pendingFiles[root] = [:] }
             pendingFiles[root]![path] = content
+            roots.insert(root)
         }
-        roots.insert(root)
+        for root in roots { scheduleDebounce(repoRoot: root) }
     }
-    for root in roots { scheduleDebounce(repoRoot: root) }
 }
 
 // MARK: - Main

--- a/agent-support/xcode/com.gitai.xcode-watcher.plist
+++ b/agent-support/xcode/com.gitai.xcode-watcher.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.gitai.xcode-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/PATH/TO/git-ai-xcode-watcher</string>
+        <string>--path</string>
+        <string>/PATH/TO/YOUR/PROJECT</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/git-ai-xcode-watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/git-ai-xcode-watcher.log</string>
+</dict>
+</plist>

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -10,6 +10,7 @@ mod jetbrains;
 mod opencode;
 mod vscode;
 mod windsurf;
+#[cfg(target_os = "macos")]
 mod xcode;
 
 pub use amp::AmpInstaller;
@@ -24,6 +25,7 @@ pub use jetbrains::JetBrainsInstaller;
 pub use opencode::OpenCodeInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
+#[cfg(target_os = "macos")]
 pub use xcode::XcodeInstaller;
 
 use super::hook_installer::HookInstaller;
@@ -43,6 +45,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
         Box::new(WindsurfInstaller),
+        #[cfg(target_os = "macos")]
         Box::new(XcodeInstaller),
     ]
 }

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -10,6 +10,7 @@ mod jetbrains;
 mod opencode;
 mod vscode;
 mod windsurf;
+mod xcode;
 
 pub use amp::AmpInstaller;
 pub use claude_code::ClaudeCodeInstaller;
@@ -23,6 +24,7 @@ pub use jetbrains::JetBrainsInstaller;
 pub use opencode::OpenCodeInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
+pub use xcode::XcodeInstaller;
 
 use super::hook_installer::HookInstaller;
 
@@ -41,5 +43,6 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
         Box::new(WindsurfInstaller),
+        Box::new(XcodeInstaller),
     ]
 }

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -46,22 +46,16 @@ impl HookInstaller for XcodeInstaller {
 
     fn install_extras(
         &self,
-        params: &HookInstallerParams,
+        _params: &HookInstallerParams,
         _dry_run: bool,
     ) -> Result<Vec<InstallResult>, GitAiError> {
-        let bin = params.binary_path.display();
         Ok(vec![InstallResult {
             changed: false,
             diff: None,
-            message: format!(
-                "Xcode: Automatic installation is not supported. \
-                 To enable known_human tracking, add the following to your Xcode scheme's \
-                 Pre-action (Product → Scheme → Edit Scheme → Build → Pre-actions):\n\
-                 \n\
-                 {bin}-xcode-watcher --path \"${{SRCROOT}}\"\n\
-                 \n\
-                 Or run as a background daemon — see docs for the launchd plist setup.",
-            ),
+            message: "Xcode: Install git-ai-xcode-watcher daemon. \
+                      Download from releases or build from agent-support/xcode/. \
+                      Run: launchctl load ~/Library/LaunchAgents/io.gitai.xcode-watcher.plist"
+                .to_string(),
         }])
     }
 }

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -1,0 +1,103 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult,
+};
+use std::path::Path;
+
+pub struct XcodeInstaller;
+
+impl HookInstaller for XcodeInstaller {
+    fn name(&self) -> &str {
+        "Xcode"
+    }
+
+    fn id(&self) -> &str {
+        "xcode"
+    }
+
+    fn uses_config_hooks(&self) -> bool {
+        false
+    }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let tool_installed = is_xcode_installed();
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed: false,
+            hooks_up_to_date: false,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(
+        &self,
+        params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        let bin = params.binary_path.display();
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: format!(
+                "Xcode: Automatic installation is not supported. \
+                 To enable known_human tracking, add the following to your Xcode scheme's \
+                 Pre-action (Product → Scheme → Edit Scheme → Build → Pre-actions):\n\
+                 \n\
+                 {bin}-xcode-watcher --path \"${{SRCROOT}}\"\n\
+                 \n\
+                 Or run as a background daemon — see docs for the launchd plist setup.",
+            ),
+        }])
+    }
+}
+
+fn is_xcode_installed() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        Path::new("/Applications/Xcode.app").exists()
+            || Path::new("/Applications/Xcode-beta.app").exists()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = Path::new("");
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_xcode_installer_name() {
+        assert_eq!(XcodeInstaller.name(), "Xcode");
+    }
+
+    #[test]
+    fn test_xcode_installer_id() {
+        assert_eq!(XcodeInstaller.id(), "xcode");
+    }
+
+    #[test]
+    fn test_xcode_install_hooks_returns_none() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        assert!(XcodeInstaller.install_hooks(&params, false).unwrap().is_none());
+    }
+}

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -98,6 +98,11 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        assert!(XcodeInstaller.install_hooks(&params, false).unwrap().is_none());
+        assert!(
+            XcodeInstaller
+                .install_hooks(&params, false)
+                .unwrap()
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- New Swift CLI `git-ai-xcode-watcher` (`agent-support/xcode/`) that uses CoreServices `FSEventStreamCreate` to watch project directories for file writes and fires `git-ai checkpoint known_human --hook-input stdin` with 500ms debounce per git repo root
- Xcode Source Editor Extensions don't expose file-save events, so this uses an FSEvents-based daemon approach instead
- New `XcodeInstaller` Rust struct (detects Xcode, surfaces manual setup steps)

## Manual setup steps (for docs site)

### Option 1: Xcode scheme pre-action
1. Build `git-ai-xcode-watcher` from `agent-support/xcode/`: `swift build -c release`
2. Copy the binary to a permanent location (e.g., `~/.git-ai/bin/git-ai-xcode-watcher`)
3. In Xcode: **Product → Scheme → Edit Scheme → Build → Pre-actions → +**
4. Add a "Run Script" action:
   ```bash
   ~/.git-ai/bin/git-ai-xcode-watcher --path "${SRCROOT}" &
   ```

### Option 2: launchd daemon
1. Build and install `git-ai-xcode-watcher` as above
2. Copy and edit `agent-support/xcode/com.gitai.xcode-watcher.plist` (update paths)
3. `launchctl load ~/Library/LaunchAgents/com.gitai.xcode-watcher.plist`

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
