### PR TITLE
perf: skip trace-ingest wait for captured checkpoints (~60x faster)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "git-ai"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "chrono",
  "clap",

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -154,7 +154,7 @@ fn ensure_daemon_running_attached(timeout: Duration) -> Result<DaemonConfig, Str
                 config.trace_socket_path.display()
             ));
         }
-        thread::sleep(Duration::from_millis(50));
+        thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -233,6 +233,9 @@ fn daemon_startup_is_blocked(config: &DaemonConfig) -> bool {
 }
 
 pub(crate) fn daemon_is_up(config: &DaemonConfig) -> bool {
+    if !config.control_socket_path.exists() || !config.trace_socket_path.exists() {
+        return false;
+    }
     local_socket_connects_with_timeout(&config.control_socket_path, Duration::from_millis(100))
         .is_ok()
         && local_socket_connects_with_timeout(&config.trace_socket_path, Duration::from_millis(100))
@@ -248,7 +251,7 @@ fn wait_for_daemon_up(config: &DaemonConfig, timeout: Duration) -> bool {
         if Instant::now() >= deadline {
             return false;
         }
-        thread::sleep(Duration::from_millis(50));
+        thread::sleep(Duration::from_millis(10));
     }
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7133,10 +7133,18 @@ impl ActorDaemonCoordinator {
             ));
         }
         let family = self.backend.resolve_family(Path::new(&repo_working_dir))?;
