### PR TITLE
fix: enable stash attribution in release builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Signal forwarding: On Unix, the git proxy installs signal handlers (SIGTERM, SIG
 
 `Config` is a global `OnceLock` singleton accessed via `Config::get()`. It reads from `~/.git-ai/config.json`. In tests, `GIT_AI_TEST_CONFIG_PATCH` env var allows overriding specific config fields without a real config file. Feature flags follow precedence: environment vars (`GIT_AI_*` prefix via `envy`) > config file > defaults.
 
-Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `rewrite_stash` (debug=true, release=false), `inter_commit_move` (false/false), `auth_keyring` (false/false).
+Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `rewrite_stash` (true/true), `inter_commit_move` (false/false), `auth_keyring` (false/false).
 
 ### Error handling
 
@@ -134,7 +134,7 @@ Uses `insta` crate. Snapshots live in `tests/snapshots/` and `tests/repos/snapsh
 
 - **Config is process-global**: `Config` uses `OnceLock`, so it's initialized once per process and cannot be changed. Tests run git-ai as a subprocess and pass config overrides via `GIT_AI_TEST_CONFIG_PATCH` env var. You cannot change config mid-test within the same process.
 
-- **Feature flag debug/release divergence**: `rewrite_stash` defaults to true in debug but false in release. Tests run debug builds, so they exercise stash rewriting by default. A test passing in debug may behave differently in release if it depends on this flag.
+- **Feature flag debug/release divergence**: Some flags have different debug/release defaults (see `define_feature_flags!` macro). Tests run debug builds, so a test passing in debug may behave differently in release if it depends on a flag that diverges.
 
 - **Working log base commit**: Working logs are keyed by the HEAD commit at checkpoint time (`.git/ai/working_logs/<sha>/`). If HEAD changes between checkpoint and commit (e.g., rebase), the post-commit hook must find and reconcile the correct working log.
 

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -52,7 +52,7 @@ macro_rules! define_feature_flags {
 // Define all feature flags in one place
 // Format: struct_field: file_and_env_name, debug = <bool>, release = <bool>
 define_feature_flags!(
-    rewrite_stash: rewrite_stash, debug = true, release = false,
+    rewrite_stash: rewrite_stash, debug = true, release = true,
     inter_commit_move: checkpoint_inter_commit_move, debug = false, release = false,
     auth_keyring: auth_keyring, debug = false, release = false,
     async_mode: async_mode, debug = false, release = true,
@@ -136,7 +136,7 @@ mod tests {
         }
         #[cfg(not(debug_assertions))]
         {
-            assert!(!flags.rewrite_stash);
+            assert!(flags.rewrite_stash);
             assert!(!flags.inter_commit_move);
             assert!(!flags.auth_keyring);
             assert!(flags.async_mode);


### PR DESCRIPTION
## Summary
- Enabled the `rewrite_stash` feature flag in release builds (`release = false` → `release = true` in `feature_flags.rs`)
- The stash attribution save/restore logic in `stash_hooks.rs` was fully implemented but gated behind this flag, which was disabled in release — causing all AI attribution to be silently lost after `git stash` / `git stash apply` cycles
- Updated `AGENTS.md` to reflect the new flag defaults

## Test plan
- [x] All 10 `feature_flags` unit tests pass (including updated release-default assertion)
- [x] All 2 `stash_hooks` unit tests pass
- [x] All 70 stash-related integration tests pass

Closes #1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
