### PR TITLE
feat(vim): add known_human checkpoint plugin

### DIFF
--- a/agent-support/vim/doc/git-ai.txt
+++ b/agent-support/vim/doc/git-ai.txt
@@ -1,0 +1,29 @@
+*git-ai.txt*  Known-human authorship tracking for git-ai
+
+INTRODUCTION                                    *git-ai*
+
+This plugin fires `git-ai checkpoint known_human` whenever you save a file
+in a git repository. This lets git-ai correctly attribute your edits as
+human-authored lines after an AI coding session.
+
+CONFIGURATION                                   *git-ai-config*
+
+Disable the plugin:
+>
+    let g:git_ai_enabled = 0
+<
+
+INSTALLATION                                    *git-ai-install*
+
+Native packages (Vim 8+):
+>
+    mkdir -p ~/.vim/pack/git-ai/start/git-ai
+    cp -r /path/to/agent-support/vim/* ~/.vim/pack/git-ai/start/git-ai/
+<
+
+vim-plug:
+>
+    Plug 'git-ai-project/git-ai', {'rtp': 'agent-support/vim'}
+<
+
+vim: ft=help

--- a/agent-support/vim/plugin/git_ai.vim
+++ b/agent-support/vim/plugin/git_ai.vim
@@ -68,20 +68,35 @@ function! s:BuildJsonPayload(root, files) abort
     let l:escaped_content = substitute(l:escaped_content, '"', '\\"', 'g')
     let l:escaped_content = substitute(l:escaped_content, "\n", '\\n', 'g')
     let l:escaped_content = substitute(l:escaped_content, "\r", '\\r', 'g')
+    let l:escaped_content = substitute(l:escaped_content, "\t", '\\t', 'g')
     let l:paths_json .= '"' . l:escaped_path . '"'
     let l:dirty_json .= '"' . l:escaped_path . '":"' . l:escaped_content . '"'
   endfor
   let l:paths_json .= ']'
   let l:dirty_json .= '}'
-  let l:version = string(v:version)
-  return '{"editor":"vim","editor_version":"' . l:version .
+  if has('nvim')
+    let l:editor = 'neovim'
+    " Neovim version: major.minor.patch
+    let l:editor_ver = luaeval('vim.version().major') . '.' .
+      \ luaeval('vim.version().minor') . '.' .
+      \ luaeval('vim.version().patch')
+  else
+    let l:editor = 'vim'
+    let l:editor_ver = string(v:version)
+  endif
+  let l:escaped_cwd = substitute(a:root, '\\', '\\\\', 'g')
+  let l:escaped_cwd = substitute(l:escaped_cwd, '"', '\\"', 'g')
+  return '{"editor":"' . l:editor . '","editor_version":"' . l:editor_ver .
     \ '","extension_version":"1.0.0","cwd":"' .
-    \ substitute(a:root, '"', '\\"', 'g') .
+    \ l:escaped_cwd .
     \ '","edited_filepaths":' . l:paths_json .
     \ ',"dirty_files":' . l:dirty_json . '}'
 endfunction
 
 function! s:FireCheckpoint(root) abort
+  if has_key(s:debounce_timers, a:root)
+    unlet s:debounce_timers[a:root]
+  endif
   if !has_key(s:pending_files, a:root)
     return
   endif

--- a/agent-support/vim/plugin/git_ai.vim
+++ b/agent-support/vim/plugin/git_ai.vim
@@ -1,0 +1,168 @@
+" git-ai known_human checkpoint plugin for Vim
+" Fires `git-ai checkpoint known_human --hook-input stdin` after each file save.
+" Debounced 500ms per git repository root.
+"
+" Installation (native packages, Vim 8+):
+"   mkdir -p ~/.vim/pack/git-ai/start/git-ai
+"   cp -r /path/to/agent-support/vim/* ~/.vim/pack/git-ai/start/git-ai/
+"
+" Installation (vim-plug):
+"   Plug 'git-ai-project/git-ai', {'rtp': 'agent-support/vim'}
+"
+" Installation (Vundle):
+"   Plugin 'git-ai-project/git-ai'
+"   (add 'set runtimepath+=~/.vim/bundle/git-ai/agent-support/vim' to .vimrc)
+
+if exists('g:loaded_git_ai') | finish | endif
+let g:loaded_git_ai = 1
+
+" Set to 0 to disable: let g:git_ai_enabled = 0
+if !exists('g:git_ai_enabled')
+  let g:git_ai_enabled = 1
+endif
+
+" Internal state: per repo root timers and pending files
+let s:debounce_timers = {}
+let s:pending_files = {}
+
+function! s:GitAiBin() abort
+  " Check known install locations first
+  let l:candidates = [
+    \ expand('~/.git-ai/bin/git-ai'),
+    \ expand('~/.git-ai/bin/git-ai.exe'),
+    \ ]
+  for l:c in l:candidates
+    if executable(l:c)
+      return l:c
+    endif
+  endfor
+  return 'git-ai'
+endfunction
+
+function! s:FindRepoRoot(file) abort
+  let l:dir = fnamemodify(a:file, ':h')
+  if l:dir ==# ''
+    return ''
+  endif
+  let l:result = systemlist(['git', '-C', l:dir, 'rev-parse', '--show-toplevel'])
+  if v:shell_error != 0 || empty(l:result)
+    return ''
+  endif
+  return trim(l:result[0])
+endfunction
+
+function! s:BuildJsonPayload(root, files) abort
+  " Build JSON manually — no external dependencies
+  let l:paths_json = '['
+  let l:dirty_json = '{'
+  let l:first = 1
+  for [l:path, l:content] in items(a:files)
+    if !l:first
+      let l:paths_json .= ','
+      let l:dirty_json .= ','
+    endif
+    let l:first = 0
+    let l:escaped_path = substitute(l:path, '\\', '\\\\', 'g')
+    let l:escaped_path = substitute(l:escaped_path, '"', '\\"', 'g')
+    let l:escaped_content = substitute(l:content, '\\', '\\\\', 'g')
+    let l:escaped_content = substitute(l:escaped_content, '"', '\\"', 'g')
+    let l:escaped_content = substitute(l:escaped_content, "\n", '\\n', 'g')
+    let l:escaped_content = substitute(l:escaped_content, "\r", '\\r', 'g')
+    let l:paths_json .= '"' . l:escaped_path . '"'
+    let l:dirty_json .= '"' . l:escaped_path . '":"' . l:escaped_content . '"'
+  endfor
+  let l:paths_json .= ']'
+  let l:dirty_json .= '}'
+  let l:version = string(v:version)
+  return '{"editor":"vim","editor_version":"' . l:version .
+    \ '","extension_version":"1.0.0","cwd":"' .
+    \ substitute(a:root, '"', '\\"', 'g') .
+    \ '","edited_filepaths":' . l:paths_json .
+    \ ',"dirty_files":' . l:dirty_json . '}'
+endfunction
+
+function! s:FireCheckpoint(root) abort
+  if !has_key(s:pending_files, a:root)
+    return
+  endif
+  let l:files = s:pending_files[a:root]
+  unlet s:pending_files[a:root]
+  if empty(l:files)
+    return
+  endif
+
+  let l:payload = s:BuildJsonPayload(a:root, l:files)
+  let l:bin = s:GitAiBin()
+  let l:cmd = [l:bin, 'checkpoint', 'known_human', '--hook-input', 'stdin']
+
+  if has('job') && has('channel')
+    " Vim 8+ async job API
+    let l:opts = {
+      \ 'in_io': 'pipe',
+      \ 'out_io': 'null',
+      \ 'err_io': 'null',
+      \ }
+    let l:job = job_start(l:cmd, l:opts)
+    if job_status(l:job) ==# 'run'
+      let l:chan = job_getchannel(l:job)
+      call ch_sendraw(l:chan, l:payload)
+      call ch_close_in(l:chan)
+    endif
+  else
+    " Fallback: synchronous (Vim < 8.0)
+    let l:shell_cmd = join(map(copy(l:cmd), 'shellescape(v:val)'), ' ')
+    call system(l:shell_cmd, l:payload)
+  endif
+endfunction
+
+function! s:OnSave() abort
+  if !g:git_ai_enabled
+    return
+  endif
+  let l:file = expand('<afile>:p')
+  if l:file ==# ''
+    return
+  endif
+  " Skip git-internal files
+  if l:file =~# '[/\\]\.git[/\\]'
+    return
+  endif
+  let l:root = s:FindRepoRoot(l:file)
+  if l:root ==# ''
+    return
+  endif
+
+  " Read current buffer content
+  let l:bufnr = bufnr(l:file)
+  if l:bufnr > 0
+    let l:content = join(getbufline(l:bufnr, 1, '$'), "\n")
+  else
+    " File closed within debounce window — read from disk
+    let l:lines = readfile(l:file)
+    let l:content = join(l:lines, "\n")
+  endif
+
+  if !has_key(s:pending_files, l:root)
+    let s:pending_files[l:root] = {}
+  endif
+  let s:pending_files[l:root][l:file] = l:content
+
+  " Cancel existing timer and start a new 500ms debounce
+  if has_key(s:debounce_timers, l:root) && s:debounce_timers[l:root] >= 0
+    call timer_stop(s:debounce_timers[l:root])
+  endif
+
+  if has('timers')
+    let l:root_copy = l:root
+    let s:debounce_timers[l:root] = timer_start(500,
+      \ {-> s:FireCheckpoint(l:root_copy)})
+  else
+    " No timer support (Vim < 8.0): fire synchronously after a short delay
+    call s:FireCheckpoint(l:root)
+  endif
+endfunction
+
+augroup git_ai_known_human
+  autocmd!
+  autocmd BufWritePost * call s:OnSave()
+augroup END

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -8,8 +8,8 @@ mod gemini;
 mod github_copilot;
 mod jetbrains;
 mod opencode;
-mod vscode;
 mod vim;
+mod vscode;
 mod windsurf;
 
 pub use amp::AmpInstaller;

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -9,6 +9,7 @@ mod github_copilot;
 mod jetbrains;
 mod opencode;
 mod vscode;
+mod vim;
 mod windsurf;
 
 pub use amp::AmpInstaller;
@@ -21,6 +22,7 @@ pub use gemini::GeminiInstaller;
 pub use github_copilot::GitHubCopilotInstaller;
 pub use jetbrains::JetBrainsInstaller;
 pub use opencode::OpenCodeInstaller;
+pub use vim::VimInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
 
@@ -40,6 +42,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(DroidInstaller),
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
+        Box::new(VimInstaller),
         Box::new(WindsurfInstaller),
     ]
 }

--- a/src/mdm/agents/vim.rs
+++ b/src/mdm/agents/vim.rs
@@ -18,7 +18,7 @@ impl HookInstaller for VimInstaller {
     }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
-        let tool_installed = binary_exists("vim") || binary_exists("gvim");
+        let tool_installed = binary_exists("vim") || binary_exists("gvim") || binary_exists("nvim");
         Ok(HookCheckResult {
             tool_installed,
             hooks_installed: false,

--- a/src/mdm/agents/vim.rs
+++ b/src/mdm/agents/vim.rs
@@ -1,0 +1,87 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult,
+};
+use crate::mdm::utils::binary_exists;
+
+pub struct VimInstaller;
+
+impl HookInstaller for VimInstaller {
+    fn name(&self) -> &str { "Vim" }
+    fn id(&self) -> &str { "vim" }
+    fn uses_config_hooks(&self) -> bool { false }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let tool_installed = binary_exists("vim") || binary_exists("gvim");
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed: false,
+            hooks_up_to_date: false,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: concat!(
+                "Vim: Automatic installation is not supported. ",
+                "Install the plugin using one of these methods:\n",
+                "\n",
+                "  Native packages (Vim 8+):\n",
+                "    mkdir -p ~/.vim/pack/git-ai/start/git-ai\n",
+                "    cp -r <repo>/agent-support/vim/* ~/.vim/pack/git-ai/start/git-ai/\n",
+                "\n",
+                "  vim-plug (~/.vimrc):\n",
+                "    Plug 'git-ai-project/git-ai', {'rtp': 'agent-support/vim'}\n",
+                "\n",
+                "  Vundle (~/.vimrc):\n",
+                "    Plugin 'git-ai-project/git-ai'\n",
+                "    (also add: set rtp+=~/.vim/bundle/git-ai/agent-support/vim)",
+            ).to_string(),
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vim_installer_name() {
+        assert_eq!(VimInstaller.name(), "Vim");
+    }
+
+    #[test]
+    fn test_vim_installer_id() {
+        assert_eq!(VimInstaller.id(), "vim");
+    }
+
+    #[test]
+    fn test_vim_install_hooks_returns_none() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        assert!(VimInstaller.install_hooks(&params, false).unwrap().is_none());
+    }
+}

--- a/src/mdm/agents/vim.rs
+++ b/src/mdm/agents/vim.rs
@@ -7,9 +7,15 @@ use crate::mdm::utils::binary_exists;
 pub struct VimInstaller;
 
 impl HookInstaller for VimInstaller {
-    fn name(&self) -> &str { "Vim" }
-    fn id(&self) -> &str { "vim" }
-    fn uses_config_hooks(&self) -> bool { false }
+    fn name(&self) -> &str {
+        "Vim"
+    }
+    fn id(&self) -> &str {
+        "vim"
+    }
+    fn uses_config_hooks(&self) -> bool {
+        false
+    }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let tool_installed = binary_exists("vim") || binary_exists("gvim");
@@ -58,7 +64,8 @@ impl HookInstaller for VimInstaller {
                 "  Vundle (~/.vimrc):\n",
                 "    Plugin 'git-ai-project/git-ai'\n",
                 "    (also add: set rtp+=~/.vim/bundle/git-ai/agent-support/vim)",
-            ).to_string(),
+            )
+            .to_string(),
         }])
     }
 }
@@ -82,6 +89,11 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        assert!(VimInstaller.install_hooks(&params, false).unwrap().is_none());
+        assert!(
+            VimInstaller
+                .install_hooks(&params, false)
+                .unwrap()
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- New Vimscript plugin (`agent-support/vim/`) that fires `git-ai checkpoint known_human --hook-input stdin` on file save with 500ms debounce per git repo root
- Uses `BufWritePost` autocmd + `timer_start(500, ...)` for async debounce
- Uses Vim 8+ async job API (`job_start`/`ch_sendraw`) for non-blocking git-ai calls; falls back to synchronous `system()` on Vim < 8.0
- New `VimInstaller` Rust struct that detects Vim and surfaces manual install instructions

## Manual install steps (for docs site)

### Native packages (Vim 8+)
```bash
mkdir -p ~/.vim/pack/git-ai/start/git-ai
cp -r agent-support/vim/* ~/.vim/pack/git-ai/start/git-ai/
```

### vim-plug (`~/.vimrc`)
```vim
Plug 'git-ai-project/git-ai', {'rtp': 'agent-support/vim'}
```

### Vundle (`~/.vimrc`)
```vim
Plugin 'git-ai-project/git-ai'
```
Add to `.vimrc`: `set rtp+=~/.vim/bundle/git-ai/agent-support/vim`

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
