### PR TITLE
test: add pre-commit hook formatter attribution tests

### DIFF
--- a/docs/superpowers/plans/2026-04-13-stats-bar-untracked.md
+++ b/docs/superpowers/plans/2026-04-13-stats-bar-untracked.md
@@ -1,0 +1,464 @@
+# Stats Bar: Untracked Segment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `mixed` (▒) bar segment with an `untracked` (·) segment driven by `unknown_additions`, show it only when > 1%, and hyperlink the label in interactive shells.
+
+**Architecture:** Single in-place edit to `write_stats_to_terminal` in `src/authorship/stats.rs`. Bar-segment math and percentage-line logic are replaced; all five existing terminal snapshots are updated via `cargo insta review`. No new files, no new functions.
+
+**Tech Stack:** Rust, `insta` snapshot testing, OSC 8 terminal hyperlinks.
+
+---
+
+### Task 1: Create worktree and branch
+
+**Files:** none
+
+- [ ] **Step 1: Create a fresh git worktree**
+
+```bash
+git worktree add ../git-ai-stats-bar-untracked -b stats-bar-untracked
+```
+
+- [ ] **Step 2: Verify the worktree exists and is on the new branch**
+
+```bash
+git -C ../git-ai-stats-bar-untracked branch --show-current
+```
+
+Expected output: `stats-bar-untracked`
+
+---
+
+### Task 2: Write all new failing tests and update existing test calls
+
+**Files:**
+- Modify: `src/authorship/stats.rs` (test block starting at line ~777)
+
+- [ ] **Step 1: Change all five existing `write_stats_to_terminal` calls in `test_terminal_stats_display` from `true` to `false`**
+
+Find these five lines inside `test_terminal_stats_display` and change each `true` to `false`:
+
+```rust
+let mixed_output = write_stats_to_terminal(&stats, false);
+// ...
+let ai_only_output = write_stats_to_terminal(&ai_stats, false);
+// ...
+let human_only_output = write_stats_to_terminal(&human_stats, false);
+// ...
+let minimal_human_output = write_stats_to_terminal(&minimal_human_stats, false);
+// ...
+let deletion_only_output = write_stats_to_terminal(&deletion_only_stats, false);
+```
+
+Rationale: `is_interactive = true` will emit OSC 8 escape codes, which would clutter snapshot files. All snapshot tests use `false`; the hyperlink test below uses `true` directly.
+
+- [ ] **Step 2: Add five new test cases immediately after the `deletion_only_output` snapshot assert**
+
+```rust
+        // --- New test cases for untracked segment ---
+
+        // 18% human / 22% untracked / 60% AI — matches the design example
+        let untracked_stats = CommitStats {
+            human_additions: 180,
+            unknown_additions: 220,
+            mixed_additions: 0,
+            ai_additions: 600,
+            ai_accepted: 462,
+            time_waiting_for_ai: 60,
+            git_diff_deleted_lines: 0,
+            git_diff_added_lines: 1000,
+            total_ai_additions: 600,
+            total_ai_deletions: 0,
+            tool_model_breakdown: BTreeMap::new(),
+        };
+        let with_untracked_output = write_stats_to_terminal(&untracked_stats, false);
+        assert_debug_snapshot!(with_untracked_output);
+
+        // untracked exactly at the 1% threshold — should NOT show untracked segment
+        let threshold_stats = CommitStats {
+            human_additions: 49,
+            unknown_additions: 1,
+            mixed_additions: 0,
+            ai_additions: 50,
+            ai_accepted: 50,
+            time_waiting_for_ai: 0,
+            git_diff_deleted_lines: 0,
+            git_diff_added_lines: 100,
+            total_ai_additions: 50,
+            total_ai_deletions: 0,
+            tool_model_breakdown: BTreeMap::new(),
+        };
+        let untracked_at_threshold_output = write_stats_to_terminal(&threshold_stats, false);
+        assert_debug_snapshot!(untracked_at_threshold_output);
+
+        // untracked just above 1% threshold (~2%) — should show untracked segment
+        let above_threshold_stats = CommitStats {
+            human_additions: 97,
+            unknown_additions: 2,
+            mixed_additions: 0,
+            ai_additions: 0,
+            ai_accepted: 0,
+            time_waiting_for_ai: 0,
+            git_diff_deleted_lines: 0,
+            git_diff_added_lines: 99,
+            total_ai_additions: 0,
+            total_ai_deletions: 0,
+            tool_model_breakdown: BTreeMap::new(),
+        };
+        let untracked_just_above_output = write_stats_to_terminal(&above_threshold_stats, false);
+        assert_debug_snapshot!(untracked_just_above_output);
+
+        // 100% untracked — entire bar is · chars
+        let all_untracked_stats = CommitStats {
+            human_additions: 0,
+            unknown_additions: 100,
+            mixed_additions: 0,
+            ai_additions: 0,
+            ai_accepted: 0,
+            time_waiting_for_ai: 0,
+            git_diff_deleted_lines: 0,
+            git_diff_added_lines: 100,
+            total_ai_additions: 0,
+            total_ai_deletions: 0,
+            tool_model_breakdown: BTreeMap::new(),
+        };
+        let all_untracked_output = write_stats_to_terminal(&all_untracked_stats, false);
+        assert_debug_snapshot!(all_untracked_output);
+
+        // OSC 8 hyperlink emitted when is_interactive = true
+        // Not a snapshot test — asserts presence of the escape sequence directly.
+        let hyperlink_output = write_stats_to_terminal(&untracked_stats, true);
+        assert!(
+            hyperlink_output.contains("\x1b]8;;https://usegitai.com/docs\x1b\\"),
+            "Expected OSC 8 hyperlink in interactive output, got: {:?}",
+            hyperlink_output
+        );
+        assert!(
+            hyperlink_output.contains("untracked"),
+            "Expected 'untracked' label in interactive output"
+        );
+```
+
+---
+
+### Task 3: Run tests to confirm failures
+
+**Files:** none (read-only)
+
+- [ ] **Step 1: Run the display test**
+
+```bash
+cd ../git-ai-stats-bar-untracked && cargo test -p git-ai "authorship::stats::tests::test_terminal_stats_display" 2>&1 | tail -50
+```
+
+Expected: compilation succeeds (signature hasn't changed yet), then test failures:
+- Existing 5 snapshots: "snapshot changed" (because `true`→`false` doesn't change output yet, but the snapshots will diverge once we change the implementation)
+- Actually at this point, changing `true`→`false` doesn't yet cause snapshot failures since the function hasn't changed. The 4 new snapshot tests will fail with "snapshot not found", and the hyperlink assert will fail because the function doesn't yet emit OSC codes.
+
+Look for: `FAILED` on `with_untracked_output`, `untracked_at_threshold_output`, `untracked_just_above_output`, `all_untracked_output`, and the hyperlink assertion.
+
+---
+
+### Task 4: Implement `write_stats_to_terminal`
+
+**Files:**
+- Modify: `src/authorship/stats.rs:97-301`
+
+- [ ] **Step 1: Rename the `print` parameter to `is_interactive` in the function signature (line 97)**
+
+Old:
+```rust
+pub fn write_stats_to_terminal(stats: &CommitStats, print: bool) -> String {
+```
+
+New:
+```rust
+pub fn write_stats_to_terminal(stats: &CommitStats, is_interactive: bool) -> String {
+```
+
+- [ ] **Step 2: Update the two `if print {` guards in the deletion-only path (lines ~115 and ~123)**
+
+Replace both occurrences:
+```rust
+        if print {
+```
+with:
+```rust
+        if is_interactive {
+```
+
+(There are exactly two of these before the `return output;` on line ~127.)
+
+- [ ] **Step 3: Replace the bar-calculation block**
+
+Find the section that starts with:
+```rust
+    // Calculate total additions for the progress bar
+    // Total = (known human + unknown) + mixed (AI-edited-by-human) + pure AI
+    // unknown_additions are unattested lines — treated as human for display until
+    // full KnownHuman attestation pipeline is in place.
+    let display_human = stats.human_additions + stats.unknown_additions;
+    let total_additions = display_human + stats.ai_additions;
+```
+
+And ends with:
+```rust
+    progress_bar.push_str(" ai");
+```
+
+Replace the entire block (from the `// Calculate total additions` comment through `progress_bar.push_str(" ai");`) with:
+
+```rust
+    // Calculate total additions: known human + unknown (untracked) + AI
+    let total_additions = stats.human_additions + stats.unknown_additions + stats.ai_additions;
+
+    // Calculate AI acceptance percentage (capped at 100%)
+    let _ai_acceptance_percentage = if stats.ai_additions > 0 {
+        ((stats.ai_accepted as f64 / stats.ai_additions as f64) * 100.0).min(100.0)
+    } else {
+        0.0
+    };
+
+    // Determine whether to show the untracked segment (raw float check, before rounding)
+    let untracked_pct_raw = if total_additions > 0 {
+        stats.unknown_additions as f64 / total_additions as f64 * 100.0
+    } else {
+        0.0
+    };
+    let show_untracked = untracked_pct_raw > 1.0;
+
+    // Calculate human bar segment
+    let human_bars = if total_additions > 0 {
+        ((stats.human_additions as f64 / total_additions as f64) * bar_width as f64) as usize
+    } else {
+        0
+    };
+
+    // Ensure human contributions get at least 2 visible blocks if they have more than 1 line
+    let min_human_bars = if stats.human_additions > 1 { 2 } else { 0 };
+    let final_human_bars = human_bars.max(min_human_bars);
+
+    // Distribute remaining width between untracked and AI proportionally.
+    // When untracked is below the 1% threshold, all remaining width goes to AI.
+    let remaining_width = bar_width.saturating_sub(final_human_bars);
+    let (final_untracked_bars, final_ai_bars) = if show_untracked {
+        let total_other = stats.unknown_additions + stats.ai_additions;
+        let untracked_bars = if total_other > 0 {
+            ((stats.unknown_additions as f64 / total_other as f64) * remaining_width as f64)
+                as usize
+        } else {
+            0
+        };
+        (untracked_bars, remaining_width.saturating_sub(untracked_bars))
+    } else {
+        (0, remaining_width)
+    };
+
+    // Build the progress bar
+    let mut progress_bar = String::new();
+    progress_bar.push_str("you  ");
+    progress_bar.push_str(&"█".repeat(final_human_bars));   // known human (attested)
+    progress_bar.push_str(&"·".repeat(final_untracked_bars)); // untracked (no attestation)
+    progress_bar.push_str(&"░".repeat(final_ai_bars));       // AI
+    progress_bar.push_str(" ai");
+```
+
+Note: `·` is U+00B7 MIDDLE DOT.
+
+- [ ] **Step 4: Replace the percentage calculation and print block**
+
+Find the section that starts with:
+```rust
+    // Print the stats
+    output.push_str(&progress_bar);
+    output.push('\n');
+    if print {
+        println!("{}", progress_bar);
+    }
+    // Print percentage line with proper spacing (40 columns total)
+```
+
+And ends with the closing `}` of the `if mixed_percentage > 0 { ... } else { ... }` block (before the `// Only show AI stats if there was actually AI code` comment).
+
+Replace with:
+
+```rust
+    // Calculate percentages for display
+    let human_percentage = if total_additions > 0 {
+        ((stats.human_additions as f64 / total_additions as f64) * 100.0).round() as u32
+    } else {
+        0
+    };
+    let ai_percentage = if total_additions > 0 {
+        ((stats.ai_additions as f64 / total_additions as f64) * 100.0).round() as u32
+    } else {
+        0
+    };
+
+    // Print the stats
+    output.push_str(&progress_bar);
+    output.push('\n');
+    if is_interactive {
+        println!("{}", progress_bar);
+    }
+
+    // Percentage line: three anchors (human / untracked / AI) when untracked is visible,
+    // two anchors (human / AI) otherwise.
+    if show_untracked {
+        let untracked_percentage = untracked_pct_raw.round() as u32;
+        // When interactive, wrap "untracked" in an OSC 8 hyperlink so it is clickable in
+        // supporting terminals (iTerm2, Warp, etc.). Spaces are constructed manually —
+        // not via format-width padding on the label — so that invisible escape bytes do
+        // not misalign the output.
+        let untracked_label = if is_interactive {
+            "\x1b]8;;https://usegitai.com/docs\x1b\\untracked\x1b]8;;\x1b\\".to_string()
+        } else {
+            "untracked".to_string()
+        };
+        let percentage_line = format!(
+            "     {:<3}{:>10}{} {:>3}%{:>10}{:>3}%",
+            format!("{}%", human_percentage),
+            "",
+            untracked_label,
+            untracked_percentage,
+            "",
+            ai_percentage
+        );
+        output.push_str(&percentage_line);
+        output.push('\n');
+        if is_interactive {
+            println!("{}", percentage_line);
+        }
+    } else {
+        let percentage_line = format!(
+            "     {:<3}{:>33}{:>3}%",
+            format!("{}%", human_percentage),
+            "",
+            ai_percentage
+        );
+        output.push_str(&percentage_line);
+        output.push('\n');
+        if is_interactive {
+            println!("{}", percentage_line);
+        }
+    }
+```
+
+- [ ] **Step 5: Update the remaining `if print {` guard in the AI-stats line (line ~295)**
+
+```rust
+        if print {
+            println!("{}", ai_acceptance_str);
+        }
+```
+
+→
+
+```rust
+        if is_interactive {
+            println!("{}", ai_acceptance_str);
+        }
+```
+
+---
+
+### Task 5: Run tests, accept snapshots, verify
+
+**Files:**
+- Modify (via insta): `src/authorship/snapshots/git_ai__authorship__stats__tests__terminal_stats_display.snap` through `-5.snap`, plus 4 new snapshot files
+
+- [ ] **Step 1: Run the display test**
+
+```bash
+cargo test -p git-ai "authorship::stats::tests::test_terminal_stats_display" 2>&1 | tail -40
+```
+
+Expected: existing 5 snapshots fail with "snapshot changed"; 4 new cases fail with "snapshot not found"; hyperlink assert **passes**.
+
+- [ ] **Step 2: Accept all updated and new snapshots**
+
+```bash
+cargo insta review
+```
+
+For each snapshot, verify it looks correct before accepting:
+
+| Snapshot expression | Expected visual |
+|---|---|
+| `mixed_output` | `██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░ ai` — no `▒`, no "mixed" label |
+| `ai_only_output` | `░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ ai` — unchanged visually |
+| `human_only_output` | `████████████████████████████████████████ ai` — unchanged |
+| `minimal_human_output` | `██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ ai` — unchanged |
+| `deletion_only_output` | gray bar, "(no additions)" — unchanged |
+| `with_untracked_output` | `███████········░░░░░░░░░░░░░░░░░░░░░░░░░ ai` + three-anchor pct line |
+| `untracked_at_threshold_output` | no `·` chars, two-anchor pct line |
+| `untracked_just_above_output` | `·` chars visible, three-anchor pct line with small untracked% |
+| `all_untracked_output` | 40 `·` chars, three-anchor pct line |
+
+- [ ] **Step 3: Run full test suite for regressions**
+
+```bash
+cargo test -p git-ai 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/authorship/stats.rs src/authorship/snapshots/
+git commit -m "$(cat <<'EOF'
+feat: replace mixed with untracked segment in stats bar
+
+- Human bar now shows only attested human_additions (not +unknown)
+- Replaces mixed (▒) segment with untracked (·) using unknown_additions
+- Hides untracked when ≤ 1% of total additions
+- Hyperlinks the untracked label (OSC 8) in interactive shells
+- Placeholder URL https://usegitai.com/docs — update manually
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Push and open PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin stats-bar-untracked
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat: replace mixed with untracked segment in stats bar" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Human bar now shows only explicitly-attested `human_additions` (not `human + unknown`)
+- Replaces the `mixed` (▒) segment with `untracked` (·) driven by `unknown_additions`
+- Untracked segment is hidden when ≤ 1% of total additions (simplified two-anchor output)
+- In interactive shells, the `untracked` label is an OSC 8 hyperlink — **placeholder URL `https://usegitai.com/docs` needs updating manually**
+- `mixed_additions` is ignored entirely by the display layer
+
+## Test plan
+
+- [ ] `cargo test -p git-ai authorship::stats` passes
+- [ ] Snapshot diffs look right: human%, untracked%, AI% sum to ~100%
+- [ ] Run `git commit` in a repo with `unknown_additions > 1%` — bar shows `·` chars
+- [ ] In a terminal that supports OSC 8 (iTerm2, Warp, Ghostty), verify `untracked` is clickable
+- [ ] Update the placeholder URL before merging
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL.

--- a/docs/superpowers/specs/2026-04-13-stats-bar-untracked-design.md
+++ b/docs/superpowers/specs/2026-04-13-stats-bar-untracked-design.md
@@ -1,0 +1,132 @@
+# Stats Bar: Untracked Segment Design
+
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Background
+
+We recently introduced "known human" attribution: code is marked human only when the IDE extension explicitly attests it. Lines with no attestation are now `unknown_additions`, not assumed-human. The visual stats bar has not yet reflected this — it still lumps `human + unknown` together as the human segment and shows a `mixed` segment for AI-edited-by-human lines.
+
+This spec updates the terminal stats bar to:
+1. Show only explicitly-attested human lines as the human segment.
+2. Replace `mixed` with `untracked` (the `unknown_additions` count).
+3. Hide untracked entirely when `unknown_additions as f64 / total as f64 * 100.0 <= 1.0` (raw float check, before rounding).
+4. Hyperlink the `untracked` label to IDE integration docs in interactive shells.
+
+## Data Model
+
+No struct changes. The three `CommitStats` fields that drive the new bar:
+
+| Field | Segment | Character |
+|---|---|---|
+| `human_additions` | human | `█` (U+2588 FULL BLOCK) |
+| `unknown_additions` | untracked | `·` (U+00B7 MIDDLE DOT) |
+| `ai_additions` | AI | `░` (U+2591 LIGHT SHADE) |
+
+`mixed_additions` is ignored entirely by `write_stats_to_terminal`.
+
+Total denominator: `human_additions + unknown_additions + ai_additions`.
+
+## Bar Rendering
+
+### Segment sizing (40-char bar)
+
+```
+human_bars     = floor(human_additions    / total * 40)
+untracked_bars = floor(unknown_additions  / total * 40)
+ai_bars        = 40 - human_bars - untracked_bars
+```
+
+Minimum visibility (preserved from current behaviour):
+- If `human_additions > 1`: `human_bars = max(human_bars, 2)`, and remaining width is redistributed between untracked and AI proportionally.
+
+### Bar line
+
+```
+you  ███████·········░░░░░░░░░░░░░░░░░░░░░░░░ ai
+```
+
+### Percentage line — untracked > 1%
+
+```
+     18%          untracked  22%          60%
+```
+
+The `untracked` label is plain text when `is_interactive = false`. When `is_interactive = true` (interactive shell), it is wrapped in an OSC 8 hyperlink:
+
+```
+\x1b]8;;https://usegitai.com/docs\x1b\untracked\x1b]8;;\x1b\
+```
+
+The surrounding spaces are constructed manually (not via format-width padding) so the invisible escape bytes don't misalign the output.
+
+### Percentage line — untracked ≤ 1%
+
+```
+     18%                                  60%
+```
+
+Same simplified two-anchor format as the current no-mixed path.
+
+### AI stats line (unchanged)
+
+```
+     77% AI code accepted | waited 1m for ai
+```
+
+Only shown when `ai_additions > 0`.
+
+## Function Signature
+
+```rust
+// Before
+pub fn write_stats_to_terminal(stats: &CommitStats, print: bool) -> String
+
+// After
+pub fn write_stats_to_terminal(stats: &CommitStats, is_interactive: bool) -> String
+```
+
+`is_interactive` controls both stdout printing and hyperlink emission. All existing call sites already pass `std::io::stdout().is_terminal()` or `true` (CLI stats command), so no logic changes at callers.
+
+## Implementation Steps
+
+1. Rename `print` → `is_interactive` throughout `write_stats_to_terminal`.
+2. Replace `display_human = human_additions + unknown_additions` with `display_human = human_additions`.
+3. Update `total_additions` to `human_additions + unknown_additions + ai_additions`.
+4. Replace `mixed_bars`/`▒` section with `untracked_bars`/`·` section.
+5. Update percentage line:
+   - Compute `untracked_pct_raw = unknown_additions as f64 / total as f64 * 100.0`.
+   - If `untracked_pct_raw > 1.0`: build three-anchor line with untracked label (hyperlinked if `is_interactive`), display rounded integer percentage.
+   - Else: build two-anchor line (human% and ai% only).
+6. Remove all references to `mixed_additions` and `mixed_percentage`.
+7. Update snapshot files via `cargo insta review`.
+
+## Test Plan
+
+### Existing cases — updated snapshots
+
+All five `test_terminal_stats_display` snapshot files change because the bar calculation changes. Run `cargo insta review` after implementing to accept the new output.
+
+| Snapshot expression | Data | Expected change |
+|---|---|---|
+| `mixed_output` | human=50, unknown=0, ai=100 | `▒` bars gone; untracked=0% so no untracked label |
+| `ai_only_output` | human=0, unknown=0, ai=100 | Snapshot updates (calculation path changes) |
+| `human_only_output` | human=75, unknown=0, ai=0 | Snapshot updates |
+| `minimal_human_output` | human=2, unknown=0, ai=100 | Snapshot updates |
+| `deletion_only_output` | deletions only | No change |
+
+### New cases added to `test_terminal_stats_display`
+
+All new snapshot-based cases call `write_stats_to_terminal(&stats, false)` (non-interactive) to keep snapshots free of OSC escape codes.
+
+| Case name | Data | Purpose |
+|---|---|---|
+| `with_untracked` | human=180, unknown=220, ai=600 | Matches 18%/22%/60% example; verifies `·` chars and "untracked  22%" label |
+| `untracked_at_threshold` | human=99, unknown=1, ai=0 | untracked=1% exactly → no untracked section shown |
+| `untracked_just_above_threshold` | human=97, unknown=2, ai=0 | untracked≈2% → untracked section shown |
+| `all_untracked` | human=0, unknown=100, ai=0 | 100% `·` chars; no AI stats line |
+| `untracked_with_hyperlink` | Same as `with_untracked`, `is_interactive=true` | Assert `output.contains("\x1b]8;;https://usegitai.com/docs")` — no snapshot |
+
+### Out of scope
+
+`write_stats_to_markdown` is not changed by this spec.

--- a/tests/integration/bash_tool_provenance.rs
+++ b/tests/integration/bash_tool_provenance.rs
@@ -8,9 +8,13 @@
 //! commands.
 
 use crate::repos::test_repo::TestRepo;
+#[cfg(unix)]
+use git_ai::commands::checkpoint_agent::bash_tool::checkpoint_context_from_active_bash;
+#[cfg(unix)]
+use git_ai::commands::checkpoint_agent::bash_tool::handle_bash_pre_tool_use_with_context;
 use git_ai::commands::checkpoint_agent::bash_tool::{
-    BashCheckpointAction, BashToolResult, HookEvent, checkpoint_context_from_active_bash, diff,
-    git_status_fallback, handle_bash_tool, handle_bash_pre_tool_use_with_context, snapshot,
+    BashCheckpointAction, BashToolResult, HookEvent, diff, git_status_fallback, handle_bash_tool,
+    snapshot,
 };
 use std::fs;
 use std::process::Command;
@@ -1579,9 +1583,8 @@ exit 0
 "#,
     );
 
-    let pre_action =
-        handle_bash_tool(HookEvent::PreToolUse, &root, "hooknew-sess", "hooknew-t1")
-            .expect("PreToolUse should succeed");
+    let pre_action = handle_bash_tool(HookEvent::PreToolUse, &root, "hooknew-sess", "hooknew-t1")
+        .expect("PreToolUse should succeed");
     assert!(matches!(
         pre_action.action,
         BashCheckpointAction::TakePreSnapshot
@@ -1603,13 +1606,8 @@ exit 0
         "pre-commit hook should have created .commit-metadata"
     );
 
-    let post_action = handle_bash_tool(
-        HookEvent::PostToolUse,
-        &root,
-        "hooknew-sess",
-        "hooknew-t1",
-    )
-    .expect("PostToolUse should succeed");
+    let post_action = handle_bash_tool(HookEvent::PostToolUse, &root, "hooknew-sess", "hooknew-t1")
+        .expect("PostToolUse should succeed");
 
     // Both the agent's file and the hook-created file should be detected
     assert_checkpoint_contains(&post_action, "feature.py");
@@ -1625,12 +1623,7 @@ fn test_bash_provenance_precommit_hook_modifies_untouched_file() {
     let repo = TestRepo::new();
     let root = repo_root(&repo);
     add_and_commit(&repo, "init.txt", "seed", "initial commit");
-    add_and_commit(
-        &repo,
-        "build-stamp.txt",
-        "build: 0\n",
-        "add build stamp",
-    );
+    add_and_commit(&repo, "build-stamp.txt", "build: 0\n", "add build stamp");
 
     install_pre_commit_hook(
         &repo,
@@ -1715,14 +1708,9 @@ exit 0
         id: "test-session-1".to_string(),
         model: "opus-4".to_string(),
     };
-    let pre_action = handle_bash_pre_tool_use_with_context(
-        &root,
-        "agent-sess",
-        "agent-t1",
-        &agent_id,
-        None,
-    )
-    .expect("PreToolUse with context should succeed");
+    let pre_action =
+        handle_bash_pre_tool_use_with_context(&root, "agent-sess", "agent-t1", &agent_id, None)
+            .expect("PreToolUse with context should succeed");
     assert!(matches!(
         pre_action.action,
         BashCheckpointAction::TakePreSnapshot
@@ -1791,8 +1779,13 @@ exit 0
 "#,
     );
 
-    let pre_action = handle_bash_tool(HookEvent::PreToolUse, &root, "multi-fmt-sess", "multi-fmt-t1")
-        .expect("PreToolUse should succeed");
+    let pre_action = handle_bash_tool(
+        HookEvent::PreToolUse,
+        &root,
+        "multi-fmt-sess",
+        "multi-fmt-t1",
+    )
+    .expect("PreToolUse should succeed");
     assert!(matches!(
         pre_action.action,
         BashCheckpointAction::TakePreSnapshot

--- a/tests/integration/bash_tool_provenance.rs
+++ b/tests/integration/bash_tool_provenance.rs
@@ -9,8 +9,8 @@
 
 use crate::repos::test_repo::TestRepo;
 use git_ai::commands::checkpoint_agent::bash_tool::{
-    BashCheckpointAction, BashToolResult, HookEvent, diff, git_status_fallback, handle_bash_tool,
-    snapshot,
+    BashCheckpointAction, BashToolResult, HookEvent, checkpoint_context_from_active_bash, diff,
+    git_status_fallback, handle_bash_tool, handle_bash_pre_tool_use_with_context, snapshot,
 };
 use std::fs;
 use std::process::Command;
@@ -1399,4 +1399,506 @@ fn test_bash_provenance_mv_directory_rename() {
         "lib/lib.rs should appear in checkpoint (created); got {:?}",
         paths
     );
+}
+
+// ===========================================================================
+// Category 14: Pre-commit hook formatter attribution
+//
+// Verifies that when a git commit runs inside an AI agent's bash tool call,
+// and git's pre-commit hook runs a formatter (or any tool that modifies files),
+// those changes are properly detected by the stat-diff mechanism and attributed
+// to the AI agent.
+// ===========================================================================
+
+/// Install a git pre-commit hook script in the test repo.
+/// The hook must be executable and located at `.git/hooks/pre-commit`.
+#[cfg(unix)]
+fn install_pre_commit_hook(repo: &TestRepo, script: &str) {
+    let git_dir = repo.path().join(".git");
+    // For linked worktrees, .git is a file pointing to the real git dir
+    let hooks_dir = if git_dir.is_file() {
+        let content = fs::read_to_string(&git_dir).expect("read .git file");
+        let real_git_dir = content
+            .trim()
+            .strip_prefix("gitdir: ")
+            .expect("parse gitdir");
+        std::path::PathBuf::from(real_git_dir).join("hooks")
+    } else {
+        git_dir.join("hooks")
+    };
+    fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+    let hook_path = hooks_dir.join("pre-commit");
+    fs::write(&hook_path, script).expect("write pre-commit hook");
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(&hook_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&hook_path, perms).expect("chmod hook");
+}
+
+/// Run a raw git command in the repo (without bypassing hooks).
+/// Unlike `run_bash`, this returns the full output including exit status
+/// without asserting success, so we can check for hook failures.
+fn run_git_with_hooks(repo: &TestRepo, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo.path())
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("git {:?} failed to start: {}", args, e))
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_formatter_modifies_staged_file() {
+    // Scenario: AI agent creates a file, commits it, and the pre-commit hook
+    // reformats the file (modifies it without re-staging). The stat-diff should
+    // detect the formatter's modification.
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+
+    // Install a pre-commit hook that appends a formatter comment to .py files.
+    // It modifies the working tree file but does NOT re-stage, so the commit
+    // contains the original content and the working tree has the formatted version.
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.py'); do
+    echo '# auto-formatted' >> "$f"
+done
+exit 0
+"#,
+    );
+
+    // Pre-snapshot: AI agent's bash tool starts
+    let pre_action = handle_bash_tool(HookEvent::PreToolUse, &root, "fmt-sess", "fmt-t1")
+        .expect("PreToolUse should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    // AI agent creates and stages a Python file
+    write_file(&repo, "main.py", "print('hello')\n");
+    run_git_with_hooks(&repo, &["add", "main.py"]);
+
+    // AI agent commits — the pre-commit hook will modify main.py
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "add main.py"]);
+    assert!(
+        commit_output.status.success(),
+        "git commit should succeed: {}",
+        String::from_utf8_lossy(&commit_output.stderr)
+    );
+
+    // Verify the formatter actually ran
+    let content = fs::read_to_string(repo.path().join("main.py")).unwrap();
+    assert!(
+        content.contains("# auto-formatted"),
+        "pre-commit hook should have appended formatter comment; got: {:?}",
+        content
+    );
+
+    // Post-snapshot: stat-diff should detect the formatter's modification
+    let post_action = handle_bash_tool(HookEvent::PostToolUse, &root, "fmt-sess", "fmt-t1")
+        .expect("PostToolUse should succeed");
+    assert_checkpoint_contains(&post_action, "main.py");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_formatter_restages_file() {
+    // Scenario: pre-commit hook formats AND re-stages the file (common pattern
+    // with tools like prettier --write + git add). The commit contains the
+    // formatted content. The stat-diff should still detect the file change.
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.py'); do
+    # Simulate a formatter that normalizes whitespace
+    sed -i 's/[[:space:]]*$//' "$f"
+    echo '# formatted-and-staged' >> "$f"
+    git add "$f"
+done
+exit 0
+"#,
+    );
+
+    let pre_action = handle_bash_tool(HookEvent::PreToolUse, &root, "fmtstage-sess", "fmtstage-t1")
+        .expect("PreToolUse should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    write_file(&repo, "app.py", "x = 1   \ny = 2   \n");
+    run_git_with_hooks(&repo, &["add", "app.py"]);
+
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "add app.py"]);
+    assert!(
+        commit_output.status.success(),
+        "git commit should succeed: {}",
+        String::from_utf8_lossy(&commit_output.stderr)
+    );
+
+    let content = fs::read_to_string(repo.path().join("app.py")).unwrap();
+    assert!(
+        content.contains("# formatted-and-staged"),
+        "formatter should have modified the file; got: {:?}",
+        content
+    );
+
+    let post_action = handle_bash_tool(
+        HookEvent::PostToolUse,
+        &root,
+        "fmtstage-sess",
+        "fmtstage-t1",
+    )
+    .expect("PostToolUse should succeed");
+    assert_checkpoint_contains(&post_action, "app.py");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_creates_new_file() {
+    // Scenario: pre-commit hook creates a new file (e.g., a lint report or
+    // generated manifest). The stat-diff should detect the new file.
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+# Generate a timestamp file on every commit
+echo "last-commit: $(date -u +%Y-%m-%dT%H:%M:%S)" > .commit-metadata
+exit 0
+"#,
+    );
+
+    let pre_action =
+        handle_bash_tool(HookEvent::PreToolUse, &root, "hooknew-sess", "hooknew-t1")
+            .expect("PreToolUse should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    write_file(&repo, "feature.py", "def feature(): pass\n");
+    run_git_with_hooks(&repo, &["add", "feature.py"]);
+
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "add feature"]);
+    assert!(
+        commit_output.status.success(),
+        "git commit should succeed: {}",
+        String::from_utf8_lossy(&commit_output.stderr)
+    );
+
+    // Verify the hook created the metadata file
+    assert!(
+        repo.path().join(".commit-metadata").exists(),
+        "pre-commit hook should have created .commit-metadata"
+    );
+
+    let post_action = handle_bash_tool(
+        HookEvent::PostToolUse,
+        &root,
+        "hooknew-sess",
+        "hooknew-t1",
+    )
+    .expect("PostToolUse should succeed");
+
+    // Both the agent's file and the hook-created file should be detected
+    assert_checkpoint_contains(&post_action, "feature.py");
+    assert_checkpoint_contains(&post_action, ".commit-metadata");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_modifies_untouched_file() {
+    // Scenario: pre-commit hook modifies a file that the AI agent did NOT touch.
+    // For example, a hook that updates a version timestamp in a config file
+    // whenever any commit is made. The stat-diff should detect this change.
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+    add_and_commit(
+        &repo,
+        "build-stamp.txt",
+        "build: 0\n",
+        "add build stamp",
+    );
+
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+# Increment build number on every commit (modifies a file the agent didn't touch)
+current=$(grep -o '[0-9]*' build-stamp.txt)
+next=$((current + 1))
+echo "build: $next" > build-stamp.txt
+exit 0
+"#,
+    );
+
+    let pre_action = handle_bash_tool(
+        HookEvent::PreToolUse,
+        &root,
+        "hookother-sess",
+        "hookother-t1",
+    )
+    .expect("PreToolUse should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    // AI agent creates a completely different file
+    thread::sleep(Duration::from_millis(50));
+    write_file(&repo, "new-feature.rs", "fn new_feature() {}\n");
+    run_git_with_hooks(&repo, &["add", "new-feature.rs"]);
+
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "add new feature"]);
+    assert!(
+        commit_output.status.success(),
+        "git commit should succeed: {}",
+        String::from_utf8_lossy(&commit_output.stderr)
+    );
+
+    // Verify the hook modified build-stamp.txt
+    let content = fs::read_to_string(repo.path().join("build-stamp.txt")).unwrap();
+    assert!(
+        content.contains("build: 1"),
+        "hook should have incremented build number; got: {:?}",
+        content
+    );
+
+    let post_action = handle_bash_tool(
+        HookEvent::PostToolUse,
+        &root,
+        "hookother-sess",
+        "hookother-t1",
+    )
+    .expect("PostToolUse should succeed");
+
+    // Both files should be detected: the agent's new file and the hook-modified file
+    assert_checkpoint_contains(&post_action, "new-feature.rs");
+    assert_checkpoint_contains(&post_action, "build-stamp.txt");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_with_agent_context_attribution() {
+    // Scenario: Same as the formatter test, but uses handle_bash_pre_tool_use_with_context
+    // to set up proper AI agent context. Verifies that checkpoint_context_from_active_bash
+    // returns AiAgent while the pre-snapshot is active (which is the case during
+    // the pre-commit hook execution).
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.py'); do
+    echo '# agent-formatted' >> "$f"
+done
+exit 0
+"#,
+    );
+
+    // Set up pre-snapshot WITH agent context (simulating a real AI agent session)
+    let agent_id = git_ai::authorship::working_log::AgentId {
+        tool: "claude".to_string(),
+        id: "test-session-1".to_string(),
+        model: "opus-4".to_string(),
+    };
+    let pre_action = handle_bash_pre_tool_use_with_context(
+        &root,
+        "agent-sess",
+        "agent-t1",
+        &agent_id,
+        None,
+    )
+    .expect("PreToolUse with context should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    // Verify that checkpoint_context_from_active_bash finds the active context
+    // (this is what the pre-commit hook would see during commit execution)
+    let repo_working_dir = root.to_string_lossy().to_string();
+    let context = checkpoint_context_from_active_bash(&root, &repo_working_dir);
+    assert!(
+        context.is_some(),
+        "checkpoint_context_from_active_bash should find active bash snapshot"
+    );
+    let (kind, agent_run) = context.unwrap();
+    assert_eq!(
+        kind,
+        git_ai::authorship::working_log::CheckpointKind::AiAgent,
+        "checkpoint kind should be AiAgent"
+    );
+    let agent_run = agent_run.expect("should have agent run result with context");
+    assert_eq!(agent_run.agent_id.tool, "claude");
+    assert_eq!(agent_run.agent_id.id, "test-session-1");
+    assert_eq!(agent_run.agent_id.model, "opus-4");
+
+    // Now run the actual commit with hooks
+    write_file(&repo, "module.py", "import os\n");
+    run_git_with_hooks(&repo, &["add", "module.py"]);
+
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "add module"]);
+    assert!(
+        commit_output.status.success(),
+        "git commit should succeed: {}",
+        String::from_utf8_lossy(&commit_output.stderr)
+    );
+
+    // Verify formatter ran
+    let content = fs::read_to_string(repo.path().join("module.py")).unwrap();
+    assert!(
+        content.contains("# agent-formatted"),
+        "formatter should have modified module.py; got: {:?}",
+        content
+    );
+
+    // Post-snapshot should detect the change
+    let post_action = handle_bash_tool(HookEvent::PostToolUse, &root, "agent-sess", "agent-t1")
+        .expect("PostToolUse should succeed");
+    assert_checkpoint_contains(&post_action, "module.py");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_modifies_multiple_files() {
+    // Scenario: pre-commit hook runs a formatter on multiple staged files.
+    // All modified files should be detected by the stat-diff.
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.py'); do
+    echo '# lint-pass' >> "$f"
+done
+exit 0
+"#,
+    );
+
+    let pre_action = handle_bash_tool(HookEvent::PreToolUse, &root, "multi-fmt-sess", "multi-fmt-t1")
+        .expect("PreToolUse should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    // AI agent creates multiple Python files
+    write_file(&repo, "src/api.py", "def api(): pass\n");
+    write_file(&repo, "src/models.py", "class Model: pass\n");
+    write_file(&repo, "src/utils.py", "def util(): pass\n");
+    write_file(&repo, "readme.md", "# Project\n"); // Not .py — won't be formatted
+
+    run_git_with_hooks(&repo, &["add", "."]);
+
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "add src"]);
+    assert!(
+        commit_output.status.success(),
+        "git commit should succeed: {}",
+        String::from_utf8_lossy(&commit_output.stderr)
+    );
+
+    // Verify all .py files were formatted
+    for py_file in &["src/api.py", "src/models.py", "src/utils.py"] {
+        let content = fs::read_to_string(repo.path().join(py_file)).unwrap();
+        assert!(
+            content.contains("# lint-pass"),
+            "{} should have been formatted; got: {:?}",
+            py_file,
+            content
+        );
+    }
+    // readme.md should NOT have been formatted
+    let readme = fs::read_to_string(repo.path().join("readme.md")).unwrap();
+    assert!(
+        !readme.contains("# lint-pass"),
+        "readme.md should not have been formatted"
+    );
+
+    let post_action = handle_bash_tool(
+        HookEvent::PostToolUse,
+        &root,
+        "multi-fmt-sess",
+        "multi-fmt-t1",
+    )
+    .expect("PostToolUse should succeed");
+
+    // All created/modified files should be detected
+    assert_checkpoint_contains(&post_action, "api.py");
+    assert_checkpoint_contains(&post_action, "models.py");
+    assert_checkpoint_contains(&post_action, "utils.py");
+    assert_checkpoint_contains(&post_action, "readme.md");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_bash_provenance_precommit_hook_fails_and_modifies_files() {
+    // Scenario: pre-commit hook modifies files but then exits with non-zero
+    // (e.g., a linter that fixes formatting but reports errors). The commit
+    // fails, but the stat-diff should still detect the modified files because
+    // the working tree was changed.
+    let repo = TestRepo::new();
+    let root = repo_root(&repo);
+    add_and_commit(&repo, "init.txt", "seed", "initial commit");
+
+    install_pre_commit_hook(
+        &repo,
+        r#"#!/bin/sh
+# Fix formatting but report failure (like a strict linter)
+for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.py'); do
+    echo '# auto-fixed' >> "$f"
+done
+exit 1
+"#,
+    );
+
+    let pre_action = handle_bash_tool(HookEvent::PreToolUse, &root, "hookfail-sess", "hookfail-t1")
+        .expect("PreToolUse should succeed");
+    assert!(matches!(
+        pre_action.action,
+        BashCheckpointAction::TakePreSnapshot
+    ));
+
+    write_file(&repo, "broken.py", "x=1\n");
+    run_git_with_hooks(&repo, &["add", "broken.py"]);
+
+    // The commit will FAIL because the hook exits 1
+    let commit_output = run_git_with_hooks(&repo, &["commit", "-m", "try commit"]);
+    assert!(
+        !commit_output.status.success(),
+        "git commit should fail due to hook exit 1"
+    );
+
+    // But the hook still modified the file
+    let content = fs::read_to_string(repo.path().join("broken.py")).unwrap();
+    assert!(
+        content.contains("# auto-fixed"),
+        "hook should have modified the file even though it failed; got: {:?}",
+        content
+    );
+
+    // The stat-diff should detect the modification
+    let post_action = handle_bash_tool(
+        HookEvent::PostToolUse,
+        &root,
+        "hookfail-sess",
+        "hookfail-t1",
+    )
+    .expect("PostToolUse should succeed");
+    assert_checkpoint_contains(&post_action, "broken.py");
 }

