### PR TITLE
fix: preserve AI attribution for unstaged files across partial commits

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -986,6 +986,57 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_add_with_snapshot_preserves_unstaged_file_attribution() {
+        // Reproduces the bug where committing only some files from a multi-file
+        // AI checkpoint via the snapshot path (daemon mode) loses attribution for
+        // the uncommitted files.
+        //
+        // Scenario:
+        //   1. AI writes file_a.py and file_b.py
+        //   2. Single checkpoint covers both files
+        //   3. User stages only file_a.py
+        //   4. Commit 1: file_a.py committed (with snapshot containing only file_a.py)
+        //   5. User stages file_b.py
+        //   6. Commit 2: file_b.py committed (with snapshot containing only file_b.py)
+        //   7. file_b.py should have AI attribution in commit 2
+        let tmp_repo = TmpRepo::new().unwrap();
+
+        let file_a_content = "def add(a, b):\n    return a + b\n";
+        let file_b_content = "class Calculator:\n    def add(self, a, b):\n        return a + b\n";
+
+        // Write both files WITHOUT staging
+        tmp_repo.write_file("file_a.py", file_a_content, false).unwrap();
+        tmp_repo.write_file("file_b.py", file_b_content, false).unwrap();
+
+        // AI checkpoint covering both files
+        tmp_repo.trigger_checkpoint_with_ai("mock_ai", None, None).unwrap();
+
+        // Commit 1: only file_a.py, using snapshot (simulates daemon with incomplete snapshot)
+        let commit1_log = tmp_repo.commit_files_with_snapshot(&["file_a.py"], "add file_a").unwrap();
+
+        assert!(
+            !commit1_log.attestations.is_empty(),
+            "Commit 1 should have AI attribution for file_a.py"
+        );
+        assert!(
+            !commit1_log.metadata.prompts.is_empty(),
+            "Commit 1 should have prompt metadata"
+        );
+
+        // Commit 2: file_b.py, also using snapshot
+        let commit2_log = tmp_repo.commit_files_with_snapshot(&["file_b.py"], "add file_b").unwrap();
+
+        assert!(
+            !commit2_log.attestations.is_empty(),
+            "Commit 2 should have AI attribution for file_b.py (carried via INITIAL)"
+        );
+        assert!(
+            !commit2_log.metadata.prompts.is_empty(),
+            "Commit 2 should have prompt metadata for the AI attribution"
+        );
+    }
+
+    #[test]
     fn test_post_commit_utf8_filename_with_ai_attribution() {
         // Create a repo with an initial commit
         let tmp_repo = TmpRepo::new().unwrap();

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -1005,14 +1005,22 @@ mod tests {
         let file_b_content = "class Calculator:\n    def add(self, a, b):\n        return a + b\n";
 
         // Write both files WITHOUT staging
-        tmp_repo.write_file("file_a.py", file_a_content, false).unwrap();
-        tmp_repo.write_file("file_b.py", file_b_content, false).unwrap();
+        tmp_repo
+            .write_file("file_a.py", file_a_content, false)
+            .unwrap();
+        tmp_repo
+            .write_file("file_b.py", file_b_content, false)
+            .unwrap();
 
         // AI checkpoint covering both files
-        tmp_repo.trigger_checkpoint_with_ai("mock_ai", None, None).unwrap();
+        tmp_repo
+            .trigger_checkpoint_with_ai("mock_ai", None, None)
+            .unwrap();
 
         // Commit 1: only file_a.py, using snapshot (simulates daemon with incomplete snapshot)
-        let commit1_log = tmp_repo.commit_files_with_snapshot(&["file_a.py"], "add file_a").unwrap();
+        let commit1_log = tmp_repo
+            .commit_files_with_snapshot(&["file_a.py"], "add file_a")
+            .unwrap();
 
         assert!(
             !commit1_log.attestations.is_empty(),
@@ -1024,7 +1032,9 @@ mod tests {
         );
 
         // Commit 2: file_b.py, also using snapshot
-        let commit2_log = tmp_repo.commit_files_with_snapshot(&["file_b.py"], "add file_b").unwrap();
+        let commit2_log = tmp_repo
+            .commit_files_with_snapshot(&["file_b.py"], "add file_b")
+            .unwrap();
 
         assert!(
             !commit2_log.attestations.is_empty(),

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1385,10 +1385,11 @@ impl VirtualAttributions {
             if let Some(snapshot) = final_state_snapshot {
                 let mut augmented = snapshot.clone();
                 for (file_path, (_, line_attrs)) in &self.attributions {
-                    if !line_attrs.is_empty() && !augmented.contains_key(file_path) {
-                        if let Some(content) = self.file_contents.get(file_path) {
-                            augmented.insert(file_path.clone(), content.clone());
-                        }
+                    if !line_attrs.is_empty()
+                        && !augmented.contains_key(file_path)
+                        && let Some(content) = self.file_contents.get(file_path)
+                    {
+                        augmented.insert(file_path.clone(), content.clone());
                     }
                 }
                 collect_unstaged_hunks_from_snapshot(repo, commit_sha, pathspecs, &augmented)?

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1383,7 +1383,15 @@ impl VirtualAttributions {
         let committed_hunks = collect_committed_hunks(repo, parent_sha, commit_sha, pathspecs)?;
         let (mut unstaged_hunks, pure_insertion_hunks) =
             if let Some(snapshot) = final_state_snapshot {
-                collect_unstaged_hunks_from_snapshot(repo, commit_sha, pathspecs, snapshot)?
+                let mut augmented = snapshot.clone();
+                for (file_path, (_, line_attrs)) in &self.attributions {
+                    if !line_attrs.is_empty() && !augmented.contains_key(file_path) {
+                        if let Some(content) = self.file_contents.get(file_path) {
+                            augmented.insert(file_path.clone(), content.clone());
+                        }
+                    }
+                }
+                collect_unstaged_hunks_from_snapshot(repo, commit_sha, pathspecs, &augmented)?
             } else {
                 collect_unstaged_hunks(repo, commit_sha, pathspecs)?
             };

--- a/src/git/test_utils/mod.rs
+++ b/src/git/test_utils/mod.rs
@@ -1,13 +1,13 @@
 use crate::authorship::attribution_tracker::Attribution;
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
-use crate::authorship::post_commit::post_commit;
+use crate::authorship::post_commit::{post_commit, post_commit_with_final_state};
 use crate::authorship::working_log::{AgentId, Checkpoint, CheckpointKind};
 use crate::commands::checkpoint_agent::agent_presets::AgentRunResult;
 use crate::commands::{blame, checkpoint::run as checkpoint};
 use crate::error::GitAiError;
 use crate::git::repository::Repository as GitAiRepository;
 use git2::{Repository, Signature};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -656,6 +656,75 @@ impl TmpRepo {
         )?;
 
         Ok(post_commit_result.1)
+    }
+
+    /// Commit specific files and run post_commit_with_final_state using a snapshot
+    /// that only contains the committed files' content. This simulates the daemon
+    /// path where the carryover snapshot may be incomplete (missing uncheckpointed
+    /// files).
+    pub fn commit_files_with_snapshot(
+        &self,
+        files_to_stage: &[&str],
+        message: &str,
+    ) -> Result<AuthorshipLog, GitAiError> {
+        let mut index = self.repo_git2.index()?;
+        for file in files_to_stage {
+            index.add_path(std::path::Path::new(file))?;
+        }
+        index.write()?;
+
+        let tree_id = index.write_tree()?;
+        let tree = self.repo_git2.find_tree(tree_id)?;
+
+        let fixed_time = git2::Time::new(1672574400, 0);
+        let signature = Signature::new("Test User", "test@example.com", &fixed_time)?;
+
+        let parent_commit = if let Ok(head) = self.repo_git2.head() {
+            head.target()
+                .and_then(|target| self.repo_git2.find_commit(target).ok())
+        } else {
+            None
+        };
+
+        let (parent_sha, commit_id) = if let Some(parent) = parent_commit {
+            let parent_sha = Some(parent.id().to_string());
+            let commit_id = self.repo_git2.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                message,
+                &tree,
+                &[&parent],
+            )?;
+            (parent_sha, commit_id)
+        } else {
+            let commit_id =
+                self.repo_git2
+                    .commit(Some("HEAD"), &signature, &signature, message, &tree, &[])?;
+            (None, commit_id)
+        };
+
+        // Build snapshot containing ONLY committed files — simulates a daemon
+        // committed_final_state that doesn't include untracked/unstaged files.
+        let mut snapshot = HashMap::new();
+        for file in files_to_stage {
+            let file_path = self.path.join(file);
+            if file_path.exists() {
+                let content = fs::read_to_string(&file_path).unwrap_or_default();
+                snapshot.insert(file.to_string(), content);
+            }
+        }
+
+        let result = post_commit_with_final_state(
+            &self.repo_gitai,
+            parent_sha,
+            commit_id.to_string(),
+            "Test User".to_string(),
+            true,
+            Some(&snapshot),
+        )?;
+
+        Ok(result.1)
     }
 
     /// Creates a new branch and switches to it

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1747,6 +1747,106 @@ fn test_ai_generated_file_then_human_full_rewrite() {
     ]);
 }
 
+#[test]
+fn test_partial_add_multifile_checkpoint_preserves_attribution_across_commits() {
+    let repo = TestRepo::new();
+
+    // --- Create two files (mimics AI writing both) ---
+    let calca_path = repo.path().join("calca9.py");
+    let calcb_path = repo.path().join("calcb9.py");
+
+    let calca_original = "\
+\"\"\"Calculator A9 - functional style addition calculator.\"\"\"
+
+
+def add(a, b):
+    return a + b
+
+
+def add_many(*numbers):
+    result = 0
+    for n in numbers:
+        result = add(result, n)
+    return result
+
+
+if __name__ == \"__main__\":
+    x = float(input(\"Enter first number: \"))
+    y = float(input(\"Enter second number: \"))
+    print(f\"{x} + {y} = {add(x, y)}\")
+";
+
+    let calcb_content = "\
+\"\"\"Calculator B9 - class-based addition calculator.\"\"\"
+
+
+class Calculator:
+    def __init__(self):
+        self.history = []
+
+    def add(self, a, b):
+        result = a + b
+        self.history.append((a, b, result))
+        return result
+
+    def add_many(self, *numbers):
+        total = numbers[0] if numbers else 0
+        for n in numbers[1:]:
+            total = self.add(total, n)
+        return total
+
+    def show_history(self):
+        for a, b, result in self.history:
+            print(f\"{a} + {b} = {result}\")
+";
+
+    fs::write(&calca_path, calca_original).unwrap();
+    fs::write(&calcb_path, calcb_content).unwrap();
+
+    // --- Single AI checkpoint covering both files (mimics real AI session) ---
+    repo.git_ai(&["checkpoint", "mock_ai", "calca9.py", "calcb9.py"])
+        .unwrap();
+
+    // --- User stages only calca9.py, then AI appends more lines ---
+    repo.git(&["add", "calca9.py"]).unwrap();
+
+    let calca_extended = format!(
+        "{}    extras = input(\"Enter more numbers separated by spaces: \").split()\n\
+    extra_nums = [float(n) for n in extras]\n\
+    all_nums = [x, y] + extra_nums\n\
+    total = add_many(*all_nums)\n\
+    print(f\"Total sum of all {{len(all_nums)}} numbers: {{total}}\")\n",
+        calca_original
+    );
+    fs::write(&calca_path, &calca_extended).unwrap();
+
+    // --- Commit 1: only the staged calca9.py (original 18 lines) ---
+    let commit1 = repo.commit("first calca9.py").unwrap();
+    assert!(
+        !commit1.authorship_log.attestations.is_empty(),
+        "Commit 1 should have AI attribution for calca9.py"
+    );
+
+    // --- Commit 2: stage the appended lines (no checkpoint for these), commit ---
+    repo.git(&["add", "calca9.py"]).unwrap();
+    let _commit2 = repo.commit("second calca9.py").unwrap();
+
+    // --- Commit 3: stage calcb9.py, commit ---
+    // calcb9.py was part of the original checkpoint but never staged until now.
+    // Its AI attribution must survive through INITIAL across commits 1 and 2.
+    repo.git(&["add", "calcb9.py"]).unwrap();
+    let commit3 = repo.commit("the rest").unwrap();
+
+    assert!(
+        !commit3.authorship_log.attestations.is_empty(),
+        "Commit 3 should have AI attribution for calcb9.py"
+    );
+    assert!(
+        !commit3.authorship_log.metadata.prompts.is_empty(),
+        "Commit 3 should have prompt metadata for the AI attribution"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_simple_additions_empty_repo,
     test_simple_additions_with_base_commit,
@@ -1759,4 +1859,5 @@ crate::reuse_tests_in_worktree!(
     test_partial_staging_filters_unstaged_lines,
     test_human_stages_some_ai_lines,
     test_ai_generated_file_then_human_full_rewrite,
+    test_partial_add_multifile_checkpoint_preserves_attribution_across_commits,
 );


### PR DESCRIPTION
## Summary

- Fixes a bug where AI attribution was lost for files that were checkpointed but not staged when another file from the same checkpoint was committed first
- The snapshot-based daemon path (`collect_unstaged_hunks_from_snapshot`) treated files missing from the snapshot as having no unstaged content, silently discarding their attribution instead of carrying it forward via INITIAL
- The fix augments the snapshot with checkpoint blob content for any attributed file missing from the snapshot, ensuring untracked/unstaged files are correctly identified and their attribution persists across partial commits

## Root cause

In `to_authorship_log_and_initial_working_log`, when using the snapshot path (daemon mode), `collect_unstaged_hunks_from_snapshot` compares committed content vs snapshot content for each file. For files not in the commit AND not in the snapshot, both are empty strings → function skips the file → all attributed lines fall through to the "neither unstaged nor committed" discard path at line 1504.

The wrapper path (`collect_unstaged_hunks`) doesn't have this issue because it reads untracked files directly from the working directory filesystem.

## Test plan

- [x] Unit test: `test_partial_add_with_snapshot_preserves_unstaged_file_attribution` — directly exercises the snapshot code path with an incomplete snapshot (commit 1 snapshot has file_a but not file_b)
- [x] Integration test: `test_partial_add_multifile_checkpoint_preserves_attribution_across_commits` — end-to-end test reproducing the exact scenario from the bug report (two files checkpointed, staged/committed incrementally across 3 commits)
- [x] All 1458 unit tests pass
- [x] All integration tests pass in wrapper, daemon, and wrapper-daemon modes
- [x] Integration test also runs in worktree mode via `reuse_tests_in_worktree!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
