### PR TITLE
Move copilot hooks to ~/.copilot/hooks

### DIFF
--- a/src/mdm/agents/github_copilot.rs
+++ b/src/mdm/agents/github_copilot.rs
@@ -16,6 +16,10 @@ pub struct GitHubCopilotInstaller;
 
 impl GitHubCopilotInstaller {
     fn hooks_path() -> PathBuf {
+        home_dir().join(".copilot").join("hooks").join("git-ai.json")
+    }
+
+    fn legacy_hooks_path() -> PathBuf {
         home_dir().join(".github").join("hooks").join("git-ai.json")
     }
 
@@ -48,12 +52,18 @@ impl HookInstaller for GitHubCopilotInstaller {
         let resolved_cli = resolve_editor_cli("code");
         let has_cli = resolved_cli.is_some();
         let has_vscode_dotfiles = home_dir().join(".vscode").exists();
+        let has_copilot_dotfiles = home_dir().join(".copilot").exists();
         let has_github_dotfiles = home_dir().join(".github").exists();
         let has_settings_targets = Self::settings_targets()
             .iter()
             .any(|path| should_process_settings_target(path));
 
-        if !has_cli && !has_vscode_dotfiles && !has_github_dotfiles && !has_settings_targets {
+        if !has_cli
+            && !has_vscode_dotfiles
+            && !has_copilot_dotfiles
+            && !has_github_dotfiles
+            && !has_settings_targets
+        {
             return Ok(HookCheckResult {
                 tool_installed: false,
                 hooks_installed: false,
@@ -292,6 +302,13 @@ impl HookInstaller for GitHubCopilotInstaller {
             root.insert("hooks".to_string(), hooks_obj);
         }
 
+        if !dry_run {
+            let legacy_path = Self::legacy_hooks_path();
+            if legacy_path.exists() {
+                let _ = fs::remove_file(&legacy_path);
+            }
+        }
+
         if existing == merged {
             return Ok(None);
         }
@@ -428,7 +445,7 @@ mod tests {
             let diff = installer.install_hooks(&params, false).unwrap();
             assert!(diff.is_some());
 
-            let hooks_path = home.join(".github").join("hooks").join("git-ai.json");
+            let hooks_path = home.join(".copilot").join("hooks").join("git-ai.json");
             assert!(hooks_path.exists());
 
             let content: Value = serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap())
@@ -473,6 +490,28 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_install_hooks_deletes_legacy_hooks_file() {
+        with_temp_home(|home| {
+            let legacy_path = home.join(".github").join("hooks").join("git-ai.json");
+            fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+            fs::write(&legacy_path, r#"{"hooks":{}}"#).unwrap();
+            assert!(legacy_path.exists());
+
+            let installer = GitHubCopilotInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            installer.install_hooks(&params, false).unwrap();
+
+            assert!(!legacy_path.exists());
+            let new_path = home.join(".copilot").join("hooks").join("git-ai.json");
+            assert!(new_path.exists());
+        });
+    }
+
+    #[test]
+    #[serial]
     fn test_install_hooks_dry_run_does_not_create_files() {
         with_temp_home(|home| {
             let installer = GitHubCopilotInstaller;
@@ -480,7 +519,7 @@ mod tests {
                 binary_path: test_binary_path(),
             };
 
-            let hooks_dir = home.join(".github").join("hooks");
+            let hooks_dir = home.join(".copilot").join("hooks");
             let hooks_path = hooks_dir.join("git-ai.json");
             assert!(!hooks_dir.exists());
             assert!(!hooks_path.exists());
@@ -496,7 +535,7 @@ mod tests {
     #[serial]
     fn test_install_hooks_repairs_non_object_hooks_field() {
         with_temp_home(|home| {
-            let hooks_path = home.join(".github").join("hooks").join("git-ai.json");
+            let hooks_path = home.join(".copilot").join("hooks").join("git-ai.json");
             fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
             fs::write(&hooks_path, r#"{"hooks":"invalid","extra":"keep"}"#).unwrap();
 
@@ -532,7 +571,7 @@ mod tests {
     #[serial]
     fn test_install_hooks_repairs_non_object_root() {
         with_temp_home(|home| {
-            let hooks_path = home.join(".github").join("hooks").join("git-ai.json");
+            let hooks_path = home.join(".copilot").join("hooks").join("git-ai.json");
             fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
             fs::write(&hooks_path, "[]").unwrap();
 
@@ -557,7 +596,7 @@ mod tests {
     #[serial]
     fn test_check_hooks_partial_pre_tool_use_counts_as_installed() {
         with_temp_home(|home| {
-            let hooks_path = home.join(".github").join("hooks").join("git-ai.json");
+            let hooks_path = home.join(".copilot").join("hooks").join("git-ai.json");
             fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
             let existing = json!({
                 "hooks": {
@@ -591,7 +630,7 @@ mod tests {
     #[serial]
     fn test_check_hooks_partial_post_tool_use_counts_as_installed() {
         with_temp_home(|home| {
-            let hooks_path = home.join(".github").join("hooks").join("git-ai.json");
+            let hooks_path = home.join(".copilot").join("hooks").join("git-ai.json");
             fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
             let existing = json!({
                 "hooks": {
@@ -625,7 +664,7 @@ mod tests {
     #[serial]
     fn test_uninstall_hooks_removes_only_git_ai_entries() {
         with_temp_home(|home| {
-            let hooks_path = home.join(".github").join("hooks").join("git-ai.json");
+            let hooks_path = home.join(".copilot").join("hooks").join("git-ai.json");
             fs::create_dir_all(hooks_path.parent().unwrap()).unwrap();
             let existing = json!({
                 "hooks": {

--- a/src/mdm/agents/github_copilot.rs
+++ b/src/mdm/agents/github_copilot.rs
@@ -87,10 +87,19 @@ impl HookInstaller for GitHubCopilotInstaller {
         }
 
         let hooks_path = Self::hooks_path();
-        if !hooks_path.exists() {
+        let legacy_path = Self::legacy_hooks_path();
+        if !hooks_path.exists() && !legacy_path.exists() {
             return Ok(HookCheckResult {
                 tool_installed: true,
                 hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        if !hooks_path.exists() && legacy_path.exists() {
+            return Ok(HookCheckResult {
+                tool_installed: true,
+                hooks_installed: true,
                 hooks_up_to_date: false,
             });
         }
@@ -331,6 +340,13 @@ impl HookInstaller for GitHubCopilotInstaller {
         _params: &HookInstallerParams,
         dry_run: bool,
     ) -> Result<Option<String>, GitAiError> {
+        if !dry_run {
+            let legacy_path = Self::legacy_hooks_path();
+            if legacy_path.exists() {
+                let _ = fs::remove_file(&legacy_path);
+            }
+        }
+
         let hooks_path = Self::hooks_path();
 
         if !hooks_path.exists() {
@@ -721,6 +737,58 @@ mod tests {
                 Some("echo before")
             );
             assert!(post.is_empty());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_uninstall_hooks_deletes_legacy_hooks_file() {
+        with_temp_home(|home| {
+            let legacy_path = home.join(".github").join("hooks").join("git-ai.json");
+            fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+            fs::write(&legacy_path, r#"{"hooks":{}}"#).unwrap();
+
+            let installer = GitHubCopilotInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            installer.uninstall_hooks(&params, false).unwrap();
+            assert!(!legacy_path.exists());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_hooks_detects_legacy_path_as_installed() {
+        with_temp_home(|home| {
+            let legacy_path = home.join(".github").join("hooks").join("git-ai.json");
+            fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+            let existing = json!({
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "type": "command",
+                            "command": "/tmp/git-ai/bin/git-ai checkpoint github-copilot --hook-input stdin"
+                        }
+                    ]
+                }
+            });
+            fs::write(
+                &legacy_path,
+                serde_json::to_string_pretty(&existing).unwrap(),
+            )
+            .unwrap();
+
+            let installer = GitHubCopilotInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            let result = installer.check_hooks(&params).unwrap();
+            assert!(result.tool_installed);
+            assert!(result.hooks_installed);
+            assert!(!result.hooks_up_to_date);
         });
     }
 }

--- a/src/mdm/agents/github_copilot.rs
+++ b/src/mdm/agents/github_copilot.rs
@@ -16,7 +16,10 @@ pub struct GitHubCopilotInstaller;
 
 impl GitHubCopilotInstaller {
     fn hooks_path() -> PathBuf {
-        home_dir().join(".copilot").join("hooks").join("git-ai.json")
+        home_dir()
+            .join(".copilot")
+            .join("hooks")
+            .join("git-ai.json")
     }
 
     fn legacy_hooks_path() -> PathBuf {

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -810,11 +810,7 @@ pub fn update_git_path_setting(
 
 /// Update VS Code chat hook settings in a settings.json/jsonc file.
 ///
-/// Ensures:
-/// - `"chat.hookFilesLocations"` contains `"~/.github/hooks": true`
-/// - `"chat.useHooks"` is set to `true`
-///
-/// Existing hook file locations are preserved.
+/// Ensures `"chat.useHooks"` is set to `true`.
 pub fn update_vscode_chat_hook_settings(
     settings_path: &Path,
     dry_run: bool,
@@ -842,45 +838,6 @@ pub fn update_vscode_chat_hook_settings(
 
     let object = root.object_value_or_set();
     let mut changed = false;
-
-    let hook_locations = match object.get("chat.hookFilesLocations") {
-        Some(prop) => match prop.object_value() {
-            Some(existing) => existing,
-            None => {
-                changed = true;
-                prop.object_value_or_set()
-            }
-        },
-        None => {
-            changed = true;
-            object.object_value_or_set("chat.hookFilesLocations")
-        }
-    };
-
-    // VS Code requires paths that are relative or start with "~/".
-    // This is cross-platform (including Windows) because the setting
-    // does not accept absolute paths or backslash separators.
-    let hook_dir_path = "~/.github/hooks";
-    match hook_locations.get(hook_dir_path) {
-        Some(prop) => {
-            let should_update = match prop.value() {
-                Some(node) => match node.as_boolean_lit() {
-                    Some(bool_node) => !bool_node.value(),
-                    None => true,
-                },
-                None => true,
-            };
-
-            if should_update {
-                prop.set_value(jsonc_parser::json!(true));
-                changed = true;
-            }
-        }
-        None => {
-            hook_locations.append(hook_dir_path, jsonc_parser::json!(true));
-            changed = true;
-        }
-    }
 
     match object.get("chat.useHooks") {
         Some(prop) => {
@@ -1132,15 +1089,11 @@ mod tests {
     }
 
     #[test]
-    fn test_update_vscode_chat_hook_settings_preserves_existing_locations() {
+    fn test_update_vscode_chat_hook_settings_enables_use_hooks() {
         let temp_dir = TempDir::new().unwrap();
         let settings_path = temp_dir.path().join("settings.json");
         let initial = r#"{
     // keep existing entries
-    "chat.hookFilesLocations": {
-        ".github/hooks": true,
-        "~/.github/hooks": true
-    },
     "chat.useHooks": false
 }
 "#;
@@ -1151,8 +1104,6 @@ mod tests {
 
         let final_content = fs::read_to_string(&settings_path).unwrap();
         assert!(final_content.contains("// keep existing entries"));
-        assert!(final_content.contains("\".github/hooks\": true"));
-        assert!(final_content.contains("\"~/.github/hooks\": true"));
         assert!(final_content.contains("\"chat.useHooks\": true"));
     }
 
@@ -1161,10 +1112,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let settings_path = temp_dir.path().join("settings.json");
         let initial = r#"{
-    "chat.hookFilesLocations": {
-        ".github/hooks": true,
-        "~/.github/hooks": true
-    },
     "chat.useHooks": true
 }
 "#;
@@ -1178,7 +1125,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_vscode_chat_hook_settings_uses_tilde_path_not_absolute() {
+    fn test_update_vscode_chat_hook_settings_adds_use_hooks_to_empty() {
         let temp_dir = TempDir::new().unwrap();
         let settings_path = temp_dir.path().join("settings.json");
         fs::write(&settings_path, "{}\n").unwrap();
@@ -1187,13 +1134,7 @@ mod tests {
         assert!(result.is_some());
 
         let final_content = fs::read_to_string(&settings_path).unwrap();
-        assert!(final_content.contains("\"~/.github/hooks\": true"));
-        let absolute_hook_dir = home_dir()
-            .join(".github")
-            .join("hooks")
-            .to_string_lossy()
-            .replace('\\', "/");
-        assert!(!final_content.contains(&format!("\"{}\": true", absolute_hook_dir)));
+        assert!(final_content.contains("\"chat.useHooks\": true"));
     }
 
     #[test]


### PR DESCRIPTION
fixes #1119 

## Summary
- Moves hooks file from `~/.github/hooks/git-ai.json` to `~/.copilot/hooks/git-ai.json` — the `~/.copilot/hooks` directory is auto-discovered by VS Code, eliminating the need to update `chat.hookFilesLocations` in settings
- Removes `chat.hookFilesLocations` management from `update_vscode_chat_hook_settings()`, keeping only `chat.useHooks: true`
- Adds migration logic to delete the legacy `~/.github/hooks/git-ai.json` on install
- Adds `~/.copilot` as a tool-installed detection signal in `check_hooks()`

## Test plan
- [x] New test `test_install_hooks_deletes_legacy_hooks_file` verifies legacy file is removed and new path is created
- [x] All existing tests updated to use `.copilot/hooks` paths
- [x] Utils tests updated for simplified `useHooks`-only settings logic
- [x] Full test suite passes (1474 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
