### PR TITLE
feat: make CI MR lookback window configurable via GIT_AI_CI_LOOKBACK_MINUTES

### DIFF
--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -62,7 +62,12 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
     };
 
     // Calculate cutoff time (10 minutes ago) with safety buffer
-    let cutoff = Utc::now() - Duration::minutes(15);
+    let lookback_minutes = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                 
+      .ok()                                                                                                                                                                                                        
+      .and_then(|v| v.parse().ok())
+      .unwrap_or(15);                                                                                                                                                                                                
+    let cutoff = Utc::now() - Duration::minutes(lookback_minutes);
+
     let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
     // Query GitLab API for recently merged MRs
@@ -348,4 +353,36 @@ mod tests {
             "GitLab CI template YAML should not be empty"
         );
     }
+
+    #[test]                                                                                                                                                                                                            
+    fn test_lookback_minutes_defaults_to_15() {
+        std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                            
+        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                   
+            .ok()                                                 
+            .and_then(|v| v.parse().ok())                                                                                                                                                                              
+            .unwrap_or(15i64);           
+        assert_eq!(lookback, 15);                                                                                                                                                                                      
+    }                                                                                                                                                                                                                
+    
+    #[test]                                                                                                                                                                                                            
+    fn test_lookback_minutes_reads_env_var() {
+        std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "4320");                                                                                                                                                       
+        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                   
+            .ok()                                                 
+            .and_then(|v| v.parse().ok())                                                                                                                                                                              
+            .unwrap_or(15i64);           
+        std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                            
+        assert_eq!(lookback, 4320);                                                                                                                                                                                  
+    }                                                                                                                                                                                                                  
+    
+    #[test]                                                                                                                                                                                                            
+    fn test_lookback_minutes_falls_back_on_invalid_value() {                                                                                                                                                         
+        std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "not-a-number");
+        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")      
+            .ok()                                                                                                                                                                                                      
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(15i64);                                                                                                                                                                                         
+        std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                          
+        assert_eq!(lookback, 15);                                                                                                                                                                                      
+    } 
 }

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -62,10 +62,10 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
     };
 
     // Calculate cutoff time (10 minutes ago) with safety buffer
-    let lookback_minutes = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                 
-      .ok()                                                                                                                                                                                                        
-      .and_then(|v| v.parse().ok())
-      .unwrap_or(15);                                                                                                                                                                                                
+    let lookback_minutes = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(15);
     let cutoff = Utc::now() - Duration::minutes(lookback_minutes);
 
     let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%SZ").to_string();
@@ -355,37 +355,37 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]                                                                                                                                                        
+    #[serial_test::serial]
     fn test_lookback_minutes_defaults_to_15() {
-        std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                            
-        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                   
-            .ok()                                                 
-            .and_then(|v| v.parse().ok())                                                                                                                                                                              
-            .unwrap_or(15i64);           
-        assert_eq!(lookback, 15);                                                                                                                                                                                      
-    }                                                                                                                                                                                                                
-    
-    #[test]
-    #[serial_test::serial]                                                                                                                                                                                                     
-    fn test_lookback_minutes_reads_env_var() {
-        std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "4320");                                                                                                                                                       
-        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                   
-            .ok()                                                 
-            .and_then(|v| v.parse().ok())                                                                                                                                                                              
-            .unwrap_or(15i64);           
-        std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                            
-        assert_eq!(lookback, 4320);                                                                                                                                                                                  
-    }                                                                                                                                                                                                                  
-    
-    #[test]
-    #[serial_test::serial]                                                                                                                                                                                                          
-    fn test_lookback_minutes_falls_back_on_invalid_value() {                                                                                                                                                         
-        std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "not-a-number");
-        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")      
-            .ok()                                                                                                                                                                                                      
+        unsafe { std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES") };
+        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")
+            .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(15i64);                                                                                                                                                                                         
-        std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                          
-        assert_eq!(lookback, 15);                                                                                                                                                                                      
-    } 
+            .unwrap_or(15i64);
+        assert_eq!(lookback, 15);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_lookback_minutes_reads_env_var() {
+        unsafe { std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "4320") };
+        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(15i64);
+        unsafe { std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES") };
+        assert_eq!(lookback, 4320);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_lookback_minutes_falls_back_on_invalid_value() {
+        unsafe { std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "not-a-number") };
+        let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(15i64);
+        unsafe { std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES") };
+        assert_eq!(lookback, 15);
+    }
 }

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -354,7 +354,8 @@ mod tests {
         );
     }
 
-    #[test]                                                                                                                                                                                                            
+    #[test]
+    #[serial_test::serial]                                                                                                                                                        
     fn test_lookback_minutes_defaults_to_15() {
         std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES");                                                                                                                                                            
         let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                   
@@ -364,7 +365,8 @@ mod tests {
         assert_eq!(lookback, 15);                                                                                                                                                                                      
     }                                                                                                                                                                                                                
     
-    #[test]                                                                                                                                                                                                            
+    #[test]
+    #[serial_test::serial]                                                                                                                                                                                                     
     fn test_lookback_minutes_reads_env_var() {
         std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "4320");                                                                                                                                                       
         let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")                                                                                                                                                   
@@ -375,7 +377,8 @@ mod tests {
         assert_eq!(lookback, 4320);                                                                                                                                                                                  
     }                                                                                                                                                                                                                  
     
-    #[test]                                                                                                                                                                                                            
+    #[test]
+    #[serial_test::serial]                                                                                                                                                                                                          
     fn test_lookback_minutes_falls_back_on_invalid_value() {                                                                                                                                                         
         std::env::set_var("GIT_AI_CI_LOOKBACK_MINUTES", "not-a-number");
         let lookback = std::env::var("GIT_AI_CI_LOOKBACK_MINUTES")      


### PR DESCRIPTION
 Fixes #1230
                                                                                                                                                                                                                     
  ## Summary                                                                                                                                                                                                         
            
  - Replace hardcoded 15-minute lookback window in `get_gitlab_ci_context()` with a value read from `GIT_AI_CI_LOOKBACK_MINUTES` env var                                                                             
  - Defaults to 15 minutes when unset or invalid — no behaviour change for existing per-project CI setups                                                                                                            
  - Enables centralized/scheduled pipeline use case where the calling script iterates over all merged MRs and invokes `git-ai ci gitlab run` per MR with the appropriate `CI_COMMIT_SHA`
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  - [x] `test_lookback_minutes_defaults_to_15` — unset env var falls back to 15                                                                                                                                      
  - [x] `test_lookback_minutes_reads_env_var` — valid value is used                                                                                                                                                  
  - [x] `test_lookback_minutes_falls_back_on_invalid_value` — non-numeric value falls back to 15
                                                                                                                                                                                                                     
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->