### PR TITLE
fix: use session ID as key in diff JSON sessions object

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1987,9 +1987,15 @@ pub fn get_diff_json_filtered(
         diff_json
             .prompts
             .retain(|key, _| prompt_id_set.contains(key));
+        // Session keys are session IDs only, but prompt_ids may contain combined IDs
+        // Extract session IDs from prompt_ids for session filtering
+        let session_id_set: HashSet<&str> = prompt_ids
+            .iter()
+            .map(|id| extract_session_id(id))
+            .collect();
         diff_json
             .sessions
-            .retain(|key, _| prompt_id_set.contains(key));
+            .retain(|key, _| session_id_set.contains(key.as_str()));
     }
 
     let mut referenced_commit_shas: HashSet<String> = HashSet::new();

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -950,15 +950,15 @@ fn apply_blame_for_side(
     for (prompt_id, prompt_record) in &analysis.prompt_records {
         if prompt_id.starts_with("s_") {
             // Session-format attestation: look up the SessionRecord from blame analysis
-            let session_key = prompt_id.split("::").next().unwrap_or(prompt_id);
+            let session_key = extract_session_id(prompt_id);
             if let Some(session_record) = analysis.session_records.get(session_key) {
                 sessions
-                    .entry(prompt_id.clone())
+                    .entry(session_key.to_string())
                     .or_insert_with(|| session_record.clone());
             } else {
                 // Fallback: convert PromptRecord back to SessionRecord
                 sessions
-                    .entry(prompt_id.clone())
+                    .entry(session_key.to_string())
                     .or_insert_with(|| SessionRecord {
                         agent_id: prompt_record.agent_id.clone(),
                         human_author: prompt_record.human_author.clone(),
@@ -1422,20 +1422,31 @@ fn merge_missing_prompts_and_sessions_from_authorship_note(
                 .entry(prompt_id.clone())
                 .or_insert_with(|| prompt_record.clone());
         }
-        // Insert session records keyed by their full attestation hashes (s_xxx::t_yyy)
+        // Insert session records keyed by session ID only (s_xxx)
         for file_attestation in &authorship_log.attestations {
             for entry in &file_attestation.entries {
                 if entry.hash.starts_with("s_") {
-                    let session_key = entry.hash.split("::").next().unwrap_or(&entry.hash);
+                    let session_key = extract_session_id(&entry.hash);
                     if let Some(session_record) = authorship_log.metadata.sessions.get(session_key)
                     {
                         sessions
-                            .entry(entry.hash.clone())
+                            .entry(session_key.to_string())
                             .or_insert_with(|| session_record.clone());
                     }
                 }
             }
         }
+    }
+}
+
+/// Extract session ID from a combined session::trace ID
+/// For session-format IDs like "s_xxx::t_yyy", returns "s_xxx"
+/// For other IDs, returns the original ID unchanged
+fn extract_session_id(id: &str) -> &str {
+    if id.starts_with("s_") {
+        id.split("::").next().unwrap_or(id)
+    } else {
+        id
     }
 }
 
@@ -1457,10 +1468,11 @@ fn calculate_diff_commit_stats(
         for (prompt_id, ranges) in annotations {
             let landed_lines = ranges.iter().map(line_range_len).sum::<u32>();
             stats.ai_lines_added += landed_lines;
+            let session_key = extract_session_id(prompt_id);
             let key = prompts
                 .get(prompt_id)
                 .map(|r| &r.agent_id)
-                .or_else(|| sessions.get(prompt_id).map(|r| &r.agent_id))
+                .or_else(|| sessions.get(session_key).map(|r| &r.agent_id))
                 .map(|agent_id| format!("{}::{}", agent_id.tool, agent_id.model));
             if let Some(key) = key {
                 let tool_stats = stats.tool_model_breakdown.entry(key).or_default();

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1989,10 +1989,8 @@ pub fn get_diff_json_filtered(
             .retain(|key, _| prompt_id_set.contains(key));
         // Session keys are session IDs only, but prompt_ids may contain combined IDs
         // Extract session IDs from prompt_ids for session filtering
-        let session_id_set: HashSet<&str> = prompt_ids
-            .iter()
-            .map(|id| extract_session_id(id))
-            .collect();
+        let session_id_set: HashSet<&str> =
+            prompt_ids.iter().map(|id| extract_session_id(id)).collect();
         diff_json
             .sessions
             .retain(|key, _| session_id_set.contains(key.as_str()));

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -1411,11 +1411,13 @@ fn test_diff_json_include_stats_exact_multi_model_with_non_landing_prompt() {
     let sessions_without_all = diff["sessions"]
         .as_object()
         .expect("sessions should be object");
-    // All sessions are included in diff output (even non-landing ones with scoped checkpoint)
+    // Only sessions with landed lines are included (without --all-prompts)
+    // codex is called twice with same conversation_id, so it has one session ID
+    // claude has no landed lines, so it's not included
     assert_eq!(
         sessions_without_all.len(),
-        3,
-        "all 3 sessions included when using scoped known_human checkpoint"
+        2,
+        "cursor and codex sessions (codex deduplicated by session ID, claude has no landed lines)"
     );
 }
 
@@ -3705,4 +3707,96 @@ crate::reuse_tests_in_worktree!(
     test_diff_json_humans_map_complete_across_multiple_commits,
     test_diff_ai_reindented_lines_attributed_to_ai,
     test_diff_ai_inserted_blank_line_with_comments_attributed_to_ai,
+    test_diff_json_sessions_use_session_id_not_combined_id,
 );
+
+#[test]
+fn test_diff_json_sessions_use_session_id_not_combined_id() {
+    let repo = TestRepo::new();
+
+    write_lines(&repo, "example.txt", &["base"]);
+    checkpoint_human(&repo);
+    let _base = commit_after_staging_all(&repo, "base");
+
+    write_lines(&repo, "example.txt", &["base", "claude line"]);
+    checkpoint_agent_v1(
+        &repo,
+        "example.txt",
+        "claude",
+        "opus-4-6",
+        "conv-123",
+        "add line",
+    );
+
+    let commit = commit_after_staging_all(&repo, "add AI line");
+    let diff = diff_json(&repo, &["diff", &commit.commit_sha, "--json"]);
+
+    let sessions = diff["sessions"]
+        .as_object()
+        .expect("sessions should be an object");
+
+    let annotations = diff["files"]["example.txt"]["annotations"]
+        .as_object()
+        .expect("annotations should be an object");
+
+    let hunks = diff["hunks"].as_array().expect("hunks should be an array");
+
+    // Bug: sessions object uses combined ID (s_xxx::t_yyy) as key
+    // Expected: sessions object should use session ID (s_xxx) as key
+    let session_keys: Vec<String> = sessions.keys().cloned().collect();
+    assert_eq!(session_keys.len(), 1, "should have exactly one session");
+
+    let session_key = &session_keys[0];
+    assert!(
+        !session_key.contains("::"),
+        "session key should be session ID only (s_xxx), not combined ID (s_xxx::t_yyy). Found: {}",
+        session_key
+    );
+    assert!(
+        session_key.starts_with("s_"),
+        "session key should start with s_. Found: {}",
+        session_key
+    );
+
+    // Annotations should still use combined ID for line attribution
+    let annotation_keys: Vec<String> = annotations.keys().cloned().collect();
+    assert_eq!(
+        annotation_keys.len(),
+        1,
+        "should have exactly one annotation"
+    );
+    let annotation_key = &annotation_keys[0];
+    assert!(
+        annotation_key.contains("::"),
+        "annotation key should be combined ID (s_xxx::t_yyy). Found: {}",
+        annotation_key
+    );
+
+    // Hunks should use combined ID in prompt_id field
+    let addition_hunk = hunks
+        .iter()
+        .find(|h| h["hunk_kind"] == "addition")
+        .expect("should have addition hunk");
+    let prompt_id = addition_hunk["prompt_id"]
+        .as_str()
+        .expect("prompt_id should be string");
+    assert!(
+        prompt_id.contains("::"),
+        "hunk prompt_id should be combined ID (s_xxx::t_yyy). Found: {}",
+        prompt_id
+    );
+
+    // Session key and annotation/hunk prefix should match
+    assert!(
+        annotation_key.starts_with(session_key),
+        "annotation key {} should start with session key {}",
+        annotation_key,
+        session_key
+    );
+    assert!(
+        prompt_id.starts_with(session_key),
+        "prompt_id {} should start with session key {}",
+        prompt_id,
+        session_key
+    );
+}

--- a/tests/integration/sessions_cutover.rs
+++ b/tests/integration/sessions_cutover.rs
@@ -1564,11 +1564,11 @@ fn test_diff_json_all_prompts_includes_sessions() {
         "new-format commit should not have entries in 'prompts'"
     );
 
-    // Session keys should use s_xxx::t_yyy format
+    // Session keys should use s_xxx format (session ID only, not combined with trace ID)
     let first_key = sessions.unwrap().keys().next().unwrap();
     assert!(
-        first_key.starts_with("s_") && first_key.contains("::t_"),
-        "session key should use s_xxx::t_yyy format, got: {}",
+        first_key.starts_with("s_") && !first_key.contains("::"),
+        "session key should be session ID only (s_xxx), not combined ID (s_xxx::t_yyy), got: {}",
         first_key
     );
 
@@ -2319,8 +2319,8 @@ fn test_diff_json_mixed_format_commit_separates_prompts_and_sessions() {
     );
     let session_key = sessions.keys().next().unwrap();
     assert!(
-        session_key.starts_with("s_") && session_key.contains("::t_"),
-        "session key should be s_xxx::t_yyy format, got: {}",
+        session_key.starts_with("s_") && !session_key.contains("::"),
+        "session key should be session ID only (s_xxx), not combined ID (s_xxx::t_yyy), got: {}",
         session_key
     );
     let session = &sessions[session_key];
@@ -2443,8 +2443,8 @@ fn test_diff_json_history_with_mixed_old_and_new_format_commits() {
     );
     let session_key = new_sessions.keys().next().unwrap();
     assert!(
-        session_key.starts_with("s_") && session_key.contains("::t_"),
-        "session key should be s_xxx::t_yyy, got: {}",
+        session_key.starts_with("s_") && !session_key.contains("::"),
+        "session key should be session ID only (s_xxx), not combined ID (s_xxx::t_yyy), got: {}",
         session_key
     );
     assert!(


### PR DESCRIPTION
## Summary

Fixes a bug where the diff JSON output was using combined session+trace IDs (`s_xxx::t_yyy`) as keys in the sessions object instead of just the session ID (`s_xxx`).

**Before:**
```json
{
  "sessions": {
    "s_84ccbf9d01f873::t_a790516cae30e7": { ... }
  }
}
```

**After:**
```json
{
  "sessions": {
    "s_84ccbf9d01f873": { ... }
  }
}
```

## Changes

- Sessions map now uses session ID only (`s_xxx`) as keys, matching authorship note format
- Multiple traces for the same session are correctly deduplicated
- Annotations continue to use combined IDs (`s_xxx::t_yyy`) for line attribution
- Hunks continue to use combined IDs in `prompt_id` field
- Added `extract_session_id()` helper to eliminate code duplication
- Fixed stats calculation to look up sessions by session ID

## Test Plan

- Added `test_diff_json_sessions_use_session_id_not_combined_id` verifying correct session ID usage
- Updated `test_diff_json_include_stats_exact_multi_model_with_non_landing_prompt` to account for session deduplication
- All 92 diff tests pass
- All 1314 library tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
