### PR TITLE
feat: add CodeBuddy CN preset and hook installer

### DIFF
--- a/src/commands/checkpoint_agent/agent_presets.rs
+++ b/src/commands/checkpoint_agent/agent_presets.rs
@@ -180,6 +180,12 @@ impl AgentCheckpointPreset for ClaudePreset {
                 "Skipping Cursor hook payload in Claude preset; use cursor hooks.".to_string(),
             ));
         }
+        if ClaudePreset::is_codebuddy_hook_payload(&hook_data) {
+            return Err(GitAiError::PresetError(
+                "Skipping CodeBuddy hook payload in Claude preset; use codebuddy hooks."
+                    .to_string(),
+            ));
+        }
 
         // Extract transcript_path and cwd from the JSON
         let transcript_path = hook_data
@@ -375,6 +381,19 @@ impl ClaudePreset {
     fn looks_like_cursor_transcript_path(path: &str) -> bool {
         let normalized = path.replace('\\', "/").to_ascii_lowercase();
         normalized.contains("/.cursor/projects/") && normalized.contains("/agent-transcripts/")
+    }
+
+    fn is_codebuddy_hook_payload(hook_data: &serde_json::Value) -> bool {
+        if hook_data.get("client").and_then(|v| v.as_str()) == Some("CodeBuddyIDE") {
+            return true;
+        }
+        if let Some(path) = hook_data.get("transcript_path").and_then(|v| v.as_str()) {
+            let normalized = path.replace('\\', "/").to_ascii_lowercase();
+            if normalized.contains("codebuddyextension") {
+                return true;
+            }
+        }
+        false
     }
 
     /// Parse a Claude Code JSONL file into a transcript and extract model info

--- a/src/commands/checkpoint_agent/codebuddy_preset.rs
+++ b/src/commands/checkpoint_agent/codebuddy_preset.rs
@@ -1,0 +1,234 @@
+use crate::{
+    authorship::{
+        transcript::{AiTranscript, Message},
+        working_log::{AgentId, CheckpointKind},
+    },
+    error::GitAiError,
+    observability::log_error,
+};
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::agent_presets::{AgentCheckpointFlags, AgentCheckpointPreset, AgentRunResult};
+
+pub struct CodeBuddyPreset;
+
+impl AgentCheckpointPreset for CodeBuddyPreset {
+    fn run(&self, flags: AgentCheckpointFlags) -> Result<AgentRunResult, GitAiError> {
+        let stdin_json = flags.hook_input.ok_or_else(|| {
+            GitAiError::PresetError("hook_input is required for CodeBuddy preset".to_string())
+        })?;
+
+        let hook_data: serde_json::Value = serde_json::from_str(&stdin_json)
+            .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
+
+        let session_id = hook_data
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                GitAiError::PresetError("session_id not found in hook_input".to_string())
+            })?
+            .to_string();
+
+        let hook_event_name = hook_data
+            .get("hook_event_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let model = hook_data
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        // Extract file_path from tool_input.filePath (camelCase, CodeBuddy convention)
+        let file_path_as_vec = hook_data
+            .get("tool_input")
+            .and_then(|ti| {
+                ti.get("filePath")
+                    .or_else(|| ti.get("file_path"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(|path| vec![path.to_string()]);
+
+        let transcript_path = hook_data
+            .get("transcript_path")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let agent_id = AgentId {
+            tool: "codebuddy".to_string(),
+            id: session_id,
+            model,
+        };
+
+        // PreToolUse → human checkpoint (snapshot before AI edits)
+        if hook_event_name == "PreToolUse" {
+            return Ok(AgentRunResult {
+                agent_id,
+                agent_metadata: None,
+                checkpoint_kind: CheckpointKind::Human,
+                transcript: None,
+                // cwd is always "/" from CodeBuddy CN — don't use it.
+                // File-based repo detection in git_ai_handlers.rs handles this.
+                repo_working_dir: None,
+                edited_filepaths: None,
+                will_edit_filepaths: file_path_as_vec,
+                dirty_files: None,
+                captured_checkpoint_id: None,
+            });
+        }
+
+        // PostToolUse → AI checkpoint
+        let transcript = match &transcript_path {
+            Some(tp) => match CodeBuddyPreset::transcript_from_codebuddy_session(tp) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("[Warning] Failed to parse CodeBuddy transcript: {e}");
+                    log_error(
+                        &e,
+                        Some(serde_json::json!({
+                            "agent_tool": "codebuddy",
+                            "operation": "transcript_from_codebuddy_session"
+                        })),
+                    );
+                    AiTranscript::new()
+                }
+            },
+            None => AiTranscript::new(),
+        };
+
+        let agent_metadata =
+            transcript_path.map(|tp| HashMap::from([("transcript_path".to_string(), tp)]));
+
+        Ok(AgentRunResult {
+            agent_id,
+            agent_metadata,
+            checkpoint_kind: CheckpointKind::AiAgent,
+            transcript: Some(transcript),
+            repo_working_dir: None,
+            edited_filepaths: file_path_as_vec,
+            will_edit_filepaths: None,
+            dirty_files: None,
+            captured_checkpoint_id: None,
+        })
+    }
+}
+
+impl CodeBuddyPreset {
+    /// Parse a CodeBuddy CN transcript from its directory-based format.
+    ///
+    /// CodeBuddy CN stores transcripts as:
+    /// ```text
+    /// {session_id}/
+    ///   index.json        — message index: {"messages": [{"id":"...","role":"user",...}, ...]}
+    ///   messages/
+    ///     {id}.json        — per-message content with double-encoded `message` field
+    /// ```
+    ///
+    /// The `transcript_path` argument should point to the `index.json` file.
+    pub fn transcript_from_codebuddy_session(
+        transcript_path: &str,
+    ) -> Result<AiTranscript, GitAiError> {
+        let index_path = Path::new(transcript_path);
+        let session_dir = index_path.parent().ok_or_else(|| {
+            GitAiError::PresetError(format!(
+                "Cannot determine session directory from transcript_path: {}",
+                transcript_path
+            ))
+        })?;
+        let messages_dir = session_dir.join("messages");
+
+        let index_content = std::fs::read_to_string(index_path).map_err(GitAiError::IoError)?;
+        let index_json: serde_json::Value = serde_json::from_str(&index_content)?;
+
+        let message_entries = index_json
+            .get("messages")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                GitAiError::PresetError("index.json missing 'messages' array".to_string())
+            })?;
+
+        let mut transcript = AiTranscript::new();
+
+        for entry in message_entries {
+            let id = match entry.get("id").and_then(|v| v.as_str()) {
+                Some(id) => id,
+                None => continue,
+            };
+            let role = entry.get("role").and_then(|v| v.as_str()).unwrap_or("");
+
+            // Read the individual message file
+            let msg_path = messages_dir.join(format!("{}.json", id));
+            let msg_content = match std::fs::read_to_string(&msg_path) {
+                Ok(c) => c,
+                Err(_) => continue, // Skip missing message files
+            };
+            let msg_json: serde_json::Value = match serde_json::from_str(&msg_content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            // The `message` field is a JSON-encoded string that must be parsed again
+            let inner = match msg_json.get("message").and_then(|v| v.as_str()) {
+                Some(json_str) => {
+                    match serde_json::from_str::<serde_json::Value>(json_str) {
+                        Ok(v) => v,
+                        Err(_) => {
+                            // Fallback: treat the raw string as plain text
+                            serde_json::json!({"content": [{"type": "text", "text": json_str}]})
+                        }
+                    }
+                }
+                None => {
+                    // If `message` is not a string, try using it directly as an object
+                    match msg_json.get("message") {
+                        Some(v) => v.clone(),
+                        None => continue,
+                    }
+                }
+            };
+
+            // Extract text from content array
+            let text = Self::extract_text_from_content(&inner);
+            if text.is_empty() {
+                continue;
+            }
+
+            match role {
+                "user" => {
+                    transcript.add_message(Message::User {
+                        text,
+                        timestamp: None,
+                    });
+                }
+                "assistant" => {
+                    transcript.add_message(Message::Assistant {
+                        text,
+                        timestamp: None,
+                    });
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(transcript)
+    }
+
+    /// Extract text content from a parsed message's `content` field.
+    /// Handles both `content` as a string and as an array of blocks.
+    fn extract_text_from_content(inner: &serde_json::Value) -> String {
+        if let Some(content_str) = inner.get("content").and_then(|v| v.as_str()) {
+            return content_str.to_string();
+        }
+        if let Some(content_array) = inner.get("content").and_then(|v| v.as_array()) {
+            let texts: Vec<&str> = content_array
+                .iter()
+                .filter(|item| item.get("type").and_then(|t| t.as_str()) == Some("text"))
+                .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+                .collect();
+            return texts.join("\n");
+        }
+        String::new()
+    }
+}

--- a/src/commands/checkpoint_agent/mod.rs
+++ b/src/commands/checkpoint_agent/mod.rs
@@ -2,5 +2,6 @@ pub mod agent_presets;
 pub mod agent_v1_preset;
 pub mod amp_preset;
 pub mod bash_tool;
+pub mod codebuddy_preset;
 pub mod opencode_preset;
 pub mod pi_preset;

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -12,6 +12,7 @@ use crate::commands::checkpoint_agent::agent_presets::{
 };
 use crate::commands::checkpoint_agent::agent_v1_preset::AgentV1Preset;
 use crate::commands::checkpoint_agent::amp_preset::AmpPreset;
+use crate::commands::checkpoint_agent::codebuddy_preset::CodeBuddyPreset;
 use crate::commands::checkpoint_agent::opencode_preset::OpenCodePreset;
 use crate::commands::checkpoint_agent::pi_preset::PiPreset;
 use crate::config;
@@ -627,6 +628,22 @@ fn handle_checkpoint(args: &[String]) {
                     }
                     Err(e) => {
                         eprintln!("Pi preset error: {}", e);
+                        std::process::exit(0);
+                    }
+                }
+            }
+            "codebuddy" => {
+                match CodeBuddyPreset.run(AgentCheckpointFlags {
+                    hook_input: hook_input.clone(),
+                }) {
+                    Ok(agent_run) => {
+                        if agent_run.repo_working_dir.is_some() {
+                            repository_working_dir = agent_run.repo_working_dir.clone().unwrap();
+                        }
+                        agent_run_result = Some(agent_run);
+                    }
+                    Err(e) => {
+                        eprintln!("CodeBuddy preset error: {}", e);
                         std::process::exit(0);
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1691,10 +1691,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let git_ai = dir.path().join("git-ai");
         fs::write(&git_ai, "fake-binary").unwrap();
-        let git = dir.path().join("git");
         #[cfg(unix)]
-        fs::hard_link(&git_ai, &git).unwrap();
-        #[cfg(unix)]
-        assert!(path_is_git_ai_binary(&git));
+        {
+            let git = dir.path().join("git");
+            fs::hard_link(&git_ai, &git).unwrap();
+            assert!(path_is_git_ai_binary(&git));
+        }
     }
 }

--- a/src/mdm/agents/codebuddy.rs
+++ b/src/mdm/agents/codebuddy.rs
@@ -1,0 +1,318 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
+use crate::mdm::utils::{generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::PathBuf;
+
+const CODEBUDDY_PRE_TOOL_CMD: &str = "checkpoint codebuddy --hook-input stdin";
+const CODEBUDDY_POST_TOOL_CMD: &str = "checkpoint codebuddy --hook-input stdin";
+
+pub struct CodeBuddyInstaller;
+
+impl CodeBuddyInstaller {
+    fn settings_dir() -> PathBuf {
+        #[cfg(target_os = "macos")]
+        {
+            home_dir()
+                .join("Library")
+                .join("Application Support")
+                .join("CodeBuddyExtension")
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            home_dir().join(".config").join("CodeBuddyExtension")
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            std::env::var("APPDATA")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| home_dir().join("AppData").join("Roaming"))
+                .join("CodeBuddyExtension")
+        }
+    }
+
+    fn settings_path() -> PathBuf {
+        Self::settings_dir().join("settings.json")
+    }
+}
+
+impl HookInstaller for CodeBuddyInstaller {
+    fn name(&self) -> &str {
+        "CodeBuddy CN"
+    }
+
+    fn id(&self) -> &str {
+        "codebuddy"
+    }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let has_dotfiles = Self::settings_dir().exists();
+
+        if !has_dotfiles {
+            return Ok(HookCheckResult {
+                tool_installed: false,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let settings_path = Self::settings_path();
+        if !settings_path.exists() {
+            return Ok(HookCheckResult {
+                tool_installed: true,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let content = fs::read_to_string(&settings_path)?;
+        let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+
+        let has_hooks = existing
+            .get("hooks")
+            .and_then(|h| h.get("PreToolUse"))
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter().any(|item| {
+                    item.get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|hooks| {
+                            hooks.iter().any(|hook| {
+                                hook.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map(is_git_ai_checkpoint_command)
+                                    .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+
+        Ok(HookCheckResult {
+            tool_installed: true,
+            hooks_installed: has_hooks,
+            hooks_up_to_date: has_hooks,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        let settings_path = Self::settings_path();
+
+        if let Some(dir) = settings_path.parent() {
+            fs::create_dir_all(dir)?;
+        }
+
+        let existing_content = if settings_path.exists() {
+            fs::read_to_string(&settings_path)?
+        } else {
+            String::new()
+        };
+
+        let existing: Value = if existing_content.trim().is_empty() {
+            json!({})
+        } else {
+            serde_json::from_str(&existing_content)?
+        };
+
+        let binary_path = params.binary_path.to_string_lossy().to_string();
+        let pre_tool_cmd = format!("{} {}", binary_path, CODEBUDDY_PRE_TOOL_CMD);
+        let post_tool_cmd = format!("{} {}", binary_path, CODEBUDDY_POST_TOOL_CMD);
+
+        let desired_hooks = json!({
+            "PreToolUse": {
+                "matcher": "Write|Edit|MultiEdit",
+                "desired_cmd": pre_tool_cmd,
+            },
+            "PostToolUse": {
+                "matcher": "Write|Edit|MultiEdit",
+                "desired_cmd": post_tool_cmd,
+            }
+        });
+
+        let mut merged = existing.clone();
+        let mut hooks_obj = merged.get("hooks").cloned().unwrap_or_else(|| json!({}));
+
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let desired_matcher = desired_hooks[hook_type]["matcher"].as_str().unwrap();
+            let desired_cmd = desired_hooks[hook_type]["desired_cmd"].as_str().unwrap();
+
+            let mut hook_type_array = hooks_obj
+                .get(*hook_type)
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            let mut found_matcher_idx: Option<usize> = None;
+            for (idx, item) in hook_type_array.iter().enumerate() {
+                if let Some(matcher) = item.get("matcher").and_then(|m| m.as_str())
+                    && matcher == desired_matcher
+                {
+                    found_matcher_idx = Some(idx);
+                    break;
+                }
+            }
+
+            let matcher_idx = match found_matcher_idx {
+                Some(idx) => idx,
+                None => {
+                    hook_type_array.push(json!({
+                        "matcher": desired_matcher,
+                        "hooks": []
+                    }));
+                    hook_type_array.len() - 1
+                }
+            };
+
+            let mut hooks_array = hook_type_array[matcher_idx]
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            let mut found_idx: Option<usize> = None;
+            let mut needs_update = false;
+
+            for (idx, hook) in hooks_array.iter().enumerate() {
+                if let Some(cmd) = hook.get("command").and_then(|c| c.as_str())
+                    && is_git_ai_checkpoint_command(cmd)
+                    && found_idx.is_none()
+                {
+                    found_idx = Some(idx);
+                    if cmd != desired_cmd {
+                        needs_update = true;
+                    }
+                }
+            }
+
+            match found_idx {
+                Some(idx) => {
+                    if needs_update {
+                        hooks_array[idx] = json!({
+                            "type": "command",
+                            "command": desired_cmd
+                        });
+                    }
+                    let keep_idx = idx;
+                    let mut current_idx = 0;
+                    hooks_array.retain(|hook| {
+                        if current_idx == keep_idx {
+                            current_idx += 1;
+                            true
+                        } else if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+                            let is_dup = is_git_ai_checkpoint_command(cmd);
+                            current_idx += 1;
+                            !is_dup
+                        } else {
+                            current_idx += 1;
+                            true
+                        }
+                    });
+                }
+                None => {
+                    hooks_array.push(json!({
+                        "type": "command",
+                        "command": desired_cmd
+                    }));
+                }
+            }
+
+            if let Some(matcher_block) = hook_type_array[matcher_idx].as_object_mut() {
+                matcher_block.insert("hooks".to_string(), Value::Array(hooks_array));
+            }
+
+            if let Some(obj) = hooks_obj.as_object_mut() {
+                obj.insert(hook_type.to_string(), Value::Array(hook_type_array));
+            }
+        }
+
+        if let Some(root) = merged.as_object_mut() {
+            root.insert("hooks".to_string(), hooks_obj);
+        }
+
+        if existing == merged {
+            return Ok(None);
+        }
+
+        let new_content = serde_json::to_string_pretty(&merged)?;
+        let diff_output = generate_diff(&settings_path, &existing_content, &new_content);
+
+        if !dry_run {
+            write_atomic(&settings_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        let settings_path = Self::settings_path();
+
+        if !settings_path.exists() {
+            return Ok(None);
+        }
+
+        let existing_content = fs::read_to_string(&settings_path)?;
+        let existing: Value = serde_json::from_str(&existing_content)?;
+
+        let mut merged = existing.clone();
+        let mut hooks_obj = match merged.get("hooks").cloned() {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+
+        let mut changed = false;
+
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            if let Some(hook_type_array) =
+                hooks_obj.get_mut(*hook_type).and_then(|v| v.as_array_mut())
+            {
+                for matcher_block in hook_type_array.iter_mut() {
+                    if let Some(hooks_array) = matcher_block
+                        .get_mut("hooks")
+                        .and_then(|h| h.as_array_mut())
+                    {
+                        let original_len = hooks_array.len();
+                        hooks_array.retain(|hook| {
+                            if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+                                !is_git_ai_checkpoint_command(cmd)
+                            } else {
+                                true
+                            }
+                        });
+                        if hooks_array.len() != original_len {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !changed {
+            return Ok(None);
+        }
+
+        if let Some(root) = merged.as_object_mut() {
+            root.insert("hooks".to_string(), hooks_obj);
+        }
+
+        let new_content = serde_json::to_string_pretty(&merged)?;
+        let diff_output = generate_diff(&settings_path, &existing_content, &new_content);
+
+        if !dry_run {
+            write_atomic(&settings_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -1,5 +1,6 @@
 mod amp;
 mod claude_code;
+mod codebuddy;
 mod codex;
 mod cursor;
 mod droid;
@@ -14,6 +15,7 @@ mod windsurf;
 
 pub use amp::AmpInstaller;
 pub use claude_code::ClaudeCodeInstaller;
+pub use codebuddy::CodeBuddyInstaller;
 pub use codex::CodexInstaller;
 pub use cursor::CursorInstaller;
 pub use droid::DroidInstaller;
@@ -32,6 +34,7 @@ use super::hook_installer::HookInstaller;
 pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
     vec![
         Box::new(ClaudeCodeInstaller),
+        Box::new(CodeBuddyInstaller),
         Box::new(CodexInstaller),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),

--- a/tests/fixtures/codebuddy-session/index.json
+++ b/tests/fixtures/codebuddy-session/index.json
@@ -1,0 +1,8 @@
+{
+  "messages": [
+    {"id": "msg001", "role": "user", "type": "text"},
+    {"id": "msg002", "role": "assistant", "type": "text"},
+    {"id": "msg003", "role": "user", "type": "text"}
+  ],
+  "requests": []
+}

--- a/tests/fixtures/codebuddy-session/messages/msg001.json
+++ b/tests/fixtures/codebuddy-session/messages/msg001.json
@@ -1,0 +1,7 @@
+{
+  "role": "user",
+  "message": "{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Write a function to add two numbers\"}]}",
+  "id": "msg001",
+  "references": [],
+  "extra": "{\"requestId\":\"req001\",\"modelId\":\"glm-5.0-turbo\"}"
+}

--- a/tests/fixtures/codebuddy-session/messages/msg002.json
+++ b/tests/fixtures/codebuddy-session/messages/msg002.json
@@ -1,0 +1,7 @@
+{
+  "role": "assistant",
+  "message": "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Here is the function:\\n\\ndef add(a, b):\\n    return a + b\"}]}",
+  "id": "msg002",
+  "references": [],
+  "extra": "{\"requestId\":\"req002\",\"modelId\":\"glm-5.0-turbo\"}"
+}

--- a/tests/fixtures/codebuddy-session/messages/msg003.json
+++ b/tests/fixtures/codebuddy-session/messages/msg003.json
@@ -1,0 +1,7 @@
+{
+  "role": "user",
+  "message": "{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Now write tests for it\"}]}",
+  "id": "msg003",
+  "references": [],
+  "extra": "{\"requestId\":\"req003\",\"modelId\":\"glm-5.0-turbo\"}"
+}

--- a/tests/integration/codebuddy.rs
+++ b/tests/integration/codebuddy.rs
@@ -1,0 +1,195 @@
+use crate::test_utils::fixture_path;
+use git_ai::authorship::transcript::Message;
+use git_ai::authorship::working_log::CheckpointKind;
+use git_ai::commands::checkpoint_agent::agent_presets::{
+    AgentCheckpointFlags, AgentCheckpointPreset,
+};
+use git_ai::commands::checkpoint_agent::codebuddy_preset::CodeBuddyPreset;
+
+#[test]
+fn test_codebuddy_preset_pretooluse_returns_human_checkpoint() {
+    let hook_input = serde_json::json!({
+        "session_id": "abc123",
+        "transcript_path": "/tmp/fake/index.json",
+        "cwd": "/",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "/tmp/project/main.py", "new_str": "print('hello')"},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE",
+        "version": "4.7.0"
+    });
+
+    let result = CodeBuddyPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input.to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(result.checkpoint_kind, CheckpointKind::Human);
+    assert!(result.transcript.is_none());
+    assert_eq!(
+        result.will_edit_filepaths,
+        Some(vec!["/tmp/project/main.py".to_string()])
+    );
+    assert!(result.edited_filepaths.is_none());
+    assert!(result.repo_working_dir.is_none());
+}
+
+#[test]
+fn test_codebuddy_preset_posttooluse_returns_ai_checkpoint() {
+    let hook_input = serde_json::json!({
+        "session_id": "abc123",
+        "transcript_path": "/tmp/fake/index.json",
+        "cwd": "/",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "/tmp/project/main.py"},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE",
+        "version": "4.7.0"
+    });
+
+    let result = CodeBuddyPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input.to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(result.checkpoint_kind, CheckpointKind::AiAgent);
+    assert_eq!(
+        result.edited_filepaths,
+        Some(vec!["/tmp/project/main.py".to_string()])
+    );
+    assert!(result.will_edit_filepaths.is_none());
+    assert!(result.repo_working_dir.is_none());
+}
+
+#[test]
+fn test_codebuddy_preset_extracts_model_from_hook_input() {
+    let hook_input = serde_json::json!({
+        "session_id": "sess-42",
+        "hook_event_name": "PreToolUse",
+        "tool_input": {"filePath": "/tmp/project/app.py"},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE"
+    });
+
+    let result = CodeBuddyPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input.to_string()),
+        })
+        .unwrap();
+
+    assert_eq!(result.agent_id.tool, "codebuddy");
+    assert_eq!(result.agent_id.id, "sess-42");
+    assert_eq!(result.agent_id.model, "glm-5.0-turbo");
+}
+
+#[test]
+fn test_codebuddy_preset_ignores_cwd() {
+    let hook_input = serde_json::json!({
+        "session_id": "abc",
+        "cwd": "/",
+        "hook_event_name": "PostToolUse",
+        "tool_input": {"filePath": "/tmp/project/file.py"},
+        "model": "glm-5.0-turbo"
+    });
+
+    let result = CodeBuddyPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input.to_string()),
+        })
+        .unwrap();
+
+    // cwd: "/" should NOT be used as repo_working_dir
+    assert!(result.repo_working_dir.is_none());
+}
+
+#[test]
+fn test_codebuddy_transcript_parsing() {
+    let fixture = fixture_path("codebuddy-session/index.json");
+    let transcript =
+        CodeBuddyPreset::transcript_from_codebuddy_session(fixture.to_str().unwrap()).unwrap();
+
+    let messages = transcript.messages();
+    assert_eq!(messages.len(), 3);
+
+    // First message: user
+    match &messages[0] {
+        Message::User { text, .. } => {
+            assert_eq!(text, "Write a function to add two numbers");
+        }
+        other => panic!("Expected User message, got {:?}", other),
+    }
+
+    // Second message: assistant
+    match &messages[1] {
+        Message::Assistant { text, .. } => {
+            assert!(text.contains("def add(a, b)"));
+        }
+        other => panic!("Expected Assistant message, got {:?}", other),
+    }
+
+    // Third message: user
+    match &messages[2] {
+        Message::User { text, .. } => {
+            assert_eq!(text, "Now write tests for it");
+        }
+        other => panic!("Expected User message, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_codebuddy_preset_missing_hook_input() {
+    let result = CodeBuddyPreset.run(AgentCheckpointFlags { hook_input: None });
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_codebuddy_preset_invalid_json() {
+    let result = CodeBuddyPreset.run(AgentCheckpointFlags {
+        hook_input: Some("not json".to_string()),
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_codebuddy_preset_missing_session_id() {
+    let hook_input = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "model": "glm-5.0-turbo"
+    });
+
+    let result = CodeBuddyPreset.run(AgentCheckpointFlags {
+        hook_input: Some(hook_input.to_string()),
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_claude_preset_rejects_codebuddy_payload() {
+    use git_ai::commands::checkpoint_agent::agent_presets::ClaudePreset;
+
+    let hook_input = serde_json::json!({
+        "session_id": "abc123",
+        "transcript_path": "/Users/test/Library/Application Support/CodeBuddyExtension/Data/uuid/CodeBuddyIDE/uuid/history/uuid/abc123/index.json",
+        "cwd": "/",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "/tmp/project/main.py"},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE"
+    });
+
+    let result = ClaudePreset.run(AgentCheckpointFlags {
+        hook_input: Some(hook_input.to_string()),
+    });
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("CodeBuddy") || err_msg.contains("codebuddy"),
+        "Error should mention CodeBuddy, got: {}",
+        err_msg
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -30,6 +30,7 @@ mod ci_local_skip_fetch;
 mod ci_partial_clone;
 mod ci_squash_rebase;
 mod claude_code;
+mod codebuddy;
 mod codex;
 mod commit_post_stats_benchmark;
 mod config_pattern_detection;

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -17,6 +17,7 @@ const AI_AUTHOR_NAMES: &[&str] = &[
     "amp",
     "windsurf",
     "devin",
+    "codebuddy",
 ];
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
## Summary

Adds support for **CodeBuddy CN** (Tencent's AI coding assistant) as requested in #1035.

- **New preset** (`codebuddy`) that parses CodeBuddy CN's unique transcript format (`index.json` + `messages/` directory with double-encoded JSON content)
- **New hook installer** that registers `PreToolUse`/`PostToolUse` hooks in CodeBuddy CN's settings
- **Claude preset guard** to prevent CodeBuddy payloads from being misrouted (detects `client: "CodeBuddyIDE"` and `CodeBuddyExtension` in transcript path)
- Handles CodeBuddy CN's `cwd: "/"` bug by relying on file-based repo detection from `tool_input.filePath`

### Key differences from Claude Code

| | Claude Code | CodeBuddy CN |
|--|------------|-------------|
| Transcript | Single JSONL file | `index.json` + `messages/{id}.json` |
| User prompt | `content[0].text` inline | Double-encoded: `message` field is JSON string → parse → `content[0].text` |
| `cwd` | Actual project dir | Always `"/"` (known bug) |
| Model source | From transcript JSONL | From hook data `model` field |

### Files changed

**New files:**
- `src/commands/checkpoint_agent/codebuddy_preset.rs` — preset implementation + transcript parser
- `src/mdm/agents/codebuddy.rs` — hook installer
- `tests/integration/codebuddy.rs` — 9 test cases
- `tests/fixtures/codebuddy-session/` — fixture directory with index.json + messages/

**Modified files:**
- `src/commands/checkpoint_agent/agent_presets.rs` — added `is_codebuddy_hook_payload` guard to ClaudePreset
- `src/commands/checkpoint_agent/mod.rs` — module registration
- `src/commands/git_ai_handlers.rs` — dispatch arm + import
- `src/mdm/agents/mod.rs` — installer registration
- `tests/integration/main.rs` — test module registration
- `tests/integration/repos/test_file.rs` — added `"codebuddy"` to `AI_AUTHOR_NAMES`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --test integration -- codebuddy` — all 9 tests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes
- [x] No `println!`/`dbg!` in production code

Closes #1035