--- a/tests/integration/bash_tool_provenance.rs
+++ b/tests/integration/bash_tool_provenance.rs
@@ -1442,6 +1442,7 @@ fn install_pre_commit_hook(repo: &TestRepo, script: &str) {
 /// Run a raw git command in the repo (without bypassing hooks).
 /// Unlike `run_bash`, this returns the full output including exit status
 /// without asserting success, so we can check for hook failures.
+#[cfg(unix)]
 fn run_git_with_hooks(repo: &TestRepo, args: &[&str]) -> std::process::Output {
     Command::new("git")
         .arg("-C")
@@ -1523,7 +1524,7 @@ fn test_bash_provenance_precommit_hook_formatter_restages_file() {
         r#"#!/bin/sh
 for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.py'); do
     # Simulate a formatter that normalizes whitespace
-    sed -i 's/[[:space:]]*$//' "$f"
+    sed -i.bak 's/[[:space:]]*$//' "$f" && rm -f "$f.bak"
     echo '# formatted-and-staged' >> "$f"
     git add "$f"
 done


### PR DESCRIPTION
## Summary
- Adds 7 integration tests verifying that file changes made by git's pre-commit hook (formatters, linters, generators) are correctly detected by the bash tool stat-diff mechanism for AI attribution
- Tests cover: formatter modifying staged files (with/without re-staging), hook creating new files, hook modifying files untouched by the agent, agent context availability via `handle_bash_pre_tool_use_with_context`, multi-file formatting, and failed hooks that still modify working tree files
- No bugs found — the existing stat-diff mechanism correctly handles all pre-commit hook scenarios

## Test plan
- [x] All 7 new `test_bash_provenance_precommit_hook_*` tests pass
- [x] All 57 provenance tests pass (including 7 new)
- [x] All 54 conformance tests pass
- [x] All 5 pre_commit unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
