### PR TITLE
Harden flaky test retry: fail-fast on >5 failures, fix Windows log streaming

### DIFF
--- a/scripts/ci-test-with-retry.ps1
+++ b/scripts/ci-test-with-retry.ps1
@@ -9,24 +9,26 @@ param(
 $ErrorActionPreference = "Continue"
 $TestMode = $env:GIT_AI_TEST_GIT_MODE
 
-# Run the full test suite, capturing output
-$output = cargo test -- --test-threads=$TestThreads 2>&1 | Out-String
+# Run the full test suite, streaming output to console and capturing to a temp file
+$tempFile = [System.IO.Path]::GetTempFileName()
+& cargo test -- --test-threads=$TestThreads 2>&1 | Tee-Object -FilePath $tempFile
 $firstExit = $LASTEXITCODE
 
-Write-Host $output
-
 if ($firstExit -eq 0) {
+    Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
     exit 0
 }
 
 # Only retry for daemon and wrapper-daemon modes
 if ($TestMode -ne "daemon" -and $TestMode -ne "wrapper-daemon") {
     Write-Host "::error::Tests failed in '$TestMode' mode (retry not enabled for this mode)"
+    Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
     exit 1
 }
 
 # Parse failed test names from cargo test output
-$lines = $output -split "`r?`n"
+$lines = Get-Content -Path $tempFile
+Remove-Item -Path $tempFile -Force
 $inFailures = $false
 $failedTests = @()
 
@@ -54,6 +56,12 @@ if ($failedTests.Count -eq 0) {
 }
 
 $failedCount = $failedTests.Count
+
+if ($failedCount -gt 5) {
+    Write-Host "::error::$failedCount tests failed on first run — too many failures to retry as flaky"
+    exit 1
+}
+
 Write-Host ""
 Write-Host "::warning::$failedCount test(s) failed on first run in '$TestMode' mode. Retrying individually..."
 Write-Host ""

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -55,6 +55,12 @@ if [ -z "$FAILED_TESTS" ]; then
 fi
 
 FAILED_COUNT=$(echo "$FAILED_TESTS" | wc -l | tr -d ' ')
+
+if [ "$FAILED_COUNT" -gt 5 ]; then
+  echo "::error::$FAILED_COUNT tests failed on first run — too many failures to retry as flaky"
+  exit 1
+fi
+
 echo ""
 echo "::warning::$FAILED_COUNT test(s) failed on first run in '$TEST_MODE' mode. Retrying individually..."
 echo ""


### PR DESCRIPTION
## Summary
- Both CI retry scripts (bash + ps1) now **bail out immediately if >5 tests fail** on the first run, since that indicates widespread breakage rather than flaky tests — retrying would just waste CI time.
- The Windows (ps1) script was **buffering all `cargo test` output** via `Out-String` and only printing it after the full suite finished, making incremental test progress invisible in GitHub Actions logs. Switched to `Tee-Object` which streams to console in real-time while capturing to a temp file for failure parsing.

## Test plan
- [ ] Ubuntu CI jobs pass (scripts-only change, no Rust code affected)
- [ ] Verify Windows job logs now show incremental test output (will be visible on next Windows CI run that uses this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
