### PR TITLE
fix(xcode): fix crashes, deadlocks, and path handling in FSEvents watcher

### DIFF
--- a/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
+++ b/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
@@ -2,10 +2,9 @@ import Foundation
 import CoreServices
 
 // MARK: - Globals
-var watchedPaths: [String] = []
-var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [path: content]
-var debounceItems: [String: DispatchWorkItem] = []  // repoRoot -> work item
-var repoRootCache: [String: String?] = [:]          // dir -> repoRoot (nil = not a repo)
+var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [relPath: content]
+var debounceItems: [String: DispatchWorkItem] = [:]  // repoRoot -> work item
+var repoRootCache: [String: String?] = [:]           // dir -> repoRoot (nil = not a repo)
 let queue = DispatchQueue(label: "io.gitai.xcode-watcher", qos: .utility)
 let gitAiBin: String = {
     let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -25,12 +24,18 @@ func findRepoRoot(for filePath: String) -> String? {
     proc.arguments = ["-C", dir, "rev-parse", "--show-toplevel"]
     let pipe = Pipe()
     proc.standardOutput = pipe
-    proc.standardError = Pipe()
-    try? proc.run()
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+    } catch {
+        repoRootCache[dir] = nil
+        return nil
+    }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
     proc.waitUntilExit()
     let result: String?
     if proc.terminationStatus == 0 {
-        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+        let out = String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         result = out?.isEmpty == false ? out : nil
     } else {
@@ -45,8 +50,17 @@ func readFileContents(_ path: String) -> String? {
 }
 
 func shouldSkip(_ path: String) -> Bool {
-    let skip = ["/.git/", "/DerivedData/", "/xcuserdata/", "/.build/", ".DS_Store"]
+    let skip = ["/.git/", "/DerivedData/", "/xcuserdata/", "/.build/", ".DS_Store",
+                "/.swiftpm/", "/Pods/"]
     return skip.contains { path.contains($0) }
+}
+
+func relativePath(_ absolutePath: String, in repoRoot: String) -> String {
+    let root = repoRoot.hasSuffix("/") ? repoRoot : repoRoot + "/"
+    if absolutePath.hasPrefix(root) {
+        return String(absolutePath.dropFirst(root.count))
+    }
+    return absolutePath
 }
 
 func fireCheckpoint(repoRoot: String) {
@@ -71,9 +85,14 @@ func fireCheckpoint(repoRoot: String) {
     proc.currentDirectoryURL = URL(fileURLWithPath: repoRoot)
     let stdinPipe = Pipe()
     proc.standardInput = stdinPipe
-    proc.standardOutput = Pipe()
-    proc.standardError = Pipe()
-    try? proc.run()
+    proc.standardOutput = FileHandle.nullDevice
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+    } catch {
+        fputs("git-ai-xcode-watcher: failed to run git-ai: \(error)\n", stderr)
+        return
+    }
     stdinPipe.fileHandleForWriting.write(jsonStr.data(using: .utf8)!)
     stdinPipe.fileHandleForWriting.closeFile()
     proc.waitUntilExit()
@@ -90,7 +109,6 @@ func scheduleDebounce(repoRoot: String) {
 // MARK: - FSEvents callback
 let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
     guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String] else { return }
-    // Collect candidate file paths on the RunLoop thread (cheap checks only).
     var candidates: [String] = []
     for path in paths {
         guard !shouldSkip(path) else { continue }
@@ -100,16 +118,14 @@ let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
         candidates.append(path)
     }
     guard !candidates.isEmpty else { return }
-    // Dispatch all heavy work (git subprocess, file reads, debounce scheduling) onto `queue`
-    // so that `pendingFiles`, `debounceItems`, and `repoRootCache` are only accessed from
-    // a single serial queue, eliminating data races.
     queue.async {
         var roots = Set<String>()
         for path in candidates {
             guard let root = findRepoRoot(for: path) else { continue }
             guard let content = readFileContents(path) else { continue }
+            let relPath = relativePath(path, in: root)
             if pendingFiles[root] == nil { pendingFiles[root] = [:] }
-            pendingFiles[root]![path] = content
+            pendingFiles[root]![relPath] = content
             roots.insert(root)
         }
         for root in roots { scheduleDebounce(repoRoot: root) }
@@ -119,17 +135,16 @@ let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
 // MARK: - Main
 var args = CommandLine.arguments.dropFirst()
 var paths: [String] = []
-var i = args.startIndex
-while i < args.endIndex {
-    if args[i] == "--path", args.index(after: i) < args.endIndex {
-        i = args.index(after: i)
-        paths.append(args[i])
+var idx = args.startIndex
+while idx < args.endIndex {
+    if args[idx] == "--path", args.index(after: idx) < args.endIndex {
+        idx = args.index(after: idx)
+        paths.append(args[idx])
     }
-    i = args.index(after: i)
+    idx = args.index(after: idx)
 }
 if paths.isEmpty { paths = [FileManager.default.currentDirectoryPath] }
 
-// Canonicalize paths
 let watchPaths = paths.map { ($0 as NSString).standardizingPath } as CFArray
 
 var context = FSEventStreamContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
@@ -140,7 +155,11 @@ guard let stream = FSEventStreamCreate(
     watchPaths,
     FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
     0.1,
-    FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer)
+    FSEventStreamCreateFlags(
+        kFSEventStreamCreateFlagFileEvents |
+        kFSEventStreamCreateFlagNoDefer |
+        kFSEventStreamCreateFlagUseCFTypes
+    )
 ) else {
     fputs("git-ai-xcode-watcher: failed to create FSEvents stream\n", stderr)
     exit(1)
@@ -148,5 +167,5 @@ guard let stream = FSEventStreamCreate(
 
 FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
 FSEventStreamStart(stream)
-print("git-ai-xcode-watcher: watching \(paths.joined(separator: ", "))")
+fputs("git-ai-xcode-watcher: watching \(paths.joined(separator: ", "))\n", stderr)
 CFRunLoopRun()


### PR DESCRIPTION
## Summary

Fixes several critical bugs in the Xcode FSEvents watcher that were discovered during local end-to-end testing on macOS.

## Changes

- **Add `kFSEventStreamCreateFlagUseCFTypes` flag**: Without this flag, `eventPaths` is a raw C array instead of a `CFArray`, causing the `Unmanaged<CFArray>` cast to read garbage or crash.

- **Fix crash from `try? proc.run()` + `waitUntilExit()`**: Replace silent `try?` with `do/catch`; calling `waitUntilExit()` on a process that failed to launch is undefined behavior.

- **Fix pipe deadlock**: Use `FileHandle.nullDevice` instead of unread `Pipe()` for stdout/stderr of spawned `git-ai` processes. If the child writes more than the pipe buffer (~64 KB), it deadlocks.

- **Fix `findRepoRoot` potential hang**: Read pipe data before `waitUntilExit()` to avoid blocking when the buffer is full, and handle launch failure gracefully.

- **Convert absolute paths to repo-relative paths**: FSEvents provides absolute file paths, but `git-ai` expects relative paths in `edited_filepaths` and `dirty_files` JSON fields. Without conversion, `dirty_files` content lookups fail silently.

- **Expand skip list**: Add `/.swiftpm/` and `/Pods/` to the ignored path patterns.

- **Use stderr for status output**: Replace `print()` with `fputs(..., stderr)` to avoid polluting structured output.

## Testing

Tested locally on macOS 14.6 (Apple Silicon) with:
- Swift 6.1 / Xcode 16.2
- `git-ai` v1.3.2
- Real Xcode project with `.swift` files
- Verified `known_human` checkpoints are created correctly
- Verified `h_` attestation appears in `git log --notes=ai`
- Verified `git-ai stats --json` reports correct `human_additions`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
