### PR TITLE
fix(vscode): keep legacy Copilot hooks active in WSL/SSH/remote contexts

### DIFF
--- a/agent-support/vscode/src/ai-edit-manager.ts
+++ b/agent-support/vscode/src/ai-edit-manager.ts
@@ -33,9 +33,12 @@ export class AIEditManager {
   private readonly STABLE_CONTENT_DEBOUNCE_MS = 2000;
 
   constructor(context: vscode.ExtensionContext) {
-    this.legacyCopilotHooksEnabled = !shouldSkipLegacyCopilotHooks(vscode.version);
+    this.legacyCopilotHooksEnabled = !shouldSkipLegacyCopilotHooks(vscode.version, vscode.env.remoteName);
     if (!this.legacyCopilotHooksEnabled) {
       console.log(`[git-ai] AIEditManager: VS Code ${vscode.version} has native hooks; skipping legacy extension checkpoints`);
+    }
+    if (vscode.env.remoteName) {
+      console.log(`[git-ai] AIEditManager: Remote context detected (${vscode.env.remoteName}); keeping legacy hooks active`);
     }
 
     if (context.storageUri?.fsPath) {

--- a/agent-support/vscode/src/test/vscode-hooks.test.ts
+++ b/agent-support/vscode/src/test/vscode-hooks.test.ts
@@ -14,4 +14,17 @@ suite("VS Code Hook Gating", () => {
     assert.strictEqual(shouldSkipLegacyCopilotHooks("1.108.0"), false);
     assert.strictEqual(shouldSkipLegacyCopilotHooks("1.109.3-alpha"), false);
   });
+
+  test("keeps legacy hooks in remote contexts (WSL, SSH) regardless of version", () => {
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.109.3", "wsl"), false);
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.110.0", "wsl"), false);
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.112.0", "ssh-remote"), false);
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.109.3", "dev-container"), false);
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.109.3", "codespaces"), false);
+  });
+
+  test("skips legacy hooks when remoteName is undefined (local)", () => {
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.109.3", undefined), true);
+    assert.strictEqual(shouldSkipLegacyCopilotHooks("1.110.0", undefined), true);
+  });
 });

--- a/agent-support/vscode/src/utils/vscode-hooks.ts
+++ b/agent-support/vscode/src/utils/vscode-hooks.ts
@@ -4,7 +4,15 @@ import { MIN_VSCODE_NATIVE_HOOKS_VERSION } from "../consts";
 /**
  * VS Code 1.109.3+ supports built-in Copilot hooks, so our extension should stop
  * emitting legacy before_edit/after_edit checkpoints to avoid duplicate attribution.
+ *
+ * However, in remote contexts (WSL, SSH, Codespaces) the native Copilot hooks fire
+ * on the Local Extension Host where Copilot runs, but git-ai runs on the Remote
+ * Extension Host. VS Code's Remote protocol does not relay these hooks across hosts,
+ * so we must keep legacy hooks active in remote sessions.
  */
-export function shouldSkipLegacyCopilotHooks(vscodeVersion: string): boolean {
+export function shouldSkipLegacyCopilotHooks(vscodeVersion: string, remoteName?: string): boolean {
+  if (remoteName) {
+    return false;
+  }
   return isVersionSatisfied(vscodeVersion, MIN_VSCODE_NATIVE_HOOKS_VERSION);
 }


### PR DESCRIPTION
Fixes #1188 