### PR TITLE
Add tools for perf analysis

### DIFF
--- a/src/auth/credential_backend.rs
+++ b/src/auth/credential_backend.rs
@@ -97,6 +97,7 @@ impl FileBackend {
 
     #[cfg(windows)]
     fn set_file_protection(path: &std::path::Path) -> Result<(), String> {
+        use crate::perf::MeasuredCommand;
         use std::process::Command;
 
         let path_str = path
@@ -113,7 +114,7 @@ impl FileBackend {
                 "/grant:r",
                 &format!("{}:F", username),
             ])
-            .output()
+            .measured_output()
             .map_err(|e| format!("Failed to run icacls: {}", e))?;
 
         if !output.status.success() {
@@ -124,7 +125,7 @@ impl FileBackend {
             );
         }
 
-        let _ = Command::new("attrib").args(["+H", path_str]).output();
+        let _ = Command::new("attrib").args(["+H", path_str]).measured_output();
 
         Ok(())
     }

--- a/src/authorship/ignore.rs
+++ b/src/authorship/ignore.rs
@@ -1,4 +1,5 @@
 use crate::git::repository::Repository;
+
 use glob::Pattern;
 use std::collections::HashSet;
 use std::fs;

--- a/src/commands/continue_session.rs
+++ b/src/commands/continue_session.rs
@@ -14,6 +14,7 @@ use crate::commands::search::{
 use crate::error::GitAiError;
 use crate::git::find_repository_in_path;
 use crate::git::repository::{InternalGitProfile, Repository, exec_git, exec_git_with_profile};
+use crate::perf::MeasuredCommand;
 use std::collections::{BTreeMap, HashSet};
 use std::env;
 use std::io::{BufRead, IsTerminal, Write};
@@ -567,7 +568,7 @@ fn is_cli_available(cmd: &str) -> bool {
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
+        .measured_status()
         .map(|s| s.success())
         .unwrap_or(false)
 }
@@ -615,7 +616,7 @@ fn launch_agent(agent: &str, context: &str, summary: bool) -> Result<(), GitAiEr
                     .stdin(Stdio::inherit())
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
-                    .status()
+                    .measured_status()
                     .map_err(|e| GitAiError::Generic(format!("Failed to spawn claude: {}", e)))?;
 
                 if !status.success() {

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -589,10 +589,12 @@ fn hard_kill_daemon(config: &DaemonConfig) -> Result<(), String> {
 
 #[cfg(windows)]
 fn hard_kill_daemon(config: &DaemonConfig) -> Result<(), String> {
+    use crate::perf::MeasuredCommand;
+
     let pid = read_daemon_pid(config).map_err(|e| format!("cannot read daemon pid: {}", e))?;
     let output = Command::new("taskkill")
         .args(["/F", "/T", "/PID", &pid.to_string()])
-        .output()
+        .measured_output()
         .map_err(|e| format!("failed to run taskkill: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,6 +1,7 @@
 use crate::auth::{AuthState, collect_auth_status, format_unix_timestamp};
 use crate::config;
 use crate::git::find_repository_in_path;
+use crate::perf::MeasuredCommand;
 use std::env;
 use std::fmt::Write as _;
 use std::process::Command;
@@ -299,7 +300,7 @@ fn append_indented_block(out: &mut String, content: &str) {
 fn run_command_capture(program: &str, args: &[&str]) -> Result<String, String> {
     let output = Command::new(program)
         .args(args)
-        .output()
+        .measured_output()
         .map_err(|e| format!("failed to execute '{}': {}", program, e))?;
 
     if !output.status.success() {

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -8,6 +8,7 @@ use crate::mdm::hook_installer::HookInstallerParams;
 use crate::mdm::skills_installer;
 use crate::mdm::spinner::{Spinner, print_diff};
 use crate::mdm::utils::{get_current_binary_path, git_shim_path};
+use crate::perf::MeasuredCommand;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -129,7 +130,7 @@ fn find_running_pids(process_names: &[&str]) -> Vec<(u32, String)> {
                 .args(["axo", "pid,comm"])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
-                .output()
+                .measured_output()
         }
         #[cfg(windows)]
         {
@@ -137,7 +138,7 @@ fn find_running_pids(process_names: &[&str]) -> Vec<(u32, String)> {
                 .args(["/FO", "CSV", "/NH"])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
-                .output()
+                .measured_output()
         }
     };
 
@@ -195,7 +196,7 @@ fn set_global_git_config_value(git_cmd: &str, key: &str, value: &str) -> Result<
         .args(["config", "--global", key, value])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()?;
+        .measured_status()?;
     if status.success() {
         Ok(())
     } else {
@@ -226,7 +227,7 @@ fn remove_global_git_config_section(git_cmd: &str, section: &str) -> Result<(), 
         .args(["config", "--global", "--remove-section", section])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()?;
+        .measured_status()?;
     // Exit code 128 means the section doesn't exist, which is fine.
     if status.success() || status.code() == Some(128) {
         Ok(())

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::perf::MeasuredCommand;
 
 /// Extract recognized Git global flags from args so they can be placed
 /// before the `log` subcommand. Everything else passes through to `git log`.
@@ -161,7 +162,7 @@ pub fn handle_log(args: &[String]) -> std::process::ExitStatus {
     cmd.stdout(std::process::Stdio::inherit());
     cmd.stderr(std::process::Stdio::inherit());
 
-    match cmd.status() {
+    match cmd.measured_status() {
         Ok(status) => status,
         Err(e) => {
             eprintln!("Failed to execute git log: {}", e);

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -586,6 +586,7 @@ fn run_install_script(script_content: &str, tag: &str, silent: bool) -> Result<(
 
     #[cfg(not(windows))]
     {
+        use crate::perf::MeasuredCommand;
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
 
@@ -617,7 +618,7 @@ fn run_install_script(script_content: &str, tag: &str, silent: bool) -> Result<(
             cmd.stdout(Stdio::null()).stderr(Stdio::null());
         }
 
-        let result = match cmd.status() {
+        let result = match cmd.measured_status() {
             Ok(status) => {
                 if status.success() {
                     Ok(())

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -10,10 +10,9 @@ use crate::git::repo_storage::RepoStorage;
 use crate::git::rewrite_log::RewriteLogEvent;
 use crate::git::status::MAX_PATHSPEC_ARGS;
 use crate::git::sync_authorship::{fetch_authorship_notes, push_authorship_notes};
-#[cfg(windows)]
-use crate::utils::is_interactive_terminal;
-use unicode_normalization::UnicodeNormalization;
+use crate::perf::MeasuredCommand;
 
+use unicode_normalization::UnicodeNormalization;
 use gix_index::entry::Stage;
 use regex::Regex;
 use std::cell::Cell;
@@ -23,9 +22,11 @@ use std::process::{Command, Output};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(windows)]
-use crate::utils::CREATE_NO_WINDOW;
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
+use {
+    crate::utils::CREATE_NO_WINDOW,
+    std::os::windows::process::CommandExt,
+    crate::utils::is_interactive_terminal,
+};
 
 // Keep a thread-local depth for low-overhead checks on the active thread and a process-global
 // depth so internal git spawned from background threads inherits suppression state.
@@ -3167,7 +3168,7 @@ pub fn exec_git_allow_nonzero_with_profile(
         }
     }
 
-    cmd.output().map_err(GitAiError::IoError)
+    cmd.measured_output().map_err(GitAiError::IoError)
 }
 
 /// Helper to execute a git command with an explicit internal profile.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod metrics;
 pub mod observability;
 pub mod repo_url;
 pub mod utils;
+pub mod perf;

--- a/src/mdm/ensure_git_symlinks.rs
+++ b/src/mdm/ensure_git_symlinks.rs
@@ -65,6 +65,7 @@ fn create_junction(
     junction_path: &std::path::Path,
     target: &std::path::Path,
 ) -> Result<(), GitAiError> {
+    use crate::perf::MeasuredCommand;
     use std::process::Command;
 
     // Use mklink /J to create a junction - this doesn't require admin privileges
@@ -76,7 +77,7 @@ fn create_junction(
             &junction_path.to_string_lossy(),
             &target.to_string_lossy(),
         ])
-        .output()
+        .measured_output()
         .map_err(|e| GitAiError::Generic(format!("Failed to run mklink: {}", e)))?;
 
     if !status.status.success() {

--- a/src/mdm/git_clients/mac_prefs.rs
+++ b/src/mdm/git_clients/mac_prefs.rs
@@ -4,6 +4,7 @@
 //! via the `defaults` command.
 
 use crate::error::GitAiError;
+use crate::perf::MeasuredCommand;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -12,7 +13,7 @@ use std::process::Command;
 /// Returns the path to the app bundle if found.
 pub fn find_app_by_bundle_id(bundle_id: &str) -> Option<PathBuf> {
     let query = format!("kMDItemCFBundleIdentifier == '{}'", bundle_id);
-    let output = Command::new("mdfind").arg(&query).output().ok()?;
+    let output = Command::new("mdfind").arg(&query).measured_output().ok()?;
 
     if output.status.success() {
         let path = String::from_utf8_lossy(&output.stdout)
@@ -33,7 +34,7 @@ pub fn find_app_by_bundle_id(bundle_id: &str) -> Option<PathBuf> {
 pub fn domain_exists(domain: &str) -> bool {
     Command::new("defaults")
         .args(["read", domain])
-        .output()
+        .measured_output()
         .map(|o| o.status.success())
         .unwrap_or(false)
 }
@@ -69,7 +70,7 @@ impl Preferences {
     pub fn read_string(&self, key: &str) -> Option<String> {
         let output = Command::new("defaults")
             .args(["read", &self.domain, key])
-            .output()
+            .measured_output()
             .ok()?;
 
         if output.status.success() {
@@ -99,7 +100,7 @@ impl Preferences {
     pub fn write_string(&self, key: &str, value: &str) -> Result<(), GitAiError> {
         let status = Command::new("defaults")
             .args(["write", &self.domain, key, "-string", value])
-            .status()
+            .measured_status()
             .map_err(|e| GitAiError::Generic(format!("Failed to write preference: {}", e)))?;
 
         if status.success() {
@@ -116,7 +117,7 @@ impl Preferences {
     pub fn write_int(&self, key: &str, value: i32) -> Result<(), GitAiError> {
         let status = Command::new("defaults")
             .args(["write", &self.domain, key, "-int", &value.to_string()])
-            .status()
+            .measured_status()
             .map_err(|e| GitAiError::Generic(format!("Failed to write preference: {}", e)))?;
 
         if status.success() {
@@ -140,7 +141,7 @@ impl Preferences {
                 "-bool",
                 if value { "YES" } else { "NO" },
             ])
-            .status()
+            .measured_status()
             .map_err(|e| GitAiError::Generic(format!("Failed to write preference: {}", e)))?;
 
         if status.success() {
@@ -157,7 +158,7 @@ impl Preferences {
     pub fn delete(&self, key: &str) -> Result<(), GitAiError> {
         let status = Command::new("defaults")
             .args(["delete", &self.domain, key])
-            .status()
+            .measured_status()
             .map_err(|e| GitAiError::Generic(format!("Failed to delete preference: {}", e)))?;
 
         // Success if deleted OR if key didn't exist

--- a/src/mdm/jetbrains/detection.rs
+++ b/src/mdm/jetbrains/detection.rs
@@ -84,9 +84,11 @@ fn find_macos_installations() -> Vec<DetectedIde> {
 
 #[cfg(target_os = "macos")]
 fn find_app_by_bundle_id(bundle_id: &str) -> Option<PathBuf> {
+    use crate::perf::MeasuredCommand;
+
     let output = Command::new("mdfind")
         .args([&format!("kMDItemCFBundleIdentifier == '{}'", bundle_id)])
-        .output()
+        .measured_output()
         .ok()?;
 
     if !output.status.success() {
@@ -157,6 +159,8 @@ fn detect_macos_ide(ide: &'static JetBrainsIde, app_path: &Path) -> Option<Detec
 
 #[cfg(target_os = "macos")]
 fn get_macos_build_metadata(app_path: &Path) -> (Option<String>, Option<u32>, Option<String>) {
+    use crate::perf::MeasuredCommand;
+
     // Try product-info.json first (newer JetBrains IDEs)
     let product_info_path = app_path.join("Contents/Resources/product-info.json");
     if product_info_path.exists()
@@ -179,7 +183,7 @@ fn get_macos_build_metadata(app_path: &Path) -> (Option<String>, Option<u32>, Op
             &app_path.join("Contents/Info.plist").to_string_lossy(),
             "CFBundleVersion",
         ])
-        .output()
+        .measured_output()
         .ok();
 
     if let Some(output) = output

--- a/src/mdm/jetbrains/download.rs
+++ b/src/mdm/jetbrains/download.rs
@@ -1,4 +1,5 @@
 use crate::error::GitAiError;
+use crate::perf::MeasuredCommand;
 use std::io::{Cursor, Read};
 use std::path::Path;
 
@@ -138,12 +139,12 @@ pub fn install_plugin_via_cli(binary_path: &Path, plugin_id: &str) -> Result<boo
     #[cfg(windows)]
     let result = Command::new(binary_path)
         .args(["installPlugins", plugin_id])
-        .output();
+        .measured_output();
 
     #[cfg(not(windows))]
     let result = Command::new(binary_path)
         .args(["installPlugins", plugin_id])
-        .output();
+        .measured_output();
 
     match result {
         Ok(output) => {

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -1,5 +1,6 @@
 use crate::authorship::imara_diff_utils::{LineChangeTag, compute_line_changes};
 use crate::error::GitAiError;
+use crate::perf::MeasuredCommand;
 use jsonc_parser::ParseOptions;
 use jsonc_parser::cst::CstRootNode;
 use std::fs;
@@ -16,7 +17,7 @@ pub const MIN_CLAUDE_VERSION: (u32, u32) = (2, 0);
 pub fn get_binary_version(binary: &str) -> Result<String, GitAiError> {
     let output = Command::new(binary)
         .arg("--version")
-        .output()
+        .measured_output()
         .map_err(|e| GitAiError::Generic(format!("Failed to run {} --version: {}", binary, e)))?;
 
     if !output.status.success() {
@@ -32,7 +33,7 @@ pub fn get_binary_version(binary: &str) -> Result<String, GitAiError> {
 
 /// Get version from an editor CLI command's --version output
 pub fn get_editor_version(cli: &EditorCliCommand) -> Result<String, GitAiError> {
-    let output = cli.command(&["--version"]).output().map_err(|e| {
+    let output = cli.command(&["--version"]).measured_output().map_err(|e| {
         GitAiError::Generic(format!("Failed to run {} --version: {}", cli.program, e))
     })?;
 
@@ -587,7 +588,7 @@ pub fn is_vsc_editor_extension_installed(
     // NOTE: We try up to 3 times, because the editor CLI can be flaky (throws intermittent JS errors)
     let mut last_error_message: Option<String> = None;
     for attempt in 1..=3 {
-        let cmd_result = cli.command(&["--list-extensions"]).output();
+        let cmd_result = cli.command(&["--list-extensions"]).measured_output();
 
         match cmd_result {
             Ok(output) => {
@@ -621,7 +622,7 @@ pub fn install_vsc_editor_extension(
     for attempt in 1..=3 {
         let cmd_status = cli
             .command(&["--install-extension", id_or_vsix, "--force"])
-            .status();
+            .measured_status();
 
         match cmd_status {
             Ok(status) => {

--- a/src/perf/README.md
+++ b/src/perf/README.md
@@ -1,0 +1,34 @@
+This directory contains tools for measuring performance,
+specifically the overhead of shelling out to subprocesses,
+which is especially slow on Windows.
+
+The `mod.rs` file is a Rust module that wraps the execution of
+subprocesses executed via `Command::output` and `Command::status`,
+via the `measured_output` and `measured_stats` wrappers.
+
+NOTE: The act of measuring a command's execution time does not happen
+automatically for all invocations of `Command::output` and `Command::status`.
+You must consciously make the decision to replace `.output()` and `.status()`
+with `.measured_output()` and `.measured_status()`,
+which allows you to omit measurements that may be irrelevant, such as in tests.
+
+The wrappers are implemented to be as low-overhead as possible when
+logging is not enabled.
+To enable logging, set the `GITAI_MEASURE_COMMAND_PERF` environment variable.
+Logs will be written to stderr.
+
+To analyze a log manually, pipe stderr to a file and pass that file's name
+to `analyze_log.py`, e.g. `python3 analyze_log.py foo.stderr`.
+
+To perform an analysis without needing to save the logged output manually,
+use `run_analysis.py`, e.g. `python3 run_analysis.py cargo run diff @..f296d`.
+This will additionally measure the overall execution time and print the
+percentage of time spent within spawned commands.
+
+For more fine-grained interactive profiling, the samply tool is recommended:
+https://github.com/mstange/samply .
+It supports both Windows and Linux.
+Example invocation: `samply record target/debug/git-ai diff @..f296d`
+Once a sample has been recorded, it can be loaded into an interactive view
+in any web browser that provides collapsible sample trees, flamegraphs,
+and stack charts.

--- a/src/perf/analyze_log.py
+++ b/src/perf/analyze_log.py
@@ -1,0 +1,66 @@
+# Analyzes logs recording the execution time of spawned subprocess.
+# To generate a logfile, set the GITAI_MEASURE_COMMAND_PERF env var.
+
+import json
+import re
+import sys
+
+def analyze(log_text):
+    records = []
+    for line in log_text.split("\n"):
+        if line.startswith("[perf] "):
+            j = line.removeprefix("[perf] ").strip()
+            record = json.loads(j)
+            records.append(record)
+
+    total_elapsed_ms = 0
+    program_results = {}
+    subcommand_results = {}
+    for record in records:
+        cmd_program = record['cmd_program']
+        elapsed_ms = record['elapsed_ms']
+
+        if cmd_program not in program_results:
+            program_results[cmd_program] = {'ms': 0, 'calls': 0}
+
+        program_results[cmd_program]['ms'] += elapsed_ms
+        program_results[cmd_program]['calls'] += 1
+
+        total_elapsed_ms += elapsed_ms
+
+        if cmd_program.endswith('git') or cmd_program.endswith('git.exe'):
+            cmd_args = record['cmd_args']
+            cmd_subcommand = ""
+            for arg in cmd_args:
+                if re.search(r"^[a-zA-Z][a-zA-Z-]*$", arg):
+                    cmd_subcommand = arg
+                    break
+
+            if cmd_subcommand not in subcommand_results:
+                subcommand_results[cmd_subcommand] = {'ms': 0, 'calls': 0}
+
+            subcommand_results[cmd_subcommand]['ms'] += elapsed_ms
+            subcommand_results[cmd_subcommand]['calls'] += 1
+
+    sorted_program_results = dict(sorted(program_results.items(), key=lambda item: item[1]['ms'], reverse=True))
+    sorted_subcommand_results = dict(sorted(subcommand_results.items(), key=lambda item: item[1]['ms'], reverse=True))
+
+    print("Time spent in each command:")
+    for (program, measurements) in sorted_program_results.items():
+        print(f"    {program}: {measurements['ms']} ms ({measurements['calls']} calls)")
+
+    print("\nTime spent in each git subcommand:")
+    for (subcommand, measurements) in sorted_subcommand_results.items():
+        print(f"    {subcommand}: {measurements['ms']} ms ({measurements['calls']} calls)")
+
+    print(f"\nTotal time spent in spawned commands: {total_elapsed_ms} ms")
+
+    return total_elapsed_ms
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+
+    with open(filename) as f:
+        log_contents = f.read()
+
+    analyze(log_contents)

--- a/src/perf/mod.rs
+++ b/src/perf/mod.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::io;
+use std::process::{Command, ExitStatus, Output};
+use std::sync::LazyLock;
+use std::time::Instant;
+
+static MEASURE_COMMAND_PERF: LazyLock<bool> = LazyLock::new(||
+    env::var("GITAI_MEASURE_COMMAND_PERF").is_ok()
+);
+
+pub trait MeasuredCommand {
+    fn measured_output(&mut self) -> io::Result<Output>;
+    fn measured_status(&mut self) -> io::Result<ExitStatus>;
+}
+
+impl MeasuredCommand for Command {
+    fn measured_output(&mut self) -> io::Result<Output> {
+        if *MEASURE_COMMAND_PERF {
+            let cmd_program = format!("{:?}", self.get_program());
+            let cmd_args = format!("{:?}", self.get_args().collect::<Vec<_>>());
+            let start = Instant::now();
+            let output = self.output();
+            let elapsed_ms = start.elapsed().as_millis();
+            eprintln!("[perf] {{\"elapsed_ms\": {elapsed_ms}, \"cmd_program\": {cmd_program}, \"cmd_args\": {cmd_args}}}");
+            output
+        } else {
+            self.output()
+        }
+    }
+
+    fn measured_status(&mut self) -> io::Result<ExitStatus> {
+        if *MEASURE_COMMAND_PERF {
+            let cmd_program = format!("{:?}", self.get_program());
+            let cmd_args = format!("{:?}", self.get_args().collect::<Vec<_>>());
+            let start = Instant::now();
+            let status = self.status();
+            let elapsed_ms = start.elapsed().as_millis();
+            eprintln!("[perf] {{\"elapsed_ms\": {elapsed_ms}, \"cmd_program\": {cmd_program}, \"cmd_args\": {cmd_args}}}");
+            status
+        } else {
+            self.status()
+        }
+    }
+}

--- a/src/perf/run_analysis.py
+++ b/src/perf/run_analysis.py
@@ -1,0 +1,31 @@
+# This script runs the given command with command perf logging enabled,
+# collects the output, and summarizes it.
+# Example invocation: python3 run_analysis.py cargo run diff @..f296d
+
+import os
+import subprocess
+import sys
+import time
+
+import analyze_log
+
+def run_analysis():
+    args = sys.argv[1:]
+
+    new_env = os.environ.copy()
+    new_env['GITAI_MEASURE_COMMAND_PERF'] = "1"
+
+    start_ms = time.time()
+    output = subprocess.run(args, env=new_env, capture_output=True, encoding="utf-8")
+    end_ms = time.time()
+    elapsed_ms = round(1000 * (end_ms - start_ms))
+
+    stderr = output.stderr
+    cmd_time_sum = analyze_log.analyze(stderr)
+
+    print(f"\nTotal program time: {elapsed_ms} ms")
+
+    print(f"\nTotal program time not spent inside commands: {elapsed_ms - cmd_time_sum} ms ({((elapsed_ms - cmd_time_sum) / elapsed_ms) * 100:.2f}%)")
+
+if __name__ == "__main__":
+    run_analysis()


### PR DESCRIPTION
This commit adds tooling for analyzing the performance overhead of spawning subprocesses. See `src/perf/README.md` for documentation.

Example output on Linux (of `cargo run diff @..f296d`):
```
Time spent in each command:
    /usr/bin/git: 2341 ms (1028 calls)

Time spent in each git subcommand:
    blame: 756 ms (113 calls)
    cat-file: 566 ms (339 calls)
    rev-parse: 344 ms (232 calls)
    notes: 296 ms (227 calls)
    diff: 195 ms (3 calls)
    ls-tree: 183 ms (113 calls)
    show: 1 ms (1 calls)

Total time spent in spawned commands: 2341 ms

Total program time: 3461 ms

Total program time not spent inside commands: 1120 ms (32.36%)
```

On Windows:
```
Time spent in each command:
    C:\\Program Files\\Git\\bin\\git.exe: 22890 ms (1028 calls)

Time spent in each git subcommand:
    cat-file: 7451 ms (339 calls)
    rev-parse: 5028 ms (232 calls)
    notes: 4827 ms (227 calls)
    blame: 2745 ms (113 calls)
    ls-tree: 2502 ms (113 calls)
    diff: 314 ms (3 calls)
    show: 23 ms (1 calls)

Total time spent in spawned commands: 22890 ms

Total program time: 24843 ms

Total program time not spent inside commands: 1953 ms (7.86%)
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
