### PR TITLE
feat(visual-studio): add known_human checkpoint VSIX extension

### DIFF
--- a/agent-support/visual-studio/DocumentSaveListener.cs
+++ b/agent-support/visual-studio/DocumentSaveListener.cs
@@ -97,6 +97,8 @@ namespace GitAi.VisualStudio
 
         private void FireCheckpoint(string repoRoot)
         {
+            _timers.TryRemove(repoRoot, out var oldTimer);
+            oldTimer?.Dispose();
             if (!_pending.TryRemove(repoRoot, out var files) || files.IsEmpty) return;
 
             var pathsList = new List<string>(files.Keys);
@@ -157,9 +159,30 @@ namespace GitAi.VisualStudio
             return null;
         }
 
-        private static string EscapeJson(string s) =>
-            s.Replace("\\", "\\\\").Replace("\"", "\\\"")
-             .Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+        private static string EscapeJson(string s)
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (char c in s)
+            {
+                switch (c)
+                {
+                    case '\\': sb.Append("\\\\"); break;
+                    case '"': sb.Append("\\\""); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    case '\b': sb.Append("\\b"); break;
+                    case '\f': sb.Append("\\f"); break;
+                    default:
+                        if (c < 0x20)
+                            sb.AppendFormat("\\u{0:X4}", (int)c);
+                        else
+                            sb.Append(c);
+                        break;
+                }
+            }
+            return sb.ToString();
+        }
 
         // Unused interface members — return S_OK
         public int OnAfterFirstDocumentLock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;