-        let ingest_high_watermark = self.trace_ingest_high_watermark();
-        if ingest_high_watermark > 0 {
-            self.wait_for_trace_ingest_processed_through(ingest_high_watermark)
-                .await?;
+
+        // Captured checkpoints carry their own file-state snapshot and do not
+        // depend on trace-ingest ordering, so we skip the potentially expensive
+        // wait.  Live checkpoints still need the daemon's view of the repo to be
+        // current, and wait=true callers explicitly asked to block.
+        let needs_trace_ingest_wait = wait || matches!(request, CheckpointRunRequest::Live(_));
+        if needs_trace_ingest_wait {
+            let ingest_high_watermark = self.trace_ingest_high_watermark();
+            if ingest_high_watermark > 0 {
+                self.wait_for_trace_ingest_processed_through(ingest_high_watermark)
+                    .await?;
+            }
         }
 
         if wait {

--- a/tests/integration/checkpoint_perf.rs
+++ b/tests/integration/checkpoint_perf.rs
@@ -1,0 +1,309 @@
+use crate::repos::test_repo::{DaemonTestScope, GitTestMode, TestRepo};
+use git_ai::authorship::working_log::CheckpointKind;
+use std::fs;
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+struct DurationStats {
+    count: usize,
+    average: Duration,
+    min: Duration,
+    max: Duration,
+    p50: Duration,
+    p95: Duration,
+}
+
+impl DurationStats {
+    fn from_durations(durations: &mut [Duration]) -> Self {
+        let count = durations.len();
+        assert!(count > 0);
+        durations.sort();
+        let total: Duration = durations.iter().sum();
+        Self {
+            count,
+            average: total / count as u32,
+            min: durations[0],
+            max: durations[count - 1],
+            p50: durations[count / 2],
+            p95: durations[(count as f64 * 0.95) as usize],
+        }
+    }
+
+    fn print(&self, label: &str) {
+        println!(
+            "{label} ({} runs): avg={:.1}ms min={:.1}ms p50={:.1}ms p95={:.1}ms max={:.1}ms",
+            self.count,
+            self.average.as_secs_f64() * 1000.0,
+            self.min.as_secs_f64() * 1000.0,
+            self.p50.as_secs_f64() * 1000.0,
+            self.p95.as_secs_f64() * 1000.0,
+            self.max.as_secs_f64() * 1000.0,
+        );
+    }
+}
+
+fn benchmark_checkpoint_wrapper(iterations: usize) -> DurationStats {
+    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo_path = repo.canonical_path();
+
+    fs::write(repo_path.join("base.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    // Warm-up run
+    fs::write(repo_path.join("warmup.txt"), "warmup\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "warmup.txt"])
+        .unwrap();
+
+    let mut durations = Vec::with_capacity(iterations);
+    for i in 0..iterations {
+        let fname = format!("file_{i}.txt");
+        fs::write(repo_path.join(&fname), format!("content {i}\n")).unwrap();
+        let start = Instant::now();
+        repo.git_ai(&["checkpoint", "mock_ai", &fname]).unwrap();
+        durations.push(start.elapsed());
+    }
+    DurationStats::from_durations(&mut durations)
+}
+
+fn benchmark_checkpoint_daemon(iterations: usize) -> DurationStats {
+    let repo =
+        TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::Dedicated);
+    let repo_path = repo.canonical_path();
+
+    fs::write(repo_path.join("base.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    // Warm-up
+    fs::write(repo_path.join("warmup.txt"), "warmup\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "warmup.txt"])
+        .unwrap();
+    repo.sync_daemon();
+
+    let mut durations = Vec::with_capacity(iterations);
+    for i in 0..iterations {
+        let fname = format!("file_{i}.txt");
+        fs::write(repo_path.join(&fname), format!("content {i}\n")).unwrap();
+        let start = Instant::now();
+        repo.git_ai(&["checkpoint", "mock_ai", &fname]).unwrap();
+        durations.push(start.elapsed());
+    }
+    DurationStats::from_durations(&mut durations)
+}
+
+fn benchmark_checkpoint_wrapper_daemon(iterations: usize) -> DurationStats {
+    let repo = TestRepo::new_with_mode_and_daemon_scope(
+        GitTestMode::WrapperDaemon,
+        DaemonTestScope::Dedicated,
+    );
+    let repo_path = repo.canonical_path();
+
+    fs::write(repo_path.join("base.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    // Warm-up
+    fs::write(repo_path.join("warmup.txt"), "warmup\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "warmup.txt"])
+        .unwrap();
+    repo.sync_daemon();
+
+    let mut durations = Vec::with_capacity(iterations);
+    for i in 0..iterations {
+        let fname = format!("file_{i}.txt");
+        fs::write(repo_path.join(&fname), format!("content {i}\n")).unwrap();
+        let start = Instant::now();
+        repo.git_ai(&["checkpoint", "mock_ai", &fname]).unwrap();
+        durations.push(start.elapsed());
+    }
+    DurationStats::from_durations(&mut durations)
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_single_file_wrapper() {
+    println!("\n=== Checkpoint Single-File Benchmark (Wrapper Mode) ===");
+    let stats = benchmark_checkpoint_wrapper(20);
+    stats.print("Wrapper checkpoint");
+    assert!(
+        stats.p95 < Duration::from_millis(200),
+        "p95 checkpoint latency too high: {:?}",
+        stats.p95
+    );
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_single_file_daemon() {
+    println!("\n=== Checkpoint Single-File Benchmark (Daemon Mode) ===");
+    let stats = benchmark_checkpoint_daemon(20);
+    stats.print("Daemon checkpoint");
+    assert!(
+        stats.p95 < Duration::from_millis(200),
+        "p95 checkpoint latency too high: {:?}",
+        stats.p95
+    );
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_single_file_wrapper_daemon() {
+    println!("\n=== Checkpoint Single-File Benchmark (WrapperDaemon Mode) ===");
+    let stats = benchmark_checkpoint_wrapper_daemon(20);
+    stats.print("WrapperDaemon checkpoint");
+    assert!(
+        stats.p95 < Duration::from_millis(200),
+        "p95 checkpoint latency too high: {:?}",
+        stats.p95
+    );
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_multi_file_wrapper() {
+    println!("\n=== Checkpoint Multi-File Benchmark (Wrapper Mode) ===");
+    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo_path = repo.canonical_path();
+    fs::write(repo_path.join("base.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    // Warm-up
+    fs::write(repo_path.join("w.txt"), "w\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "w.txt"]).unwrap();
+
+    let file_counts = [1, 5, 10, 20];
+    for &file_count in &file_counts {
+        let mut durations = Vec::with_capacity(10);
+        for iter in 0..10 {
+            let mut files = Vec::with_capacity(file_count);
+            for f in 0..file_count {
+                let fname = format!("multi_{iter}_{f}.txt");
+                fs::write(repo_path.join(&fname), format!("content {iter}_{f}\n")).unwrap();
+                files.push(fname);
+            }
+            let mut args: Vec<&str> = vec!["checkpoint", "mock_ai"];
+            args.extend(files.iter().map(|s| s.as_str()));
+            let start = Instant::now();
+            repo.git_ai(&args).unwrap();
+            durations.push(start.elapsed());
+        }
+        let stats = DurationStats::from_durations(&mut durations);
+        stats.print(&format!("  {file_count} files"));
+    }
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_multi_file_daemon() {
+    println!("\n=== Checkpoint Multi-File Benchmark (Daemon Mode) ===");
+    let repo =
+        TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::Dedicated);
+    let repo_path = repo.canonical_path();
+    fs::write(repo_path.join("base.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    // Warm-up
+    fs::write(repo_path.join("w.txt"), "w\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "w.txt"]).unwrap();
+    repo.sync_daemon();
+
+    let file_counts = [1, 5, 10, 20];
+    for &file_count in &file_counts {
+        let mut durations = Vec::with_capacity(10);
+        for iter in 0..10 {
+            let mut files = Vec::with_capacity(file_count);
+            for f in 0..file_count {
+                let fname = format!("multi_{iter}_{f}.txt");
+                fs::write(repo_path.join(&fname), format!("content {iter}_{f}\n")).unwrap();
+                files.push(fname);
+            }
+            let mut args: Vec<&str> = vec!["checkpoint", "mock_ai"];
+            args.extend(files.iter().map(|s| s.as_str()));
+            let start = Instant::now();
+            repo.git_ai(&args).unwrap();
+            durations.push(start.elapsed());
+        }
+        let stats = DurationStats::from_durations(&mut durations);
+        stats.print(&format!("  {file_count} files"));
+    }
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_correctness_after_optimization() {
+    println!("\n=== Checkpoint Correctness Verification ===");
+    let repo =
+        TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::Dedicated);
+    let repo_path = repo.canonical_path();
+
+    fs::write(repo_path.join("verified.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    fs::write(repo_path.join("verified.txt"), "modified by AI\n").unwrap();
+    let start = Instant::now();
+    repo.git_ai(&["checkpoint", "mock_ai", "verified.txt"])
+        .unwrap();
+    let checkpoint_dur = start.elapsed();
+
+    repo.sync_daemon();
+
+    let checkpoints = repo
+        .current_working_logs()
+        .read_all_checkpoints()
+        .expect("should read checkpoints");
+
+    assert!(
+        !checkpoints.is_empty(),
+        "at least one checkpoint should exist"
+    );
+
+    let last = checkpoints.last().unwrap();
+    assert!(
+        last.kind == CheckpointKind::AiAgent,
+        "checkpoint kind should be AiAgent"
+    );
+    assert!(
+        !last.entries.is_empty(),
+        "checkpoint should have file entries"
+    );
+    assert!(
+        last.entries.iter().any(|e| e.file == "verified.txt"),
+        "checkpoint should include verified.txt"
+    );
+
+    println!(
+        "Correctness verified: checkpoint took {:.1}ms, {} entries",
+        checkpoint_dur.as_secs_f64() * 1000.0,
+        last.entries.len()
+    );
+}
+
+#[test]
+#[ignore]
+fn bench_checkpoint_all_modes_summary() {
+    println!("\n============================================");
+    println!("  Checkpoint Performance Summary (All Modes)");
+    println!("============================================\n");
+
+    let wrapper = benchmark_checkpoint_wrapper(20);
+    wrapper.print("Wrapper");
+
+    let daemon = benchmark_checkpoint_daemon(20);
+    daemon.print("Daemon");
+
+    let wrapper_daemon = benchmark_checkpoint_wrapper_daemon(20);
+    wrapper_daemon.print("WrapperDaemon");
+
+    println!("\n============================================\n");
+
+    assert!(
+        wrapper.p95 < Duration::from_millis(200),
+        "Wrapper p95 too high"
+    );
+    assert!(
+        daemon.p95 < Duration::from_millis(200),
+        "Daemon p95 too high"
+    );
+    assert!(
+        wrapper_daemon.p95 < Duration::from_millis(200),
+        "WrapperDaemon p95 too high"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -22,6 +22,7 @@ mod blame_flags;
 mod blame_subdirectory;
 mod checkout_switch;
 mod checkpoint_explicit_paths;
+mod checkpoint_perf;
 mod checkpoint_size;
 mod cherry_pick;
 mod chinese_text_edits;


### PR DESCRIPTION
## Summary

- **Root cause**: Every daemon checkpoint (including fire-and-forget captured ones) blocked on `wait_for_trace_ingest_processed_through()`, which waits for ALL pending trace2 events to be processed. This added ~500ms of unnecessary latency.
- **Fix**: Make trace-ingest wait conditional — only block for live checkpoints and explicit `wait=true` requests. Captured checkpoints carry their own file-state snapshot and don't depend on trace ordering.
- **Secondary**: Fast-fail path check in `daemon_is_up` and reduced polling intervals (50ms → 10ms) in daemon startup helpers.

### Before
```
Checkpoint queued in 623.642191ms
```

### After
```
Checkpoint queued in 9.810833ms
```

## Changes

| File | What |
|------|------|
| `src/daemon.rs` | Conditional trace-ingest wait in `ingest_checkpoint_payload` |
| `src/commands/daemon.rs` | Fast-fail socket path check, reduced poll intervals |
| `tests/integration/checkpoint_perf.rs` | New benchmark suite (8 `#[ignore]` tests) covering Wrapper, Daemon, WrapperDaemon modes |
| `tests/integration/main.rs` | Register new test module |

## Test plan

- [x] Verified with repro script: `bash ~/repro-partial-add-commit-bug.sh --cleanup` → 9ms vs 623ms
- [x] Verified attribution correctness preserved via `git-ai log`
- [x] New benchmark tests pass: `cargo test checkpoint_perf -- --ignored`
- [ ] CI passes (all existing tests, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
