### PR TITLE
feat(notepad-plus-plus): add known_human checkpoint plugin

### DIFF
--- a/agent-support/notepad-plus-plus/GitAiPlugin.csproj
+++ b/agent-support/notepad-plus-plus/GitAiPlugin.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>git-ai</AssemblyName>
+    <RootNamespace>GitAi.NotepadPlusPlus</RootNamespace>
+    <Platforms>x64;x86</Platforms>
+    <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- NppPlugin.NET provides the Notepad++ plugin API wrapper -->
+    <PackageReference Include="NppPlugin.NET" Version="0.94.00" />
+  </ItemGroup>
+</Project>

--- a/agent-support/notepad-plus-plus/Plugin.cs
+++ b/agent-support/notepad-plus-plus/Plugin.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -49,6 +48,14 @@ namespace GitAi.NotepadPlusPlus
             else if (notification.Header.Code == (uint)NppMsg.NPPN_FILESAVED)
             {
                 OnFileSaved();
+            }
+            else if (notification.Header.Code == (uint)NppMsg.NPPN_SHUTDOWN)
+            {
+                // Cancel all pending timers
+                foreach (var timer in _timers.Values)
+                    timer?.Dispose();
+                _timers.Clear();
+                _pending.Clear();
             }
         }
 
@@ -128,8 +135,8 @@ namespace GitAi.NotepadPlusPlus
                 {
                     UseShellExecute = false,
                     RedirectStandardInput = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
+                    RedirectStandardOutput = false,
+                    RedirectStandardError = false,
                     CreateNoWindow = true,
                     WorkingDirectory = repoRoot,
                 };
@@ -169,8 +176,10 @@ namespace GitAi.NotepadPlusPlus
             _nppHandle = notepadPlusData._nppHandle;
         }
 
+        private static readonly IntPtr _namePtr = Marshal.StringToHGlobalUni(PluginName);
+
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
-        public static IntPtr getName() => Marshal.StringToHGlobalUni(PluginName);
+        public static IntPtr getName() => _namePtr;
 
         [DllExport(CallingConvention = CallingConvention.Cdecl)]
         public static FuncItem[] getFuncsArray(ref int nbF)

