### PR TITLE
feat(ci): add --skip-push to ci local merge

### DIFF
--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -46,6 +46,7 @@ pub enum CiRunResult {
 pub struct CiRunOptions {
     pub skip_fetch_notes: bool,
     pub skip_fetch_base: bool,
+    pub skip_push: bool,
 }
 
 #[derive(Debug)]
@@ -234,9 +235,13 @@ impl CiContext {
                 // Check if authorship was created for THIS specific commit
                 match get_reference_as_authorship_log_v3(&self.repo, merge_commit_sha) {
                     Ok(authorship_log) => {
-                        println!("Pushing authorship...");
-                        self.repo.push_authorship("origin")?;
-                        println!("Pushed authorship. Done.");
+                        if options.skip_push {
+                            println!("Skipping authorship push (--skip-push). Done.");
+                        } else {
+                            println!("Pushing authorship...");
+                            self.repo.push_authorship("origin")?;
+                            println!("Pushed authorship. Done.");
+                        }
                         Ok(CiRunResult::AuthorshipRewritten { authorship_log })
                     }
                     Err(e) => {

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -203,6 +203,7 @@ fn handle_ci_local(args: &[String]) {
             let skip_fetch_all = has_bool_flag("--skip-fetch");
             let skip_fetch_notes = skip_fetch_all || has_bool_flag("--skip-fetch-notes");
             let skip_fetch_base = skip_fetch_all || has_bool_flag("--skip-fetch-base");
+            let skip_push = has_bool_flag("--skip-push");
 
             // Required inputs for merge
             let merge_commit_sha = match flag("--merge-commit-sha") {
@@ -263,6 +264,7 @@ fn handle_ci_local(args: &[String]) {
             match ctx.run_with_options(CiRunOptions {
                 skip_fetch_notes,
                 skip_fetch_base,
+                skip_push,
             }) {
                 Ok(result) => {
                     tracing::debug!("Local CI result: {:?}", result);
@@ -301,7 +303,7 @@ fn print_ci_help_and_exit() -> ! {
         "                     merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha>"
     );
     eprintln!(
-        "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch]"
+        "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch] [--skip-push]"
     );
     std::process::exit(1);
 }
@@ -315,7 +317,7 @@ fn print_ci_local_help_and_exit() -> ! {
     eprintln!(
         "  merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha>"
     );
-    eprintln!("         [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch]");
+    eprintln!("         [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch] [--skip-push]");
     std::process::exit(1);
 }
 

--- a/tests/integration/ci_local_skip_push.rs
+++ b/tests/integration/ci_local_skip_push.rs
@@ -1,0 +1,82 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+
+crate::reuse_tests_in_worktree!(test_ci_local_merge_skip_push_leaves_remote_notes_untouched,);
+
+#[test]
+fn test_ci_local_merge_skip_push_leaves_remote_notes_untouched() {
+    let (repo, upstream) = TestRepo::new_with_remote();
+
+    // base commit on main, pushed to origin
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    let base_sha = repo.stage_all_and_commit("base").unwrap().commit_sha;
+    repo.git_og(&["branch", "-M", "main"]).unwrap();
+    repo.git_og(&["push", "-u", "origin", "main"]).unwrap();
+
+    // feature branch with an AI-attributed commit
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+    let mut feat = repo.filename("feat.txt");
+    feat.set_contents(crate::lines!["// ai line".ai()]);
+    let head_sha = repo.stage_all_and_commit("feat").unwrap().commit_sha;
+    repo.git_og(&["push", "-u", "origin", "feature"]).unwrap();
+
+    // simulate squash merge on main (new commit, no note yet)
+    repo.git_og(&["checkout", "main"]).unwrap();
+    repo.git_og(&["merge", "--squash", "feature"]).unwrap();
+    repo.git_og(&["commit", "-m", "squash merge"]).unwrap();
+    let merge_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git_og(&["push", "origin", "main"]).unwrap();
+
+    let remote_notes_before = upstream
+        .git_og(&["rev-parse", "--verify", "refs/notes/ai"])
+        .ok()
+        .map(|s| s.trim().to_string());
+
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "merge",
+            "--merge-commit-sha",
+            merge_sha.as_str(),
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "feature",
+            "--head-sha",
+            head_sha.as_str(),
+            "--base-sha",
+            base_sha.as_str(),
+            "--skip-fetch",
+            "--skip-push",
+        ])
+        .expect("expected local ci to succeed with --skip-push");
+
+    let remote_notes_after = upstream
+        .git_og(&["rev-parse", "--verify", "refs/notes/ai"])
+        .ok()
+        .map(|s| s.trim().to_string());
+
+    // the rewrite branch executed and push was suppressed
+    assert!(
+        output.contains("Skipping authorship push"),
+        "expected --skip-push log line, got: {}",
+        output
+    );
+    assert!(
+        !output.contains("Pushing authorship..."),
+        "expected no push attempt, got: {}",
+        output
+    );
+
+    // remote must be untouched
+    assert_eq!(
+        remote_notes_before, remote_notes_after,
+        "remote refs/notes/ai must be unchanged with --skip-push"
+    );
+}

--- a/tests/integration/ci_partial_clone.rs
+++ b/tests/integration/ci_partial_clone.rs
@@ -74,6 +74,7 @@ fn test_squash_merge_single_parent_not_on_base_ref() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_push: false,
     });
 
     // Should not fail with "No parent of commit" error
@@ -140,6 +141,7 @@ fn test_single_commit_rebase_parent_on_base_ref() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_push: false,
     });
 
     assert!(
@@ -221,6 +223,7 @@ fn test_multi_commit_squash_merge_single_parent() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_push: false,
     });
 
     assert!(
@@ -326,6 +329,7 @@ fn test_regular_two_parent_merge_skipped() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_push: false,
     });
 
     assert!(

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -599,6 +599,7 @@ fn test_ci_rebase_merge_commit_order_pairing() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_push: false,
     });
     assert!(
         result.is_ok(),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -28,6 +28,7 @@ mod cherry_pick;
 mod chinese_text_edits;
 mod ci_handlers_comprehensive;
 mod ci_local_skip_fetch;
+mod ci_local_skip_push;
 mod ci_partial_clone;
 mod ci_squash_rebase;
 mod claude_code;


### PR DESCRIPTION
Intended for offline batch-backfill of authorship notes across many historical MRs: rewrite locally in bulk first, inspect or aggregate the results, and push to origin once at the end — instead of paying a push round-trip per MR.

Behavior: when --skip-push is set, ci local merge still fetches, rewrites, and writes the authorship note into the local refs/notes/ai as usual; only the final `push_authorship("origin")` step is suppressed, leaving the remote refs/notes/ai untouched.

Closes #1191.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
