### PR TITLE
Fix Windows daemon restart and self-update flow

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -104,9 +104,9 @@ function Stop-GitAiManagedProcesses {
     $pids = @($processes | Sort-Object ProcessId -Unique | Select-Object -ExpandProperty ProcessId)
     Write-Warning ("Stopping lingering git-ai processes: {0}" -f ($pids -join ', '))
 
-    foreach ($pid in $pids) {
+    foreach ($managedPid in $pids) {
         try {
-            Stop-Process -Id $pid -Force -ErrorAction Stop
+            Stop-Process -Id $managedPid -Force -ErrorAction Stop
         } catch { }
     }
 
@@ -519,6 +519,13 @@ try {
     Write-Success 'Successfully set up IDE/agent hooks'
 } catch {
     Write-Warning "Warning: Failed to set up IDE/agent hooks. Please try running 'git-ai install-hooks' manually."
+}
+
+# Best-effort restart so detached self-updates can bring the background service back.
+try {
+    & $finalExe bg start *> $null
+} catch {
+    Write-Warning "Warning: Failed to restart git-ai background service automatically."
 }
 
 # Update PATH so our shim takes precedence over any Git entries

--- a/install.ps1
+++ b/install.ps1
@@ -1,11 +1,30 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+function Start-DaemonIfRequested {
+    if ($env:GIT_AI_RESTART_DAEMON_AFTER_INSTALL -ne '1') {
+        return
+    }
+
+    $daemonExe = Join-Path $HOME '.git-ai\bin\git-ai.exe'
+    if (-not (Test-Path $daemonExe)) {
+        Write-Warning 'Warning: Failed to locate git-ai.exe for daemon restart after install.'
+        return
+    }
+
+    try {
+        & $daemonExe bg start *> $null
+    } catch {
+        Write-Warning 'Warning: Failed to restart git-ai background service automatically.'
+    }
+}
+
 function Write-ErrorAndExit {
     param(
         [Parameter(Mandatory = $true)][string]$Message
     )
     Write-Host "Error: $Message" -ForegroundColor Red
+    Start-DaemonIfRequested
     exit 1
 }
 
@@ -521,12 +540,8 @@ try {
     Write-Warning "Warning: Failed to set up IDE/agent hooks. Please try running 'git-ai install-hooks' manually."
 }
 
-# Best-effort restart so detached self-updates can bring the background service back.
-try {
-    & $finalExe bg start *> $null
-} catch {
-    Write-Warning "Warning: Failed to restart git-ai background service automatically."
-}
+# Best-effort restart only for daemon-initiated self-updates.
+Start-DaemonIfRequested
 
 # Update PATH so our shim takes precedence over any Git entries
 $skipPathUpdate = $env:GIT_AI_SKIP_PATH_UPDATE -eq '1'

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -192,24 +192,24 @@ fn handle_run(args: &[String]) -> Result<(), String> {
         .block_on(async move { crate::daemon::run_daemon(config).await })
         .map_err(|e| e.to_string())?;
 
-    // Daemon is fully dead (lock released, sockets removed, threads joined).
-    // Now safe to self-update — the daemon can decide whether a fresh instance
-    // should be started based on the shutdown reason and install outcome.
-    #[cfg(not(windows))]
-    let update_installed = crate::daemon::daemon_run_pending_self_update();
-
-    #[cfg(windows)]
-    crate::daemon::daemon_run_pending_self_update();
-
     match exit_action {
         crate::daemon::DaemonExitAction::Stop => {}
         crate::daemon::DaemonExitAction::Restart => {
             ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
         }
         crate::daemon::DaemonExitAction::RestartAfterUpdate => {
-            #[cfg(not(windows))]
-            {
-                if update_installed {
+            // Daemon is fully dead (lock released, sockets removed, threads joined).
+            // Now safe to self-update — if the install cannot proceed, bring the
+            // daemon back so a failed update does not leave the service down.
+            match crate::daemon::daemon_run_pending_self_update() {
+                crate::daemon::DaemonSelfUpdateOutcome::Installed => {
+                    #[cfg(not(windows))]
+                    {
+                        ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
+                    }
+                }
+                crate::daemon::DaemonSelfUpdateOutcome::NoUpdate
+                | crate::daemon::DaemonSelfUpdateOutcome::Failed => {
                     ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
                 }
             }

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -193,7 +193,12 @@ fn handle_run(args: &[String]) -> Result<(), String> {
         .map_err(|e| e.to_string())?;
 
     // Daemon is fully dead (lock released, sockets removed, threads joined).
-    // Now safe to self-update — install.sh can start a fresh daemon.
+    // Now safe to self-update — the daemon can decide whether a fresh instance
+    // should be started based on the shutdown reason and install outcome.
+    #[cfg(not(windows))]
+    let update_installed = crate::daemon::daemon_run_pending_self_update();
+
+    #[cfg(windows)]
     crate::daemon::daemon_run_pending_self_update();
 
     match exit_action {
@@ -204,7 +209,9 @@ fn handle_run(args: &[String]) -> Result<(), String> {
         crate::daemon::DaemonExitAction::RestartAfterUpdate => {
             #[cfg(not(windows))]
             {
-                ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
+                if update_installed {
+                    ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
+                }
             }
         }
     }

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -188,13 +188,26 @@ fn handle_run(args: &[String]) -> Result<(), String> {
         .enable_all()
         .build()
         .map_err(|e| e.to_string())?;
-    runtime
+    let exit_action = runtime
         .block_on(async move { crate::daemon::run_daemon(config).await })
         .map_err(|e| e.to_string())?;
 
     // Daemon is fully dead (lock released, sockets removed, threads joined).
     // Now safe to self-update — install.sh can start a fresh daemon.
     crate::daemon::daemon_run_pending_self_update();
+
+    match exit_action {
+        crate::daemon::DaemonExitAction::Stop => {}
+        crate::daemon::DaemonExitAction::Restart => {
+            ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
+        }
+        crate::daemon::DaemonExitAction::RestartAfterUpdate => {
+            #[cfg(not(windows))]
+            {
+                ensure_daemon_running(Duration::from_secs(5)).map(|_| ())?;
+            }
+        }
+    }
 
     Ok(())
 }

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -661,7 +661,7 @@ pub fn run_with_args(args: &[String]) {
 }
 
 fn run_impl(force: bool, background: bool) {
-    let config = config::Config::get();
+    let config = config::Config::fresh();
     let channel = config.update_channel();
     let skip_install = background && config.auto_updates_disabled();
     let _ = run_impl_with_url(force, config.api_base_url(), channel, skip_install);

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -50,6 +50,8 @@ unsafe extern "system" {
 
 const UPDATE_CHECK_INTERVAL_HOURS: u64 = 24;
 const GIT_AI_RELEASE_ENV: &str = "GIT_AI_RELEASE_TAG";
+#[cfg(windows)]
+const GIT_AI_RESTART_DAEMON_AFTER_INSTALL_ENV: &str = "GIT_AI_RESTART_DAEMON_AFTER_INSTALL";
 const BACKGROUND_SPAWN_THROTTLE_SECS: u64 = 60;
 const ENV_BACKGROUND_UPGRADE_WORKER: &str = "GIT_AI_BACKGROUND_UPGRADE_WORKER";
 
@@ -311,6 +313,11 @@ fn persist_update_state(channel: UpdateChannel, release: Option<&ChannelRelease>
     write_update_cache(&cache);
 }
 
+pub(crate) fn clear_cached_update_state() {
+    let channel = config::Config::fresh().update_channel();
+    persist_update_state(channel, None);
+}
+
 fn releases_endpoint() -> &'static str {
     "/worker/releases"
 }
@@ -530,17 +537,21 @@ fn run_install_script(script_content: &str, tag: &str, silent: bool) -> Result<(
              Start-Transcript -Path $logFile -Append -Force | Out-Null; \
              Write-Host 'Running verified install script...'; \
              try {{ \
-                 $ErrorActionPreference = 'Continue'; \
-                 & '{}'; \
-                 Write-Host 'Install script completed'; \
-             }} catch {{ \
-                 Write-Host \"Error: $_\"; \
-                 Write-Host \"Stack trace: $($_.ScriptStackTrace)\"; \
-             }} finally {{ \
-                 Stop-Transcript | Out-Null; \
-                 Remove-Item -Path '{}' -Force -ErrorAction SilentlyContinue; \
-             }}",
-            log_path_str, script_path_str, script_path_str
+                  $ErrorActionPreference = 'Continue'; \
+                  & '{}'; \
+                  Write-Host 'Install script completed'; \
+              }} catch {{ \
+                  Write-Host \"Error: $_\"; \
+                  Write-Host \"Stack trace: $($_.ScriptStackTrace)\"; \
+              }} finally {{ \
+                  if ($env:{} -eq '1') {{ \
+                      $daemonExe = Join-Path $HOME '.git-ai\\bin\\git-ai.exe'; \
+                      if (Test-Path $daemonExe) {{ try {{ & $daemonExe bg start *> $null }} catch {{ }} }} \
+                  }}; \
+                  Stop-Transcript | Out-Null; \
+                  Remove-Item -Path '{}' -Force -ErrorAction SilentlyContinue; \
+              }}",
+            log_path_str, script_path_str, GIT_AI_RESTART_DAEMON_AFTER_INSTALL_ENV, script_path_str
         );
 
         let spawn_powershell = |exe: &str| -> std::io::Result<std::process::Child> {
@@ -556,6 +567,7 @@ fn run_install_script(script_content: &str, tag: &str, silent: bool) -> Result<(
             cmd.creation_flags(CREATE_NO_WINDOW);
 
             if silent {
+                cmd.env(GIT_AI_RESTART_DAEMON_AFTER_INSTALL_ENV, "1");
                 cmd.stdout(Stdio::null()).stderr(Stdio::null());
             }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3903,6 +3903,13 @@ pub(crate) enum DaemonExitAction {
     RestartAfterUpdate,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DaemonSelfUpdateOutcome {
+    Installed,
+    NoUpdate,
+    Failed,
+}
+
 impl DaemonExitAction {
     fn as_u8(self) -> u8 {
         match self {
@@ -8286,7 +8293,7 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
 /// On Unix the installer atomically replaces the binary via `mv`; on Windows
 /// the installer is spawned as a detached process that polls until the exe is
 /// unlocked.
-pub(crate) fn daemon_run_pending_self_update() -> bool {
+pub(crate) fn daemon_run_pending_self_update() -> DaemonSelfUpdateOutcome {
     use crate::commands::upgrade::{
         DaemonUpdateCheckResult, check_and_install_update_if_available,
     };
@@ -8294,15 +8301,16 @@ pub(crate) fn daemon_run_pending_self_update() -> bool {
     match check_and_install_update_if_available() {
         Ok(DaemonUpdateCheckResult::UpdateReady) => {
             tracing::info!("self-update: installation completed successfully");
-            true
+            DaemonSelfUpdateOutcome::Installed
         }
         Ok(DaemonUpdateCheckResult::NoUpdate) => {
             tracing::info!("self-update: no update to install");
-            false
+            DaemonSelfUpdateOutcome::NoUpdate
         }
         Err(err) => {
             tracing::warn!(%err, "self-update: installation failed");
-            false
+            crate::commands::upgrade::clear_cached_update_state();
+            DaemonSelfUpdateOutcome::Failed
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -58,7 +58,7 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot};
@@ -3884,6 +3884,7 @@ pub struct ActorDaemonCoordinator {
     wrapper_states: Mutex<HashMap<String, WrapperStateEntry>>,
     wrapper_state_notify: Notify,
     shutting_down: AtomicBool,
+    shutdown_action: AtomicU8,
     shutdown_notify: Notify,
     shutdown_condvar: std::sync::Condvar,
     shutdown_condvar_mutex: Mutex<()>,
@@ -3893,6 +3894,31 @@ struct WrapperStateEntry {
     pre_repo: Option<RepoContext>,
     post_repo: Option<RepoContext>,
     received_at_ns: u128,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DaemonExitAction {
+    Stop,
+    Restart,
+    RestartAfterUpdate,
+}
+
+impl DaemonExitAction {
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Stop => 0,
+            Self::Restart => 1,
+            Self::RestartAfterUpdate => 2,
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Restart,
+            2 => Self::RestartAfterUpdate,
+            _ => Self::Stop,
+        }
+    }
 }
 
 enum TracePayloadApplyOutcome {
@@ -3949,6 +3975,7 @@ impl ActorDaemonCoordinator {
             wrapper_states: Mutex::new(HashMap::new()),
             wrapper_state_notify: Notify::new(),
             shutting_down: AtomicBool::new(false),
+            shutdown_action: AtomicU8::new(DaemonExitAction::Stop.as_u8()),
             shutdown_notify: Notify::new(),
             shutdown_condvar: std::sync::Condvar::new(),
             shutdown_condvar_mutex: Mutex::new(()),
@@ -3978,6 +4005,24 @@ impl ActorDaemonCoordinator {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         self.shutdown_condvar.notify_all();
+    }
+
+    fn request_restart(&self) {
+        self.shutdown_action
+            .store(DaemonExitAction::Restart.as_u8(), Ordering::SeqCst);
+        self.request_shutdown();
+    }
+
+    fn request_restart_after_update(&self) {
+        self.shutdown_action.store(
+            DaemonExitAction::RestartAfterUpdate.as_u8(),
+            Ordering::SeqCst,
+        );
+        self.request_shutdown();
+    }
+
+    fn shutdown_action(&self) -> DaemonExitAction {
+        DaemonExitAction::from_u8(self.shutdown_action.load(Ordering::SeqCst))
     }
 
     async fn wait_for_shutdown(&self) {
@@ -8210,7 +8255,7 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
         match check_for_update_available() {
             Ok(DaemonUpdateCheckResult::UpdateReady) => {
                 tracing::info!("update check: newer version available, requesting shutdown");
-                coordinator.request_shutdown();
+                coordinator.request_restart_after_update();
                 return;
             }
             Ok(DaemonUpdateCheckResult::NoUpdate) => {
@@ -8224,7 +8269,7 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
         let uptime_ns = now_unix_nanos().saturating_sub(started_at_ns);
         if uptime_ns >= daemon_max_uptime_ns() {
             tracing::info!("uptime exceeded max, requesting restart");
-            coordinator.request_shutdown();
+            coordinator.request_restart();
             return;
         }
     }
@@ -8253,7 +8298,7 @@ pub(crate) fn daemon_run_pending_self_update() {
     }
 }
 
-pub async fn run_daemon(config: DaemonConfig) -> Result<(), GitAiError> {
+pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction, GitAiError> {
     sanitize_git_env_for_daemon();
     disable_trace2_for_daemon_process();
     config.ensure_parent_dirs()?;
@@ -8438,9 +8483,10 @@ pub async fn run_daemon(config: DaemonConfig) -> Result<(), GitAiError> {
     remove_socket_if_exists(&config.control_socket_path)?;
     remove_pid_metadata(&config)?;
 
-    tracing::info!("daemon shutdown complete");
+    let action = coordinator.shutdown_action();
+    tracing::info!(?action, "daemon shutdown complete");
 
-    Ok(())
+    Ok(action)
 }
 
 fn checkpoint_control_timeout_uses_ci_or_test_budget() -> bool {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8280,7 +8280,7 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
 /// On Unix the installer atomically replaces the binary via `mv`; on Windows
 /// the installer is spawned as a detached process that polls until the exe is
 /// unlocked.
-pub(crate) fn daemon_run_pending_self_update() {
+pub(crate) fn daemon_run_pending_self_update() -> bool {
     use crate::commands::upgrade::{
         DaemonUpdateCheckResult, check_and_install_update_if_available,
     };
@@ -8288,12 +8288,15 @@ pub(crate) fn daemon_run_pending_self_update() {
     match check_and_install_update_if_available() {
         Ok(DaemonUpdateCheckResult::UpdateReady) => {
             tracing::info!("self-update: installation completed successfully");
+            true
         }
         Ok(DaemonUpdateCheckResult::NoUpdate) => {
             tracing::info!("self-update: no update to install");
+            false
         }
         Err(err) => {
             tracing::warn!(%err, "self-update: installation failed");
+            false
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8976,6 +8976,29 @@ mod tests {
         assert_eq!(normalized.get("example.txt"), carryover.get("example.txt"));
     }
 
+    #[test]
+    fn explicit_stop_overrides_prior_restart_intent() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let coordinator = ActorDaemonCoordinator::new();
+
+            coordinator.request_restart_after_update();
+            assert_eq!(
+                coordinator.shutdown_action(),
+                DaemonExitAction::RestartAfterUpdate
+            );
+
+            coordinator.request_stop();
+
+            assert!(coordinator.is_shutting_down());
+            assert_eq!(coordinator.shutdown_action(), DaemonExitAction::Stop);
+        });
+    }
+
     // -----------------------------------------------------------------------
     // Readonly command ingress fast-path tests
     //

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4007,6 +4007,12 @@ impl ActorDaemonCoordinator {
         self.shutdown_condvar.notify_all();
     }
 
+    fn request_stop(&self) {
+        self.shutdown_action
+            .store(DaemonExitAction::Stop.as_u8(), Ordering::SeqCst);
+        self.request_shutdown();
+    }
+
     fn request_restart(&self) {
         self.shutdown_action
             .store(DaemonExitAction::Restart.as_u8(), Ordering::SeqCst);
@@ -7829,7 +7835,7 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
         reader.get_mut().write_all(b"\n")?;
         reader.get_mut().flush()?;
         if shutdown_after_response {
-            coordinator.request_shutdown();
+            coordinator.request_stop();
         }
     }
     Ok(())

--- a/tests/integration/bash_tool_provenance.rs
+++ b/tests/integration/bash_tool_provenance.rs
@@ -1248,15 +1248,15 @@ fn test_bash_provenance_mv_directory_rename() {
 
     let pre = snapshot(&root, "mvdir-sess", "mvdir-t1", None).unwrap();
 
-    run_bash(&repo, "mv", &["src", "lib"]);
+    std::fs::rename(root.join("src"), root.join("lib")).unwrap();
 
     let post = snapshot(&root, "mvdir-sess", "mvdir-t2", None).unwrap();
     let result = diff(&pre, &post);
     assert!(
-        result
-            .created
-            .iter()
-            .any(|p| p.display().to_string().contains("lib/lib.rs")),
+        result.created.iter().any(|p| p
+            .to_string_lossy()
+            .replace('\\', "/")
+            .contains("lib/lib.rs")),
         "lib/lib.rs should appear as created after directory rename; got created={:?}",
         result.created,
     );

--- a/tests/windows_install_script.rs
+++ b/tests/windows_install_script.rs
@@ -432,3 +432,16 @@ fn windows_git_extension_upgrade_requires_direct_git_ai_binary() {
         combined
     );
 }
+
+#[test]
+fn windows_install_script_does_not_shadow_reserved_pid_variable() {
+    let script = fs::read_to_string(install_script_path()).expect("failed to read install.ps1");
+    assert!(
+        !script.contains("foreach ($pid in $pids)"),
+        "install.ps1 should not iterate with the reserved $PID variable name"
+    );
+    assert!(
+        script.contains("foreach ($managedPid in $pids)"),
+        "install.ps1 should use a non-reserved loop variable for managed process ids"
+    );
+}

--- a/tests/windows_install_script.rs
+++ b/tests/windows_install_script.rs
@@ -445,3 +445,16 @@ fn windows_install_script_does_not_shadow_reserved_pid_variable() {
         "install.ps1 should use a non-reserved loop variable for managed process ids"
     );
 }
+
+#[test]
+fn windows_install_script_gates_daemon_restart_to_self_update() {
+    let script = fs::read_to_string(install_script_path()).expect("failed to read install.ps1");
+    assert!(
+        script.contains("GIT_AI_RESTART_DAEMON_AFTER_INSTALL"),
+        "install.ps1 should only restart the daemon when the self-update env flag is set"
+    );
+    assert!(
+        script.contains("Start-DaemonIfRequested"),
+        "install.ps1 should funnel daemon restart attempts through the gated helper"
+    );
+}


### PR DESCRIPTION
## Summary
- separate daemon shutdown into stop, restart, and restart-after-update actions
- restart the daemon after max-uptime exits and let the Windows installer own restart timing after self-updates
- fix the Windows installer reserved `$PID` loop bug and add a regression test

## Testing
- `cargo test --package git-ai --test windows_install_script -- --nocapture`
- `cargo fmt -- --check`

## Manual validation
- reproduced the pre-fix Windows max-uptime failure with auto-updates and version checks explicitly enabled
- reproduced the pre-fix Windows installer failure caused by the reserved PowerShell `$PID` loop variable
- verified the fixed daemon now restarts on max uptime and takes the cached-update shutdown path on Windows

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
