### PR TITLE
feat: scope codex apply_patch checkpoints

### DIFF
--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -1159,6 +1159,49 @@ pub(crate) fn load_captured_checkpoint_manifest(
     Ok(serde_json::from_str(&manifest)?)
 }
 
+pub(crate) fn pending_captured_checkpoint_manifests() -> Vec<PreparedCheckpointManifest> {
+    let Ok(storage_dir) = async_checkpoint_storage_dir() else {
+        return Vec::new();
+    };
+    if !storage_dir.exists() {
+        return Vec::new();
+    }
+
+    let Ok(entries) = fs::read_dir(storage_dir) else {
+        return Vec::new();
+    };
+
+    let mut manifests = Vec::new();
+    for entry in entries {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let manifest_path = entry.path().join("manifest.json");
+        let Ok(data) = fs::read(&manifest_path) else {
+            continue;
+        };
+        match serde_json::from_slice::<PreparedCheckpointManifest>(&data) {
+            Ok(manifest) => manifests.push(manifest),
+            Err(error) => {
+                tracing::debug!(
+                    "failed parsing pending captured checkpoint manifest {}: {}",
+                    manifest_path.display(),
+                    error
+                );
+            }
+        }
+    }
+
+    manifests
+}
+
 fn validate_captured_checkpoint_manifest_repo(
     repo: &Repository,
     manifest: &PreparedCheckpointManifest,

--- a/src/commands/checkpoint_agent/agent_presets.rs
+++ b/src/commands/checkpoint_agent/agent_presets.rs
@@ -7,7 +7,7 @@ use crate::{
         self, Agent, BashCheckpointAction, HookEvent, ToolClass,
     },
     error::GitAiError,
-    git::repository::find_repository_for_file,
+    git::repository::{find_repository_for_file, find_repository_in_path},
     observability::log_error,
     utils::normalize_to_posix,
 };
