### PR TITLE
fix(post-commit): skip expensive stats for mass-deletion commits

### DIFF
--- a/docs/superpowers/plans/2026-04-11-multi-ide-known-human.md
+++ b/docs/superpowers/plans/2026-04-11-multi-ide-known-human.md
@@ -1,0 +1,555 @@
+# Multi-IDE Known-Human Checkpoint — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `known_human` checkpoint support (fire `git-ai checkpoint known_human --hook-input stdin` on file save with 500ms debounce) to 9 IDE/editor targets, one PR each, running as parallel worktree subagents.
+
+**Architecture:** Each PR follows the two-layer pattern established by VS Code (agent-support/vscode/) and JetBrains (agent-support/intellij/): (1) extension/plugin code that hooks the IDE's save event and calls git-ai, and (2) a Rust installer in src/mdm/agents/ that auto-installs the extension where possible. All 9 are independent — no shared code between PRs.
+
+**Tech Stack:** Rust (all installers), TypeScript/Python/Java/Swift/Vimscript/Lua/C# per IDE, HookInstaller trait (src/mdm/hook_installer.rs).
+
+**Spec:** docs/superpowers/specs/2026-04-11-multi-ide-known-human-design.md
+
+---
+
+## Common Pattern (applies to all 9 tasks)
+
+### Reference files to read first (every subagent):
+- `docs/superpowers/specs/2026-04-11-multi-ide-known-human-design.md` — full spec
+- `agent-support/vscode/src/known-human-checkpoint-manager.ts` — TypeScript reference
+- `agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/listener/DocumentSaveListener.kt` — Kotlin reference
+- `src/mdm/agents/cursor.rs` — extension-based installer with auto-install pattern
+- `src/mdm/agents/vscode.rs` — extension-based installer
+- `src/mdm/hook_installer.rs` — HookInstaller trait
+- `src/mdm/utils.rs` — binary_exists(), home_dir(), resolve_editor_cli(), install_vsc_editor_extension()
+- `src/mdm/agents/mod.rs` — wiring pattern
+
+### Rust installer skeleton (adapt for each IDE):
+```rust
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult};
+use crate::mdm::utils::{binary_exists, home_dir};
+
+pub struct <Name>Installer;
+
+impl HookInstaller for <Name>Installer {
+    fn name(&self) -> &str { "<Human Name>" }
+    fn id(&self) -> &str { "<kebab-id>" }
+    fn uses_config_hooks(&self) -> bool { false }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let detected = binary_exists("<binary>") || home_dir().join(".<dir>").exists();
+        Ok(HookCheckResult {
+            tool_installed: detected,
+            hooks_installed: false,  // update to check actual install state
+            hooks_up_to_date: false,
+        })
+    }
+
+    fn install_hooks(&self, _params: &HookInstallerParams, _dry_run: bool) -> Result<Option<String>, GitAiError> {
+        Ok(None)  // extension-based: no config file hooks
+    }
+
+    fn uninstall_hooks(&self, _params: &HookInstallerParams, _dry_run: bool) -> Result<Option<String>, GitAiError> {
+        Ok(None)
+    }
+
+    fn install_extras(&self, params: &HookInstallerParams, dry_run: bool) -> Result<Vec<InstallResult>, GitAiError> {
+        // auto-install logic or manual message
+        todo!()
+    }
+}
+```
+
+### mod.rs wiring — add to BOTH sections:
+```rust
+// At top (mod declarations):
+mod <name>;
+pub use <name>::<Name>Installer;
+
+// In get_all_installers():
+Box::new(<Name>Installer),
+```
+
+### CI commands (run before PR):
+```bash
+cargo check 2>&1 | head -50
+cargo clippy -- -D warnings 2>&1 | head -50
+cargo test -- --test-threads=4 2>&1 | tail -20
+```
+
+### PR creation:
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet points>
+
+## Manual install steps (for docs site)
+<steps if applicable>
+
+## Test plan
+- [ ] cargo clippy passes
+- [ ] cargo test passes
+
+🤖 Generated with Claude Code
+EOF
+)"
+```
+
+---
+
+## Task 1 — Windsurf
+
+**Branch:** `feat/known-human-windsurf`  
+**Files modified** (no new extension code):
+- `src/mdm/utils.rs` — add windsurf to `get_editor_cli_candidates()`
+- `src/mdm/agents/windsurf.rs` — add `install_extras()` + update `check_hooks()`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] In `src/mdm/utils.rs`, find the `get_editor_cli_candidates()` match arm for `"cursor"` and add a `"windsurf"` arm after it:
+```rust
+"windsurf" => {
+    #[cfg(target_os = "macos")]
+    {
+        for apps_dir in [PathBuf::from("/Applications"), home.join("Applications")] {
+            let app = apps_dir.join("Windsurf.app");
+            candidates.push((
+                app.join("Contents").join("MacOS").join("Windsurf"),
+                app.join("Contents").join("Resources").join("app").join("out").join("cli.js"),
+            ));
+        }
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        for base in [
+            PathBuf::from("/opt/Windsurf"),
+            home.join(".local").join("share").join("windsurf"),
+            home.join(".local").join("share").join("Windsurf"),
+        ] {
+            candidates.push((
+                base.join("windsurf"),
+                base.join("resources").join("app").join("out").join("cli.js"),
+            ));
+        }
+    }
+    #[cfg(windows)]
+    {
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            let base = PathBuf::from(local_app_data).join("Programs").join("Windsurf");
+            candidates.push((
+                base.join("Windsurf.exe"),
+                base.join("resources").join("app").join("out").join("cli.js"),
+            ));
+        }
+    }
+}
+```
+- [ ] In `src/mdm/agents/windsurf.rs`, add `install_vsc_editor_extension`, `is_vsc_editor_extension_installed`, `resolve_editor_cli` to imports, then add `install_extras()` method mirroring `cursor.rs` exactly (substitute `"windsurf"` for `"cursor"`, extension ID stays `"git-ai.git-ai-vscode"`). Also update `check_hooks()` to check extension install status using `resolve_editor_cli("windsurf")`.
+- [ ] `cargo check && cargo clippy -- -D warnings`
+- [ ] `cargo test 2>&1 | tail -20`
+- [ ] Commit: `git commit -m "feat(windsurf): auto-install VS Code extension for known_human checkpoint"`
+- [ ] Push and create PR
+
+---
+
+## Task 2 — Zed
+
+**Branch:** `feat/known-human-zed`  
+**New files:**
+- `agent-support/zed/Cargo.toml`
+- `agent-support/zed/src/lib.rs`
+- `agent-support/zed/extension.toml`
+- `src/mdm/agents/zed.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Research the current `zed_extension_api` crate on crates.io/GitHub to understand the 2025 API. Check if `on_save` or `workspace_did_save` hooks exist. If not, document the fallback approach chosen.
+- [ ] Scaffold from `zed-extension-api` template. Create `agent-support/zed/` with proper Cargo.toml targeting `wasm32-wasip1`.
+- [ ] Implement the save hook in `agent-support/zed/src/lib.rs`:
+  - Listen for file-save events
+  - 500ms debounce per repo root
+  - Build JSON payload with `editor: "zed"`, `editor_version`, `cwd`, `edited_filepaths`, `dirty_files`
+  - Spawn `git-ai checkpoint known_human --hook-input stdin` with JSON on stdin
+- [ ] Create `src/mdm/agents/zed.rs` — detect `zed` binary or `~/.config/zed/`. `install_extras()` writes the WASM + extension.toml to `~/.config/zed/extensions/git-ai/` (embed WASM via `include_bytes!` from pre-built `agent-support/zed/dist/extension.wasm` if possible, or document build step in PR).
+- [ ] Wire into `src/mdm/agents/mod.rs`
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR
+
+---
+
+## Task 3 — Sublime Text
+
+**Branch:** `feat/known-human-sublime-text`  
+**New files:**
+- `agent-support/sublime-text/git_ai.py`
+- `src/mdm/agents/sublime_text.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Find the Package Control "Package Example" repo for boilerplate structure reference
+- [ ] Create `agent-support/sublime-text/git_ai.py`:
+```python
+import sublime
+import sublime_plugin
+import subprocess
+import threading
+import json
+import os
+
+_timers = {}  # repo_root -> threading.Timer
+_pending = {}  # repo_root -> list of (path, content)
+_lock = threading.Lock()
+
+GIT_AI_BIN = os.path.expanduser("~/.git-ai/bin/git-ai")
+
+def find_repo_root(path):
+    d = os.path.dirname(path)
+    while d != os.path.dirname(d):
+        if os.path.isdir(os.path.join(d, ".git")):
+            return d
+        d = os.path.dirname(d)
+    return None
+
+def fire_checkpoint(repo_root):
+    with _lock:
+        files = list(_pending.get(repo_root, []))
+        _pending[repo_root] = []
+    if not files:
+        return
+    dirty_files = {}
+    for path, content in files:
+        dirty_files[path] = content
+    payload = json.dumps({
+        "editor": "sublime-text",
+        "editor_version": sublime.version(),
+        "extension_version": "1.0.0",
+        "cwd": repo_root,
+        "edited_filepaths": list(dirty_files.keys()),
+        "dirty_files": dirty_files,
+    })
+    try:
+        proc = subprocess.Popen(
+            [GIT_AI_BIN, "checkpoint", "known_human", "--hook-input", "stdin"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=repo_root,
+        )
+        proc.stdin.write(payload.encode("utf-8"))
+        proc.stdin.close()
+        proc.wait(timeout=10)
+    except Exception as e:
+        print(f"[git-ai] checkpoint error: {e}")
+
+class GitAiSaveListener(sublime_plugin.EventListener):
+    def on_post_save_async(self, view):
+        path = view.file_name()
+        if not path:
+            return
+        if "/.git/" in path.replace("\\", "/"):
+            return
+        if path.endswith(".sublime-workspace") or path.endswith(".sublime-project"):
+            return
+        repo_root = find_repo_root(path)
+        if not repo_root:
+            return
+        content = view.substr(sublime.Region(0, view.size()))
+        with _lock:
+            if repo_root not in _pending:
+                _pending[repo_root] = []
+            # Update or append entry for this path
+            existing = [(p, c) for p, c in _pending[repo_root] if p != path]
+            existing.append((path, content))
+            _pending[repo_root] = existing
+            if repo_root in _timers:
+                _timers[repo_root].cancel()
+            t = threading.Timer(0.5, fire_checkpoint, args=[repo_root])
+            _timers[repo_root] = t
+            t.start()
+```
+- [ ] Create `src/mdm/agents/sublime_text.rs` with `SublimeTextInstaller`. `check_hooks()` detects `subl` binary or Packages directory. `install_extras()` writes `git_ai.py` (with GIT_AI_BIN path substituted to `params.binary_path`) to `Packages/git-ai/git_ai.py`. Platform paths: macOS `~/Library/Application Support/Sublime Text/Packages/`, Linux `~/.config/sublime-text/Packages/`, Windows `%APPDATA%\Sublime Text\Packages\`.
+- [ ] Wire into mod.rs
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR
+
+---
+
+## Task 4 — Eclipse
+
+**Branch:** `feat/known-human-eclipse`  
+**New files:**
+- `agent-support/eclipse/` (Maven multi-module: plugin + feature)
+- `src/mdm/agents/eclipse.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Scaffold via Eclipse PDE Maven archetype or manually create the OSGi bundle structure. Key files: `MANIFEST.MF`, `plugin.xml`, `pom.xml`, main `Activator.java`, `GitAiSaveListener.java`.
+- [ ] Implement `GitAiSaveListener implements IResourceChangeListener` in `agent-support/eclipse/plugin/src/io/gitai/eclipse/`:
+  - Register on `ResourcesPlugin.getWorkspace().addResourceChangeListener(this, IResourceChangeEvent.POST_CHANGE)`
+  - Walk delta, collect `IResourceDelta.CHANGED | IResourceDelta.CONTENT` files not under `.git/`
+  - 500ms debounce per repo root using `ScheduledExecutorService`
+  - On fire: read contents via `IFile.getContents()`, build JSON, call git-ai via `ProcessBuilder`
+  - Find repo root: walk `IContainer.getParent()` checking for `.git` child
+- [ ] Create `src/mdm/agents/eclipse.rs` — `check_hooks()` detects `eclipse` binary or `~/.p2/`. `install_extras()` returns manual message with placeholder update site URL.
+- [ ] Wire into mod.rs
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR (include full manual install steps in PR body)
+
+---
+
+## Task 5 — Xcode
+
+**Branch:** `feat/known-human-xcode`  
+**New files:**
+- `agent-support/xcode/` (Swift Package, `git-ai-xcode-watcher` CLI target)
+- `src/mdm/agents/xcode.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Scaffold a Swift Package with `swift package init --type executable`. Rename the target to `git-ai-xcode-watcher`.
+- [ ] Implement `Sources/git-ai-xcode-watcher/main.swift`:
+  - Parse `--path <dir>` args (multiple allowed)
+  - Use `CoreServices.FSEventStreamCreate` to watch each directory
+  - Filter events: skip `.git/`, `DerivedData/`, `xcuserdata/`, `.build/`
+  - 500ms debounce per git repo root (find root with `git -C <dir> rev-parse --show-toplevel`)
+  - On fire: read file contents, build JSON payload, exec `git-ai checkpoint known_human --hook-input stdin`
+- [ ] Create `src/mdm/agents/xcode.rs` — macOS only (`#[cfg(target_os = "macos")]`). `check_hooks()` detects `/Applications/Xcode.app`. `install_extras()` returns instructions for adding to Xcode scheme pre-action and launchd plist.
+- [ ] Wire into mod.rs (wrap with `#[cfg(target_os = "macos")]` if needed, or use runtime detection)
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR (include scheme script + launchd plist in PR body)
+
+---
+
+## Task 6 — Vim
+
+**Branch:** `feat/known-human-vim`  
+**New files:**
+- `agent-support/vim/plugin/git_ai.vim`
+- `agent-support/vim/doc/git-ai.txt`
+- `src/mdm/agents/vim.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Find a well-starred `vim-plugin-template` on GitHub for structural reference
+- [ ] Create `agent-support/vim/plugin/git_ai.vim`:
+```vim
+if exists('g:loaded_git_ai') | finish | endif
+let g:loaded_git_ai = 1
+
+if !exists('g:git_ai_enabled')
+  let g:git_ai_enabled = 1
+endif
+
+let s:debounce_timers = {}
+let s:pending_files = {}
+
+function! s:GitAiBin() abort
+  return expand('~/.git-ai/bin/git-ai')
+endfunction
+
+function! s:FindRepoRoot(file) abort
+  let l:dir = fnamemodify(a:file, ':h')
+  let l:result = systemlist('git -C ' . shellescape(l:dir) . ' rev-parse --show-toplevel 2>/dev/null')
+  return empty(l:result) ? '' : l:result[0]
+endfunction
+
+function! s:FireCheckpoint(root) abort
+  let l:files = get(s:pending_files, a:root, {})
+  if empty(l:files) | return | endif
+  let s:pending_files[a:root] = {}
+
+  let l:dirty = {}
+  for [l:path, l:content] in items(l:files)
+    let l:dirty[l:path] = l:content
+  endfor
+
+  let l:payload = json_encode({
+    \ 'editor': 'vim',
+    \ 'editor_version': string(v:version),
+    \ 'extension_version': '1.0.0',
+    \ 'cwd': a:root,
+    \ 'edited_filepaths': keys(l:dirty),
+    \ 'dirty_files': l:dirty,
+    \ })
+
+  let l:cmd = [s:GitAiBin(), 'checkpoint', 'known_human', '--hook-input', 'stdin']
+  if has('job')
+    let l:job = job_start(l:cmd, {
+      \ 'in_mode': 'raw',
+      \ 'cwd': a:root,
+      \ })
+    call ch_sendraw(job_getchannel(l:job), l:payload)
+    call ch_close_in(job_getchannel(l:job))
+  else
+    " Fallback: synchronous (blocks briefly on slow systems)
+    call system(join(map(copy(l:cmd), 'shellescape(v:val)'), ' '), l:payload)
+  endif
+endfunction
+
+function! s:OnSave() abort
+  if !g:git_ai_enabled | return | endif
+  let l:file = expand('<afile>:p')
+  if l:file =~# '/\.git/' | return | endif
+  let l:root = s:FindRepoRoot(l:file)
+  if empty(l:root) | return | endif
+  let l:content = join(getline(1, '$'), "\n")
+  if !has_key(s:pending_files, l:root)
+    let s:pending_files[l:root] = {}
+  endif
+  let s:pending_files[l:root][l:file] = l:content
+  if has_key(s:debounce_timers, l:root)
+    call timer_stop(s:debounce_timers[l:root])
+  endif
+  let s:debounce_timers[l:root] = timer_start(500, {-> s:FireCheckpoint(l:root)})
+endfunction
+
+augroup git_ai_known_human
+  autocmd!
+  autocmd BufWritePost * call s:OnSave()
+augroup END
+```
+- [ ] Create minimal `agent-support/vim/doc/git-ai.txt` help file
+- [ ] Create `src/mdm/agents/vim.rs` — `check_hooks()` detects `vim` binary. `install_extras()` returns message listing all install variants (native pack, vim-plug, Vundle).
+- [ ] Wire into mod.rs
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR (include all package manager install variants in PR body)
+
+---
+
+## Task 7 — Neovim
+
+**Branch:** `feat/known-human-neovim`  
+**New files:**
+- `agent-support/neovim/lua/git-ai/init.lua`
+- `agent-support/neovim/plugin/git-ai.lua`
+- `agent-support/neovim/README.md`
+- `src/mdm/agents/neovim.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Check out `nvim-lua/nvim-plugin-template` on GitHub for structural reference
+- [ ] Create `agent-support/neovim/plugin/git-ai.lua` (auto-load shim):
+```lua
+-- Auto-load shim: loaded by Neovim on startup
+if vim.g.loaded_git_ai then return end
+vim.g.loaded_git_ai = 1
+require('git-ai').setup()
+```
+- [ ] Create `agent-support/neovim/lua/git-ai/init.lua`:
+```lua
+local M = {}
+local timers = {}   -- repo_root -> uv timer
+local pending = {}  -- repo_root -> { [path] = content }
+
+local function git_ai_bin()
+  return vim.fn.expand('~/.git-ai/bin/git-ai')
+end
+
+local function find_repo_root(file)
+  local dir = vim.fn.fnamemodify(file, ':h')
+  local result = vim.fn.systemlist({'git', '-C', dir, 'rev-parse', '--show-toplevel'})
+  if vim.v.shell_error ~= 0 or #result == 0 then return nil end
+  return result[1]
+end
+
+local function fire(root)
+  local files = pending[root]
+  if not files or next(files) == nil then return end
+  pending[root] = {}
+
+  local dirty = {}
+  local paths = {}
+  for path, content in pairs(files) do
+    dirty[path] = content
+    table.insert(paths, path)
+  end
+
+  local payload = vim.json.encode({
+    editor = 'neovim',
+    editor_version = tostring(vim.version()),
+    extension_version = '1.0.0',
+    cwd = root,
+    edited_filepaths = paths,
+    dirty_files = dirty,
+  })
+
+  local stdin = vim.loop.new_pipe(false)
+  vim.loop.spawn(git_ai_bin(), {
+    args = {'checkpoint', 'known_human', '--hook-input', 'stdin'},
+    stdio = {stdin, nil, nil},
+    cwd = root,
+  }, function() end)
+  vim.loop.write(stdin, payload)
+  vim.loop.shutdown(stdin, function() vim.loop.close(stdin) end)
+end
+
+local function on_save(args)
+  if not vim.g.git_ai_enabled then return end
+  local file = vim.api.nvim_buf_get_name(args.buf)
+  if file == '' then return end
+  if file:find('/.git/') then return end
+  local root = find_repo_root(file)
+  if not root then return end
+
+  local lines = vim.api.nvim_buf_get_lines(args.buf, 0, -1, false)
+  local content = table.concat(lines, '\n')
+
+  if not pending[root] then pending[root] = {} end
+  pending[root][file] = content
+
+  if timers[root] then
+    timers[root]:stop()
+  else
+    timers[root] = vim.loop.new_timer()
+  end
+  timers[root]:start(500, 0, vim.schedule_wrap(function() fire(root) end))
+end
+
+function M.setup(opts)
+  opts = opts or {}
+  vim.g.git_ai_enabled = opts.enabled ~= false
+  vim.api.nvim_create_autocmd('BufWritePost', {
+    group = vim.api.nvim_create_augroup('GitAiKnownHuman', { clear = true }),
+    callback = on_save,
+  })
+end
+
+return M
+```
+- [ ] Create `src/mdm/agents/neovim.rs` — `check_hooks()` detects `nvim` binary. `install_extras()` returns message with lazy.nvim, packer, and native install variants.
+- [ ] Wire into mod.rs
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR (include all package manager install variants in PR body)
+
+---
+
+## Task 8 — Visual Studio
+
+**Branch:** `feat/known-human-visual-studio`  
+**New files:**
+- `agent-support/visual-studio/` (C# VSIX project)
+- `src/mdm/agents/visual_studio.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Research `dotnet new vsix` template or Visual Studio VSIX Project wizard. Scaffold the project structure.
+- [ ] Implement C# VSIX in `agent-support/visual-studio/`:
+  - `GitAiPackage.cs`: `AsyncPackage` subclass, `InitializeAsync` gets `IVsRunningDocumentTable` and subscribes
+  - `DocumentSaveListener.cs`: implements `IVsRunningDocTableEvents3.OnAfterSave`, 500ms `System.Threading.Timer` debounce per solution root, `Process.Start` to call git-ai with JSON on stdin
+  - `.vsixmanifest`: target VS 2019 (16.0) + VS 2022 (17.0)
+- [ ] Create `src/mdm/agents/visual_studio.rs` — Windows-only. `check_hooks()` scans `%ProgramFiles%\Microsoft Visual Studio\` for `devenv.exe`. `install_extras()` finds `Common7\IDE\VSIXInstaller.exe` and runs it quietly with the bundled VSIX (or returns Marketplace fallback message). `uninstall_extras()` runs `/uninstall:io.gitai.visualstudio`.
+- [ ] Wire into mod.rs
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR (include Marketplace manual install steps in PR body)
+
+---
+
+## Task 9 — Notepad++
+
+**Branch:** `feat/known-human-notepad-plus-plus`  
+**New files:**
+- `agent-support/notepad-plus-plus/` (C# .NET 4.8 class library)
+- `src/mdm/agents/notepad_plus_plus.rs`
+
+- [ ] Read reference files listed in Common Pattern above
+- [ ] Scaffold from `kbilsted/NotepadPlusPlusPluginPack.Net` template on GitHub
+- [ ] Implement C# plugin in `agent-support/notepad-plus-plus/`:
+  - `Plugin.cs`: hook `NPPN_FILESAVED` in `beNotified()`, get path via `NPPM_GETFULLCURRENTPATH`, 500ms `System.Threading.Timer` debounce per repo root, `Process.Start` with JSON on stdin
+  - Build both x86 and x64 DLL variants
+  - DLL output name: `git-ai.dll`
+- [ ] Create `src/mdm/agents/notepad_plus_plus.rs` — Windows-only. `check_hooks()` detects `%ProgramFiles%\Notepad++\notepad++.exe` or registry key. `install_extras()` reads PE header of notepad++.exe to choose x86/x64 DLL, copies to `%APPDATA%\Notepad++\plugins\git-ai\git-ai.dll`. Returns note that Notepad++ must be restarted.
+- [ ] Wire into mod.rs
+- [ ] `cargo check && cargo clippy -- -D warnings && cargo test 2>&1 | tail -20`
+- [ ] Commit and create PR (include manual DLL copy steps in PR body)

--- a/docs/superpowers/specs/2026-04-11-multi-ide-known-human-design.md
+++ b/docs/superpowers/specs/2026-04-11-multi-ide-known-human-design.md
@@ -1,0 +1,398 @@
+# Multi-IDE Known-Human Checkpoint — Design Spec
+
+**Date:** 2026-04-11  
+**Status:** Approved  
+
+---
+
+## Background
+
+PR #1023 introduced the `known_human` checkpoint: when a user saves a file in an IDE, the
+extension fires `git-ai checkpoint known_human --hook-input stdin` with a JSON payload containing
+the saved file paths and content. This lets git-ai attribute those lines to the human author
+rather than leaving them as unknown after an AI edit session.
+
+VS Code (via its extension, `agent-support/vscode/`) and JetBrains IDEs (via the IntelliJ
+plugin, `agent-support/intellij/`) already implement this. Cursor reuses the VS Code extension.
+
+This spec covers adding the same capability to 9 additional IDE/editor targets, one PR each,
+with subagents running in parallel git worktrees.
+
+---
+
+## Checkpoint Protocol (unchanged)
+
+Every integration must call:
+
+```
+git-ai checkpoint known_human --hook-input stdin
+```
+
+with the following JSON written to stdin:
+
+```json
+{
+  "editor": "<editor-id>",
+  "editor_version": "<version string>",
+  "extension_version": "<plugin/extension version>",
+  "cwd": "/absolute/path/to/git/repo/root",
+  "edited_filepaths": ["/abs/path/file1.ext", "/abs/path/file2.ext"],
+  "dirty_files": {
+    "/abs/path/file1.ext": "<full file content after save>",
+    "/abs/path/file2.ext": "<full file content after save>"
+  }
+}
+```
+
+Key requirements:
+- **500ms debounce per repo root** — reset the timer on each save within the window; fire once
+  after the window closes. "Save All" must produce one checkpoint, not N.
+- **Absolute file paths only** in both `edited_filepaths` and `dirty_files` keys.
+- **Skip IDE-internal paths** (`.idea/`, `.vscode/`, `.git/`, etc.).
+- **Find repo root** by walking up from the saved file path looking for a `.git` directory.
+- **Async / non-blocking** — the save event handler must not block the UI thread.
+
+Reference implementations: `agent-support/vscode/src/known-human-checkpoint-manager.ts` (TypeScript)
+and `agent-support/intellij/src/main/kotlin/.../listener/DocumentSaveListener.kt` (Kotlin).
+
+---
+
+## Two-Layer Architecture
+
+Each integration has two layers:
+
+**Layer 1 — Extension/plugin code** (`agent-support/<ide>/`)  
+Native code for the IDE that listens to the save event, debounces, and calls git-ai.
+
+**Layer 2 — Rust installer** (`src/mdm/agents/<ide>.rs`)  
+Implements the `HookInstaller` trait. Auto-installs the extension where feasible; otherwise
+returns a message with manual steps. Wired into `src/mdm/agents/mod.rs`.
+
+---
+
+## Official Starter Templates
+
+Each subagent **must** find and scaffold from the official starter/template for the target IDE
+before writing any logic. Do not invent boilerplate from scratch. The starters to use:
+
+| IDE | Official starter |
+|-----|-----------------|
+| Zed | `zed-extension-api` crate template on GitHub; or `zed extension new` CLI if available |
+| Sublime Text | Package Control "Package Example" repo |
+| Eclipse | Eclipse PDE Plug-in Project archetype (`mvn archetype:generate`) |
+| Xcode | Xcode built-in "Source Editor Extension" template (Swift Package scaffold) |
+| Vim | community `vim-plugin-template` on GitHub (search for a well-starred one) |
+| Neovim | `nvim-lua/nvim-plugin-template` on GitHub |
+| Visual Studio | `dotnet new vsix` / Visual Studio "VSIX Project" wizard template |
+| Notepad++ | `kbilsted/NotepadPlusPlusPluginPack.Net` — canonical .NET plugin starter |
+
+---
+
+## Per-IDE Specifications
+
+### PR 1 — Windsurf
+
+**Auto-install:** Yes (via `windsurf --install-extension` CLI).  
+**New extension code:** None — reuses the existing `git-ai.git-ai-vscode` VS Code extension.
+The VS Code extension already detects Windsurf via `host-kind.ts`.
+
+**`src/mdm/utils.rs`**  
+Add Windsurf to `get_editor_cli_candidates()`:
+- macOS: `/Applications/Windsurf.app` and `~/Applications/Windsurf.app`
+- Linux: `/opt/Windsurf/`, `~/.local/share/windsurf/`, `~/.local/share/Windsurf/`
+- Windows: `%LOCALAPPDATA%\Programs\Windsurf\`
+
+**`src/mdm/agents/windsurf.rs`** (modify existing file)  
+- `check_hooks()`: additionally check whether the VS Code extension is installed using
+  `resolve_editor_cli("windsurf")` + `is_vsc_editor_extension_installed(&cli, "git-ai.git-ai-vscode")`.
+- `install_extras()`: call `resolve_editor_cli("windsurf")` then
+  `install_vsc_editor_extension(&cli, "git-ai.git-ai-vscode")`, mirroring the pattern in
+  `cursor.rs` exactly. Include Codespaces guard (same as VS Code installer).
+- `uninstall_extras()`: note that the extension must be uninstalled manually.
+
+Check whether Windsurf uses the same settings directory layout as Cursor
+(`~/.codeium/windsurf/` exists already for Cascade hooks). If Windsurf also respects a
+`settings.json` for `git.path`, add a `settings_paths_for_products(&["Windsurf"])` call
+in `install_extras()`.
+
+---
+
+### PR 2 — Zed
+
+**Auto-install:** Yes (drop compiled extension into `~/.config/zed/extensions/git-ai/`).  
+**Extension language:** Rust, compiled to WebAssembly.
+
+**`agent-support/zed/`**  
+Scaffold from the `zed-extension-api` template. Implement the `Extension` trait.
+
+For the save hook: Zed's extension API as of early 2025 is evolving. The subagent must
+verify whether `workspace_did_save` or equivalent is exposed in the current
+`zed_extension_api` crate. If a stable on-save hook exists, use it directly. If not,
+investigate whether a Zed "task" (`.zed/tasks.json`) can be written that runs on save and
+calls git-ai — accepting that this requires the user to have the task configured. Document
+the chosen approach clearly in the PR.
+
+The extension must:
+- Find the git repo root from the saved file path
+- Debounce 500ms per repo root
+- Construct the JSON payload and call git-ai via OS process
+
+**`src/mdm/agents/zed.rs`**  
+- `check_hooks()`: detect `zed` binary or `~/.config/zed/` directory.
+- `install_extras()`: write the compiled WASM artifact + `extension.toml` into
+  `~/.config/zed/extensions/git-ai/`. Zed discovers extensions in that directory on restart.
+  The WASM bytes must be available at install time — embed them in the Rust binary via
+  `include_bytes!` pointing to a pre-built artifact committed to `agent-support/zed/dist/`,
+  or build them on-the-fly if `cargo` + `wasm32-wasi` toolchain is present. Document the
+  chosen approach in the PR.
+- `install_hooks()` / `uninstall_hooks()`: no-ops.
+
+---
+
+### PR 3 — Sublime Text
+
+**Auto-install:** Yes (drop Python package into Packages directory, hot-reloaded).  
+**Extension language:** Python 3.
+
+**`agent-support/sublime-text/`**  
+Scaffold from the Package Control "Package Example" repo. Single-file plugin `git_ai.py`.
+
+Implement `sublime_plugin.EventListener` with `on_post_save_async(self, view)`:
+- Get absolute file path from `view.file_name()`
+- Skip paths containing `.git/`, `.sublime-workspace`, `.sublime-project`
+- Walk up from file path to find `.git/` directory (repo root)
+- Per-repo-root debounce: cancel existing `threading.Timer` for that root, start new 500ms timer
+- On timer fire: read current file contents (re-read from disk, the file is already saved),
+  build JSON payload, call git-ai via `subprocess.Popen` with JSON on stdin
+- Use `sublime.packages_path()` at runtime to locate the git-ai binary relative to the
+  known install path (`~/.git-ai/bin/git-ai`), not relative to the package
+
+**`src/mdm/agents/sublime_text.rs`**  
+Packages path by platform:
+- macOS: `~/Library/Application Support/Sublime Text/Packages/`
+- Linux: `~/.config/sublime-text/Packages/`
+- Windows: `%APPDATA%\Sublime Text\Packages\`
+
+- `check_hooks()`: detect `subl` binary or the Packages directory. Check whether
+  `Packages/git-ai/git_ai.py` exists and contains the current binary path.
+- `install_extras()`: write `git_ai.py` (with binary path substituted) into
+  `Packages/git-ai/git_ai.py`. Sublime hot-reloads on write — no restart needed.
+- `install_hooks()` / `uninstall_hooks()`: no-ops.
+
+---
+
+### PR 4 — Eclipse
+
+**Auto-install:** No.  
+**Extension language:** Java (OSGi bundle / Eclipse plugin).
+
+**`agent-support/eclipse/`**  
+Scaffold via Eclipse PDE `mvn archetype:generate` using the standard plug-in archetype.
+Maven multi-module project: one `plugin` module and one `feature` module (for the p2
+update site).
+
+Plugin implementation:
+- Register an `IResourceChangeListener` on `ResourcesPlugin.getWorkspace()` at bundle
+  activation for `IResourceChangeEvent.POST_CHANGE`.
+- Walk `IResourceDelta` tree; collect files with `CHANGED | CONTENT` flag that are not in
+  `.git/` or `.settings/` directories.
+- Per-repo-root debounce: `ScheduledExecutorService` with `ScheduledFuture` cancel/reschedule.
+- On fire: read file contents from `IFile.getContents()`, build JSON, call git-ai via
+  `ProcessBuilder`.
+- Find repo root: walk `IResource.getParent()` up to workspace root, checking for `.git`.
+- Bundle ID: `io.gitai.eclipse`.
+
+**`src/mdm/agents/eclipse.rs`**  
+- `check_hooks()`: detect `eclipse` binary or `~/.p2/` (Eclipse provisioning metadata).
+- `install_extras()`: no auto-install. Return a message:
+  ```
+  Eclipse: Install from the update site — Help → Install New Software →
+  Add site: <update-site-url-tbd> — then restart Eclipse.
+  ```
+  (The update site URL is TBD; the subagent should use a placeholder and note it in the PR.)
+- PR description must include full manual install steps for the docs site.
+
+---
+
+### PR 5 — Xcode
+
+**Auto-install:** No.  
+**Approach:** Lightweight Swift CLI daemon using `FSEvents`, not a Source Editor Extension
+(Xcode extensions don't receive save events).
+
+**`agent-support/xcode/`**  
+Scaffold from Xcode's Swift Package template. Build target: `git-ai-xcode-watcher` CLI.
+
+Implementation:
+- Accept `--path <dir>` argument(s) (the Xcode project root directory).
+- Use `FSEvents` (`FSEventStreamCreate`) to watch for file-system events under each path.
+- Filter for actual file writes (not directory events, not `.git/` or `DerivedData/`).
+- 500ms debounce per repo root (same logic as other integrations).
+- On fire: read saved file contents, build JSON payload, call git-ai.
+- Can run as a persistent process (e.g., via launchd) or as a one-shot watcher.
+
+Users integrate by adding `git-ai-xcode-watcher --path "$SRCROOT"` to their Xcode scheme's
+"Pre-action" or "Post-action" run scripts, or by installing the provided launchd plist.
+
+**`src/mdm/agents/xcode.rs`**  
+- `check_hooks()`: macOS only; detect `/Applications/Xcode.app`.
+- `install_extras()`: no auto-install. Return instructions:
+  ```
+  Xcode: Run 'git-ai-xcode-watcher --path <project-dir>' as a background process,
+  or add it to your Xcode scheme's Pre-action script. See docs for launchd setup.
+  ```
+- PR description must include scheme script snippet and launchd plist for the docs site.
+
+---
+
+### PR 6 — Vim
+
+**Auto-install:** No.  
+**Extension language:** Vimscript.
+
+**`agent-support/vim/`**  
+Scaffold from a well-starred community `vim-plugin-template` on GitHub (subagent to find
+the best current option). Structure: `plugin/git-ai.vim` (auto-loaded), `doc/git-ai.txt`.
+
+`plugin/git-ai.vim` implementation:
+- Guard: `if exists('g:loaded_git_ai') | finish | endif`
+- `autocmd BufWritePost * call s:GitAiKnownHuman(expand('<afile>:p'))`
+- Per-repo-root debounce: `timer_stop()` on existing timer for that root, `timer_start(500, ...)`
+- On timer fire: construct JSON string, call git-ai via `job_start(['git-ai', 'checkpoint',
+  'known_human', '--hook-input', 'stdin'], {'in_io': 'pipe'})` with JSON piped to `in_buf`.
+  Fall back to synchronous `system()` for Vim < 8.0 (no job API).
+- Find repo root: `systemlist('git -C ' . shellescape(dir) . ' rev-parse --show-toplevel')[0]`
+- Skip internal paths: files under `.git/`.
+- Respects `g:git_ai_enabled` global flag (default on).
+
+**`src/mdm/agents/vim.rs`**  
+- `check_hooks()`: detect `vim` binary.
+- `install_extras()`: no auto-install. Return message with all package manager variants:
+  - Native: copy to `~/.vim/pack/git-ai/start/git-ai/`
+  - vim-plug: `Plug 'git-ai-project/git-ai', {'rtp': 'agent-support/vim'}`
+  - Vundle: `Plugin 'git-ai-project/git-ai'`
+- PR description includes all install variants for the docs site.
+
+---
+
+### PR 7 — Neovim
+
+**Auto-install:** No.  
+**Extension language:** Lua.
+
+**`agent-support/neovim/`**  
+Scaffold from `nvim-lua/nvim-plugin-template` on GitHub. Structure:
+`lua/git-ai/init.lua` (main module), `plugin/git-ai.lua` (auto-load shim).
+
+`lua/git-ai/init.lua` implementation:
+- `M.setup(opts)` entry point (lazy.nvim / packer convention).
+- `vim.api.nvim_create_autocmd('BufWritePost', { callback = on_save })`.
+- Per-repo-root debounce: `vim.loop.new_timer()` stored in module-level table keyed by repo
+  root; `timer:stop()` + `timer:start(500, 0, callback)` on each save.
+- On fire: read file with `io.open(path, 'r')`, construct JSON, call git-ai via
+  `vim.loop.spawn('git-ai', { args = {'checkpoint', 'known_human', '--hook-input', 'stdin'},
+  stdio = {stdin_pipe, nil, nil} })`, write JSON to stdin pipe.
+- Find repo root: `vim.fn.systemlist({'git', '-C', dir, 'rev-parse', '--show-toplevel'})[1]`.
+- Skip `.git/` internal paths.
+- Respects `require('git-ai').setup({ enabled = false })` opt-out.
+
+**`src/mdm/agents/neovim.rs`**  
+- `check_hooks()`: detect `nvim` binary.
+- `install_extras()`: no auto-install. Return message with package manager variants:
+  - lazy.nvim: `{ 'git-ai-project/git-ai', opts = {} }`
+  - packer: `use 'git-ai-project/git-ai'`
+  - Native: copy `lua/` + `plugin/` to `~/.config/nvim/`
+- PR description includes all variants for the docs site.
+
+---
+
+### PR 8 — Visual Studio
+
+**Auto-install:** Yes (via `VSIXInstaller.exe /quiet`).  
+**Extension language:** C# (AsyncPackage VSIX).
+
+**`agent-support/visual-studio/`**  
+Scaffold from `dotnet new vsix` or the Visual Studio "VSIX Project" wizard template.
+Target: VS 2019 (16.0+) and VS 2022 (17.0+). Framework: .NET Framework 4.7.2.
+
+Plugin implementation:
+- `GitAiPackage : AsyncPackage` — initialize on IDE load.
+- Get `IVsRunningDocumentTable` service and register `IVsRunningDocTableEvents3`.
+- `OnAfterSave(uint docCookie)`: resolve file path from the document table, skip `.git/`
+  internal paths, find repo root by walking up.
+- Per-repo-root debounce: `System.Threading.Timer` (cancel on new save, restart 500ms).
+- On fire: `File.ReadAllText()` for each pending path, build JSON, call git-ai via
+  `Process.Start()` with `RedirectStandardInput = true`, write JSON to stdin.
+- Package targets: `<InstallationTarget Version="[16.0, 18.0)">` covering VS2019 + VS2022.
+
+**`src/mdm/agents/visual_studio.rs`**  
+- `check_hooks()`: Windows-only. Detect VS installations by scanning
+  `%ProgramFiles%\Microsoft Visual Studio\` subdirectories for `devenv.exe`. Check whether
+  the VSIX is already installed by inspecting the VS extension manifest directories.
+- `install_extras()`: locate `VSIXInstaller.exe` within the VS installation
+  (`Common7\IDE\VSIXInstaller.exe`). Spawn `VSIXInstaller.exe /quiet /admin <path-to-vsix>`
+  with the VSIX path resolved from the git-ai binary's sibling `lib/` directory (or embedded
+  in the binary as bytes, written to a temp file). Attempt for each detected VS installation.
+  Fall back to a Marketplace link message if VSIXInstaller not found.
+- `uninstall_extras()`: run `VSIXInstaller.exe /quiet /uninstall:io.gitai.visualstudio`.
+- PR description includes manual Marketplace install steps for the docs site.
+
+---
+
+### PR 9 — Notepad++
+
+**Auto-install:** Yes (copy DLL to plugins directory).  
+**Extension language:** C# (.NET Framework 4.8, compiled to DLL).
+
+**`agent-support/notepad-plus-plus/`**  
+Scaffold from `kbilsted/NotepadPlusPlusPluginPack.Net` (the canonical .NET plugin starter).
+The template provides the `NppPlugin` base class and P/Invoke declarations.
+
+Plugin implementation:
+- Handle `NPPN_FILESAVED` notification in `beNotified(ScNotification notification)`.
+- Extract the saved file path by calling `Win32.SendMessage(nppHandle,
+  NppMsg.NPPM_GETFULLCURRENTPATH, ...)` — do not use `notification.nmhdr.idFrom`
+  (that is the control ID, not the path).
+- Skip `.git\` internal paths.
+- Per-repo-root debounce: `System.Threading.Timer` (cancel/restart 500ms).
+- On fire: `File.ReadAllText()`, find repo root by walking up, build JSON, call git-ai via
+  `Process.Start()` with `RedirectStandardInput = true`.
+- Build both x86 and x64 DLL variants (Notepad++ ships both architectures).
+- DLL name: `git-ai.dll` inside folder `git-ai\` (Notepad++ 8.x plugin layout).
+
+**`src/mdm/agents/notepad_plus_plus.rs`**  
+- `check_hooks()`: Windows-only. Detect Notepad++ via
+  `%ProgramFiles%\Notepad++\notepad++.exe` or `%ProgramFiles(x86)%\Notepad++\` or
+  registry `HKCU\Software\Notepad++`. Check whether
+  `%APPDATA%\Notepad++\plugins\git-ai\git-ai.dll` exists.
+- `install_extras()`: determine Notepad++ architecture (read PE header of `notepad++.exe` to
+  choose x86 vs x64 DLL). Copy the matching DLL to
+  `%APPDATA%\Notepad++\plugins\git-ai\git-ai.dll`. Notepad++ loads plugins from this
+  directory on next launch. Return a note that Notepad++ must be restarted.
+- `uninstall_extras()`: delete `%APPDATA%\Notepad++\plugins\git-ai\`.
+- PR description includes manual install steps (download DLL, place in folder) for the docs site.
+
+---
+
+## Subagent Execution Plan
+
+Each PR is implemented by one subagent in its own git worktree branching from `main`.
+All 9 run in parallel. Each subagent must:
+
+1. Read this design doc and the reference implementations (`vscode/known-human-checkpoint-manager.ts`,
+   `intellij/.../DocumentSaveListener.kt`, `src/mdm/agents/cursor.rs`, `src/mdm/agents/vscode.rs`).
+2. Find and scaffold from the official starter template listed in the "Official Starter Templates"
+   section above. Do not invent boilerplate.
+3. Implement the extension/plugin code in `agent-support/<ide>/`.
+4. Implement the Rust installer in `src/mdm/agents/<ide>.rs`.
+5. Wire the new installer into `src/mdm/agents/mod.rs` (`get_all_installers()`).
+6. For IDEs with manual-only install: write clear manual steps in the PR description,
+   structured for copy-paste into the docs site.
+7. Open a PR against `main`.
+
+## Non-Goals
+
+- Emacs integration (explicitly deferred).
+- Changes to the `known_human` checkpoint protocol or backend logic.
+- Automated tests for the extension/plugin code (integration-tested by the existing
+  Rust test suite via the checkpoint pathway).

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -23,12 +23,18 @@ const STATS_SKIP_MAX_HUNKS: usize = 1000;
 const STATS_SKIP_MAX_ADDED_LINES: usize = 6000;
 /// Skip expensive stats for extremely wide commits touching many added-line files.
 const STATS_SKIP_MAX_FILES_WITH_ADDITIONS: usize = 200;
+/// Skip expensive stats for commits that delete a large number of lines.
+/// Deletion-heavy commits (e.g. removing many files) trigger the same expensive
+/// diff-parsing path as large addition commits, but the added-lines estimate is
+/// near zero, so the cost was previously invisible to the estimator.
+const STATS_SKIP_MAX_DELETED_LINES: usize = 6000;
 
 #[derive(Debug, Clone, Copy)]
 struct StatsCostEstimate {
     files_with_additions: usize,
     added_lines: usize,
     hunk_ranges: usize,
+    deleted_lines: usize,
 }
 
 fn checkpoint_entry_requires_post_processing(
@@ -272,10 +278,11 @@ pub fn post_commit_with_final_state(
             }
             Some(StatsSkipReason::Expensive(estimate)) => {
                 debug_log(&format!(
-                    "Skipping expensive post-commit stats for {} (files_with_additions={}, added_lines={}, hunks={})",
+                    "Skipping expensive post-commit stats for {} (files_with_additions={}, added_lines={}, deleted_lines={}, hunks={})",
                     commit_sha,
                     estimate.files_with_additions,
                     estimate.added_lines,
+                    estimate.deleted_lines,
                     estimate.hunk_ranges
                 ));
             }
@@ -315,9 +322,10 @@ pub fn post_commit_with_final_state(
                 }
                 Some(StatsSkipReason::Expensive(estimate)) => {
                     eprintln!(
-                        "[git-ai] Skipped git-ai stats for large commit (files_with_additions={}, added_lines={}, hunks={}). Run `git-ai stats {}` to compute stats on demand.",
+                        "[git-ai] Skipped git-ai stats for large commit (files_with_additions={}, added_lines={}, deleted_lines={}, hunks={}). Run `git-ai stats {}` to compute stats on demand.",
                         estimate.files_with_additions,
                         estimate.added_lines,
+                        estimate.deleted_lines,
                         estimate.hunk_ranges,
                         commit_sha
                     );
@@ -339,6 +347,7 @@ fn should_skip_expensive_post_commit_stats(estimate: &StatsCostEstimate) -> bool
     estimate.hunk_ranges >= STATS_SKIP_MAX_HUNKS
         || estimate.added_lines >= STATS_SKIP_MAX_ADDED_LINES
         || estimate.files_with_additions >= STATS_SKIP_MAX_FILES_WITH_ADDITIONS
+        || estimate.deleted_lines >= STATS_SKIP_MAX_DELETED_LINES
 }
 
 /// Public result of the stats cost estimate for a commit, used by the async
@@ -382,7 +391,8 @@ fn estimate_stats_cost(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<StatsCostEstimate, GitAiError> {
-    let mut added_lines_by_file = repo.diff_added_lines(parent_sha, commit_sha, None)?;
+    let (mut added_lines_by_file, total_deleted_lines) =
+        repo.diff_added_lines_with_deleted_count(parent_sha, commit_sha)?;
     let ignore_matcher = build_ignore_matcher(ignore_patterns);
     added_lines_by_file
         .retain(|file_path, _| !should_ignore_file_with_matcher(file_path, &ignore_matcher));
@@ -407,6 +417,7 @@ fn estimate_stats_cost(
         files_with_additions,
         added_lines,
         hunk_ranges,
+        deleted_lines: total_deleted_lines,
     })
 }
 
@@ -733,8 +744,9 @@ fn record_commit_metrics(
 #[cfg(test)]
 mod tests {
     use super::{
-        STATS_SKIP_MAX_ADDED_LINES, STATS_SKIP_MAX_FILES_WITH_ADDITIONS, STATS_SKIP_MAX_HUNKS,
-        StatsCostEstimate, count_line_ranges, should_skip_expensive_post_commit_stats,
+        STATS_SKIP_MAX_ADDED_LINES, STATS_SKIP_MAX_DELETED_LINES,
+        STATS_SKIP_MAX_FILES_WITH_ADDITIONS, STATS_SKIP_MAX_HUNKS, StatsCostEstimate,
+        count_line_ranges, should_skip_expensive_post_commit_stats,
     };
     use crate::git::test_utils::TmpRepo;
 
@@ -754,6 +766,7 @@ mod tests {
             files_with_additions: STATS_SKIP_MAX_FILES_WITH_ADDITIONS - 1,
             added_lines: STATS_SKIP_MAX_ADDED_LINES - 1,
             hunk_ranges: STATS_SKIP_MAX_HUNKS - 1,
+            deleted_lines: STATS_SKIP_MAX_DELETED_LINES - 1,
         };
         assert!(!should_skip_expensive_post_commit_stats(&below_threshold));
 
@@ -761,6 +774,7 @@ mod tests {
             files_with_additions: 1,
             added_lines: 1,
             hunk_ranges: STATS_SKIP_MAX_HUNKS,
+            deleted_lines: 0,
         };
         assert!(should_skip_expensive_post_commit_stats(&by_hunks));
 
@@ -768,6 +782,7 @@ mod tests {
             files_with_additions: 1,
             added_lines: STATS_SKIP_MAX_ADDED_LINES,
             hunk_ranges: 1,
+            deleted_lines: 0,
         };
         assert!(should_skip_expensive_post_commit_stats(&by_added_lines));
 
@@ -775,8 +790,17 @@ mod tests {
             files_with_additions: STATS_SKIP_MAX_FILES_WITH_ADDITIONS,
             added_lines: 1,
             hunk_ranges: 1,
+            deleted_lines: 0,
         };
         assert!(should_skip_expensive_post_commit_stats(&by_files));
+
+        let by_deleted_lines = StatsCostEstimate {
+            files_with_additions: 0,
+            added_lines: 0,
+            hunk_ranges: 0,
+            deleted_lines: STATS_SKIP_MAX_DELETED_LINES,
+        };
+        assert!(should_skip_expensive_post_commit_stats(&by_deleted_lines));
     }
 
     #[test]
@@ -879,6 +903,7 @@ mod tests {
             files_with_additions: 0,
             added_lines: 0,
             hunk_ranges: STATS_SKIP_MAX_HUNKS,
+            deleted_lines: 0,
         };
         assert!(
             should_skip_expensive_post_commit_stats(&at_hunks),
@@ -890,6 +915,7 @@ mod tests {
             files_with_additions: 0,
             added_lines: STATS_SKIP_MAX_ADDED_LINES,
             hunk_ranges: 0,
+            deleted_lines: 0,
         };
         assert!(
             should_skip_expensive_post_commit_stats(&at_added),
@@ -901,10 +927,23 @@ mod tests {
             files_with_additions: STATS_SKIP_MAX_FILES_WITH_ADDITIONS,
             added_lines: 0,
             hunk_ranges: 0,
+            deleted_lines: 0,
         };
         assert!(
             should_skip_expensive_post_commit_stats(&at_files),
             "Exactly at files-with-additions threshold should skip"
+        );
+
+        // Exactly at deleted-lines threshold alone should trigger skip.
+        let at_deleted = StatsCostEstimate {
+            files_with_additions: 0,
+            added_lines: 0,
+            hunk_ranges: 0,
+            deleted_lines: STATS_SKIP_MAX_DELETED_LINES,
+        };
+        assert!(
+            should_skip_expensive_post_commit_stats(&at_deleted),
+            "Exactly at deleted-lines threshold should skip"
         );
 
         // All at zero should NOT skip.
@@ -912,6 +951,7 @@ mod tests {
             files_with_additions: 0,
             added_lines: 0,
             hunk_ranges: 0,
+            deleted_lines: 0,
         };
         assert!(
             !should_skip_expensive_post_commit_stats(&all_zero),

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2246,7 +2246,7 @@ impl Repository {
         let output = exec_git_with_profile(&args, InternalGitProfile::PatchParse)?;
         let diff_output = String::from_utf8_lossy(&output.stdout);
 
-        let mut result = parse_diff_added_lines(&diff_output)?;
+        let (mut result, _deleted_count) = parse_diff_added_lines(&diff_output)?;
 
         if needs_post_filter && let Some(paths) = pathspecs {
             let nfc_paths: HashSet<String> = paths.iter().map(|s| s.nfc().collect()).collect();
@@ -2254,6 +2254,28 @@ impl Repository {
         }
 
         Ok(result)
+    }
+
+    /// Like [`diff_added_lines`] but also returns the total number of deleted
+    /// lines across all hunks in the diff.  Used by the post-commit stats-cost
+    /// estimator to detect deletion-heavy commits without a second git invocation.
+    pub fn diff_added_lines_with_deleted_count(
+        &self,
+        from_ref: &str,
+        to_ref: &str,
+    ) -> Result<(HashMap<String, Vec<u32>>, usize), GitAiError> {
+        let mut args = self.global_args_for_exec();
+        args.push("diff".to_string());
+        args.push("-U0".to_string());
+        args.push("--no-color".to_string());
+        args.push("--find-renames=1%".to_string());
+        args.push(from_ref.to_string());
+        args.push(to_ref.to_string());
+
+        let output = exec_git_with_profile(&args, InternalGitProfile::PatchParse)?;
+        let diff_output = String::from_utf8_lossy(&output.stdout);
+
+        parse_diff_added_lines(&diff_output)
     }
 
     /// Get list of changed files between two refs using `git diff --name-only`
@@ -2324,7 +2346,7 @@ impl Repository {
         let output = exec_git_with_profile(&args, InternalGitProfile::PatchParse)?;
         let diff_output = String::from_utf8_lossy(&output.stdout);
 
-        let mut result = parse_diff_added_lines(&diff_output)?;
+        let (mut result, _deleted_count) = parse_diff_added_lines(&diff_output)?;
 
         if needs_post_filter && let Some(paths) = pathspecs {
             let nfc_paths: HashSet<String> = paths.iter().map(|s| s.nfc().collect()).collect();
@@ -3342,19 +3364,30 @@ fn parse_git_version(version_str: &str) -> Option<(u32, u32, u32)> {
 ///
 /// This means: old file line 10 (2 lines), new file line 15 (5 lines)
 /// We extract the "new file" line numbers to know which lines were added.
-fn parse_diff_added_lines(diff_output: &str) -> Result<HashMap<String, Vec<u32>>, GitAiError> {
+///
+/// Also returns the total number of deleted lines across all hunks so that
+/// callers can estimate the cost of a deletion-heavy commit without a second
+/// git invocation.
+fn parse_diff_added_lines(
+    diff_output: &str,
+) -> Result<(HashMap<String, Vec<u32>>, usize), GitAiError> {
     let mut result: HashMap<String, Vec<u32>> = HashMap::new();
     let mut current_file: Option<String> = None;
+    let mut total_deleted: usize = 0;
 
     for line in diff_output.lines() {
         if let Some(path_opt) = parse_new_file_path_from_plus_header_line(line) {
             current_file = path_opt;
         } else if line.starts_with("@@ ") {
             // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
-            if let Some(ref file) = current_file
-                && let Some((added_lines, _is_pure_insertion)) = parse_hunk_header(line)
-            {
-                result.entry(file.clone()).or_default().extend(added_lines);
+            if let Some((added_lines, _is_pure_insertion, old_count)) = parse_hunk_header(line) {
+                // Count deleted lines for ALL hunks, including those from purely
+                // deleted files (where current_file is None because +++ /dev/null).
+                total_deleted += old_count as usize;
+                // Only record added-line numbers when there is a destination file.
+                if let Some(ref file) = current_file {
+                    result.entry(file.clone()).or_default().extend(added_lines);
+                }
             }
         }
     }
@@ -3365,7 +3398,7 @@ fn parse_diff_added_lines(diff_output: &str) -> Result<HashMap<String, Vec<u32>>
         lines.dedup();
     }
 
-    Ok(result)
+    Ok((result, total_deleted))
 }
 
 /// Parses the unified diff output to extract line numbers of added lines,
@@ -3386,7 +3419,7 @@ fn parse_diff_added_lines_with_insertions(
         } else if line.starts_with("@@ ") {
             // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
             if let Some(ref file) = current_file
-                && let Some((added_lines, is_pure_insertion)) = parse_hunk_header(line)
+                && let Some((added_lines, is_pure_insertion, _old_count)) = parse_hunk_header(line)
             {
                 all_lines
                     .entry(file.clone())
@@ -3448,7 +3481,12 @@ fn parse_new_file_path_from_plus_header_line(line: &str) -> Option<Option<String
 /// Format: @@ -old_start,old_count +new_start,new_count @@
 /// Returns (line numbers that were added, is_pure_insertion)
 /// is_pure_insertion is true when old_count=0, meaning these are new lines, not modifications
-fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool)> {
+/// Returns `(added_line_numbers, is_pure_insertion, old_count)`.
+///
+/// `old_count` is the number of lines removed in the old file for this hunk
+/// (the value after the comma in `@@ -old_start,old_count …`).  Callers that
+/// only need the added-line numbers can discard it with `_`.
+fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool, u32)> {
     // Find the part between @@ and @@
     let parts: Vec<&str> = line.split("@@").collect();
     if parts.len() < 2 {
@@ -3494,7 +3532,7 @@ fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool)> {
 
     // If count is 0, no lines were added (only deleted)
     if count == 0 {
-        return Some((Vec::new(), false));
+        return Some((Vec::new(), false, old_count));
     }
 
     // Generate all line numbers in the range
@@ -3503,7 +3541,7 @@ fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool)> {
     // Pure insertion if old_count is 0 (no lines from old file were modified)
     let is_pure_insertion = old_count == 0;
 
-    Some((lines, is_pure_insertion))
+    Some((lines, is_pure_insertion, old_count))
 }
 
 #[cfg(test)]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2256,7 +2256,7 @@ impl Repository {
         Ok(result)
     }
 
-    /// Like [`diff_added_lines`] but also returns the total number of deleted
+    /// Like `diff_added_lines` but also returns the total number of deleted
     /// lines across all hunks in the diff.  Used by the post-commit stats-cost
     /// estimator to detect deletion-heavy commits without a second git invocation.
     pub fn diff_added_lines_with_deleted_count(

--- a/tests/integration/commit_post_stats_benchmark.rs
+++ b/tests/integration/commit_post_stats_benchmark.rs
@@ -7,6 +7,7 @@
 //! `cargo test benchmark_stats_hunk_density_hotspot -- --ignored --nocapture`
 
 use git_ai::authorship::diff_ai_accepted::diff_ai_accepted_stats;
+use git_ai::authorship::post_commit::estimate_stats_cost_for_head;
 use git_ai::authorship::stats::{get_git_diff_stats, stats_for_commit_stats};
 use git_ai::git::find_repository_in_path;
 use std::fs;
@@ -427,5 +428,112 @@ fn benchmark_stats_thousands_changed_files_fast_path() {
         avg_ms,
         max_avg_ms,
         file_count
+    );
+}
+
+/// Build a repo that matches the user-reported hang pattern:
+/// many files deleted, each with many lines, very few (or no) additions.
+/// Mirrors the ~124 files / ~91K deletions / ~22 additions from:
+/// 537f4caca27837aa7aa729dbdbcf954fdab856ff (~/projects/monorepo)
+fn setup_repo_with_mass_deletion(file_count: usize, lines_per_file: usize) -> TempDir {
+    let tmp = TempDir::new().expect("failed to create tempdir");
+    let repo = tmp.path();
+
+    run_git(repo, &["init", "-q"]);
+    run_git(repo, &["config", "user.name", "Perf User"]);
+    run_git(repo, &["config", "user.email", "perf@example.com"]);
+
+    // Create many files with many lines each
+    for i in 1..=file_count {
+        let content = (1..=lines_per_file)
+            .map(|l| format!("file{:03} line {:04}\n", i, l))
+            .collect::<String>();
+        fs::write(repo.join(format!("f{:03}.txt", i)), content).expect("failed to write file");
+    }
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-q", "-m", "initial"]);
+
+    // Delete all files — this is the commit that triggers the hang
+    for i in 1..=file_count {
+        fs::remove_file(repo.join(format!("f{:03}.txt", i))).expect("failed to delete file");
+    }
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-q", "-m", "mass-deletion"]);
+
+    tmp
+}
+
+/// Regression test: the stats-cost estimator must flag a mass-deletion commit
+/// (many files deleted, no additions) as expensive so the post-commit hook
+/// skips the full stats pass.
+///
+/// Previously `estimate_stats_cost_for_head` only counted *added* lines, so a
+/// commit deleting 100 files × 750 lines (= 75 000 deletions, 0 additions) was
+/// classified as cheap.  The hook then ran `get_diff_with_line_numbers` which
+/// had to parse and allocate storage for all 75 000 deleted-content lines,
+/// causing a multi-second hang that users perceived as git-ai freezing.
+#[test]
+fn estimate_stats_cost_skips_mass_deletion_commit() {
+    // 100 files × 750 lines ≈ 75 000 deleted lines, zero additions.
+    // Matches the scale of the real-world hang (537f4cac in ~/projects/monorepo).
+    let tmp = setup_repo_with_mass_deletion(100, 750);
+    let repo = find_repository_in_path(tmp.path().to_str().expect("non-utf8 path"))
+        .expect("failed to open repository");
+
+    let head_sha = repo
+        .head()
+        .expect("failed to get HEAD")
+        .target()
+        .expect("failed to resolve HEAD target");
+
+    let estimate = estimate_stats_cost_for_head(&repo, &head_sha, &[])
+        .expect("estimate_stats_cost_for_head should succeed");
+
+    assert!(
+        estimate.should_skip(),
+        "expected estimate_stats_cost_for_head to flag a 75K-deletion commit as \
+         expensive (should_skip=true), but got should_skip=false. \
+         The estimator only counted added lines and missed the large deletion cost."
+    );
+}
+
+/// Performance guard: post-commit stats for a mass-deletion commit must
+/// complete within 2 seconds now that the fast path is taken.
+#[test]
+#[ignore] // Run manually: cargo test benchmark_stats_mass_deletion_fast_path -- --ignored --nocapture
+fn benchmark_stats_mass_deletion_fast_path() {
+    const FILE_COUNT: usize = 100;
+    const LINES_PER_FILE: usize = 750;
+    const MAX_MS: f64 = 2_000.0;
+
+    let tmp = setup_repo_with_mass_deletion(FILE_COUNT, LINES_PER_FILE);
+    let repo = find_repository_in_path(tmp.path().to_str().expect("non-utf8 path"))
+        .expect("failed to open repository");
+
+    let head_sha = repo
+        .head()
+        .expect("failed to get HEAD")
+        .target()
+        .expect("failed to resolve HEAD target");
+
+    let ignore_patterns: Vec<String> = vec![];
+
+    let start = Instant::now();
+    let _stats = stats_for_commit_stats(&repo, &head_sha, &ignore_patterns)
+        .expect("stats_for_commit_stats should succeed");
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    println!(
+        "\n=== Stats Benchmark: Mass File Deletion ({} files × {} lines) ===",
+        FILE_COUNT, LINES_PER_FILE
+    );
+    println!("elapsed: {:.2}ms", elapsed_ms);
+    println!("budget:  {:.2}ms", MAX_MS);
+
+    assert!(
+        elapsed_ms <= MAX_MS,
+        "stats_for_commit_stats took {:.2}ms for mass-deletion commit, expected <= {:.2}ms",
+        elapsed_ms,
+        MAX_MS
     );
 }


### PR DESCRIPTION
## Summary

- **Bug**: post-commit hook hung for seconds when committing large file deletions (e.g. the reported case: 124 files / 91K deletions / 22 additions)
- **Root cause**: `estimate_stats_cost()` only counted *added* lines when deciding whether to skip expensive stats computation. For deletion-heavy commits, added-line counts were near zero, so the estimator always said "cheap" and the hook ran `get_diff_with_line_numbers` — which had to parse and store string content for every deleted line
- **Fix**: extend `parse_diff_added_lines` to also tally `old_count` from every `@@ -start,count @@` hunk header (including headers for purely-deleted files where `+++ /dev/null` makes `current_file = None`). Adds a `STATS_SKIP_MAX_DELETED_LINES = 6000` threshold (mirroring the existing added-lines guard) so deletion-heavy commits are flagged as expensive and bypass the full stats pass

No new git invocation: the same `git diff -U0 --find-renames=1%` output already scanned for hunk headers now also accumulates the old-side line count at no extra cost.

Reproducer: commit `537f4caca27837aa7aa729dbdbcf954fdab856ff` in `~/projects/monorepo` — 124 files, 91 248 deletions, 22 additions ("reset pg schema").

## Test plan

- [x] New regression test `estimate_stats_cost_skips_mass_deletion_commit` asserts that a 100-file × 750-line deletion commit (≈ 75K deletions, 0 additions) is classified as expensive (`should_skip = true`)  
- [x] New unit test case for `STATS_SKIP_MAX_DELETED_LINES` threshold in `test_should_skip_stats_exactly_at_thresholds`
- [x] New benchmark `benchmark_stats_mass_deletion_fast_path` (ignored, run manually) confirms the fast path completes in < 2 s
- [x] All 1396 lib unit tests pass
- [x] All 2938 integration tests pass (62 ignored benchmarks)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