--- a/agent-support/notepad-plus-plus/Plugin.cs
+++ b/agent-support/notepad-plus-plus/Plugin.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using Kbg.NppPluginNET.PluginInfrastructure;
+
+namespace GitAi.NotepadPlusPlus
+{
+    /// <summary>
+    /// git-ai Notepad++ plugin — fires known_human checkpoint on file save.
+    ///
+    /// Installation:
+    ///   Copy git-ai.dll to %APPDATA%\Notepad++\plugins\git-ai\git-ai.dll
+    ///   Restart Notepad++.
+    /// </summary>
+    public class Plugin
+    {
+        public const string PluginName = "git-ai";
+
+        private static IntPtr _nppHandle = IntPtr.Zero;
+        private static readonly ConcurrentDictionary<string, Timer> _timers = new();
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _pending = new();
+        private const int DebounceMs = 500;
+
+        private static string GitAiBin
+        {
+            get
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var exe = Path.Combine(home, ".git-ai", "bin", "git-ai.exe");
+                return File.Exists(exe) ? exe : "git-ai";
+            }
+        }
+
+        /// Called by the plugin host to set up commands. We have no menu items.
+        public static void CommandMenuInit() { }
+
+        /// Called by Notepad++ with notification messages.
+        public static void beNotified(ScNotification notification)
+        {
+            if (notification.Header.Code == (uint)NppMsg.NPPN_NATIVELANGCHANGED)
+            {
+                // No-op
+            }
+            else if (notification.Header.Code == (uint)NppMsg.NPPN_FILESAVED)
+            {
+                OnFileSaved();
+            }
+        }
+
+        private static void OnFileSaved()
+        {
+            // Get the current file path via NPPM_GETFULLCURRENTPATH
+            var filePath = GetCurrentFilePath();
+            if (string.IsNullOrEmpty(filePath)) return;
+
+            var norm = filePath.Replace('\\', '/');
+            if (norm.Contains("/.git/")) return;
+
+            var repoRoot = FindRepoRoot(Path.GetDirectoryName(filePath));
+            if (repoRoot == null) return;
+
+            string content;
+            try { content = File.ReadAllText(filePath, Encoding.UTF8); }
+            catch { return; }
+
+            var files = _pending.GetOrAdd(repoRoot, _ => new ConcurrentDictionary<string, string>());
+            files[filePath] = content;
+
+            _timers.AddOrUpdate(repoRoot,
+                _ =>
+                {
+                    var t = new Timer(_ => FireCheckpoint(repoRoot), null, DebounceMs, Timeout.Infinite);
+                    return t;
+                },
+                (_, existing) =>
+                {
+                    existing.Change(DebounceMs, Timeout.Infinite);
+                    return existing;
+                });
+        }
+
+        private static string? GetCurrentFilePath()
+        {
+            if (_nppHandle == IntPtr.Zero) return null;
+            var sb = new StringBuilder(Win32.MAX_PATH);
+            Win32.SendMessage(_nppHandle, NppMsg.NPPM_GETFULLCURRENTPATH,
+                (IntPtr)Win32.MAX_PATH, sb);
+            var result = sb.ToString();
+            return string.IsNullOrEmpty(result) ? null : result;
+        }
+
+        private static void FireCheckpoint(string repoRoot)
+        {
+            if (!_pending.TryRemove(repoRoot, out var files) || files.IsEmpty) return;
+
+            var sb = new StringBuilder();
+            sb.Append("{\"editor\":\"notepad-plus-plus\",\"editor_version\":\"unknown\",");
+            sb.Append("\"extension_version\":\"1.0.0\",");
+            sb.Append("\"cwd\":\"").Append(EscapeJson(repoRoot)).Append("\",");
+            sb.Append("\"edited_filepaths\":[");
+            bool first = true;
+            foreach (var p in files.Keys)
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                sb.Append('"').Append(EscapeJson(p)).Append('"');
+            }
+            sb.Append("],\"dirty_files\":{");
+            first = true;
+            foreach (var kv in files)
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                sb.Append('"').Append(EscapeJson(kv.Key)).Append("\":\"")
+                  .Append(EscapeJson(kv.Value)).Append('"');
+            }
+            sb.Append("}}");
+
+            try
+            {
+                var psi = new ProcessStartInfo(GitAiBin,
+                    "checkpoint known_human --hook-input stdin")
+                {
+                    UseShellExecute = false,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                    WorkingDirectory = repoRoot,
+                };
+                using var proc = Process.Start(psi);
+                if (proc == null) return;
+                proc.StandardInput.Write(sb.ToString());
+                proc.StandardInput.Close();
+                proc.WaitForExit(10000);
+            }
+            catch { /* best-effort */ }
+        }
+
+        private static string? FindRepoRoot(string? dir)
+        {
+            var d = dir;
+            while (!string.IsNullOrEmpty(d))
+            {
+                if (Directory.Exists(Path.Combine(d, ".git"))) return d;
+                var parent = Path.GetDirectoryName(d);
+                if (parent == d) break;
+                d = parent;
+            }
+            return null;
+        }
+
+        private static string EscapeJson(string s) =>
+            s.Replace("\\", "\\\\").Replace("\"", "\\\"")
+             .Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
+
+        /// Called by the plugin loader with the Notepad++ window handle.
+        public static void SetToolBarIcon() { }
+        public static IntPtr GetNppHandle() => _nppHandle;
+
+        [DllExport(CallingConvention = CallingConvention.Cdecl)]
+        public static void setInfo(NppData notepadPlusData)
+        {
+            _nppHandle = notepadPlusData._nppHandle;
+        }
+
+        [DllExport(CallingConvention = CallingConvention.Cdecl)]
+        public static IntPtr getName() => Marshal.StringToHGlobalUni(PluginName);
+
+        [DllExport(CallingConvention = CallingConvention.Cdecl)]
+        public static FuncItem[] getFuncsArray(ref int nbF)
+        {
+            nbF = 0;
+            return Array.Empty<FuncItem>();
+        }
+
+        [DllExport(CallingConvention = CallingConvention.Cdecl)]
+        public static void beNotified(IntPtr notifyCode)
+        {
+            var sc = (ScNotification)Marshal.PtrToStructure(notifyCode, typeof(ScNotification))!;
+            beNotified(sc);
+        }
+
+        [DllExport(CallingConvention = CallingConvention.Cdecl)]
+        public static IntPtr messageProc(uint msg, IntPtr wParam, IntPtr lParam) => IntPtr.Zero;
+
+        [DllExport(CallingConvention = CallingConvention.Cdecl)]
+        public static bool isUnicode() => true;
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -7,6 +7,7 @@ mod firebender;
 mod gemini;
 mod github_copilot;
 mod jetbrains;
