### PR TITLE
fix(jetbrains): use Google plugin dir for Android Studio on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
  "ureq",
  "url",
  "uuid",
+ "winreg",
  "zip",
 ]
 
@@ -4232,6 +4233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.4.1"
+winreg = "0.55"
 
 [features]
 test-support = ["git2"]

--- a/src/mdm/jetbrains/detection.rs
+++ b/src/mdm/jetbrains/detection.rs
@@ -553,39 +553,39 @@ fn get_plugins_dir(
 
     #[cfg(target_os = "macos")]
     {
-        return plugins_dir_for_platform(
+        plugins_dir_for_platform(
             JetBrainsPlatform::Macos,
             &home,
             None,
             data_directory_name,
             product_code,
             build_number,
-        );
+        )
     }
 
     #[cfg(windows)]
     {
         let appdata = std::env::var("APPDATA").ok();
-        return plugins_dir_for_platform(
+        plugins_dir_for_platform(
             JetBrainsPlatform::Windows,
             &home,
             appdata.as_deref().map(Path::new),
             data_directory_name,
             product_code,
             build_number,
-        );
+        )
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        return plugins_dir_for_platform(
+        plugins_dir_for_platform(
             JetBrainsPlatform::Linux,
             &home,
             None,
             data_directory_name,
             product_code,
             build_number,
-        );
+        )
     }
 }
 

--- a/src/mdm/jetbrains/detection.rs
+++ b/src/mdm/jetbrains/detection.rs
@@ -3,6 +3,11 @@ use crate::mdm::utils::home_dir;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
+#[cfg(windows)]
+use winreg::{
+    RegKey,
+    enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE},
+};
 
 /// Find all installed JetBrains IDEs on the system
 pub fn find_jetbrains_installations() -> Vec<DetectedIde> {
@@ -206,13 +211,10 @@ fn find_windows_installations() -> Vec<DetectedIde> {
         }
     }
 
-    // Scan Program Files directories
-    let program_dirs = vec![
-        std::env::var("ProgramFiles").ok().map(PathBuf::from),
-        std::env::var("ProgramFiles(x86)").ok().map(PathBuf::from),
-    ];
+    // Scan Program Files directories for JetBrains IDEs and the default Android Studio install.
+    let program_dirs = windows_program_files_dirs();
 
-    for program_dir in program_dirs.into_iter().flatten() {
+    for program_dir in &program_dirs {
         let jetbrains_dir = program_dir.join("JetBrains");
         if jetbrains_dir.exists()
             && let Ok(entries) = std::fs::read_dir(&jetbrains_dir)
@@ -231,6 +233,17 @@ fn find_windows_installations() -> Vec<DetectedIde> {
                     }
                 }
             }
+        }
+    }
+
+    let android_studio = android_studio_ide();
+    for install_path in windows_android_studio_installation_candidates(&program_dirs) {
+        if let Some(detected_ide) = detect_windows_ide(android_studio, &install_path)
+            && !detected
+                .iter()
+                .any(|d| d.install_path == detected_ide.install_path)
+        {
+            detected.push(detected_ide);
         }
     }
 
