### PR TITLE
ci: retry flaky tests in daemon/wrapper-daemon modes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
+      - 'scripts/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'Taskfile.yml'
@@ -17,6 +18,7 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
+      - 'scripts/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'Taskfile.yml'
@@ -107,13 +109,22 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get install -y mold
 
-      - name: Run tests
-        run: cargo test -- --test-threads=${{ matrix.test_threads }}
+      - name: Run tests (Unix)
+        if: runner.os != 'Windows'
+        run: bash scripts/ci-test-with-retry.sh ${{ matrix.test_threads }}
         env:
           CARGO_INCREMENTAL: 0
           GIT_AI_TEST_GIT_MODE: ${{ matrix.test_mode }}
           GIT_AI_TEST_SHARED_DAEMON_POOL_SIZE: ${{ matrix.daemon_pool }}
           RUSTFLAGS: ${{ runner.os == 'Linux' && '-C link-arg=-fuse-ld=mold' || '' }}
+
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        run: pwsh scripts/ci-test-with-retry.ps1 -TestThreads ${{ matrix.test_threads }}
+        env:
+          CARGO_INCREMENTAL: 0
+          GIT_AI_TEST_GIT_MODE: ${{ matrix.test_mode }}
+          GIT_AI_TEST_SHARED_DAEMON_POOL_SIZE: ${{ matrix.daemon_pool }}
 
   test-ignored:
     name: Test SCM e2e tests on just Ubuntu

--- a/scripts/ci-test-with-retry.ps1
+++ b/scripts/ci-test-with-retry.ps1
@@ -26,16 +26,17 @@ if ($TestMode -ne "daemon" -and $TestMode -ne "wrapper-daemon") {
 }
 
 # Parse failed test names from cargo test output
