### PR TITLE
fix: prevent total_additions inflation on amend

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -673,13 +673,14 @@ pub fn rewrite_authorship_after_squash_or_rebase(
     authorship_log.metadata.base_commit_sha = merge_commit_sha.to_string();
 
     // Preserve accumulated totals from source commits (squash/rebase should not drop session totals).
-    let mut summed_totals: HashMap<String, (u32, u32)> = HashMap::new();
+    // Use max (not sum) because totals are cumulative — later commits already include earlier values.
+    let mut max_totals: HashMap<String, (u32, u32)> = HashMap::new();
     for commit_sha in &source_commits {
         if let Ok(log) = get_reference_as_authorship_log_v3(repo, commit_sha) {
             for (prompt_id, record) in log.metadata.prompts {
-                let entry = summed_totals.entry(prompt_id).or_insert((0, 0));
-                entry.0 = entry.0.saturating_add(record.total_additions);
-                entry.1 = entry.1.saturating_add(record.total_deletions);
+                let entry = max_totals.entry(prompt_id).or_insert((0, 0));
+                entry.0 = entry.0.max(record.total_additions);
+                entry.1 = entry.1.max(record.total_deletions);
             }
             for (hash, record) in log.metadata.humans {
                 authorship_log.metadata.humans.entry(hash).or_insert(record);
@@ -688,7 +689,7 @@ pub fn rewrite_authorship_after_squash_or_rebase(
     }
 
     for (prompt_id, record) in authorship_log.metadata.prompts.iter_mut() {
-        if let Some((additions, deletions)) = summed_totals.get(prompt_id) {
+        if let Some((additions, deletions)) = max_totals.get(prompt_id) {
             record.total_additions = *additions;
             record.total_deletions = *deletions;
         }
@@ -3368,6 +3369,7 @@ fn build_metadata_only_authorship_log_from_source_notes(
     use crate::authorship::authorship_log::HumanRecord;
 
     let mut merged_prompts = BTreeMap::new();
+    // Use max (not sum) because totals are cumulative — later commits already include earlier values.
     let mut prompt_totals: HashMap<String, (u32, u32)> = HashMap::new();
     let mut merged_humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
     let mut saw_any_note = false;
@@ -3380,8 +3382,8 @@ fn build_metadata_only_authorship_log_from_source_notes(
 
         for (prompt_id, prompt_record) in log.metadata.prompts {
             let entry = prompt_totals.entry(prompt_id.clone()).or_insert((0, 0));
-            entry.0 = entry.0.saturating_add(prompt_record.total_additions);
-            entry.1 = entry.1.saturating_add(prompt_record.total_deletions);
+            entry.0 = entry.0.max(prompt_record.total_additions);
+            entry.1 = entry.1.max(prompt_record.total_deletions);
             merged_prompts.insert(prompt_id, prompt_record);
         }
         for (hash, record) in log.metadata.humans {

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1995,14 +1995,14 @@ impl VirtualAttributions {
             // Only add inherited base for sessions that had new checkpoint data.
             // Sessions without new checkpoints already carry the correct cumulative
             // value from INITIAL (preserved by calculate_and_update_prompt_metrics).
-            if session_additions.contains_key(session_id) {
-                if let Some(&(inherited_adds, inherited_dels)) = inherited_totals.get(session_id) {
-                    for prompt_record in commits.values_mut() {
-                        prompt_record.total_additions =
-                            prompt_record.total_additions.saturating_add(inherited_adds);
-                        prompt_record.total_deletions =
-                            prompt_record.total_deletions.saturating_add(inherited_dels);
-                    }
+            if session_additions.contains_key(session_id)
+                && let Some(&(inherited_adds, inherited_dels)) = inherited_totals.get(session_id)
+            {
+                for prompt_record in commits.values_mut() {
+                    prompt_record.total_additions =
+                        prompt_record.total_additions.saturating_add(inherited_adds);
+                    prompt_record.total_deletions =
+                        prompt_record.total_deletions.saturating_add(inherited_dels);
                 }
             }
         }

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -2168,8 +2168,8 @@ pub fn merge_attributions_favoring_first(
         &HashMap::new(),
     );
 
-    // Overwrite total_additions/total_deletions with the summed values from both sources,
-    // since merge should reflect the combined totals from primary + secondary.
+    // Overwrite total_additions/total_deletions with the max values from both sources,
+    // since totals are cumulative and merge should reflect the highest seen across sources.
     for (prompt_id, commits) in merged.prompts.iter_mut() {
         if let Some(&(additions, deletions)) = saved_totals.get(prompt_id) {
             for prompt_record in commits.values_mut() {

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -338,6 +338,18 @@ impl VirtualAttributions {
                 .insert(String::new(), prompt_record.clone());
         }
 
+        // Save inherited cumulative totals from INITIAL prompts before checkpoint
+        // processing may overwrite them. Used later to make session deltas cumulative.
+        let inherited_totals: HashMap<String, (u32, u32)> = prompts
+            .iter()
+            .filter_map(|(id, commits)| {
+                commits
+                    .values()
+                    .next()
+                    .map(|r| (id.clone(), (r.total_additions, r.total_deletions)))
+            })
+            .collect();
+
         // Load known human records from INITIAL attributions
         for (hash, human_record) in &initial_attributions.humans {
             humans
@@ -466,6 +478,10 @@ impl VirtualAttributions {
             &session_deletions,
         );
 
+        // Make total_additions cumulative by adding inherited base from INITIAL.
+        // This ensures merge operations using max() produce correct results.
+        Self::add_inherited_totals(&mut prompts, &inherited_totals, &session_additions);
+
         Ok(VirtualAttributions {
             repo,
             base_commit,
@@ -505,6 +521,18 @@ impl VirtualAttributions {
                 .or_insert_with(BTreeMap::new)
                 .insert(String::new(), prompt_record.clone());
         }
+
+        // Save inherited cumulative totals from INITIAL prompts before checkpoint
+        // processing may overwrite them. Used later to make session deltas cumulative.
+        let inherited_totals: HashMap<String, (u32, u32)> = prompts
+            .iter()
+            .filter_map(|(id, commits)| {
+                commits
+                    .values()
+                    .next()
+                    .map(|r| (id.clone(), (r.total_additions, r.total_deletions)))
+            })
+            .collect();
 
         // Load known human records from INITIAL attributions
         for (hash, human_record) in &initial_attributions.humans {
@@ -615,6 +643,9 @@ impl VirtualAttributions {
             &session_deletions,
         );
 
+        // Make total_additions cumulative by adding inherited base from INITIAL.
+        Self::add_inherited_totals(&mut prompts, &inherited_totals, &session_additions);
+
         Ok(VirtualAttributions {
             repo,
             base_commit,
@@ -655,6 +686,18 @@ impl VirtualAttributions {
                 .or_insert_with(BTreeMap::new)
                 .insert(String::new(), prompt_record.clone());
         }
+
+        // Save inherited cumulative totals from INITIAL prompts before checkpoint
+        // processing may overwrite them. Used later to make session deltas cumulative.
+        let inherited_totals: HashMap<String, (u32, u32)> = prompts
+            .iter()
+            .filter_map(|(id, commits)| {
+                commits
+                    .values()
+                    .next()
+                    .map(|r| (id.clone(), (r.total_additions, r.total_deletions)))
+            })
+            .collect();
 
         // Load known human records from INITIAL attributions
         for (hash, human_record) in &initial_attributions.humans {
@@ -771,6 +814,9 @@ impl VirtualAttributions {
             &session_additions,
             &session_deletions,
         );
+
+        // Make total_additions cumulative by adding inherited base from INITIAL.
+        Self::add_inherited_totals(&mut prompts, &inherited_totals, &session_additions);
 
         Ok(VirtualAttributions {
             repo,
@@ -1818,15 +1864,18 @@ impl VirtualAttributions {
             // Sort records oldest to newest using the Ord implementation
             all_records.sort();
 
-            // Take the last (newest) record and accumulate totals across all records
+            // Take the last (newest) record and use the max totals across all records.
+            // total_additions/total_deletions are cumulative, so the highest value
+            // represents the most up-to-date count. Using max instead of sum prevents
+            // inflation when the same prompt appears in both checkpoint and blame VAs.
             if let Some(newest_record) = all_records.last() {
                 let mut merged_record = newest_record.clone();
                 let mut total_additions = 0u32;
                 let mut total_deletions = 0u32;
 
                 for record in &all_records {
-                    total_additions = total_additions.saturating_add(record.total_additions);
-                    total_deletions = total_deletions.saturating_add(record.total_deletions);
+                    total_additions = total_additions.max(record.total_additions);
+                    total_deletions = total_deletions.max(record.total_deletions);
                 }
 
                 merged_record.total_additions = total_additions;
@@ -1924,6 +1973,37 @@ impl VirtualAttributions {
                     *session_accepted_lines.get(session_id).unwrap_or(&0);
                 prompt_record.overriden_lines =
                     *session_overridden_lines.get(session_id).unwrap_or(&0);
+            }
+        }
+    }
+
+    /// Add inherited INITIAL totals to prompts that had new checkpoint data,
+    /// making their `total_additions`/`total_deletions` cumulative rather than
+    /// session-delta-only. Prompts without new checkpoint data already carry
+    /// the inherited cumulative value (preserved by the conditional update in
+    /// `calculate_and_update_prompt_metrics`).
+    ///
+    /// This must be called after `calculate_and_update_prompt_metrics` and before
+    /// any merge operation, so that all prompts carry cumulative values and the
+    /// merge can use `max` instead of `sum`.
+    pub fn add_inherited_totals(
+        prompts: &mut BTreeMap<String, BTreeMap<String, PromptRecord>>,
+        inherited_totals: &HashMap<String, (u32, u32)>,
+        session_additions: &HashMap<String, u32>,
+    ) {
+        for (session_id, commits) in prompts.iter_mut() {
+            // Only add inherited base for sessions that had new checkpoint data.
+            // Sessions without new checkpoints already carry the correct cumulative
+            // value from INITIAL (preserved by calculate_and_update_prompt_metrics).
+            if session_additions.contains_key(session_id) {
+                if let Some(&(inherited_adds, inherited_dels)) = inherited_totals.get(session_id) {
+                    for prompt_record in commits.values_mut() {
+                        prompt_record.total_additions =
+                            prompt_record.total_additions.saturating_add(inherited_adds);
+                        prompt_record.total_deletions =
+                            prompt_record.total_deletions.saturating_add(inherited_dels);
+                    }
+                }
             }
         }
     }
@@ -2064,14 +2144,17 @@ pub fn merge_attributions_favoring_first(
             .insert(file_path, final_content.clone());
     }
 
-    // Save total_additions and total_deletions by summing across sources so squash/rebase preserves totals.
+    // Save total_additions and total_deletions using max across sources.
+    // These values are cumulative, so the highest value is the most up-to-date.
+    // Using max instead of sum prevents inflation when the same prompt appears
+    // in both sources (e.g., checkpoint VA and blame VA during amend).
     let mut saved_totals: HashMap<String, (u32, u32)> = HashMap::new();
     for source in [&primary.prompts, &secondary.prompts] {
         for (prompt_id, commits) in source {
             for prompt_record in commits.values() {
                 let entry = saved_totals.entry(prompt_id.clone()).or_insert((0, 0));
-                entry.0 = entry.0.saturating_add(prompt_record.total_additions);
-                entry.1 = entry.1.saturating_add(prompt_record.total_deletions);
+                entry.0 = entry.0.max(prompt_record.total_additions);
+                entry.1 = entry.1.max(prompt_record.total_deletions);
             }
         }
     }
@@ -2754,6 +2837,211 @@ mod tests {
         assert_eq!(
             prompt.total_deletions, 30,
             "empty session_deletions map should not zero out existing total_deletions"
+        );
+    }
+
+    /// Regression test for https://github.com/git-ai-project/git-ai/issues/1098
+    ///
+    /// When the same prompt_id appears in both sources with cumulative total_additions,
+    /// merge_prompts_picking_newest should take the max, not sum, to avoid inflating
+    /// the total on each successive amend.
+    #[test]
+    fn test_merge_prompts_does_not_inflate_totals_for_same_prompt() {
+        use crate::authorship::authorship_log::PromptRecord;
+        use crate::authorship::working_log::AgentId;
+
+        let mut source1 = BTreeMap::new();
+        let mut source2 = BTreeMap::new();
+
+        // Source 1 (checkpoint VA): prompt with cumulative total_additions = 13
+        let record1 = PromptRecord {
+            agent_id: AgentId {
+                tool: "cursor".to_string(),
+                id: "s1".to_string(),
+                model: "gpt-4".to_string(),
+            },
+            human_author: None,
+            messages: vec![],
+            total_additions: 13,
+            total_deletions: 5,
+            accepted_lines: 0,
+            overriden_lines: 0,
+            messages_url: None,
+            custom_attributes: None,
+        };
+        source1
+            .entry("prompt_a".to_string())
+            .or_insert_with(BTreeMap::new)
+            .insert(String::new(), record1);
+
+        // Source 2 (blame VA): same prompt with same cumulative total_additions = 13
+        let record2 = PromptRecord {
+            agent_id: AgentId {
+                tool: "cursor".to_string(),
+                id: "s1".to_string(),
+                model: "gpt-4".to_string(),
+            },
+            human_author: None,
+            messages: vec![],
+            total_additions: 13,
+            total_deletions: 5,
+            accepted_lines: 0,
+            overriden_lines: 0,
+            messages_url: None,
+            custom_attributes: None,
+        };
+        source2
+            .entry("prompt_a".to_string())
+            .or_insert_with(BTreeMap::new)
+            .insert("abc123".to_string(), record2);
+
+        let merged = VirtualAttributions::merge_prompts_picking_newest(&[&source1, &source2]);
+
+        let prompt = merged["prompt_a"].values().next().unwrap();
+        assert_eq!(
+            prompt.total_additions, 13,
+            "merge should not double cumulative total_additions (got {}, expected 13)",
+            prompt.total_additions
+        );
+        assert_eq!(
+            prompt.total_deletions, 5,
+            "merge should not double cumulative total_deletions"
+        );
+    }
+
+    /// When primary (checkpoint_va) has a higher cumulative value from new checkpoints,
+    /// merge should use the higher value.
+    #[test]
+    fn test_merge_prompts_picks_higher_cumulative_total() {
+        use crate::authorship::authorship_log::PromptRecord;
+        use crate::authorship::working_log::AgentId;
+
+        let mut source1 = BTreeMap::new();
+        let mut source2 = BTreeMap::new();
+
+        // Source 1: updated cumulative after new checkpoints (13 inherited + 5 new = 18)
+        let record1 = PromptRecord {
+            agent_id: AgentId {
+                tool: "cursor".to_string(),
+                id: "s1".to_string(),
+                model: "gpt-4".to_string(),
+            },
+            human_author: None,
+            messages: vec![],
+            total_additions: 18,
+            total_deletions: 7,
+            accepted_lines: 0,
+            overriden_lines: 0,
+            messages_url: None,
+            custom_attributes: None,
+        };
+        source1
+            .entry("prompt_a".to_string())
+            .or_insert_with(BTreeMap::new)
+            .insert(String::new(), record1);
+
+        // Source 2: old cumulative from committed note
+        let record2 = PromptRecord {
+            agent_id: AgentId {
+                tool: "cursor".to_string(),
+                id: "s1".to_string(),
+                model: "gpt-4".to_string(),
+            },
+            human_author: None,
+            messages: vec![],
+            total_additions: 13,
+            total_deletions: 5,
+            accepted_lines: 0,
+            overriden_lines: 0,
+            messages_url: None,
+            custom_attributes: None,
+        };
+        source2
+            .entry("prompt_a".to_string())
+            .or_insert_with(BTreeMap::new)
+            .insert("abc123".to_string(), record2);
+
+        let merged = VirtualAttributions::merge_prompts_picking_newest(&[&source1, &source2]);
+
+        let prompt = merged["prompt_a"].values().next().unwrap();
+        assert_eq!(
+            prompt.total_additions, 18,
+            "merge should use the higher cumulative value"
+        );
+        assert_eq!(
+            prompt.total_deletions, 7,
+            "merge should use the higher cumulative value for deletions"
+        );
+    }
+
+    /// Verify that calculate_and_update_prompt_metrics produces cumulative totals
+    /// when session deltas are added on top of inherited INITIAL values.
+    #[test]
+    fn test_session_delta_plus_inherited_base_is_cumulative() {
+        use crate::authorship::authorship_log::PromptRecord;
+        use crate::authorship::working_log::AgentId;
+
+        let mut prompts = BTreeMap::new();
+        let prompt_record = PromptRecord {
+            agent_id: AgentId {
+                tool: "cursor".to_string(),
+                id: "s1".to_string(),
+                model: "gpt-4".to_string(),
+            },
+            human_author: None,
+            messages: vec![],
+            total_additions: 0, // Checkpoint replaced the INITIAL entry
+            total_deletions: 0,
+            accepted_lines: 0,
+            overriden_lines: 0,
+            messages_url: None,
+            custom_attributes: None,
+        };
+        prompts
+            .entry("session_a".to_string())
+            .or_insert_with(BTreeMap::new)
+            .insert(String::new(), prompt_record);
+
+        let mut session_additions = HashMap::new();
+        session_additions.insert("session_a".to_string(), 3u32);
+        let mut session_deletions = HashMap::new();
+        session_deletions.insert("session_a".to_string(), 1u32);
+
+        let attributions: HashMap<String, (Vec<Attribution>, Vec<LineAttribution>)> =
+            HashMap::new();
+
+        // Simulate inherited totals saved before checkpoint processing
+        let inherited_totals: HashMap<String, (u32, u32)> =
+            [("session_a".to_string(), (10u32, 2u32))]
+                .into_iter()
+                .collect();
+
+        VirtualAttributions::calculate_and_update_prompt_metrics(
+            &mut prompts,
+            &attributions,
+            &session_additions,
+            &session_deletions,
+        );
+
+        // After metrics: total_additions = 3 (session delta only)
+        let prompt = prompts["session_a"].values().next().unwrap();
+        assert_eq!(prompt.total_additions, 3);
+
+        // Add inherited base to make cumulative
+        VirtualAttributions::add_inherited_totals(
+            &mut prompts,
+            &inherited_totals,
+            &session_additions,
+        );
+
+        let prompt = prompts["session_a"].values().next().unwrap();
+        assert_eq!(
+            prompt.total_additions, 13,
+            "session delta (3) + inherited base (10) = cumulative (13)"
+        );
+        assert_eq!(
+            prompt.total_deletions, 3,
+            "session delta (1) + inherited base (2) = cumulative (3)"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1691,10 +1691,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let git_ai = dir.path().join("git-ai");
         fs::write(&git_ai, "fake-binary").unwrap();
-        let git = dir.path().join("git");
         #[cfg(unix)]
-        fs::hard_link(&git_ai, &git).unwrap();
-        #[cfg(unix)]
-        assert!(path_is_git_ai_binary(&git));
+        {
+            let git = dir.path().join("git");
+            fs::hard_link(&git_ai, &git).unwrap();
+            assert!(path_is_git_ai_binary(&git));
+        }
     }
 }

--- a/tests/integration/virtual_attribution_merge.rs
+++ b/tests/integration/virtual_attribution_merge.rs
@@ -5,7 +5,7 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::virtual_attribution::VirtualAttributions;
 
 #[test]
-fn test_merge_prompts_picking_newest_sums_totals_on_collision() {
+fn test_merge_prompts_picking_newest_uses_max_totals_on_collision() {
     let repo = TestRepo::new();
     let mut file = repo.filename("file.txt");
 
@@ -63,13 +63,15 @@ fn test_merge_prompts_picking_newest_sums_totals_on_collision() {
         .next()
         .expect("merged prompt record should exist");
 
+    // total_additions/total_deletions are cumulative, so merge should use max, not sum.
+    // This prevents inflation when the same prompt appears in both checkpoint and blame VAs.
     assert_eq!(
         merged_record.total_additions,
-        record1.total_additions + record2.total_additions
+        record1.total_additions.max(record2.total_additions)
     );
     assert_eq!(
         merged_record.total_deletions,
-        record1.total_deletions + record2.total_deletions
+        record1.total_deletions.max(record2.total_deletions)
     );
     assert_eq!(merged_record.overriden_lines, record2.overriden_lines);
 
@@ -77,4 +79,4 @@ fn test_merge_prompts_picking_newest_sums_totals_on_collision() {
     assert_eq!(merged_record.agent_id, record2.agent_id);
 }
 
-crate::reuse_tests_in_worktree!(test_merge_prompts_picking_newest_sums_totals_on_collision,);
+crate::reuse_tests_in_worktree!(test_merge_prompts_picking_newest_uses_max_totals_on_collision,);


### PR DESCRIPTION
## Summary

- Switch `merge_prompts_picking_newest` and `merge_attributions_favoring_first` from summing (`saturating_add`) to using `max` for `total_additions`/`total_deletions`, since these fields are already cumulative — summing them doubles the count on every `git commit --amend`
- Add `add_inherited_totals` helper that layers inherited base totals onto fresh session deltas, so metrics grow monotonically across sessions rather than resetting when checkpoint data is present
- Update integration test to expect max-based merge semantics

Closes #1098

## Test plan

- [x] 3 new unit tests: `test_merge_prompts_does_not_inflate_totals_for_same_prompt`, `test_merge_prompts_picks_higher_cumulative_total`, `test_session_delta_plus_inherited_base_is_cumulative`
- [x] Updated integration test `test_merge_prompts_picking_newest_uses_max_totals_on_collision` (+ worktree variant)
- [x] All 1414 lib unit tests pass
- [ ] CI green on all ubuntu-based (fast) checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
