### PR TITLE
cursor bg support

### DIFF
--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -10,6 +10,19 @@ use std::path::PathBuf;
 
 pub struct CursorPreset;
 
+pub struct CursorBackgroundPreset;
+
+impl AgentPreset for CursorBackgroundPreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        if std::env::var("HOSTNAME").ok().as_deref() != Some("cursor") {
+            return Err(GitAiError::PresetError(
+                "Skipping cursor-background hook outside cursor agent environment.".to_string(),
+            ));
+        }
+        CursorPreset.parse(hook_input, trace_id)
+    }
+}
+
 impl AgentPreset for CursorPreset {
     fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
         let data: serde_json::Value = serde_json::from_str(hook_input)

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -149,6 +149,7 @@ pub fn resolve_preset(name: &str) -> Result<Box<dyn AgentPreset>, GitAiError> {
         "windsurf" => Ok(Box::new(windsurf::WindsurfPreset)),
         "continue-cli" => Ok(Box::new(continue_cli::ContinueCliPreset)),
         "cursor" => Ok(Box::new(cursor::CursorPreset)),
+        "cursor-background" => Ok(Box::new(cursor::CursorBackgroundPreset)),
         "github-copilot" => Ok(Box::new(github_copilot::GithubCopilotPreset)),
         "amp" => Ok(Box::new(amp::AmpPreset)),
         "ai_tab" => Ok(Box::new(ai_tab::AiTabPreset)),


### PR DESCRIPTION
This PR adds a preset for `cursor-background` which will provide enhanced telemetry inside Cursor Agent. The Cursor team worked with us to get hooks stable and triggering properly inside the agent environment the last few weeks. 

- Hooks have to be manually set up in a repo where a user wants to use with background agents. Cursor Background Agents don't support user level hooks so they have to be set at the project level
- Skipped locally as to not conflict with regular user-level Git AI Cursor hooks. Only triggered when `HOSTNAME=cursor` 

```
{
  "hooks": {
    "afterFileEdit": [
      {
        "command": "git-ai checkpoint cursor-background --hook-input stdin"
      }
    ],
    "postToolUse": [
      {
        "command": "git-ai checkpoint cursor-background --hook-input stdin"
      }
    ],
    "preToolUse": [
      {
        "command": "git-ai checkpoint cursor-background --hook-input stdin"
      }
    ]
  },
  "version": 1
}
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