--- a/agent-support/visual-studio/DocumentSaveListener.cs
+++ b/agent-support/visual-studio/DocumentSaveListener.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace GitAi.VisualStudio
+{
+    internal sealed class DocumentSaveListener : IVsRunningDocTableEvents3, IDisposable
+    {
+        private readonly AsyncPackage _package;
+        private IVsRunningDocumentTable _rdt;
+        private uint _rdtCookie;
+
+        // Per-repo-root debounce state
+        private readonly ConcurrentDictionary<string, Timer> _timers = new();
+        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _pending = new();
+
+        private const int DebounceMs = 500;
+
+        private static string GitAiBin
+        {
+            get
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var p = Path.Combine(home, ".git-ai", "bin", "git-ai.exe");
+                return File.Exists(p) ? p : "git-ai";
+            }
+        }
+
+        public DocumentSaveListener(AsyncPackage package) => _package = package;
+
+        public async Task InitializeAsync()
+        {
+            await _package.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _rdt = await _package.GetServiceAsync(typeof(SVsRunningDocumentTable))
+                as IVsRunningDocumentTable;
+            if (_rdt == null) return;
+            _rdt.AdviseRunningDocTableEvents(this, out _rdtCookie);
+        }
+
+        public void Dispose()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            if (_rdtCookie != 0)
+            {
+                _rdt?.UnadviseRunningDocTableEvents(_rdtCookie);
+                _rdtCookie = 0;
+            }
+            foreach (var t in _timers.Values) t.Dispose();
+            _timers.Clear();
+        }
+
+        // IVsRunningDocTableEvents3
+        public int OnAfterSave(uint docCookie)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            if (_rdt == null) return VSConstants.S_OK;
+
+            _rdt.GetDocumentInfo(docCookie,
+                out _, out _, out _, out string filePath,
+                out _, out _, out _);
+
+            if (string.IsNullOrEmpty(filePath)) return VSConstants.S_OK;
+            var norm = filePath.Replace('\\', '/');
+            if (norm.Contains("/.git/")) return VSConstants.S_OK;
+
+            var repoRoot = FindRepoRoot(Path.GetDirectoryName(filePath));
+            if (repoRoot == null) return VSConstants.S_OK;
+
+            string content;
+            try { content = File.ReadAllText(filePath, Encoding.UTF8); }
+            catch { return VSConstants.S_OK; }
+
+            var files = _pending.GetOrAdd(repoRoot, _ => new ConcurrentDictionary<string, string>());
+            files[filePath] = content;
+
+            _timers.AddOrUpdate(repoRoot,
+                _ =>
+                {
+                    var t = new Timer(_ => FireCheckpoint(repoRoot), null, DebounceMs, Timeout.Infinite);
+                    return t;
+                },
+                (_, existing) =>
+                {
+                    existing.Change(DebounceMs, Timeout.Infinite);
+                    return existing;
+                });
+
+            return VSConstants.S_OK;
+        }
+
+        private void FireCheckpoint(string repoRoot)
+        {
+            if (!_pending.TryRemove(repoRoot, out var files) || files.IsEmpty) return;
+
+            var pathsList = new List<string>(files.Keys);
+            var sb = new StringBuilder();
+            sb.Append("{\"editor\":\"visual-studio\",\"editor_version\":\"unknown\",");
+            sb.Append("\"extension_version\":\"1.0.0\",");
+            sb.Append("\"cwd\":\"").Append(EscapeJson(repoRoot)).Append("\",");
+            sb.Append("\"edited_filepaths\":[");
+            bool first = true;
+            foreach (var p in pathsList)
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                sb.Append('"').Append(EscapeJson(p)).Append('"');
+            }
+            sb.Append("],\"dirty_files\":{");
+            first = true;
+            foreach (var kv in files)
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                sb.Append('"').Append(EscapeJson(kv.Key)).Append("\":\"")
+                  .Append(EscapeJson(kv.Value)).Append('"');
+            }
+            sb.Append("}}");
+
+            try
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo(GitAiBin,
+                    "checkpoint known_human --hook-input stdin")
+                {
+                    UseShellExecute = false,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                    WorkingDirectory = repoRoot,
+                };
+                using var proc = System.Diagnostics.Process.Start(psi);
+                if (proc == null) return;
+                proc.StandardInput.Write(sb.ToString());
+                proc.StandardInput.Close();
+                proc.WaitForExit(10000);
+            }
+            catch { /* best-effort */ }
+        }
+
+        private static string FindRepoRoot(string dir)
+        {
+            var d = dir;
+            while (!string.IsNullOrEmpty(d))
+            {
+                if (Directory.Exists(Path.Combine(d, ".git"))) return d;
+                var parent = Path.GetDirectoryName(d);
+                if (parent == d) break;
+                d = parent;
+            }
+            return null;
+        }
+
+        private static string EscapeJson(string s) =>
+            s.Replace("\\", "\\\\").Replace("\"", "\\\"")
+             .Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+
+        // Unused interface members — return S_OK
+        public int OnAfterFirstDocumentLock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;
+        public int OnBeforeLastDocumentUnlock(uint docCookie, uint dwRDTLockType, uint dwReadLocksRemaining, uint dwEditLocksRemaining) => VSConstants.S_OK;
+        public int OnAfterAttributeChange(uint docCookie, uint grfAttribs) => VSConstants.S_OK;
+        public int OnBeforeDocumentWindowShow(uint docCookie, int fFirstShow, Microsoft.VisualStudio.Shell.Interop.IVsWindowFrame pFrame) => VSConstants.S_OK;
+        public int OnAfterDocumentWindowHide(uint docCookie, Microsoft.VisualStudio.Shell.Interop.IVsWindowFrame pFrame) => VSConstants.S_OK;
+        public int OnAfterAttributeChangeEx(uint docCookie, uint grfAttribs, IVsHierarchy pHierOld, uint itemidOld, string pszMkDocumentOld, IVsHierarchy pHierNew, uint itemidNew, string pszMkDocumentNew) => VSConstants.S_OK;
+        public int OnBeforeSave(uint docCookie) => VSConstants.S_OK;
+    }
+}

--- a/agent-support/visual-studio/GitAiExtension.csproj
+++ b/agent-support/visual-studio/GitAiExtension.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>GitAiExtension</AssemblyName>
+    <RootNamespace>GitAi.VisualStudio</RootNamespace>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <UseCodebase>true</UseCodebase>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
+  </ItemGroup>
+</Project>

