### PR TITLE
cargo: set default-run to git-ai for cargo run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "git-ai"
 version = "1.3.0"
 edition = "2024"
+default-run = "git-ai"
 
 [dependencies]
 clap = { version = "4.6", features = ["derive"] }


### PR DESCRIPTION
I was just looking through contrib and noticed the cargo.toml needs a `default-run` for `GIT_AI=git cargo run -- status` to work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
