### PR TITLE
feat(neovim): add known_human checkpoint plugin

### DIFF
--- a/agent-support/neovim/README.md
+++ b/agent-support/neovim/README.md
@@ -1,0 +1,54 @@
+# git-ai Neovim Plugin
+
+Fires `git-ai checkpoint known_human --hook-input stdin` on every file save,
+debounced 500 ms per git repository root.
+
+## Requirements
+
+- Neovim 0.8+
+- `git-ai` installed at `~/.git-ai/bin/git-ai` (or available on `$PATH`)
+
+## Installation
+
+### lazy.nvim (recommended)
+
+```lua
+{ 'git-ai-project/git-ai', opts = {} }
+```
+
+### packer.nvim
+
+```lua
+use {
+  'git-ai-project/git-ai',
+  config = function() require('git-ai').setup() end,
+}
+```
+
+### Native (`~/.config/nvim/init.lua`)
+
+```bash
+# Copy or symlink the plugin directory into your Neovim runtime path
+cp -r agent-support/neovim ~/.local/share/nvim/site/pack/git-ai/start/git-ai
+```
+
+Or add to `init.lua`:
+
+```lua
+vim.opt.rtp:prepend('/path/to/agent-support/neovim')
+require('git-ai').setup()
+```
+
+## Configuration
+
+```lua
+require('git-ai').setup({
+  enabled = true,  -- set to false to disable (default: true)
+})
+```
+
+## Disabling at runtime
+
+```vim
+:let g:git_ai_enabled = v:false
+```

--- a/agent-support/neovim/lua/git-ai/init.lua
+++ b/agent-support/neovim/lua/git-ai/init.lua
@@ -1,0 +1,138 @@
+--- git-ai known_human checkpoint plugin for Neovim
+--- Fires `git-ai checkpoint known_human --hook-input stdin` after each file save,
+--- debounced 500ms per git repository root.
+---
+--- Setup (lazy.nvim):
+---   { 'git-ai-project/git-ai', opts = {} }
+---
+--- Setup (packer.nvim):
+---   use { 'git-ai-project/git-ai', config = function() require('git-ai').setup() end }
+---
+--- Setup (native, ~/.config/nvim/init.lua):
+---   require('git-ai').setup()    -- after adding plugin dir to rtp
+
+local M = {}
+
+--- Per-repo-root state
+local timers = {}   -- [repo_root] -> uv.timer
+local pending = {}  -- [repo_root] -> { [path] = content }
+
+--- Resolve the git-ai binary path.
+local function git_ai_bin()
+  local home = vim.fn.expand('~')
+  local candidates = {
+    home .. '/.git-ai/bin/git-ai',
+    home .. '/.git-ai/bin/git-ai.exe',
+  }
+  for _, p in ipairs(candidates) do
+    if vim.fn.executable(p) == 1 then
+      return p
+    end
+  end
+  return 'git-ai'
+end
+
+--- Find the nearest .git directory walking up from `file`.
+--- Returns the repo root path, or nil.
+local function find_repo_root(file)
+  local dir = vim.fn.fnamemodify(file, ':h')
+  if dir == '' then return nil end
+  local result = vim.fn.systemlist({'git', '-C', dir, 'rev-parse', '--show-toplevel'})
+  if vim.v.shell_error ~= 0 or #result == 0 then return nil end
+  local root = result[1]
+  return (root and root ~= '') and root or nil
+end
+
+--- Fire the checkpoint for `root` with all accumulated pending files.
+local function fire(root)
+  local files = pending[root]
+  if not files or next(files) == nil then return end
+  pending[root] = {}
+
+  local paths = {}
+  for p in pairs(files) do table.insert(paths, p) end
+
+  local payload = vim.json.encode({
+    editor            = 'neovim',
+    editor_version    = tostring(vim.version()),
+    extension_version = '1.0.0',
+    cwd               = root,
+    edited_filepaths  = paths,
+    dirty_files       = files,
+  })
+
+  local bin = git_ai_bin()
+  local stdin_pipe = vim.loop.new_pipe(false)
+  local handle, _ = vim.loop.spawn(bin, {
+    args  = {'checkpoint', 'known_human', '--hook-input', 'stdin'},
+    stdio = {stdin_pipe, nil, nil},
+    cwd   = root,
+  }, function(code, _)
+    if code ~= 0 then
+      vim.schedule(function()
+        vim.notify('[git-ai] checkpoint known_human exited with code ' .. code, vim.log.levels.DEBUG)
+      end)
+    end
+  end)
+
+  if not handle then
+    stdin_pipe:close()
+    return
+  end
+
+  stdin_pipe:write(payload, function()
+    stdin_pipe:shutdown(function()
+      stdin_pipe:close()
+    end)
+  end)
+end
+
+--- BufWritePost callback.
+local function on_save(args)
+  if vim.g.git_ai_enabled == false then return end
+
+  local file = vim.api.nvim_buf_get_name(args.buf)
+  if file == '' then return end
+
+  -- Skip git-internal paths
+  if file:find('[/\\]%.git[/\\]') then return end
+
+  local root = find_repo_root(file)
+  if not root then return end
+
+  -- Collect buffer content
+  local lines = vim.api.nvim_buf_get_lines(args.buf, 0, -1, false)
+  local content = table.concat(lines, '\n')
+
+  if not pending[root] then pending[root] = {} end
+  pending[root][file] = content
+
+  -- Cancel existing debounce and start a new 500ms timer
+  if timers[root] then
+    timers[root]:stop()
+    -- Reuse the same timer object
+    timers[root]:start(500, 0, vim.schedule_wrap(function() fire(root) end))
+  else
+    local t = vim.loop.new_timer()
+    timers[root] = t
+    t:start(500, 0, vim.schedule_wrap(function() fire(root) end))
+  end
+end
+
+--- Setup the plugin. Call this once during Neovim startup.
+--- @param opts table|nil Optional config. Pass { enabled = false } to disable.
+function M.setup(opts)
+  opts = opts or {}
+  if opts.enabled == false then
+    vim.g.git_ai_enabled = false
+    return
+  end
+  vim.g.git_ai_enabled = true
+
+  vim.api.nvim_create_autocmd('BufWritePost', {
+    group    = vim.api.nvim_create_augroup('GitAiKnownHuman', {clear = true}),
+    callback = on_save,
+  })
+end
+
+return M