@@ -455,21 +468,28 @@ fn get_linux_build_metadata(install_path: &Path) -> (Option<String>, Option<u32>
 
 // ===== Shared Utilities =====
 
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum JetBrainsPlatform {
+    Macos,
+    Windows,
+    Linux,
+}
+
 /// Parse the major build number from a build string like "252.12345.67"
 fn parse_major_build(build: &str) -> Option<u32> {
     build.split('.').next()?.parse().ok()
 }
 
-/// Get the plugins directory for an IDE
-fn get_plugins_dir(
+fn plugin_version_suffix(
     data_directory_name: Option<&str>,
     product_code: &str,
     build_number: Option<&str>,
-) -> PathBuf {
+) -> String {
     // Prefer the IDE's real dataDirectoryName from product-info.json when available.
     // This matches the actual config/plugins directory used by modern JetBrains IDEs
     // (for example "IntelliJIdea2026.1"), avoiding incorrect guesses like "IU2026.1".
-    let version_suffix = data_directory_name
+    data_directory_name
         .map(ToOwned::to_owned)
         .or_else(|| {
             build_number.and_then(parse_major_build).map(|major| {
@@ -479,68 +499,427 @@ fn get_plugins_dir(
                 format!("{}{}.{}", product_code, year, minor)
             })
         })
-        .unwrap_or_else(|| product_code.to_string());
+        .unwrap_or_else(|| product_code.to_string())
+}
+
+fn plugins_parent_dir_name(product_code: &str) -> &'static str {
+    match product_code {
+        // Android Studio stores its user directories under Google instead of JetBrains.
+        "AI" => "Google",
+        _ => "JetBrains",
+    }
+}
+
+fn plugins_dir_for_platform(
+    platform: JetBrainsPlatform,
+    home_dir: &Path,
+    appdata: Option<&Path>,
+    data_directory_name: Option<&str>,
+    product_code: &str,
+    build_number: Option<&str>,
+) -> PathBuf {
+    let version_suffix = plugin_version_suffix(data_directory_name, product_code, build_number);
+    let parent_dir = plugins_parent_dir_name(product_code);
+
+    match platform {
+        JetBrainsPlatform::Macos => home_dir
+            .join("Library")
+            .join("Application Support")
+            .join(parent_dir)
+            .join(&version_suffix)
+            .join("plugins"),
+        JetBrainsPlatform::Windows => appdata
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| home_dir.join("AppData").join("Roaming"))
+            .join(parent_dir)
+            .join(&version_suffix)
+            .join("plugins"),
+        // Linux stores user-installed plugins directly in the share directory root.
+        JetBrainsPlatform::Linux => home_dir
+            .join(".local")
+            .join("share")
+            .join(parent_dir)
+            .join(&version_suffix),
+    }
+}
+
+/// Get the plugins directory for an IDE
+fn get_plugins_dir(
+    data_directory_name: Option<&str>,
+    product_code: &str,
+    build_number: Option<&str>,
+) -> PathBuf {
+    let home = home_dir();
 
     #[cfg(target_os = "macos")]
     {
-        home_dir()
-            .join("Library")
-            .join("Application Support")
-            .join("JetBrains")
-            .join(&version_suffix)
-            .join("plugins")
+        return plugins_dir_for_platform(
+            JetBrainsPlatform::Macos,
+            &home,
+            None,
+            data_directory_name,
+            product_code,
+            build_number,
+        );
     }
 
     #[cfg(windows)]
     {
-        if let Ok(appdata) = std::env::var("APPDATA") {
-            PathBuf::from(appdata)
-                .join("JetBrains")
-                .join(&version_suffix)
-                .join("plugins")
-        } else {
-            home_dir()
-                .join("AppData")
-                .join("Roaming")
-                .join("JetBrains")
-                .join(&version_suffix)
-                .join("plugins")
-        }
+        let appdata = std::env::var("APPDATA").ok();
+        return plugins_dir_for_platform(
+            JetBrainsPlatform::Windows,
+            &home,
+            appdata.as_deref().map(Path::new),
+            data_directory_name,
+            product_code,
+            build_number,
+        );
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        home_dir()
-            .join(".local")
-            .join("share")
-            .join("JetBrains")
-            .join(&version_suffix)
-            .join("plugins")
+        return plugins_dir_for_platform(
+            JetBrainsPlatform::Linux,
+            &home,
+            None,
+            data_directory_name,
+            product_code,
+            build_number,
+        );
+    }
+}
+
+#[cfg(windows)]
+fn windows_program_files_dirs() -> Vec<PathBuf> {
+    [
+        std::env::var("ProgramFiles").ok(),
+        std::env::var("ProgramFiles(x86)").ok(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(PathBuf::from)
+    .collect()
+}
+
+#[cfg(windows)]
+fn android_studio_ide() -> &'static JetBrainsIde {
+    JETBRAINS_IDES
+        .iter()
+        .find(|ide| ide.product_code == "AI")
+        .expect("Android Studio must remain in JETBRAINS_IDES")
+}
+
+#[cfg(windows)]
+fn windows_android_studio_installation_candidates(program_dirs: &[PathBuf]) -> Vec<PathBuf> {
+    let mut candidates = default_windows_android_studio_install_paths(program_dirs);
+    for candidate in read_windows_android_studio_registry_candidates() {
+        push_unique_path(&mut candidates, candidate);
+    }
+    candidates
+}
+
+#[cfg(windows)]
+fn default_windows_android_studio_install_paths(program_dirs: &[PathBuf]) -> Vec<PathBuf> {
+    program_dirs
+        .iter()
+        .map(|program_dir| program_dir.join("Android").join("Android Studio"))
+        .collect()
+}
+
+#[cfg(windows)]
+fn read_windows_android_studio_registry_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for hive in [
+        RegKey::predef(HKEY_CURRENT_USER),
+        RegKey::predef(HKEY_LOCAL_MACHINE),
+    ] {
+        for candidate in collect_windows_android_studio_paths_from_hive(&hive) {
+            push_unique_path(&mut candidates, candidate);
+        }
+    }
+    candidates
+}
+
+#[cfg(windows)]
+fn collect_windows_android_studio_paths_from_hive(hive: &RegKey) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Ok(android_studio_key) = hive.open_subkey("Software\\Android Studio")
+        && let Some(path) = read_windows_string_value(&android_studio_key, "Path")
+        && let Some(candidate) = normalize_windows_install_path_candidate(&path)
+    {
+        push_unique_path(&mut candidates, candidate);
+    }
+
+    for uninstall_path in [
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+        "Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+    ] {
+        if let Ok(uninstall_root) = hive.open_subkey(uninstall_path) {
+            for subkey_name in uninstall_root.enum_keys().flatten() {
+                if let Ok(uninstall_entry) = uninstall_root.open_subkey(&subkey_name)
+                    && read_windows_string_value(&uninstall_entry, "DisplayName")
+                        .as_deref()
+                        .is_some_and(|name| name.contains("Android Studio"))
+                {
+                    for value_name in ["InstallLocation", "DisplayIcon"] {
+                        if let Some(value) = read_windows_string_value(&uninstall_entry, value_name)
+                            && let Some(candidate) =
+                                normalize_windows_install_path_candidate(&value)
+                        {
+                            push_unique_path(&mut candidates, candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    candidates
+}
+
+#[cfg(windows)]
+fn read_windows_string_value(key: &RegKey, value_name: &str) -> Option<String> {
+    key.get_value::<String, _>(value_name)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+#[cfg(windows)]
+fn normalize_windows_install_path_candidate(raw_value: &str) -> Option<PathBuf> {
+    let trimmed = raw_value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let path = if let Some(quoted) = trimmed.strip_prefix('"') {
+        let end_quote = quoted.find('"')?;
+        PathBuf::from(&quoted[..end_quote])
+    } else {
+        PathBuf::from(trimmed.split(',').next().unwrap_or(trimmed).trim())
+    };
+
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase());
+
+    match file_name.as_deref() {
+        Some("studio.exe") | Some("studio64.exe") => path.parent()?.parent().map(Path::to_path_buf),
+        Some("bin") => path.parent().map(Path::to_path_buf),
+        Some(_) if path.extension().is_some() => None,
+        _ => Some(path),
+    }
+}
+
+#[cfg(windows)]
+fn push_unique_path(paths: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if !paths.iter().any(|path| path == &candidate) {
+        paths.push(candidate);
     }
 }
 
 /// Check if the Git AI plugin is installed for a detected IDE
 pub fn is_plugin_installed(detected: &DetectedIde) -> bool {
-    let plugin_dir = detected.plugins_dir.join("git-ai-intellij");
-    plugin_dir.exists()
+    // Support both the legacy extracted directory name and the Marketplace-installed
+    // directory name that JetBrains/Android Studio writes on disk.
+    ["git-ai-intellij", "Git AI"]
+        .into_iter()
+        .map(|dir_name| detected.plugins_dir.join(dir_name))
+        .any(|plugin_dir| plugin_dir.exists())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::get_plugins_dir;
+    use super::*;
     use std::path::PathBuf;
 
     #[test]
-    fn test_get_plugins_dir_prefers_product_info_data_directory_name() {
-        let plugins_dir = get_plugins_dir(Some("IntelliJIdea2026.1"), "IU", Some("261.22158.277"));
-        let expected_suffix = PathBuf::from("IntelliJIdea2026.1").join("plugins");
-        assert!(plugins_dir.ends_with(&expected_suffix));
+    fn test_plugin_version_suffix_prefers_product_info_data_directory_name() {
+        let version_suffix =
+            plugin_version_suffix(Some("IntelliJIdea2026.1"), "IU", Some("261.22158.277"));
+        assert_eq!(version_suffix, "IntelliJIdea2026.1");
     }
 
     #[test]
-    fn test_get_plugins_dir_falls_back_to_product_code_when_data_directory_name_missing() {
-        let plugins_dir = get_plugins_dir(None, "IU", Some("252.27397.103"));
-        let expected_suffix = PathBuf::from("IU2025.2").join("plugins");
-        assert!(plugins_dir.ends_with(&expected_suffix));
+    fn test_plugin_version_suffix_falls_back_to_product_code_when_data_directory_name_missing() {
+        let version_suffix = plugin_version_suffix(None, "IU", Some("252.27397.103"));
+        assert_eq!(version_suffix, "IU2025.2");
+    }
+
+    #[test]
+    fn test_plugins_dir_for_windows_keeps_jetbrains_parent_for_regular_ides() {
+        let plugins_dir = plugins_dir_for_platform(
+            JetBrainsPlatform::Windows,
+            Path::new("home"),
+            Some(Path::new("appdata")),
+            Some("IntelliJIdea2026.1"),
+            "IU",
+            Some("261.22158.277"),
+        );
+        assert_eq!(
+            plugins_dir,
+            PathBuf::from("appdata")
+                .join("JetBrains")
+                .join("IntelliJIdea2026.1")
+                .join("plugins")
+        );
+    }
+
+    #[test]
+    fn test_plugins_dir_for_windows_uses_google_parent_for_android_studio() {
+        let plugins_dir = plugins_dir_for_platform(
+            JetBrainsPlatform::Windows,
+            Path::new("home"),
+            Some(Path::new("appdata")),
+            Some("AndroidStudio2025.3.3"),
+            "AI",
+            Some("253.31033.145"),
+        );
+        assert_eq!(
+            plugins_dir,
+            PathBuf::from("appdata")
+                .join("Google")
+                .join("AndroidStudio2025.3.3")
+                .join("plugins")
+        );
+    }
+
+    #[test]
+    fn test_plugins_dir_for_macos_uses_google_parent_for_android_studio() {
+        let plugins_dir = plugins_dir_for_platform(
+            JetBrainsPlatform::Macos,
+            Path::new("home"),
+            None,
+            Some("AndroidStudio2025.3.3"),
+            "AI",
+            Some("253.31033.145"),
+        );
+        assert_eq!(
+            plugins_dir,
+            PathBuf::from("home")
+                .join("Library")
+                .join("Application Support")
+                .join("Google")
+                .join("AndroidStudio2025.3.3")
+                .join("plugins")
+        );
+    }
+
+    #[test]
+    fn test_plugins_dir_for_linux_uses_google_parent_for_android_studio_without_plugins_suffix() {
+        let plugins_dir = plugins_dir_for_platform(
+            JetBrainsPlatform::Linux,
+            Path::new("home"),
+            None,
+            Some("AndroidStudio2025.3.3"),
+            "AI",
+            Some("253.31033.145"),
+        );
+        assert_eq!(
+            plugins_dir,
+            PathBuf::from("home")
+                .join(".local")
+                .join("share")
+                .join("Google")
+                .join("AndroidStudio2025.3.3")
+        );
+    }
+
+    #[test]
+    fn test_plugins_dir_for_linux_keeps_documented_jetbrains_plugins_root() {
+        let plugins_dir = plugins_dir_for_platform(
+            JetBrainsPlatform::Linux,
+            Path::new("home"),
+            None,
+            Some("WebStorm2026.1"),
+            "WS",
+            Some("261.24980.77"),
+        );
+        assert_eq!(
+            plugins_dir,
+            PathBuf::from("home")
+                .join(".local")
+                .join("share")
+                .join("JetBrains")
+                .join("WebStorm2026.1")
+        );
+    }
+
+    #[test]
+    fn test_is_plugin_installed_detects_legacy_extracted_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("git-ai-intellij")).unwrap();
+
+        let detected = DetectedIde {
+            ide: &JETBRAINS_IDES[0],
+            install_path: PathBuf::from("install"),
+            binary_path: PathBuf::from("binary"),
+            build_number: Some("261.22158.277".to_string()),
+            major_build: Some(261),
+            plugins_dir: temp.path().to_path_buf(),
+        };
+
+        assert!(is_plugin_installed(&detected));
+    }
+
+    #[test]
+    fn test_is_plugin_installed_detects_marketplace_directory_name() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("Git AI")).unwrap();
+
+        let detected = DetectedIde {
+            ide: &JETBRAINS_IDES[0],
+            install_path: PathBuf::from("install"),
+            binary_path: PathBuf::from("binary"),
+            build_number: Some("261.22158.277".to_string()),
+            major_build: Some(261),
+            plugins_dir: temp.path().to_path_buf(),
+        };
+
+        assert!(is_plugin_installed(&detected));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_default_windows_android_studio_install_paths_cover_both_program_files_roots() {
+        let program_dirs = vec![
+            PathBuf::from(r"C:\Program Files"),
+            PathBuf::from(r"C:\Program Files (x86)"),
+        ];
+        let candidates = default_windows_android_studio_install_paths(&program_dirs);
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from(r"C:\Program Files\Android\Android Studio"),
+                PathBuf::from(r"C:\Program Files (x86)\Android\Android Studio"),
+            ]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_normalize_windows_install_path_candidate_accepts_install_root() {
+        assert_eq!(
+            normalize_windows_install_path_candidate(r"D:\software\as"),
+            Some(PathBuf::from(r"D:\software\as"))
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_normalize_windows_install_path_candidate_strips_bin_and_executable_suffixes() {
+        assert_eq!(
+            normalize_windows_install_path_candidate(r"D:\software\as\bin"),
+            Some(PathBuf::from(r"D:\software\as"))
+        );
+        assert_eq!(
+            normalize_windows_install_path_candidate(r#""D:\software\as\bin\studio64.exe",0"#),
+            Some(PathBuf::from(r"D:\software\as"))
+        );
+        assert_eq!(
+            normalize_windows_install_path_candidate(r"D:\software\as\bin\studio.exe"),
+            Some(PathBuf::from(r"D:\software\as"))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- fix macOS JetBrains plugin path resolution for Android Studio
- use the IDE's Google-scoped plugins directory instead of the generic JetBrains parent
- add a regression test for the Android Studio macOS path

## What bug does this fix?
Android Studio is already listed as a supported JetBrains IDE, but on macOS its plugins live under `~/Library/Application Support/Google/<dataDirectoryName>/plugins`.

The current code always uses `~/Library/Application Support/JetBrains/...`, so git-ai can install/check the plugin in the wrong directory for Android Studio. This means the plugin may appear missing or fail to load even though installation reported success.

This change keeps the existing behavior for other JetBrains IDEs and only switches Android Studio to the Google-scoped parent directory on macOS.