### PR TITLE
Enforce prompt_storage policy on every notes_add rewrite path

### DIFF
--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -10,6 +10,7 @@ pub mod internal_db;
 pub mod move_detection;
 pub mod post_commit;
 pub mod pre_commit;
+pub mod prompt_storage_policy;
 pub mod prompt_utils;
 pub mod range_authorship;
 pub mod rebase_authorship;

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -1,14 +1,12 @@
-use crate::api::{ApiClient, ApiContext};
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
 use crate::authorship::prompt_utils::{PromptUpdateResult, update_prompt_from_tool};
-use crate::authorship::secrets::{redact_secrets_from_prompts, strip_prompt_messages};
 use crate::authorship::stats::{stats_for_commit_stats, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry};
-use crate::config::{Config, PromptStorageMode};
+use crate::config::Config;
 use crate::error::GitAiError;
 use crate::git::refs::notes_add;
 use crate::git::repository::Repository;
@@ -158,69 +156,10 @@ pub fn post_commit_with_final_state(
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 
-    // Long-lived daemon processes should read a fresh config snapshot.
-    // Always use Config::fresh() to support runtime config updates
-    // (especially important for daemon mode, but also good for consistency)
-    let config = Config::fresh();
-    let (effective_storage, using_custom_api, custom_attrs) = (
-        config.effective_prompt_storage(&Some(repo.clone())),
-        config.api_base_url() != crate::config::DEFAULT_API_BASE_URL,
-        config.custom_attributes().clone(),
-    );
-
-    // Inject custom attributes into all PromptRecords.
-    if !custom_attrs.is_empty() {
-        for pr in authorship_log.metadata.prompts.values_mut() {
-            pr.custom_attributes = Some(custom_attrs.clone());
-        }
-    }
-
-    match effective_storage {
-        PromptStorageMode::Local => {
-            // Local only: strip all messages from notes (they stay in sqlite only)
-            strip_prompt_messages(&mut authorship_log.metadata.prompts);
-        }
-        PromptStorageMode::Notes => {
-            // Store in notes: redact secrets but keep messages in notes
-            let count = redact_secrets_from_prompts(&mut authorship_log.metadata.prompts);
-            if count > 0 {
-                tracing::debug!("Redacted {} secrets from prompts", count);
-            }
-        }
-        PromptStorageMode::Default => {
-            // "default" - attempt CAS upload, NEVER keep messages in notes
-            // Check conditions for CAS upload:
-            // - user is logged in OR has API key OR using custom API URL
-            let context = ApiContext::new(None);
-            let client = ApiClient::new(context);
-            let should_enqueue_cas =
-                client.is_logged_in() || client.has_api_key() || using_custom_api;
-
-            if should_enqueue_cas {
-                // Redact secrets before uploading to CAS
-                let redaction_count =
-                    redact_secrets_from_prompts(&mut authorship_log.metadata.prompts);
-                if redaction_count > 0 {
-                    tracing::debug!(
-                        "Redacted {} secrets from prompts before CAS upload",
-                        redaction_count
-                    );
-                }
-
-                if let Err(e) =
-                    enqueue_prompt_messages_to_cas(repo, &mut authorship_log.metadata.prompts)
-                {
-                    tracing::debug!("[Warning] Failed to enqueue prompt messages to CAS: {}", e);
-                    // Enqueue failed - still strip messages (never keep in notes for "default")
-                    strip_prompt_messages(&mut authorship_log.metadata.prompts);
-                }
-                // Success: enqueue function already cleared messages
-            } else {
-                // Not enqueueing - strip messages (never keep in notes for "default")
-                strip_prompt_messages(&mut authorship_log.metadata.prompts);
-            }
-        }
-    }
+    crate::authorship::prompt_storage_policy::apply_prompt_storage_policy(
+        repo,
+        &mut authorship_log,
+    )?;
 
     // Serialize the authorship log
     let authorship_json = authorship_log
@@ -544,94 +483,6 @@ fn batch_upsert_prompts_to_db(
         .map_err(|e| GitAiError::Generic(format!("Failed to lock database: {}", e)))?;
 
     db_guard.batch_upsert_prompts(&records)?;
-
-    Ok(())
-}
-
-/// Enqueue prompt messages to CAS for external storage.
-/// For each prompt with non-empty messages:
-/// - Serialize messages to JSON
-/// - Enqueue to CAS (returns hash)
-/// - Set messages_url (format: {api_base_url}/cas/{hash}) and clear messages
-fn enqueue_prompt_messages_to_cas(
-    repo: &Repository,
-    prompts: &mut std::collections::BTreeMap<
-        String,
-        crate::authorship::authorship_log::PromptRecord,
-    >,
-) -> Result<(), GitAiError> {
-    use crate::authorship::internal_db::InternalDatabase;
-
-    let db = InternalDatabase::global()?;
-    let mut db_lock = db
-        .lock()
-        .map_err(|e| GitAiError::Generic(format!("Failed to lock database: {}", e)))?;
-
-    // CAS metadata for prompt messages
-    let mut metadata = HashMap::new();
-    metadata.insert("api_version".to_string(), "v1".to_string());
-    metadata.insert("kind".to_string(), "prompt".to_string());
-
-    // Get repo URL from default remote
-    let repo_url = repo
-        .get_default_remote()
-        .ok()
-        .flatten()
-        .and_then(|remote_name| {
-            repo.remotes_with_urls().ok().and_then(|remotes| {
-                remotes
-                    .into_iter()
-                    .find(|(name, _)| name == &remote_name)
-                    .map(|(_, url)| url)
-            })
-        });
-
-    if let Some(url) = repo_url
-        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
-    {
-        metadata.insert("repo_url".to_string(), normalized);
-    }
-
-    // Get API base URL for constructing messages_url
-    // Always use Config::fresh() to support runtime config updates
-    let api_base_url = Config::fresh().api_base_url().to_string();
-
-    for (_key, prompt) in prompts.iter_mut() {
-        if !prompt.messages.is_empty() {
-            // Wrap messages in CasMessagesObject and serialize to JSON
-            let messages_obj = crate::api::types::CasMessagesObject {
-                messages: prompt.messages.clone(),
-            };
-            let messages_json = serde_json::to_value(&messages_obj)
-                .map_err(|e| GitAiError::Generic(format!("Failed to serialize messages: {}", e)))?;
-
-            // Enqueue to CAS (returns hash)
-            let hash = db_lock.enqueue_cas_object(&messages_json, Some(&metadata))?;
-
-            let metadata_json = serde_json::to_string(&metadata).ok();
-            let canonical = serde_json_canonicalizer::to_string(&messages_json)
-                .unwrap_or_else(|_| messages_json.to_string());
-            let cas_payload = crate::daemon::control_api::CasSyncPayload {
-                hash: hash.clone(),
-                data: canonical,
-                metadata: metadata_json,
-            };
-
-            // In daemon mode, submit directly to the in-process telemetry worker.
-            // In wrapper-daemon mode, forward over the control socket so the
-            // background daemon can upload it immediately.
-            if crate::daemon::daemon_process_active() {
-                let _ =
-                    crate::daemon::telemetry_worker::submit_daemon_internal_cas(vec![cas_payload]);
-            } else if crate::daemon::telemetry_handle::daemon_telemetry_available() {
-                crate::daemon::telemetry_handle::submit_cas(vec![cas_payload]);
-            }
-
-            // Set full URL and clear messages
-            prompt.messages_url = Some(format!("{}/cas/{}", api_base_url, hash));
-            prompt.messages.clear();
-        }
-    }
 
     Ok(())
 }

--- a/src/authorship/prompt_storage_policy.rs
+++ b/src/authorship/prompt_storage_policy.rs
@@ -1,0 +1,172 @@
+//! Applies the effective prompt-storage policy to an `AuthorshipLog` right
+//! before it is written to git notes.
+//!
+//! This was originally inline in `post_commit.rs`. It is extracted here so
+//! `rebase_authorship.rs`'s rewrite paths (amend / rebase / cherry-pick /
+//! squash-merge) can enforce the same policy on every `notes_add`. See
+//! `fix/prompt-storage-in-rewrite-paths` for why that matters.
+
+use std::collections::HashMap;
+
+use crate::api::{ApiClient, ApiContext};
+use crate::authorship::authorship_log::PromptRecord;
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::secrets::{redact_secrets_from_prompts, strip_prompt_messages};
+use crate::config::{Config, PromptStorageMode};
+use crate::error::GitAiError;
+use crate::git::repository::Repository;
+
+/// Mutate `authorship_log.metadata.prompts` so that the note written to disk
+/// reflects the effective `prompt_storage` mode for `repo`:
+///
+/// - `Local`  — strip all `messages` (prompts stay in SQLite only).
+/// - `Notes`  — keep `messages`, but redact secrets first.
+/// - `Default` — attempt a CAS upload (when logged in / API key / custom URL)
+///   and clear `messages` from the note regardless of upload outcome.
+///
+/// Custom attributes from config are also injected into every prompt record.
+pub fn apply_prompt_storage_policy(
+    repo: &Repository,
+    authorship_log: &mut AuthorshipLog,
+) -> Result<(), GitAiError> {
+    let config = Config::fresh();
+    let effective_storage = config.effective_prompt_storage(&Some(repo.clone()));
+    let using_custom_api = config.api_base_url() != crate::config::DEFAULT_API_BASE_URL;
+    let custom_attrs = config.custom_attributes().clone();
+
+    if !custom_attrs.is_empty() {
+        for pr in authorship_log.metadata.prompts.values_mut() {
+            pr.custom_attributes = Some(custom_attrs.clone());
+        }
+    }
+
+    match effective_storage {
+        PromptStorageMode::Local => {
+            strip_prompt_messages(&mut authorship_log.metadata.prompts);
+        }
+        PromptStorageMode::Notes => {
+            let count = redact_secrets_from_prompts(&mut authorship_log.metadata.prompts);
+            if count > 0 {
+                tracing::debug!("Redacted {} secrets from prompts", count);
+            }
+        }
+        PromptStorageMode::Default => {
+            let context = ApiContext::new(None);
+            let client = ApiClient::new(context);
+            let should_enqueue_cas =
+                client.is_logged_in() || client.has_api_key() || using_custom_api;
+
+            if should_enqueue_cas {
+                let redaction_count =
+                    redact_secrets_from_prompts(&mut authorship_log.metadata.prompts);
+                if redaction_count > 0 {
+                    tracing::debug!(
+                        "Redacted {} secrets from prompts before CAS upload",
+                        redaction_count
+                    );
+                }
+
+                if let Err(e) =
+                    enqueue_prompt_messages_to_cas(repo, &mut authorship_log.metadata.prompts)
+                {
+                    tracing::debug!("[Warning] Failed to enqueue prompt messages to CAS: {}", e);
+                    strip_prompt_messages(&mut authorship_log.metadata.prompts);
+                }
+            } else {
+                strip_prompt_messages(&mut authorship_log.metadata.prompts);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Apply the effective policy to an already-serialized note body. Used by the
+/// fast-path remap callers in `rebase_authorship.rs` that byte-copy a source
+/// note: we must parse, re-apply policy, and re-serialize so that the current
+/// policy is enforced on every rewrite (preventing propagation of stale
+/// messages from older/leaky upstream notes).
+pub fn apply_prompt_storage_policy_to_note(
+    repo: &Repository,
+    note_content: &str,
+) -> Result<String, GitAiError> {
+    let mut log = match AuthorshipLog::deserialize_from_string(note_content) {
+        Ok(log) => log,
+        // If we can't parse it, pass it through unchanged. The downstream reader
+        // will produce the same error, but we don't want to silently lose data.
+        Err(_) => return Ok(note_content.to_string()),
+    };
+    apply_prompt_storage_policy(repo, &mut log)?;
+    log.serialize_to_string()
+        .map_err(|_| GitAiError::Generic("Failed to serialize authorship log".to_string()))
+}
+
+fn enqueue_prompt_messages_to_cas(
+    repo: &Repository,
+    prompts: &mut std::collections::BTreeMap<String, PromptRecord>,
+) -> Result<(), GitAiError> {
+    use crate::authorship::internal_db::InternalDatabase;
+
+    let db = InternalDatabase::global()?;
+    let mut db_lock = db
+        .lock()
+        .map_err(|e| GitAiError::Generic(format!("Failed to lock database: {}", e)))?;
+
+    let mut metadata = HashMap::new();
+    metadata.insert("api_version".to_string(), "v1".to_string());
+    metadata.insert("kind".to_string(), "prompt".to_string());
+
+    let repo_url = repo
+        .get_default_remote()
+        .ok()
+        .flatten()
+        .and_then(|remote_name| {
+            repo.remotes_with_urls().ok().and_then(|remotes| {
+                remotes
+                    .into_iter()
+                    .find(|(name, _)| name == &remote_name)
+                    .map(|(_, url)| url)
+            })
+        });
+
+    if let Some(url) = repo_url
+        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
+    {
+        metadata.insert("repo_url".to_string(), normalized);
+    }
+
+    let api_base_url = Config::fresh().api_base_url().to_string();
+
+    for (_key, prompt) in prompts.iter_mut() {
+        if !prompt.messages.is_empty() {
+            let messages_obj = crate::api::types::CasMessagesObject {
+                messages: prompt.messages.clone(),
+            };
+            let messages_json = serde_json::to_value(&messages_obj)
+                .map_err(|e| GitAiError::Generic(format!("Failed to serialize messages: {}", e)))?;
+
+            let hash = db_lock.enqueue_cas_object(&messages_json, Some(&metadata))?;
+
+            let metadata_json = serde_json::to_string(&metadata).ok();
+            let canonical = serde_json_canonicalizer::to_string(&messages_json)
+                .unwrap_or_else(|_| messages_json.to_string());
+            let cas_payload = crate::daemon::control_api::CasSyncPayload {
+                hash: hash.clone(),
+                data: canonical,
+                metadata: metadata_json,
+            };
+
+            if crate::daemon::daemon_process_active() {
+                let _ =
+                    crate::daemon::telemetry_worker::submit_daemon_internal_cas(vec![cas_payload]);
+            } else if crate::daemon::telemetry_handle::daemon_telemetry_available() {
+                crate::daemon::telemetry_handle::submit_cas(vec![cas_payload]);
+            }
+
+            prompt.messages_url = Some(format!("{}/cas/{}", api_base_url, hash));
+            prompt.messages.clear();
+        }
+    }
+
+    Ok(())
+}

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -620,11 +620,15 @@ pub fn rewrite_authorship_after_squash_or_rebase(
             tracing::debug!(
                 "No AI-touched files in merge, but notes exist in source commits; writing empty authorship log",
             );
-            if let Some(authorship_log) = build_metadata_only_authorship_log_from_source_notes(
+            if let Some(mut authorship_log) = build_metadata_only_authorship_log_from_source_notes(
                 repo,
                 &source_commits,
                 merge_commit_sha,
             )? {
+                crate::authorship::prompt_storage_policy::apply_prompt_storage_policy(
+                    repo,
+                    &mut authorship_log,
+                )?;
                 let authorship_json = authorship_log.serialize_to_string().map_err(|_| {
                     GitAiError::Generic("Failed to serialize authorship log".to_string())
                 })?;
@@ -711,6 +715,10 @@ pub fn rewrite_authorship_after_squash_or_rebase(
     );
 
     // Step 7: Save authorship log to git notes
+    crate::authorship::prompt_storage_policy::apply_prompt_storage_policy(
+        repo,
+        &mut authorship_log,
+    )?;
     let authorship_json = authorship_log
         .serialize_to_string()
         .map_err(|_| GitAiError::Generic("Failed to serialize authorship log".to_string()))?;
@@ -1867,6 +1875,11 @@ pub fn rewrite_authorship_after_rebase_v2(
 
     let phase_start = std::time::Instant::now();
     if !pending_note_entries.is_empty() {
+        for (_sha, note) in pending_note_entries.iter_mut() {
+            *note = crate::authorship::prompt_storage_policy::apply_prompt_storage_policy_to_note(
+                repo, note,
+            )?;
+        }
         crate::git::refs::notes_add_batch(repo, &pending_note_entries)?;
     }
     timing_phases.push((
@@ -2086,6 +2099,10 @@ pub fn rewrite_authorship_after_cherry_pick(
         let computed_note_has_payload =
             !authorship_log.attestations.is_empty() || !authorship_log.metadata.prompts.is_empty();
         let authorship_json = if computed_note_has_payload {
+            crate::authorship::prompt_storage_policy::apply_prompt_storage_policy(
+                repo,
+                &mut authorship_log,
+            )?;
             authorship_log.serialize_to_string().map_err(|_| {
                 GitAiError::Generic("Failed to serialize authorship log".to_string())
             })?
@@ -2096,8 +2113,15 @@ pub fn rewrite_authorship_after_cherry_pick(
                 source_note_content_loaded = true;
             }
             if let Some(raw_note) = source_note_content_by_new_commit.get(new_commit) {
-                remap_note_content_for_target_commit(raw_note, new_commit)
+                let remapped = remap_note_content_for_target_commit(raw_note, new_commit);
+                crate::authorship::prompt_storage_policy::apply_prompt_storage_policy_to_note(
+                    repo, &remapped,
+                )?
             } else {
+                crate::authorship::prompt_storage_policy::apply_prompt_storage_policy(
+                    repo,
+                    &mut authorship_log,
+                )?;
                 authorship_log.serialize_to_string().map_err(|_| {
                     GitAiError::Generic("Failed to serialize authorship log".to_string())
                 })?
@@ -2939,15 +2963,12 @@ pub fn rewrite_authorship_after_commit_amend_with_snapshot(
         }
     }
 
-    // Inject custom attributes into all PromptRecords (same behavior as post_commit).
-    // Always use Config::fresh() to support runtime config updates
-    // (especially important for daemon mode, but also good for consistency)
-    let custom_attrs = crate::config::Config::fresh().custom_attributes().clone();
-    if !custom_attrs.is_empty() {
-        for pr in authorship_log.metadata.prompts.values_mut() {
-            pr.custom_attributes = Some(custom_attrs.clone());
-        }
-    }
+    // Apply prompt_storage policy (custom_attributes + strip/redact/CAS) so the
+    // amended note honors the same mode as post_commit.rs does on regular commits.
+    crate::authorship::prompt_storage_policy::apply_prompt_storage_policy(
+        repo,
+        &mut authorship_log,
+    )?;
 
     // Save authorship log
     let authorship_json = authorship_log
@@ -3413,10 +3434,12 @@ fn remap_notes_for_commit_pairs(
     let mut entries = Vec::new();
     for (original_commit, new_commit) in commit_pairs {
         if let Some(raw_note) = original_note_contents.get(original_commit) {
-            entries.push((
-                new_commit.clone(),
-                remap_note_content_for_target_commit(raw_note, new_commit),
-            ));
+            let remapped = remap_note_content_for_target_commit(raw_note, new_commit);
+            let policy_applied =
+                crate::authorship::prompt_storage_policy::apply_prompt_storage_policy_to_note(
+                    repo, &remapped,
+                )?;
+            entries.push((new_commit.clone(), policy_applied));
         }
     }
 
@@ -3553,10 +3576,12 @@ fn try_fast_path_rebase_note_remap_cached(
         let Some(raw_note) = note_cache.original_note_contents.get(original_commit) else {
             return Ok(false);
         };
-        remapped_note_entries.push((
-            new_commit.clone(),
-            remap_note_content_for_target_commit(raw_note, new_commit),
-        ));
+        let remapped = remap_note_content_for_target_commit(raw_note, new_commit);
+        let policy_applied =
+            crate::authorship::prompt_storage_policy::apply_prompt_storage_policy_to_note(
+                repo, &remapped,
+            )?;
+        remapped_note_entries.push((new_commit.clone(), policy_applied));
     }
 
     let remapped_count = remapped_note_entries.len();
@@ -3643,10 +3668,12 @@ fn try_fast_path_cherry_pick_note_remap(
         let Some(raw_note) = blob_contents.get(&blob_oid) else {
             return Ok(false);
         };
-        remapped_note_entries.push((
-            new_commit.clone(),
-            remap_note_content_for_target_commit(raw_note, &new_commit),
-        ));
+        let remapped = remap_note_content_for_target_commit(raw_note, &new_commit);
+        let policy_applied =
+            crate::authorship::prompt_storage_policy::apply_prompt_storage_policy_to_note(
+                repo, &remapped,
+            )?;
+        remapped_note_entries.push((new_commit.clone(), policy_applied));
     }
 
     let remapped_count = remapped_note_entries.len();

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -75,6 +75,7 @@ mod pi;
 mod prompt_across_commit;
 mod prompt_hash_migration;
 mod prompt_picker_test;
+mod prompt_storage_rewrite_paths;
 mod prompts_db_test;
 mod pull_rebase_ff;
 mod push_upstream_authorship;

--- a/tests/integration/prompt_storage_rewrite_paths.rs
+++ b/tests/integration/prompt_storage_rewrite_paths.rs
@@ -1,0 +1,451 @@
+//! Regression tests for a bug where prompt_storage = "default" | "local" is
+//! honored by the initial post-commit path but ignored by the rewrite paths
+//! (amend, rebase, cherry-pick, merge).
+//!
+//! Expected behavior (per post_commit.rs):
+//! - PromptStorageMode::Default | Local → messages must be stripped before notes_add
+//! - PromptStorageMode::Notes         → messages kept, but secrets must be redacted
+//!
+//! Under the current rebase_authorship.rs, none of these policies are applied
+//! on the rewrite paths. These tests pin down that behavior for each entry
+//! point so we can validate a shared-policy fix.
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+use git_ai::authorship::transcript::{AiTranscript, Message};
+use git_ai::git::refs::notes_add;
+use std::fs;
+
+/// Set up a test repo configured for `prompt_storage = "local"` (which should
+/// always strip messages from notes). `local` is the cleanest mode to test:
+/// it deterministically strips without depending on login state / CAS enqueue.
+///
+/// Uses a dedicated daemon because parallel tests in this file flip between
+/// `local` and `notes` modes — sharing a daemon/config across them causes
+/// config-patch races where one test's mode leaks into another's commit.
+fn repo_with_local_storage() -> TestRepo {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+        patch.prompt_storage = Some("local".to_string());
+    });
+    repo
+}
+
+fn repo_with_notes_storage() -> TestRepo {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+        patch.prompt_storage = Some("notes".to_string());
+    });
+    repo
+}
+
+/// Agent-v1 checkpoint with a non-empty transcript. Mirrors the helper in
+/// tests/integration/ignore_prompts.rs.
+fn checkpoint_with_message(repo: &TestRepo, user_text: &str, edited: Vec<String>) {
+    let mut transcript = AiTranscript::new();
+    transcript.add_message(Message::user(user_text.to_string(), None));
+    transcript.add_message(Message::assistant(
+        "I'll help you with that.".to_string(),
+        None,
+    ));
+
+    let hook_input = serde_json::json!({
+        "type": "ai_agent",
+        "repo_working_dir": repo.path().to_str().unwrap(),
+        "edited_filepaths": edited,
+        "transcript": transcript,
+        "agent_name": "test-agent",
+        "model": "test-model",
+        "conversation_id": "test-conversation-id",
+    });
+
+    repo.git_ai(&[
+        "checkpoint",
+        "agent-v1",
+        "--hook-input",
+        &serde_json::to_string(&hook_input).unwrap(),
+    ])
+    .expect("checkpoint should succeed");
+}
+
+fn read_log(repo: &TestRepo, sha: &str) -> AuthorshipLog {
+    let note = repo
+        .read_authorship_note(sha)
+        .unwrap_or_else(|| panic!("expected authorship note on {}", sha));
+    AuthorshipLog::deserialize_from_string(&note).expect("parse authorship note")
+}
+
+fn assert_messages_empty(log: &AuthorshipLog, ctx: &str) {
+    assert!(
+        !log.metadata.prompts.is_empty(),
+        "{ctx}: expected a prompt record to exist"
+    );
+    for (id, prompt) in &log.metadata.prompts {
+        assert!(
+            prompt.messages.is_empty(),
+            "{ctx}: prompt {id} leaked {} messages (prompt_storage=\"local\" should strip)",
+            prompt.messages.len()
+        );
+    }
+}
+
+/// Control: prompt_storage = "local" strips messages on the initial commit.
+/// If this fails, the other tests are not meaningful.
+#[test]
+fn test_initial_commit_strips_messages_under_local_storage() {
+    let repo = repo_with_local_storage();
+
+    let readme = repo.path().join("README.md");
+    fs::write(&readme, "# Test\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "write ai file", vec!["ai.txt".to_string()]);
+
+    repo.git(&["add", "-A"]).unwrap();
+    let commit = repo.commit("add ai").expect("commit");
+
+    assert_messages_empty(&commit.authorship_log, "initial commit");
+}
+
+/// Amend: rewrite_authorship_after_amend reads the working-log transcript to
+/// build a fresh AuthorshipLog and writes it to notes without consulting
+/// prompt_storage. Messages leak into the amended note.
+#[test]
+fn test_amend_strips_messages_under_local_storage() {
+    let repo = repo_with_local_storage();
+
+    // Seed: initial non-AI commit so the amend target is not the root.
+    let readme = repo.path().join("README.md");
+    fs::write(&readme, "# Test\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+
+    // AI commit with a transcript.
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "original prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let original = repo.commit("add ai").expect("commit");
+    assert_messages_empty(&original.authorship_log, "pre-amend commit (sanity)");
+
+    // Amend by adding another AI line with another transcript checkpoint.
+    fs::write(&ai_file, "AI line 1\nAI line 2\nAI line 3\n").unwrap();
+    checkpoint_with_message(&repo, "amended prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "--amend", "-m", "add ai (amended)"])
+        .unwrap();
+
+    let amended_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let amended_log = read_log(&repo, &amended_sha);
+    assert_messages_empty(&amended_log, "amended commit");
+}
+
+/// Rebase: slow-path rebase builds a new note per rebased commit. When the
+/// attribution state comes from the blame-based fallback (not from existing
+/// notes), prompts are populated directly from working-log transcripts and
+/// messages leak through.
+#[test]
+fn test_rebase_strips_messages_under_local_storage() {
+    let repo = repo_with_local_storage();
+
+    let base = repo.path().join("base.txt");
+    fs::write(&base, "base\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    // Feature branch from the initial commit.
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "feature prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+    assert_messages_empty(
+        &feature_commit.authorship_log,
+        "feature commit (before rebase)",
+    );
+
+    // Advance default branch with a non-conflicting commit.
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let other = repo.path().join("other.txt");
+    fs::write(&other, "other\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "main advances"]).unwrap();
+
+    // Rebase feature onto the advanced default branch.
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+    let rebased_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let rebased_log = read_log(&repo, &rebased_sha);
+    assert_messages_empty(&rebased_log, "rebased commit");
+}
+
+/// Cherry-pick: rewrite_authorship_after_cherry_pick assembles an authorship
+/// log per cherry-picked commit from VirtualAttributions — which loads
+/// prompts (with messages) and writes straight to notes.
+#[test]
+fn test_cherry_pick_strips_messages_under_local_storage() {
+    let repo = repo_with_local_storage();
+
+    let base = repo.path().join("base.txt");
+    fs::write(&base, "base\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    // Build feature branch with an AI commit carrying a transcript.
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "cherry prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+    assert_messages_empty(&feature_commit.authorship_log, "feature commit (sanity)");
+    let feature_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // Back to default branch and cherry-pick the feature commit onto it.
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["cherry-pick", &feature_sha]).unwrap();
+
+    let picked_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let picked_log = read_log(&repo, &picked_sha);
+    assert_messages_empty(&picked_log, "cherry-picked commit");
+}
+
+/// Squash-merge: rewrite_authorship_after_squash_merge merges VirtualAttributions
+/// from both branches and writes a fresh note. Prompts carry messages through.
+#[test]
+fn test_squash_merge_strips_messages_under_local_storage() {
+    let repo = repo_with_local_storage();
+
+    let base = repo.path().join("main.txt");
+    fs::write(&base, "line 1\nline 2\nline 3\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&base, "line 1\nline 2\nline 3\n// AI feature line\n").unwrap();
+    checkpoint_with_message(&repo, "feature prompt", vec!["main.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+    assert_messages_empty(&feature_commit.authorship_log, "feature commit (sanity)");
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    let squash_commit = repo.commit("squashed feature").expect("commit");
+
+    let squashed_sha = squash_commit.commit_sha.clone();
+    let squashed_log = read_log(&repo, &squashed_sha);
+    assert_messages_empty(&squashed_log, "squash-merge commit");
+}
+
+// The tests below mimic the production leak pattern: a pre-existing source
+// note with messages populated (as written by older git-ai versions, before
+// the append-time transcript strip landed) gets rebased / cherry-picked /
+// squash-merged forward. Under the current policy the new note must strip
+// those messages — otherwise the leak propagates with every rewrite.
+
+fn inject_leaky_source_note(repo: &TestRepo, commit_sha: &str, session_text: &str) {
+    let note = repo
+        .read_authorship_note(commit_sha)
+        .expect("source commit should have a note to mutate");
+    let mut log = AuthorshipLog::deserialize_from_string(&note).expect("parse source note");
+    assert!(
+        !log.metadata.prompts.is_empty(),
+        "setup: expected at least one prompt on source commit {}",
+        commit_sha
+    );
+    for prompt in log.metadata.prompts.values_mut() {
+        prompt.messages = vec![
+            Message::user(session_text.to_string(), None),
+            Message::assistant("I'll help you with that.".to_string(), None),
+        ];
+    }
+    let mutated = log.serialize_to_string().expect("serialize mutated note");
+    let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("find repository");
+    notes_add(&git_ai_repo, commit_sha, &mutated).expect("overwrite source note with messages");
+
+    // Sanity: the mutated note now carries messages.
+    let re_read = repo
+        .read_authorship_note(commit_sha)
+        .expect("note exists after mutation");
+    let verify = AuthorshipLog::deserialize_from_string(&re_read).expect("re-parse mutated note");
+    assert!(
+        verify
+            .metadata
+            .prompts
+            .values()
+            .any(|p| !p.messages.is_empty()),
+        "mutated note should have non-empty messages",
+    );
+}
+
+/// Leaky upstream: a commit gets rewritten (rebased). Under Local storage the
+/// rewritten note must strip messages even though the source note leaked.
+#[test]
+fn test_rebase_strips_leaky_upstream_messages() {
+    let repo = repo_with_local_storage();
+
+    let base = repo.path().join("base.txt");
+    fs::write(&base, "base\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "feature prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+    assert_messages_empty(&feature_commit.authorship_log, "feature commit (baseline)");
+
+    // Simulate an older git-ai version that left messages on the source note.
+    inject_leaky_source_note(&repo, &feature_commit.commit_sha, "leaky upstream prompt");
+
+    // Advance default branch and rebase.
+    repo.git(&["checkout", &default_branch]).unwrap();
+    fs::write(repo.path().join("other.txt"), "other\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "main advances"]).unwrap();
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+
+    let rebased_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let rebased_log = read_log(&repo, &rebased_sha);
+    assert_messages_empty(&rebased_log, "rebased commit (leaky upstream)");
+}
+
+/// Leaky upstream + cherry-pick: the picked commit's note must not inherit
+/// messages from the source note under Local storage.
+#[test]
+fn test_cherry_pick_strips_leaky_upstream_messages() {
+    let repo = repo_with_local_storage();
+
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "cherry prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+    assert_messages_empty(&feature_commit.authorship_log, "feature commit (baseline)");
+
+    inject_leaky_source_note(&repo, &feature_commit.commit_sha, "leaky upstream prompt");
+
+    let feature_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["cherry-pick", &feature_sha]).unwrap();
+
+    let picked_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let picked_log = read_log(&repo, &picked_sha);
+    assert_messages_empty(&picked_log, "cherry-picked commit (leaky upstream)");
+}
+
+/// Leaky upstream + squash-merge: this is the exact production pattern seen
+/// in the DB — branch notes clean, squash-merge commit mixed/leaked. With
+/// the fix the squash commit strips inherited messages.
+#[test]
+fn test_squash_merge_strips_leaky_upstream_messages() {
+    let repo = repo_with_local_storage();
+
+    let base = repo.path().join("main.txt");
+    fs::write(&base, "line 1\nline 2\nline 3\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&base, "line 1\nline 2\nline 3\n// AI feature line\n").unwrap();
+    checkpoint_with_message(&repo, "feature prompt", vec!["main.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+    assert_messages_empty(&feature_commit.authorship_log, "feature commit (baseline)");
+
+    inject_leaky_source_note(&repo, &feature_commit.commit_sha, "leaky upstream prompt");
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    let squash_commit = repo.commit("squashed feature").expect("commit");
+
+    let squashed_log = read_log(&repo, &squash_commit.commit_sha);
+    assert_messages_empty(&squashed_log, "squash-merge commit (leaky upstream)");
+}
+
+/// Notes mode: storage policy says messages SHOULD be kept in notes. Verify
+/// rewrite paths honor that too (i.e. the shared helper does not over-strip).
+#[test]
+fn test_notes_mode_keeps_messages_through_rebase() {
+    let repo = repo_with_notes_storage();
+
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "initial"]).unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let ai_file = repo.path().join("ai.txt");
+    fs::write(&ai_file, "AI line 1\nAI line 2\n").unwrap();
+    checkpoint_with_message(&repo, "notes-mode prompt", vec!["ai.txt".to_string()]);
+    repo.git(&["add", "-A"]).unwrap();
+    let feature_commit = repo.commit("feature ai commit").expect("commit");
+
+    // Under Notes mode the initial note should retain messages.
+    let initial_had_messages = feature_commit
+        .authorship_log
+        .metadata
+        .prompts
+        .values()
+        .any(|p| !p.messages.is_empty());
+    assert!(
+        initial_had_messages,
+        "precondition: Notes mode should keep messages on initial commit"
+    );
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    fs::write(repo.path().join("other.txt"), "other\n").unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "main advances"]).unwrap();
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+
+    let rebased_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let rebased_log = read_log(&repo, &rebased_sha);
+    assert!(
+        rebased_log
+            .metadata
+            .prompts
+            .values()
+            .any(|p| !p.messages.is_empty()),
+        "rebased commit under Notes mode should still carry messages: {:?}",
+        rebased_log
+            .metadata
+            .prompts
+            .values()
+            .map(|p| p.messages.len())
+            .collect::<Vec<_>>()
+    );
+}
+
+crate::reuse_tests_in_worktree!(
+    test_initial_commit_strips_messages_under_local_storage,
+    test_amend_strips_messages_under_local_storage,
+    test_rebase_strips_messages_under_local_storage,
+    test_cherry_pick_strips_messages_under_local_storage,
+    test_squash_merge_strips_messages_under_local_storage,
+    test_rebase_strips_leaky_upstream_messages,
+    test_cherry_pick_strips_leaky_upstream_messages,
+    test_squash_merge_strips_leaky_upstream_messages,
+    test_notes_mode_keeps_messages_through_rebase,
+);


### PR DESCRIPTION
## Summary

- `src/authorship/post_commit.rs:164–223` correctly honors `effective_prompt_storage` (strip / redact / CAS) before `notes_add`. The **eight** `notes_add`/`notes_add_batch` callsites in `src/authorship/rebase_authorship.rs` (merge, rebase slow-path, cherry-pick, amend, and the three remap paths) bypassed this entirely — so on amend / rebase / cherry-pick / squash-merge, messages from upstream notes or from working-log checkpoints were serialized straight into git notes, breaking the documented \"default mode strips messages\" contract.
- Extracts the policy block into a new module `src/authorship/prompt_storage_policy.rs` with two helpers and wires it into every rewrite callsite.
- `post_commit.rs` behavior is unchanged; the rewrite paths now match it.
- Incidentally closes a secondary (security) gap: under `prompt_storage = \"notes\"`, the rewrite paths never ran `redact_secrets_from_prompts` either, so secrets could land in notes on any rebase/amend/etc.

## Observed symptom

- Spans every `git_ai_version` from 1.0.37 through 1.3.2 — not a regression in one release.
- **Zero** leaked prompts have `messages_url` set → none traversed the `Default` / CAS branch of the policy block.
- Same squash-merge commit carries a mix of stripped and populated prompts
- We saw this in commits with `accepted_lines > 0` and `total_additions: 0, total_deletions: 0`, which lines up with rebase/squash metadata-template assembly.

Exactly what you'd see if `rebase_authorship.rs` skipped the policy block — which, per the audit, it did.

## Callsite audit (`src/authorship/rebase_authorship.rs`)

| Line | Caller / context | Source of `AuthorshipLog` or note body | strip / redact before this PR? |
|---|---|---|---|
| 631 | Merge (empty-diff branch) → `build_metadata_only_authorship_log_from_source_notes` | Source notes | No |
| 722 | Merge (normal path) → `merged_va.to_authorship_log()` | `new_for_base_commit` → notes + blame | No |
| 1883 | Slow-path rebase batch | Cached per-file attestation text + metadata template | No |
| 2107 | `rewrite_authorship_after_cherry_pick` → `current_va.to_authorship_log()` | `new_for_base_commit` → notes | No |
| 2956 | `rewrite_authorship_after_commit_amend` → `working_va.to_authorship_log_and_initial_working_log()` | Working log (transcripts when present) | No |
| 3449 | `remap_notes_for_commit_pairs` (slow-path fallback) | Source note content, byte-copied | No |
| 3587 | Fast-path rebase note remap | Source note content, byte-copied | No |
| 3682 | Fast-path cherry-pick note remap | Source note blob, byte-copied | No |

The non-test callsite list is exhaustive; nothing else writes notes in this file. Fast-path remap paths need `apply_prompt_storage_policy_to_note` (parse → apply → reserialize) because they operate on raw note bytes. The cost is per-note JSON deserialize+serialize on rebase/cherry-pick — trading raw-byte speed for correctness parity with post_commit.

## Design notes

`apply_prompt_storage_policy(repo, &mut AuthorshipLog)` owns the full policy: custom_attributes injection + match on `PromptStorageMode::{Local, Notes, Default}` + CAS enqueue + strip-on-fallback. `post_commit.rs` now calls it once instead of inlining the block. The amend path also loses its duplicate custom_attributes injection since the helper covers it.

`apply_prompt_storage_policy_to_note(repo, &str)` is the byte-level variant for remap callers. Parse failure falls through unchanged (the downstream reader would fail either way; we don't want to silently lose data).

## Security consideration

Under `prompt_storage = \"notes\"`, `post_commit.rs` calls `redact_secrets_from_prompts` before writing the note. The rewrite paths never did — so any secrets detected at commit time were re-exposed on any subsequent rebase / amend / squash-merge (because that path produced a fresh note without redaction). This PR closes that gap incidentally: the same shared helper enforces redaction on every write.

## Test plan

`tests/integration/prompt_storage_rewrite_paths.rs`:

- [x] Control: `prompt_storage = \"local\"`, initial commit strips messages.
- [x] Amend under local: amended note strips messages (this was the direct reproduction of the leak with agent-v1 / non-refetch preset).
- [x] Rebase / cherry-pick / squash-merge under local, no pre-existing leak.
- [x] **Leaky-upstream propagation tests**: seed a source note with messages (simulating an older git-ai version or an unrelated leak path), then rebase / cherry-pick / squash-merge — new notes must strip. This is the production pattern.
- [x] `prompt_storage = \"notes\"`: initial commit *keeps* messages AND rebased commit *keeps* messages (policy honored both ways — no over-stripping).
- [x] Full suite green locally (`task test`): 1,475 lib + 3,017 integration + 33 + 56 + 17 + 8 + 7 others, zero failures, no snapshot updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