--- a/agent-support/neovim/lua/git-ai/init.lua
+++ b/agent-support/neovim/lua/git-ai/init.lua
@@ -13,9 +13,14 @@
 
 local M = {}
 
+local uv = vim.uv or vim.loop  -- vim.uv available since Neovim 0.9
+
 --- Per-repo-root state
 local timers = {}   -- [repo_root] -> uv.timer
 local pending = {}  -- [repo_root] -> { [path] = content }
+
+--- Cache for find_repo_root results to avoid blocking systemlist calls per save.
+local _repo_root_cache = {}  -- [dir] -> root_string or false
 
 --- Resolve the git-ai binary path.
 local function git_ai_bin()
@@ -37,10 +42,13 @@ end
 local function find_repo_root(file)
   local dir = vim.fn.fnamemodify(file, ':h')
   if dir == '' then return nil end
+  if _repo_root_cache[dir] ~= nil then
+    return _repo_root_cache[dir] or nil  -- false means "no repo"
+  end
   local result = vim.fn.systemlist({'git', '-C', dir, 'rev-parse', '--show-toplevel'})
-  if vim.v.shell_error ~= 0 or #result == 0 then return nil end
-  local root = result[1]
-  return (root and root ~= '') and root or nil
+  local root = (vim.v.shell_error == 0 and #result > 0 and result[1] ~= '') and result[1] or false
+  _repo_root_cache[dir] = root
+  return root or nil
 end
 
 --- Fire the checkpoint for `root` with all accumulated pending files.
@@ -52,9 +60,12 @@ local function fire(root)
   local paths = {}
   for p in pairs(files) do table.insert(paths, p) end
 
+  local v = vim.version()
+  local editor_version = string.format('%d.%d.%d', v.major, v.minor, v.patch)
+
   local payload = vim.json.encode({
     editor            = 'neovim',
-    editor_version    = tostring(vim.version()),
+    editor_version    = editor_version,
     extension_version = '1.0.0',
     cwd               = root,
     edited_filepaths  = paths,
@@ -62,15 +73,18 @@ local function fire(root)
   })
 
   local bin = git_ai_bin()
-  local stdin_pipe = vim.loop.new_pipe(false)
-  local handle, _ = vim.loop.spawn(bin, {
+  local stdin_pipe = uv.new_pipe(false)
+  local handle
+  handle = uv.spawn(bin, {
     args  = {'checkpoint', 'known_human', '--hook-input', 'stdin'},
     stdio = {stdin_pipe, nil, nil},
     cwd   = root,
   }, function(code, _)
+    handle:close()
+    stdin_pipe:close()
     if code ~= 0 then
       vim.schedule(function()
-        vim.notify('[git-ai] checkpoint known_human exited with code ' .. code, vim.log.levels.DEBUG)
+        vim.notify('[git-ai] checkpoint known_human exited with code ' .. tostring(code), vim.log.levels.DEBUG)
       end)
     end
   end)
@@ -81,9 +95,7 @@ local function fire(root)
   end
 
   stdin_pipe:write(payload, function()
-    stdin_pipe:shutdown(function()
-      stdin_pipe:close()
-    end)
+    stdin_pipe:shutdown(function() end)
   end)
 end
 
@@ -113,7 +125,7 @@ local function on_save(args)
     -- Reuse the same timer object
     timers[root]:start(500, 0, vim.schedule_wrap(function() fire(root) end))
   else
-    local t = vim.loop.new_timer()
+    local t = uv.new_timer()
     timers[root] = t
     t:start(500, 0, vim.schedule_wrap(function() fire(root) end))
   end

--- a/agent-support/neovim/plugin/git-ai.lua
+++ b/agent-support/neovim/plugin/git-ai.lua
@@ -1,0 +1,7 @@
+-- Shim loaded automatically by Neovim on startup.
+-- Calls setup() with default options.
+if vim.g.loaded_git_ai then
+  return
+end
+vim.g.loaded_git_ai = 1
+require('git-ai').setup()

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -7,6 +7,7 @@ mod firebender;
 mod gemini;
 mod github_copilot;
 mod jetbrains;
+mod neovim;
 mod opencode;
 mod vscode;
 mod windsurf;
@@ -20,6 +21,7 @@ pub use firebender::FirebenderInstaller;
 pub use gemini::GeminiInstaller;
 pub use github_copilot::GitHubCopilotInstaller;
 pub use jetbrains::JetBrainsInstaller;
+pub use neovim::NeovimInstaller;
 pub use opencode::OpenCodeInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
@@ -40,6 +42,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(DroidInstaller),
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
+        Box::new(NeovimInstaller),
         Box::new(WindsurfInstaller),
     ]
 }

--- a/src/mdm/agents/neovim.rs
+++ b/src/mdm/agents/neovim.rs
@@ -7,9 +7,15 @@ use crate::mdm::utils::binary_exists;
 pub struct NeovimInstaller;
 
 impl HookInstaller for NeovimInstaller {
-    fn name(&self) -> &str { "Neovim" }
-    fn id(&self) -> &str { "neovim" }
-    fn uses_config_hooks(&self) -> bool { false }
+    fn name(&self) -> &str {
+        "Neovim"
+    }
+    fn id(&self) -> &str {
+        "neovim"
+    }
+    fn uses_config_hooks(&self) -> bool {
+        false
+    }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let tool_installed = binary_exists("nvim");
@@ -58,7 +64,8 @@ impl HookInstaller for NeovimInstaller {
                 "  Native (~/.config/nvim/init.lua):\n",
                 "    vim.opt.rtp:prepend('/path/to/agent-support/neovim')\n",
                 "    require('git-ai').setup()",
-            ).to_string(),
+            )
+            .to_string(),
         }])
     }
 }
