### PR TITLE
Bump rand 0.8 → 0.10 and update all API usages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +507,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1063,6 +1083,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1096,7 +1117,7 @@ dependencies = [
  "named_pipe",
  "once_cell",
  "paste",
- "rand",
+ "rand 0.10.1",
  "ratatui",
  "regex",
  "rstest",
@@ -2378,7 +2399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2471,15 +2492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,19 +2555,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2563,9 +2574,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -3061,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3082,7 +3096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ git-ai = { path = ".", features = ["test-support"] }
 rustls-native-certs = "0.8"
 tempfile = "3.27"
 insta = "1.47"
-rand = "0.8"
+rand = "0.10"
 regex = "1.12"
 filetime = "0.2"
 serial_test = "3.4"

--- a/tests/integration/checkpoint_size.rs
+++ b/tests/integration/checkpoint_size.rs
@@ -1,12 +1,12 @@
 use crate::repos::test_repo::TestRepo;
-use rand::{Rng, distributions::Alphanumeric};
+use rand::{RngExt, distr::Alphanumeric};
 use std::{fs, time::Instant};
 
 #[test]
 fn test_checkpoint_size_logging_large_ai_rewrites() {
     eprintln!("test_checkpoint_size_logging_large_ai_rewrites started...");
     let repo = TestRepo::new();
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // (target_lines, iterations)
     let configs: &[(usize, usize)] = &[

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -1,6 +1,5 @@
 use git_ai::feature_flags::FeatureFlags;
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::seq::IndexedRandom;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -32,7 +31,7 @@ fn setup() {
 mod tests {
     use super::*;
     use git_ai::observability::wrapper_performance_targets::PERFORMANCE_FLOOR_MS;
-    use rand::seq::SliceRandom;
+    use rand::seq::IndexedRandom;
     use rstest::rstest;
 
     #[rstest]
@@ -375,9 +374,9 @@ mod tests {
                 .expect("Checkpoint mock_ai should succeed");
 
             // Step 3: Select 100 random files from the 1000 and edit them (simulating human edits)
-            let mut rng = thread_rng();
+            let mut rng = rand::rng();
             let files_to_re_edit: Vec<String> = all_files
-                .choose_multiple(&mut rng, 100.min(all_files.len()))
+                .sample(&mut rng, 100.min(all_files.len()))
                 .cloned()
                 .collect();
 
@@ -577,7 +576,7 @@ pub fn find_random_files_with_options(
         return Err("No files found in repository".to_string());
     }
 
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     // Find large files using file size as a proxy (> 100KB considered large)
     // This is much faster than reading files to count lines
@@ -609,7 +608,7 @@ pub fn find_random_files_with_options(
         .collect();
 
     let random_files: Vec<String> = candidates
-        .choose_multiple(&mut rng, options.random_file_count.min(candidates.len()))
+        .sample(&mut rng, options.random_file_count.min(candidates.len()))
         .map(|s| (*s).clone())
         .collect();
 

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -13,7 +13,7 @@ use git_ai::git::repo_storage::PersistedWorkingLog;
 use git_ai::git::repository as GitAiRepository;
 use git_ai::observability::wrapper_performance_targets::BenchmarkResult;
 use insta::{Settings, assert_debug_snapshot};
-use rand::Rng;
+use rand::RngExt;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fs;
@@ -478,8 +478,8 @@ fn shared_daemon_process(repo_path: &Path) -> Arc<DaemonProcess> {
 }
 
 fn start_shared_daemon_process(repo_path: &Path, shard: Option<usize>) -> DaemonProcess {
-    let mut rng = rand::thread_rng();
-    let n: u64 = rng.gen_range(0..10_000_000_000);
+    let mut rng = rand::rng();
+    let n: u64 = rng.random_range(0..10_000_000_000);
     let base = std::env::temp_dir();
     let shard_suffix = shard
         .map(|shard| format!("-pool-{}", shard))
@@ -936,8 +936,8 @@ impl TestRepo {
         let default_branch = default_branchname();
         let base_branch = base.current_branch();
         if base_branch == default_branch {
-            let mut rng = rand::thread_rng();
-            let n: u64 = rng.gen_range(0..10_000_000_000);
+            let mut rng = rand::rng();
+            let n: u64 = rng.random_range(0..10_000_000_000);
             let temp_branch = format!("base-worktree-{}", n);
             let temp_ref = format!("refs/heads/{}", temp_branch);
             let switch_output = Command::new(real_git_executable())
@@ -959,8 +959,8 @@ impl TestRepo {
             }
         }
 
-        let mut rng = rand::thread_rng();
-        let wt_n: u64 = rng.gen_range(0..10_000_000_000);
+        let mut rng = rand::rng();
+        let wt_n: u64 = rng.random_range(0..10_000_000_000);
         let worktree_path = std::env::temp_dir().join(format!("{}-wt", wt_n));
 
         let output = Command::new(real_git_executable())
@@ -1039,7 +1039,7 @@ impl TestRepo {
             // Reuse the base DB path for linked worktrees so test expectations and daemon writes align.
             base_test_db_path.clone()
         } else {
-            let wt_db_n: u64 = rng.gen_range(0..10_000_000_000);
+            let wt_db_n: u64 = rng.random_range(0..10_000_000_000);
             std::env::temp_dir().join(format!("{}-db", wt_db_n))
         };
 
@@ -1073,8 +1073,8 @@ impl TestRepo {
         // Isolate this test binary's HOME before any git or git-ai subprocess is spawned.
         ensure_isolated_process_home();
 
-        let mut rng = rand::thread_rng();
-        let n: u64 = rng.gen_range(0..10000000000);
+        let mut rng = rand::rng();
+        let n: u64 = rng.random_range(0..10000000000);
         let base = std::env::temp_dir();
         let path = base.join(n.to_string());
         let test_home = base.join(format!("{}-home", n));
@@ -1116,8 +1116,8 @@ impl TestRepo {
         git_mode: GitTestMode,
         daemon_scope: DaemonTestScope,
     ) -> Self {
-        let mut rng = rand::thread_rng();
-        let n: u64 = rng.gen_range(0..10000000000);
+        let mut rng = rand::rng();
+        let n: u64 = rng.random_range(0..10000000000);
         let base = std::env::temp_dir();
         let main_path = base.join(format!("{}-main", n));
         let worktree_path = base.join(format!("{}-wt", n));
@@ -1199,8 +1199,8 @@ impl TestRepo {
         git_mode: GitTestMode,
         daemon_scope: DaemonTestScope,
     ) -> Self {
-        let mut rng = rand::thread_rng();
-        let n: u64 = rng.gen_range(0..10000000000);
+        let mut rng = rand::rng();
+        let n: u64 = rng.random_range(0..10000000000);
         let base = std::env::temp_dir();
         let path = base.join(n.to_string());
         let test_home = base.join(format!("{}-home", n));
@@ -1256,11 +1256,11 @@ impl TestRepo {
         git_mode: GitTestMode,
         daemon_scope: DaemonTestScope,
     ) -> (Self, Self) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let base = std::env::temp_dir();
 
         // Create bare upstream repository (acts as the remote server)
-        let upstream_n: u64 = rng.gen_range(0..10000000000);
+        let upstream_n: u64 = rng.random_range(0..10000000000);
         let upstream_path = base.join(upstream_n.to_string());
         let upstream_test_home = base.join(format!("{}-home", upstream_n));
         let upstream_test_db_path =
@@ -1285,7 +1285,7 @@ impl TestRepo {
         let _ = upstream.git(&["symbolic-ref", "HEAD", "refs/heads/main"]);
 
         // Clone upstream to create mirror with origin configured
-        let mirror_n: u64 = rng.gen_range(0..10000000000);
+        let mirror_n: u64 = rng.random_range(0..10000000000);
         let mirror_path = base.join(mirror_n.to_string());
         let mirror_test_home = base.join(format!("{}-home", mirror_n));
         let mirror_test_db_path =
@@ -1352,8 +1352,8 @@ impl TestRepo {
         git_mode: GitTestMode,
         daemon_scope: DaemonTestScope,
     ) -> Self {
-        let mut rng = rand::thread_rng();
-        let db_n: u64 = rng.gen_range(0..10000000000);
+        let mut rng = rand::rng();
+        let db_n: u64 = rng.random_range(0..10000000000);
         let test_home = std::env::temp_dir().join(format!("{}-home", db_n));
         let test_db_path = resolve_test_db_path(&std::env::temp_dir(), db_n, &test_home, git_mode);
 

--- a/tests/integration/worktrees.rs
+++ b/tests/integration/worktrees.rs
@@ -8,7 +8,7 @@ use git_ai::authorship::transcript::Message;
 use git_ai::authorship::working_log::{AgentId, CheckpointKind};
 use git_ai::git::repository as GitAiRepository;
 use insta::assert_debug_snapshot;
-use rand::Rng;
+use rand::RngExt;
 use regex::Regex;
 use serde_json::json;
 use std::collections::HashMap;
@@ -155,8 +155,8 @@ fn assert_file_lines(
 }
 
 fn unique_worktree_path() -> PathBuf {
-    let mut rng = rand::thread_rng();
-    let n: u64 = rng.gen_range(0..10_000_000_000);
+    let mut rng = rand::rng();
+    let n: u64 = rng.random_range(0..10_000_000_000);
     std::env::temp_dir().join(format!("git-ai-worktree-{}", n))
 }
 


### PR DESCRIPTION
## Summary

Upgrades the `rand` dev-dependency from 0.8 to 0.10 and migrates all test code to the new API surface. No production code changes — `rand` is only used in integration tests for generating random temp directory names and selecting random file subsets.

### API migrations applied

| rand 0.8 | rand 0.10 |
|---|---|
| `rand::thread_rng()` | `rand::rng()` |
| `rand::Rng` trait | `rand::RngExt` trait |
| `.gen_range(range)` | `.random_range(range)` |
| `rand::distributions::Alphanumeric` | `rand::distr::Alphanumeric` |
| `rand::seq::SliceRandom` | `rand::seq::IndexedRandom` |
| `.choose_multiple(&mut rng, n)` | `.sample(&mut rng, n)` |

### Files changed
- **`Cargo.toml`** / **`Cargo.lock`**: Version bump + dependency tree update (rand_chacha/ppv-lite86 replaced by chacha20)
- **`tests/integration/repos/test_repo.rs`**: 8 call sites updated (random temp dir names)
- **`tests/integration/performance.rs`**: Imports + 4 call sites (random file selection)
- **`tests/integration/checkpoint_size.rs`**: Import + 1 call site (random string generation)
- **`tests/integration/worktrees.rs`**: Import + 1 call site (unique worktree path)

## Review & Testing Checklist for Human

- [ ] Verify `.sample()` (rand 0.10 `IndexedRandom`) is semantically equivalent to `.choose_multiple()` (rand 0.8 `SliceRandom`) — both should return `n` random elements without replacement
- [ ] Confirm CI passes on all three platforms (Ubuntu, macOS, Windows) since rand's RNG backend changed from ppv-lite86 to chacha20
- [ ] Spot-check that no test relies on deterministic RNG output (all usages appear to be for unique temp dir names / random subset selection, so this should be fine)

### Notes
- `rand 0.8.5` remains in `Cargo.lock` as a transitive dependency of `phf_generator` — this is expected and harmless.
- Supersedes #1087 which had the version bump but not the API migration fixes.

Link to Devin session: https://app.devin.ai/sessions/75f76db47e0247a08f64c032f757b9e6
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