--- a/agent-support/visual-studio/GitAiPackage.cs
+++ b/agent-support/visual-studio/GitAiPackage.cs
@@ -27,8 +27,15 @@ namespace GitAi.VisualStudio
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-                _saveListener?.Dispose();
+            if (disposing && _saveListener != null)
+            {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    _saveListener.Dispose();
+                    _saveListener = null;
+                });
+            }
             base.Dispose(disposing);
         }
     }

--- a/agent-support/visual-studio/GitAiPackage.cs
+++ b/agent-support/visual-studio/GitAiPackage.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace GitAi.VisualStudio
+{
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [Guid("A1B2C3D4-E5F6-7890-ABCD-EF1234567890")]
+    [ProvideAutoLoad(Microsoft.VisualStudio.VSConstants.UICONTEXT.NoSolution_string,
+        PackageAutoLoadFlags.BackgroundLoad)]
+    [ProvideAutoLoad(Microsoft.VisualStudio.VSConstants.UICONTEXT.SolutionExists_string,
+        PackageAutoLoadFlags.BackgroundLoad)]
+    public sealed class GitAiPackage : AsyncPackage
+    {
+        private DocumentSaveListener _saveListener;
+
+        protected override async Task InitializeAsync(
+            CancellationToken cancellationToken,
+            IProgress<ServiceProgressData> progress)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            _saveListener = new DocumentSaveListener(this);
+            await _saveListener.InitializeAsync();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _saveListener?.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/agent-support/visual-studio/source.extension.vsixmanifest
+++ b/agent-support/visual-studio/source.extension.vsixmanifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
+  <Metadata>
+    <Identity Id="io.gitai.visualstudio" Version="1.0.0" Language="en-US" Publisher="git-ai" />
+    <DisplayName>git-ai</DisplayName>
+    <Description>Known-human authorship tracking for git-ai</Description>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,18.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Professional" Version="[16.0,18.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[16.0,18.0)" />
+  </Installation>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|"/>
+  </Assets>
+</PackageManifest>

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -8,6 +8,7 @@ mod gemini;
 mod github_copilot;
 mod jetbrains;
 mod opencode;
+mod visual_studio;
 mod vscode;
 mod windsurf;
 
@@ -21,6 +22,7 @@ pub use gemini::GeminiInstaller;
 pub use github_copilot::GitHubCopilotInstaller;
 pub use jetbrains::JetBrainsInstaller;
 pub use opencode::OpenCodeInstaller;
+pub use visual_studio::VisualStudioInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
 
@@ -41,5 +43,6 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
         Box::new(WindsurfInstaller),
+        Box::new(VisualStudioInstaller),
     ]
 }

--- a/src/mdm/agents/visual_studio.rs
+++ b/src/mdm/agents/visual_studio.rs
@@ -1,0 +1,242 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
+};
+
+pub struct VisualStudioInstaller;
+
+impl HookInstaller for VisualStudioInstaller {
+    fn name(&self) -> &str { "Visual Studio" }
+    fn id(&self) -> &str { "visual-studio" }
+    fn uses_config_hooks(&self) -> bool { false }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let tool_installed = is_visual_studio_installed();
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed: false,
+            hooks_up_to_date: false,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        install_vsix(params, dry_run)
+    }
+
+    fn uninstall_extras(
+        &self,
+        params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<UninstallResult>, GitAiError> {
+        Ok(vec![run_vsix_uninstall(params)])
+    }
+}
+
+fn is_visual_studio_installed() -> bool {
+    #[cfg(windows)]
+    {
+        find_vs_installations().is_some()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn install_vsix(params: &HookInstallerParams, dry_run: bool) -> Result<Vec<InstallResult>, GitAiError> {
+    #[cfg(windows)]
+    {
+        install_vsix_windows(params, dry_run)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (params, dry_run);
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: Only available on Windows".to_string(),
+        }])
+    }
+}
+
+fn run_vsix_uninstall(params: &HookInstallerParams) -> UninstallResult {
+    #[cfg(windows)]
+    {
+        uninstall_vsix_windows(params)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = params;
+        UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: Only available on Windows".to_string(),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn find_vs_installations() -> Option<std::path::PathBuf> {
+    // Scan %ProgramFiles%\Microsoft Visual Studio\ for devenv.exe
+    let program_files = std::env::var("ProgramFiles").ok()
+        .or_else(|| std::env::var("ProgramFiles(x86)").ok())?;
+    let vs_root = std::path::PathBuf::from(program_files).join("Microsoft Visual Studio");
+    if !vs_root.exists() { return None; }
+
+    // Look for devenv.exe in year/edition subdirs
+    for year in &["2022", "2019", "2017"] {
+        for edition in &["Enterprise", "Professional", "Community", "BuildTools"] {
+            let devenv = vs_root.join(year).join(edition)
+                .join("Common7").join("IDE").join("devenv.exe");
+            if devenv.exists() {
+                return Some(vs_root.join(year).join(edition));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn find_vsix_installer(vs_root: &std::path::Path) -> Option<std::path::PathBuf> {
+    let vsix_installer = vs_root.join("Common7").join("IDE").join("VSIXInstaller.exe");
+    if vsix_installer.exists() { Some(vsix_installer) } else { None }
+}
+
+#[cfg(windows)]
+fn vsix_path(params: &HookInstallerParams) -> Option<std::path::PathBuf> {
+    // Look for VSIX next to the git-ai binary: <bin-dir>/lib/visual-studio/GitAiExtension.vsix
+    let bin_dir = params.binary_path.parent()?;
+    let vsix = bin_dir.join("lib").join("visual-studio").join("GitAiExtension.vsix");
+    if vsix.exists() { Some(vsix) } else { None }
+}
+
+#[cfg(windows)]
+fn install_vsix_windows(params: &HookInstallerParams, dry_run: bool) -> Result<Vec<InstallResult>, GitAiError> {
+    let Some(vs_root) = find_vs_installations() else {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: Not detected. Install Visual Studio 2019 or 2022 first.".to_string(),
+        }]);
+    };
+
+    let Some(vsix_installer) = find_vsix_installer(&vs_root) else {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: VSIXInstaller.exe not found. Install the extension manually from the Visual Studio Marketplace.".to_string(),
+        }]);
+    };
+
+    let Some(vsix) = vsix_path(params) else {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: VSIX package not found. Install the extension manually from https://marketplace.visualstudio.com (search for git-ai).".to_string(),
+        }]);
+    };
+
+    if dry_run {
+        return Ok(vec![InstallResult {
+            changed: true,
+            diff: None,
+            message: format!("Visual Studio: Pending VSIX install via {}", vsix_installer.display()),
+        }]);
+    }
+
+    let output = std::process::Command::new(&vsix_installer)
+        .args(["/quiet", "/admin", &vsix.display().to_string()])
+        .output()?;
+
+    if output.status.success() {
+        Ok(vec![InstallResult {
+            changed: true,
+            diff: None,
+            message: "Visual Studio: Extension installed. Restart Visual Studio to activate.".to_string(),
+        }])
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: format!("Visual Studio: VSIX install failed: {}. Install manually from the Marketplace.", stderr.trim()),
+        }])
+    }
+}
+
+#[cfg(windows)]
+fn uninstall_vsix_windows(params: &HookInstallerParams) -> UninstallResult {
+    let Some(vs_root) = find_vs_installations() else {
+        return UninstallResult { changed: false, diff: None,
+            message: "Visual Studio: Not detected".to_string() };
+    };
+    let Some(vsix_installer) = find_vsix_installer(&vs_root) else {
+        return UninstallResult { changed: false, diff: None,
+            message: "Visual Studio: VSIXInstaller.exe not found".to_string() };
+    };
+    let _ = params;
+    let output = std::process::Command::new(&vsix_installer)
+        .args(["/quiet", "/uninstall:io.gitai.visualstudio"])
+        .output();
+    match output {
+        Ok(o) if o.status.success() => UninstallResult {
+            changed: true, diff: None,
+            message: "Visual Studio: Extension uninstalled".to_string() },
+        _ => UninstallResult { changed: false, diff: None,
+            message: "Visual Studio: Extension uninstall failed or was not installed".to_string() },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visual_studio_installer_name() {
+        assert_eq!(VisualStudioInstaller.name(), "Visual Studio");
+    }
+
+    #[test]
+    fn test_visual_studio_installer_id() {
+        assert_eq!(VisualStudioInstaller.id(), "visual-studio");
+    }
+
+    #[test]
+    fn test_visual_studio_install_hooks_returns_none() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        assert!(VisualStudioInstaller.install_hooks(&params, false).unwrap().is_none());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_install_extras_non_windows_returns_windows_only_message() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        let results = VisualStudioInstaller.install_extras(&params, false).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].message.contains("Windows"));
+    }
+}

