### PR TITLE
feat: daemon support for update-ref plumbing commands

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6712,7 +6712,15 @@ impl ActorDaemonCoordinator {
         let primary = cmd.primary_command.as_deref().unwrap_or("unknown");
         let is_write_op = matches!(
             primary,
-            "commit" | "rebase" | "merge" | "cherry-pick" | "am" | "stash" | "reset" | "push"
+            "commit"
+                | "rebase"
+                | "merge"
+                | "cherry-pick"
+                | "am"
+                | "stash"
+                | "reset"
+                | "push"
+                | "update-ref"
         );
         if is_write_op && cmd.exit_code == 0 {
             let repo_path = cmd
@@ -7039,6 +7047,45 @@ impl ActorDaemonCoordinator {
                 )?;
             }
         }
+
+        // Handle fast-forward update-ref: rename working log when the ref update
+        // is a fast-forward that affects the currently checked-out branch.
+        // Non-ancestor (rewrite) cases are already handled by
+        // rewrite_events_from_semantic_events() above.
+        if primary == "update-ref"
+            && let Some(worktree) = cmd.worktree.as_ref()
+        {
+            let current_branch = cmd.pre_repo.as_ref().and_then(|r| r.branch.clone());
+            for event in events {
+                if let crate::daemon::domain::SemanticEvent::RefUpdated {
+                    reference,
+                    old,
+                    new,
+                } = event
+                {
+                    if !reference.starts_with("refs/heads/")
+                        || !is_valid_oid(old)
+                        || is_zero_oid(old)
+                        || !is_valid_oid(new)
+                        || is_zero_oid(new)
+                        || old == new
+                    {
+                        continue;
+                    }
+                    let affects_checked_out_branch =
+                        current_branch.as_deref().is_some_and(|branch| {
+                            reference == &format!("refs/heads/{}", branch) || reference == branch
+                        });
+                    if affects_checked_out_branch
+                        && let Ok(repo) = find_repository_in_path(&worktree.to_string_lossy())
+                        && repo_is_ancestor(&repo, old, new)
+                    {
+                        let _ = repo.storage.rename_working_log(old, new);
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -9,7 +9,7 @@ use git_ai::git::find_repository_in_path;
 use git_ai::git::refs::show_authorship_note;
 use git_ai::git::repository::Repository as GitAiRepository;
 use repos::test_file::ExpectedLineExt;
-use repos::test_repo::{GitTestMode, TestRepo};
+use repos::test_repo::TestRepo;
 
 fn setup_initial_commit(repo: &TestRepo) {
     let mut readme = repo.filename("README.md");
@@ -125,22 +125,9 @@ fn graphite_style_restack_child_branch(
     new_head
 }
 
-fn should_skip_for_hooks_mode() -> bool {
-    let mode = std::env::var("GIT_AI_TEST_GIT_MODE").unwrap_or_else(|_| "wrapper".to_string());
-    if matches!(GitTestMode::from_mode_name(&mode), GitTestMode::Hooks) {
-        eprintln!("SKIP: commit-tree/update-ref regression only runs in wrapper mode");
-        return true;
-    }
-    false
-}
-
 #[test]
 fn test_commit_tree_update_ref_preserves_authorship_notes_on_reparent() {
-    if should_skip_for_hooks_mode() {
-        return;
-    }
-
-    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo = TestRepo::new();
     setup_initial_commit(&repo);
 
     repo.git(&["checkout", "-b", "feature"])
@@ -175,6 +162,8 @@ fn test_commit_tree_update_ref_preserves_authorship_notes_on_reparent() {
         "feature commit",
     );
 
+    repo.sync_daemon();
+
     let git_ai_repo = open_repo(&repo);
     assert!(
         show_authorship_note(&git_ai_repo, &new_head).is_some(),
@@ -189,11 +178,7 @@ fn test_commit_tree_update_ref_preserves_authorship_notes_on_reparent() {
 
 #[test]
 fn test_commit_tree_update_ref_moves_working_log_to_rewritten_head() {
-    if should_skip_for_hooks_mode() {
-        return;
-    }
-
-    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo = TestRepo::new();
     setup_initial_commit(&repo);
 
     repo.git(&["checkout", "-b", "feature"])
@@ -234,6 +219,8 @@ fn test_commit_tree_update_ref_moves_working_log_to_rewritten_head() {
         "feature commit",
     );
 
+    repo.sync_daemon();
+
     let git_ai_repo = open_repo(&repo);
     assert!(
         git_ai_repo.storage.has_working_log(&new_head),
@@ -261,11 +248,7 @@ fn test_commit_tree_update_ref_moves_working_log_to_rewritten_head() {
 
 #[test]
 fn test_reset_keep_rewrite_preserves_authorship_notes_on_current_branch() {
-    if should_skip_for_hooks_mode() {
-        return;
-    }
-
-    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo = TestRepo::new();
     setup_initial_commit(&repo);
 
     repo.git(&["checkout", "-b", "feature"])
@@ -300,6 +283,8 @@ fn test_reset_keep_rewrite_preserves_authorship_notes_on_current_branch() {
     repo.git(&["reset", "--keep", &new_head])
         .expect("git reset --keep should succeed");
 
+    repo.sync_daemon();
+
     let git_ai_repo = open_repo(&repo);
     assert!(
         show_authorship_note(&git_ai_repo, &new_head).is_some(),
@@ -314,11 +299,7 @@ fn test_reset_keep_rewrite_preserves_authorship_notes_on_current_branch() {
 
 #[test]
 fn test_update_ref_restack_after_parent_amend_preserves_child_attribution() {
-    if should_skip_for_hooks_mode() {
-        return;
-    }
-
-    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo = TestRepo::new();
     setup_initial_commit(&repo);
 
     repo.git(&["checkout", "-b", "parent"])
@@ -365,6 +346,8 @@ fn test_update_ref_restack_after_parent_amend_preserves_child_attribution() {
         "child",
     );
 
+    repo.sync_daemon();
+
     let git_ai_repo = open_repo(&repo);
     assert!(
         show_authorship_note(&git_ai_repo, &new_child_head).is_some(),
@@ -387,11 +370,7 @@ fn test_update_ref_restack_after_parent_amend_preserves_child_attribution() {
 /// git-ai must detect the N-commit rewrite and remap all N authorship notes.
 #[test]
 fn test_graphite_style_multi_commit_single_update_ref() {
-    if should_skip_for_hooks_mode() {
-        return;
-    }
-
-    let repo = TestRepo::new_with_mode(GitTestMode::Wrapper);
+    let repo = TestRepo::new();
     setup_initial_commit(&repo);
     let default_branch = repo.current_branch();
 
@@ -506,6 +485,8 @@ fn test_graphite_style_multi_commit_single_update_ref() {
     repo.git(&["update-ref", "refs/heads/feature", &new_tip, &old_tip])
         .expect("update-ref");
     repo.git(&["reset", "--hard", &new_tip]).expect("reset");
+
+    repo.sync_daemon();
 
     // Verify all 3 rebased commits have authorship notes
     let rebased_commits_str = repo

--- a/tests/integration/ci_partial_clone.rs
+++ b/tests/integration/ci_partial_clone.rs
@@ -1,10 +1,10 @@
-use crate::repos::test_repo::{GitTestMode, TestRepo};
+use crate::repos::test_repo::TestRepo;
 use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunOptions, CiRunResult};
 use git_ai::git::repository as GitAiRepository;
 use std::fs;
 
 fn direct_test_repo() -> TestRepo {
-    TestRepo::new_with_mode(GitTestMode::Wrapper)
+    TestRepo::new()
 }
 
 /// Test that single-parent squash merges work even when the parent is not reachable

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1,10 +1,10 @@
 use crate::repos::test_file::ExpectedLineExt;
-use crate::repos::test_repo::{GitTestMode, TestRepo};
+use crate::repos::test_repo::TestRepo;
 use git_ai::git::refs::get_reference_as_authorship_log_v3;
 use git_ai::git::repository as GitAiRepository;
 
 fn direct_test_repo() -> TestRepo {
-    TestRepo::new_with_mode(GitTestMode::Wrapper)
+    TestRepo::new()
 }
 
 /// Test basic squash merge via CI - AI code from feature branch squashed into main

--- a/tests/integration/rebase_benchmark.rs
+++ b/tests/integration/rebase_benchmark.rs
@@ -1919,13 +1919,6 @@ fn benchmark_monorepo_rebase() {
 #[test]
 #[ignore]
 fn benchmark_monorepo_graphite_rebase() {
-    // Skip in hooks mode — commit-tree/update-ref detection requires wrapper mode
-    let mode = std::env::var("GIT_AI_TEST_GIT_MODE").unwrap_or_else(|_| "wrapper".to_string());
-    if mode == "hooks" {
-        eprintln!("SKIP: graphite-style benchmark only runs in wrapper mode");
-        return;
-    }
-
     // Simple deterministic PRNG (xorshift64)
     struct Rng(u64);
     impl Rng {


### PR DESCRIPTION
## Summary
- Add fast-forward working log rename for `update-ref` in daemon mode — the daemon now handles the same working log migration the wrapper does when a checked-out branch is advanced via `update-ref` (e.g., Graphite restacks)
- Convert 13 wrapper-only tests to mode-parametric (`commit_tree_update_ref.rs`, `ci_partial_clone.rs`, `ci_squash_rebase.rs`) so they run in daemon and wrapper-daemon modes
- Remove dead hooks-mode skip logic from graphite rebase benchmark

## Context
The synchronous wrapper mode is being sunset in favor of daemon and wrapper-daemon modes. This PR closes the `update-ref` / `commit-tree` plumbing gap in the daemon and ensures no integration tests are scoped only to wrapper mode.

The daemon already handled non-ancestor ref rewrites (e.g., Graphite-style `commit-tree` + `update-ref` restacks) via `rewrite_events_from_semantic_events()`. The missing piece was fast-forward working log renames, which are now handled in `maybe_apply_side_effects_for_applied_command()`.

## Test plan
- [x] All 5 `commit_tree_update_ref` tests pass in daemon mode (previously wrapper-only)
- [x] All 4 `ci_partial_clone` tests pass in daemon mode
- [x] All 4 `ci_squash_rebase` tests pass in daemon mode
- [x] Full suite passes in daemon mode (2791 passed)
- [x] Full suite passes in wrapper-daemon mode (2792 passed)
- [x] `cargo fmt` and `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
