### PR TITLE
fix: harden release workflow version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,11 +452,11 @@ jobs:
           echo "New version: $NEW_VERSION"
           
           # Update Cargo.toml
-          sed -i.bak "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" Cargo.toml
+          sed -i.bak "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" Cargo.toml
           rm Cargo.toml.bak
           
           # Update flake.nix version to match
-          sed -i.bak "s/version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" flake.nix
+          sed -i.bak "s/version = \".*\"/version = \"${NEW_VERSION}\"/" flake.nix
           rm flake.nix.bak
           
           # Update Cargo.lock
@@ -471,6 +471,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock flake.nix
           git commit -m "chore: bump version to ${{ steps.bump-version.outputs.new_version }} [skip ci]"
+          git pull --rebase origin main
           git push origin main
 
       - name: Trigger release channel update


### PR DESCRIPTION
## Summary
- Use wildcard patterns in sed version replacements instead of exact-match on `CURRENT_VERSION`, preventing silent no-ops if the file version has drifted
- Add `git pull --rebase origin main` before push so the workflow doesn't fail if another commit lands on main during the run

## Test plan
- [ ] Trigger a release and verify the version bump step succeeds
- [ ] Verify version is correctly updated in Cargo.toml, Cargo.lock, and flake.nix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
