### PR TITLE
feat(windows): add dev.ps1 so task dev works natively on Windows

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,10 @@ tasks:
     desc: Setup git-ai debug build for local dev
     deps: [build-debug]
     cmds:
-      - ./scripts/dev.sh
+      - cmd: powershell -NonInteractive -NoProfile -ExecutionPolicy Bypass -File scripts/dev.ps1
+        platforms: [windows]
+      - cmd: ./scripts/dev.sh
+        platforms: [linux, darwin]
   build:
     desc: Build the project in release mode
     cmds:

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -10,6 +10,80 @@ if ($args.Count -gt 0 -and $args[0] -eq '--release') {
 $InstallDir = Join-Path $HOME '.git-ai\bin'
 $ConfigPath = Join-Path $HOME '.git-ai\config.json'
 $GitAiExe = Join-Path $InstallDir 'git-ai.exe'
+$GitShim = Join-Path $InstallDir 'git.exe'
+
+function Test-FileAvailable {
+    param([Parameter(Mandatory)][string]$Path)
+    try {
+        $stream = [System.IO.File]::Open($Path, 'Open', 'Write', 'None')
+        $stream.Close()
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Stop-GitAiDaemon {
+    param([Parameter(Mandatory)][string]$GitAiExe, [switch]$Hard)
+    if (-not (Test-Path -LiteralPath $GitAiExe)) { return $false }
+    $shutdownArgs = @('bg', 'shutdown')
+    if ($Hard) { $shutdownArgs += '--hard' }
+    try { & $GitAiExe @shutdownArgs *> $null; return ($LASTEXITCODE -eq 0) } catch { return $false }
+}
+
+function Wait-ForFileAvailable {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$GitAiExe,
+        [int]$MaxWaitSeconds = 30,
+        [int]$RetryIntervalSeconds = 2,
+        [int]$HardKillAfterSeconds = 10
+    )
+    [void](Stop-GitAiDaemon -GitAiExe $GitAiExe)
+    $elapsed = 0
+    while ($elapsed -lt $MaxWaitSeconds) {
+        if (Test-FileAvailable -Path $Path) { return $true }
+        if ($elapsed -ge $HardKillAfterSeconds) {
+            [void](Stop-GitAiDaemon -GitAiExe $GitAiExe -Hard)
+            $dir = Split-Path $GitAiExe -Parent
+            $targets = @(
+                ([IO.Path]::GetFullPath($GitAiExe)).ToLowerInvariant(),
+                ([IO.Path]::GetFullPath((Join-Path $dir 'git.exe'))).ToLowerInvariant()
+            )
+            @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+                Where-Object { $_.ProcessId -ne $PID -and $_.ExecutablePath -and
+                    ($targets -contains $_.ExecutablePath.ToLowerInvariant()) }) |
+                ForEach-Object { try { Stop-Process -Id $_.ProcessId -Force } catch { } }
+        }
+        if ($elapsed -eq 0) {
+            Write-Host "Waiting for file to be available: $Path" -ForegroundColor Yellow
+        }
+        Start-Sleep -Seconds $RetryIntervalSeconds
+        $elapsed += $RetryIntervalSeconds
+    }
+    return $false
+}
+
+# Atomically replace $DstPath with $SrcPath, stopping the daemon first if needed.
+# Uses Remove + Move rather than Move-Item -Force because Move-Item -Force raises
+# ERROR_ALREADY_EXISTS when the destination is locked even after unlocking.
+function Install-Binary {
+    param(
+        [Parameter(Mandatory)][string]$SrcPath,
+        [Parameter(Mandatory)][string]$DstPath,
+        [Parameter(Mandatory)][string]$GitAiExe
+    )
+    $tmpPath = "$DstPath.tmp.$PID"
+    Copy-Item -Force -Path $SrcPath -Destination $tmpPath
+    if (Test-Path -LiteralPath $DstPath) {
+        if (-not (Wait-ForFileAvailable -Path $DstPath -GitAiExe $GitAiExe)) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $tmpPath
+            throw "Timeout waiting for '$DstPath' to be available. Close any running git-ai processes and try again."
+        }
+        Remove-Item -Force -Path $DstPath
+    }
+    Move-Item -Path $tmpPath -Destination $DstPath
+}
 
 # Run production installer if ~/.git-ai isn't set up or ~/.git-ai/bin isn't on PATH
 $needsInstall = $false
@@ -32,9 +106,7 @@ if (-not $needsInstall) {
             }
         } catch { }
     }
