### PR TITLE
Add wall-clock timeout and SSH hardening to authorship note fetch

### DIFF
--- a/src/commands/hooks/checkout_hooks.rs
+++ b/src/commands/hooks/checkout_hooks.rs
@@ -142,10 +142,7 @@ pub fn post_checkout_hook(
             .storage
             .delete_working_log_for_base_commit(&old_head)
         {
-            tracing::debug!(
-                "Failed to delete working log for {}: {}",
-                &old_head, e
-            );
+            tracing::debug!("Failed to delete working log for {}: {}", &old_head, e);
         }
         return;
     }
@@ -184,10 +181,7 @@ pub fn post_checkout_hook(
                 .storage
                 .delete_working_log_for_base_commit(&old_head)
             {
-                tracing::debug!(
-                    "Failed to delete working log for {}: {}",
-                    &old_head, e
-                );
+                tracing::debug!("Failed to delete working log for {}: {}", &old_head, e);
             }
             restore_stashed_va(repository, &old_head, &new_head, stashed_va);
             return;
@@ -203,7 +197,9 @@ pub fn post_checkout_hook(
     if let Err(e) = repository.storage.rename_working_log(&old_head, &new_head) {
         tracing::debug!(
             "Failed to rename working log {} -> {}: {}",
-            &old_head, &new_head, e
+            &old_head,
+            &new_head,
+            e
         );
     }
 }

--- a/src/commands/hooks/fetch_hooks.rs
+++ b/src/commands/hooks/fetch_hooks.rs
@@ -246,7 +246,9 @@ pub fn pull_post_command_hook(
         if let Err(e) = repository.storage.rename_working_log(&old_head, &new_head) {
             tracing::debug!(
                 "Failed to rename working log {} -> {}: {}",
-                old_head, new_head, e
+                old_head,
+                new_head,
+                e
             );
         }
         return;

--- a/src/commands/hooks/reset_hooks.rs
+++ b/src/commands/hooks/reset_hooks.rs
@@ -165,10 +165,7 @@ fn handle_reset_hard(repository: &Repository, old_head_sha: &str, _target_commit
         .storage
         .delete_working_log_for_base_commit(old_head_sha)
     {
-        tracing::debug!(
-            "Failed to delete working log for {}: {}",
-            old_head_sha, e
-        );
+        tracing::debug!("Failed to delete working log for {}: {}", old_head_sha, e);
     }
 
     tracing::debug!("Reset --hard: deleted working log for {}", old_head_sha);
@@ -223,7 +220,9 @@ fn handle_reset_preserve_working_dir(
         {
             tracing::debug!(
                 "Failed to rename working log {} -> {}: {}",
-                old_head_sha, target_commit_sha, e
+                old_head_sha,
+                target_commit_sha,
+                e
             );
         }
         return;
@@ -383,7 +382,8 @@ fn handle_reset_pathspec_preserve_working_dir(
     {
         tracing::debug!(
             "Failed to delete working log for {}: {}",
-            target_commit_sha, e
+            target_commit_sha,
+            e
         );
     }
 

--- a/src/commands/hooks/switch_hooks.rs
+++ b/src/commands/hooks/switch_hooks.rs
@@ -101,10 +101,7 @@ pub fn post_switch_hook(
             .storage
             .delete_working_log_for_base_commit(&old_head)
         {
-            tracing::debug!(
-                "Failed to delete working log for {}: {}",
-                &old_head, e
-            );
+            tracing::debug!("Failed to delete working log for {}: {}", &old_head, e);
         }
         return;
     }
@@ -138,10 +135,7 @@ pub fn post_switch_hook(
                 .storage
                 .delete_working_log_for_base_commit(&old_head)
             {
-                tracing::debug!(
-                    "Failed to delete working log for {}: {}",
-                    &old_head, e
-                );
+                tracing::debug!("Failed to delete working log for {}: {}", &old_head, e);
             }
             restore_stashed_va(repository, &old_head, &new_head, stashed_va);
             return;
@@ -157,7 +151,9 @@ pub fn post_switch_hook(
     if let Err(e) = repository.storage.rename_working_log(&old_head, &new_head) {
         tracing::debug!(
             "Failed to rename working log {} -> {}: {}",
-            &old_head, &new_head, e
+            &old_head,
+            &new_head,
+            e
         );
     }
 }

--- a/src/commands/hooks/update_ref_hooks.rs
+++ b/src/commands/hooks/update_ref_hooks.rs
@@ -76,7 +76,9 @@ pub fn post_update_ref_hook(
         {
             tracing::debug!(
                 "Failed to rename working log {} -> {}: {}",
-                &old_target, &new_target, e
+                &old_target,
+                &new_target,
+                e
             );
         }
         return;

--- a/src/git/authorship_traversal.rs
+++ b/src/git/authorship_traversal.rs
@@ -192,7 +192,17 @@ mod tests {
     use crate::git::{find_repository_in_path, sync_authorship::fetch_authorship_notes};
     use std::time::Instant;
 
+    // DISABLED: This is a smoke/integration test, not a unit test. It runs against the
+    // developer's live CWD and performs a real `git fetch origin refs/notes/ai` over the
+    // network. It caused a ~5-hour hang in CI when the SSH handshake to github.com stalled
+    // with no timeout (see fetch_authorship_notes hardening with GIT_TERMINAL_PROMPT=0,
+    // GIT_SSH_COMMAND BatchMode, and a 60s wall-clock timeout — those guard the production
+    // path but this test still depends on network, SSH credentials, and the remote having
+    // at least 3 authorship notes, none of which are guaranteed in CI or on a developer
+    // machine. Re-enable only after porting to a hermetic TestRepo + local file:// remote
+    // seeded with notes (see tests/integration/repos/test_repo.rs for the framework).
     #[test]
+    #[ignore]
     fn test_load_ai_touched_files_for_specific_commits() {
         smol::block_on(async {
             let repo = find_repository_in_path(".").unwrap();

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -3195,6 +3195,107 @@ pub fn exec_git_with_profile(
     Ok(output)
 }
 
+/// Execute git with extra environment variables and a wall-clock timeout.
+///
+/// If the child has not exited within `timeout`, it is killed and a `GitCliError`
+/// with `code: None` is returned whose stderr contains `git-ai: command timed out
+/// after ...`. Callers that need to soft-fail on timeout should match on that
+/// marker.
+///
+/// Entries in `env` are applied on top of the inherited environment; passing
+/// `("GIT_SSH_COMMAND", "")` would clobber any user-provided value, so callers
+/// should check and only set when unset.
+pub fn exec_git_with_env_and_timeout(
+    args: &[String],
+    env: &[(String, String)],
+    timeout: std::time::Duration,
+) -> Result<Output, GitAiError> {
+    let profile = InternalGitProfile::General;
+    let effective_args =
+        args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
+    let mut cmd = Command::new(config::Config::get().git_cmd());
+    cmd.args(&effective_args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    for (k, v) in env.iter() {
+        cmd.env(k, v);
+    }
+    cmd.env_remove("GIT_EXTERNAL_DIFF");
+    cmd.env_remove("GIT_DIFF_OPTS");
+
+    #[cfg(windows)]
+    {
+        if !is_interactive_terminal() {
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+    }
+
+    let mut child = cmd.spawn().map_err(GitAiError::IoError)?;
+
+    // Drain stdout/stderr in background threads so the child never blocks on a
+    // full pipe buffer while we poll try_wait below.
+    let stdout_reader = child.stdout.take().map(|mut s| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = std::io::Read::read_to_end(&mut s, &mut buf);
+            buf
+        })
+    });
+    let stderr_reader = child.stderr.take().map(|mut s| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = std::io::Read::read_to_end(&mut s, &mut buf);
+            buf
+        })
+    });
+
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(100);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(s)) => break s,
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(GitAiError::GitCliError {
+                        code: None,
+                        stderr: format!(
+                            "git-ai: command timed out after {:?} and was killed",
+                            timeout
+                        ),
+                        args: effective_args,
+                    });
+                }
+                std::thread::sleep(poll_interval);
+            }
+            Err(e) => return Err(GitAiError::IoError(e)),
+        }
+    };
+
+    let stdout = stdout_reader
+        .map(|t| t.join().unwrap_or_default())
+        .unwrap_or_default();
+    let stderr = stderr_reader
+        .map(|t| t.join().unwrap_or_default())
+        .unwrap_or_default();
+
+    if !status.success() {
+        return Err(GitAiError::GitCliError {
+            code: status.code(),
+            stderr: String::from_utf8_lossy(&stderr).to_string(),
+            args: effective_args,
+        });
+    }
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
 /// Helper to execute a git command with data provided on stdin
 pub fn exec_git_stdin(args: &[String], stdin_data: &[u8]) -> Result<Output, GitAiError> {
     exec_git_stdin_with_profile(args, stdin_data, InternalGitProfile::General)

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -4,8 +4,35 @@ use crate::git::refs::{
 };
 use crate::{
     error::GitAiError,
-    git::{cli_parser::ParsedGitInvocation, repository::exec_git},
+    git::{
+        cli_parser::ParsedGitInvocation,
+        repository::{exec_git, exec_git_with_env_and_timeout},
+    },
 };
+use std::time::Duration;
+
+/// Wall-clock timeout for `git fetch refs/notes/ai`. Authorship notes are tiny; a
+/// healthy fetch completes in well under a second. Anything past this point is
+/// almost certainly a hung SSH connection or dead remote.
+const AUTHORSHIP_FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Environment hardening applied to internal `git fetch` of authorship notes so
+/// a stalled remote cannot block the caller indefinitely:
+/// - `GIT_TERMINAL_PROMPT=0` disables any interactive credential prompt.
+/// - `GIT_SSH_COMMAND` (only when unset) forces non-interactive SSH with short
+///   connect/keepalive timeouts so a dead TCP connection fails fast.
+fn authorship_fetch_env() -> Vec<(String, String)> {
+    let mut env = vec![("GIT_TERMINAL_PROMPT".to_string(), "0".to_string())];
+    if std::env::var_os("GIT_SSH_COMMAND").is_none() {
+        env.push((
+            "GIT_SSH_COMMAND".to_string(),
+            "ssh -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 \
+             -o ServerAliveCountMax=3"
+                .to_string(),
+        ));
+    }
+    env
+}
 
 use super::repository::Repository;
 
@@ -155,7 +182,8 @@ pub fn fetch_authorship_notes(
 
     tracing::debug!("fetch command: {:?}", fetch_authorship);
 
-    match exec_git(&fetch_authorship) {
+    let fetch_env = authorship_fetch_env();
+    match exec_git_with_env_and_timeout(&fetch_authorship, &fetch_env, AUTHORSHIP_FETCH_TIMEOUT) {
         Ok(output) => {
             tracing::debug!(
                 "fetch stdout: '{}'",

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1108,8 +1108,8 @@ impl TestRepo {
     }
 
     pub fn new_worktree() -> Self {
-    Self::new_worktree_with_mode(GitTestMode::from_env())
-}
+        Self::new_worktree_with_mode(GitTestMode::from_env())
+    }
 
     pub fn new_worktree_with_mode(git_mode: GitTestMode) -> Self {
         Self::new_worktree_with_mode_and_daemon_scope(git_mode, DaemonTestScope::Shared)
@@ -1235,23 +1235,23 @@ impl TestRepo {
     }
 
     /// Create a pair of test repos: a local mirror and its upstream remote.
-/// The mirror is cloned from the upstream, so "origin" is automatically configured.
-/// Returns (mirror, upstream) tuple.
-///
-/// # Example
-/// ```ignore
-/// let (mirror, upstream) = TestRepo::new_with_remote();
-///
-/// // Make changes in mirror
-/// mirror.filename("test.txt").write("hello").stage();
-/// mirror.commit("initial commit");
-///
-/// // Push to upstream
-/// mirror.git(&["push", "origin", "main"]);
-/// ```
-pub fn new_with_remote() -> (Self, Self) {
-    Self::new_with_remote_with_mode(GitTestMode::from_env())
-}
+    /// The mirror is cloned from the upstream, so "origin" is automatically configured.
+    /// Returns (mirror, upstream) tuple.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let (mirror, upstream) = TestRepo::new_with_remote();
+    ///
+    /// // Make changes in mirror
+    /// mirror.filename("test.txt").write("hello").stage();
+    /// mirror.commit("initial commit");
+    ///
+    /// // Push to upstream
+    /// mirror.git(&["push", "origin", "main"]);
+    /// ```
+    pub fn new_with_remote() -> (Self, Self) {
+        Self::new_with_remote_with_mode(GitTestMode::from_env())
+    }
 
     pub fn new_with_remote_with_mode(git_mode: GitTestMode) -> (Self, Self) {
         Self::new_with_remote_with_mode_and_daemon_scope(git_mode, DaemonTestScope::Shared)


### PR DESCRIPTION
Add wall-clock timeout and SSH hardening to authorship note fetch

`fetch_authorship_notes` previously shelled out to `git fetch` via
`exec_git`, which uses `Command::output()` and blocks the calling
thread indefinitely. In practice this meant a stalled SSH handshake
to the remote -- credential prompt with no TTY, dead TCP connection,
or BatchMode-less keepalive loss -- would freeze the caller forever
with no way to recover. We observed a ~5 hour hang in a test run
where `ssh git@github.com` never completed.

Introduce `exec_git_with_env_and_timeout` in repository.rs: it spawns
the child with piped stdout/stderr drained by background threads
(to avoid pipe-buffer deadlock), polls `try_wait` with a short
interval, and on timeout kills the child and returns a `GitCliError`
marked with `code: None` and a descriptive stderr.

Route `fetch_authorship_notes` through it with a 60s deadline --
authorship notes are tiny, anything longer is a hung remote -- plus
two env vars that prevent hangs at the SSH layer:

- `GIT_TERMINAL_PROMPT=0` disables interactive credential prompts.
- `GIT_SSH_COMMAND` forces `BatchMode=yes`, `ConnectTimeout=10`, and
  short keepalives so a dead connection fails fast. Only applied
  when the user has not set `GIT_SSH_COMMAND` themselves.

Either guard alone would have killed the observed hang within
seconds; together they provide defense in depth.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Disable env-dependent authorship traversal smoke test

`test_load_ai_touched_files_for_specific_commits` performs a real
`git fetch origin refs/notes/ai` against the developer's CWD remote
and requires the remote to have at least 3 authorship notes. It is
a smoke test, not a unit test: in CI or on a machine without SSH
credentials to the configured origin it will either fail or (before
the preceding fetch-timeout hardening) hang indefinitely.

Mark it `#[ignore]` with a comment spelling out the preconditions
and what a proper hermetic rewrite would look like (a TestRepo with
a local file:// remote seeded with synthetic notes). Re-enable once
ported. The other four tests in the module remain environment-
dependent on CWD but do not touch the network, so are left alone
here.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Apply pending cargo fmt to hooks and test_repo

Pure rustfmt output -- indentation and macro-call wrapping only.
No behavior change. These were produced by `task fmt` during an
unrelated session and are bundled here separately to keep them
out of the hang-fix commits.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>