### PR TITLE
feat(vscode): require dirty keystrokes since last saved for known human checkpoints

### DIFF
--- a/agent-support/vscode/src/extension.ts
+++ b/agent-support/vscode/src/extension.ts
@@ -53,6 +53,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidSaveTextDocument((doc) => {
       knownHumanManager.handleSaveEvent(doc);
     }),
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      knownHumanManager.handleContentChangeEvent(event);
+    }),
+    vscode.workspace.onDidCloseTextDocument((doc) => {
+      knownHumanManager.handleCloseEvent(doc);
+    }),
     { dispose: () => knownHumanManager.dispose() },
   );
 

--- a/agent-support/vscode/src/extension.ts
+++ b/agent-support/vscode/src/extension.ts
@@ -56,6 +56,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument((event) => {
       knownHumanManager.handleContentChangeEvent(event);
     }),
+    vscode.window.onDidChangeTextEditorSelection((event) => {
+      knownHumanManager.handleSelectionChangeEvent(event);
+    }),
     vscode.workspace.onDidCloseTextDocument((doc) => {
       knownHumanManager.handleCloseEvent(doc);
     }),

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -20,10 +20,61 @@ export class KnownHumanCheckpointManager {
   // per repo root: set of absolute file paths queued in current debounce window
   private pendingPaths = new Map<string, Set<string>>();
 
+  // Files that have received a genuine human keystroke since their last save.
+  // Cleared on every save of that file, regardless of whether we checkpoint.
+  private keystrokeDirty = new Set<string>();
+
   constructor(
     private readonly editorVersion: string,
     private readonly extensionVersion: string,
   ) {}
+
+  public handleContentChangeEvent(event: vscode.TextDocumentChangeEvent): void {
+    const doc = event.document;
+    if (doc.uri.scheme !== "file") {
+      return;
+    }
+    const filePath = doc.uri.fsPath;
+    if (this.isInternalVSCodePath(filePath)) {
+      return;
+    }
+    if (!this.isHumanKeystroke(event)) {
+      return;
+    }
+    this.keystrokeDirty.add(filePath);
+  }
+
+  public handleCloseEvent(doc: vscode.TextDocument): void {
+    if (doc.uri.scheme !== "file") {
+      return;
+    }
+    this.keystrokeDirty.delete(doc.uri.fsPath);
+  }
+
+  private isHumanKeystroke(event: vscode.TextDocumentChangeEvent): boolean {
+    // Human typing requires the doc to be the active editor. AI WorkspaceEdit
+    // writes typically target non-active documents.
+    if (vscode.window.activeTextEditor?.document !== event.document) {
+      return false;
+    }
+    // Exclude undo/redo.
+    if (event.reason !== undefined) {
+      return false;
+    }
+    const changes = event.contentChanges;
+    if (changes.length === 0 || changes.length > 2) {
+      return false;
+    }
+    for (const c of changes) {
+      if (c.range.end.line - c.range.start.line > 1) {
+        return false;
+      }
+      if (c.text.length > 256) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   public handleSaveEvent(doc: vscode.TextDocument): void {
     if (doc.uri.scheme !== "file") {
@@ -34,6 +85,23 @@ export class KnownHumanCheckpointManager {
 
     if (this.isInternalVSCodePath(filePath)) {
       console.log("[git-ai] KnownHumanCheckpointManager: Ignoring internal VSCode file:", filePath);
+      return;
+    }
+
+    // Save resets the keystroke-evidence window for this file regardless of
+    // whether we end up checkpointing.
+    const hadKeystroke = this.keystrokeDirty.delete(filePath);
+
+    const visible = vscode.window.visibleTextEditors.some(
+      (e) => e.document.uri.scheme === "file" && e.document.uri.fsPath === filePath,
+    );
+    if (!visible) {
+      console.log("[git-ai] KnownHumanCheckpointManager: File not visible in any editor, skipping:", filePath);
+      return;
+    }
+
+    if (!hadKeystroke) {
+      console.log("[git-ai] KnownHumanCheckpointManager: No human keystroke since last save, skipping:", filePath);
       return;
     }
 
@@ -157,5 +225,6 @@ export class KnownHumanCheckpointManager {
     }
     this.pendingTimers.clear();
     this.pendingPaths.clear();
+    this.keystrokeDirty.clear();
   }
 }

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -61,19 +61,9 @@ export class KnownHumanCheckpointManager {
     if (event.reason !== undefined) {
       return false;
     }
-    const changes = event.contentChanges;
-    if (changes.length === 0 || changes.length > 2) {
-      return false;
-    }
-    for (const c of changes) {
-      if (c.range.end.line - c.range.start.line > 1) {
-        return false;
-      }
-      if (c.text.length > 256) {
-        return false;
-      }
-    }
-    return true;
+    return event.contentChanges.some(
+      (c) => c.range.end.line - c.range.start.line <= 1,
+    );
   }
 
   public handleSaveEvent(doc: vscode.TextDocument): void {

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -17,21 +17,27 @@ export class KnownHumanCheckpointManager {
   // per repo root: pending debounce timer
   private pendingTimers = new Map<string, NodeJS.Timeout>();
 
-  // per repo root: set of absolute file paths queued in current debounce window
-  private pendingPaths = new Map<string, Set<string>>();
+  // per repo root: absolute file path -> content captured at the time of the
+  // save event. We capture eagerly because Cascade can overwrite the buffer
+  // during the debounce window and re-reading at fire time would send the
+  // wrong content.
+  private pendingPaths = new Map<string, Map<string, string>>();
 
-  // Per-file timestamps. Comparing at save time is order-independent — typing
-  // fires contentChange before selectionChange, so checking at change time
-  // would miss the first keystroke after a save.
-  private lastContentChange = new Map<string, number>();      // any contentChange
-  private lastKeyboardSelection = new Map<string, number>();  // Keyboard-kind only
-  private lastSave = new Map<string, number>();
+  // Per-file: buffer content at the moment of the most recent Keyboard-kind
+  // selection change. Typing produces such selections (cursor moves with each
+  // character); AI WorkspaceEdits do not. At save time we require the buffer
+  // to still equal this snapshot — if Cascade overwrote the buffer in between,
+  // the snapshot won't match and we skip.
+  private humanSnapshot = new Map<string, string>();
+  // Records that we've seen a Keyboard selection on this file since last save —
+  // used purely for noisy logging.
+  private sawKbdSinceSave = new Set<string>();
 
   constructor(
     private readonly editorVersion: string,
     private readonly extensionVersion: string,
   ) {
-    console.log("[git-ai][KHC] v5 constructed");
+    console.log("[git-ai][KHC] v6 (snapshot-anchored) constructed");
   }
 
   public handleSelectionChangeEvent(event: vscode.TextEditorSelectionChangeEvent): void {
@@ -42,8 +48,13 @@ export class KnownHumanCheckpointManager {
     if (doc.uri.scheme !== "file") {
       return;
     }
-    this.lastKeyboardSelection.set(doc.uri.fsPath, Date.now());
-    console.log("[git-ai][KHC] keyboard-selection", doc.uri.fsPath);
+    const filePath = doc.uri.fsPath;
+    if (this.isInternalVSCodePath(filePath)) {
+      return;
+    }
+    this.humanSnapshot.set(filePath, doc.getText());
+    this.sawKbdSinceSave.add(filePath);
+    console.log("[git-ai][KHC] keyboard-selection — snapshot updated", filePath, "len=" + doc.getText().length);
   }
 
   public handleContentChangeEvent(event: vscode.TextDocumentChangeEvent): void {
@@ -58,8 +69,7 @@ export class KnownHumanCheckpointManager {
     if (event.contentChanges.length === 0) {
       return;
     }
-    this.lastContentChange.set(filePath, Date.now());
-    console.log("[git-ai][KHC] edit recorded", filePath, "changes=" + event.contentChanges.length);
+    console.log("[git-ai][KHC] edit observed", filePath, "changes=" + event.contentChanges.length, "newLen=" + doc.getText().length);
   }
 
   public handleCloseEvent(doc: vscode.TextDocument): void {
@@ -67,9 +77,8 @@ export class KnownHumanCheckpointManager {
       return;
     }
     const fsPath = doc.uri.fsPath;
-    this.lastContentChange.delete(fsPath);
-    this.lastKeyboardSelection.delete(fsPath);
-    this.lastSave.delete(fsPath);
+    this.humanSnapshot.delete(fsPath);
+    this.sawKbdSinceSave.delete(fsPath);
   }
 
   public handleSaveEvent(doc: vscode.TextDocument): void {
@@ -84,21 +93,19 @@ export class KnownHumanCheckpointManager {
       return;
     }
 
-    const prevSave = this.lastSave.get(filePath) ?? 0;
-    const lastChange = this.lastContentChange.get(filePath) ?? 0;
-    const lastKbd = this.lastKeyboardSelection.get(filePath) ?? 0;
-    this.lastSave.set(filePath, Date.now());
-
     const visible = vscode.window.visibleTextEditors.some(
       (e) => e.document.uri.scheme === "file" && e.document.uri.fsPath === filePath,
     );
-    const changedSinceSave = lastChange > prevSave;
-    const kbdSinceSave = lastKbd > prevSave;
+    const snapshot = this.humanSnapshot.get(filePath);
+    const currentText = doc.getText();
+    const snapshotMatches = snapshot !== undefined && snapshot === currentText;
+    const sawKbd = this.sawKbdSinceSave.delete(filePath);
+
     console.log(
       "[git-ai][KHC] save gates visible=" + visible,
-      "changedSinceSave=" + changedSinceSave,
-      "kbdSinceSave=" + kbdSinceSave,
-      "(prevSave=" + prevSave + " lastChange=" + lastChange + " lastKbd=" + lastKbd + ")",
+      "sawKbdSinceSave=" + sawKbd,
+      "snapshotMatches=" + snapshotMatches,
+      "(snapshotLen=" + (snapshot?.length ?? "none") + " currentLen=" + currentText.length + ")",
       "path=" + filePath,
     );
 
@@ -106,12 +113,13 @@ export class KnownHumanCheckpointManager {
       console.log("[git-ai][KHC] SKIP: not visible —", filePath);
       return;
     }
-    if (!changedSinceSave) {
-      console.log("[git-ai][KHC] SKIP: no edit since last save —", filePath);
-      return;
-    }
-    if (!kbdSinceSave) {
-      console.log("[git-ai][KHC] SKIP: no keyboard activity since last save —", filePath);
+    if (!snapshotMatches) {
+      // Either no snapshot ever taken (no human keyboard activity on this file)
+      // or buffer changed since the last keyboard selection (Cascade overwrite).
+      // Reset snapshot to the current buffer state so subsequent typing rebuilds
+      // a clean baseline.
+      this.humanSnapshot.delete(filePath);
+      console.log("[git-ai][KHC] SKIP: snapshot mismatch —", filePath);
       return;
     }
 
@@ -121,13 +129,16 @@ export class KnownHumanCheckpointManager {
       return;
     }
 
-    // Accumulate file into pending set for this repo root
+    // Capture content NOW (matches the snapshot we just verified). If Cascade
+    // overwrites during the debounce window, that overwrite triggers a separate
+    // save event which fails the snapshot gate, but our captured content here
+    // remains the human-typed buffer.
     let pending = this.pendingPaths.get(repoRoot);
     if (!pending) {
-      pending = new Set();
+      pending = new Map();
       this.pendingPaths.set(repoRoot, pending);
     }
-    pending.add(filePath);
+    pending.set(filePath, currentText);
 
     // Reset debounce timer
     const existing = this.pendingTimers.get(repoRoot);
@@ -152,38 +163,14 @@ export class KnownHumanCheckpointManager {
     if (!paths || paths.size === 0) {
       return;
     }
-    const snapshot = [...paths];
-    paths.clear();
-
-    // Build dirty_files as absolute path → current content
+    // Use the content captured at save time, not what's currently in the
+    // buffer or on disk — Cascade may have overwritten either during the
+    // debounce window.
     const dirtyFiles: Record<string, string> = {};
-    for (const absolutePath of snapshot) {
-      const doc = vscode.workspace.textDocuments.find(
-        (d) => d.uri.fsPath === absolutePath && d.uri.scheme === "file"
-      );
-
-      let content: string | null = null;
-      if (doc) {
-        // Use open document buffer if available (handles codespaces/remote lag)
-        content = doc.getText();
-      } else {
-        // Fall back to reading from disk if document was closed within debounce window
-        try {
-          const bytes = await vscode.workspace.fs.readFile(vscode.Uri.file(absolutePath));
-          content = Buffer.from(bytes).toString("utf-8");
-        } catch (err) {
-          console.error("[git-ai] KnownHumanCheckpointManager: Failed to read file", absolutePath, err);
-        }
-      }
-
-      if (content !== null) {
-        dirtyFiles[absolutePath] = content;
-      }
+    for (const [absolutePath, capturedContent] of paths) {
+      dirtyFiles[absolutePath] = capturedContent;
     }
-
-    if (Object.keys(dirtyFiles).length === 0) {
-      return;
-    }
+    paths.clear();
 
     const editedFilepaths = Object.keys(dirtyFiles);
 
@@ -235,8 +222,7 @@ export class KnownHumanCheckpointManager {
     }
     this.pendingTimers.clear();
     this.pendingPaths.clear();
-    this.lastContentChange.clear();
-    this.lastKeyboardSelection.clear();
-    this.lastSave.clear();
+    this.humanSnapshot.clear();
+    this.sawKbdSinceSave.clear();
   }
 }

--- a/agent-support/vscode/src/known-human-checkpoint-manager.ts
+++ b/agent-support/vscode/src/known-human-checkpoint-manager.ts
@@ -20,14 +20,31 @@ export class KnownHumanCheckpointManager {
   // per repo root: set of absolute file paths queued in current debounce window
   private pendingPaths = new Map<string, Set<string>>();
 
-  // Files that have received a genuine human keystroke since their last save.
-  // Cleared on every save of that file, regardless of whether we checkpoint.
-  private keystrokeDirty = new Set<string>();
+  // Per-file timestamps. Comparing at save time is order-independent — typing
+  // fires contentChange before selectionChange, so checking at change time
+  // would miss the first keystroke after a save.
+  private lastContentChange = new Map<string, number>();      // any contentChange
+  private lastKeyboardSelection = new Map<string, number>();  // Keyboard-kind only
+  private lastSave = new Map<string, number>();
 
   constructor(
     private readonly editorVersion: string,
     private readonly extensionVersion: string,
-  ) {}
+  ) {
+    console.log("[git-ai][KHC] v5 constructed");
+  }
+
+  public handleSelectionChangeEvent(event: vscode.TextEditorSelectionChangeEvent): void {
+    if (event.kind !== vscode.TextEditorSelectionChangeKind.Keyboard) {
+      return;
+    }
+    const doc = event.textEditor.document;
+    if (doc.uri.scheme !== "file") {
+      return;
+    }
+    this.lastKeyboardSelection.set(doc.uri.fsPath, Date.now());
+    console.log("[git-ai][KHC] keyboard-selection", doc.uri.fsPath);
+  }
 
   public handleContentChangeEvent(event: vscode.TextDocumentChangeEvent): void {
     const doc = event.document;
@@ -38,60 +55,63 @@ export class KnownHumanCheckpointManager {
     if (this.isInternalVSCodePath(filePath)) {
       return;
     }
-    if (!this.isHumanKeystroke(event)) {
+    if (event.contentChanges.length === 0) {
       return;
     }
-    this.keystrokeDirty.add(filePath);
+    this.lastContentChange.set(filePath, Date.now());
+    console.log("[git-ai][KHC] edit recorded", filePath, "changes=" + event.contentChanges.length);
   }
 
   public handleCloseEvent(doc: vscode.TextDocument): void {
     if (doc.uri.scheme !== "file") {
       return;
     }
-    this.keystrokeDirty.delete(doc.uri.fsPath);
-  }
-
-  private isHumanKeystroke(event: vscode.TextDocumentChangeEvent): boolean {
-    // Human typing requires the doc to be the active editor. AI WorkspaceEdit
-    // writes typically target non-active documents.
-    if (vscode.window.activeTextEditor?.document !== event.document) {
-      return false;
-    }
-    // Exclude undo/redo.
-    if (event.reason !== undefined) {
-      return false;
-    }
-    return event.contentChanges.some(
-      (c) => c.range.end.line - c.range.start.line <= 1,
-    );
+    const fsPath = doc.uri.fsPath;
+    this.lastContentChange.delete(fsPath);
+    this.lastKeyboardSelection.delete(fsPath);
+    this.lastSave.delete(fsPath);
   }
 
   public handleSaveEvent(doc: vscode.TextDocument): void {
+    const filePath = doc.uri.fsPath;
+    console.log("[git-ai][KHC] save event scheme=" + doc.uri.scheme, "path=" + filePath);
     if (doc.uri.scheme !== "file") {
       return;
     }
 
-    const filePath = doc.uri.fsPath;
-
     if (this.isInternalVSCodePath(filePath)) {
-      console.log("[git-ai] KnownHumanCheckpointManager: Ignoring internal VSCode file:", filePath);
+      console.log("[git-ai][KHC] Ignoring internal VSCode file:", filePath);
       return;
     }
 
-    // Save resets the keystroke-evidence window for this file regardless of
-    // whether we end up checkpointing.
-    const hadKeystroke = this.keystrokeDirty.delete(filePath);
+    const prevSave = this.lastSave.get(filePath) ?? 0;
+    const lastChange = this.lastContentChange.get(filePath) ?? 0;
+    const lastKbd = this.lastKeyboardSelection.get(filePath) ?? 0;
+    this.lastSave.set(filePath, Date.now());
 
     const visible = vscode.window.visibleTextEditors.some(
       (e) => e.document.uri.scheme === "file" && e.document.uri.fsPath === filePath,
     );
+    const changedSinceSave = lastChange > prevSave;
+    const kbdSinceSave = lastKbd > prevSave;
+    console.log(
+      "[git-ai][KHC] save gates visible=" + visible,
+      "changedSinceSave=" + changedSinceSave,
+      "kbdSinceSave=" + kbdSinceSave,
+      "(prevSave=" + prevSave + " lastChange=" + lastChange + " lastKbd=" + lastKbd + ")",
+      "path=" + filePath,
+    );
+
     if (!visible) {
-      console.log("[git-ai] KnownHumanCheckpointManager: File not visible in any editor, skipping:", filePath);
+      console.log("[git-ai][KHC] SKIP: not visible —", filePath);
       return;
     }
-
-    if (!hadKeystroke) {
-      console.log("[git-ai] KnownHumanCheckpointManager: No human keystroke since last save, skipping:", filePath);
+    if (!changedSinceSave) {
+      console.log("[git-ai][KHC] SKIP: no edit since last save —", filePath);
+      return;
+    }
+    if (!kbdSinceSave) {
+      console.log("[git-ai][KHC] SKIP: no keyboard activity since last save —", filePath);
       return;
     }
 
@@ -215,6 +235,8 @@ export class KnownHumanCheckpointManager {
     }
     this.pendingTimers.clear();
     this.pendingPaths.clear();
-    this.keystrokeDirty.clear();
+    this.lastContentChange.clear();
+    this.lastKeyboardSelection.clear();
+    this.lastSave.clear();
   }
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
