### PR TITLE
feat: blanket-attribute commits to no-hooks background agents

### DIFF
--- a/src/authorship/background_agent.rs
+++ b/src/authorship/background_agent.rs
@@ -1,0 +1,138 @@
+use crate::authorship::authorship_log::SessionRecord;
+use crate::authorship::authorship_log_serialization::{
+    AttestationEntry, AuthorshipLog, generate_session_id, generate_trace_id,
+};
+use crate::authorship::working_log::AgentId;
+use std::collections::HashMap;
+
+const DEVIN_ID_PATH: &str = "/opt/.devin/devin_id";
+const DEVIN_DIR_PATH: &str = "/opt/.devin";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackgroundAgent {
+    WithHooks { tool: String },
+    NoHooks { tool: String, id: String },
+    None,
+}
+
+pub fn detect() -> BackgroundAgent {
+    if std::env::var("CLAUDE_CODE_REMOTE")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+    {
+        return BackgroundAgent::WithHooks {
+            tool: "claude-web".to_string(),
+        };
+    }
+
+    if std::env::var("CURSOR_AGENT")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return BackgroundAgent::WithHooks {
+            tool: "cursor-agent".to_string(),
+        };
+    }
+
+    if std::env::vars().any(|(k, _)| k.starts_with("CLOUD_AGENT_")) {
+        return BackgroundAgent::NoHooks {
+            tool: "cloud-agent".to_string(),
+            id: placeholder_id("CLOUD_AGENT"),
+        };
+    }
+
+    if std::path::Path::new(DEVIN_DIR_PATH).is_dir() {
+        let id = std::fs::read_to_string(DEVIN_ID_PATH)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| placeholder_id("DEVIN"));
+        return BackgroundAgent::NoHooks {
+            tool: "devin".to_string(),
+            id,
+        };
+    }
+
+    if std::env::var("CODEX_INTERNAL_ORIGINATOR_OVERRIDE")
+        .map(|v| v == "codex_web_agent")
+        .unwrap_or(false)
+    {
+        let id = std::env::var("CODEX_THREAD_ID")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| placeholder_id("CODEX_CLOUD"));
+        return BackgroundAgent::NoHooks {
+            tool: "codex-cloud".to_string(),
+            id,
+        };
+    }
+
+    if std::env::var("GIT_AI_CLOUD_AGENT")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return BackgroundAgent::NoHooks {
+            tool: "git-ai-cloud-agent".to_string(),
+            id: placeholder_id("GIT_AI_CLOUD_AGENT"),
+        };
+    }
+
+    BackgroundAgent::None
+}
+
+/// If running in a no-hooks background agent with an empty authorship log (no
+/// checkpoints were fired), blanket-attribute all committed lines to the agent.
+/// Returns true if attribution was applied.
+pub fn apply_blanket_attribution(
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<crate::authorship::authorship_log::LineRange>>,
+    human_author: &str,
+) -> bool {
+    let BackgroundAgent::NoHooks { tool, id } = detect() else {
+        return false;
+    };
+
+    if committed_hunks.is_empty() {
+        return false;
+    }
+
+    let agent_id = AgentId {
+        tool: tool.clone(),
+        id: id.clone(),
+        model: "unknown".to_string(),
+    };
+
+    let session_key = generate_session_id(&id, &tool);
+    let trace_id = generate_trace_id();
+    let attestation_hash = format!("{}::{}", session_key, trace_id);
+
+    authorship_log.metadata.sessions.insert(
+        session_key,
+        SessionRecord {
+            agent_id,
+            human_author: Some(human_author.to_string()),
+            custom_attributes: None,
+        },
+    );
+
+    for (file_path, line_ranges) in committed_hunks {
+        if line_ranges.is_empty() {
+            continue;
+        }
+        let file_attestation = authorship_log.get_or_create_file(file_path);
+        file_attestation.add_entry(AttestationEntry::new(
+            attestation_hash.clone(),
+            line_ranges.clone(),
+        ));
+    }
+
+    true
+}
+
+fn placeholder_id(name: &str) -> String {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("{name}_SESSION{ts}")
+}