@@ -1527,6 +1527,9 @@ impl ContinueCliPreset {
 
 pub struct CodexPreset;
 
+const CODEX_SCOPED_FILE_EDIT_CHECKPOINT_META: &str = "codex_scoped_file_edit_checkpoint";
+const CODEX_TURN_ID_META: &str = "codex_turn_id";
+
 impl AgentCheckpointPreset for CodexPreset {
     fn run(&self, flags: AgentCheckpointFlags) -> Result<AgentRunResult, GitAiError> {
         let stdin_json = flags.hook_input.ok_or_else(|| {
@@ -1544,6 +1547,59 @@ impl AgentCheckpointPreset for CodexPreset {
             .get("cwd")
             .and_then(|v| v.as_str())
             .ok_or_else(|| GitAiError::PresetError("cwd not found in hook_input".to_string()))?;
+
+        let stdin_model = hook_data
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let hook_event_name = hook_data
+            .get("hook_event_name")
+            .or_else(|| hook_data.get("hookEventName"))
+            .and_then(|v| v.as_str());
+        let tool_name = hook_data
+            .get("tool_name")
+            .and_then(|v| v.as_str())
+            .or_else(|| hook_data.get("toolName").and_then(|v| v.as_str()));
+        let tool_class = tool_name
+            .map(|name| bash_tool::classify_tool(Agent::Codex, name))
+            .unwrap_or(ToolClass::Skip);
+        let is_bash_tool = tool_class == ToolClass::Bash;
+        let is_file_edit_tool = tool_class == ToolClass::FileEdit;
+
+        if hook_event_name == Some("PreToolUse") && is_file_edit_tool {
+            let agent_id = AgentId {
+                tool: "codex".to_string(),
+                id: session_id,
+                model: stdin_model.unwrap_or_else(|| "unknown".to_string()),
+            };
+
+            return Ok(AgentRunResult {
+                agent_id,
+                agent_metadata: None,
+                checkpoint_kind: CheckpointKind::Human,
+                transcript: None,
+                repo_working_dir: Some(cwd.to_string()),
+                edited_filepaths: None,
+                will_edit_filepaths: CodexPreset::extract_filepaths_from_tool_input(&hook_data),
+                dirty_files: None,
+                captured_checkpoint_id: None,
+            });
+        }
+
+        let turn_id = CodexPreset::turn_id_from_hook_data(&hook_data);
+        if hook_event_name == Some("Stop")
+            && CodexPreset::has_scoped_file_edit_checkpoint_for_turn(
+                cwd,
+                &session_id,
+                turn_id.as_deref(),
+            )
+        {
+            return Err(GitAiError::PresetError(
+                "Skipping Codex Stop checkpoint; scoped file-edit checkpoint already recorded for this turn."
+                    .to_string(),
+            ));
+        }
 
         let transcript_path = hook_data
             .get("transcript_path")
@@ -1569,7 +1625,7 @@ impl AgentCheckpointPreset for CodexPreset {
                 },
             );
 
-        let (transcript, model) = if let Some(path) = transcript_path.as_deref() {
+        let (transcript, rollout_model) = if let Some(path) = transcript_path.as_deref() {
             match CodexPreset::transcript_and_model_from_codex_rollout_jsonl(path) {
                 Ok((transcript, model)) => (transcript, model),
                 Err(e) => {
@@ -1590,18 +1646,6 @@ impl AgentCheckpointPreset for CodexPreset {
             );
             (AiTranscript::new(), Some("unknown".to_string()))
         };
-
-        let hook_event_name = hook_data
-            .get("hook_event_name")
-            .or_else(|| hook_data.get("hookEventName"))
-            .and_then(|v| v.as_str());
-        let tool_name = hook_data
-            .get("tool_name")
-            .and_then(|v| v.as_str())
-            .or_else(|| hook_data.get("toolName").and_then(|v| v.as_str()));
-        let is_bash_tool = tool_name
-            .map(|name| bash_tool::classify_tool(Agent::Codex, name) == ToolClass::Bash)
-            .unwrap_or(false);
         let tool_use_id = hook_data
             .get("tool_use_id")
             .or_else(|| hook_data.get("toolUseId"))
@@ -1611,10 +1655,12 @@ impl AgentCheckpointPreset for CodexPreset {
         let agent_id = AgentId {
             tool: "codex".to_string(),
             id: session_id.clone(),
-            model: model.unwrap_or_else(|| "unknown".to_string()),
+            model: stdin_model
+                .or(rollout_model)
+                .unwrap_or_else(|| "unknown".to_string()),
         };
 
-        let agent_metadata =
+        let mut agent_metadata =
             transcript_path.map(|path| HashMap::from([("transcript_path".to_string(), path)]));
 
         match hook_event_name {
@@ -1649,6 +1695,31 @@ impl AgentCheckpointPreset for CodexPreset {
                 ));
             }
             Some("PostToolUse") => {
+                if is_file_edit_tool {
+                    let edited_filepaths =
+                        CodexPreset::extract_filepaths_from_tool_input(&hook_data).or_else(|| {
+                            CodexPreset::extract_filepaths_from_tool_response(&hook_data)
+                        });
+                    if edited_filepaths.is_some() {
+                        CodexPreset::mark_scoped_file_edit_metadata(
+                            &mut agent_metadata,
+                            &hook_data,
+                        );
+                    }
+
+                    return Ok(AgentRunResult {
+                        agent_id,
+                        agent_metadata,
+                        checkpoint_kind: CheckpointKind::AiAgent,
+                        transcript: Some(transcript),
+                        repo_working_dir: Some(cwd.to_string()),
+                        edited_filepaths,
+                        will_edit_filepaths: None,
+                        dirty_files: None,
+                        captured_checkpoint_id: None,
+                    });
+                }
+
                 if !is_bash_tool {
                     return Err(GitAiError::PresetError(format!(
                         "Skipping Codex PostToolUse for unsupported tool {}",
@@ -1728,6 +1799,203 @@ impl CodexPreset {
                     .and_then(|v| v.as_str())
             })
             .map(|s| s.to_string())
+    }
+
+    fn turn_id_from_hook_data(hook_data: &serde_json::Value) -> Option<String> {
+        hook_data
+            .get("turn_id")
+            .and_then(|v| v.as_str())
+            .or_else(|| hook_data.get("turnId").and_then(|v| v.as_str()))
+            .or_else(|| hook_data.get("turn-id").and_then(|v| v.as_str()))
+            .or_else(|| {
+                hook_data
+                    .get("hook_event")
+                    .and_then(|ev| ev.get("turn_id"))
+                    .and_then(|v| v.as_str())
+            })
+            .or_else(|| {
+                hook_data
+                    .get("hook_event")
+                    .and_then(|ev| ev.get("turn-id"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(|s| s.to_string())
+    }
+
+    fn mark_scoped_file_edit_metadata(
+        agent_metadata: &mut Option<HashMap<String, String>>,
+        hook_data: &serde_json::Value,
+    ) {
+        let metadata = agent_metadata.get_or_insert_with(HashMap::new);
+        metadata.insert(
+            CODEX_SCOPED_FILE_EDIT_CHECKPOINT_META.to_string(),
+            "true".to_string(),
+        );
+
+        if let Some(turn_id) = Self::turn_id_from_hook_data(hook_data) {
+            metadata.insert(CODEX_TURN_ID_META.to_string(), turn_id);
+        }
+    }
+
+    fn has_scoped_file_edit_checkpoint_for_turn(
+        cwd: &str,
+        session_id: &str,
+        turn_id: Option<&str>,
+    ) -> bool {
+        let Some(turn_id) = turn_id else {
+            return false;
+        };
+        let Ok(repo) = find_repository_in_path(cwd) else {
+            return false;
+        };
+        let repo_workdir = repo.workdir().ok();
+
+        if let Some(repo_workdir) = repo_workdir.as_deref()
+            && Self::has_pending_scoped_file_edit_checkpoint_for_turn(
+                repo_workdir,
+                session_id,
+                turn_id,
+            )
+        {
+            return true;
+        }
+
+        let base_commit = repo
+            .head()
+            .and_then(|head| head.target())
+            .unwrap_or_else(|_| "initial".to_string());
+        let Ok(working_log) = repo.storage.working_log_for_base_commit(&base_commit) else {
+            return false;
+        };
+        let Ok(checkpoints) = working_log.read_all_checkpoints() else {
+            return false;
+        };
+
+        checkpoints.iter().rev().any(|checkpoint| {
+            checkpoint.kind == CheckpointKind::AiAgent
+                && !checkpoint.entries.is_empty()
+                && Self::agent_id_matches_codex_session(checkpoint.agent_id.as_ref(), session_id)
+                && Self::metadata_matches_scoped_file_edit_turn(
+                    checkpoint.agent_metadata.as_ref(),
+                    turn_id,
+                )
+        })
+    }
+
+    fn has_pending_scoped_file_edit_checkpoint_for_turn(
+        repo_workdir: &Path,
+        session_id: &str,
+        turn_id: &str,
+    ) -> bool {
+        let repo_workdir = repo_workdir
+            .canonicalize()
+            .unwrap_or_else(|_| repo_workdir.to_path_buf());
+        crate::commands::checkpoint::pending_captured_checkpoint_manifests()
+            .into_iter()
+            .any(|manifest| {
+                if manifest.kind != CheckpointKind::AiAgent || manifest.files.is_empty() {
+                    return false;
+                }
+
+                let manifest_repo = Path::new(&manifest.repo_working_dir)
+                    .canonicalize()
+                    .unwrap_or_else(|_| PathBuf::from(&manifest.repo_working_dir));
+
+                manifest_repo == repo_workdir
+                    && manifest.agent_run_result.as_ref().is_some_and(|result| {
+                        Self::agent_id_matches_codex_session(Some(&result.agent_id), session_id)
+                            && Self::metadata_matches_scoped_file_edit_turn(
+                                result.agent_metadata.as_ref(),
+                                turn_id,
+                            )
+                    })
+            })
+    }
+
+    fn agent_id_matches_codex_session(agent_id: Option<&AgentId>, session_id: &str) -> bool {
+        agent_id.is_some_and(|agent_id| agent_id.tool == "codex" && agent_id.id == session_id)
+    }
+
+    fn metadata_matches_scoped_file_edit_turn(
+        metadata: Option<&HashMap<String, String>>,
+        turn_id: &str,
+    ) -> bool {
+        metadata.is_some_and(|metadata| {
+            metadata
+                .get(CODEX_SCOPED_FILE_EDIT_CHECKPOINT_META)
+                .is_some_and(|value| value == "true")
+                && metadata
+                    .get(CODEX_TURN_ID_META)
+                    .is_some_and(|checkpoint_turn_id| checkpoint_turn_id == turn_id)
+        })
+    }
+
+    fn extract_filepaths_from_tool_input(hook_data: &serde_json::Value) -> Option<Vec<String>> {
+        let tool_input = hook_data
+            .get("tool_input")
+            .or_else(|| hook_data.get("toolInput"))?;
+
+        let mut paths = Vec::new();
+        if let Some(command) = tool_input.get("command").and_then(|v| v.as_str()) {
+            Self::collect_apply_patch_paths_from_text(command, &mut paths);
+        }
+
+        if paths.is_empty() { None } else { Some(paths) }
+    }
+
+    fn extract_filepaths_from_tool_response(hook_data: &serde_json::Value) -> Option<Vec<String>> {
+        let tool_response = hook_data.get("tool_response")?;
+        let output = if let Some(raw) = tool_response.as_str() {
+            serde_json::from_str::<serde_json::Value>(raw)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("output")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                })
+                .unwrap_or_else(|| raw.to_string())
+        } else {
+            tool_response
+                .get("output")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())?
+        };
+
+        let mut paths = Vec::new();
+        for line in output.lines() {
+            let trimmed = line.trim();
+            if trimmed.len() > 2
+                && trimmed.as_bytes()[1] == b' '
+                && matches!(trimmed.as_bytes()[0], b'A' | b'M' | b'D' | b'R' | b'U')
+            {
+                Self::push_unique_path(&mut paths, &trimmed[2..]);
+            }
+        }
+
+        if paths.is_empty() { None } else { Some(paths) }
+    }
+
+    fn collect_apply_patch_paths_from_text(raw: &str, out: &mut Vec<String>) {
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            let maybe_path = trimmed
+                .strip_prefix("*** Update File: ")
+                .or_else(|| trimmed.strip_prefix("*** Add File: "))
+                .or_else(|| trimmed.strip_prefix("*** Delete File: "))
+                .or_else(|| trimmed.strip_prefix("*** Move to: "));
+
+            if let Some(path) = maybe_path {
+                Self::push_unique_path(out, path);
+            }
+        }
+    }
+
+    fn push_unique_path(out: &mut Vec<String>, path: &str) {
+        let path = path.trim();
+        if !path.is_empty() && !out.iter().any(|existing| existing == path) {
+            out.push(path.to_string());
+        }
     }
 
     pub fn codex_home_dir() -> PathBuf {

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -457,9 +457,7 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             _ => ToolClass::Skip,
         },
         Agent::Codex => match tool_name {
-            // Codex currently only emits usable PreToolUse/PostToolUse hooks for Bash.
-            // File edits like `apply_patch` are still attributed via the turn-level Stop hook.
-            // TODO: classify Codex file-edit tools here once Codex ships file-edit tool hooks.
+            "apply_patch" => ToolClass::FileEdit,
             "Bash" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
@@ -1923,6 +1921,13 @@ mod tests {
         assert_eq!(classify_tool(Agent::OpenCode, "edit"), ToolClass::FileEdit);
         assert_eq!(classify_tool(Agent::OpenCode, "bash"), ToolClass::Bash);
         assert_eq!(classify_tool(Agent::OpenCode, "shell"), ToolClass::Bash);
+
+        // Codex
+        assert_eq!(
+            classify_tool(Agent::Codex, "apply_patch"),
+            ToolClass::FileEdit
+        );
+        assert_eq!(classify_tool(Agent::Codex, "Bash"), ToolClass::Bash);
     }
 
     #[test]

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -1,7 +1,8 @@
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
-    binary_exists, generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic,
+    MIN_CODEX_VERSION, binary_exists, generate_diff, get_binary_version, home_dir,
+    is_git_ai_checkpoint_command, parse_version, version_meets_requirement, write_atomic,
 };
 use serde_json::{Value as JsonValue, json};
 use std::fs;
@@ -21,6 +22,19 @@ impl CodexInstaller {
 
     fn hooks_path() -> PathBuf {
         home_dir().join(".codex").join("hooks.json")
+    }
+
+    fn validate_codex_version(version_str: &str) -> Result<(), GitAiError> {
+        if let Some(version) = parse_version(version_str)
+            && !version_meets_requirement(version, MIN_CODEX_VERSION)
+        {
+            return Err(GitAiError::Generic(format!(
+                "Codex version {}.{} detected, but minimum version {}.{} is required for apply_patch hooks",
+                version.0, version.1, MIN_CODEX_VERSION.0, MIN_CODEX_VERSION.1
+            )));
+        }
+
+        Ok(())
     }
 
     fn desired_command(binary_path: &Path) -> String {
@@ -397,6 +411,10 @@ impl HookInstaller for CodexInstaller {
             });
         }
 
+        if has_binary && let Ok(version_str) = get_binary_version("codex") {
+            Self::validate_codex_version(&version_str)?;
+        }
+
         let config_path = Self::config_path();
         let hooks_path = Self::hooks_path();
         let config = if config_path.exists() {
@@ -637,6 +655,19 @@ mod tests {
         ];
 
         assert!(!CodexInstaller::is_git_ai_codex_notify_args(&args));
+    }
+
+    #[test]
+    fn test_validate_codex_version_requires_apply_patch_hook_support() {
+        assert!(CodexInstaller::validate_codex_version("codex-cli 0.124.0").is_ok());
+        assert!(CodexInstaller::validate_codex_version("codex-cli 0.125.0").is_ok());
+
+        let error = CodexInstaller::validate_codex_version("codex-cli 0.123.0")
+            .expect_err("old Codex versions should be rejected");
+        assert!(
+            error.to_string().contains("minimum version 0.124"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 pub const MIN_CURSOR_VERSION: (u32, u32) = (1, 7);
 pub const MIN_CODE_VERSION: (u32, u32) = (1, 99);
 pub const MIN_CLAUDE_VERSION: (u32, u32) = (2, 0);
+pub const MIN_CODEX_VERSION: (u32, u32) = (0, 124);
 
 /// Get version from a binary's --version output
 pub fn get_binary_version(binary: &str) -> Result<String, GitAiError> {
@@ -48,21 +49,30 @@ pub fn get_editor_version(cli: &EditorCliCommand) -> Result<String, GitAiError> 
 }
 
 /// Parse version string to extract major.minor version
-/// Handles formats like "1.7.38", "1.104.3", "2.0.8 (Claude Code)"
+/// Handles formats like "1.7.38", "1.104.3", "2.0.8 (Claude Code)",
+/// and "codex-cli 0.124.0".
 pub fn parse_version(version_str: &str) -> Option<(u32, u32)> {
-    // Split by whitespace and take the first part (handles "2.0.8 (Claude Code)")
-    let version_part = version_str.split_whitespace().next()?;
+    for token in version_str.split_whitespace() {
+        let version_part = token
+            .trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '.')
+            .trim_start_matches('v');
 
-    // Split by dots and take first two numbers
-    let parts: Vec<&str> = version_part.split('.').collect();
-    if parts.len() < 2 {
-        return None;
+        let parts: Vec<&str> = version_part.split('.').collect();
+        if parts.len() < 2 {
+            continue;
+        }
+
+        let Ok(major) = parts[0].parse::<u32>() else {
+            continue;
+        };
+        let Ok(minor) = parts[1].parse::<u32>() else {
+            continue;
+        };
+
+        return Some((major, minor));
     }
 
-    let major = parts[0].parse::<u32>().ok()?;
-    let minor = parts[1].parse::<u32>().ok()?;
-
-    Some((major, minor))
+    None
 }
 
 /// Compare version against minimum requirement
@@ -895,6 +905,8 @@ mod tests {
 
         // Test version with extra text
         assert_eq!(parse_version("2.0.8 (Claude Code)"), Some((2, 0)));
+        assert_eq!(parse_version("codex-cli 0.124.0"), Some((0, 124)));
+        assert_eq!(parse_version("v0.124.0"), Some((0, 124)));
 
         // Test edge cases
         assert_eq!(parse_version("1.0"), Some((1, 0)));
@@ -961,6 +973,13 @@ mod tests {
         // Claude Code 1.x should fail
         let old_claude = parse_version("1.9.9").unwrap();
         assert!(!version_meets_requirement(old_claude, MIN_CLAUDE_VERSION));
+
+        // Codex 0.124.0 added apply_patch hooks.
+        let codex_version = parse_version("codex-cli 0.124.0").unwrap();
+        assert!(version_meets_requirement(codex_version, MIN_CODEX_VERSION));
+
+        let old_codex = parse_version("codex-cli 0.123.0").unwrap();
+        assert!(!version_meets_requirement(old_codex, MIN_CODEX_VERSION));
     }
 
     #[test]

--- a/tests/integration/bash_tool_conformance.rs
+++ b/tests/integration/bash_tool_conformance.rs
@@ -629,9 +629,10 @@ fn test_classify_tool_opencode() {
 #[test]
 fn test_classify_tool_codex() {
     assert_eq!(classify_tool(Agent::Codex, "Bash"), ToolClass::Bash);
-    // `apply_patch` is a real Codex edit tool, but today Codex file edits are
-    // handled via Stop rather than PreToolUse/PostToolUse tool hooks.
-    assert_eq!(classify_tool(Agent::Codex, "apply_patch"), ToolClass::Skip);
+    assert_eq!(
+        classify_tool(Agent::Codex, "apply_patch"),
+        ToolClass::FileEdit
+    );
     assert_eq!(classify_tool(Agent::Codex, "unknown"), ToolClass::Skip);
 }
 

--- a/tests/integration/codex.rs
+++ b/tests/integration/codex.rs
@@ -312,6 +312,226 @@ fn test_codex_preset_bash_post_tool_use_detects_changed_files() {
 }
 
 #[test]
+fn test_codex_apply_patch_pre_tool_use_records_will_edit_paths_from_command() {
+    let hook_input = json!({
+        "session_id": "session-apply-patch-pre",
+        "cwd": "/Users/test/projects/git-ai",
+        "hook_event_name": "PreToolUse",
+        "model": "gpt-5.4",
+        "tool_name": "apply_patch",
+        "tool_use_id": "apply-patch-call-1",
+        "tool_input": {
+            "command": "*** Begin Patch\n*** Add File: src/new.rs\n+pub fn new() {}\n*** Update File: README.md\n@@\n-old\n+new\n*** Move to: docs/README.md\n*** Delete File: obsolete.txt\n*** End Patch"
+        }
+    })
+    .to_string();
+
+    let result = CodexPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input),
+        })
+        .expect("Codex apply_patch pre-hook should produce a scoped human checkpoint");
+
+    assert_eq!(result.checkpoint_kind, CheckpointKind::Human);
+    assert_eq!(result.agent_id.tool, "codex");
+    assert_eq!(result.agent_id.model, "gpt-5.4");
+    assert!(result.transcript.is_none());
+    assert_eq!(
+        result.will_edit_filepaths,
+        Some(vec![
+            "src/new.rs".to_string(),
+            "README.md".to_string(),
+            "docs/README.md".to_string(),
+            "obsolete.txt".to_string(),
+        ])
+    );
+    assert!(result.edited_filepaths.is_none());
+}
+
+#[test]
+fn test_codex_apply_patch_post_tool_use_records_edited_paths_from_command() {
+    let hook_input = json!({
+        "session_id": "session-apply-patch-post",
+        "turn_id": "turn-apply-patch-post",
+        "cwd": "/Users/test/projects/git-ai",
+        "hook_event_name": "PostToolUse",
+        "model": "gpt-5.4",
+        "tool_name": "apply_patch",
+        "tool_use_id": "apply-patch-call-2",
+        "tool_input": {
+            "command": "*** Begin Patch\n*** Add File: src/lib.rs\n+pub mod lib {}\n*** Update File: README.md\n@@\n-old\n+new\n*** End Patch"
+        },
+        "tool_response": "{\"output\":\"Success. Updated the following files:\\nA src/lib.rs\\nM README.md\\n\",\"metadata\":{\"exit_code\":0}}"
+    })
+    .to_string();
+
+    let result = CodexPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input),
+        })
+        .expect("Codex apply_patch post-hook should produce a scoped AI checkpoint");
+
+    assert_eq!(result.checkpoint_kind, CheckpointKind::AiAgent);
+    assert_eq!(result.agent_id.model, "gpt-5.4");
+    assert!(result.transcript.is_some());
+    assert_eq!(
+        result.edited_filepaths,
+        Some(vec!["src/lib.rs".to_string(), "README.md".to_string()])
+    );
+    let metadata = result
+        .agent_metadata
+        .as_ref()
+        .expect("scoped apply_patch checkpoints should persist turn metadata");
+    assert_eq!(
+        metadata.get("codex_scoped_file_edit_checkpoint"),
+        Some(&"true".to_string())
+    );
+    assert_eq!(
+        metadata.get("codex_turn_id"),
+        Some(&"turn-apply-patch-post".to_string())
+    );
+    assert!(result.will_edit_filepaths.is_none());
+}
+
+#[test]
+fn test_codex_apply_patch_post_tool_use_falls_back_to_tool_response_paths() {
+    let hook_input = json!({
+        "session_id": "session-apply-patch-response",
+        "cwd": "/Users/test/projects/git-ai",
+        "hook_event_name": "PostToolUse",
+        "model": "gpt-5.4",
+        "tool_name": "apply_patch",
+        "tool_use_id": "apply-patch-call-3",
+        "tool_input": {
+            "command": "apply_patch"
+        },
+        "tool_response": {
+            "output": "Success. Updated the following files:\nA src/from-response.rs\nM Cargo.toml\n",
+            "metadata": {"exit_code": 0}
+        }
+    })
+    .to_string();
+
+    let result = CodexPreset
+        .run(AgentCheckpointFlags {
+            hook_input: Some(hook_input),
+        })
+        .expect("Codex apply_patch post-hook should parse response paths");
+
+    assert_eq!(
+        result.edited_filepaths,
+        Some(vec![
+            "src/from-response.rs".to_string(),
+            "Cargo.toml".to_string()
+        ])
+    );
+}
+
+#[test]
+fn test_codex_stop_hook_skips_after_scoped_apply_patch_checkpoint() {
+    use crate::repos::test_repo::TestRepo;
+
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+    let readme_path = repo_root.join("README.md");
+    fs::write(&readme_path, "old\n").unwrap();
+    repo.stage_all_and_commit("Initial README").unwrap();
+
+    let fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-apply-patch-rollout.jsonl");
+    fs::copy(&fixture, &transcript_path).unwrap();
+
+    let session_id = "session-apply-patch-stop-skip";
+    let turn_id = "turn-apply-patch-stop-skip";
+    let pre_hook_input = json!({
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "model": "gpt-5.4",
+        "tool_name": "apply_patch",
+        "tool_use_id": "apply-patch-stop-call",
+        "tool_input": {
+            "command": "*** Begin Patch\n*** Update File: README.md\n@@\n-old\n+new\n*** End Patch"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("pre-hook checkpoint should succeed");
+
+    fs::write(&readme_path, "new\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "model": "gpt-5.4",
+        "tool_name": "apply_patch",
+        "tool_use_id": "apply-patch-stop-call",
+        "tool_input": {
+            "command": "*** Begin Patch\n*** Update File: README.md\n@@\n-old\n+new\n*** End Patch"
+        },
+        "tool_response": "{\"output\":\"Success. Updated the following files:\\nM README.md\\n\",\"metadata\":{\"exit_code\":0}}",
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("post-hook checkpoint should succeed");
+
+    let stop_hook_input = json!({
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "Stop",
+        "model": "gpt-5.4",
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    let stop_output = repo
+        .git_ai(&["checkpoint", "codex", "--hook-input", &stop_hook_input])
+        .expect("stop hook should exit successfully after skipping");
+
+    assert!(
+        stop_output.contains("Skipping Codex Stop checkpoint"),
+        "Stop hook should skip instead of running a broad checkpoint: {stop_output}"
+    );
+
+    let checkpoints = repo
+        .current_working_logs()
+        .read_all_checkpoints()
+        .expect("working log should be readable");
+    let codex_checkpoints = checkpoints
+        .iter()
+        .filter(|checkpoint| {
+            checkpoint.kind == CheckpointKind::AiAgent
+                && checkpoint
+                    .agent_id
+                    .as_ref()
+                    .is_some_and(|agent_id| agent_id.tool == "codex" && agent_id.id == session_id)
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        codex_checkpoints.len(),
+        1,
+        "Stop hook should not append a duplicate Codex checkpoint"
+    );
+    assert_eq!(
+        codex_checkpoints[0]
+            .agent_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("codex_turn_id"))
+            .map(String::as_str),
+        Some(turn_id)
+    );
+}
+
+#[test]
 fn test_find_rollout_path_for_session_in_home() {
     let fixture = fixture_path("codex-session-simple.jsonl");
     let temp = tempfile::tempdir().unwrap();
@@ -834,6 +1054,10 @@ crate::reuse_tests_in_worktree!(
     test_codex_preset_bash_pre_tool_use_skips_checkpoint_after_capturing_snapshot,
     test_codex_preset_bash_pre_tool_use_supports_camel_case_hook_event_name,
     test_codex_preset_bash_post_tool_use_detects_changed_files,
+    test_codex_apply_patch_pre_tool_use_records_will_edit_paths_from_command,
+    test_codex_apply_patch_post_tool_use_records_edited_paths_from_command,
+    test_codex_apply_patch_post_tool_use_falls_back_to_tool_response_paths,
+    test_codex_stop_hook_skips_after_scoped_apply_patch_checkpoint,
     test_find_rollout_path_for_session_in_home,
     test_codex_e2e_commit_resync_uses_latest_rollout,
     test_codex_commit_inside_bash_inflight_is_attributed_to_codex,


### PR DESCRIPTION
## Summary

Codex apply_patch started emitting PreToolUse/PostToolUse hooks in Codex 0.124.0 via [#18391](https://github.com/openai/codex/pull/18391).

The hook input exposes the raw patch through tool_input.command.This updates the Codex checkpoint preset to treat `apply_patch` as a scoped file-edit checkpoint instead of letting the later `Stop` hook fall back to a broad AI checkpoint.

Changes include:

- Extract edited paths for Codex `apply_patch` from `tool_input.command`, which matches the current Codex hook payload shape.
- Record scoped Codex file-edit checkpoints with turn metadata.
- Skip the Codex `Stop` checkpoint when the same session/turn already recorded a scoped file-edit checkpoint.
- Check both written working-log checkpoints and pending captured checkpoint manifests, so the skip path still works while async checkpoint capture is in flight.
- Add integration coverage for `apply_patch` PreToolUse/PostToolUse path extraction and the Stop-hook skip behavior.

## Why

Newer Codex emits `apply_patch` through PostToolUse with enough information to identify the edited files directly. Without this handling, git-ai can do duplicate work in a normal Codex turn:

1. PostToolUse records a scoped checkpoint for the files edited by `apply_patch`.
2. Stop later parses the rollout transcript again and runs a broader pathless AI checkpoint.

That second checkpoint is redundant and can be much more expensive on large repositories.

## Performance Impact

For Codex turns that edit files through `apply_patch`, the Stop hook can now take a cheap skip path instead of re-reading the rollout transcript and scanning broadly for changed files. This reduces duplicate checkpoint work and keeps attribution focused on the files Codex actually edited.

## Testing

- `cargo fmt`
- `cargo test codex_apply_patch --features test-support`
- `cargo test codex_stop_hook_skips --features test-support`
- `git diff --check`

## Related

#544 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
