### PR TITLE
Strip prompt messages during serialization in release builds

### DIFF
--- a/src/authorship/authorship_log.rs
+++ b/src/authorship/authorship_log.rs
@@ -1,8 +1,19 @@
 use crate::authorship::transcript::Message;
 use crate::authorship::working_log::AgentId;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 use std::fmt;
+
+fn serialize_messages_release_empty<S: Serializer>(
+    messages: &Vec<Message>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    if cfg!(debug_assertions) {
+        messages.serialize(serializer)
+    } else {
+        Vec::<Message>::new().serialize(serializer)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Author {
@@ -199,6 +210,7 @@ pub struct HumanRecord {
 pub struct PromptRecord {
     pub agent_id: AgentId,
     pub human_author: Option<String>,
+    #[serde(serialize_with = "serialize_messages_release_empty")]
     pub messages: Vec<Message>,
     #[serde(default)]
     pub total_additions: u32,


### PR DESCRIPTION
## Summary
- Add a custom serde serializer on `PromptRecord.messages` that always serializes to `[]` in release builds
- Acts as a safety net ensuring messages never leak into git notes even if upstream stripping logic (CAS upload, `strip_prompt_messages`) fails
- Debug builds preserve messages so tests remain unaffected

## Test plan
- [ ] Verify `task build` compiles cleanly
- [ ] Verify `task test TEST_FILTER=prompt` passes (all debug-mode tests unaffected)
- [ ] Verify release build serializes messages as `[]` regardless of field contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