--- a/src/authorship/background_agent.rs
+++ b/src/authorship/background_agent.rs
@@ -1,9 +1,9 @@
-use crate::authorship::authorship_log::SessionRecord;
+use crate::authorship::authorship_log::{LineRange, SessionRecord};
 use crate::authorship::authorship_log_serialization::{
     AttestationEntry, AuthorshipLog, generate_session_id, generate_trace_id,
 };
 use crate::authorship::working_log::AgentId;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 const DEVIN_ID_PATH: &str = "/opt/.devin/devin_id";
 const DEVIN_DIR_PATH: &str = "/opt/.devin";
@@ -80,12 +80,13 @@ pub fn detect() -> BackgroundAgent {
     BackgroundAgent::None
 }
 
-/// If running in a no-hooks background agent with an empty authorship log (no
-/// checkpoints were fired), blanket-attribute all committed lines to the agent.
-/// Returns true if attribution was applied.
-pub fn apply_blanket_attribution(
+/// If running in a no-hooks background agent, attribute any committed lines
+/// that have no existing attestation ("holes") to the detected agent.
+/// Existing attributions (human, other AI) are preserved.
+/// Returns true if any attribution was applied.
+pub fn fill_unattributed_lines(
     authorship_log: &mut AuthorshipLog,
-    committed_hunks: &HashMap<String, Vec<crate::authorship::authorship_log::LineRange>>,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
     human_author: &str,
 ) -> bool {
     let BackgroundAgent::NoHooks { tool, id } = detect() else {
@@ -93,6 +94,43 @@ pub fn apply_blanket_attribution(
     };
 
     if committed_hunks.is_empty() {
+        return false;
+    }
+
+    // Collect already-attributed lines per file
+    let mut attributed_lines: HashMap<&str, HashSet<u32>> = HashMap::new();
+    for file_attestation in &authorship_log.attestations {
+        let lines = attributed_lines
+            .entry(&file_attestation.file_path)
+            .or_default();
+        for entry in &file_attestation.entries {
+            for range in &entry.line_ranges {
+                for line in range.expand() {
+                    lines.insert(line);
+                }
+            }
+        }
+    }
+
+    // Find unattributed lines per file
+    let mut unattributed_hunks: HashMap<String, Vec<LineRange>> = HashMap::new();
+    for (file_path, line_ranges) in committed_hunks {
+        let existing = attributed_lines.get(file_path.as_str());
+        let mut unattributed: Vec<u32> = Vec::new();
+        for range in line_ranges {
+            for line in range.expand() {
+                if existing.is_none_or(|set| !set.contains(&line)) {
+                    unattributed.push(line);
+                }
+            }
+        }
+        if !unattributed.is_empty() {
+            unattributed.sort();
+            unattributed_hunks.insert(file_path.clone(), LineRange::compress_lines(&unattributed));
+        }
+    }
+
+    if unattributed_hunks.is_empty() {
         return false;
     }
 
@@ -115,15 +153,9 @@ pub fn apply_blanket_attribution(
         },
     );
 
-    for (file_path, line_ranges) in committed_hunks {
-        if line_ranges.is_empty() {
-            continue;
-        }
-        let file_attestation = authorship_log.get_or_create_file(file_path);
-        file_attestation.add_entry(AttestationEntry::new(
-            attestation_hash.clone(),
-            line_ranges.clone(),
-        ));
+    for (file_path, line_ranges) in unattributed_hunks {
+        let file_attestation = authorship_log.get_or_create_file(&file_path);
+        file_attestation.add_entry(AttestationEntry::new(attestation_hash.clone(), line_ranges));
     }
 
     true

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_detection;
 pub mod attribution_tracker;
 pub mod authorship_log;
 pub mod authorship_log_serialization;
+pub mod background_agent;
 pub mod diff_ai_accepted;
 pub mod git_ai_hooks;
 pub mod ignore;

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -140,10 +140,14 @@ pub fn post_commit_with_final_state(
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 
-    // No-hooks background agents (Devin, Codex Cloud, etc.) never fire checkpoints,
-    // so the working log is empty and every line would be "untracked." Detect this
-    // and blanket-attribute all committed lines to the agent.
-    if authorship_log.attestations.is_empty() {
+    // No-hooks background agents (Devin, Codex Cloud, etc.) may not fire checkpoints
+    // for all edits. Attribute any committed lines that have no existing attestation
+    // ("holes") to the detected agent, preserving explicit attributions.
+    if !matches!(
+        crate::authorship::background_agent::detect(),
+        crate::authorship::background_agent::BackgroundAgent::None
+            | crate::authorship::background_agent::BackgroundAgent::WithHooks { .. }
+    ) {
         let diff_base = if parent_sha == "initial" {
             "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
         } else {
@@ -163,7 +167,7 @@ pub fn post_commit_with_final_state(
                     )
                 })
                 .collect();
-            crate::authorship::background_agent::apply_blanket_attribution(
+            crate::authorship::background_agent::fill_unattributed_lines(
                 &mut authorship_log,
                 &committed_hunks,
                 &human_author,

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -140,6 +140,37 @@ pub fn post_commit_with_final_state(
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 
+    // No-hooks background agents (Devin, Codex Cloud, etc.) never fire checkpoints,
+    // so the working log is empty and every line would be "untracked." Detect this
+    // and blanket-attribute all committed lines to the agent.
+    if authorship_log.attestations.is_empty() {
+        let diff_base = if parent_sha == "initial" {
+            "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        } else {
+            &parent_sha
+        };
+        if let Ok(added_lines) = repo.diff_added_lines(diff_base, &commit_sha, None) {
+            let committed_hunks: HashMap<
+                String,
+                Vec<crate::authorship::authorship_log::LineRange>,
+            > = added_lines
+                .into_iter()
+                .filter(|(_, lines)| !lines.is_empty())
+                .map(|(path, lines)| {
+                    (
+                        path,
+                        crate::authorship::authorship_log::LineRange::compress_lines(&lines),
+                    )
+                })
+                .collect();
+            crate::authorship::background_agent::apply_blanket_attribution(
+                &mut authorship_log,
+                &committed_hunks,
+                &human_author,
+            );
+        }
+    }
+
     // Long-lived daemon processes should read a fresh config snapshot.
     // Always use Config::fresh() to support runtime config updates
     // (especially important for daemon mode, but also good for consistency)

--- a/src/authorship/rebase_authorship.rs
+++ b/src/authorship/rebase_authorship.rs
@@ -3003,6 +3003,39 @@ pub fn rewrite_authorship_after_commit_amend_with_snapshot(
     // Update base commit SHA
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 
+    // Fill unattributed lines with bg agent attribution (same as post_commit path)
+    if !matches!(
+        crate::authorship::background_agent::detect(),
+        crate::authorship::background_agent::BackgroundAgent::None
+            | crate::authorship::background_agent::BackgroundAgent::WithHooks { .. }
+    ) {
+        let diff_base = if parent_sha == "initial" {
+            "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        } else {
+            &parent_sha
+        };
+        if let Ok(added_lines) = repo.diff_added_lines(diff_base, amended_commit, None) {
+            let committed_hunks: std::collections::HashMap<
+                String,
+                Vec<crate::authorship::authorship_log::LineRange>,
+            > = added_lines
+                .into_iter()
+                .filter(|(_, lines)| !lines.is_empty())
+                .map(|(path, lines)| {
+                    (
+                        path,
+                        crate::authorship::authorship_log::LineRange::compress_lines(&lines),
+                    )
+                })
+                .collect();
+            crate::authorship::background_agent::fill_unattributed_lines(
+                &mut authorship_log,
+                &committed_hunks,
+                &human_author,
+            );
+        }
+    }
+
     // Preserve human contributors from the original commit's note — deleting a
     // KnownHuman-attributed line removes the attribution coordinate but must not
     // erase the contributor's association with the commit.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 static IS_TERMINAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-static IS_IN_BACKGROUND_AGENT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
 /// Print a git diff in a readable format
 ///
@@ -146,17 +145,10 @@ pub fn is_interactive_terminal() -> bool {
 
 /// Returns true if the process is running inside a background AI agent environment.
 pub fn is_in_background_agent() -> bool {
-    *IS_IN_BACKGROUND_AGENT.get_or_init(|| {
-        // Claude Code remote agent (Anthropic)
-        std::env::var("CLAUDE_CODE_REMOTE").map(|v| v == "true").unwrap_or(false)
-            // Cursor background agent
-            || std::env::var("CURSOR_AGENT").map(|v| v == "1").unwrap_or(false)
-            // Cloud agent environment (CLOUD_AGENT_* prefix)
-            || std::env::vars().any(|(k, _)| k.starts_with("CLOUD_AGENT_"))
-            || std::path::Path::new("/opt/.devin").is_dir()
-            // Explicit opt-in for cloud/background agent environments
-            || std::env::var("GIT_AI_CLOUD_AGENT").map(|v| v == "1").unwrap_or(false)
-    })
+    !matches!(
+        crate::authorship::background_agent::detect(),
+        crate::authorship::background_agent::BackgroundAgent::None
+    )
 }
 
 /// A cross-platform exclusive file lock.

--- a/tests/integration/background_agent_attribution.rs
+++ b/tests/integration/background_agent_attribution.rs
@@ -1,5 +1,5 @@
 use crate::repos::test_file::ExpectedLineExt;
-use crate::repos::test_repo::{DaemonTestScope, GitTestMode, TestRepo};
+use crate::repos::test_repo::TestRepo;
 use std::fs;
 
 /// When git-ai runs inside a no-hooks background agent (simulated via

--- a/tests/integration/background_agent_attribution.rs
+++ b/tests/integration/background_agent_attribution.rs
@@ -1,5 +1,5 @@
 use crate::repos::test_file::ExpectedLineExt;
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{DaemonTestScope, GitTestMode, TestRepo};
 use std::fs;
 
 /// When git-ai runs inside a no-hooks background agent (simulated via
@@ -113,4 +113,58 @@ fn test_with_hooks_agent_does_not_blanket_attribute() {
 
     let mut file = repo.filename("file.txt");
     file.assert_committed_lines(crate::lines!["line".unattributed_human()]);
+}
+
+/// Rebase must NOT re-attribute lines to the background agent. The original
+/// attribution (from the commit being rebased) should be preserved through
+/// the rebase operation.
+#[test]
+fn test_rebase_does_not_reattribute_to_bg_agent() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    // Commit 1: base
+    fs::write(repo.path().join("file.txt"), "base line\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+
+    // Commit 2: AI adds a line (attributed to bg agent via our new logic)
+    fs::write(repo.path().join("file.txt"), "base line\nai line\n").unwrap();
+    repo.stage_all_and_commit("ai commit").unwrap();
+
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["base line".ai(), "ai line".ai()]);
+
+    // Create a side branch from base and add a different file
+    repo.git(&["checkout", "-b", "side", "HEAD~1"]).unwrap();
+    fs::write(repo.path().join("other.txt"), "side content\n").unwrap();
+    repo.stage_all_and_commit("side commit").unwrap();
+
+    // Go back to main and rebase onto side
+    repo.git(&["checkout", "-"]).unwrap();
+    repo.git(&["rebase", "side"]).unwrap();
+
+    // After rebase, the AI line should still be attributed to AI (the same
+    // agent), not re-attributed or doubled.
+    file.assert_committed_lines(crate::lines!["base line".ai(), "ai line".ai()]);
+}
+
+/// Amend preserves existing attribution and fills holes for new lines.
+#[test]
+fn test_amend_preserves_existing_and_attributes_new_lines() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    // Commit with explicit AI checkpoint
+    fs::write(repo.path().join("file.txt"), "original\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "file.txt"]).unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["original".ai()]);
+
+    // Amend: add a line without firing a checkpoint
+    fs::write(repo.path().join("file.txt"), "original\namended line\n").unwrap();
+    repo.git(&["add", "."]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"]).unwrap();
+
+    // Original AI attribution preserved; new line attributed to bg agent
+    file.assert_committed_lines(crate::lines!["original".ai(), "amended line".ai()]);
 }

--- a/tests/integration/background_agent_attribution.rs
+++ b/tests/integration/background_agent_attribution.rs
@@ -6,19 +6,84 @@ use std::fs;
 /// `GIT_AI_CLOUD_AGENT=1` on the daemon), commits should be attributed wholly
 /// to the detected AI tool even though no checkpoints were fired.
 #[test]
-fn test_no_hooks_background_agent_commit_attributed_to_ai() {
+fn test_no_hooks_agent_all_lines_attributed() {
     let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
 
-    fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
-    repo.stage_all_and_commit("seed").unwrap();
-    let mut seed_file = repo.filename("seed.txt");
-    seed_file.assert_committed_lines(crate::lines!["seed line".ai()]);
+    fs::write(repo.path().join("file.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    repo.stage_all_and_commit("first commit").unwrap();
 
-    fs::write(repo.path().join("cloud.txt"), "alpha\nbeta\ngamma\n").unwrap();
-    repo.stage_all_and_commit("cloud agent edit").unwrap();
-
-    let mut file = repo.filename("cloud.txt");
+    let mut file = repo.filename("file.txt");
     file.assert_committed_lines(crate::lines!["alpha".ai(), "beta".ai(), "gamma".ai()]);
+}
+
+/// Multiple files in a single commit are all attributed.
+#[test]
+fn test_no_hooks_agent_multiple_files() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    fs::write(repo.path().join("a.txt"), "line a\n").unwrap();
+    fs::write(repo.path().join("b.txt"), "line b\n").unwrap();
+    repo.stage_all_and_commit("multi file").unwrap();
+
+    let mut a = repo.filename("a.txt");
+    a.assert_committed_lines(crate::lines!["line a".ai()]);
+    let mut b = repo.filename("b.txt");
+    b.assert_committed_lines(crate::lines!["line b".ai()]);
+}
+
+/// When lines already have explicit attribution (e.g. from a KnownHuman
+/// checkpoint fired by an IDE extension), only the unattributed "holes"
+/// get the background agent attribution.
+#[test]
+fn test_no_hooks_agent_preserves_existing_attribution() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    // Seed commit so we have a base
+    fs::write(repo.path().join("seed.txt"), "seed\n").unwrap();
+    repo.stage_all_and_commit("seed").unwrap();
+
+    // Simulate: human types some lines (KnownHuman checkpoint), then agent adds more
+    // without firing its own checkpoint.
+    let content = "human typed this\nagent added this\nagent also added this\n";
+    fs::write(repo.path().join("mixed.txt"), content).unwrap();
+    // Fire a KnownHuman checkpoint for the file BEFORE the agent edits
+    // (simulates IDE extension detecting human keystrokes for just the first line)
+    fs::write(repo.path().join("mixed.txt"), "human typed this\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "mixed.txt"])
+        .unwrap();
+
+    // Now the agent adds more lines without firing a checkpoint
+    fs::write(
+        repo.path().join("mixed.txt"),
+        "human typed this\nagent added this\nagent also added this\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("mixed edit").unwrap();
+
+    let mut file = repo.filename("mixed.txt");
+    file.assert_committed_lines(crate::lines![
+        "human typed this".human(),
+        "agent added this".ai(),
+        "agent also added this".ai(),
+    ]);
+}
+
+/// When the background agent modifies an existing file (appends lines),
+/// only the new lines get attributed.
+#[test]
+fn test_no_hooks_agent_append_to_existing_file() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    fs::write(repo.path().join("file.txt"), "original\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["original".ai()]);
+
+    fs::write(repo.path().join("file.txt"), "original\nnew line\n").unwrap();
+    repo.stage_all_and_commit("append").unwrap();
+
+    file.assert_committed_lines(crate::lines!["original".ai(), "new line".ai()]);
 }
 
 /// Negative control: same shape, no env var. Lines that arrived without any
@@ -26,11 +91,6 @@ fn test_no_hooks_background_agent_commit_attributed_to_ai() {
 #[test]
 fn test_without_background_agent_env_lines_are_untracked() {
     let repo = TestRepo::new();
-
-    fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
-    repo.stage_all_and_commit("seed").unwrap();
-    let mut seed_file = repo.filename("seed.txt");
-    seed_file.assert_committed_lines(crate::lines!["seed line".unattributed_human()]);
 
     fs::write(repo.path().join("plain.txt"), "alpha\nbeta\n").unwrap();
     repo.stage_all_and_commit("no agent").unwrap();
@@ -42,18 +102,15 @@ fn test_without_background_agent_env_lines_are_untracked() {
     ]);
 }
 
-/// When the background agent modifies an existing file, only the new/changed
-/// lines get attributed — pre-existing lines remain unaffected.
+/// With-hooks agents (Claude Code remote, Cursor) should NOT trigger
+/// blanket attribution — they fire their own checkpoints.
 #[test]
-fn test_background_agent_partial_file_edit() {
-    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+fn test_with_hooks_agent_does_not_blanket_attribute() {
+    let repo = TestRepo::new_with_daemon_env(&[("CLAUDE_CODE_REMOTE", "true")]);
 
-    fs::write(repo.path().join("file.txt"), "original\n").unwrap();
-    repo.stage_all_and_commit("initial").unwrap();
-
-    fs::write(repo.path().join("file.txt"), "original\nnew line\n").unwrap();
-    repo.stage_all_and_commit("add line").unwrap();
+    fs::write(repo.path().join("file.txt"), "line\n").unwrap();
+    repo.stage_all_and_commit("commit").unwrap();
 
     let mut file = repo.filename("file.txt");
-    file.assert_committed_lines(crate::lines!["original".ai(), "new line".ai()]);
+    file.assert_committed_lines(crate::lines!["line".unattributed_human()]);
 }

--- a/tests/integration/background_agent_attribution.rs
+++ b/tests/integration/background_agent_attribution.rs
@@ -1,0 +1,59 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+/// When git-ai runs inside a no-hooks background agent (simulated via
+/// `GIT_AI_CLOUD_AGENT=1` on the daemon), commits should be attributed wholly
+/// to the detected AI tool even though no checkpoints were fired.
+#[test]
+fn test_no_hooks_background_agent_commit_attributed_to_ai() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
+    repo.stage_all_and_commit("seed").unwrap();
+    let mut seed_file = repo.filename("seed.txt");
+    seed_file.assert_committed_lines(crate::lines!["seed line".ai()]);
+
+    fs::write(repo.path().join("cloud.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    repo.stage_all_and_commit("cloud agent edit").unwrap();
+
+    let mut file = repo.filename("cloud.txt");
+    file.assert_committed_lines(crate::lines!["alpha".ai(), "beta".ai(), "gamma".ai()]);
+}
+
+/// Negative control: same shape, no env var. Lines that arrived without any
+/// checkpoint are untracked.
+#[test]
+fn test_without_background_agent_env_lines_are_untracked() {
+    let repo = TestRepo::new();
+
+    fs::write(repo.path().join("seed.txt"), "seed line\n").unwrap();
+    repo.stage_all_and_commit("seed").unwrap();
+    let mut seed_file = repo.filename("seed.txt");
+    seed_file.assert_committed_lines(crate::lines!["seed line".unattributed_human()]);
+
+    fs::write(repo.path().join("plain.txt"), "alpha\nbeta\n").unwrap();
+    repo.stage_all_and_commit("no agent").unwrap();
+
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(crate::lines![
+        "alpha".unattributed_human(),
+        "beta".unattributed_human(),
+    ]);
+}
+
+/// When the background agent modifies an existing file, only the new/changed
+/// lines get attributed — pre-existing lines remain unaffected.
+#[test]
+fn test_background_agent_partial_file_edit() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_CLOUD_AGENT", "1")]);
+
+    fs::write(repo.path().join("file.txt"), "original\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(repo.path().join("file.txt"), "original\nnew line\n").unwrap();
+    repo.stage_all_and_commit("add line").unwrap();
+
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["original".ai(), "new line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod ai_tab;
 mod amend;
 mod amp;
 mod attribution_tracker_comprehensive;
+mod background_agent_attribution;
 mod bash_attribution;
 mod bash_tool_benchmark;
 mod bash_tool_conformance;

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -17,6 +17,9 @@ const AI_AUTHOR_NAMES: &[&str] = &[
     "amp",
     "windsurf",
     "devin",
+    "cloud-agent",
+    "codex-cloud",
+    "git-ai-cloud-agent",
 ];
 
 #[derive(Debug, Clone, PartialEq)]

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -204,6 +204,15 @@ impl DaemonProcess {
     }
 
     fn start(repo_path: &Path, test_home: &Path, test_db_path: &Path) -> Self {
+        Self::start_with_env(repo_path, test_home, test_db_path, &[])
+    }
+
+    fn start_with_env(
+        repo_path: &Path,
+        test_home: &Path,
+        test_db_path: &Path,
+        extra_env: &[(&str, &str)],
+    ) -> Self {
         let control_socket_path = Self::control_socket_path_for_home(test_home);
         let trace_socket_path = Self::trace_socket_path_for_home(test_home);
         let stderr_log_path = test_home
@@ -240,6 +249,9 @@ impl DaemonProcess {
                     .try_clone()
                     .expect("failed to clone daemon stderr log file"),
             );
+        for (key, value) in extra_env {
+            command.env(key, value);
+        }
         configure_test_home_env(&mut command, test_home);
 
         let mut child = command
@@ -1240,6 +1252,50 @@ impl TestRepo {
         repo.setup_daemon_mode();
         repo.setup_git_hooks_mode();
 
+        repo
+    }
+
+    pub fn new_with_daemon_env(daemon_env: &[(&str, &str)]) -> Self {
+        ensure_isolated_process_home();
+
+        let mut rng = rand::rng();
+        let n: u64 = rng.random_range(0..10000000000);
+        let base = std::env::temp_dir();
+        let path = base.join(n.to_string());
+        let test_home = base.join(format!("{}-home", n));
+        let git_mode = GitTestMode::from_env();
+        let test_db_path = resolve_test_db_path(&base, n, &test_home, git_mode);
+
+        clone_template_to(&path);
+
+        let mut repo = Self {
+            path,
+            feature_flags: FeatureFlags::default(),
+            config_patch: None,
+            test_db_path,
+            test_home,
+            git_mode,
+            daemon_scope: DaemonTestScope::Dedicated,
+            daemon_process: None,
+            _base_repo_path: None,
+            _base_test_db_path: None,
+            daemon_family_key: OnceLock::new(),
+        };
+
+        repo.apply_default_config_patch();
+
+        // Start a dedicated daemon with extra env vars
+        let daemon = Arc::new(DaemonProcess::start_with_env(
+            &repo.path,
+            &repo.test_home,
+            &repo.test_db_path,
+            daemon_env,
+        ));
+        repo.test_db_path = daemon.test_db_path.clone();
+        repo.daemon_process = Some(daemon);
+        repo.sync_test_home_config_for_hooks();
+
+        repo.setup_git_hooks_mode();
         repo
     }
 


### PR DESCRIPTION
## Summary

Simpler replacement for #1234. Instead of synthesizing fake checkpoints through the full checkpoint machinery (wrapper pre-commit + daemon replay + synthetic `CheckpointRequest`), this detects no-hooks background agents at authorship finalization time and blanket-attributes all committed lines when no checkpoints exist.

**Key insight:** The daemon runs inside the agent sandbox and inherits its env vars. There's no need to route through the wrapper (which may not even be in the git path in these environments).

## How it works

In `post_commit_with_final_state`, after the authorship log is generated:
1. If the log has zero attestation entries (no checkpoints were fired)
2. AND `background_agent::detect()` returns a no-hooks agent (Devin, Codex Cloud, etc.)
3. Then compute the committed diff and attribute all added lines to the detected agent

This is ~30 lines of logic in one place vs the previous PR's approach of threading synthetic checkpoints through 3 different code paths.

## Changes

- `src/authorship/background_agent.rs` — new module: agent detection (`detect()`) and `apply_blanket_attribution()`
- `src/authorship/post_commit.rs` — 15-line integration point after authorship log generation
- `src/utils.rs` — `is_in_background_agent()` now delegates to the new module
- Test infrastructure: `TestRepo::new_with_daemon_env()` / `DaemonProcess::start_with_env()` for passing env vars to the test daemon

## Test plan

- [x] `test_no_hooks_background_agent_commit_attributed_to_ai` — all lines attributed to AI
- [x] `test_without_background_agent_env_lines_are_untracked` — negative control
- [x] `test_background_agent_partial_file_edit` — appended lines also attributed
- [x] Existing `agent_commits_blame` tests pass (25/25)
- [x] Existing `ai_tab` tests pass (12/12)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->