### PR TITLE
fix: bg tail should print and exit by default, require -f/--follow to follow

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -437,7 +437,8 @@ fn handle_tail(args: &[String]) -> Result<(), String> {
         return Err(format!("log file not found: {}", log_path.display()));
     }
 
-    let full = has_flag(args, "--full") || has_flag(args, "-f");
+    let full = has_flag(args, "--full");
+    let follow = has_flag(args, "--follow") || has_flag(args, "-f");
     let lines: usize = parse_number_arg(args, "-n")
         .or_else(|| parse_number_arg(args, "--lines"))
         .unwrap_or(20);
@@ -457,8 +458,11 @@ fn handle_tail(args: &[String]) -> Result<(), String> {
         print_last_n_lines(&file, lines).map_err(|e| e.to_string())?;
     }
 
-    // Tail: poll for new content.
-    tail_file(file).map_err(|e| e.to_string())
+    if follow {
+        tail_file(file).map_err(|e| e.to_string())
+    } else {
+        Ok(())
+    }
 }
 
 fn parse_number_arg(args: &[String], flag: &str) -> Option<usize> {
@@ -494,7 +498,7 @@ fn print_last_n_lines(file: &std::fs::File, n: usize) -> Result<(), std::io::Err
         println!("{}", line);
     }
 
-    // Seek to end for tailing.
+    // Seek to end so tail_file can pick up from here.
     f.seek(SeekFrom::End(0))?;
     Ok(())
 }
@@ -699,5 +703,5 @@ fn print_help() {
     eprintln!("  git-ai bg status [--repo <path>]");
     eprintln!("  git-ai bg shutdown [--hard]");
     eprintln!("  git-ai bg restart [--hard]");
-    eprintln!("  git-ai bg tail [-n <lines>] [--full]");
+    eprintln!("  git-ai bg tail [-n <lines>] [--full] [-f | --follow]");
 }


### PR DESCRIPTION
## Summary
`git-ai bg tail` now prints the last N lines and exits immediately, matching the behavior of standard `tail` without `-f`. To follow the log in real-time (previous default behavior), pass `-f` or `--follow`.

**Breaking change:** `-f` was previously a shorthand for `--full` (print entire file). It now means `--follow` (consistent with Unix `tail -f`). `--full` still works via its long form.

## Review & Testing Checklist for Human
- [ ] Run `git-ai bg tail` and verify it prints last 20 lines then exits
- [ ] Run `git-ai bg tail -f` and verify it follows the log (old default behavior)
- [ ] Run `git-ai bg tail --follow` and verify same follow behavior
- [ ] Run `git-ai bg tail --full` and verify it still prints the entire file (but now exits without following unless `-f` is also passed)

### Notes
- Help text updated to show the new `[-f | --follow]` option

Link to Devin session: https://app.devin.ai/sessions/951d3fdb847b46fe8c26dd509cea59a6
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->