### PR TITLE
Extract model_name from Windsurf hook payload

### DIFF
--- a/src/commands/checkpoint_agent/agent_presets.rs
+++ b/src/commands/checkpoint_agent/agent_presets.rs
@@ -726,10 +726,17 @@ impl AgentCheckpointPreset for WindsurfPreset {
                     .to_string()
             });
 
+        // Extract model_name from hook payload (Windsurf provides this on every hook event)
+        let hook_model = hook_data
+            .get("model_name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty() && *s != "Unknown")
+            .map(|s| s.to_string());
+
         // Parse transcript (best-effort)
-        let transcript =
+        let (transcript, transcript_model) =
             match WindsurfPreset::transcript_and_model_from_windsurf_jsonl(&transcript_path) {
-                Ok((transcript, _model)) => transcript,
+                Ok((transcript, model)) => (transcript, model),
                 Err(e) => {
                     eprintln!("[Warning] Failed to parse Windsurf JSONL: {e}");
                     log_error(
@@ -739,15 +746,19 @@ impl AgentCheckpointPreset for WindsurfPreset {
                             "operation": "transcript_and_model_from_windsurf_jsonl"
                         })),
                     );
-                    crate::authorship::transcript::AiTranscript::new()
+                    (crate::authorship::transcript::AiTranscript::new(), None)
                 }
             };
 
-        // Windsurf doesn't expose model info in hooks yet — hardcode to "unknown"
+        // Prefer hook-level model_name, fall back to transcript, then "unknown"
+        let model = hook_model
+            .or(transcript_model)
+            .unwrap_or_else(|| "unknown".to_string());
+
         let agent_id = AgentId {
             tool: "windsurf".to_string(),
             id: trajectory_id.to_string(),
-            model: "unknown".to_string(),
+            model,
         };
 
         // Extract file_path from tool_info if present
@@ -793,7 +804,8 @@ impl AgentCheckpointPreset for WindsurfPreset {
 impl WindsurfPreset {
     /// Parse a Windsurf JSONL transcript file into a transcript.
     /// Each line is a JSON object with a "type" field.
-    /// Model info is not present in the format — always returns None.
+    /// Model info is not present in the JSONL format — always returns None.
+    /// (Model is instead provided via `model_name` in the hook payload.)
     pub fn transcript_and_model_from_windsurf_jsonl(
         transcript_path: &str,
     ) -> Result<(AiTranscript, Option<String>), GitAiError> {

--- a/tests/integration/windsurf.rs
+++ b/tests/integration/windsurf.rs
@@ -18,6 +18,7 @@ fn test_windsurf_preset_human_checkpoint() {
     let hook_input = json!({
         "trajectory_id": "traj-abc-123",
         "agent_action_name": "pre_write_code",
+        "model_name": "GPT 4.1",
         "tool_info": {
             "file_path": "/home/user/project/main.rs"
         }
@@ -42,6 +43,7 @@ fn test_windsurf_preset_human_checkpoint() {
     assert!(result.agent_metadata.is_none());
     assert_eq!(result.agent_id.tool, "windsurf");
     assert_eq!(result.agent_id.id, "traj-abc-123");
+    assert_eq!(result.agent_id.model, "GPT 4.1");
 }
 
 #[test]
@@ -73,6 +75,52 @@ fn test_windsurf_preset_ai_checkpoint_post_write_code() {
     assert!(result.transcript.is_some());
     assert!(result.agent_metadata.is_some());
     assert_eq!(result.agent_id.tool, "windsurf");
+    // No model_name in hook input → falls back to "unknown"
+    assert_eq!(result.agent_id.model, "unknown");
+}
+
+#[test]
+fn test_windsurf_preset_extracts_model_name_from_hook() {
+    let hook_input = json!({
+        "trajectory_id": "traj-abc-123",
+        "agent_action_name": "post_write_code",
+        "model_name": "Claude Sonnet 4",
+        "tool_info": {
+            "file_path": "/home/user/project/main.rs"
+        }
+    });
+
+    let flags = AgentCheckpointFlags {
+        hook_input: Some(hook_input.to_string()),
+    };
+
+    let result = WindsurfPreset
+        .run(flags)
+        .expect("Failed to run WindsurfPreset");
+
+    assert_eq!(result.agent_id.model, "Claude Sonnet 4");
+}
+
+#[test]
+fn test_windsurf_preset_ignores_unknown_model_name() {
+    let hook_input = json!({
+        "trajectory_id": "traj-abc-123",
+        "agent_action_name": "post_write_code",
+        "model_name": "Unknown",
+        "tool_info": {
+            "file_path": "/home/user/project/main.rs"
+        }
+    });
+
+    let flags = AgentCheckpointFlags {
+        hook_input: Some(hook_input.to_string()),
+    };
+
+    let result = WindsurfPreset
+        .run(flags)
+        .expect("Failed to run WindsurfPreset");
+
+    // "Unknown" from Windsurf should be treated as absent, falling back to "unknown"
     assert_eq!(result.agent_id.model, "unknown");
 }
 


### PR DESCRIPTION
## Summary

Windsurf Cascade hooks now include a `model_name` field on every event (e.g. `"Claude Sonnet 4"`, `"GPT 4.1"`). This PR parses that field and uses it for `AgentId.model` instead of hardcoding `"unknown"`. The sentinel value `"Unknown"` that Windsurf sends when the model can't be determined is filtered out and falls back gracefully.

## Test plan

- [x] New test: `test_windsurf_preset_extracts_model_name_from_hook` — verifies model name flows through
- [x] New test: `test_windsurf_preset_ignores_unknown_model_name` — verifies `"Unknown"` sentinel is filtered
- [x] Updated existing tests to include `model_name` in payloads and assert propagation
- [x] All 15 Windsurf integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