-    if (-not $onPath) {
-        $needsInstall = $true
-    }
+    if (-not $onPath) { $needsInstall = $true }
 }
 
 if ($needsInstall) {
@@ -51,22 +123,14 @@ if ($BuildType -eq 'release') {
 }
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-# Install binary via temp file + atomic Move-Item to avoid Windows file-lock issues
-# with running processes reusing the same on-disk binary (mirrors the macOS inode
-# workaround in dev.sh but needed on Windows for a different reason: antivirus/
-# Defender scanning the file while it's being replaced).
+# Replace git-ai.exe, stopping the daemon first if it is running
 Write-Host "Installing binary to $GitAiExe..."
-$tmpBin = "$GitAiExe.tmp.$PID"
-Copy-Item -Force -Path "target\$BuildType\git-ai.exe" -Destination $tmpBin
-Move-Item -Force -Path $tmpBin -Destination $GitAiExe
+Install-Binary -SrcPath "target\$BuildType\git-ai.exe" -DstPath $GitAiExe -GitAiExe $GitAiExe
 
 # Keep the git.exe shim in sync with the updated binary
-$gitShim = Join-Path $InstallDir 'git.exe'
-if (Test-Path -LiteralPath $gitShim) {
+if (Test-Path -LiteralPath $GitShim) {
     Write-Host 'Updating git.exe shim...'
-    $tmpShim = "$gitShim.tmp.$PID"
-    Copy-Item -Force -Path $GitAiExe -Destination $tmpShim
-    Move-Item -Force -Path $tmpShim -Destination $gitShim
+    Install-Binary -SrcPath $GitAiExe -DstPath $GitShim -GitAiExe $GitAiExe
 }
 
 # Run install hooks

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Parse arguments
+$BuildType = 'debug'
+if ($args.Count -gt 0 -and $args[0] -eq '--release') {
+    $BuildType = 'release'
+}
+
+$InstallDir = Join-Path $HOME '.git-ai\bin'
+$ConfigPath = Join-Path $HOME '.git-ai\config.json'
+$GitAiExe = Join-Path $InstallDir 'git-ai.exe'
+
+# Run production installer if ~/.git-ai isn't set up or ~/.git-ai/bin isn't on PATH
+$needsInstall = $false
+if (-not (Test-Path -LiteralPath $InstallDir) -or
+    -not (Test-Path -LiteralPath $ConfigPath)) {
+    $needsInstall = $true
+}
+
+if (-not $needsInstall) {
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $installDirNorm = ([IO.Path]::GetFullPath($InstallDir)).TrimEnd('\').ToLowerInvariant()
+    $onPath = $false
+    foreach ($entry in (("$userPath;$machinePath") -split ';')) {
+        if (-not $entry.Trim()) { continue }
+        try {
+            if (([IO.Path]::GetFullPath($entry.Trim())).TrimEnd('\').ToLowerInvariant() -eq $installDirNorm) {
+                $onPath = $true
+                break
+            }
+        } catch { }
+    }
+    if (-not $onPath) {
+        $needsInstall = $true
+    }
+}
+
+if ($needsInstall) {
+    Write-Host 'Running git-ai installer...'
+    & (Join-Path $PSScriptRoot '..\install.ps1')
+}
+
+# Build the binary
+Write-Host "Building $BuildType binary..."
+if ($BuildType -eq 'release') {
+    cargo build --release
+} else {
+    cargo build
+}
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# Install binary via temp file + atomic Move-Item to avoid Windows file-lock issues
+# with running processes reusing the same on-disk binary (mirrors the macOS inode
+# workaround in dev.sh but needed on Windows for a different reason: antivirus/
+# Defender scanning the file while it's being replaced).
+Write-Host "Installing binary to $GitAiExe..."
+$tmpBin = "$GitAiExe.tmp.$PID"
+Copy-Item -Force -Path "target\$BuildType\git-ai.exe" -Destination $tmpBin
+Move-Item -Force -Path $tmpBin -Destination $GitAiExe
+
+# Keep the git.exe shim in sync with the updated binary
+$gitShim = Join-Path $InstallDir 'git.exe'
+if (Test-Path -LiteralPath $gitShim) {
+    Write-Host 'Updating git.exe shim...'
+    $tmpShim = "$gitShim.tmp.$PID"
+    Copy-Item -Force -Path $GitAiExe -Destination $tmpShim
+    Move-Item -Force -Path $tmpShim -Destination $gitShim
+}
+
+# Run install hooks
+Write-Host 'Running install hooks...'
+& $GitAiExe install
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host 'Done!'


### PR DESCRIPTION
## Summary

- `task dev` was failing on Windows with `%1 is not a valid Win32 application` because go-task tried to fork-exec `scripts/dev.sh` directly
- Add `platforms:` conditions to the `dev` task in `Taskfile.yml` so Windows routes through PowerShell and Linux/macOS keep using the existing `dev.sh`
- Add `scripts/dev.ps1` as a Windows-native equivalent of `dev.sh`

## What dev.ps1 does

Mirrors `dev.sh` step for step using Windows idioms:

1. **Installer check** — if `~/.git-ai/bin` or `config.json` are missing, or the install dir isn't on PATH, delegates to the repo's existing `install.ps1` (same trigger logic as `dev.sh`'s curl-installer check)
2. **Build** — runs `cargo build` (or `cargo build --release` with `--release` arg)
3. **Atomic binary replace** — copies to a `.tmp.$PID` side-file then `Move-Item` into place, avoiding Defender/AV file-lock races (analogous to the macOS inode workaround in `dev.sh`)
4. **Shim sync** — updates `git.exe` (the PATH shim) to match the new binary
5. **Hook install** — runs `git-ai install` to refresh IDE/agent hooks

## Test plan

- [ ] `task dev` on Windows completes without the `%1 is not a valid Win32 application` error
- [ ] `task dev` on Linux/macOS still uses `dev.sh` (no regression)
- [ ] Running `task dev` a second time (everything already installed) is a no-op for the installer step and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
