### PR TITLE
fix: windsurf hooks would not try to install if no .codium/windsurf folder present

### DIFF
--- a/src/commands/checkpoint_agent/agent_presets.rs
+++ b/src/commands/checkpoint_agent/agent_presets.rs
@@ -120,6 +120,33 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_escape_control_chars_in_json_strings_fixes_raw_newlines() {
+        let raw = "{\n  \"tool_info\": {\"command\": \"echo hi\nbye\tend\"},\n  \"other\": \"ok\"\n}";
+        let sanitized = escape_control_chars_in_json_strings(raw);
+        // Strict parse must now succeed.
+        let v: serde_json::Value = serde_json::from_str(&sanitized).unwrap();
+        assert_eq!(
+            v.get("tool_info")
+                .and_then(|t| t.get("command"))
+                .and_then(|c| c.as_str())
+                .unwrap(),
+            "echo hi\nbye\tend"
+        );
+        assert_eq!(v.get("other").and_then(|v| v.as_str()).unwrap(), "ok");
+    }
+
+    #[test]
+    fn test_escape_control_chars_preserves_escaped_quotes_and_utf8() {
+        let raw = "{\"msg\": \"line1\nquote:\\\"x\\\" — 你好\"}";
+        let sanitized = escape_control_chars_in_json_strings(raw);
+        let v: serde_json::Value = serde_json::from_str(&sanitized).unwrap();
+        assert_eq!(
+            v.get("msg").and_then(|v| v.as_str()).unwrap(),
+            "line1\nquote:\"x\" — 你好"
+        );
+    }
+
+    #[test]
     fn test_prepare_agent_bash_pre_hook_swallows_snapshot_errors() {
         let temp = tempfile::tempdir().unwrap();
         let missing_repo = temp.path().join("missing-repo");
@@ -685,6 +712,50 @@ impl GeminiPreset {
         Ok((transcript, model))
     }
 }
+/// Escape raw ASCII control characters (0x00..=0x1F) that appear inside JSON
+/// string literals so the input parses under strict serde_json. Bytes outside
+/// string literals, already-escaped sequences, and non-control bytes are left
+/// untouched. This is a byte-level pass; it does not validate the rest of the
+/// JSON grammar.
+fn escape_control_chars_in_json_strings(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut in_string = false;
+    let mut escaped = false;
+    for &b in bytes {
+        if in_string {
+            if escaped {
+                out.push(b);
+                escaped = false;
+            } else if b == b'\\' {
+                out.push(b);
+                escaped = true;
+            } else if b == b'"' {
+                out.push(b);
+                in_string = false;
+            } else if b < 0x20 {
+                match b {
+                    b'\n' => out.extend_from_slice(b"\\n"),
+                    b'\r' => out.extend_from_slice(b"\\r"),
+                    b'\t' => out.extend_from_slice(b"\\t"),
+                    0x08 => out.extend_from_slice(b"\\b"),
+                    0x0C => out.extend_from_slice(b"\\f"),
+                    _ => out.extend_from_slice(format!("\\u{:04x}", b).as_bytes()),
+                }
+            } else {
+                out.push(b);
+            }
+        } else {
+            if b == b'"' {
+                in_string = true;
+            }
+            out.push(b);
+        }
+    }
+    // Safe: input was valid UTF-8, and we only inserted ASCII escape sequences.
+    String::from_utf8(out).unwrap_or_else(|_| input.to_string())
+}
+
 pub struct WindsurfPreset;
 impl AgentCheckpointPreset for WindsurfPreset {
     fn run(&self, flags: AgentCheckpointFlags) -> Result<AgentRunResult, GitAiError> {
@@ -692,7 +763,11 @@ impl AgentCheckpointPreset for WindsurfPreset {
             GitAiError::PresetError("hook_input is required for Windsurf preset".to_string())
         })?;
 
-        let hook_data: serde_json::Value = serde_json::from_str(&stdin_json)
+        // Windsurf sometimes emits raw control characters (unescaped newlines, tabs, etc.)
+        // inside JSON string values (e.g. captured command output in `tool_info`). Strict
+        // serde_json rejects those, so escape them inside string literals before parsing.
+        let sanitized = escape_control_chars_in_json_strings(&stdin_json);
+        let hook_data: serde_json::Value = serde_json::from_str(&sanitized)
             .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
 
         let trajectory_id = hook_data
@@ -739,6 +814,13 @@ impl AgentCheckpointPreset for WindsurfPreset {
         let (transcript, transcript_model) =
             match WindsurfPreset::transcript_and_model_from_windsurf_jsonl(&transcript_path) {
                 Ok((transcript, model)) => (transcript, model),
+                Err(GitAiError::IoError(ref io_err))
+                    if io_err.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    // JSONL may not exist yet on the first hook event of a session; treat
+                    // as empty transcript without warning/logging.
+                    (crate::authorship::transcript::AiTranscript::new(), None)
+                }
                 Err(e) => {
                     eprintln!("[Warning] Failed to parse Windsurf JSONL: {e}");
                     log_error(

--- a/src/commands/checkpoint_agent/agent_presets.rs
+++ b/src/commands/checkpoint_agent/agent_presets.rs
@@ -121,7 +121,8 @@ mod tests {
 
     #[test]
     fn test_escape_control_chars_in_json_strings_fixes_raw_newlines() {
-        let raw = "{\n  \"tool_info\": {\"command\": \"echo hi\nbye\tend\"},\n  \"other\": \"ok\"\n}";
+        let raw =
+            "{\n  \"tool_info\": {\"command\": \"echo hi\nbye\tend\"},\n  \"other\": \"ok\"\n}";
         let sanitized = escape_control_chars_in_json_strings(raw);
         // Strict parse must now succeed.
         let v: serde_json::Value = serde_json::from_str(&sanitized).unwrap();

--- a/src/mdm/agents/windsurf.rs
+++ b/src/mdm/agents/windsurf.rs
@@ -211,7 +211,7 @@ impl HookInstaller for WindsurfInstaller {
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let has_cli = resolve_editor_cli("windsurf").is_some();
-        let has_dotfiles = home_dir().join(".codeium").join("windsurf").exists();
+        let has_dotfiles = home_dir().join(".codeium").exists() || home_dir().join(".windsurf").exists();
 
         if !has_cli && !has_dotfiles {
             return Ok(HookCheckResult {

--- a/src/mdm/agents/windsurf.rs
+++ b/src/mdm/agents/windsurf.rs
@@ -211,7 +211,8 @@ impl HookInstaller for WindsurfInstaller {
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let has_cli = resolve_editor_cli("windsurf").is_some();
-        let has_dotfiles = home_dir().join(".codeium").exists() || home_dir().join(".windsurf").exists();
+        let has_dotfiles =
+            home_dir().join(".codeium").exists() || home_dir().join(".windsurf").exists();
 
         if !has_cli && !has_dotfiles {
             return Ok(HookCheckResult {


### PR DESCRIPTION
Developers that have had windsurf for a long time may not have`.codium/windsurf` folders. In this case were skipping install
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