+mod notepad_plus_plus;
 mod opencode;
 mod vscode;
 mod windsurf;
@@ -20,6 +21,7 @@ pub use firebender::FirebenderInstaller;
 pub use gemini::GeminiInstaller;
 pub use github_copilot::GitHubCopilotInstaller;
 pub use jetbrains::JetBrainsInstaller;
+pub use notepad_plus_plus::NotepadPlusPlusInstaller;
 pub use opencode::OpenCodeInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
@@ -41,5 +43,6 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
         Box::new(WindsurfInstaller),
+        Box::new(NotepadPlusPlusInstaller),
     ]
 }

--- a/src/mdm/agents/notepad_plus_plus.rs
+++ b/src/mdm/agents/notepad_plus_plus.rs
@@ -138,12 +138,7 @@ fn notepad_exe_path() -> Option<std::path::PathBuf> {
                 .join("notepad++.exe")
         }),
     ];
-    for c in candidates.into_iter().flatten() {
-        if c.exists() {
-            return Some(c);
-        }
-    }
-    None
+    candidates.into_iter().flatten().find(|c| c.exists())
 }
 
 #[cfg(windows)]
@@ -244,16 +239,15 @@ fn uninstall_plugin_windows() -> UninstallResult {
             message: "Notepad++: Could not determine plugin directory".to_string(),
         };
     };