-$lines = $output -split "`n"
+$lines = $output -split "`r?`n"
 $inFailures = $false
 $failedTests = @()
 
 foreach ($line in $lines) {
-    if ($line -match "^failures:$") {
+    $line = $line.TrimEnd()
+    if ($line -eq "failures:") {
         $inFailures = $true
         continue
     }
-    if ($inFailures -and ($line -match "^$" -or $line -match "^test result:")) {
+    if ($inFailures -and ($line -eq "" -or $line -match "^test result:")) {
         $inFailures = $false
         continue
     }

--- a/scripts/ci-test-with-retry.ps1
+++ b/scripts/ci-test-with-retry.ps1
@@ -1,0 +1,88 @@
+# Retry logic for flaky tests in daemon and wrapper-daemon modes (Windows).
+# Only re-runs failed tests (not the full suite) for speed.
+# Exits 0 with a warning if flaky tests pass on retry.
+
+param(
+    [int]$TestThreads = 4
+)
+
+$ErrorActionPreference = "Continue"
+$TestMode = $env:GIT_AI_TEST_GIT_MODE
+
+# Run the full test suite, capturing output
+$output = cargo test -- --test-threads=$TestThreads 2>&1 | Out-String
+$firstExit = $LASTEXITCODE
+
+Write-Host $output
+
+if ($firstExit -eq 0) {
+    exit 0
+}
+
+# Only retry for daemon and wrapper-daemon modes
+if ($TestMode -ne "daemon" -and $TestMode -ne "wrapper-daemon") {
+    Write-Host "::error::Tests failed in '$TestMode' mode (retry not enabled for this mode)"
+    exit 1
+}
+
+# Parse failed test names from cargo test output
+$lines = $output -split "`n"
+$inFailures = $false
+$failedTests = @()
+
+foreach ($line in $lines) {
+    if ($line -match "^failures:$") {
+        $inFailures = $true
+        continue
+    }
+    if ($inFailures -and ($line -match "^$" -or $line -match "^test result:")) {
+        $inFailures = $false
+        continue
+    }
+    if ($inFailures -and $line -match "^\s+(\S+)") {
+        $testName = $Matches[1].Trim()
+        if ($testName -and $testName -ne "----") {
+            $failedTests += $testName
+        }
+    }
+}
+
+if ($failedTests.Count -eq 0) {
+    Write-Host "::error::Tests failed but could not parse failed test names for retry"
+    exit 1
+}
+
+$failedCount = $failedTests.Count
+Write-Host ""
+Write-Host "::warning::$failedCount test(s) failed on first run in '$TestMode' mode. Retrying individually..."
+Write-Host ""
+
+# Retry each failed test individually
+$stillFailing = @()
+$passedOnRetry = @()
+
+foreach ($testName in $failedTests) {
+    Write-Host "--- Retrying: $testName ---"
+    cargo test $testName -- --test-threads=1 --exact
+    if ($LASTEXITCODE -eq 0) {
+        $passedOnRetry += $testName
+    } else {
+        $stillFailing += $testName
+    }
+}
+
+Write-Host ""
+
+if ($stillFailing.Count -gt 0) {
+    Write-Host "::error::The following tests failed even on retry:"
+    foreach ($t in $stillFailing) {
+        Write-Host "  - $t"
+    }
+    exit 1
+}
+
+Write-Host "::warning::All $failedCount previously-failed test(s) passed on retry (flaky in '$TestMode' mode):"
+foreach ($t in $passedOnRetry) {
+    Write-Host "  - $t"
+}
+exit 0

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Retry logic for flaky tests in daemon and wrapper-daemon modes.
+# Only re-runs failed tests (not the full suite) for speed.
+# Exits 0 with a warning if flaky tests pass on retry.
+
+TEST_THREADS="${1:-4}"
+TEST_MODE="${GIT_AI_TEST_GIT_MODE:-}"
+
+run_cargo_test() {
+  local filter="${1:-}"
+  local extra_args=""
+  if [ -n "$filter" ]; then
+    extra_args="--exact"
+  fi
+  cargo test $filter -- --test-threads="$TEST_THREADS" $extra_args
+}
+
+# Run the full test suite, capturing output
+OUTPUT_FILE=$(mktemp)
+cargo test -- --test-threads="$TEST_THREADS" 2>&1 | tee "$OUTPUT_FILE"
+FIRST_EXIT=${PIPESTATUS[0]}
+
+if [ "$FIRST_EXIT" -eq 0 ]; then
+  rm -f "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Only retry for daemon and wrapper-daemon modes
+if [ "$TEST_MODE" != "daemon" ] && [ "$TEST_MODE" != "wrapper-daemon" ]; then
+  echo "::error::Tests failed in '$TEST_MODE' mode (retry not enabled for this mode)"
+  rm -f "$OUTPUT_FILE"
+  exit 1
+fi
+
+# Parse failed test names from the output.
+# cargo test prints a failures section like:
+#   failures:
+#       test_name_1
+#       test_name_2
+# We extract those names.
+FAILED_TESTS=$(awk '
+  /^failures:$/ { in_failures=1; next }
+  in_failures && /^$/ { in_failures=0; next }
+  in_failures && /^test result:/ { in_failures=0; next }
+  in_failures && /^[[:space:]]+[a-zA-Z_]/ { gsub(/^[[:space:]]+/, ""); print }
+' "$OUTPUT_FILE")
+
+rm -f "$OUTPUT_FILE"
+
+if [ -z "$FAILED_TESTS" ]; then
+  echo "::error::Tests failed but could not parse failed test names for retry"
+  exit 1
+fi
+
+FAILED_COUNT=$(echo "$FAILED_TESTS" | wc -l | tr -d ' ')
+echo ""
+echo "::warning::$FAILED_COUNT test(s) failed on first run in '$TEST_MODE' mode. Retrying individually..."
+echo ""
+
+# Retry each failed test individually
+STILL_FAILING=""
+PASSED_ON_RETRY=""
+
+while IFS= read -r test_name; do
+  [ -z "$test_name" ] && continue
+  echo "--- Retrying: $test_name ---"
+  if cargo test "$test_name" -- --test-threads=1 --exact; then
+    PASSED_ON_RETRY="${PASSED_ON_RETRY}${test_name}\n"
+  else
+    STILL_FAILING="${STILL_FAILING}${test_name}\n"
+  fi
+done <<< "$FAILED_TESTS"
+
+echo ""
+
+if [ -n "$STILL_FAILING" ]; then
+  echo "::error::The following tests failed even on retry:"
+  echo -e "$STILL_FAILING" | while IFS= read -r t; do
+    [ -n "$t" ] && echo "  - $t"
+  done
+  exit 1
+fi
+
+echo "::warning::All $FAILED_COUNT previously-failed test(s) passed on retry (flaky in '$TEST_MODE' mode):"
+echo -e "$PASSED_ON_RETRY" | while IFS= read -r t; do
+  [ -n "$t" ] && echo "  - $t"
+done
+exit 0


### PR DESCRIPTION
## Summary
- Adds retry logic for flaky tests in CI for `daemon` and `wrapper-daemon` test modes only
- On first failure, parses failed test names from cargo output and re-runs only those specific tests individually
- If all retried tests pass on second run, emits a GitHub Actions warning annotation and exits successfully
- Tests that fail on retry still fail the build normally
- `wrapper` mode has no retry — failures there are treated as real
- Supports both Unix (bash script) and Windows (PowerShell script)

## Test plan
- [ ] Verify Ubuntu CI passes (daemon + wrapper-daemon + wrapper modes)
- [ ] Verify macOS CI passes
- [ ] Verify Windows CI passes
- [ ] Confirm wrapper mode still fails immediately on test failure (no retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