--- a/src/mdm/agents/visual_studio.rs
+++ b/src/mdm/agents/visual_studio.rs
@@ -6,9 +6,15 @@ use crate::mdm::hook_installer::{
 pub struct VisualStudioInstaller;
 
 impl HookInstaller for VisualStudioInstaller {
-    fn name(&self) -> &str { "Visual Studio" }
-    fn id(&self) -> &str { "visual-studio" }
-    fn uses_config_hooks(&self) -> bool { false }
+    fn name(&self) -> &str {
+        "Visual Studio"
+    }
+    fn id(&self) -> &str {
+        "visual-studio"
+    }
+    fn uses_config_hooks(&self) -> bool {
+        false
+    }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let tool_installed = is_visual_studio_installed();
@@ -63,7 +69,10 @@ fn is_visual_studio_installed() -> bool {
     }
 }
 
-fn install_vsix(params: &HookInstallerParams, dry_run: bool) -> Result<Vec<InstallResult>, GitAiError> {
+fn install_vsix(
+    params: &HookInstallerParams,
+    dry_run: bool,
+) -> Result<Vec<InstallResult>, GitAiError> {
     #[cfg(windows)]
     {
         install_vsix_windows(params, dry_run)
@@ -98,16 +107,23 @@ fn run_vsix_uninstall(params: &HookInstallerParams) -> UninstallResult {
 #[cfg(windows)]
 fn find_vs_installations() -> Option<std::path::PathBuf> {
     // Scan %ProgramFiles%\Microsoft Visual Studio\ for devenv.exe
-    let program_files = std::env::var("ProgramFiles").ok()
+    let program_files = std::env::var("ProgramFiles")
+        .ok()
         .or_else(|| std::env::var("ProgramFiles(x86)").ok())?;
     let vs_root = std::path::PathBuf::from(program_files).join("Microsoft Visual Studio");
-    if !vs_root.exists() { return None; }
+    if !vs_root.exists() {
+        return None;
+    }
 
     // Look for devenv.exe in year/edition subdirs
     for year in &["2022", "2019", "2017"] {
         for edition in &["Enterprise", "Professional", "Community", "BuildTools"] {
-            let devenv = vs_root.join(year).join(edition)
-                .join("Common7").join("IDE").join("devenv.exe");
+            let devenv = vs_root
+                .join(year)
+                .join(edition)
+                .join("Common7")
+                .join("IDE")
+                .join("devenv.exe");
             if devenv.exists() {
                 return Some(vs_root.join(year).join(edition));
             }
@@ -118,25 +134,39 @@ fn find_vs_installations() -> Option<std::path::PathBuf> {
 
 #[cfg(windows)]
 fn find_vsix_installer(vs_root: &std::path::Path) -> Option<std::path::PathBuf> {
-    let vsix_installer = vs_root.join("Common7").join("IDE").join("VSIXInstaller.exe");
-    if vsix_installer.exists() { Some(vsix_installer) } else { None }
+    let vsix_installer = vs_root
+        .join("Common7")
+        .join("IDE")
+        .join("VSIXInstaller.exe");
+    if vsix_installer.exists() {
+        Some(vsix_installer)
+    } else {
+        None
+    }
 }
 
 #[cfg(windows)]
 fn vsix_path(params: &HookInstallerParams) -> Option<std::path::PathBuf> {
     // Look for VSIX next to the git-ai binary: <bin-dir>/lib/visual-studio/GitAiExtension.vsix
     let bin_dir = params.binary_path.parent()?;
-    let vsix = bin_dir.join("lib").join("visual-studio").join("GitAiExtension.vsix");
+    let vsix = bin_dir
+        .join("lib")
+        .join("visual-studio")
+        .join("GitAiExtension.vsix");
     if vsix.exists() { Some(vsix) } else { None }
 }
 
 #[cfg(windows)]
-fn install_vsix_windows(params: &HookInstallerParams, dry_run: bool) -> Result<Vec<InstallResult>, GitAiError> {
+fn install_vsix_windows(
+    params: &HookInstallerParams,
+    dry_run: bool,
+) -> Result<Vec<InstallResult>, GitAiError> {
     let Some(vs_root) = find_vs_installations() else {
         return Ok(vec![InstallResult {
             changed: false,
             diff: None,
-            message: "Visual Studio: Not detected. Install Visual Studio 2019 or 2022 first.".to_string(),
+            message: "Visual Studio: Not detected. Install Visual Studio 2019 or 2022 first."
+                .to_string(),
         }]);
     };
 
@@ -160,7 +190,10 @@ fn install_vsix_windows(params: &HookInstallerParams, dry_run: bool) -> Result<V
         return Ok(vec![InstallResult {
             changed: true,
             diff: None,
-            message: format!("Visual Studio: Pending VSIX install via {}", vsix_installer.display()),
+            message: format!(
+                "Visual Studio: Pending VSIX install via {}",
+                vsix_installer.display()
+            ),
         }]);
     }
 
@@ -172,14 +205,18 @@ fn install_vsix_windows(params: &HookInstallerParams, dry_run: bool) -> Result<V
         Ok(vec![InstallResult {
             changed: true,
             diff: None,
-            message: "Visual Studio: Extension installed. Restart Visual Studio to activate.".to_string(),
+            message: "Visual Studio: Extension installed. Restart Visual Studio to activate."
+                .to_string(),
         }])
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         Ok(vec![InstallResult {
             changed: false,
             diff: None,
-            message: format!("Visual Studio: VSIX install failed: {}. Install manually from the Marketplace.", stderr.trim()),
+            message: format!(
+                "Visual Studio: VSIX install failed: {}. Install manually from the Marketplace.",
+                stderr.trim()
+            ),
         }])
     }
 }
@@ -187,12 +224,18 @@ fn install_vsix_windows(params: &HookInstallerParams, dry_run: bool) -> Result<V
 #[cfg(windows)]
 fn uninstall_vsix_windows(params: &HookInstallerParams) -> UninstallResult {
     let Some(vs_root) = find_vs_installations() else {
-        return UninstallResult { changed: false, diff: None,
-            message: "Visual Studio: Not detected".to_string() };
+        return UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: Not detected".to_string(),
+        };
     };
     let Some(vsix_installer) = find_vsix_installer(&vs_root) else {
-        return UninstallResult { changed: false, diff: None,
-            message: "Visual Studio: VSIXInstaller.exe not found".to_string() };
+        return UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: VSIXInstaller.exe not found".to_string(),
+        };
     };
     let _ = params;
     let output = std::process::Command::new(&vsix_installer)
@@ -200,10 +243,15 @@ fn uninstall_vsix_windows(params: &HookInstallerParams) -> UninstallResult {
         .output();
     match output {
         Ok(o) if o.status.success() => UninstallResult {
-            changed: true, diff: None,
-            message: "Visual Studio: Extension uninstalled".to_string() },
-        _ => UninstallResult { changed: false, diff: None,
-            message: "Visual Studio: Extension uninstall failed or was not installed".to_string() },
+            changed: true,
+            diff: None,
+            message: "Visual Studio: Extension uninstalled".to_string(),
+        },
+        _ => UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Visual Studio: Extension uninstall failed or was not installed".to_string(),
+        },
     }
 }
 
@@ -226,7 +274,12 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        assert!(VisualStudioInstaller.install_hooks(&params, false).unwrap().is_none());
+        assert!(
+            VisualStudioInstaller
+                .install_hooks(&params, false)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[cfg(not(windows))]
@@ -235,7 +288,9 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        let results = VisualStudioInstaller.install_extras(&params, false).unwrap();
+        let results = VisualStudioInstaller
+            .install_extras(&params, false)
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].message.contains("Windows"));
     }

--- a/src/mdm/agents/visual_studio.rs
+++ b/src/mdm/agents/visual_studio.rs
@@ -18,10 +18,11 @@ impl HookInstaller for VisualStudioInstaller {
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let tool_installed = is_visual_studio_installed();
+        let hooks_installed = is_vsix_installed();
         Ok(HookCheckResult {
             tool_installed,
-            hooks_installed: false,
-            hooks_up_to_date: false,
+            hooks_installed,
+            hooks_up_to_date: hooks_installed,
         })
     }
 
@@ -69,6 +70,36 @@ fn is_visual_studio_installed() -> bool {
     }
 }
 
+fn is_vsix_installed() -> bool {
+    #[cfg(windows)]
+    {
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            let vs_dir = std::path::PathBuf::from(local_app_data)
+                .join("Microsoft")
+                .join("VisualStudio");
+            if let Ok(entries) = std::fs::read_dir(&vs_dir) {
+                for entry in entries.flatten() {
+                    let ext_dir = entry.path().join("Extensions");
+                    if let Ok(exts) = std::fs::read_dir(&ext_dir) {
+                        for ext in exts.flatten() {
+                            if ext.path().join("git-ai.vsix").exists()
+                                || ext.file_name().to_string_lossy().contains("git-ai")
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 fn install_vsix(
     params: &HookInstallerParams,
     dry_run: bool,
@@ -107,16 +138,14 @@ fn run_vsix_uninstall(params: &HookInstallerParams) -> UninstallResult {
 #[cfg(windows)]
 fn find_vs_installations() -> Option<std::path::PathBuf> {
     // Scan %ProgramFiles%\Microsoft Visual Studio\ for devenv.exe
-    let program_files = std::env::var("ProgramFiles")
-        .ok()
-        .or_else(|| std::env::var("ProgramFiles(x86)").ok())?;
+    let program_files = std::env::var("ProgramFiles").ok()?;
     let vs_root = std::path::PathBuf::from(program_files).join("Microsoft Visual Studio");
     if !vs_root.exists() {
         return None;
     }
 
     // Look for devenv.exe in year/edition subdirs
-    for year in &["2022", "2019", "2017"] {
+    for year in &["2022", "2019"] {
         for edition in &["Enterprise", "Professional", "Community", "BuildTools"] {
             let devenv = vs_root
                 .join(year)


### PR DESCRIPTION
## Summary
- New C# VSIX extension (`agent-support/visual-studio/`) for Visual Studio 2019/2022 that fires `git-ai checkpoint known_human --hook-input stdin` on file save with 500ms debounce per git repo root
- Uses `IVsRunningDocTableEvents3.OnAfterSave` via the Running Document Table — the standard VS API for file-save tracking
- No external NuGet dependencies; JSON built inline
- New `VisualStudioInstaller` Rust struct that auto-installs via `VSIXInstaller.exe /quiet` on Windows; falls back to Marketplace instructions if VSIX or installer not found

## Manual install steps (for docs site)
1. Download `GitAiExtension.vsix` from https://github.com/git-ai-project/git-ai/releases (or build from `agent-support/visual-studio/`)
2. Double-click the `.vsix` file, or run: `"%VS170COMNTOOLS%\..\..\Common7\IDE\VSIXInstaller.exe" /quiet GitAiExtension.vsix`
3. Restart Visual Studio

To build from source:
\`\`\`bash
cd agent-support/visual-studio
dotnet build -c Release
\`\`\`

## Test plan
- [ ] `cargo clippy -- -D warnings` passes (Linux)
- [ ] `cargo test` passes (Linux)

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