@@ -82,6 +89,11 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        assert!(NeovimInstaller.install_hooks(&params, false).unwrap().is_none());
+        assert!(
+            NeovimInstaller
+                .install_hooks(&params, false)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/src/mdm/agents/neovim.rs
+++ b/src/mdm/agents/neovim.rs
@@ -1,0 +1,87 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult,
+};
+use crate::mdm::utils::binary_exists;
+
+pub struct NeovimInstaller;
+
+impl HookInstaller for NeovimInstaller {
+    fn name(&self) -> &str { "Neovim" }
+    fn id(&self) -> &str { "neovim" }
+    fn uses_config_hooks(&self) -> bool { false }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let tool_installed = binary_exists("nvim");
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed: false,
+            hooks_up_to_date: false,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: concat!(
+                "Neovim: Automatic installation is not supported. ",
+                "Install the plugin using one of these methods:\n",
+                "\n",
+                "  lazy.nvim (recommended):\n",
+                "    { 'git-ai-project/git-ai', opts = {} }\n",
+                "\n",
+                "  packer.nvim:\n",
+                "    use { 'git-ai-project/git-ai',\n",
+                "          config = function() require('git-ai').setup() end }\n",
+                "\n",
+                "  Native (~/.config/nvim/init.lua):\n",
+                "    vim.opt.rtp:prepend('/path/to/agent-support/neovim')\n",
+                "    require('git-ai').setup()",
+            ).to_string(),
+        }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_neovim_installer_name() {
+        assert_eq!(NeovimInstaller.name(), "Neovim");
+    }
+
+    #[test]
+    fn test_neovim_installer_id() {
+        assert_eq!(NeovimInstaller.id(), "neovim");
+    }
+
+    #[test]
+    fn test_neovim_install_hooks_returns_none() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        assert!(NeovimInstaller.install_hooks(&params, false).unwrap().is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- New Lua plugin (`agent-support/neovim/`) that fires `git-ai checkpoint known_human --hook-input stdin` on file save with 500ms debounce per git repo root
- Uses `BufWritePost` autocmd + `vim.loop.new_timer()` for debounce
- Uses `vim.loop.spawn()` for non-blocking async git-ai invocation
- Follows the lazy.nvim `opts = {}` / `setup()` convention
- New `NeovimInstaller` Rust struct that detects nvim and surfaces manual install instructions

## Manual install steps (for docs site)

### lazy.nvim (`~/.config/nvim/init.lua`)
```lua
{ 'git-ai-project/git-ai', opts = {} }
```

### packer.nvim
```lua
use { 'git-ai-project/git-ai',
      config = function() require('git-ai').setup() end }
```

### Native install
```bash
# Clone or copy plugin to Neovim rtp
cp -r agent-support/neovim ~/.local/share/nvim/site/pack/git-ai/start/git-ai
```
Or add to `init.lua`:
```lua
vim.opt.rtp:prepend('/path/to/agent-support/neovim')
require('git-ai').setup()
```

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
