### PR TITLE
bg agents attribution no hooks

### DIFF
--- a/src/authorship/background_agent.rs
+++ b/src/authorship/background_agent.rs
@@ -1,4 +1,9 @@
-use crate::utils::is_interactive_terminal;
+use crate::authorship::authorship_log_serialization::generate_trace_id;
+use crate::authorship::working_log::{AgentId, CheckpointKind};
+use crate::commands::checkpoint::PreparedPathRole;
+use crate::commands::checkpoint_agent::orchestrator::CheckpointRequest;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 const DEVIN_ID_PATH: &str = "/opt/.devin/devin_id";
 const DEVIN_DIR_PATH: &str = "/opt/.devin";
@@ -13,11 +18,6 @@ pub enum BackgroundAgent {
 
 /// Returns the background-agent environment we're running in, if any.
 pub fn detect_background_agent() -> BackgroundAgent {
-
-    if is_interactive_terminal() {
-        return BackgroundAgent::NotInBackgroundAgent;
-    }
-
     if std::env::var("CLAUDE_CODE_REMOTE")
         .map(|v| v == "true")
         .unwrap_or(false)
@@ -84,7 +84,51 @@ pub fn detect_background_agent() -> BackgroundAgent {
 
 /// Returns true if the process is running inside a background AI agent environment.
 pub fn is_in_background_agent() -> bool {
-    !matches!(detect_background_agent(), BackgroundAgent::NotInBackgroundAgent)
+    !matches!(
+        detect_background_agent(),
+        BackgroundAgent::NotInBackgroundAgent
+    )
+}
+
+/// If we're running inside a `BackgroundAgentNoHooks` environment, build a
+/// synthetic AI `CheckpointRequest` that callers can hand to
+/// `checkpoint::run` so the resulting commit gets attributed wholly to the
+/// detected tool.
+///
+/// Returns `None` for `BackgroundAgentWithHooks` (those agents fire their
+/// own checkpoints) and for `NotInBackgroundAgent`.
+///
+/// Callers may overlay `file_paths` / `dirty_files` on the returned request
+/// before passing it through — the daemon path supplies a precomputed diff
+/// snapshot, while the wrapper path leaves them empty and lets
+/// `checkpoint::run` discover dirty files itself.
+pub fn synthetic_ai_checkpoint_request_for_no_hooks_agent(
+    repo_working_dir: PathBuf,
+) -> Option<(AgentId, CheckpointRequest)> {
+    let BackgroundAgent::BackgroundAgentNoHooks { tool, id } = detect_background_agent() else {
+        return None;
+    };
+
+    let agent_id = AgentId {
+        tool,
+        id,
+        model: "unknown".to_string(),
+    };
+
+    let request = CheckpointRequest {
+        trace_id: generate_trace_id(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(agent_id.clone()),
+        repo_working_dir,
+        file_paths: vec![],
+        path_role: PreparedPathRole::Edited,
+        dirty_files: None,
+        transcript_source: None,
+        metadata: HashMap::new(),
+        captured_checkpoint_id: None,
+    };
+
+    Some((agent_id, request))
 }
 
 fn placeholder(name: &str) -> String {
@@ -93,4 +137,64 @@ fn placeholder(name: &str) -> String {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     format!("{name}_SESSION{ts}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_agent_env_vars() {
+        unsafe {
+            std::env::remove_var("CLAUDE_CODE_REMOTE");
+            std::env::remove_var("CURSOR_AGENT");
+            std::env::remove_var(CODEX_INTERNAL_ORIGINATOR_OVERRIDE);
+            std::env::remove_var("CODEX_THREAD_ID");
+            std::env::remove_var("GIT_AI_CLOUD_AGENT");
+            for (k, _) in std::env::vars() {
+                if k.starts_with("CLOUD_AGENT_") {
+                    std::env::remove_var(&k);
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn synthetic_request_returns_none_when_not_in_agent() {
+        clear_agent_env_vars();
+        let result = synthetic_ai_checkpoint_request_for_no_hooks_agent(PathBuf::from("/tmp"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn synthetic_request_returns_none_for_with_hooks_agents() {
+        clear_agent_env_vars();
+        unsafe {
+            std::env::set_var("CLAUDE_CODE_REMOTE", "true");
+        }
+        let result = synthetic_ai_checkpoint_request_for_no_hooks_agent(PathBuf::from("/tmp"));
+        clear_agent_env_vars();
+        assert!(
+            result.is_none(),
+            "BackgroundAgentWithHooks must not synthesise a checkpoint"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn synthetic_request_for_codex_cloud() {
+        clear_agent_env_vars();
+        unsafe {
+            std::env::set_var(CODEX_INTERNAL_ORIGINATOR_OVERRIDE, "codex_web_agent");
+            std::env::set_var("CODEX_THREAD_ID", "thread-abc-123");
+        }
+        let result = synthetic_ai_checkpoint_request_for_no_hooks_agent(PathBuf::from("/tmp/repo"));
+        clear_agent_env_vars();
+
+        let (agent_id, _) = result.expect("should synthesise an AI request");
+        assert_eq!(agent_id.tool, "codex-cloud");
+        assert_eq!(agent_id.id, "thread-abc-123");
+    }
 }

--- a/src/authorship/background_agent.rs
+++ b/src/authorship/background_agent.rs
@@ -1,0 +1,96 @@
+use crate::utils::is_interactive_terminal;
+
+const DEVIN_ID_PATH: &str = "/opt/.devin/devin_id";
+const DEVIN_DIR_PATH: &str = "/opt/.devin";
+const CODEX_INTERNAL_ORIGINATOR_OVERRIDE: &str = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackgroundAgent {
+    BackgroundAgentWithHooks { tool: String },
+    BackgroundAgentNoHooks { tool: String, id: String },
+    NotInBackgroundAgent,
+}
+
+/// Returns the background-agent environment we're running in, if any.
+pub fn detect_background_agent() -> BackgroundAgent {
+
+    if is_interactive_terminal() {
+        return BackgroundAgent::NotInBackgroundAgent;
+    }
+
+    if std::env::var("CLAUDE_CODE_REMOTE")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        return BackgroundAgent::BackgroundAgentWithHooks {
+            tool: "claude-web".to_string(),
+        };
+    }
+
+    if std::env::var("CURSOR_AGENT")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return BackgroundAgent::BackgroundAgentWithHooks {
+            tool: "cursor-agent".to_string(),
+        };
+    }
+
+    if std::env::vars().any(|(k, _)| k.starts_with("CLOUD_AGENT_")) {
+        return BackgroundAgent::BackgroundAgentNoHooks {
+            tool: "cloud-agent".to_string(),
+            id: placeholder("CLOUD_AGENT"),
+        };
+    }
+
+    if std::path::Path::new(DEVIN_DIR_PATH).is_dir() {
+        let id = std::fs::read_to_string(DEVIN_ID_PATH)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| placeholder("DEVIN"));
+        return BackgroundAgent::BackgroundAgentNoHooks {
+            tool: "devin".to_string(),
+            id,
+        };
+    }
+
+    if std::env::var(CODEX_INTERNAL_ORIGINATOR_OVERRIDE)
+        .map(|v| v == "codex_web_agent")
+        .unwrap_or(false)
+    {
+        let id = std::env::var("CODEX_THREAD_ID")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| placeholder("CODEX_CLOUD"));
+        return BackgroundAgent::BackgroundAgentNoHooks {
+            tool: "codex-cloud".to_string(),
+            id,
+        };
+    }
+
+    if std::env::var("GIT_AI_CLOUD_AGENT")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return BackgroundAgent::BackgroundAgentNoHooks {
+            tool: "git-ai-cloud-agent".to_string(),
+            id: placeholder("GIT_AI_CLOUD_AGENT"),
+        };
+    }
+
+    BackgroundAgent::NotInBackgroundAgent
+}
+
+/// Returns true if the process is running inside a background AI agent environment.
+pub fn is_in_background_agent() -> bool {
+    !matches!(detect_background_agent(), BackgroundAgent::NotInBackgroundAgent)
+}
+
+fn placeholder(name: &str) -> String {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("{name}_SESSION{ts}")
+}

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_detection;
 pub mod attribution_tracker;
 pub mod authorship_log;
 pub mod authorship_log_serialization;
+pub mod background_agent;
 pub mod diff_ai_accepted;
 pub mod git_ai_hooks;
 pub mod ignore;

--- a/src/authorship/pre_commit.rs
+++ b/src/authorship/pre_commit.rs
@@ -1,3 +1,4 @@
+use crate::authorship::background_agent::synthetic_ai_checkpoint_request_for_no_hooks_agent;
 use crate::authorship::working_log::CheckpointKind;
 use crate::commands::checkpoint_agent::orchestrator::CheckpointRequest;
 use crate::error::GitAiError;
@@ -33,6 +34,13 @@ fn pre_commit_checkpoint_context(repo: &Repository) -> (CheckpointKind, Option<C
     {
         tracing::debug!("pre-commit: using active bash context for AI checkpoint");
         return (checkpoint_kind, agent_run_result);
+    }
+
+    if let Some((_, request)) =
+        synthetic_ai_checkpoint_request_for_no_hooks_agent(repo_root.to_path_buf())
+    {
+        tracing::debug!("pre-commit: detected no-hooks background agent, attributing commit to AI");
+        return (CheckpointKind::AiAgent, Some(request));
     }
 
     tracing::debug!("pre-commit: no active inflight bash agent context, using human checkpoint");

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -140,7 +140,7 @@ pub fn handle_git(args: &[String]) {
             crate::authorship::background_agent::BackgroundAgent::BackgroundAgentNoHooks { .. }
         )
     {
-        let default_author = repo.git_author_identity().name_or_unknown();
+        let default_author = repo.git_author_identity().formatted_or_unknown();
         if let Err(e) = crate::authorship::pre_commit::pre_commit(repo, default_author) {
             tracing::debug!("pre-commit synthetic AI checkpoint failed: {}", e);
         }

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -126,6 +126,26 @@ pub fn handle_git(args: &[String]) {
     // processes the atexit trace event and starts the wrapper state timeout.
     send_wrapper_pre_state_to_daemon(&invocation_id, worktree.as_deref(), &pre_state);
 
+    // When committing inside a no-hooks background agent (Devin, Codex Cloud,
+    // etc.) the agent never fires its own checkpoints, so the working log is
+    // empty and the daemon would attribute every line as untracked human.
+    // Fire a synthetic AI pre-commit checkpoint here from the wrapper — its
+    // process inherits the agent's env vars, while the long-lived daemon may
+    // not. The daemon's own commit-replay then sees this AI checkpoint and
+    // produces correct attribution.
+    if parsed.command.as_deref() == Some("commit")
+        && let Some(repo) = repository.as_ref()
+        && matches!(
+            crate::authorship::background_agent::detect_background_agent(),
+            crate::authorship::background_agent::BackgroundAgent::BackgroundAgentNoHooks { .. }
+        )
+    {
+        let default_author = repo.git_author_identity().name_or_unknown();
+        if let Err(e) = crate::authorship::pre_commit::pre_commit(repo, default_author) {
+            tracing::debug!("pre-commit synthetic AI checkpoint failed: {}", e);
+        }
+    }
+
     let exit_status = proxy_to_git(args, false, Some(&invocation_id));
 
     let post_state = worktree

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2599,8 +2599,31 @@ fn sync_pre_commit_checkpoint_for_daemon_commit(
                 (kind, result)
             }
             None => {
-                let result = build_human_replay_checkpoint_request(changed_files, dirty_files);
-                (CheckpointKind::Human, result)
+                // No bash inflight. If we're running inside a no-hooks background
+                // agent (Devin, Codex Cloud, etc.) the agent never fired its own
+                // checkpoints — attribute the entire commit to the detected tool
+                // instead of recording it as untracked human edits.
+                if let Some((_, mut ai_result)) =
+                    crate::authorship::background_agent::synthetic_ai_checkpoint_request_for_no_hooks_agent(
+                        std::path::PathBuf::from(&repo_workdir),
+                    )
+                {
+                    ai_result.file_paths = changed_files
+                        .into_iter()
+                        .map(std::path::PathBuf::from)
+                        .collect();
+                    ai_result.path_role = PreparedPathRole::Edited;
+                    ai_result.dirty_files = Some(
+                        dirty_files
+                            .into_iter()
+                            .map(|(k, v)| (std::path::PathBuf::from(k), v))
+                            .collect(),
+                    );
+                    (CheckpointKind::AiAgent, ai_result)
+                } else {
+                    let result = build_human_replay_checkpoint_request(changed_files, dirty_files);
+                    (CheckpointKind::Human, result)
+                }
             }
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -143,7 +143,6 @@ pub fn is_interactive_terminal() -> bool {
     *IS_TERMINAL.get_or_init(|| std::io::stdin().is_terminal())
 }
 
-
 /// A cross-platform exclusive file lock.
 ///
 /// Holds an exclusive advisory lock (Unix) or exclusive-access file handle (Windows)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 static IS_TERMINAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-static IS_IN_BACKGROUND_AGENT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 /// Print a git diff in a readable format
 ///
@@ -144,20 +143,6 @@ pub fn is_interactive_terminal() -> bool {
     *IS_TERMINAL.get_or_init(|| std::io::stdin().is_terminal())
 }
 
-/// Returns true if the process is running inside a background AI agent environment.
-pub fn is_in_background_agent() -> bool {
-    *IS_IN_BACKGROUND_AGENT.get_or_init(|| {
-        // Claude Code remote agent (Anthropic)
-        std::env::var("CLAUDE_CODE_REMOTE").map(|v| v == "true").unwrap_or(false)
-            // Cursor background agent
-            || std::env::var("CURSOR_AGENT").map(|v| v == "1").unwrap_or(false)
-            // Cloud agent environment (CLOUD_AGENT_* prefix)
-            || std::env::vars().any(|(k, _)| k.starts_with("CLOUD_AGENT_"))
-            || std::path::Path::new("/opt/.devin").is_dir()
-            // Explicit opt-in for cloud/background agent environments
-            || std::env::var("GIT_AI_CLOUD_AGENT").map(|v| v == "1").unwrap_or(false)
-    })
-}
 
 /// A cross-platform exclusive file lock.
 ///

--- a/tests/integration/background_agent_attribution.rs
+++ b/tests/integration/background_agent_attribution.rs
@@ -1,0 +1,53 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::{DaemonTestScope, GitTestMode, TestRepo};
+use std::fs;
+
+/// When git-ai's wrapper runs inside a no-hooks background agent (here
+/// simulated via `GIT_AI_CLOUD_AGENT=1`), commits should be attributed wholly
+/// to the detected AI tool even though no AI checkpoints were ever fired.
+///
+/// The wrapper subprocess inherits the env var the test sets via
+/// `stage_all_and_commit_with_env` and fires a synthetic AI pre-commit
+/// checkpoint before proxying to git. The test therefore runs in
+/// WrapperDaemon mode — pure Daemon mode bypasses the wrapper entirely and
+/// can't see per-invocation env vars.
+#[test]
+fn test_no_hooks_background_agent_commit_attributed_to_ai() {
+    let repo = TestRepo::new_with_mode_and_daemon_scope(
+        GitTestMode::WrapperDaemon,
+        DaemonTestScope::Dedicated,
+    );
+
+    fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
+    repo.stage_all_and_commit("seed").unwrap();
+
+    fs::write(repo.path().join("cloud.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    repo.stage_all_and_commit_with_env("cloud agent edit", &[("GIT_AI_CLOUD_AGENT", "1")])
+        .unwrap();
+
+    let mut file = repo.filename("cloud.txt");
+    file.assert_committed_lines(crate::lines!["alpha".ai(), "beta".ai(), "gamma".ai(),]);
+}
+
+/// Negative control: same shape, no env var. Lines that arrived without any
+/// checkpoint are flagged as untracked (legacy human) — confirms the previous
+/// test isn't passing because of an unrelated default.
+#[test]
+fn test_without_background_agent_env_lines_are_untracked() {
+    let repo = TestRepo::new_with_mode_and_daemon_scope(
+        GitTestMode::WrapperDaemon,
+        DaemonTestScope::Dedicated,
+    );
+
+    fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
+    repo.stage_all_and_commit("seed").unwrap();
+
+    fs::write(repo.path().join("plain.txt"), "alpha\nbeta\n").unwrap();
+    repo.stage_all_and_commit("no agent").unwrap();
+
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(crate::lines![
+        "alpha".unattributed_human(),
+        "beta".unattributed_human(),
+    ]);
+}

--- a/tests/integration/background_agent_attribution.rs
+++ b/tests/integration/background_agent_attribution.rs
@@ -20,6 +20,8 @@ fn test_no_hooks_background_agent_commit_attributed_to_ai() {
 
     fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
     repo.stage_all_and_commit("seed").unwrap();
+    let mut seed_file = repo.filename("seed.txt");
+    seed_file.assert_committed_lines(crate::lines!["seed line".unattributed_human()]);
 
     fs::write(repo.path().join("cloud.txt"), "alpha\nbeta\ngamma\n").unwrap();
     repo.stage_all_and_commit_with_env("cloud agent edit", &[("GIT_AI_CLOUD_AGENT", "1")])
@@ -41,6 +43,8 @@ fn test_without_background_agent_env_lines_are_untracked() {
 
     fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
     repo.stage_all_and_commit("seed").unwrap();
+    let mut seed_file = repo.filename("seed.txt");
+    seed_file.assert_committed_lines(crate::lines!["seed line".unattributed_human()]);
 
     fs::write(repo.path().join("plain.txt"), "alpha\nbeta\n").unwrap();
     repo.stage_all_and_commit("no agent").unwrap();

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod ai_tab;
 mod amend;
 mod amp;
 mod attribution_tracker_comprehensive;
+mod background_agent_attribution;
 mod bash_tool_benchmark;
 mod bash_tool_conformance;
 mod bash_tool_provenance;

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -17,6 +17,7 @@ const AI_AUTHOR_NAMES: &[&str] = &[
     "amp",
     "windsurf",
     "devin",
+    "cloud-agent",
 ];
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Not all the background agent harnesses support our hooks yet - this PR will allow teams to install Git AI in their cloud sandboxes for accurate attribution w/o full session telemetry. 

Tested in Devin and Codex
<img width="643" height="464" alt="screenshot" src="https://github.com/user-attachments/assets/d60cb4e8-efb6-4ef4-b4fd-8d38d05db918" />
