### PR TITLE
feat(xcode): integrate watcher install and path management

### DIFF
--- a/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
+++ b/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
@@ -28,7 +28,7 @@ func findRepoRoot(for filePath: String) -> String? {
     do {
         try proc.run()
     } catch {
-        repoRootCache[dir] = nil
+        repoRootCache.updateValue(nil, forKey: dir)
         return nil
     }
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
@@ -41,7 +41,7 @@ func findRepoRoot(for filePath: String) -> String? {
     } else {
         result = nil
     }
-    repoRootCache[dir] = result
+    repoRootCache.updateValue(result, forKey: dir)
     return result
 }
 

--- a/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
+++ b/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
@@ -2,10 +2,9 @@ import Foundation
 import CoreServices
 
 // MARK: - Globals
-var watchedPaths: [String] = []
-var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [path: content]
-var debounceItems: [String: DispatchWorkItem] = []  // repoRoot -> work item
-var repoRootCache: [String: String?] = [:]          // dir -> repoRoot (nil = not a repo)
+var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [relPath: content]
+var debounceItems: [String: DispatchWorkItem] = [:]  // repoRoot -> work item
+var repoRootCache: [String: String?] = [:]           // dir -> repoRoot (nil = not a repo)
 let queue = DispatchQueue(label: "io.gitai.xcode-watcher", qos: .utility)
 let gitAiBin: String = {
     let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -25,12 +24,18 @@ func findRepoRoot(for filePath: String) -> String? {
     proc.arguments = ["-C", dir, "rev-parse", "--show-toplevel"]
     let pipe = Pipe()
     proc.standardOutput = pipe
-    proc.standardError = Pipe()
-    try? proc.run()
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+    } catch {
+        repoRootCache[dir] = nil
+        return nil
+    }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
     proc.waitUntilExit()
     let result: String?
     if proc.terminationStatus == 0 {
-        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+        let out = String(data: data, encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         result = out?.isEmpty == false ? out : nil
     } else {
@@ -45,8 +50,17 @@ func readFileContents(_ path: String) -> String? {
 }
 
 func shouldSkip(_ path: String) -> Bool {
-    let skip = ["/.git/", "/DerivedData/", "/xcuserdata/", "/.build/", ".DS_Store"]
+    let skip = ["/.git/", "/DerivedData/", "/xcuserdata/", "/.build/", ".DS_Store",
+                "/.swiftpm/", "/Pods/"]
     return skip.contains { path.contains($0) }
+}
+
+func relativePath(_ absolutePath: String, in repoRoot: String) -> String {
+    let root = repoRoot.hasSuffix("/") ? repoRoot : repoRoot + "/"
+    if absolutePath.hasPrefix(root) {
+        return String(absolutePath.dropFirst(root.count))
+    }
+    return absolutePath
 }
 
 func fireCheckpoint(repoRoot: String) {
@@ -71,9 +85,14 @@ func fireCheckpoint(repoRoot: String) {
     proc.currentDirectoryURL = URL(fileURLWithPath: repoRoot)
     let stdinPipe = Pipe()
     proc.standardInput = stdinPipe
-    proc.standardOutput = Pipe()
-    proc.standardError = Pipe()
-    try? proc.run()
+    proc.standardOutput = FileHandle.nullDevice
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+    } catch {
+        fputs("git-ai-xcode-watcher: failed to run git-ai: \(error)\n", stderr)
+        return
+    }
     stdinPipe.fileHandleForWriting.write(jsonStr.data(using: .utf8)!)
     stdinPipe.fileHandleForWriting.closeFile()
     proc.waitUntilExit()
@@ -90,7 +109,6 @@ func scheduleDebounce(repoRoot: String) {
 // MARK: - FSEvents callback
 let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
     guard let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as? [String] else { return }
-    // Collect candidate file paths on the RunLoop thread (cheap checks only).
     var candidates: [String] = []
     for path in paths {
         guard !shouldSkip(path) else { continue }
@@ -100,16 +118,14 @@ let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
         candidates.append(path)
     }
     guard !candidates.isEmpty else { return }
-    // Dispatch all heavy work (git subprocess, file reads, debounce scheduling) onto `queue`
-    // so that `pendingFiles`, `debounceItems`, and `repoRootCache` are only accessed from
-    // a single serial queue, eliminating data races.
     queue.async {
         var roots = Set<String>()
         for path in candidates {
             guard let root = findRepoRoot(for: path) else { continue }
             guard let content = readFileContents(path) else { continue }
+            let relPath = relativePath(path, in: root)
             if pendingFiles[root] == nil { pendingFiles[root] = [:] }
-            pendingFiles[root]![path] = content
+            pendingFiles[root]![relPath] = content
             roots.insert(root)
         }
         for root in roots { scheduleDebounce(repoRoot: root) }
@@ -119,17 +135,16 @@ let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
 // MARK: - Main
 var args = CommandLine.arguments.dropFirst()
 var paths: [String] = []
-var i = args.startIndex
-while i < args.endIndex {
-    if args[i] == "--path", args.index(after: i) < args.endIndex {
-        i = args.index(after: i)
-        paths.append(args[i])
+var idx = args.startIndex
+while idx < args.endIndex {
+    if args[idx] == "--path", args.index(after: idx) < args.endIndex {
+        idx = args.index(after: idx)
+        paths.append(args[idx])
     }
-    i = args.index(after: i)
+    idx = args.index(after: idx)
 }
 if paths.isEmpty { paths = [FileManager.default.currentDirectoryPath] }
 
-// Canonicalize paths
 let watchPaths = paths.map { ($0 as NSString).standardizingPath } as CFArray
 
 var context = FSEventStreamContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
@@ -140,7 +155,11 @@ guard let stream = FSEventStreamCreate(
     watchPaths,
     FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
     0.1,
-    FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer)
+    FSEventStreamCreateFlags(
+        kFSEventStreamCreateFlagFileEvents |
+        kFSEventStreamCreateFlagNoDefer |
+        kFSEventStreamCreateFlagUseCFTypes
+    )
 ) else {
     fputs("git-ai-xcode-watcher: failed to create FSEvents stream\n", stderr)
     exit(1)
@@ -148,5 +167,5 @@ guard let stream = FSEventStreamCreate(
 
 FSEventStreamScheduleWithRunLoop(stream, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue)
 FSEventStreamStart(stream)
-print("git-ai-xcode-watcher: watching \(paths.joined(separator: ", "))")
+fputs("git-ai-xcode-watcher: watching \(paths.joined(separator: ", "))\n", stderr)
 CFRunLoopRun()

--- a/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
+++ b/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreServices
 
 // MARK: - Globals
-var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [relPath: content]
+var pendingFiles: [String: [String: String]] = [:]  // repoRoot -> [absPath: content]
 var debounceItems: [String: DispatchWorkItem] = [:]  // repoRoot -> work item
 var repoRootCache: [String: String?] = [:]           // dir -> repoRoot (nil = not a repo)
 let queue = DispatchQueue(label: "io.gitai.xcode-watcher", qos: .utility)
@@ -53,14 +53,6 @@ func shouldSkip(_ path: String) -> Bool {
     let skip = ["/.git/", "/DerivedData/", "/xcuserdata/", "/.build/", ".DS_Store",
                 "/.swiftpm/", "/Pods/"]
     return skip.contains { path.contains($0) }
-}
-
-func relativePath(_ absolutePath: String, in repoRoot: String) -> String {
-    let root = repoRoot.hasSuffix("/") ? repoRoot : repoRoot + "/"
-    if absolutePath.hasPrefix(root) {
-        return String(absolutePath.dropFirst(root.count))
-    }
-    return absolutePath
 }
 
 func fireCheckpoint(repoRoot: String) {
@@ -123,9 +115,9 @@ let callback: FSEventStreamCallback = { (_, _, numEvents, eventPaths, _, _) in
         for path in candidates {
             guard let root = findRepoRoot(for: path) else { continue }
             guard let content = readFileContents(path) else { continue }
-            let relPath = relativePath(path, in: root)
+            let absolutePath = (path as NSString).standardizingPath
             if pendingFiles[root] == nil { pendingFiles[root] = [:] }
-            pendingFiles[root]![relPath] = content
+            pendingFiles[root]![absolutePath] = content
             roots.insert(root)
         }
         for root in roots { scheduleDebounce(repoRoot: root) }

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -53,6 +53,12 @@ const AGENT_USAGE_MIN_INTERVAL_SECS: u64 = 150;
 #[cfg(not(any(test, feature = "test-support")))]
 const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 1;
 
+/// When an AI checkpoint arrives, reclaim files from any KnownHuman checkpoint
+/// that fired within this window. This handles the Xcode watcher race condition
+/// where FSEvents triggers a KnownHuman checkpoint on AI-written files before
+/// the AI tool sends its own checkpoint.
+const AI_RECLAIM_FROM_KNOWN_HUMAN_WINDOW_SECS: u64 = 10;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PreparedPathRole {
@@ -828,6 +834,45 @@ fn execute_resolved_checkpoint(
         resolved.files.len(),
         save_states_start.elapsed()
     ));
+
+    // AI Reclaim: When an AI checkpoint arrives, remove entries for the same files
+    // from recent KnownHuman checkpoints IF:
+    //   1. The KnownHuman has known_human_metadata (production checkpoint from a
+    //      real editor/watcher, not a test mock). Note: production KnownHuman
+    //      checkpoints store editor info in `known_human_metadata`, NOT in
+    //      `agent_metadata` (which is only set for AI checkpoints).
+    //   2. It occurred within the reclaim time window
+    //   3. The content hashes match (KnownHuman captured the EXACT same content)
+    // This handles the Xcode/FSEvents watcher race where the watcher fires a
+    // KnownHuman checkpoint on AI-written files before the AI tool sends its own
+    // checkpoint. By removing those entries, the AI checkpoint diffs against the
+    // pre-KnownHuman state, correctly attributing AI-written code. The KnownHuman
+    // entries remain in the persisted JSONL, but post-commit's HashMap::insert
+    // ensures the later AI entry takes precedence.
+    if kind.is_ai() {
+        let current_ts_secs = (resolved.ts / 1000) as u64;
+        for cp in &mut checkpoints {
+            if cp.kind == CheckpointKind::KnownHuman && cp.known_human_metadata.is_some() {
+                let time_diff = current_ts_secs.saturating_sub(cp.timestamp);
+                if time_diff < AI_RECLAIM_FROM_KNOWN_HUMAN_WINDOW_SECS {
+                    let before_len = cp.entries.len();
+                    cp.entries.retain(|e| {
+                        !matches!(
+                            file_content_hashes.get(&e.file),
+                            Some(ai_content_hash) if e.blob_sha == *ai_content_hash
+                        )
+                    });
+                    let removed = before_len - cp.entries.len();
+                    if removed > 0 {
+                        debug_log(&format!(
+                            "[AI Reclaim] Removed {} KnownHuman entries with matching content (time_diff={}s)",
+                            removed, time_diff
+                        ));
+                    }
+                }
+            }
+        }
+    }
 
     let hash_compute_start = Instant::now();
     let mut ordered_hashes: Vec<_> = file_content_hashes.iter().collect();

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,8 +1,11 @@
 use dirs;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::git::repository::find_repository_in_path;
+#[cfg(target_os = "macos")]
+use crate::mdm::agents::XcodeInstaller;
 
 /// Determines the type of pattern value provided
 #[derive(Debug, PartialEq)]
@@ -97,6 +100,7 @@ fn print_config_help() {
     eprintln!();
     eprintln!("Configuration Keys:");
     eprintln!("  git_path                     Path to git binary");
+    eprintln!("  xcode_paths                  Xcode watcher workspace roots (array)");
     eprintln!("  exclude_prompts_in_repositories  Repos to exclude prompts from (array)");
     eprintln!("  allow_repositories           Allowed repos (array)");
     eprintln!("  exclude_repositories         Excluded repos (array)");
@@ -126,6 +130,7 @@ fn print_config_help() {
     eprintln!("  git-ai config set exclude_repositories .         # Uses current repo's remotes");
     eprintln!("  git-ai config --add exclude_repositories \"temp/*\"");
     eprintln!("  git-ai config --add allow_repositories ~/projects/my-repo");
+    eprintln!("  git-ai config --add xcode_paths ~/work/ios");
     eprintln!("  git-ai config --add feature_flags.my_flag true");
     eprintln!("  git-ai config --add git_ai_hooks.post_notes_updated \"./my-hook.sh\"");
     eprintln!("  git-ai config unset exclude_repositories");
@@ -225,6 +230,15 @@ fn show_all_config() -> Result<(), String> {
         "git_path".to_string(),
         Value::String(runtime_config.git_cmd().to_string()),
     );
+
+    if let Some(ref paths) = file_config.xcode_paths {
+        effective_config.insert(
+            "xcode_paths".to_string(),
+            serde_json::to_value(paths).unwrap(),
+        );
+    } else {
+        effective_config.insert("xcode_paths".to_string(), Value::Array(vec![]));
+    }
 
     // Arrays
     if let Some(ref repos) = file_config.exclude_prompts_in_repositories {
@@ -341,6 +355,13 @@ fn get_config_value(key: &str) -> Result<(), String> {
     if key_path.len() == 1 {
         let value = match key_path[0].as_str() {
             "git_path" => Value::String(runtime_config.git_cmd().to_string()),
+            "xcode_paths" => {
+                if let Some(ref paths) = file_config.xcode_paths {
+                    serde_json::to_value(paths).unwrap()
+                } else {
+                    Value::Array(vec![])
+                }
+            }
             "exclude_prompts_in_repositories" => {
                 if let Some(ref repos) = file_config.exclude_prompts_in_repositories {
                     serde_json::to_value(repos).unwrap()
@@ -449,6 +470,11 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.git_path = Some(value.to_string());
                 crate::config::save_file_config(&file_config)?;
                 eprintln!("[git_path]: {}", value);
+            }
+            "xcode_paths" => {
+                let added = set_xcode_paths_field(&mut file_config.xcode_paths, value, add_mode)?;
+                crate::config::save_file_config(&file_config)?;
+                log_array_changes(&added, add_mode);
             }
             "exclude_prompts_in_repositories" => {
                 let added = set_repository_array_field(
@@ -683,6 +709,13 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                     eprintln!("- [git_path]: {}", v);
                 }
             }
+            "xcode_paths" => {
+                let old_values = file_config.xcode_paths.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(items) = old_values {
+                    log_array_removals(&items);
+                }
+            }
             "exclude_prompts_in_repositories" => {
                 let old_values = file_config.exclude_prompts_in_repositories.take();
                 crate::config::save_file_config(&file_config)?;
@@ -883,6 +916,68 @@ fn parse_key_path(key: &str) -> Vec<String> {
     key.split('.').map(|s| s.to_string()).collect()
 }
 
+#[cfg(target_os = "macos")]
+fn set_xcode_paths_field(
+    field: &mut Option<Vec<String>>,
+    value: &str,
+    add_mode: bool,
+) -> Result<Vec<String>, String> {
+    let mut existing_paths = if add_mode {
+        let file_config = crate::config::FileConfig {
+            xcode_paths: field.clone(),
+            ..Default::default()
+        };
+        XcodeInstaller::configured_paths_from_file_config(&file_config)?
+    } else {
+        Vec::new()
+    };
+
+    let values_to_apply = if value.starts_with('[') {
+        let json_value: Value =
+            serde_json::from_str(value).map_err(|e| format!("Invalid JSON array: {}", e))?;
+        let array = json_value
+            .as_array()
+            .ok_or_else(|| "Expected a JSON array".to_string())?;
+
+        let mut paths = Vec::new();
+        for item in array {
+            let raw = item
+                .as_str()
+                .ok_or_else(|| "Array must contain only strings".to_string())?;
+            paths.push(XcodeInstaller::validate_new_watch_path(Path::new(raw))?);
+        }
+        paths
+    } else {
+        vec![XcodeInstaller::validate_new_watch_path(Path::new(value))?]
+    };
+
+    if add_mode {
+        existing_paths.extend(values_to_apply);
+        existing_paths = XcodeInstaller::normalize_watch_paths(existing_paths);
+        *field = XcodeInstaller::serialize_watch_paths(&existing_paths);
+        Ok(existing_paths
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect())
+    } else {
+        let normalized = XcodeInstaller::normalize_watch_paths(values_to_apply);
+        *field = XcodeInstaller::serialize_watch_paths(&normalized);
+        Ok(normalized
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_xcode_paths_field(
+    _field: &mut Option<Vec<String>>,
+    _value: &str,
+    _add_mode: bool,
+) -> Result<Vec<String>, String> {
+    Err("xcode_paths can only be configured on macOS".to_string())
+}
+
 /// Set array field for repository patterns (exclude_repositories, allow_repositories, exclude_prompts_in_repositories)
 /// This function handles the special logic of detecting if a value is:
 ///  - A global wildcard pattern like "*"
@@ -1080,6 +1175,34 @@ fn validate_prompt_storage_value(value: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let temp = tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+        }
+
+        f(&home);
+
+        unsafe {
+            match prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
 
     #[test]
     fn test_prompt_storage_valid_values() {
@@ -1254,6 +1377,37 @@ mod tests {
     fn test_parse_key_path_empty() {
         let result = parse_key_path("");
         assert_eq!(result, vec![""]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_set_xcode_paths_field_canonicalizes_and_collapses() {
+        with_temp_home(|home| {
+            let parent = home.join("ios");
+            let child = parent.join("AppA");
+            std::fs::create_dir_all(&child).unwrap();
+
+            let mut field = Some(vec![child.to_string_lossy().to_string()]);
+            let updated =
+                set_xcode_paths_field(&mut field, parent.to_str().unwrap(), true).unwrap();
+
+            let expected = std::fs::canonicalize(parent).unwrap();
+            assert_eq!(field, Some(vec![expected.to_string_lossy().to_string()]));
+            assert_eq!(updated, vec![expected.to_string_lossy().to_string()]);
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_set_xcode_paths_field_rejects_home_directory() {
+        with_temp_home(|home| {
+            let mut field = None;
+            let error =
+                set_xcode_paths_field(&mut field, home.to_str().unwrap(), true).unwrap_err();
+            assert!(error.contains("HOME directory"));
+        });
     }
 
     #[test]

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -952,11 +952,13 @@ fn set_xcode_paths_field(
     };
 
     if add_mode {
+        let original_existing = existing_paths.clone();
         existing_paths.extend(values_to_apply);
         existing_paths = XcodeInstaller::normalize_watch_paths(existing_paths);
         *field = XcodeInstaller::serialize_watch_paths(&existing_paths);
         Ok(existing_paths
             .iter()
+            .filter(|path| !original_existing.contains(path))
             .map(|path| path.to_string_lossy().to_string())
             .collect())
     } else {
@@ -1395,6 +1397,36 @@ mod tests {
             let expected = std::fs::canonicalize(parent).unwrap();
             assert_eq!(field, Some(vec![expected.to_string_lossy().to_string()]));
             assert_eq!(updated, vec![expected.to_string_lossy().to_string()]);
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_set_xcode_paths_field_add_mode_returns_only_new_paths() {
+        with_temp_home(|home| {
+            let parent = home.join("ios");
+            let existing_child = parent.join("AppA");
+            let new_child = parent.join("AppB");
+            std::fs::create_dir_all(&existing_child).unwrap();
+            std::fs::create_dir_all(&new_child).unwrap();
+
+            let mut field = Some(vec![existing_child.to_string_lossy().to_string()]);
+            let added =
+                set_xcode_paths_field(&mut field, new_child.to_str().unwrap(), true).unwrap();
+
+            let expected_added = std::fs::canonicalize(new_child).unwrap();
+            assert_eq!(
+                field,
+                Some(vec![
+                    std::fs::canonicalize(existing_child)
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string(),
+                    expected_added.to_string_lossy().to_string(),
+                ])
+            );
+            assert_eq!(added, vec![expected_added.to_string_lossy().to_string()]);
         });
     }
 

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -62,6 +62,7 @@ pub fn handle_git_ai(args: &[String]) {
                 | "install-hooks"
                 | "install"
                 | "uninstall-hooks"
+                | "xcode"
         );
         if needs_daemon {
             use crate::daemon::telemetry_handle::{
@@ -106,6 +107,12 @@ pub fn handle_git_ai(args: &[String]) {
             commands::config::handle_config(&args[1..]);
             if is_interactive_terminal() {
                 log_message("config", "info", None)
+            }
+        }
+        "xcode" => {
+            commands::xcode::handle_xcode(&args[1..]);
+            if is_interactive_terminal() {
+                log_message("xcode", "info", None)
             }
         }
         "debug" => {
@@ -306,6 +313,11 @@ fn print_help() {
     eprintln!("    set <key> <value>     Set a config value (arrays: single value = [value])");
     eprintln!("    --add <key> <value>   Add to array or upsert into object");
     eprintln!("    unset <key>           Remove config value (reverts to default)");
+    eprintln!("  xcode              Manage Xcode watcher paths and launch agent");
+    eprintln!("    add-path <path>       Register a workspace root and reload watcher");
+    eprintln!("    remove-path <path>    Remove a workspace root and reload watcher");
+    eprintln!("    list-paths            Show configured Xcode watcher roots");
+    eprintln!("    reload                Rebuild LaunchAgent from current config");
     eprintln!("  debug              Print support/debug diagnostics");
     eprintln!("  bg                 Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -32,3 +32,4 @@ pub mod status;
 pub mod sync_prompts;
 pub mod upgrade;
 pub mod whoami;
+pub mod xcode;

--- a/src/commands/xcode.rs
+++ b/src/commands/xcode.rs
@@ -1,0 +1,313 @@
+use crate::config::{load_file_config_public, save_file_config};
+#[cfg(target_os = "macos")]
+use crate::mdm::agents::XcodeInstaller;
+use crate::mdm::utils::home_dir;
+use std::path::{Path, PathBuf};
+
+struct CommandOutput {
+    lines: Vec<String>,
+    warnings: Vec<String>,
+}
+
+impl CommandOutput {
+    fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    fn push_line(&mut self, line: impl Into<String>) {
+        self.lines.push(line.into());
+    }
+
+    fn push_warning(&mut self, warning: impl Into<String>) {
+        self.warnings.push(warning.into());
+    }
+}
+
+pub fn handle_xcode(args: &[String]) {
+    if args.is_empty() || matches!(args[0].as_str(), "help" | "--help" | "-h") {
+        print_xcode_help();
+        return;
+    }
+
+    match run_xcode(args) {
+        Ok(output) => {
+            for line in output.lines {
+                println!("{line}");
+            }
+            for warning in output.warnings {
+                eprintln!("{warning}");
+            }
+        }
+        Err(error) => {
+            eprintln!("Error: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn print_xcode_help() {
+    eprintln!("git-ai xcode - Manage Xcode watcher paths and LaunchAgent");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("  git-ai xcode add-path <path>");
+    eprintln!("  git-ai xcode remove-path <path>");
+    eprintln!("  git-ai xcode list-paths");
+    eprintln!("  git-ai xcode reload");
+    eprintln!();
+    eprintln!("Examples:");
+    eprintln!("  git-ai xcode add-path ~/work/ios");
+    eprintln!("  git-ai xcode remove-path ~/work/ios");
+    eprintln!("  git-ai xcode list-paths");
+    eprintln!("  git-ai xcode reload");
+    eprintln!();
+    std::process::exit(0);
+}
+
+#[cfg(target_os = "macos")]
+fn run_xcode(args: &[String]) -> Result<CommandOutput, String> {
+    match args[0].as_str() {
+        "add-path" => {
+            let path = args
+                .get(1)
+                .ok_or_else(|| "Usage: git-ai xcode add-path <path>".to_string())?;
+            run_add_path(path)
+        }
+        "remove-path" => {
+            let path = args
+                .get(1)
+                .ok_or_else(|| "Usage: git-ai xcode remove-path <path>".to_string())?;
+            run_remove_path(path)
+        }
+        "list-paths" => run_list_paths(),
+        "reload" => run_reload(),
+        other => Err(format!("Unknown xcode subcommand: {other}")),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run_xcode(_args: &[String]) -> Result<CommandOutput, String> {
+    Err("Xcode watcher configuration is only supported on macOS".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn run_add_path(path: &str) -> Result<CommandOutput, String> {
+    let mut file_config = load_file_config_public()?;
+    let existing_paths = XcodeInstaller::configured_paths_from_file_config(&file_config)?;
+    let new_path = XcodeInstaller::validate_new_watch_path(Path::new(path))?;
+
+    let mut output = CommandOutput::new();
+
+    if existing_paths.iter().any(|existing| existing == &new_path) {
+        output.push_line(format!(
+            "Xcode: Watch path already configured: {}",
+            new_path.display()
+        ));
+        apply_launch_agent_output(&existing_paths, &mut output)?;
+        return Ok(output);
+    }
+
+    if let Some(parent) = existing_paths
+        .iter()
+        .find(|existing| new_path.starts_with(existing.as_path()))
+    {
+        output.push_line(format!(
+            "Xcode: {} is already covered by existing watch root {}",
+            new_path.display(),
+            parent.display()
+        ));
+        apply_launch_agent_output(&existing_paths, &mut output)?;
+        return Ok(output);
+    }
+
+    let removed_descendants = existing_paths
+        .iter()
+        .filter(|existing| existing.starts_with(&new_path))
+        .count();
+
+    let mut updated_paths = existing_paths.clone();
+    updated_paths.push(new_path.clone());
+    updated_paths = XcodeInstaller::normalize_watch_paths(updated_paths);
+
+    file_config.xcode_paths = XcodeInstaller::serialize_watch_paths(&updated_paths);
+    save_file_config(&file_config)?;
+
+    output.push_line(format!("Xcode: Added watch path {}", new_path.display()));
+    if removed_descendants > 0 {
+        output.push_line(format!(
+            "Xcode: Collapsed {} narrower path(s) under {}",
+            removed_descendants,
+            new_path.display()
+        ));
+    }
+    apply_launch_agent_output(&updated_paths, &mut output)?;
+    Ok(output)
+}
+
+#[cfg(target_os = "macos")]
+fn run_remove_path(path: &str) -> Result<CommandOutput, String> {
+    let mut file_config = load_file_config_public()?;
+    let existing_paths = XcodeInstaller::configured_paths_from_file_config(&file_config)?;
+    let normalized_target = normalize_remove_target(path)?;
+
+    let updated_paths: Vec<PathBuf> = existing_paths
+        .iter()
+        .filter(|existing| **existing != normalized_target)
+        .cloned()
+        .collect();
+
+    let mut output = CommandOutput::new();
+    if updated_paths.len() == existing_paths.len() {
+        output.push_line(format!(
+            "Xcode: Watch path not configured: {}",
+            normalized_target.display()
+        ));
+        return Ok(output);
+    }
+
+    file_config.xcode_paths = XcodeInstaller::serialize_watch_paths(&updated_paths);
+    save_file_config(&file_config)?;
+
+    output.push_line(format!(
+        "Xcode: Removed watch path {}",
+        normalized_target.display()
+    ));
+    apply_launch_agent_output(&updated_paths, &mut output)?;
+    Ok(output)
+}
+
+#[cfg(target_os = "macos")]
+fn run_list_paths() -> Result<CommandOutput, String> {
+    let paths = XcodeInstaller::configured_paths_from_disk()?;
+    let mut output = CommandOutput::new();
+
+    if paths.is_empty() {
+        output.push_line("Xcode: No watch paths configured");
+        return Ok(output);
+    }
+
+    for path in paths {
+        output.push_line(path.display().to_string());
+    }
+
+    Ok(output)
+}
+
+#[cfg(target_os = "macos")]
+fn run_reload() -> Result<CommandOutput, String> {
+    let paths = XcodeInstaller::configured_paths_from_disk()?;
+    let mut output = CommandOutput::new();
+    apply_launch_agent_output(&paths, &mut output)?;
+    Ok(output)
+}
+
+#[cfg(target_os = "macos")]
+fn apply_launch_agent_output(paths: &[PathBuf], output: &mut CommandOutput) -> Result<(), String> {
+    let apply_result = XcodeInstaller::apply_launch_agent(paths)?;
+    output.push_line(apply_result.message);
+    if let Some(warning) = apply_result.warning {
+        output.push_warning(format!("Xcode: {warning}"));
+    }
+    Ok(())
+}
+
+fn normalize_remove_target(path: &str) -> Result<PathBuf, String> {
+    let raw = Path::new(path);
+    let expanded = if let Ok(stripped) = raw.strip_prefix("~") {
+        home_dir().join(stripped)
+    } else if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| format!("Unable to resolve current directory: {}", e))?
+            .join(raw)
+    };
+
+    match std::fs::canonicalize(&expanded) {
+        Ok(canonical) => Ok(canonical),
+        Err(_) => Ok(expanded),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let temp = tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+        }
+
+        f(&home);
+
+        unsafe {
+            match prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_normalize_remove_target_resolves_relative_paths() {
+        with_temp_home(|home| {
+            let workspace = home.join("workspace");
+            std::fs::create_dir_all(&workspace).unwrap();
+
+            let prev_dir = std::env::current_dir().unwrap();
+            std::env::set_current_dir(home).unwrap();
+            let resolved = normalize_remove_target("workspace").unwrap();
+            std::env::set_current_dir(prev_dir).unwrap();
+
+            assert_eq!(resolved, std::fs::canonicalize(workspace).unwrap());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_add_path_collapse_is_visible_in_saved_config() {
+        with_temp_home(|home| {
+            let parent = home.join("ios");
+            let child = parent.join("AppA");
+            std::fs::create_dir_all(&child).unwrap();
+            std::fs::create_dir_all(XcodeInstaller::watcher_binary_path().parent().unwrap())
+                .unwrap();
+            std::fs::write(XcodeInstaller::watcher_binary_path(), "binary").unwrap();
+
+            let mut file_config = load_file_config_public().unwrap();
+            file_config.xcode_paths = Some(vec![child.to_string_lossy().to_string()]);
+            save_file_config(&file_config).unwrap();
+
+            let output = run_add_path(parent.to_str().unwrap()).unwrap();
+            assert!(output.lines.iter().any(|line| line.contains("Collapsed 1")));
+
+            let saved = load_file_config_public().unwrap();
+            assert_eq!(
+                saved.xcode_paths,
+                Some(vec![
+                    std::fs::canonicalize(parent)
+                        .unwrap()
+                        .to_string_lossy()
+                        .to_string()
+                ])
+            );
+        });
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,8 @@ pub struct FileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub xcode_paths: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_prompts_in_repositories: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub include_prompts_in_repositories: Option<Vec<String>>,

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -1,10 +1,206 @@
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{
-    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult,
+    HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
-use std::path::Path;
+use crate::mdm::utils::home_dir;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const XCODE_WATCHER_BINARY_NAME: &str = "git-ai-xcode-watcher";
+const XCODE_WATCHER_VERSION_FILE: &str = "git-ai-xcode-watcher.version";
+const XCODE_WATCHER_MAIN_SWIFT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift"
+));
+const XCODE_WATCHER_PACKAGE_SWIFT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/agent-support/xcode/Package.swift"
+));
+const XCODE_MONITORING_GUIDANCE: &str = "Xcode: Unable to auto-configure monitoring scope. To start the watcher, run: git-ai-xcode-watcher --path /path/to/xcode/project";
 
 pub struct XcodeInstaller;
+
+impl XcodeInstaller {
+    fn watcher_binary_path() -> PathBuf {
+        home_dir()
+            .join(".git-ai")
+            .join("bin")
+            .join(XCODE_WATCHER_BINARY_NAME)
+    }
+
+    fn version_file_path() -> PathBuf {
+        home_dir()
+            .join(".git-ai")
+            .join("bin")
+            .join(XCODE_WATCHER_VERSION_FILE)
+    }
+
+    fn plist_path() -> PathBuf {
+        home_dir()
+            .join("Library")
+            .join("LaunchAgents")
+            .join("com.gitai.xcode-watcher.plist")
+    }
+
+    fn build_cache_dir() -> PathBuf {
+        home_dir()
+            .join(".git-ai")
+            .join("cache")
+            .join("xcode-watcher-build")
+    }
+
+    fn built_binary_path() -> PathBuf {
+        Self::build_cache_dir()
+            .join(".build")
+            .join("release")
+            .join(XCODE_WATCHER_BINARY_NAME)
+    }
+
+    fn developer_dir_looks_like_xcode(path: &str) -> bool {
+        path.trim().contains(".app/Contents/Developer")
+    }
+
+    fn xcode_select_developer_dir() -> Option<String> {
+        let output = Command::new("xcode-select").args(["-p"]).output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path.is_empty() { None } else { Some(path) }
+    }
+
+    fn xcode_app_fallback_paths() -> [&'static Path; 2] {
+        [
+            Path::new("/Applications/Xcode.app"),
+            Path::new("/Applications/Xcode-beta.app"),
+        ]
+    }
+
+    fn is_xcode_ide_available_with(
+        xcode_select_path: Option<&str>,
+        path_exists: impl Fn(&Path) -> bool,
+    ) -> bool {
+        if let Some(path) = xcode_select_path
+            && Self::developer_dir_looks_like_xcode(path)
+        {
+            return true;
+        }
+
+        Self::xcode_app_fallback_paths()
+            .iter()
+            .any(|path| path_exists(path))
+    }
+
+    fn is_xcode_ide_available() -> bool {
+        let xcode_select_path = Self::xcode_select_developer_dir();
+        Self::is_xcode_ide_available_with(xcode_select_path.as_deref(), Path::exists)
+    }
+
+    fn has_any_installation() -> bool {
+        Self::watcher_binary_path().exists()
+            || Self::plist_path().exists()
+            || Self::version_file_path().exists()
+            || Self::build_cache_dir().exists()
+    }
+
+    fn check_result_for_environment(
+        xcode_ide_available: bool,
+        has_any_installation: bool,
+        hooks_up_to_date: bool,
+    ) -> HookCheckResult {
+        if !xcode_ide_available && !has_any_installation {
+            return HookCheckResult {
+                tool_installed: false,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            };
+        }
+
+        HookCheckResult {
+            tool_installed: true,
+            hooks_installed: has_any_installation,
+            hooks_up_to_date,
+        }
+    }
+
+    fn is_watcher_up_to_date() -> bool {
+        match fs::read_to_string(Self::version_file_path()) {
+            Ok(version) => version.trim() == env!("CARGO_PKG_VERSION"),
+            Err(_) => false,
+        }
+    }
+
+    fn install_warning(message: impl Into<String>) -> InstallResult {
+        InstallResult {
+            changed: false,
+            diff: None,
+            message: message.into(),
+        }
+    }
+
+    fn compile_watcher(build_dir: &Path) -> Result<(), InstallResult> {
+        const MAX_BUILD_ATTEMPTS: usize = 3;
+
+        for attempt in 0..MAX_BUILD_ATTEMPTS {
+            let build_output = Command::new("xcrun")
+                .args(["swift", "build", "-c", "release"])
+                .current_dir(build_dir)
+                .output();
+
+            match build_output {
+                Err(e) => {
+                    return Err(Self::install_warning(format!(
+                        "Xcode: Unable to run Swift compiler: {}",
+                        e
+                    )));
+                }
+                Ok(output) if output.status.success() => return Ok(()),
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    if stderr.contains("Another instance of SwiftPM is already running")
+                        && attempt + 1 < MAX_BUILD_ATTEMPTS
+                    {
+                        std::thread::sleep(std::time::Duration::from_secs(1));
+                        continue;
+                    }
+
+                    let stderr_preview: String = stderr.chars().take(200).collect();
+                    return Err(Self::install_warning(format!(
+                        "Xcode: Unable to compile watcher (swift build exit {}): {}",
+                        output.status.code().unwrap_or(-1),
+                        stderr_preview
+                    )));
+                }
+            }
+        }
+
+        Err(Self::install_warning(
+            "Xcode: Unable to compile watcher after retrying",
+        ))
+    }
+
+    fn remove_file_if_exists(path: &Path) -> Result<bool, String> {
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        fs::remove_file(path)
+            .map(|_| true)
+            .map_err(|e| format!("Unable to remove {}: {}", path.display(), e))
+    }
+
+    fn remove_dir_if_exists(path: &Path) -> Result<bool, String> {
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        fs::remove_dir_all(path)
+            .map(|_| true)
+            .map_err(|e| format!("Unable to remove {}: {}", path.display(), e))
+    }
+}
 
 impl HookInstaller for XcodeInstaller {
     fn name(&self) -> &str {
@@ -20,12 +216,24 @@ impl HookInstaller for XcodeInstaller {
     }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
-        let tool_installed = is_xcode_installed();
-        Ok(HookCheckResult {
-            tool_installed,
-            hooks_installed: false,
-            hooks_up_to_date: false,
-        })
+        if cfg!(not(target_os = "macos")) {
+            return Ok(HookCheckResult {
+                tool_installed: false,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let xcode_ide_available = Self::is_xcode_ide_available();
+        let has_any_installation = Self::has_any_installation();
+        let hooks_up_to_date =
+            Self::watcher_binary_path().exists() && Self::is_watcher_up_to_date();
+
+        Ok(Self::check_result_for_environment(
+            xcode_ide_available,
+            has_any_installation,
+            hooks_up_to_date,
+        ))
     }
 
     fn install_hooks(
@@ -47,56 +255,556 @@ impl HookInstaller for XcodeInstaller {
     fn install_extras(
         &self,
         _params: &HookInstallerParams,
-        _dry_run: bool,
+        dry_run: bool,
     ) -> Result<Vec<InstallResult>, GitAiError> {
-        Ok(vec![InstallResult {
-            changed: false,
-            diff: None,
-            message: "Xcode: Install git-ai-xcode-watcher daemon. \
-                      Download from releases or build from agent-support/xcode/. \
-                      Run: launchctl load ~/Library/LaunchAgents/io.gitai.xcode-watcher.plist"
-                .to_string(),
-        }])
-    }
-}
+        let mut results = Vec::new();
 
-fn is_xcode_installed() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        Path::new("/Applications/Xcode.app").exists()
-            || Path::new("/Applications/Xcode-beta.app").exists()
+        if cfg!(not(target_os = "macos")) {
+            return Ok(results);
+        }
+
+        if !Self::is_xcode_ide_available() {
+            return Ok(results);
+        }
+
+        let watcher_bin = Self::watcher_binary_path();
+        if watcher_bin.exists() && Self::is_watcher_up_to_date() {
+            results.push(InstallResult {
+                changed: false,
+                diff: None,
+                message: "Xcode: Watcher already installed and up to date. To monitor a project, run: git-ai-xcode-watcher --path /path/to/xcode/project".to_string(),
+            });
+            return Ok(results);
+        }
+
+        if dry_run {
+            results.push(InstallResult {
+                changed: true,
+                diff: None,
+                message: "Xcode: Pending watcher compilation and installation".to_string(),
+            });
+            return Ok(results);
+        }
+
+        let build_dir = Self::build_cache_dir();
+        let sources_dir = build_dir.join("Sources").join(XCODE_WATCHER_BINARY_NAME);
+        if let Err(e) = fs::create_dir_all(&sources_dir) {
+            results.push(Self::install_warning(format!(
+                "Xcode: Unable to create build cache directory: {}",
+                e
+            )));
+            return Ok(results);
+        }
+
+        if let Err(e) = fs::write(build_dir.join("Package.swift"), XCODE_WATCHER_PACKAGE_SWIFT) {
+            results.push(Self::install_warning(format!(
+                "Xcode: Unable to write Package.swift: {}",
+                e
+            )));
+            return Ok(results);
+        }
+
+        if let Err(e) = fs::write(sources_dir.join("main.swift"), XCODE_WATCHER_MAIN_SWIFT) {
+            results.push(Self::install_warning(format!(
+                "Xcode: Unable to write main.swift: {}",
+                e
+            )));
+            return Ok(results);
+        }
+
+        if let Err(result) = Self::compile_watcher(&build_dir) {
+            results.push(result);
+            return Ok(results);
+        }
+
+        let built_binary = Self::built_binary_path();
+        if !built_binary.exists() {
+            results.push(Self::install_warning(
+                "Xcode: Unable to find compiled binary after swift build",
+            ));
+            return Ok(results);
+        }
+
+        if let Some(parent) = watcher_bin.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            results.push(Self::install_warning(format!(
+                "Xcode: Unable to create binary directory: {}",
+                e
+            )));
+            return Ok(results);
+        }
+
+        if let Err(e) = fs::copy(&built_binary, &watcher_bin) {
+            results.push(Self::install_warning(format!(
+                "Xcode: Unable to install watcher binary: {}",
+                e
+            )));
+            return Ok(results);
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let _ = fs::set_permissions(&watcher_bin, fs::Permissions::from_mode(0o755));
+        }
+
+        if let Err(e) = fs::write(Self::version_file_path(), env!("CARGO_PKG_VERSION")) {
+            results.push(Self::install_warning(format!(
+                "Xcode: Unable to write watcher version file: {}",
+                e
+            )));
+        }
+
+        results.push(InstallResult {
+            changed: true,
+            diff: None,
+            message: format!(
+                "Xcode: Watcher binary installed to {}",
+                watcher_bin.display()
+            ),
+        });
+        results.push(Self::install_warning(XCODE_MONITORING_GUIDANCE));
+
+        Ok(results)
     }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = Path::new("");
-        false
+
+    fn uninstall_extras(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Vec<UninstallResult>, GitAiError> {
+        let mut results = Vec::new();
+
+        if cfg!(not(target_os = "macos")) {
+            return Ok(results);
+        }
+
+        let plist_path = Self::plist_path();
+        let watcher_bin = Self::watcher_binary_path();
+        let version_file = Self::version_file_path();
+        let build_cache = Self::build_cache_dir();
+
+        let has_anything = plist_path.exists()
+            || watcher_bin.exists()
+            || version_file.exists()
+            || build_cache.exists();
+
+        if !has_anything {
+            results.push(UninstallResult {
+                changed: false,
+                diff: None,
+                message: "Xcode: Watcher not installed, nothing to uninstall".to_string(),
+            });
+            return Ok(results);
+        }
+
+        if dry_run {
+            results.push(UninstallResult {
+                changed: true,
+                diff: None,
+                message: "Xcode: Pending watcher removal".to_string(),
+            });
+            return Ok(results);
+        }
+
+        if plist_path.exists() {
+            let _ = Command::new("launchctl")
+                .args(["unload", &plist_path.to_string_lossy()])
+                .output();
+
+            match Self::remove_file_if_exists(&plist_path) {
+                Ok(true) => results.push(UninstallResult {
+                    changed: true,
+                    diff: None,
+                    message: "Xcode: launchd service unloaded and plist removed".to_string(),
+                }),
+                Ok(false) => {}
+                Err(message) => results.push(UninstallResult {
+                    changed: false,
+                    diff: None,
+                    message: format!("Xcode: {}", message),
+                }),
+            }
+        }
+
+        match Self::remove_file_if_exists(&watcher_bin) {
+            Ok(true) => results.push(UninstallResult {
+                changed: true,
+                diff: None,
+                message: "Xcode: Watcher binary removed".to_string(),
+            }),
+            Ok(false) => {}
+            Err(message) => results.push(UninstallResult {
+                changed: false,
+                diff: None,
+                message: format!("Xcode: {}", message),
+            }),
+        }
+
+        match Self::remove_file_if_exists(&version_file) {
+            Ok(true) => results.push(UninstallResult {
+                changed: true,
+                diff: None,
+                message: "Xcode: Watcher version marker removed".to_string(),
+            }),
+            Ok(false) => {}
+            Err(message) => results.push(UninstallResult {
+                changed: false,
+                diff: None,
+                message: format!("Xcode: {}", message),
+            }),
+        }
+
+        match Self::remove_dir_if_exists(&build_cache) {
+            Ok(true) => results.push(UninstallResult {
+                changed: true,
+                diff: None,
+                message: "Xcode: Build cache removed".to_string(),
+            }),
+            Ok(false) => {}
+            Err(message) => results.push(UninstallResult {
+                changed: false,
+                diff: None,
+                message: format!("Xcode: {}", message),
+            }),
+        }
+
+        Ok(results)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mdm::hook_installer::{HookInstaller, HookInstallerParams};
+    use serial_test::serial;
+    use tempfile::tempdir;
 
-    #[test]
-    fn test_xcode_installer_name() {
-        assert_eq!(XcodeInstaller.name(), "Xcode");
+    fn test_params() -> HookInstallerParams {
+        HookInstallerParams {
+            binary_path: PathBuf::from("/usr/local/bin/git-ai"),
+        }
+    }
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let temp = tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+        }
+
+        f(&home);
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
     }
 
     #[test]
-    fn test_xcode_installer_id() {
-        assert_eq!(XcodeInstaller.id(), "xcode");
+    fn test_xcode_installer_name_and_id() {
+        let installer = XcodeInstaller;
+        assert_eq!(installer.name(), "Xcode");
+        assert_eq!(installer.id(), "xcode");
     }
 
     #[test]
-    fn test_xcode_install_hooks_returns_none() {
-        let params = HookInstallerParams {
-            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
-        };
-        assert!(
-            XcodeInstaller
-                .install_hooks(&params, false)
-                .unwrap()
-                .is_none()
+    fn test_uses_config_hooks_returns_false() {
+        let installer = XcodeInstaller;
+        assert!(!installer.uses_config_hooks());
+    }
+
+    #[test]
+    fn test_install_hooks_returns_none() {
+        let installer = XcodeInstaller;
+        assert_eq!(
+            installer.install_hooks(&test_params(), false).unwrap(),
+            None
         );
+    }
+
+    #[test]
+    fn test_uninstall_hooks_returns_none() {
+        let installer = XcodeInstaller;
+        assert_eq!(
+            installer.uninstall_hooks(&test_params(), false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_xcode_paths_are_under_home_directory() {
+        with_temp_home(|home| {
+            assert_eq!(
+                XcodeInstaller::watcher_binary_path(),
+                home.join(".git-ai/bin/git-ai-xcode-watcher")
+            );
+            assert_eq!(
+                XcodeInstaller::version_file_path(),
+                home.join(".git-ai/bin/git-ai-xcode-watcher.version")
+            );
+            assert_eq!(
+                XcodeInstaller::plist_path(),
+                home.join("Library/LaunchAgents/com.gitai.xcode-watcher.plist")
+            );
+            assert_eq!(
+                XcodeInstaller::build_cache_dir(),
+                home.join(".git-ai/cache/xcode-watcher-build")
+            );
+        });
+    }
+
+    #[test]
+    fn test_embedded_sources_not_empty() {
+        assert!(!XCODE_WATCHER_MAIN_SWIFT.is_empty());
+        assert!(!XCODE_WATCHER_PACKAGE_SWIFT.is_empty());
+        assert!(XCODE_WATCHER_PACKAGE_SWIFT.contains("swift-tools-version"));
+        assert!(XCODE_WATCHER_MAIN_SWIFT.contains("FSEventStream"));
+    }
+
+    #[test]
+    fn test_embedded_sources_contain_known_human_preset() {
+        assert!(XCODE_WATCHER_MAIN_SWIFT.contains("known_human"));
+        assert!(XCODE_WATCHER_MAIN_SWIFT.contains("checkpoint"));
+    }
+
+    #[test]
+    fn test_failure_messages_use_visibility_keywords() {
+        let messages = [
+            "Xcode: Unable to create build cache directory: permission denied",
+            "Xcode: Unable to write Package.swift: disk full",
+            "Xcode: Unable to run Swift compiler: not found",
+            "Xcode: Unable to compile watcher (swift build exit 1): error",
+            "Xcode: Unable to find compiled binary after swift build",
+            "Xcode: Unable to install watcher binary: permission denied",
+            "Xcode: Unable to write watcher version file: permission denied",
+        ];
+
+        for message in messages {
+            assert!(
+                message.contains("Unable") || message.contains("Failed"),
+                "message '{message}' must contain visibility keywords"
+            );
+        }
+    }
+
+    #[test]
+    fn test_developer_dir_looks_like_xcode() {
+        assert!(XcodeInstaller::developer_dir_looks_like_xcode(
+            "/Applications/Xcode.app/Contents/Developer"
+        ));
+        assert!(XcodeInstaller::developer_dir_looks_like_xcode(
+            "/Applications/Xcode-beta.app/Contents/Developer"
+        ));
+        assert!(!XcodeInstaller::developer_dir_looks_like_xcode(
+            "/Library/Developer/CommandLineTools"
+        ));
+    }
+
+    #[test]
+    fn test_is_xcode_ide_available_with_prefers_xcode_select_path() {
+        let available = XcodeInstaller::is_xcode_ide_available_with(
+            Some("/opt/Xcodes/Xcode-16.app/Contents/Developer"),
+            |_| false,
+        );
+        assert!(available);
+    }
+
+    #[test]
+    fn test_is_xcode_ide_available_with_uses_fallback_paths() {
+        let available = XcodeInstaller::is_xcode_ide_available_with(
+            Some("/Library/Developer/CommandLineTools"),
+            |path| path == Path::new("/Applications/Xcode-beta.app"),
+        );
+        assert!(available);
+    }
+
+    #[test]
+    fn test_is_xcode_ide_available_with_rejects_clt_only() {
+        let available = XcodeInstaller::is_xcode_ide_available_with(
+            Some("/Library/Developer/CommandLineTools"),
+            |_| false,
+        );
+        assert!(!available);
+    }
+
+    #[test]
+    fn test_check_result_matrix() {
+        let unavailable = XcodeInstaller::check_result_for_environment(false, false, false);
+        assert!(!unavailable.tool_installed);
+        assert!(!unavailable.hooks_installed);
+        assert!(!unavailable.hooks_up_to_date);
+
+        let fresh_install = XcodeInstaller::check_result_for_environment(true, false, false);
+        assert!(fresh_install.tool_installed);
+        assert!(!fresh_install.hooks_installed);
+        assert!(!fresh_install.hooks_up_to_date);
+
+        let residual = XcodeInstaller::check_result_for_environment(false, true, false);
+        assert!(residual.tool_installed);
+        assert!(residual.hooks_installed);
+        assert!(!residual.hooks_up_to_date);
+
+        let up_to_date = XcodeInstaller::check_result_for_environment(true, true, true);
+        assert!(up_to_date.tool_installed);
+        assert!(up_to_date.hooks_installed);
+        assert!(up_to_date.hooks_up_to_date);
+    }
+
+    #[test]
+    #[serial]
+    fn test_is_watcher_up_to_date_reads_version_file() {
+        with_temp_home(|_| {
+            let version_path = XcodeInstaller::version_file_path();
+            fs::create_dir_all(version_path.parent().unwrap()).unwrap();
+            fs::write(&version_path, env!("CARGO_PKG_VERSION")).unwrap();
+
+            assert!(XcodeInstaller::is_watcher_up_to_date());
+
+            fs::write(&version_path, "0.0.0").unwrap();
+            assert!(!XcodeInstaller::is_watcher_up_to_date());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_check_hooks_reports_residual_installation_without_xcode() {
+        with_temp_home(|_| {
+            let installer = XcodeInstaller;
+            let build_cache = XcodeInstaller::build_cache_dir();
+            fs::create_dir_all(&build_cache).unwrap();
+
+            let result = installer.check_hooks(&test_params()).unwrap();
+            assert!(result.tool_installed);
+            assert!(result.hooks_installed);
+            assert!(!result.hooks_up_to_date);
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_uninstall_extras_removes_residual_artifacts() {
+        with_temp_home(|home| {
+            let installer = XcodeInstaller;
+
+            let plist_path = XcodeInstaller::plist_path();
+            let watcher_bin = XcodeInstaller::watcher_binary_path();
+            let version_file = XcodeInstaller::version_file_path();
+            let build_cache = XcodeInstaller::build_cache_dir();
+
+            fs::create_dir_all(plist_path.parent().unwrap()).unwrap();
+            fs::create_dir_all(watcher_bin.parent().unwrap()).unwrap();
+            fs::create_dir_all(build_cache.join(".build")).unwrap();
+            fs::write(&plist_path, "plist").unwrap();
+            fs::write(&watcher_bin, "binary").unwrap();
+            fs::write(&version_file, env!("CARGO_PKG_VERSION")).unwrap();
+            fs::write(build_cache.join(".build/placeholder"), "cache").unwrap();
+
+            let results = installer.uninstall_extras(&test_params(), false).unwrap();
+
+            assert!(
+                results
+                    .iter()
+                    .any(|result| result.message.contains("Watcher binary removed"))
+            );
+            assert!(
+                results
+                    .iter()
+                    .any(|result| result.message.contains("Build cache removed"))
+            );
+            assert!(home.join(".git-ai/bin").exists());
+            assert!(!plist_path.exists());
+            assert!(!watcher_bin.exists());
+            assert!(!version_file.exists());
+            assert!(!build_cache.exists());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_uninstall_extras_reports_version_file_only_cleanup() {
+        with_temp_home(|_| {
+            let installer = XcodeInstaller;
+            let version_file = XcodeInstaller::version_file_path();
+            fs::create_dir_all(version_file.parent().unwrap()).unwrap();
+            fs::write(&version_file, "stale-version").unwrap();
+
+            let results = installer.uninstall_extras(&test_params(), false).unwrap();
+
+            assert!(
+                results
+                    .iter()
+                    .any(|result| result.message.contains("Watcher version marker removed"))
+            );
+            assert!(!version_file.exists());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_install_extras_builds_binary_and_is_idempotent() {
+        with_temp_home(|_| {
+            if !XcodeInstaller::is_xcode_ide_available() {
+                return;
+            }
+
+            let installer = XcodeInstaller;
+            let first_results = installer.install_extras(&test_params(), false).unwrap();
+
+            assert!(XcodeInstaller::watcher_binary_path().exists());
+            assert!(XcodeInstaller::version_file_path().exists());
+            assert!(XcodeInstaller::build_cache_dir().exists());
+            assert!(first_results.iter().any(|result| {
+                result.changed && result.message.contains("Watcher binary installed")
+            }));
+            assert!(first_results.iter().any(|result| {
+                !result.changed
+                    && result
+                        .message
+                        .contains("Unable to auto-configure monitoring scope")
+            }));
+
+            let check_result = installer.check_hooks(&test_params()).unwrap();
+            assert!(check_result.tool_installed);
+            assert!(check_result.hooks_installed);
+            assert!(check_result.hooks_up_to_date);
+
+            let second_results = installer.install_extras(&test_params(), false).unwrap();
+            assert_eq!(second_results.len(), 1);
+            assert!(!second_results[0].changed);
+            assert!(
+                second_results[0]
+                    .message
+                    .contains("already installed and up to date")
+            );
+
+            let uninstall_results = installer.uninstall_extras(&test_params(), false).unwrap();
+            assert!(uninstall_results.iter().any(|result| {
+                result.changed && result.message.contains("Watcher binary removed")
+            }));
+            assert!(!XcodeInstaller::watcher_binary_path().exists());
+            assert!(!XcodeInstaller::version_file_path().exists());
+            assert!(!XcodeInstaller::build_cache_dir().exists());
+        });
     }
 }

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -533,25 +533,25 @@ impl XcodeInstaller {
         };
 
         let service = format!("{}/{}", domain, XCODE_WATCHER_LABEL);
-        let mut launchctl_warning = Self::bootout_launch_agent(&domain).err();
+        let bootout_warning = Self::bootout_launch_agent(&domain).err();
 
-        if launchctl_warning.is_none() {
-            let bootstrap_args = vec![
-                "bootstrap".to_string(),
-                domain.clone(),
-                Self::plist_path().to_string_lossy().to_string(),
-            ];
-            if let Err(error) = Self::run_launchctl(&bootstrap_args) {
-                launchctl_warning = Some(error);
-            }
-        }
-
-        if launchctl_warning.is_none() {
+        let bootstrap_args = vec![
+            "bootstrap".to_string(),
+            domain.clone(),
+            Self::plist_path().to_string_lossy().to_string(),
+        ];
+        let launchctl_warning = if let Err(error) = Self::run_launchctl(&bootstrap_args) {
+            Some(match bootout_warning {
+                Some(bootout) => format!(
+                    "Bootstrap failed: {} (preceded by bootout warning: {})",
+                    error, bootout
+                ),
+                None => error,
+            })
+        } else {
             let kickstart_args = vec!["kickstart".to_string(), "-k".to_string(), service];
-            if let Err(error) = Self::run_launchctl(&kickstart_args) {
-                launchctl_warning = Some(error);
-            }
-        }
+            Self::run_launchctl(&kickstart_args).err()
+        };
 
         Ok(LaunchAgentApplyResult {
             message: format!(
@@ -1029,6 +1029,17 @@ mod tests {
         fs::set_permissions(&stub_path, fs::Permissions::from_mode(0o755)).unwrap();
     }
 
+    fn write_launchctl_bootout_io_error_stub(bin_dir: &Path, log_path: &Path) {
+        let stub_path = bin_dir.join("launchctl");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{}'\nif [ \"$1\" = \"bootout\" ]; then\n  echo 'Boot-out failed: 5: Input/output error' >&2\n  exit 5\nfi\nexit 0\n",
+            log_path.display(),
+        );
+        fs::write(&stub_path, script).unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&stub_path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
     #[test]
     fn test_xcode_installer_name_and_id() {
         let installer = XcodeInstaller;
@@ -1440,6 +1451,38 @@ mod tests {
                         .contains("Unable to reload watcher automatically")
                 );
                 assert!(XcodeInstaller::plist_path().exists());
+            });
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_apply_launch_agent_ignores_bootout_io_error_if_restart_succeeds() {
+        with_temp_home(|home| {
+            with_path_override(|bin_dir| {
+                let workspace = home.join("ios");
+                let launchctl_log = home.join("launchctl.log");
+                fs::create_dir_all(&workspace).unwrap();
+                fs::create_dir_all(XcodeInstaller::watcher_binary_path().parent().unwrap())
+                    .unwrap();
+                fs::write(XcodeInstaller::watcher_binary_path(), "#!/bin/sh\n").unwrap();
+                #[cfg(unix)]
+                fs::set_permissions(
+                    XcodeInstaller::watcher_binary_path(),
+                    fs::Permissions::from_mode(0o755),
+                )
+                .unwrap();
+                write_launchctl_bootout_io_error_stub(bin_dir, &launchctl_log);
+
+                let result = XcodeInstaller::apply_launch_agent(&[workspace]).unwrap();
+                assert!(result.warning.is_none());
+                assert!(XcodeInstaller::plist_path().exists());
+
+                let log = fs::read_to_string(launchctl_log).unwrap();
+                assert!(log.contains("bootout"));
+                assert!(log.contains("bootstrap"));
+                assert!(log.contains("kickstart"));
             });
         });
     }

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 
 const XCODE_WATCHER_BINARY_NAME: &str = "git-ai-xcode-watcher";
 const XCODE_WATCHER_VERSION_FILE: &str = "git-ai-xcode-watcher.version";
+const XCODE_WATCHER_LABEL: &str = "com.gitai.xcode-watcher";
 const XCODE_WATCHER_MAIN_SWIFT: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/agent-support/xcode/Sources/git-ai-xcode-watcher/main.swift"
@@ -40,7 +41,7 @@ impl XcodeInstaller {
         home_dir()
             .join("Library")
             .join("LaunchAgents")
-            .join("com.gitai.xcode-watcher.plist")
+            .join(format!("{}.plist", XCODE_WATCHER_LABEL))
     }
 
     fn build_cache_dir() -> PathBuf {
@@ -179,6 +180,59 @@ impl XcodeInstaller {
         Err(Self::install_warning(
             "Xcode: Unable to compile watcher after retrying",
         ))
+    }
+
+    fn launchctl_domain_target() -> Result<String, String> {
+        let uid = unsafe { libc::geteuid() };
+        if uid == 0 {
+            return Err(
+                "Unable to stop the watcher automatically from a root or non-GUI session"
+                    .to_string(),
+            );
+        }
+        Ok(format!("gui/{}", uid))
+    }
+
+    fn run_launchctl(args: &[String]) -> Result<(), String> {
+        let output = Command::new("launchctl")
+            .args(args)
+            .output()
+            .map_err(|e| format!("Unable to run launchctl: {}", e))?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("exit {}", output.status.code().unwrap_or(-1))
+        };
+        Err(detail)
+    }
+
+    fn bootout_launch_agent(domain: &str) -> Result<(), String> {
+        let args = vec![
+            "bootout".to_string(),
+            domain.to_string(),
+            Self::plist_path().to_string_lossy().to_string(),
+        ];
+        match Self::run_launchctl(&args) {
+            Ok(()) => Ok(()),
+            Err(error)
+                if error.contains("Could not find service")
+                    || error.contains("No such process")
+                    || error.contains("not loaded")
+                    || error.contains("service could not be found") =>
+            {
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
     }
 
     fn remove_file_if_exists(path: &Path) -> Result<bool, String> {
@@ -410,9 +464,10 @@ impl HookInstaller for XcodeInstaller {
         }
 
         if plist_path.exists() {
-            let _ = Command::new("launchctl")
-                .args(["unload", &plist_path.to_string_lossy()])
-                .output();
+            let launchctl_warning = match Self::launchctl_domain_target() {
+                Ok(domain) => Self::bootout_launch_agent(&domain).err(),
+                Err(warning) => Some(warning),
+            };
 
             match Self::remove_file_if_exists(&plist_path) {
                 Ok(true) => results.push(UninstallResult {
@@ -426,6 +481,17 @@ impl HookInstaller for XcodeInstaller {
                     diff: None,
                     message: format!("Xcode: {}", message),
                 }),
+            }
+
+            if let Some(warning) = launchctl_warning {
+                results.push(UninstallResult {
+                    changed: false,
+                    diff: None,
+                    message: format!(
+                        "Xcode: Unable to stop watcher LaunchAgent automatically: {}",
+                        warning
+                    ),
+                });
             }
         }
 
@@ -480,6 +546,8 @@ mod tests {
     use super::*;
     use crate::mdm::hook_installer::{HookInstaller, HookInstallerParams};
     use serial_test::serial;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
     fn test_params() -> HookInstallerParams {
@@ -514,6 +582,43 @@ mod tests {
                 None => std::env::remove_var("USERPROFILE"),
             }
         }
+    }
+
+    fn with_path_override<F: FnOnce(&Path)>(f: F) {
+        let temp = tempdir().unwrap();
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        let prev_path = std::env::var_os("PATH");
+        let new_path = match &prev_path {
+            Some(existing) => format!("{}:{}", bin_dir.display(), existing.to_string_lossy()),
+            None => bin_dir.display().to_string(),
+        };
+
+        unsafe {
+            std::env::set_var("PATH", &new_path);
+        }
+
+        f(&bin_dir);
+
+        unsafe {
+            match prev_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+
+    fn write_launchctl_stub(bin_dir: &Path, exit_code: i32, log_path: &Path) {
+        let stub_path = bin_dir.join("launchctl");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{}'\nexit {}\n",
+            log_path.display(),
+            exit_code
+        );
+        fs::write(&stub_path, script).unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&stub_path, fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     #[test]
@@ -756,6 +861,36 @@ mod tests {
                     .any(|result| result.message.contains("Watcher version marker removed"))
             );
             assert!(!version_file.exists());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_uninstall_extras_uses_bootout_for_launch_agent() {
+        with_temp_home(|home| {
+            with_path_override(|bin_dir| {
+                let installer = XcodeInstaller;
+                let plist_path = XcodeInstaller::plist_path();
+                let launchctl_log = home.join("launchctl.log");
+
+                fs::create_dir_all(plist_path.parent().unwrap()).unwrap();
+                fs::write(&plist_path, "plist").unwrap();
+                write_launchctl_stub(bin_dir, 0, &launchctl_log);
+
+                let results = installer.uninstall_extras(&test_params(), false).unwrap();
+
+                assert!(
+                    results
+                        .iter()
+                        .any(|result| result.message.contains("launchd service unloaded"))
+                );
+                assert!(!plist_path.exists());
+
+                let log = fs::read_to_string(launchctl_log).unwrap();
+                assert!(log.contains("bootout"));
+                assert!(!log.contains("unload"));
+            });
         });
     }
 

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -1,9 +1,11 @@
+use crate::config::{FileConfig, load_file_config_public};
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{
     HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
 use crate::mdm::utils::home_dir;
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -18,26 +20,48 @@ const XCODE_WATCHER_PACKAGE_SWIFT: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/agent-support/xcode/Package.swift"
 ));
-const XCODE_MONITORING_GUIDANCE: &str = "Xcode: Unable to auto-configure monitoring scope. To start the watcher, run: git-ai-xcode-watcher --path /path/to/xcode/project";
+const XCODE_ADD_PATH_GUIDANCE: &str =
+    "Xcode: Register a workspace with: git-ai xcode add-path /path/to/workspace";
 
 pub struct XcodeInstaller;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LaunchAgentApplyResult {
+    pub message: String,
+    pub warning: Option<String>,
+}
+
 impl XcodeInstaller {
-    fn watcher_binary_path() -> PathBuf {
+    fn expand_home_path(path: &Path) -> PathBuf {
+        if let Ok(stripped) = path.strip_prefix("~") {
+            home_dir().join(stripped)
+        } else {
+            path.to_path_buf()
+        }
+    }
+
+    pub(crate) fn watcher_binary_path() -> PathBuf {
         home_dir()
             .join(".git-ai")
             .join("bin")
             .join(XCODE_WATCHER_BINARY_NAME)
     }
 
-    fn version_file_path() -> PathBuf {
+    fn launch_log_path() -> PathBuf {
+        home_dir()
+            .join(".git-ai")
+            .join("logs")
+            .join("xcode-watcher.log")
+    }
+
+    pub(crate) fn version_file_path() -> PathBuf {
         home_dir()
             .join(".git-ai")
             .join("bin")
             .join(XCODE_WATCHER_VERSION_FILE)
     }
 
-    fn plist_path() -> PathBuf {
+    pub(crate) fn plist_path() -> PathBuf {
         home_dir()
             .join("Library")
             .join("LaunchAgents")
@@ -182,12 +206,227 @@ impl XcodeInstaller {
         ))
     }
 
+    fn remove_file_if_exists(path: &Path) -> Result<bool, String> {
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        fs::remove_file(path)
+            .map(|_| true)
+            .map_err(|e| format!("Unable to remove {}: {}", path.display(), e))
+    }
+
+    fn remove_dir_if_exists(path: &Path) -> Result<bool, String> {
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        fs::remove_dir_all(path)
+            .map(|_| true)
+            .map_err(|e| format!("Unable to remove {}: {}", path.display(), e))
+    }
+
+    pub(crate) fn configured_paths_from_file_config(
+        file_config: &FileConfig,
+    ) -> Result<Vec<PathBuf>, String> {
+        let mut paths = Vec::new();
+        for raw_path in file_config.xcode_paths.as_deref().unwrap_or(&[]) {
+            let trimmed = raw_path.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let mut path = Self::expand_home_path(Path::new(trimmed));
+            if !path.is_absolute() {
+                return Err(format!(
+                    "Configured xcode_paths entry '{}' must be an absolute path",
+                    trimmed
+                ));
+            }
+            if path.exists()
+                && let Ok(canonical) = fs::canonicalize(&path)
+            {
+                path = canonical;
+            }
+            paths.push(path);
+        }
+
+        Ok(Self::normalize_watch_paths(paths))
+    }
+
+    pub(crate) fn configured_paths_from_disk() -> Result<Vec<PathBuf>, String> {
+        let file_config = load_file_config_public()?;
+        Self::configured_paths_from_file_config(&file_config)
+    }
+
+    pub(crate) fn validate_new_watch_path(path: &Path) -> Result<PathBuf, String> {
+        let path = Self::expand_home_path(path);
+        let metadata = fs::metadata(&path).map_err(|e| {
+            format!(
+                "Path '{}' does not exist or is not accessible: {}",
+                path.display(),
+                e
+            )
+        })?;
+        if !metadata.is_dir() {
+            return Err(format!("Path '{}' must be a directory", path.display()));
+        }
+
+        let canonical = fs::canonicalize(&path)
+            .map_err(|e| format!("Unable to resolve path '{}': {}", path.display(), e))?;
+        let home = fs::canonicalize(home_dir()).unwrap_or_else(|_| home_dir());
+
+        if canonical == Path::new("/") {
+            return Err("Refusing to watch '/'; choose a narrower workspace root".to_string());
+        }
+        if canonical == home {
+            return Err(
+                "Refusing to watch your HOME directory; choose a narrower workspace root"
+                    .to_string(),
+            );
+        }
+        if canonical == Path::new("/Users") {
+            return Err("Refusing to watch '/Users'; choose a narrower workspace root".to_string());
+        }
+
+        Ok(canonical)
+    }
+
+    pub(crate) fn normalize_watch_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+        let mut sorted_paths = paths;
+        sorted_paths.sort_by(|left, right| {
+            left.components()
+                .count()
+                .cmp(&right.components().count())
+                .then_with(|| left.as_os_str().cmp(right.as_os_str()))
+        });
+
+        let mut normalized = Vec::new();
+        for path in sorted_paths {
+            if normalized
+                .iter()
+                .any(|existing: &PathBuf| path == *existing || path.starts_with(existing))
+            {
+                continue;
+            }
+
+            normalized.retain(|existing| !existing.starts_with(&path));
+            normalized.push(path);
+        }
+
+        normalized.sort_by(|left, right| left.as_os_str().cmp(right.as_os_str()));
+        normalized
+    }
+
+    pub(crate) fn serialize_watch_paths(paths: &[PathBuf]) -> Option<Vec<String>> {
+        if paths.is_empty() {
+            None
+        } else {
+            Some(
+                paths
+                    .iter()
+                    .map(|path| path.to_string_lossy().to_string())
+                    .collect(),
+            )
+        }
+    }
+
+    pub(crate) fn validate_paths_for_launch(paths: &[PathBuf]) -> Result<(), String> {
+        for path in paths {
+            let metadata = fs::metadata(path).map_err(|e| {
+                format!(
+                    "Configured Xcode watch path '{}' is not accessible: {}",
+                    path.display(),
+                    e
+                )
+            })?;
+            if !metadata.is_dir() {
+                return Err(format!(
+                    "Configured Xcode watch path '{}' is not a directory",
+                    path.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn plist_xml(paths: &[PathBuf]) -> String {
+        fn escape_xml(value: &str) -> String {
+            value
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;")
+                .replace('\"', "&quot;")
+                .replace('\'', "&apos;")
+        }
+
+        let mut args = vec![format!(
+            "    <string>{}</string>",
+            escape_xml(&Self::watcher_binary_path().to_string_lossy())
+        )];
+        for path in paths {
+            args.push("    <string>--path</string>".to_string());
+            args.push(format!(
+                "    <string>{}</string>",
+                escape_xml(&path.to_string_lossy())
+            ));
+        }
+
+        let log_path = escape_xml(&Self::launch_log_path().to_string_lossy());
+
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+{args}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>{log_path}</string>
+  <key>StandardErrorPath</key>
+  <string>{log_path}</string>
+</dict>
+</plist>
+"#,
+            label = XCODE_WATCHER_LABEL,
+            args = args.join("\n"),
+            log_path = log_path,
+        )
+    }
+
+    fn write_launch_agent_plist(paths: &[PathBuf]) -> Result<(), String> {
+        if let Some(parent) = Self::plist_path().parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                format!(
+                    "Unable to create LaunchAgents directory {}: {}",
+                    parent.display(),
+                    e
+                )
+            })?;
+        }
+        if let Some(parent) = Self::launch_log_path().parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                format!("Unable to create log directory {}: {}", parent.display(), e)
+            })?;
+        }
+
+        fs::write(Self::plist_path(), Self::plist_xml(paths))
+            .map_err(|e| format!("Unable to write plist: {}", e))
+    }
+
     fn launchctl_domain_target() -> Result<String, String> {
         let uid = unsafe { libc::geteuid() };
         if uid == 0 {
             return Err(
-                "Unable to stop the watcher automatically from a root or non-GUI session"
-                    .to_string(),
+                "Unable to reload watcher automatically from a root or non-GUI session. Run 'git-ai xcode reload' from the target user's login session.".to_string(),
             );
         }
         Ok(format!("gui/{}", uid))
@@ -235,24 +474,97 @@ impl XcodeInstaller {
         }
     }
 
-    fn remove_file_if_exists(path: &Path) -> Result<bool, String> {
-        if !path.exists() {
-            return Ok(false);
+    fn clean_launch_agent() -> Result<LaunchAgentApplyResult, String> {
+        let launchctl_warning = match Self::launchctl_domain_target() {
+            Ok(domain) => Self::bootout_launch_agent(&domain).err(),
+            Err(warning) => Some(warning),
+        };
+
+        match fs::remove_file(Self::plist_path()) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(format!("Unable to remove plist: {}", error)),
         }
 
-        fs::remove_file(path)
-            .map(|_| true)
-            .map_err(|e| format!("Unable to remove {}: {}", path.display(), e))
+        Ok(LaunchAgentApplyResult {
+            message: "Xcode: Watcher LaunchAgent removed; no Xcode paths are configured"
+                .to_string(),
+            warning: launchctl_warning,
+        })
     }
 
-    fn remove_dir_if_exists(path: &Path) -> Result<bool, String> {
-        if !path.exists() {
-            return Ok(false);
+    pub(crate) fn apply_launch_agent(paths: &[PathBuf]) -> Result<LaunchAgentApplyResult, String> {
+        if cfg!(not(target_os = "macos")) {
+            return Err("Xcode watcher configuration is only supported on macOS".to_string());
         }
 
-        fs::remove_dir_all(path)
-            .map(|_| true)
-            .map_err(|e| format!("Unable to remove {}: {}", path.display(), e))
+        if paths.is_empty() {
+            return Self::clean_launch_agent();
+        }
+
+        Self::validate_paths_for_launch(paths)?;
+
+        if !Self::watcher_binary_path().exists() {
+            let _ = fs::remove_file(Self::plist_path());
+            return Ok(LaunchAgentApplyResult {
+                message: format!(
+                    "Xcode: Saved {} watch path(s), but watcher binary is not installed yet",
+                    paths.len()
+                ),
+                warning: Some(
+                    "Run 'git-ai install-hooks' to install git-ai-xcode-watcher, then run 'git-ai xcode reload'.".to_string(),
+                ),
+            });
+        }
+
+        Self::write_launch_agent_plist(paths)?;
+
+        let domain = match Self::launchctl_domain_target() {
+            Ok(domain) => domain,
+            Err(warning) => {
+                return Ok(LaunchAgentApplyResult {
+                    message: format!(
+                        "Xcode: LaunchAgent updated with {} watch path(s)",
+                        paths.len()
+                    ),
+                    warning: Some(warning),
+                });
+            }
+        };
+
+        let service = format!("{}/{}", domain, XCODE_WATCHER_LABEL);
+        let mut launchctl_warning = Self::bootout_launch_agent(&domain).err();
+
+        if launchctl_warning.is_none() {
+            let bootstrap_args = vec![
+                "bootstrap".to_string(),
+                domain.clone(),
+                Self::plist_path().to_string_lossy().to_string(),
+            ];
+            if let Err(error) = Self::run_launchctl(&bootstrap_args) {
+                launchctl_warning = Some(error);
+            }
+        }
+
+        if launchctl_warning.is_none() {
+            let kickstart_args = vec!["kickstart".to_string(), "-k".to_string(), service];
+            if let Err(error) = Self::run_launchctl(&kickstart_args) {
+                launchctl_warning = Some(error);
+            }
+        }
+
+        Ok(LaunchAgentApplyResult {
+            message: format!(
+                "Xcode: LaunchAgent updated with {} watch path(s)",
+                paths.len()
+            ),
+            warning: launchctl_warning.map(|error| {
+                format!(
+                    "Unable to reload watcher automatically: {}. Run 'git-ai xcode reload' manually.",
+                    error
+                )
+            }),
+        })
     }
 }
 
@@ -321,13 +633,60 @@ impl HookInstaller for XcodeInstaller {
             return Ok(results);
         }
 
+        let configured_paths = match Self::configured_paths_from_disk() {
+            Ok(paths) => paths,
+            Err(error) => {
+                results.push(Self::install_warning(format!(
+                    "Xcode: Unable to read configured xcode_paths: {}. Run 'git-ai xcode reload' manually after fixing the config.",
+                    error
+                )));
+                Vec::new()
+            }
+        };
+
         let watcher_bin = Self::watcher_binary_path();
         if watcher_bin.exists() && Self::is_watcher_up_to_date() {
-            results.push(InstallResult {
-                changed: false,
-                diff: None,
-                message: "Xcode: Watcher already installed and up to date. To monitor a project, run: git-ai-xcode-watcher --path /path/to/xcode/project".to_string(),
-            });
+            results.push(Self::install_warning(
+                "Xcode: Watcher already installed and up to date",
+            ));
+            if configured_paths.is_empty() {
+                if Self::plist_path().exists() {
+                    match Self::clean_launch_agent() {
+                        Ok(apply_result) => {
+                            results.push(InstallResult {
+                                changed: false,
+                                diff: None,
+                                message: apply_result.message,
+                            });
+                            if let Some(warning) = apply_result.warning {
+                                results.push(Self::install_warning(format!("Xcode: {}", warning)));
+                            }
+                        }
+                        Err(error) => results.push(Self::install_warning(format!(
+                            "Xcode: Unable to remove stale LaunchAgent automatically: {}. Run 'git-ai xcode reload' manually.",
+                            error
+                        ))),
+                    }
+                }
+                results.push(Self::install_warning(XCODE_ADD_PATH_GUIDANCE));
+            } else {
+                match Self::apply_launch_agent(&configured_paths) {
+                    Ok(apply_result) => {
+                        results.push(InstallResult {
+                            changed: false,
+                            diff: None,
+                            message: apply_result.message,
+                        });
+                        if let Some(warning) = apply_result.warning {
+                            results.push(Self::install_warning(format!("Xcode: {}", warning)));
+                        }
+                    }
+                    Err(error) => results.push(Self::install_warning(format!(
+                        "Xcode: Unable to reload watcher automatically: {}. Run 'git-ai xcode reload' manually.",
+                        error
+                    ))),
+                }
+            }
             return Ok(results);
         }
 
@@ -337,6 +696,18 @@ impl HookInstaller for XcodeInstaller {
                 diff: None,
                 message: "Xcode: Pending watcher compilation and installation".to_string(),
             });
+            if configured_paths.is_empty() {
+                if Self::plist_path().exists() {
+                    results.push(Self::install_warning(
+                        "Xcode: Pending stale LaunchAgent removal because no xcode_paths are configured",
+                    ));
+                }
+                results.push(Self::install_warning(XCODE_ADD_PATH_GUIDANCE));
+            } else {
+                results.push(Self::install_warning(
+                    "Xcode: Pending LaunchAgent reload from configured xcode_paths",
+                ));
+            }
             return Ok(results);
         }
 
@@ -419,7 +790,44 @@ impl HookInstaller for XcodeInstaller {
                 watcher_bin.display()
             ),
         });
-        results.push(Self::install_warning(XCODE_MONITORING_GUIDANCE));
+        if configured_paths.is_empty() {
+            if Self::plist_path().exists() {
+                match Self::clean_launch_agent() {
+                    Ok(apply_result) => {
+                        results.push(InstallResult {
+                            changed: false,
+                            diff: None,
+                            message: apply_result.message,
+                        });
+                        if let Some(warning) = apply_result.warning {
+                            results.push(Self::install_warning(format!("Xcode: {}", warning)));
+                        }
+                    }
+                    Err(error) => results.push(Self::install_warning(format!(
+                        "Xcode: Unable to remove stale LaunchAgent automatically: {}. Run 'git-ai xcode reload' manually.",
+                        error
+                    ))),
+                }
+            }
+            results.push(Self::install_warning(XCODE_ADD_PATH_GUIDANCE));
+        } else {
+            match Self::apply_launch_agent(&configured_paths) {
+                Ok(apply_result) => {
+                    results.push(InstallResult {
+                        changed: false,
+                        diff: None,
+                        message: apply_result.message,
+                    });
+                    if let Some(warning) = apply_result.warning {
+                        results.push(Self::install_warning(format!("Xcode: {}", warning)));
+                    }
+                }
+                Err(error) => results.push(Self::install_warning(format!(
+                    "Xcode: Unable to reload watcher automatically: {}. Run 'git-ai xcode reload' manually.",
+                    error
+                ))),
+            }
+        }
 
         Ok(results)
     }
@@ -669,9 +1077,70 @@ mod tests {
                 home.join("Library/LaunchAgents/com.gitai.xcode-watcher.plist")
             );
             assert_eq!(
+                XcodeInstaller::launch_log_path(),
+                home.join(".git-ai/logs/xcode-watcher.log")
+            );
+            assert_eq!(
                 XcodeInstaller::build_cache_dir(),
                 home.join(".git-ai/cache/xcode-watcher-build")
             );
+        });
+    }
+
+    #[test]
+    fn test_normalize_watch_paths_collapses_descendants() {
+        let parent = PathBuf::from("/tmp/workspace");
+        let child = parent.join("AppA");
+        let grandchild = child.join("Feature");
+
+        let normalized =
+            XcodeInstaller::normalize_watch_paths(vec![grandchild, child, parent.clone()]);
+
+        assert_eq!(normalized, vec![parent]);
+    }
+
+    #[test]
+    #[serial]
+    fn test_validate_new_watch_path_rejects_overly_broad_roots() {
+        with_temp_home(|home| {
+            let home_error = XcodeInstaller::validate_new_watch_path(home).unwrap_err();
+            assert!(home_error.contains("HOME directory"));
+
+            let root_error = XcodeInstaller::validate_new_watch_path(Path::new("/")).unwrap_err();
+            assert!(root_error.contains("Refusing to watch '/'"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_configured_paths_from_file_config_canonicalizes_existing_entries() {
+        with_temp_home(|home| {
+            let workspace = home.join("ios").join("AppA");
+            fs::create_dir_all(&workspace).unwrap();
+
+            let file_config = FileConfig {
+                xcode_paths: Some(vec![workspace.to_string_lossy().to_string()]),
+                ..Default::default()
+            };
+
+            let paths = XcodeInstaller::configured_paths_from_file_config(&file_config).unwrap();
+            assert_eq!(paths, vec![fs::canonicalize(workspace).unwrap()]);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_plist_xml_contains_all_paths_and_log_file() {
+        with_temp_home(|home| {
+            let path_a = home.join("ios");
+            let path_b = home.join("mac");
+            let plist = XcodeInstaller::plist_xml(&[path_a.clone(), path_b.clone()]);
+
+            assert!(plist.contains(XCODE_WATCHER_LABEL));
+            assert!(plist.contains(&*XcodeInstaller::watcher_binary_path().to_string_lossy()));
+            assert!(plist.contains(&*path_a.to_string_lossy()));
+            assert!(plist.contains(&*path_b.to_string_lossy()));
+            assert!(plist.contains(&*XcodeInstaller::launch_log_path().to_string_lossy()));
         });
     }
 
@@ -867,6 +1336,167 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     #[serial]
+    fn test_apply_launch_agent_warns_when_binary_missing() {
+        with_temp_home(|home| {
+            let workspace = home.join("ios");
+            fs::create_dir_all(&workspace).unwrap();
+
+            let result = XcodeInstaller::apply_launch_agent(&[workspace]).unwrap();
+            assert!(result.message.contains("watch path"));
+            assert!(
+                result
+                    .warning
+                    .as_deref()
+                    .unwrap()
+                    .contains("git-ai install-hooks")
+            );
+            assert!(!XcodeInstaller::plist_path().exists());
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_apply_launch_agent_writes_plist_and_calls_launchctl() {
+        with_temp_home(|home| {
+            with_path_override(|bin_dir| {
+                let workspace = home.join("ios");
+                let launchctl_log = home.join("launchctl.log");
+                fs::create_dir_all(&workspace).unwrap();
+                fs::create_dir_all(XcodeInstaller::watcher_binary_path().parent().unwrap())
+                    .unwrap();
+                fs::write(XcodeInstaller::watcher_binary_path(), "#!/bin/sh\n").unwrap();
+                #[cfg(unix)]
+                fs::set_permissions(
+                    XcodeInstaller::watcher_binary_path(),
+                    fs::Permissions::from_mode(0o755),
+                )
+                .unwrap();
+                write_launchctl_stub(bin_dir, 0, &launchctl_log);
+
+                let result =
+                    XcodeInstaller::apply_launch_agent(std::slice::from_ref(&workspace)).unwrap();
+                assert!(result.warning.is_none());
+                assert!(XcodeInstaller::plist_path().exists());
+
+                let plist = fs::read_to_string(XcodeInstaller::plist_path()).unwrap();
+                assert!(plist.contains(&*workspace.to_string_lossy()));
+
+                let log = fs::read_to_string(launchctl_log).unwrap();
+                assert!(log.contains("bootout"));
+                assert!(log.contains("bootstrap"));
+                assert!(log.contains("kickstart"));
+            });
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_apply_launch_agent_with_no_paths_removes_plist_and_calls_bootout() {
+        with_temp_home(|home| {
+            with_path_override(|bin_dir| {
+                let launchctl_log = home.join("launchctl.log");
+                fs::create_dir_all(XcodeInstaller::plist_path().parent().unwrap()).unwrap();
+                fs::write(XcodeInstaller::plist_path(), "stale plist").unwrap();
+                write_launchctl_stub(bin_dir, 0, &launchctl_log);
+
+                let result = XcodeInstaller::apply_launch_agent(&[]).unwrap();
+                assert!(result.warning.is_none());
+                assert!(!XcodeInstaller::plist_path().exists());
+
+                let log = fs::read_to_string(launchctl_log).unwrap();
+                assert!(log.contains("bootout"));
+            });
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_apply_launch_agent_returns_warning_when_launchctl_fails() {
+        with_temp_home(|home| {
+            with_path_override(|bin_dir| {
+                let workspace = home.join("ios");
+                let launchctl_log = home.join("launchctl.log");
+                fs::create_dir_all(&workspace).unwrap();
+                fs::create_dir_all(XcodeInstaller::watcher_binary_path().parent().unwrap())
+                    .unwrap();
+                fs::write(XcodeInstaller::watcher_binary_path(), "#!/bin/sh\n").unwrap();
+                #[cfg(unix)]
+                fs::set_permissions(
+                    XcodeInstaller::watcher_binary_path(),
+                    fs::Permissions::from_mode(0o755),
+                )
+                .unwrap();
+                write_launchctl_stub(bin_dir, 1, &launchctl_log);
+
+                let result = XcodeInstaller::apply_launch_agent(&[workspace]).unwrap();
+                assert!(
+                    result
+                        .warning
+                        .as_deref()
+                        .unwrap()
+                        .contains("Unable to reload watcher automatically")
+                );
+                assert!(XcodeInstaller::plist_path().exists());
+            });
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
+    fn test_install_extras_cleans_stale_launch_agent_when_no_paths_are_configured() {
+        with_temp_home(|home| {
+            if !XcodeInstaller::is_xcode_ide_available() {
+                return;
+            }
+
+            with_path_override(|bin_dir| {
+                let launchctl_log = home.join("launchctl.log");
+                let installer = XcodeInstaller;
+
+                fs::create_dir_all(XcodeInstaller::watcher_binary_path().parent().unwrap())
+                    .unwrap();
+                fs::write(XcodeInstaller::watcher_binary_path(), "#!/bin/sh\n").unwrap();
+                #[cfg(unix)]
+                fs::set_permissions(
+                    XcodeInstaller::watcher_binary_path(),
+                    fs::Permissions::from_mode(0o755),
+                )
+                .unwrap();
+                fs::write(
+                    XcodeInstaller::version_file_path(),
+                    env!("CARGO_PKG_VERSION"),
+                )
+                .unwrap();
+                fs::create_dir_all(XcodeInstaller::plist_path().parent().unwrap()).unwrap();
+                fs::write(XcodeInstaller::plist_path(), "stale plist").unwrap();
+                write_launchctl_stub(bin_dir, 0, &launchctl_log);
+
+                let results = installer.install_extras(&test_params(), false).unwrap();
+
+                assert!(results.iter().any(|result| {
+                    !result.changed
+                        && result
+                            .message
+                            .contains("Watcher LaunchAgent removed; no Xcode paths are configured")
+                }));
+                assert!(results.iter().any(|result| {
+                    !result.changed && result.message.contains("git-ai xcode add-path")
+                }));
+                assert!(!XcodeInstaller::plist_path().exists());
+
+                let log = fs::read_to_string(launchctl_log).unwrap();
+                assert!(log.contains("bootout"));
+            });
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[serial]
     fn test_uninstall_extras_uses_bootout_for_launch_agent() {
         with_temp_home(|home| {
             with_path_override(|bin_dir| {
@@ -913,10 +1543,7 @@ mod tests {
                 result.changed && result.message.contains("Watcher binary installed")
             }));
             assert!(first_results.iter().any(|result| {
-                !result.changed
-                    && result
-                        .message
-                        .contains("Unable to auto-configure monitoring scope")
+                !result.changed && result.message.contains("git-ai xcode add-path")
             }));
 
             let check_result = installer.check_hooks(&test_params()).unwrap();
@@ -925,12 +1552,13 @@ mod tests {
             assert!(check_result.hooks_up_to_date);
 
             let second_results = installer.install_extras(&test_params(), false).unwrap();
-            assert_eq!(second_results.len(), 1);
-            assert!(!second_results[0].changed);
+            assert!(second_results.iter().any(|result| !result.changed
+                && result.message.contains("already installed and up to date")));
             assert!(
-                second_results[0]
-                    .message
-                    .contains("already installed and up to date")
+                second_results
+                    .iter()
+                    .any(|result| !result.changed
+                        && result.message.contains("git-ai xcode add-path"))
             );
 
             let uninstall_results = installer.uninstall_extras(&test_params(), false).unwrap();

--- a/src/mdm/agents/xcode.rs
+++ b/src/mdm/agents/xcode.rs
@@ -4,6 +4,7 @@ use crate::mdm::hook_installer::{
     HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
 use crate::mdm::utils::home_dir;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -152,9 +153,21 @@ impl XcodeInstaller {
 
     fn is_watcher_up_to_date() -> bool {
         match fs::read_to_string(Self::version_file_path()) {
-            Ok(version) => version.trim() == env!("CARGO_PKG_VERSION"),
+            Ok(version) => version.trim() == Self::watcher_version_marker(),
             Err(_) => false,
         }
+    }
+
+    fn watcher_version_marker() -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(XCODE_WATCHER_PACKAGE_SWIFT.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(XCODE_WATCHER_MAIN_SWIFT.as_bytes());
+        format!(
+            "{}+sha256:{:x}",
+            env!("CARGO_PKG_VERSION"),
+            hasher.finalize()
+        )
     }
 
     fn install_warning(message: impl Into<String>) -> InstallResult {
@@ -775,7 +788,7 @@ impl HookInstaller for XcodeInstaller {
             let _ = fs::set_permissions(&watcher_bin, fs::Permissions::from_mode(0o755));
         }
 
-        if let Err(e) = fs::write(Self::version_file_path(), env!("CARGO_PKG_VERSION")) {
+        if let Err(e) = fs::write(Self::version_file_path(), Self::watcher_version_marker()) {
             results.push(Self::install_warning(format!(
                 "Xcode: Unable to write watcher version file: {}",
                 e
@@ -1170,6 +1183,14 @@ mod tests {
     }
 
     #[test]
+    fn test_embedded_xcode_watcher_sends_absolute_checkpoint_paths() {
+        assert!(XCODE_WATCHER_MAIN_SWIFT.contains("pendingFiles[root]![absolutePath] = content"));
+        assert!(XCODE_WATCHER_MAIN_SWIFT.contains("\"edited_filepaths\": Array(files.keys)"));
+        assert!(XCODE_WATCHER_MAIN_SWIFT.contains("\"dirty_files\": files"));
+        assert!(!XCODE_WATCHER_MAIN_SWIFT.contains("relativePath("));
+    }
+
+    #[test]
     fn test_failure_messages_use_visibility_keywords() {
         let messages = [
             "Xcode: Unable to create build cache directory: permission denied",
@@ -1258,9 +1279,12 @@ mod tests {
         with_temp_home(|_| {
             let version_path = XcodeInstaller::version_file_path();
             fs::create_dir_all(version_path.parent().unwrap()).unwrap();
-            fs::write(&version_path, env!("CARGO_PKG_VERSION")).unwrap();
+            fs::write(&version_path, XcodeInstaller::watcher_version_marker()).unwrap();
 
             assert!(XcodeInstaller::is_watcher_up_to_date());
+
+            fs::write(&version_path, env!("CARGO_PKG_VERSION")).unwrap();
+            assert!(!XcodeInstaller::is_watcher_up_to_date());
 
             fs::write(&version_path, "0.0.0").unwrap();
             assert!(!XcodeInstaller::is_watcher_up_to_date());

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -101,3 +101,4 @@ mod virtual_attribution_merge;
 mod windsurf;
 mod worktrees;
 mod wrapper_performance_targets;
+mod xcode_command;

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1747,6 +1747,90 @@ fn test_ai_generated_file_then_human_full_rewrite() {
     ]);
 }
 
+/// Helper to simulate an Xcode watcher KnownHuman checkpoint via the production
+/// `known_human` preset (which sets `known_human_metadata`, enabling AI Reclaim).
+fn xcode_known_human_checkpoint(repo: &TestRepo, files: &[&str]) {
+    let cwd = repo.path().to_string_lossy().to_string();
+    let edited: Vec<String> = files.iter().map(|f| f.to_string()).collect();
+    let mut dirty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for f in files {
+        let abs = repo.path().join(f);
+        if abs.exists() {
+            dirty.insert(f.to_string(), fs::read_to_string(&abs).unwrap_or_default());
+        }
+    }
+    let payload = serde_json::json!({
+        "editor": "xcode",
+        "editor_version": "16.0",
+        "extension_version": "1.0.0",
+        "cwd": cwd,
+        "edited_filepaths": edited,
+        "dirty_files": dirty,
+    });
+    repo.git_ai_with_stdin(
+        &["checkpoint", "known_human", "--hook-input", "stdin"],
+        payload.to_string().as_bytes(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_xcode_watcher_race_known_human_before_ai() {
+    // Regression test for the Xcode watcher race condition:
+    // FSEvents-based watcher fires a KnownHuman checkpoint on AI-written files
+    // BEFORE the AI tool sends its own checkpoint, causing AI code to be
+    // misattributed as human. The AI Reclaim mechanism should fix this.
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("data.txt");
+
+    fs::write(&file_path, "line1\nline2\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(&file_path, "line1\nline2\nAI_line3\n").unwrap();
+
+    xcode_known_human_checkpoint(&repo, &["data.txt"]);
+
+    repo.git_ai(&["checkpoint", "mock_ai", "data.txt"]).unwrap();
+
+    repo.stage_all_and_commit("AI adds line3").unwrap();
+
+    let mut file = repo.filename("data.txt");
+    file.assert_lines_and_blame(crate::lines![
+        "line1".human(),
+        "line2".human(),
+        "AI_line3".ai(),
+    ]);
+}
+
+#[test]
+fn test_xcode_watcher_race_does_not_affect_different_files() {
+    // Verify that AI Reclaim only removes KnownHuman entries for files
+    // that the AI checkpoint claims, not other files.
+    let repo = TestRepo::new();
+    let file_a = repo.path().join("file_a.txt");
+    let file_b = repo.path().join("file_b.txt");
+
+    fs::write(&file_a, "original_a\n").unwrap();
+    fs::write(&file_b, "original_b\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(&file_a, "original_a\nAI_line\n").unwrap();
+    fs::write(&file_b, "original_b\nhuman_line\n").unwrap();
+
+    xcode_known_human_checkpoint(&repo, &["file_a.txt", "file_b.txt"]);
+
+    repo.git_ai(&["checkpoint", "mock_ai", "file_a.txt"])
+        .unwrap();
+
+    repo.stage_all_and_commit("Mixed changes").unwrap();
+
+    let mut fa = repo.filename("file_a.txt");
+    fa.assert_lines_and_blame(crate::lines!["original_a".human(), "AI_line".ai(),]);
+
+    let mut fb = repo.filename("file_b.txt");
+    fb.assert_lines_and_blame(crate::lines!["original_b".human(), "human_line".human(),]);
+}
+
 crate::reuse_tests_in_worktree!(
     test_simple_additions_empty_repo,
     test_simple_additions_with_base_commit,

--- a/tests/integration/xcode_command.rs
+++ b/tests/integration/xcode_command.rs
@@ -1,0 +1,146 @@
+#![cfg(target_os = "macos")]
+
+use crate::repos::test_repo::get_binary_path;
+use serde_json::Value;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn write_launchctl_stub(bin_dir: &Path, exit_code: i32, log_path: &Path) {
+    let stub_path = bin_dir.join("launchctl");
+    let script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" >> '{}'\nexit {}\n",
+        log_path.display(),
+        exit_code
+    );
+    fs::write(&stub_path, script).expect("write launchctl stub");
+    #[cfg(unix)]
+    fs::set_permissions(&stub_path, fs::Permissions::from_mode(0o755))
+        .expect("chmod launchctl stub");
+}
+
+fn write_watcher_binary(home: &Path) -> PathBuf {
+    let watcher = home.join(".git-ai/bin/git-ai-xcode-watcher");
+    fs::create_dir_all(watcher.parent().expect("watcher parent")).expect("create watcher dir");
+    fs::write(&watcher, "#!/bin/sh\n").expect("write watcher stub");
+    #[cfg(unix)]
+    fs::set_permissions(&watcher, fs::Permissions::from_mode(0o755)).expect("chmod watcher stub");
+    watcher
+}
+
+fn run_git_ai(home: &Path, fake_bin: &Path, args: &[&str]) -> Output {
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let path_with_stub = format!("{}:{}", fake_bin.display(), existing_path);
+
+    let mut command = Command::new(get_binary_path());
+    command
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("PATH", path_with_stub);
+
+    command.output().expect("run git-ai command")
+}
+
+#[test]
+fn test_xcode_add_path_command_updates_config_and_launch_agent() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().to_path_buf();
+    let fake_bin = home.join("fake-bin");
+    let workspace = home.join("work/ios/AppA");
+    let launchctl_log = home.join("launchctl.log");
+
+    fs::create_dir_all(&fake_bin).expect("create fake bin");
+    fs::create_dir_all(&workspace).expect("create workspace");
+    write_launchctl_stub(&fake_bin, 0, &launchctl_log);
+    let watcher = write_watcher_binary(&home);
+
+    let output = run_git_ai(
+        &home,
+        &fake_bin,
+        &["xcode", "add-path", workspace.to_str().unwrap()],
+    );
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let canonical_workspace = fs::canonicalize(&workspace).expect("canonical workspace");
+    assert!(stdout.contains("Added watch path"));
+    assert!(stdout.contains("LaunchAgent updated"));
+
+    let config: Value = serde_json::from_str(
+        &fs::read_to_string(home.join(".git-ai/config.json")).expect("read config"),
+    )
+    .expect("parse config");
+    assert_eq!(
+        config["xcode_paths"],
+        Value::Array(vec![Value::String(
+            canonical_workspace.to_string_lossy().to_string()
+        )])
+    );
+
+    let plist = fs::read_to_string(home.join("Library/LaunchAgents/com.gitai.xcode-watcher.plist"))
+        .expect("read plist");
+    assert!(plist.contains(&*watcher.to_string_lossy()));
+    assert!(plist.contains(&*canonical_workspace.to_string_lossy()));
+
+    let launchctl_log = fs::read_to_string(launchctl_log).expect("read launchctl log");
+    assert!(launchctl_log.contains("bootstrap"));
+    assert!(launchctl_log.contains("kickstart"));
+}
+
+#[test]
+fn test_xcode_remove_path_command_disables_launch_agent_when_last_path_removed() {
+    let temp = tempdir().expect("tempdir");
+    let home = temp.path().to_path_buf();
+    let fake_bin = home.join("fake-bin");
+    let workspace = home.join("work/ios/AppA");
+    let launchctl_log = home.join("launchctl.log");
+
+    fs::create_dir_all(&fake_bin).expect("create fake bin");
+    fs::create_dir_all(&workspace).expect("create workspace");
+    write_launchctl_stub(&fake_bin, 0, &launchctl_log);
+    write_watcher_binary(&home);
+
+    let add_output = run_git_ai(
+        &home,
+        &fake_bin,
+        &["xcode", "add-path", workspace.to_str().unwrap()],
+    );
+    assert!(add_output.status.success());
+
+    let remove_output = run_git_ai(
+        &home,
+        &fake_bin,
+        &["xcode", "remove-path", workspace.to_str().unwrap()],
+    );
+    assert!(
+        remove_output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&remove_output.stdout),
+        String::from_utf8_lossy(&remove_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&remove_output.stdout);
+    assert!(stdout.contains("Removed watch path"));
+    assert!(stdout.contains("Watcher LaunchAgent removed"));
+
+    let config: Value = serde_json::from_str(
+        &fs::read_to_string(home.join(".git-ai/config.json")).expect("read config"),
+    )
+    .expect("parse config");
+    assert!(config.get("xcode_paths").is_none());
+    assert!(
+        !home
+            .join("Library/LaunchAgents/com.gitai.xcode-watcher.plist")
+            .exists()
+    );
+}


### PR DESCRIPTION
## Summary
- fix Xcode watcher stability issues in the Swift FSEvents helper
- install `git-ai-xcode-watcher` through `git-ai install-hooks`
- add `xcode_paths` config plus `git-ai xcode add-path/remove-path/list-paths/reload`
- generate and reload the LaunchAgent from configured Xcode workspace roots
- keep path normalization safe by rejecting overly broad roots and collapsing redundant descendants

## Testing
- cargo fmt -- --check
- cargo test xcode -- --nocapture
- cargo clippy --all-targets -- -D warnings
- xcrun swift build
- manual isolated command flow with temporary HOME: `git-ai xcode add-path`, `list-paths`, `reload`, `remove-path`
