### PR TITLE
fix(e2e): update codex hook verification to check hooks.json

### DIFF
--- a/.github/workflows/install-scripts-local.yml
+++ b/.github/workflows/install-scripts-local.yml
@@ -99,8 +99,10 @@ jobs:
               grep -F "checkpoint claude" "$HOME/.claude/settings.json"
               ;;
             codex)
-              # Codex uses TOML array format: notify = ["<bin>", "checkpoint", "codex", ...]
-              grep -F "checkpoint" "$HOME/.codex/config.toml"
+              # Codex writes a feature flag to config.toml and the actual hook
+              # commands to hooks.json (separate file since the hooks refactor).
+              grep -F "codex_hooks" "$HOME/.codex/config.toml"
+              grep -F "checkpoint" "$HOME/.codex/hooks.json"
               ;;
             gemini)
               grep -F "checkpoint gemini" "$HOME/.gemini/settings.json"
@@ -260,9 +262,12 @@ jobs:
               if (-not (Select-String -Path $settings -Pattern "checkpoint claude")) { throw "Claude hooks not configured" }
             }
             "codex" {
+              # Codex writes a feature flag to config.toml and the actual hook
+              # commands to hooks.json (separate file since the hooks refactor).
               $config = Join-Path $env:USERPROFILE ".codex\config.toml"
-              # Codex uses TOML array format: notify = ["<bin>", "checkpoint", "codex", ...]
-              if (-not (Select-String -Path $config -Pattern "checkpoint")) { throw "Codex hooks not configured" }
+              if (-not (Select-String -Path $config -Pattern "codex_hooks")) { throw "Codex feature flag not set in config.toml" }
+              $hooks = Join-Path $env:USERPROFILE ".codex\hooks.json"
+              if (-not (Select-String -Path $hooks -Pattern "checkpoint")) { throw "Codex hooks not configured in hooks.json" }
             }
             "gemini" {
               $settings = Join-Path $env:USERPROFILE ".gemini\settings.json"


### PR DESCRIPTION
## Summary

- The `CodexInstaller` was refactored to write `[features] codex_hooks = true` to `~/.codex/config.toml` and the actual `checkpoint codex --hook-input stdin` commands to a separate `~/.codex/hooks.json` file
- The E2E verification steps in `install-scripts-local.yml` were still searching `config.toml` for `"checkpoint"`, which no longer exists there — causing all 3 codex platform jobs to fail on every run
- Updates both the Unix (bash `case`) and Windows (PowerShell `switch`) checks to: (1) verify `codex_hooks = true` is set in `config.toml`, and (2) verify the `checkpoint` command is present in `hooks.json`

Fixes the failures visible in https://github.com/git-ai-project/git-ai/actions/runs/24287703149/job/70919744734

## Test plan

- [ ] E2E codex on ubuntu-latest — "Verify shell configs and agent hooks" step passes
- [ ] E2E codex on macos-latest — "Verify shell configs and agent hooks" step passes
- [ ] E2E codex on windows-latest — "Verify agent hooks" step passes
- [ ] No regressions on claude / gemini / opencode jobs (those checks are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