-    if let Some(dir) = dest.parent() {
-        if dir.exists() {
-            if std::fs::remove_dir_all(dir).is_ok() {
-                return UninstallResult {
-                    changed: true,
-                    diff: None,
-                    message: "Notepad++: Plugin removed".to_string(),
-                };
-            }
-        }
+    if let Some(dir) = dest.parent()
+        && dir.exists()
+        && std::fs::remove_dir_all(dir).is_ok()
+    {
+        return UninstallResult {
+            changed: true,
+            diff: None,
+            message: "Notepad++: Plugin removed".to_string(),
+        };
     }
     UninstallResult {
         changed: false,

--- a/src/mdm/agents/notepad_plus_plus.rs
+++ b/src/mdm/agents/notepad_plus_plus.rs
@@ -44,6 +44,17 @@ impl HookInstaller for NotepadPlusPlusInstaller {
         Ok(None)
     }
 
+    fn process_names(&self) -> Vec<&str> {
+        #[cfg(windows)]
+        {
+            vec!["notepad++"]
+        }
+        #[cfg(not(windows))]
+        {
+            vec![]
+        }
+    }
+
     fn install_extras(
         &self,
         params: &HookInstallerParams,

--- a/src/mdm/agents/notepad_plus_plus.rs
+++ b/src/mdm/agents/notepad_plus_plus.rs
@@ -121,20 +121,22 @@ fn uninstall_plugin() -> UninstallResult {
 fn notepad_exe_path() -> Option<std::path::PathBuf> {
     // Check common install locations
     let candidates = [
-        std::env::var("ProgramFiles")
-            .ok()
-            .map(|p| std::path::PathBuf::from(p).join("Notepad++").join("notepad++.exe")),
-        std::env::var("ProgramFiles(x86)")
-            .ok()
-            .map(|p| std::path::PathBuf::from(p).join("Notepad++").join("notepad++.exe")),
-        std::env::var("LOCALAPPDATA")
-            .ok()
-            .map(|p| {
-                std::path::PathBuf::from(p)
-                    .join("Programs")
-                    .join("Notepad++")
-                    .join("notepad++.exe")
-            }),
+        std::env::var("ProgramFiles").ok().map(|p| {
+            std::path::PathBuf::from(p)
+                .join("Notepad++")
+                .join("notepad++.exe")
+        }),
+        std::env::var("ProgramFiles(x86)").ok().map(|p| {
+            std::path::PathBuf::from(p)
+                .join("Notepad++")
+                .join("notepad++.exe")
+        }),
+        std::env::var("LOCALAPPDATA").ok().map(|p| {
+            std::path::PathBuf::from(p)
+                .join("Programs")
+                .join("Notepad++")
+                .join("notepad++.exe")
+        }),
     ];
     for c in candidates.into_iter().flatten() {
         if c.exists() {
@@ -279,10 +281,12 @@ mod tests {
         let params = HookInstallerParams {
             binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
         };
-        assert!(NotepadPlusPlusInstaller
-            .install_hooks(&params, false)
-            .unwrap()
-            .is_none());
+        assert!(
+            NotepadPlusPlusInstaller
+                .install_hooks(&params, false)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[cfg(not(windows))]

--- a/src/mdm/agents/notepad_plus_plus.rs
+++ b/src/mdm/agents/notepad_plus_plus.rs
@@ -1,0 +1,300 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
+};
+
+pub struct NotepadPlusPlusInstaller;
+
+impl HookInstaller for NotepadPlusPlusInstaller {
+    fn name(&self) -> &str {
+        "Notepad++"
+    }
+
+    fn id(&self) -> &str {
+        "notepad-plus-plus"
+    }
+
+    fn uses_config_hooks(&self) -> bool {
+        false
+    }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let tool_installed = is_notepad_plus_plus_installed();
+        let hooks_installed = is_plugin_installed();
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed,
+            hooks_up_to_date: hooks_installed,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Vec<InstallResult>, GitAiError> {
+        install_plugin(params, dry_run)
+    }
+
+    fn uninstall_extras(
+        &self,
+        _params: &HookInstallerParams,
+        _dry_run: bool,
+    ) -> Result<Vec<UninstallResult>, GitAiError> {
+        Ok(vec![uninstall_plugin()])
+    }
+}
+
+fn is_notepad_plus_plus_installed() -> bool {
+    #[cfg(windows)]
+    {
+        notepad_exe_path().is_some()
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn is_plugin_installed() -> bool {
+    #[cfg(windows)]
+    {
+        plugin_dest_path().map(|p| p.exists()).unwrap_or(false)
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn install_plugin(
+    params: &HookInstallerParams,
+    dry_run: bool,
+) -> Result<Vec<InstallResult>, GitAiError> {
+    #[cfg(windows)]
+    {
+        install_plugin_windows(params, dry_run)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (params, dry_run);
+        Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Notepad++: Only available on Windows".to_string(),
+        }])
+    }
+}
+
+fn uninstall_plugin() -> UninstallResult {
+    #[cfg(windows)]
+    {
+        uninstall_plugin_windows()
+    }
+    #[cfg(not(windows))]
+    {
+        UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Notepad++: Only available on Windows".to_string(),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn notepad_exe_path() -> Option<std::path::PathBuf> {
+    // Check common install locations
+    let candidates = [
+        std::env::var("ProgramFiles")
+            .ok()
+            .map(|p| std::path::PathBuf::from(p).join("Notepad++").join("notepad++.exe")),
+        std::env::var("ProgramFiles(x86)")
+            .ok()
+            .map(|p| std::path::PathBuf::from(p).join("Notepad++").join("notepad++.exe")),
+        std::env::var("LOCALAPPDATA")
+            .ok()
+            .map(|p| {
+                std::path::PathBuf::from(p)
+                    .join("Programs")
+                    .join("Notepad++")
+                    .join("notepad++.exe")
+            }),
+    ];
+    for c in candidates.into_iter().flatten() {
+        if c.exists() {
+            return Some(c);
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn plugin_dest_path() -> Option<std::path::PathBuf> {
+    let appdata = std::env::var("APPDATA").ok()?;
+    Some(
+        std::path::PathBuf::from(appdata)
+            .join("Notepad++")
+            .join("plugins")
+            .join("git-ai")
+            .join("git-ai.dll"),
+    )
+}
+
+#[cfg(windows)]
+fn dll_source_path(params: &HookInstallerParams) -> Option<std::path::PathBuf> {
+    // Look for the DLL next to the git-ai binary: <bin-dir>/lib/notepad-plus-plus/git-ai.dll
+    let bin_dir = params.binary_path.parent()?;
+    let dll = bin_dir
+        .join("lib")
+        .join("notepad-plus-plus")
+        .join("git-ai.dll");
+    if dll.exists() { Some(dll) } else { None }
+}
+
+#[cfg(windows)]
+fn install_plugin_windows(
+    params: &HookInstallerParams,
+    dry_run: bool,
+) -> Result<Vec<InstallResult>, GitAiError> {
+    if notepad_exe_path().is_none() {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Notepad++: Not detected. Install Notepad++ first.".to_string(),
+        }]);
+    }
+
+    let Some(dest) = plugin_dest_path() else {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Notepad++: Could not determine plugin directory".to_string(),
+        }]);
+    };
+
+    if dest.exists() {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: "Notepad++: Plugin already installed".to_string(),
+        }]);
+    }
+
+    let Some(src) = dll_source_path(params) else {
+        return Ok(vec![InstallResult {
+            changed: false,
+            diff: None,
+            message: concat!(
+                "Notepad++: Plugin DLL not found. Install manually: ",
+                "download git-ai.dll and copy it to ",
+                "%APPDATA%\\Notepad++\\plugins\\git-ai\\git-ai.dll, ",
+                "then restart Notepad++."
+            )
+            .to_string(),
+        }]);
+    };
+
+    if dry_run {
+        return Ok(vec![InstallResult {
+            changed: true,
+            diff: None,
+            message: format!("Notepad++: Pending plugin install to {}", dest.display()),
+        }]);
+    }
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::copy(&src, &dest)?;
+
+    Ok(vec![InstallResult {
+        changed: true,
+        diff: None,
+        message: format!(
+            "Notepad++: Plugin installed to {}. Restart Notepad++ to activate.",
+            dest.display()
+        ),
+    }])
+}
+
+#[cfg(windows)]
+fn uninstall_plugin_windows() -> UninstallResult {
+    let Some(dest) = plugin_dest_path() else {
+        return UninstallResult {
+            changed: false,
+            diff: None,
+            message: "Notepad++: Could not determine plugin directory".to_string(),
+        };
+    };
+    if let Some(dir) = dest.parent() {
+        if dir.exists() {
+            if std::fs::remove_dir_all(dir).is_ok() {
+                return UninstallResult {
+                    changed: true,
+                    diff: None,
+                    message: "Notepad++: Plugin removed".to_string(),
+                };
+            }
+        }
+    }
+    UninstallResult {
+        changed: false,
+        diff: None,
+        message: "Notepad++: Plugin was not installed".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_notepad_plus_plus_installer_name() {
+        assert_eq!(NotepadPlusPlusInstaller.name(), "Notepad++");
+    }
+
+    #[test]
+    fn test_notepad_plus_plus_installer_id() {
+        assert_eq!(NotepadPlusPlusInstaller.id(), "notepad-plus-plus");
+    }
+
+    #[test]
+    fn test_notepad_install_hooks_returns_none() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        assert!(NotepadPlusPlusInstaller
+            .install_hooks(&params, false)
+            .unwrap()
+            .is_none());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_install_extras_non_windows_message() {
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        let results = NotepadPlusPlusInstaller
+            .install_extras(&params, false)
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].message.contains("Windows"));
+    }
+}


### PR DESCRIPTION
## Summary
- New C# .NET 4.8 Notepad++ plugin (`agent-support/notepad-plus-plus/`) that fires `git-ai checkpoint known_human --hook-input stdin` on file save with 500ms debounce per git repo root
- Handles `NPPN_FILESAVED` notification; retrieves file path via `NPPM_GETFULLCURRENTPATH` (not `nmhdr.idFrom`)
- No external JSON serializer — JSON built inline
- New `NotepadPlusPlusInstaller` Rust struct that auto-installs by copying the DLL to `%APPDATA%\Notepad++\plugins\git-ai\git-ai.dll`; all Windows-specific code is `#[cfg(windows)]`-gated

## Manual install steps (for docs site)
1. Download `git-ai.dll` from https://github.com/git-ai-project/git-ai/releases (or build from `agent-support/notepad-plus-plus/`)
2. Create the folder: `%APPDATA%\Notepad++\plugins\git-ai\`
3. Copy `git-ai.dll` into that folder
4. Restart Notepad++

To build from source:
```cmd
cd agent-support\notepad-plus-plus
dotnet build -c Release -p:Platform=x64
```
Choose `x86` or `x64` to match your Notepad++ installation.

## Test plan
- [ ] `cargo clippy -- -D warnings` passes (Linux)
- [ ] `cargo test` passes (Linux)

🤖 Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
