### PR TITLE
fix: centralize agent_usage metric emission for all AI hooks

### DIFF
--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -937,14 +937,6 @@ fn execute_resolved_checkpoint(
         let attrs =
             build_checkpoint_attrs(repo, &resolved.base_commit, checkpoint.agent_id.as_ref());
 
-        if kind.is_ai()
-            && let Some(agent_id) = checkpoint.agent_id.as_ref()
-            && should_emit_agent_usage(agent_id)
-        {
-            let values = crate::metrics::AgentUsageValues::new();
-            crate::metrics::record(values, attrs.clone());
-        }
-
         for (entry, file_stat) in entries.iter().zip(file_stats.iter()) {
             let values = crate::metrics::CheckpointValues::new()
                 .checkpoint_ts(checkpoint.timestamp)

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -828,6 +828,25 @@ fn handle_checkpoint(args: &[String]) {
         }
     }
 
+    // Emit agent_usage metric for every AI hook, regardless of whether a
+    // file-edit checkpoint is created downstream.  The existing per-prompt
+    // throttle (`should_emit_agent_usage`) prevents duplicate events.
+    if let Some(ref result) = agent_run_result
+        && result.checkpoint_kind.is_ai()
+        && commands::checkpoint::should_emit_agent_usage(&result.agent_id)
+    {
+        let prompt_id = generate_short_hash(&result.agent_id.id, &result.agent_id.tool);
+        let attrs = crate::metrics::EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+            .tool(&result.agent_id.tool)
+            .model(&result.agent_id.model)
+            .prompt_id(prompt_id)
+            .external_prompt_id(&result.agent_id.id)
+            .custom_attributes_map(crate::config::Config::fresh().custom_attributes());
+
+        let values = crate::metrics::AgentUsageValues::new();
+        crate::metrics::record(values, attrs);
+    }
+
     let final_working_dir = agent_run_result
         .as_ref()
         .and_then(|r| r.repo_working_dir.clone())
@@ -919,7 +938,6 @@ fn handle_checkpoint(args: &[String]) {
                     "Failed to find any git repositories for the edited files. Orphaned files: {:?}",
                     orphan_files
                 );
-                emit_no_repo_agent_metrics(agent_run_result.as_ref());
                 std::process::exit(0);
             }
 
@@ -1068,7 +1086,6 @@ fn handle_checkpoint(args: &[String]) {
         eprintln!(
             "Failed to find repository: workspace root is not a git repository and no edited files provided"
         );
-        emit_no_repo_agent_metrics(agent_run_result.as_ref());
         std::process::exit(0);
     }
 
@@ -2130,31 +2147,6 @@ fn handle_git_hooks(args: &[String]) {
             std::process::exit(1);
         }
     }
-}
-
-fn emit_no_repo_agent_metrics(agent_run_result: Option<&AgentRunResult>) {
-    let Some(result) = agent_run_result else {
-        return;
-    };
-    if !result.checkpoint_kind.is_ai() {
-        return;
-    }
-
-    let agent_id = &result.agent_id;
-    if !commands::checkpoint::should_emit_agent_usage(agent_id) {
-        return;
-    }
-
-    let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
-    let attrs = crate::metrics::EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
-        .tool(&agent_id.tool)
-        .model(&agent_id.model)
-        .prompt_id(prompt_id)
-        .external_prompt_id(&agent_id.id)
-        .custom_attributes_map(crate::config::Config::fresh().custom_attributes());
-
-    let values = crate::metrics::AgentUsageValues::new();
-    crate::metrics::record(values, attrs);
 }
 
 fn get_all_files_for_mock_ai(working_dir: &str) -> Vec<String> {


### PR DESCRIPTION
## Summary
- Moves `agent_usage` metric emission to a single centralized location in `handle_checkpoint()`, right after `preset.run()` completes — the convergence point for all AI agent hooks
- Removes the previous emission site inside file-edit checkpoint processing (`checkpoint.rs`) and the `emit_no_repo_agent_metrics()` fallback, which together only covered file-edit scenarios
- All AI hooks (tool-use, command, file-edit) now emit `agent_usage` through the same throttling system (`should_emit_agent_usage`)

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo test` — all tests pass
- [ ] Verify agent_usage events fire for non-file-edit AI hooks (e.g. Amp `PreToolUse`/`PostToolUse`)
- [ ] Verify throttling still prevents duplicate events within the 150s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
