### PR TITLE
fix: preserve humans metadata during squash rebase and include email in author identity

### DIFF
--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -1702,6 +1702,23 @@ pub fn rewrite_authorship_after_rebase_v2(
                         });
                     }
                 }
+                // Also check current_attributions for h_-prefixed author IDs
+                // in this commit's changed files. During squash rebase the working
+                // log for the new commit's parent won't contain the original human
+                // checkpoints, but the reconstructed attributions from original
+                // notes will have the h_ entries.
+                for file_path in &changed_files_in_commit {
+                    if let Some((_, line_attrs)) = current_attributions.get(file_path) {
+                        for line_attr in line_attrs {
+                            if line_attr.author_id.starts_with("h_") {
+                                let hash = line_attr.author_id.clone();
+                                if let Some(record) = initial_humans.get(&hash) {
+                                    map.entry(hash).or_insert_with(|| record.clone());
+                                }
+                            }
+                        }
+                    }
+                }
                 map
             };
             // Per-commit-delta sessions: s_<id> entries for session-attributed lines in this commit.

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -393,7 +393,7 @@ fn handle_checkpoint(args: &[String]) {
                 for extra in results {
                     let working_dir = extra.repo_working_dir.to_string_lossy().to_string();
                     if let Ok(extra_repo) = find_repository_in_path(&working_dir) {
-                        let user_name = extra_repo.git_author_identity().name_or_unknown();
+                        let user_name = extra_repo.git_author_identity().formatted_or_unknown();
                         let _ = run_checkpoint_via_daemon_or_local(
                             &extra_repo,
                             &user_name,
@@ -569,7 +569,7 @@ fn handle_checkpoint(args: &[String]) {
                 );
 
                 // Get user name from this repo's config
-                let default_user_name = repo.git_author_identity().name_or_unknown();
+                let default_user_name = repo.git_author_identity().formatted_or_unknown();
 
                 // Create a modified checkpoint_request with only this repo's files
                 let repo_checkpoint_request = checkpoint_request.as_ref().map(|r| {
@@ -729,7 +729,7 @@ fn handle_checkpoint(args: &[String]) {
     }
 
     // Get the current user name
-    let default_user_name = repo.git_author_identity().name_or_unknown();
+    let default_user_name = repo.git_author_identity().formatted_or_unknown();
 
     let checkpoint_start = std::time::Instant::now();
     let agent_tool = checkpoint_request
@@ -822,7 +822,7 @@ fn handle_checkpoint(args: &[String]) {
                 continue;
             }
 
-            let ext_user_name = ext_repo.git_author_identity().name_or_unknown();
+            let ext_user_name = ext_repo.git_author_identity().formatted_or_unknown();
 
             let mut modified = base_result.clone();
             modified.repo_working_dir = repo_workdir.clone();

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -51,7 +51,7 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
     let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&ignore_patterns);
 
-    let default_user_name = repo.git_author_identity().name_or_unknown();
+    let default_user_name = repo.git_author_identity().formatted_or_unknown();
 
     let _ = checkpoint::run(
         &repo,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1654,7 +1654,7 @@ fn apply_checkout_switch_working_log_side_effect(
                     &old_head,
                     &new_head,
                     clean_snapshot,
-                    Some(repo.git_author_identity().name_or_unknown()),
+                    Some(repo.git_author_identity().formatted_or_unknown()),
                 )?;
             }
             repo.storage.delete_working_log_for_base_commit(&old_head)?;
@@ -2624,7 +2624,7 @@ fn apply_rewrite_side_effect(
     reset_pathspecs: Option<&[String]>,
 ) -> Result<(), GitAiError> {
     let mut repo = find_repository_in_path(worktree)?;
-    let author = repo.git_author_identity().name_or_unknown();
+    let author = repo.git_author_identity().formatted_or_unknown();
     ensure_rewrite_prerequisites(
         coordinator,
         &repo,
@@ -6815,7 +6815,7 @@ impl ActorDaemonCoordinator {
                         let carried_va = crate::authorship::virtual_attribution::VirtualAttributions::from_persisted_working_log(
                             repo.clone(),
                             old_head.clone(),
-                            Some(repo.git_author_identity().name_or_unknown()),
+                            Some(repo.git_author_identity().formatted_or_unknown()),
                         )?;
                         Some((new_head, carried_va, snapshot.clone()))
                     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1367,7 +1367,7 @@ fn apply_checkpoint_side_effect(request: CheckpointRunRequest) -> Result<(), Git
                 .unwrap_or(CheckpointKind::Human);
             let author = request
                 .author
-                .unwrap_or_else(|| repo.git_author_identity().name_or_unknown());
+                .unwrap_or_else(|| repo.git_author_identity().formatted_or_unknown());
 
             let _ = crate::commands::checkpoint::run(
                 &repo,

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1132,6 +1132,11 @@ impl GitAuthorIdentity {
     pub fn name_or_unknown(&self) -> String {
         self.name.clone().unwrap_or_else(|| "unknown".to_string())
     }
+
+    /// Return the full identity (`"Name <email>"`) or fall back to name-only / `"unknown"`.
+    pub fn formatted_or_unknown(&self) -> String {
+        self.formatted().unwrap_or_else(|| "unknown".to_string())
+    }
 }
 
 /// Parse `git var GIT_COMMITTER_IDENT` output into name and email.

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1128,11 +1128,6 @@ impl GitAuthorIdentity {
         }
     }
 
-    /// Return the name or `"unknown"` as fallback.
-    pub fn name_or_unknown(&self) -> String {
-        self.name.clone().unwrap_or_else(|| "unknown".to_string())
-    }
-
     /// Return the full identity (`"Name <email>"`) or fall back to name-only / `"unknown"`.
     pub fn formatted_or_unknown(&self) -> String {
         self.formatted().unwrap_or_else(|| "unknown".to_string())

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -224,12 +224,12 @@ fn test_ci_squash_merge_mixed_content() {
     // Verify metadata.humans contains the known human attribution
     let merge_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
     assert!(
-        merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
-        "squash note should carry h_9e95a89b42f1fb from human-attributed lines in mixed content"
+        merge_log.metadata.humans.contains_key("h_e858f2c2faea28"),
+        "squash note should carry h_e858f2c2faea28 from human-attributed lines in mixed content"
     );
     assert_eq!(
-        merge_log.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        merge_log.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
 
     // Verify mixed authorship is preserved
@@ -407,12 +407,12 @@ fn test_ci_squash_merge_with_manual_changes() {
     // Verify metadata.humans contains the known human attribution
     let merge_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
     assert!(
-        merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
-        "squash note should carry h_9e95a89b42f1fb from human-attributed lines in config"
+        merge_log.metadata.humans.contains_key("h_e858f2c2faea28"),
+        "squash note should carry h_e858f2c2faea28 from human-attributed lines in config"
     );
     assert_eq!(
-        merge_log.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        merge_log.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
 
     // Verify AI authorship is preserved for AI lines, human for manual additions
@@ -500,12 +500,12 @@ fn test_ci_rebase_merge_multiple_commits() {
     // Verify metadata.humans contains the known human attribution
     let merge_log = get_reference_as_authorship_log_v3(&git_ai_repo, &merge_sha).unwrap();
     assert!(
-        merge_log.metadata.humans.contains_key("h_9e95a89b42f1fb"),
-        "squash note should carry h_9e95a89b42f1fb from human function lines"
+        merge_log.metadata.humans.contains_key("h_e858f2c2faea28"),
+        "squash note should carry h_e858f2c2faea28 from human function lines"
     );
     assert_eq!(
-        merge_log.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        merge_log.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
 
     // Verify all authorship is correctly attributed

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -2847,7 +2847,7 @@ fn test_diff_visual_output_shows_human_author_name_not_id() {
 
     // Bug: Currently shows the h_-prefixed ID instead of the author name
     // Expected behavior: should show a readable author name like "Test User <test@example.com>"
-    // Actual behavior: shows "h_9e95a89b42f1fb" (the hash ID)
+    // Actual behavior: shows "h_e858f2c2faea28" (the hash ID)
     // This assertion will fail until we fix it
     assert!(
         !displayed_name.starts_with("h_"),

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -2489,6 +2489,12 @@ sed -i.bak '3s/pick/fixup/' "$1"
         !squashed_log.metadata.humans.is_empty(),
         "Post-squash: humans metadata block must be preserved (issue #1214)"
     );
+    for record in squashed_log.metadata.humans.values() {
+        assert_eq!(
+            record.author, "Test User <test@example.com>",
+            "HumanRecord.author should include email"
+        );
+    }
 
     // Verify line-level attribution: human line must still show as human
     // Note: the closing `}` may lose AI attribution during squash-rebase

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -2173,6 +2173,8 @@ crate::reuse_tests_in_worktree_with_attrs!(
     test_rebase_squash_preserves_all_authorship,
     test_rebase_reword_commit_with_children,
     test_rebase_interactive_drop_preserves_attribution,
+    test_rebase_squash_preserves_human_attribution,
+    test_rebase_squash_preserves_session_attribution,
 );
 
 /// Regression test: file modified via hunk path, then deleted, then recreated.
@@ -2318,5 +2320,356 @@ fn test_rebase_preserves_authorship_with_multibyte_utf8_in_diff_context() {
             .ai(),
         "    result = run_rules()".ai(),
         "    assert result".ai()
+    ]);
+}
+
+/// Regression test for issue #1214: after squash rebase of 3 commits (2 AI + 1 human),
+/// the merged note loses the humans block entirely — known-human line attribution is gone.
+///
+/// Repro from the issue:
+/// 1. AI commit 1: AI adds lines to a file (with some lines the human later overrides)
+/// 2. Human commit: human edits the same file (known_human checkpoint)
+/// 3. AI commit 2: AI adds more lines
+/// 4. git rebase -i HEAD~3 → fixup all into first commit
+/// 5. Inspect merged note → humans block must be preserved
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_rebase_squash_preserves_human_attribution() {
+    use std::io::Write;
+
+    let repo = TestRepo::new();
+
+    // Create initial commit on default branch
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let default_branch = repo.current_branch();
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+
+    let file_path = repo.path().join("handler.go");
+
+    // --- AI commit 1: AI adds lines ---
+    // Pre-edit checkpoint: file doesn't exist yet, take a snapshot of "nothing"
+    repo.git_ai(&["checkpoint", "human", "handler.go"]).unwrap();
+    let ai_content_1 = "\
+func handleOrder() {
+    validate()
+    process()
+}
+";
+    std::fs::write(&file_path, ai_content_1).unwrap();
+    // Post-edit checkpoint: AI wrote the content
+    repo.git_ai(&["checkpoint", "mock_ai", "handler.go"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit 1").unwrap();
+
+    let mut handler = repo.filename("handler.go");
+    handler.assert_committed_lines(crate::lines![
+        "func handleOrder() {".ai(),
+        "    validate()".ai(),
+        "    process()".ai(),
+        "}".ai(),
+    ]);
+
+    // --- Human commit: human edits the file, adding a line ---
+    let human_content = "\
+func handleOrder() {
+    validate()
+    log(\"order received\")
+    process()
+}
+";
+    std::fs::write(&file_path, human_content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "handler.go"])
+        .unwrap();
+    repo.stage_all_and_commit("Human commit").unwrap();
+
+    handler.assert_committed_lines(crate::lines![
+        "func handleOrder() {".ai(),
+        "    validate()".ai(),
+        "    log(\"order received\")".human(),
+        "    process()".ai(),
+        "}".ai(),
+    ]);
+
+    // Verify humans block exists before squash
+    let human_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let human_note = repo
+        .read_authorship_note(&human_sha)
+        .expect("human commit should have authorship note");
+    let human_log = AuthorshipLog::deserialize_from_string(&human_note).expect("parse human note");
+    assert!(
+        !human_log.metadata.humans.is_empty(),
+        "Pre-squash: human commit should have humans metadata block"
+    );
+
+    // --- AI commit 2: AI adds more lines ---
+    // Pre-edit checkpoint: snapshot current state before AI edits
+    repo.git_ai(&["checkpoint", "human", "handler.go"]).unwrap();
+    let ai_content_2 = "\
+func handleOrder() {
+    validate()
+    log(\"order received\")
+    process()
+    sendMetrics()
+}
+";
+    std::fs::write(&file_path, ai_content_2).unwrap();
+    // Post-edit checkpoint: AI wrote the new line
+    repo.git_ai(&["checkpoint", "mock_ai", "handler.go"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit 2").unwrap();
+
+    handler.assert_committed_lines(crate::lines![
+        "func handleOrder() {".ai(),
+        "    validate()".ai(),
+        "    log(\"order received\")".human(),
+        "    process()".ai(),
+        "    sendMetrics()".ai(),
+        "}".ai(),
+    ]);
+
+    // Advance main branch so rebase has something to replay onto
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let mut main_file2 = repo.filename("main2.txt");
+    main_file2.set_contents(crate::lines!["main work"]);
+    repo.stage_all_and_commit("Main advances").unwrap();
+    let base_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // --- Squash rebase: fixup all 3 commits into the first ---
+    repo.git(&["checkout", "feature"]).unwrap();
+
+    let script_content = r#"#!/bin/sh
+sed -i.bak '2s/pick/fixup/' "$1"
+sed -i.bak '3s/pick/fixup/' "$1"
+"#;
+
+    let script_path = repo.path().join("squash_script.sh");
+    let mut script_file = std::fs::File::create(&script_path).unwrap();
+    script_file.write_all(script_content.as_bytes()).unwrap();
+    drop(script_file);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let rebase_result = repo.git_with_env(
+        &["rebase", "-i", &base_commit],
+        &[
+            ("GIT_SEQUENCE_EDITOR", script_path.to_str().unwrap()),
+            ("GIT_EDITOR", "true"),
+        ],
+        None,
+    );
+
+    if rebase_result.is_err() {
+        eprintln!("git rebase output: {:?}", rebase_result);
+        panic!("Interactive rebase with fixup failed");
+    }
+
+    // Verify file content survived the squash
+    assert!(
+        repo.path().join("handler.go").exists(),
+        "handler.go should exist after squash"
+    );
+
+    // Verify the merged note has the humans block preserved
+    let squashed_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let squashed_note = repo
+        .read_authorship_note(&squashed_sha)
+        .expect("squashed commit should have authorship note");
+    let squashed_log =
+        AuthorshipLog::deserialize_from_string(&squashed_note).expect("parse squashed note");
+    assert!(
+        !squashed_log.metadata.humans.is_empty(),
+        "Post-squash: humans metadata block must be preserved (issue #1214)"
+    );
+
+    // Verify line-level attribution: human line must still show as human
+    // Note: the closing `}` may lose AI attribution during squash-rebase
+    // content-diff reconstruction (it's a common line that gets re-attributed
+    // to the commit author). The critical assertion is that the human-authored
+    // line retains its known-human attribution.
+    handler.assert_lines_and_blame(crate::lines![
+        "func handleOrder() {".ai(),
+        "    validate()".ai(),
+        "    log(\"order received\")".human(),
+        "    process()".ai(),
+        "    sendMetrics()".ai(),
+        "}".unattributed_human(),
+    ]);
+}
+
+/// Verify that session metadata survives squash rebase.
+/// This is the session-format counterpart of test_rebase_squash_preserves_human_attribution.
+/// Sessions use s_<id>::t_<hash> attestation entries and are the current default format.
+/// The delta_sessions code already scans current_attributions (unlike the old delta_humans
+/// code), so this test should pass without additional fixes.
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_rebase_squash_preserves_session_attribution() {
+    use std::io::Write;
+
+    let repo = TestRepo::new();
+
+    // Create initial commit on default branch
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let default_branch = repo.current_branch();
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+
+    let file_path = repo.path().join("service.go");
+
+    // --- AI commit 1: AI adds initial lines ---
+    repo.git_ai(&["checkpoint", "human", "service.go"]).unwrap();
+    let ai_content_1 = "\
+func serve() {
+    listen()
+    handle()
+}
+";
+    std::fs::write(&file_path, ai_content_1).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "service.go"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit 1").unwrap();
+
+    let mut service = repo.filename("service.go");
+    service.assert_committed_lines(crate::lines![
+        "func serve() {".ai(),
+        "    listen()".ai(),
+        "    handle()".ai(),
+        "}".ai(),
+    ]);
+
+    // Verify session metadata exists on commit 1
+    let sha1 = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let note1 = repo
+        .read_authorship_note(&sha1)
+        .expect("AI commit 1 should have note");
+    let log1 = AuthorshipLog::deserialize_from_string(&note1).expect("parse note 1");
+    assert_eq!(
+        log1.metadata.sessions.len(),
+        1,
+        "AI commit 1 should have exactly 1 session"
+    );
+
+    // --- AI commit 2: AI adds more lines ---
+    repo.git_ai(&["checkpoint", "human", "service.go"]).unwrap();
+    let ai_content_2 = "\
+func serve() {
+    listen()
+    handle()
+    logMetrics()
+}
+";
+    std::fs::write(&file_path, ai_content_2).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "service.go"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit 2").unwrap();
+
+    service.assert_committed_lines(crate::lines![
+        "func serve() {".ai(),
+        "    listen()".ai(),
+        "    handle()".ai(),
+        "    logMetrics()".ai(),
+        "}".ai(),
+    ]);
+
+    // --- AI commit 3: AI adds yet more ---
+    repo.git_ai(&["checkpoint", "human", "service.go"]).unwrap();
+    let ai_content_3 = "\
+func serve() {
+    listen()
+    handle()
+    logMetrics()
+    shutdown()
+}
+";
+    std::fs::write(&file_path, ai_content_3).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "service.go"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit 3").unwrap();
+
+    service.assert_committed_lines(crate::lines![
+        "func serve() {".ai(),
+        "    listen()".ai(),
+        "    handle()".ai(),
+        "    logMetrics()".ai(),
+        "    shutdown()".ai(),
+        "}".ai(),
+    ]);
+
+    // Advance main branch so rebase has something to replay onto
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let mut main_file2 = repo.filename("main2.txt");
+    main_file2.set_contents(crate::lines!["main work"]);
+    repo.stage_all_and_commit("Main advances").unwrap();
+    let base_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // --- Squash rebase: fixup all 3 commits into the first ---
+    repo.git(&["checkout", "feature"]).unwrap();
+
+    let script_content = r#"#!/bin/sh
+sed -i.bak '2s/pick/fixup/' "$1"
+sed -i.bak '3s/pick/fixup/' "$1"
+"#;
+
+    let script_path = repo.path().join("squash_script.sh");
+    let mut script_file = std::fs::File::create(&script_path).unwrap();
+    script_file.write_all(script_content.as_bytes()).unwrap();
+    drop(script_file);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let rebase_result = repo.git_with_env(
+        &["rebase", "-i", &base_commit],
+        &[
+            ("GIT_SEQUENCE_EDITOR", script_path.to_str().unwrap()),
+            ("GIT_EDITOR", "true"),
+        ],
+        None,
+    );
+
+    if rebase_result.is_err() {
+        eprintln!("git rebase output: {:?}", rebase_result);
+        panic!("Interactive rebase with fixup failed");
+    }
+
+    // Verify the merged note has sessions metadata preserved
+    let squashed_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let squashed_note = repo
+        .read_authorship_note(&squashed_sha)
+        .expect("squashed commit should have authorship note");
+    let squashed_log =
+        AuthorshipLog::deserialize_from_string(&squashed_note).expect("parse squashed note");
+    // Each mock_ai checkpoint creates a distinct session, so the squashed
+    // note should have all 3 sessions merged from the 3 original commits.
+    assert_eq!(
+        squashed_log.metadata.sessions.len(),
+        3,
+        "Post-squash: squashed note should have all 3 sessions merged"
+    );
+
+    // Verify line-level AI attribution survived the squash
+    service.assert_lines_and_blame(crate::lines![
+        "func serve() {".ai(),
+        "    listen()".ai(),
+        "    handle()".ai(),
+        "    logMetrics()".ai(),
+        "    shutdown()".ai(),
+        "}".unattributed_human(),
     ]);
 }

--- a/tests/integration/rebase_realworld.rs
+++ b/tests/integration/rebase_realworld.rs
@@ -9893,12 +9893,12 @@ fn test_conflict_ai_resolves_timeout_constant() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c3' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -10335,12 +10335,12 @@ fn test_conflict_ai_resolves_preserving_human_context_lines() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c3' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -10533,12 +10533,12 @@ fn test_conflict_ai_resolves_on_first_commit() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c1' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c1' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -10739,12 +10739,12 @@ fn test_conflict_ai_resolves_on_last_commit() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c5' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c5' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -10965,12 +10965,12 @@ fn test_conflict_ai_resolves_multiple_files_in_same_commit() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c3' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -11166,12 +11166,12 @@ fn test_conflict_ai_resolves_then_more_ai_builds_on_result() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c2' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c2' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -11389,12 +11389,12 @@ fn test_conflict_ai_resolves_rust_struct_fields() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c3' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c3' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {
@@ -11651,12 +11651,12 @@ fn test_conflict_ai_resolves_complex_function_with_error_handling() {
         conflict_note
             .metadata
             .humans
-            .contains_key("h_9e95a89b42f1fb"),
-        "c4' should have h_9e95a89b42f1fb in metadata.humans (human context lines in resolved file)"
+            .contains_key("h_e858f2c2faea28"),
+        "c4' should have h_e858f2c2faea28 in metadata.humans (human context lines in resolved file)"
     );
     assert_eq!(
-        conflict_note.metadata.humans["h_9e95a89b42f1fb"].author,
-        "Test User"
+        conflict_note.metadata.humans["h_e858f2c2faea28"].author,
+        "Test User <test@example.com>"
     );
     // Other commits (pure AI) should have no humans entry
     for (i, sha) in chain.iter().enumerate() {

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -191,12 +191,19 @@ impl<'a> TestFile<'a> {
         }
     }
 
-    /// Helper function to check if an author string indicates AI authorship
+    /// Helper function to check if an author string indicates AI authorship.
+    /// Strips email (angle-bracket portion) before matching to avoid false positives
+    /// like "amp" inside "example.com".
     fn is_ai_author_helper(author: &str) -> bool {
-        let author_lower = author.to_lowercase();
+        let name_only = if let Some(bracket) = author.find('<') {
+            &author[..bracket]
+        } else {
+            author
+        };
+        let name_lower = name_only.to_lowercase();
         AI_AUTHOR_NAMES
             .iter()
-            .any(|&name| author_lower.contains(name))
+            .any(|&ai_name| name_lower.contains(ai_name))
     }
 
     /// Static version of parse_blame_line for use in from_existing_file

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1920,6 +1920,215 @@ fn test_session_record_human_author_includes_email() {
     }
 }
 
+/// Helper: assert every SessionRecord.human_author in the note for `sha` contains the email.
+fn assert_session_authors_have_email(repo: &TestRepo, sha: &str) {
+    let note = repo
+        .read_authorship_note(sha)
+        .unwrap_or_else(|| panic!("commit {} should have authorship note", &sha[..8]));
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    assert!(
+        !log.metadata.sessions.is_empty(),
+        "commit {} should have sessions metadata",
+        &sha[..8]
+    );
+    for (id, record) in &log.metadata.sessions {
+        let author = record
+            .human_author
+            .as_deref()
+            .unwrap_or_else(|| panic!("session {} should have human_author", id));
+        assert_eq!(
+            author, "Test User <test@example.com>",
+            "session {} human_author should be full git identity",
+            id
+        );
+    }
+}
+
+/// Helper: assert every HumanRecord.author in the note for `sha` contains the email.
+fn assert_human_records_have_email(repo: &TestRepo, sha: &str) {
+    let note = repo
+        .read_authorship_note(sha)
+        .unwrap_or_else(|| panic!("commit {} should have authorship note", &sha[..8]));
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    assert!(
+        !log.metadata.humans.is_empty(),
+        "commit {} should have humans metadata",
+        &sha[..8]
+    );
+    for (id, record) in &log.metadata.humans {
+        assert_eq!(
+            record.author, "Test User <test@example.com>",
+            "human record {} author should be full git identity",
+            id
+        );
+    }
+}
+
+/// Verify that SessionRecord.human_author includes email after checkout carryover.
+/// Exercises daemon.rs working log carryover path (checkout_hooks → restore_working_log_carryover).
+#[test]
+fn test_checkout_carryover_preserves_author_email_in_session() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("work.txt");
+
+    fs::write(repo.path().join("README.md"), "init\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    repo.git(&["branch", "feature"]).unwrap();
+
+    // Create AI checkpoint on main (uncommitted)
+    repo.git_ai(&["checkpoint", "human", "work.txt"]).unwrap();
+    fs::write(&file_path, "AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "work.txt"]).unwrap();
+
+    // Checkout feature — working log carries over
+    repo.git(&["checkout", "feature"]).unwrap();
+
+    // Commit on feature branch
+    repo.stage_all_and_commit("commit on feature").unwrap();
+
+    let mut file = repo.filename("work.txt");
+    file.assert_committed_lines(crate::lines!["AI line".ai()]);
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_session_authors_have_email(&repo, &sha);
+}
+
+/// Verify that SessionRecord.human_author includes email after `git switch` carryover.
+/// Exercises daemon.rs switch_hooks → restore_working_log_carryover path.
+#[test]
+fn test_switch_carryover_preserves_author_email_in_session() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("work.txt");
+
+    fs::write(repo.path().join("README.md"), "init\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    repo.git(&["branch", "feature"]).unwrap();
+
+    // Create AI checkpoint on main (uncommitted)
+    repo.git_ai(&["checkpoint", "human", "work.txt"]).unwrap();
+    fs::write(&file_path, "AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "work.txt"]).unwrap();
+
+    // Switch to feature — working log carries over
+    repo.git(&["switch", "feature"]).unwrap();
+
+    // Commit on feature branch
+    repo.stage_all_and_commit("commit on feature").unwrap();
+
+    let mut file = repo.filename("work.txt");
+    file.assert_committed_lines(crate::lines!["AI line".ai()]);
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_session_authors_have_email(&repo, &sha);
+}
+
+/// Verify that SessionRecord.human_author includes email after rebase rewrites the note.
+/// Exercises daemon.rs apply_rewrite_prerequisites → post_commit path.
+#[test]
+fn test_rebase_rewrite_preserves_author_email_in_session() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("code.rs");
+
+    // Base commit
+    fs::write(&file_path, "fn base() {}\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+
+    // AI commit on top
+    repo.git_ai(&["checkpoint", "human", "code.rs"]).unwrap();
+    fs::write(&file_path, "fn base() {}\nfn ai() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "code.rs"]).unwrap();
+    repo.stage_all_and_commit("ai commit").unwrap();
+
+    let mut file = repo.filename("code.rs");
+    file.assert_committed_lines(crate::lines![
+        "fn base() {}".unattributed_human(),
+        "fn ai() {}".ai(),
+    ]);
+
+    // Create a new base commit on a side branch to rebase onto
+    repo.git(&["checkout", "-b", "new-base", "HEAD~1"]).unwrap();
+    fs::write(repo.path().join("other.txt"), "other\n").unwrap();
+    repo.stage_all_and_commit("new base commit").unwrap();
+    let new_base = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // Go back to the AI commit's branch and rebase
+    repo.git(&["checkout", "-"]).unwrap();
+    repo.git(&["rebase", &new_base]).unwrap();
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_session_authors_have_email(&repo, &sha);
+}
+
+/// Verify that HumanRecord.author includes email after rebase rewrites the note.
+#[test]
+fn test_rebase_rewrite_preserves_author_email_in_human_record() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("code.rs");
+
+    // Base commit
+    fs::write(&file_path, "fn base() {}\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+
+    // Known-human commit on top
+    fs::write(&file_path, "fn base() {}\nfn human() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "code.rs"])
+        .unwrap();
+    repo.stage_all_and_commit("human commit").unwrap();
+
+    let mut file = repo.filename("code.rs");
+    file.assert_committed_lines(crate::lines![
+        "fn base() {}".unattributed_human(),
+        "fn human() {}".human(),
+    ]);
+
+    // Create a new base commit on a side branch
+    repo.git(&["checkout", "-b", "new-base", "HEAD~1"]).unwrap();
+    fs::write(repo.path().join("other.txt"), "other\n").unwrap();
+    repo.stage_all_and_commit("new base commit").unwrap();
+    let new_base = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // Go back and rebase
+    repo.git(&["checkout", "-"]).unwrap();
+    repo.git(&["rebase", &new_base]).unwrap();
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_human_records_have_email(&repo, &sha);
+}
+
+/// Verify that `git-ai status` implicit checkpoint flows through to email in SessionRecord.
+/// Exercises status.rs → checkpoint::run → post_commit path.
+#[test]
+fn test_status_checkpoint_preserves_author_email_in_session() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("app.py");
+
+    // Base commit
+    fs::write(&file_path, "print('hello')\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+
+    // AI edits
+    repo.git_ai(&["checkpoint", "human", "app.py"]).unwrap();
+    fs::write(&file_path, "print('hello')\nprint('ai')\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "app.py"]).unwrap();
+
+    // Run git-ai status (triggers implicit human checkpoint internally)
+    let _ = repo.git_ai(&["status", "--json"]);
+
+    // Commit after status
+    repo.stage_all_and_commit("post-status commit").unwrap();
+
+    let mut file = repo.filename("app.py");
+    file.assert_committed_lines(crate::lines![
+        "print('hello')".unattributed_human(),
+        "print('ai')".ai(),
+    ]);
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_session_authors_have_email(&repo, &sha);
+}
+
 crate::reuse_tests_in_worktree!(
     test_simple_additions_empty_repo,
     test_simple_additions_with_base_commit,
@@ -1934,4 +2143,9 @@ crate::reuse_tests_in_worktree!(
     test_ai_generated_file_then_human_full_rewrite,
     test_known_human_record_includes_email,
     test_session_record_human_author_includes_email,
+    test_checkout_carryover_preserves_author_email_in_session,
+    test_switch_carryover_preserves_author_email_in_session,
+    test_rebase_rewrite_preserves_author_email_in_session,
+    test_rebase_rewrite_preserves_author_email_in_human_record,
+    test_status_checkpoint_preserves_author_email_in_session,
 );

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use std::fs;
 
 fn configure_diff_settings(repo: &TestRepo, settings: &[(&str, &str)]) {
@@ -1832,6 +1833,59 @@ fn test_ai_generated_file_then_human_full_rewrite() {
     ]);
 }
 
+/// Regression test: known-human checkpoint must store the full git identity
+/// ("Name <email>") in the HumanRecord, not just the name.
+///
+/// The test harness configures user.name = "Test User" and
+/// user.email = "test@example.com", so the expected author field is
+/// "Test User <test@example.com>".
+#[test]
+fn test_known_human_record_includes_email() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("app.go");
+
+    // AI writes the initial file
+    repo.git_ai(&["checkpoint", "human", "app.go"]).unwrap();
+    fs::write(&file_path, "func main() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "app.go"]).unwrap();
+    repo.stage_all_and_commit("AI commit").unwrap();
+
+    // Human edits the file
+    fs::write(&file_path, "func main() {}\nfunc helper() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "app.go"])
+        .unwrap();
+    repo.stage_all_and_commit("Human commit").unwrap();
+
+    let mut file = repo.filename("app.go");
+    file.assert_committed_lines(crate::lines![
+        "func main() {}".ai(),
+        "func helper() {}".human(),
+    ]);
+
+    // Verify the HumanRecord has the full identity with email
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let note = repo
+        .read_authorship_note(&sha)
+        .expect("human commit should have note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    assert!(
+        !log.metadata.humans.is_empty(),
+        "should have humans metadata"
+    );
+    for record in log.metadata.humans.values() {
+        assert!(
+            record.author.contains('<') && record.author.contains('>'),
+            "HumanRecord.author should include email in angle brackets, got: {:?}",
+            record.author
+        );
+        assert_eq!(
+            record.author, "Test User <test@example.com>",
+            "HumanRecord.author should be the full git identity"
+        );
+    }
+}
+
 crate::reuse_tests_in_worktree!(
     test_simple_additions_empty_repo,
     test_simple_additions_with_base_commit,
@@ -1844,4 +1898,5 @@ crate::reuse_tests_in_worktree!(
     test_partial_staging_filters_unstaged_lines,
     test_human_stages_some_ai_lines,
     test_ai_generated_file_then_human_full_rewrite,
+    test_known_human_record_includes_email,
 );

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1886,6 +1886,40 @@ fn test_known_human_record_includes_email() {
     }
 }
 
+#[test]
+fn test_session_record_human_author_includes_email() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("main.rs");
+
+    repo.git_ai(&["checkpoint", "human", "main.rs"]).unwrap();
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "main.rs"]).unwrap();
+    repo.stage_all_and_commit("AI commit").unwrap();
+
+    let mut file = repo.filename("main.rs");
+    file.assert_committed_lines(crate::lines!["fn main() {}".ai()]);
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let note = repo
+        .read_authorship_note(&sha)
+        .expect("AI commit should have note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    assert!(
+        !log.metadata.sessions.is_empty(),
+        "should have sessions metadata"
+    );
+    for record in log.metadata.sessions.values() {
+        let author = record
+            .human_author
+            .as_deref()
+            .expect("human_author should be set");
+        assert_eq!(
+            author, "Test User <test@example.com>",
+            "SessionRecord.human_author should be the full git identity"
+        );
+    }
+}
+
 crate::reuse_tests_in_worktree!(
     test_simple_additions_empty_repo,
     test_simple_additions_with_base_commit,
@@ -1899,4 +1933,5 @@ crate::reuse_tests_in_worktree!(
     test_human_stages_some_ai_lines,
     test_ai_generated_file_then_human_full_rewrite,
     test_known_human_record_includes_email,
+    test_session_record_human_author_includes_email,
 );


### PR DESCRIPTION
## Summary

Fixes #1214. Also fixes two related bugs where author identity was missing the email address.

### Bug 1: Humans metadata block lost during squash rebase

**Root cause:** During interactive squash rebase, `rewrite_authorship_after_rebase_v2` computes per-commit `delta_humans` by looking up working logs under the new commit's parent SHA. During squash, the original working logs don't exist under the new parent SHAs, so `delta_humans` was always empty. The `humans` metadata block was omitted from serialization (`skip_serializing_if = "BTreeMap::is_empty"`), and `git-ai blame` couldn't resolve `h_`-prefixed attestation entries — silently dropping known-human line attribution.

**Fix:** Added a fallback in `delta_humans` computation that scans `current_attributions` for `h_`-prefixed author IDs in the commit's changed files, mirroring the pattern already used by `delta_sessions` for `s_`-prefixed entries.

### Bug 2: HumanRecord.author missing email

**Root cause:** Checkpoint call sites used `name_or_unknown()` which returns only the git user name (e.g. `"First Last"`), discarding the email. The `h_` hash is computed from this string, so notes showed `"author": "First Last"` even when git config had the email. Regression introduced in `71c29371` (Devin's `GitAuthorIdentity` refactor) — the struct correctly parsed both name and email from `git var GIT_COMMITTER_IDENT`, but `name_or_unknown()` discarded the email at every call site.

**Fix:** Added `formatted_or_unknown()` to `GitAuthorIdentity` which returns `"Name <email>"` when both are available. Changed all 9 call sites and removed the dead `name_or_unknown()` method entirely.

### Bug 3: SessionRecord.human_author and telemetry author missing email

**Root cause:** Same as Bug 2 — additional `name_or_unknown()` call sites in `status.rs` and `daemon.rs` fed into `SessionRecord.human_author` and the telemetry `EventAttributes.author` field.

**Fix:** Same — all call sites now use `formatted_or_unknown()`.

**Changes:**
- `src/authorship/rebase_authorship.rs` — scan `current_attributions` for `h_` entries in `delta_humans`
- `src/git/repository.rs` — add `formatted_or_unknown()`, remove dead `name_or_unknown()`
- `src/commands/git_ai_handlers.rs` — 4 call sites updated
- `src/commands/status.rs` — 1 call site updated
- `src/daemon.rs` — 4 call sites updated
- `tests/integration/repos/test_file.rs` — fix `is_ai_author_helper` to strip email before matching
- `tests/integration/rebase.rs` — 2 regression tests + email assertion on human squash test
- `tests/integration/simple_additions.rs` — 7 new regression tests covering every author identity path:
  - `test_known_human_record_includes_email` — basic HumanRecord
  - `test_session_record_human_author_includes_email` — basic SessionRecord
  - `test_checkout_carryover_preserves_author_email_in_session` — checkout hook carryover
  - `test_switch_carryover_preserves_author_email_in_session` — switch hook carryover
  - `test_rebase_rewrite_preserves_author_email_in_session` — rebase rewrite (session)
  - `test_rebase_rewrite_preserves_author_email_in_human_record` — rebase rewrite (human)
  - `test_status_checkpoint_preserves_author_email_in_session` — status implicit checkpoint
- Updated hardcoded `h_` hashes in `rebase_realworld.rs`, `ci_squash_rebase.rs`, `diff.rs`

## Test plan

- [x] All 7 email regression tests pass (+ worktree variants = 14 tests)
- [x] `test_rebase_squash_preserves_human_attribution` passes (+ worktree)
- [x] `test_rebase_squash_preserves_session_attribution` passes (+ worktree)
- [x] 3056 integration tests pass (3 pre-existing flaky failures unrelated)
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)