### PR TITLE
feat: add CodeBuddy CN preset and hook installer (rebased on new framework)

### DIFF
--- a/src/commands/checkpoint_agent/presets/claude.rs
+++ b/src/commands/checkpoint_agent/presets/claude.rs
@@ -28,6 +28,22 @@ impl ClaudePreset {
                 .map(|p| p.contains(".cursor"))
                 .unwrap_or(false)
     }
+
+    fn is_codebuddy_hook_payload(data: &serde_json::Value) -> bool {
+        if data.get("client").and_then(|v| v.as_str()) == Some("CodeBuddyIDE") {
+            return true;
+        }
+        // Path-segment match (not raw substring) so legitimate Claude paths
+        // that merely contain the string "codebuddyextension" elsewhere don't
+        // get falsely rejected. CodeBuddy CN's real layout has the segment
+        // exactly: e.g. ".../CodeBuddyExtension/Data/...".
+        parse::optional_str(data, "transcript_path")
+            .map(|p| {
+                let normalized = p.replace('\\', "/").to_lowercase();
+                normalized.contains("/codebuddyextension/")
+            })
+            .unwrap_or(false)
+    }
 }
 
 impl AgentPreset for ClaudePreset {
@@ -44,6 +60,12 @@ impl AgentPreset for ClaudePreset {
         if Self::is_cursor_hook_payload(&data) {
             return Err(GitAiError::PresetError(
                 "Skipping Cursor hook payload in Claude preset; use cursor hooks.".to_string(),
+            ));
+        }
+        if Self::is_codebuddy_hook_payload(&data) {
+            return Err(GitAiError::PresetError(
+                "Skipping CodeBuddy hook payload in Claude preset; use codebuddy hooks."
+                    .to_string(),
             ));
         }
 
@@ -251,5 +273,68 @@ mod tests {
         })
         .to_string();
         assert!(ClaudePreset.parse(&input, "t_test123456789a").is_err());
+    }
+
+    #[test]
+    fn test_claude_skips_codebuddy_payload_by_client() {
+        let input = json!({
+            "transcript_path": "/home/user/.claude/projects/abc.jsonl",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/main.rs"},
+            "client": "CodeBuddyIDE"
+        })
+        .to_string();
+        let result = ClaudePreset.parse(&input, "t_test123456789a");
+        assert!(result.is_err());
+        match result {
+            Err(GitAiError::PresetError(msg)) => {
+                assert!(
+                    msg.to_lowercase().contains("codebuddy"),
+                    "expected CodeBuddy hint in error: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected PresetError"),
+        }
+    }
+
+    #[test]
+    fn test_claude_skips_codebuddy_payload_by_transcript_path() {
+        let input = json!({
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/sess/index.json",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string();
+        assert!(ClaudePreset.parse(&input, "t_test123456789a").is_err());
+    }
+
+    #[test]
+    fn test_claude_does_not_falsely_reject_paths_containing_codebuddyextension_substring() {
+        // Regression: an earlier substring-based guard would falsely reject
+        // legitimate Claude paths that happened to contain the string
+        // "codebuddyextension" anywhere (e.g. a project named like the upstream
+        // tool). The guard must require the exact `/codebuddyextension/`
+        // path segment.
+        let input = json!({
+            "transcript_path": "/Users/u/work/codebuddyextension-port/.claude/projects/abc.jsonl",
+            "cwd": "/Users/u/work/codebuddyextension-port",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string();
+        // Should parse cleanly as a Claude payload.
+        let events = ClaudePreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "claude");
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
     }
 }

--- a/src/commands/checkpoint_agent/presets/codebuddy.rs
+++ b/src/commands/checkpoint_agent/presets/codebuddy.rs
@@ -1,0 +1,420 @@
+//! CodeBuddy CN preset.
+//!
+//! CodeBuddy CN (Tencent) is Claude Code-compatible at the hook protocol layer
+//! but diverges in three notable ways:
+//!   1. `tool_input.filePath` is camelCase (Claude uses `file_path`).
+//!   2. `cwd` is always `"/"` due to a known CodeBuddy bug — repo discovery
+//!      relies on the absolute paths in `tool_input.filePath` instead.
+//!   3. Identifying signals: `client: "CodeBuddyIDE"` and a transcript path
+//!      under `CodeBuddyExtension`. CodeBuddy supports many models (e.g.
+//!      `glm-5.0-turbo`, Claude variants, Hunyuan); the model field is
+//!      passed through verbatim.
+//!
+//! Tool naming for file edits mirrors Claude (`Write`/`Edit`/`MultiEdit`),
+//! so we reuse `bash_tool::Agent::Claude` for tool classification of edits.
+//!
+//! **Bash tool calls are intentionally not handled.** CodeBuddy's `cwd: "/"`
+//! bug means `discover_repository_in_path` would either fail or — worse —
+//! find an unrelated parent repo. Until CodeBuddy fixes the bug or sends
+//! `tool_input.cwd`, we skip bash hooks entirely (no checkpoint emitted).
+//!
+//! Transcript reading for the directory-based `index.json + messages/` layout
+//! is intentionally deferred — `transcript_source` is set to `None` so the
+//! orchestrator does not try to feed a directory to a JSONL reader. Hook
+//! attribution still works without it.
+
+use super::parse;
+use super::{AgentPreset, ParsedHookEvent, PostFileEdit, PreFileEdit, PresetContext};
+use crate::authorship::working_log::AgentId;
+use crate::commands::checkpoint_agent::bash_tool::{self, Agent, ToolClass};
+use crate::error::GitAiError;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub struct CodeBuddyPreset;
+
+impl CodeBuddyPreset {
+    /// Extract the absolute file path from `tool_input.filePath`. CodeBuddy CN
+    /// uses camelCase, distinct from Claude's `file_path`. The path is always
+    /// absolute when present.
+    fn file_path_from_tool_input(data: &Value) -> Vec<PathBuf> {
+        let Some(tool_input) = data.get("tool_input") else {
+            return vec![];
+        };
+        match tool_input.get("filePath").and_then(|v| v.as_str()) {
+            Some(p) if !p.is_empty() => vec![PathBuf::from(p)],
+            _ => vec![],
+        }
+    }
+
+    /// Derive a session id from the transcript path when no explicit `session_id`
+    /// field is present. CodeBuddy CN's transcript files are always named
+    /// `index.json` and live under `.../<session-uuid>/index.json`, so the file
+    /// stem ("index") is useless — use the parent directory name instead.
+    fn session_id_from_transcript_path(transcript_path: &str) -> String {
+        std::path::Path::new(transcript_path)
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
+impl AgentPreset for CodeBuddyPreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        let data: Value = serde_json::from_str(hook_input)
+            .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
+
+        let transcript_path = parse::required_str(&data, "transcript_path")?;
+        let cwd = parse::optional_str(&data, "cwd").unwrap_or("/");
+
+        let session_id = parse::optional_str(&data, "session_id")
+            .map(str::to_string)
+            .unwrap_or_else(|| Self::session_id_from_transcript_path(transcript_path));
+
+        let model = parse::optional_str(&data, "model")
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let tool_name = parse::optional_str_multi(&data, &["tool_name", "toolName"]);
+        let hook_event = parse::optional_str_multi(&data, &["hook_event_name", "hookEventName"]);
+
+        // CodeBuddy mirrors Claude's tool taxonomy for file edits. Bash hooks
+        // are explicitly skipped — see the module-level comment above.
+        let tool_class = tool_name
+            .map(|n| bash_tool::classify_tool(Agent::Claude, n))
+            .unwrap_or(ToolClass::Skip);
+        if tool_class == ToolClass::Bash {
+            return Err(GitAiError::PresetError(
+                "CodeBuddy bash hooks are not supported (cwd: \"/\" makes repo discovery unreliable)"
+                    .to_string(),
+            ));
+        }
+
+        let mut metadata =
+            HashMap::from([("transcript_path".to_string(), transcript_path.to_string())]);
+        if let Some(client) = parse::optional_str(&data, "client") {
+            metadata.insert("client".to_string(), client.to_string());
+        }
+        if let Some(version) = parse::optional_str(&data, "version") {
+            metadata.insert("client_version".to_string(), version.to_string());
+        }
+        if let Some(generation_id) = parse::optional_str(&data, "generation_id") {
+            metadata.insert("generation_id".to_string(), generation_id.to_string());
+        }
+
+        let context = PresetContext {
+            agent_id: AgentId {
+                tool: "codebuddy".to_string(),
+                id: session_id.clone(),
+                model,
+            },
+            session_id,
+            trace_id: trace_id.to_string(),
+            cwd: PathBuf::from(cwd),
+            metadata,
+        };
+
+        // Transcript reader for the directory-based index.json+messages/ layout
+        // is not yet implemented. Set transcript_source to None — pointing the
+        // existing JSONL reader at index.json (a JSON object, not JSONL) would
+        // produce noisy parse errors in daemon logs without recovering any
+        // events. Hook-based attribution works without it; a dedicated reader
+        // can land in a follow-up.
+        let transcript_source = None;
+
+        let event = match hook_event {
+            Some("PreToolUse") => ParsedHookEvent::PreFileEdit(PreFileEdit {
+                context,
+                file_paths: Self::file_path_from_tool_input(&data),
+                dirty_files: None,
+            }),
+            _ => ParsedHookEvent::PostFileEdit(PostFileEdit {
+                context,
+                file_paths: Self::file_path_from_tool_input(&data),
+                dirty_files: None,
+                transcript_source,
+            }),
+        };
+
+        Ok(vec![event])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::checkpoint_agent::presets::*;
+    use serde_json::json;
+
+    fn make_hook_input(event: &str, tool: &str) -> String {
+        json!({
+            "session_id": "sess-cb-1",
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/u1/CodeBuddyIDE/u2/history/u3/sess-cb-1/index.json",
+            "cwd": "/",
+            "hook_event_name": event,
+            "tool_name": tool,
+            "tool_input": {"filePath": "/private/tmp/git-ai-demo/app.py", "new_str": "print('hi')"},
+            "generation_id": "gen-1",
+            "model": "glm-5.0-turbo",
+            "client": "CodeBuddyIDE",
+            "version": "4.7.0"
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codebuddy_post_file_edit_basic() {
+        let input = make_hook_input("PostToolUse", "Edit");
+        let events = CodeBuddyPreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "codebuddy");
+                assert_eq!(e.context.agent_id.id, "sess-cb-1");
+                assert_eq!(e.context.session_id, "sess-cb-1");
+                assert_eq!(e.context.trace_id, "t_test123456789a");
+                assert_eq!(e.context.cwd, PathBuf::from("/"));
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/private/tmp/git-ai-demo/app.py")]
+                );
+                assert!(e.transcript_source.is_none());
+                assert!(e.dirty_files.is_none());
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_uses_filepath_for_repo_discovery_when_cwd_is_root() {
+        // When cwd is "/" (the CodeBuddy bug), the file_paths must still carry
+        // the file path verbatim from `tool_input.filePath` so the orchestrator's
+        // repo discovery (which uses file_paths[0], not cwd) succeeds. We don't
+        // assert `is_absolute()` here because that's platform-dependent (Windows
+        // considers a Unix-style `/private/tmp/...` non-absolute since it lacks
+        // a drive letter), and CodeBuddy CN's hook payloads are produced by
+        // macOS/Linux clients — what we care about is byte-for-byte preservation.
+        let input = make_hook_input("PostToolUse", "Write");
+        let events = CodeBuddyPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.cwd, PathBuf::from("/"));
+                assert_eq!(e.file_paths.len(), 1);
+                assert_eq!(
+                    e.file_paths[0],
+                    PathBuf::from("/private/tmp/git-ai-demo/app.py")
+                );
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_extracts_model_from_hook_data() {
+        let input = make_hook_input("PostToolUse", "Edit");
+        let events = CodeBuddyPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.model, "glm-5.0-turbo");
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_default_model_when_missing() {
+        let input = json!({
+            "session_id": "sess-cb-2",
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/u1/CodeBuddyIDE/u2/history/u3/sess-cb-2/index.json",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"filePath": "/tmp/proj/file.rs"}
+        })
+        .to_string();
+        let events = CodeBuddyPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.model, "unknown");
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_pre_file_edit() {
+        let input = make_hook_input("PreToolUse", "Edit");
+        let events = CodeBuddyPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "codebuddy");
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/private/tmp/git-ai-demo/app.py")]
+                );
+                assert!(e.dirty_files.is_none());
+            }
+            _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_pre_bash_call_is_rejected() {
+        // CodeBuddy bash hooks cannot be safely processed because cwd:"/"
+        // makes repo discovery unreliable. The preset must explicitly reject
+        // bash payloads rather than silently mis-attribute to the wrong repo.
+        let input = json!({
+            "session_id": "sess-cb-bash",
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/u1/CodeBuddyIDE/u2/history/u3/sess-cb-bash/index.json",
+            "cwd": "/",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tu-bash-1",
+            "tool_input": {"command": "ls"},
+            "model": "glm-5.0-turbo",
+            "client": "CodeBuddyIDE"
+        })
+        .to_string();
+        let result = CodeBuddyPreset.parse(&input, "t_test");
+        assert!(result.is_err());
+        match result {
+            Err(GitAiError::PresetError(msg)) => {
+                assert!(
+                    msg.contains("bash hooks are not supported"),
+                    "expected bash rejection message, got: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected PresetError"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_post_bash_call_is_rejected() {
+        let input = json!({
+            "session_id": "sess-cb-bash2",
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/u1/CodeBuddyIDE/u2/history/u3/sess-cb-bash2/index.json",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tu-bash-2",
+            "tool_input": {"command": "ls"},
+            "model": "glm-5.0-turbo",
+            "client": "CodeBuddyIDE"
+        })
+        .to_string();
+        let result = CodeBuddyPreset.parse(&input, "t_test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_codebuddy_metadata_includes_client_and_version() {
+        let input = make_hook_input("PostToolUse", "Edit");
+        let events = CodeBuddyPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(
+                    e.context.metadata.get("client").map(String::as_str),
+                    Some("CodeBuddyIDE")
+                );
+                assert_eq!(
+                    e.context.metadata.get("client_version").map(String::as_str),
+                    Some("4.7.0")
+                );
+                assert_eq!(
+                    e.context.metadata.get("generation_id").map(String::as_str),
+                    Some("gen-1")
+                );
+                assert!(e.context.metadata.contains_key("transcript_path"));
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_session_id_falls_back_to_transcript_stem() {
+        // No explicit session_id; should derive from transcript_path's parent
+        // directory name (CodeBuddy stores transcripts as <session-id>/index.json,
+        // so the file stem "index" is useless and we use the parent dir).
+        let input = json!({
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/derived-id-123/index.json",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"filePath": "/tmp/file.rs"}
+        })
+        .to_string();
+        let events = CodeBuddyPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.session_id, "derived-id-123");
+                assert_eq!(e.context.agent_id.id, "derived-id-123");
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_invalid_json_errors() {
+        let result = CodeBuddyPreset.parse("not valid json", "t_test");
+        assert!(result.is_err());
+        match result {
+            Err(GitAiError::PresetError(msg)) => {
+                assert!(msg.contains("Invalid JSON"), "msg was: {}", msg);
+            }
+            _ => panic!("Expected PresetError"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_missing_transcript_path_errors() {
+        let input = json!({
+            "session_id": "x",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"filePath": "/tmp/file.rs"}
+        })
+        .to_string();
+        let result = CodeBuddyPreset.parse(&input, "t_test");
+        assert!(result.is_err());
+        match result {
+            Err(GitAiError::PresetError(msg)) => {
+                assert!(
+                    msg.contains("transcript_path"),
+                    "expected transcript_path in msg: {}",
+                    msg
+                );
+            }
+            _ => panic!("Expected PresetError for missing transcript_path"),
+        }
+    }
+
+    #[test]
+    fn test_codebuddy_missing_tool_input_filepath_yields_empty_paths() {
+        // Hook event with no filePath should still parse but produce empty
+        // file_paths — the orchestrator will then no-op gracefully (no repo
+        // discovery target, no checkpoint emitted).
+        let input = json!({
+            "session_id": "sess",
+            "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/sess/index.json",
+            "cwd": "/",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {}
+        })
+        .to_string();
+        let events = CodeBuddyPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert!(e.file_paths.is_empty());
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+}

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -4,6 +4,7 @@ mod agent_v1;
 mod ai_tab;
 mod amp;
 mod claude;
+mod codebuddy;
 mod codex;
 mod continue_cli;
 mod cursor;
@@ -144,6 +145,7 @@ pub trait AgentPreset {
 pub fn resolve_preset(name: &str) -> Result<Box<dyn AgentPreset>, GitAiError> {
     match name {
         "claude" => Ok(Box::new(claude::ClaudePreset)),
+        "codebuddy" => Ok(Box::new(codebuddy::CodeBuddyPreset)),
         "codex" => Ok(Box::new(codex::CodexPreset)),
         "gemini" => Ok(Box::new(gemini::GeminiPreset)),
         "windsurf" => Ok(Box::new(windsurf::WindsurfPreset)),

--- a/src/mdm/agents/codebuddy.rs
+++ b/src/mdm/agents/codebuddy.rs
@@ -1,0 +1,1018 @@
+//! Hook installer for CodeBuddy CN (Tencent's Claude Code-compatible IDE).
+//!
+//! CodeBuddy CN's settings.json schema mirrors Claude Code's
+//! (`hooks.PreToolUse[].matcher` + `hooks` array of `{type, command}` entries),
+//! so the install/uninstall logic mirrors `ClaudeCodeInstaller` closely.
+//!
+//! Settings location varies by OS (and can be overridden via the
+//! `CODEBUDDY_CONFIG_DIR` env var):
+//!   - macOS:   `~/Library/Application Support/CodeBuddyExtension/settings.json`
+//!   - Linux:   `~/.config/CodeBuddyExtension/settings.json`
+//!   - Windows: `%APPDATA%\CodeBuddyExtension\settings.json`
+//!
+//! Per CodeBuddy CN docs, the `*` catch-all matcher is not supported; tool
+//! matchers must be regex patterns. We use `".*"` to match all tools.
+
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
+use crate::mdm::utils::{
+    generate_diff, home_dir, is_git_ai_checkpoint_command, to_git_bash_path, write_atomic,
+};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CODEBUDDY_PRE_TOOL_CMD: &str = "checkpoint codebuddy --hook-input stdin";
+const CODEBUDDY_POST_TOOL_CMD: &str = "checkpoint codebuddy --hook-input stdin";
+/// CodeBuddy CN requires regex matchers; `*` alone does not match. Use `.*`.
+const CODEBUDDY_CATCH_ALL_MATCHER: &str = ".*";
+
+/// Returns true only for git-ai commands belonging to *this* preset
+/// (`git-ai checkpoint codebuddy ...`). The shared `is_git_ai_checkpoint_command`
+/// helper matches any `git-ai checkpoint <preset>` line, which would cause this
+/// installer to clobber sibling presets' commands if a user happened to mix them
+/// in the same `settings.json`.
+fn is_codebuddy_checkpoint_command(cmd: &str) -> bool {
+    is_git_ai_checkpoint_command(cmd) && cmd.contains("checkpoint codebuddy")
+}
+
+pub struct CodeBuddyInstaller;
+
+impl CodeBuddyInstaller {
+    /// CodeBuddy CN settings directory. Honors `CODEBUDDY_CONFIG_DIR` when set,
+    /// so users on systems with a non-standard install location can correct
+    /// the path without a code change.
+    fn settings_dir() -> PathBuf {
+        if let Ok(dir) = std::env::var("CODEBUDDY_CONFIG_DIR")
+            && !dir.is_empty()
+        {
+            return PathBuf::from(dir);
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            home_dir()
+                .join("Library")
+                .join("Application Support")
+                .join("CodeBuddyExtension")
+        }
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            home_dir().join(".config").join("CodeBuddyExtension")
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            std::env::var("APPDATA")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| home_dir().join("AppData").join("Roaming"))
+                .join("CodeBuddyExtension")
+        }
+    }
+
+    fn settings_path() -> PathBuf {
+        Self::settings_dir().join("settings.json")
+    }
+
+    /// Returns `(hooks_installed, hooks_up_to_date)` from a parsed settings value.
+    /// `hooks_installed` = git-ai checkpoint command exists in ANY matcher block.
+    /// `hooks_up_to_date` = git-ai checkpoint command exists in the catch-all block.
+    fn hook_status(settings: &Value) -> (bool, bool) {
+        let pre_tool_blocks = settings
+            .get("hooks")
+            .and_then(|h| h.get("PreToolUse"))
+            .and_then(|v| v.as_array());
+
+        let Some(blocks) = pre_tool_blocks else {
+            return (false, false);
+        };
+
+        let mut hooks_installed = false;
+        let mut hooks_up_to_date = false;
+
+        for block in blocks {
+            let is_catch_all = block
+                .get("matcher")
+                .and_then(|m| m.as_str())
+                .map(|m| m == CODEBUDDY_CATCH_ALL_MATCHER)
+                .unwrap_or(false);
+
+            let has_git_ai = block
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .map(|hooks| {
+                    hooks.iter().any(|hook| {
+                        hook.get("command")
+                            .and_then(|c| c.as_str())
+                            .map(is_codebuddy_checkpoint_command)
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false);
+
+            if has_git_ai {
+                hooks_installed = true;
+                if is_catch_all {
+                    hooks_up_to_date = true;
+                }
+            }
+        }
+
+        (hooks_installed, hooks_up_to_date)
+    }
+
+    fn install_hooks_at(
+        settings_path: &Path,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        if let Some(dir) = settings_path.parent() {
+            fs::create_dir_all(dir)?;
+        }
+
+        let existing_content = if settings_path.exists() {
+            fs::read_to_string(settings_path)?
+        } else {
+            String::new()
+        };
+
+        let existing: Value = if existing_content.trim().is_empty() {
+            json!({})
+        } else {
+            serde_json::from_str(&existing_content)?
+        };
+
+        let binary_path_str = to_git_bash_path(&params.binary_path);
+        let pre_tool_cmd = format!("{} {}", binary_path_str, CODEBUDDY_PRE_TOOL_CMD);
+        let post_tool_cmd = format!("{} {}", binary_path_str, CODEBUDDY_POST_TOOL_CMD);
+
+        let mut merged = existing.clone();
+        let mut hooks_obj = merged.get("hooks").cloned().unwrap_or_else(|| json!({}));
+
+        for (hook_type, desired_cmd) in &[
+            ("PreToolUse", &pre_tool_cmd),
+            ("PostToolUse", &post_tool_cmd),
+        ] {
+            let mut hook_type_array = hooks_obj
+                .get(*hook_type)
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            // Step 1: Strip git-ai from every non-catch-all matcher block (migration
+            // path — preserves user-defined hooks attached to specific tools).
+            let mut emptied_by_migration = vec![false; hook_type_array.len()];
+            for (i, block) in hook_type_array.iter_mut().enumerate() {
+                let is_catch_all = block
+                    .get("matcher")
+                    .and_then(|m| m.as_str())
+                    .map(|m| m == CODEBUDDY_CATCH_ALL_MATCHER)
+                    .unwrap_or(false);
+                if !is_catch_all
+                    && let Some(hooks) = block.get_mut("hooks").and_then(|h| h.as_array_mut())
+                {
+                    let before = hooks.len();
+                    hooks.retain(|hook| {
+                        hook.get("command")
+                            .and_then(|c| c.as_str())
+                            .map(|cmd| !is_codebuddy_checkpoint_command(cmd))
+                            .unwrap_or(true)
+                    });
+                    if hooks.is_empty() && before > 0 {
+                        emptied_by_migration[i] = true;
+                    }
+                }
+            }
+            let mut i = 0;
+            hook_type_array.retain(|_| {
+                let remove = emptied_by_migration[i];
+                i += 1;
+                !remove
+            });
+
+            // Step 2: Find or create the catch-all matcher block.
+            let catch_all_idx = hook_type_array
+                .iter()
+                .position(|b| {
+                    b.get("matcher")
+                        .and_then(|m| m.as_str())
+                        .map(|m| m == CODEBUDDY_CATCH_ALL_MATCHER)
+                        .unwrap_or(false)
+                })
+                .unwrap_or_else(|| {
+                    hook_type_array.push(json!({
+                        "matcher": CODEBUDDY_CATCH_ALL_MATCHER,
+                        "hooks": []
+                    }));
+                    hook_type_array.len() - 1
+                });
+
+            // Step 3: Ensure exactly one git-ai command in the catch-all block.
+            let mut hooks_array = hook_type_array[catch_all_idx]
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            let mut found_idx: Option<usize> = None;
+            let mut needs_update = false;
+
+            for (idx, hook) in hooks_array.iter().enumerate() {
+                if let Some(cmd) = hook.get("command").and_then(|c| c.as_str())
+                    && is_codebuddy_checkpoint_command(cmd)
+                    && found_idx.is_none()
+                {
+                    found_idx = Some(idx);
+                    if cmd != *desired_cmd {
+                        needs_update = true;
+                    }
+                }
+            }
+
+            match found_idx {
+                Some(idx) => {
+                    if needs_update {
+                        hooks_array[idx] = json!({
+                            "type": "command",
+                            "command": desired_cmd
+                        });
+                    }
+                    let keep_idx = idx;
+                    let mut current_idx = 0;
+                    hooks_array.retain(|hook| {
+                        if current_idx == keep_idx {
+                            current_idx += 1;
+                            true
+                        } else if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+                            let is_dup = is_codebuddy_checkpoint_command(cmd);
+                            current_idx += 1;
+                            !is_dup
+                        } else {
+                            current_idx += 1;
+                            true
+                        }
+                    });
+                }
+                None => {
+                    hooks_array.push(json!({
+                        "type": "command",
+                        "command": desired_cmd
+                    }));
+                }
+            }
+
+            if let Some(matcher_block) = hook_type_array[catch_all_idx].as_object_mut() {
+                matcher_block.insert("hooks".to_string(), Value::Array(hooks_array));
+            }
+
+            if let Some(obj) = hooks_obj.as_object_mut() {
+                obj.insert(hook_type.to_string(), Value::Array(hook_type_array));
+            }
+        }
+
+        if let Some(root) = merged.as_object_mut() {
+            root.insert("hooks".to_string(), hooks_obj);
+        }
+
+        if existing == merged {
+            return Ok(None);
+        }
+
+        let new_content = serde_json::to_string_pretty(&merged)?;
+        let diff_output = generate_diff(settings_path, &existing_content, &new_content);
+
+        if !dry_run {
+            write_atomic(settings_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+
+    fn uninstall_hooks_at(
+        settings_path: &Path,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        if !settings_path.exists() {
+            return Ok(None);
+        }
+
+        let existing_content = fs::read_to_string(settings_path)?;
+        let existing: Value = serde_json::from_str(&existing_content)?;
+
+        let mut merged = existing.clone();
+        let mut hooks_obj = match merged.get("hooks").cloned() {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+
+        let mut changed = false;
+
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            if let Some(hook_type_array) =
+                hooks_obj.get_mut(*hook_type).and_then(|v| v.as_array_mut())
+            {
+                for matcher_block in hook_type_array.iter_mut() {
+                    if let Some(hooks_array) = matcher_block
+                        .get_mut("hooks")
+                        .and_then(|h| h.as_array_mut())
+                    {
+                        let original_len = hooks_array.len();
+                        hooks_array.retain(|hook| {
+                            if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+                                !is_codebuddy_checkpoint_command(cmd)
+                            } else {
+                                true
+                            }
+                        });
+                        if hooks_array.len() != original_len {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !changed {
+            return Ok(None);
+        }
+
+        if let Some(root) = merged.as_object_mut() {
+            root.insert("hooks".to_string(), hooks_obj);
+        }
+
+        let new_content = serde_json::to_string_pretty(&merged)?;
+        let diff_output = generate_diff(settings_path, &existing_content, &new_content);
+
+        if !dry_run {
+            write_atomic(settings_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+}
+
+impl HookInstaller for CodeBuddyInstaller {
+    fn name(&self) -> &str {
+        "CodeBuddy CN"
+    }
+
+    fn id(&self) -> &str {
+        "codebuddy"
+    }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let has_dotfiles = Self::settings_dir().exists();
+
+        if !has_dotfiles {
+            return Ok(HookCheckResult {
+                tool_installed: false,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let settings_path = Self::settings_path();
+        if !settings_path.exists() {
+            return Ok(HookCheckResult {
+                tool_installed: true,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let content = fs::read_to_string(&settings_path)?;
+        let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+        let (hooks_installed, hooks_up_to_date) = Self::hook_status(&existing);
+
+        Ok(HookCheckResult {
+            tool_installed: true,
+            hooks_installed,
+            hooks_up_to_date,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Self::install_hooks_at(&Self::settings_path(), params, dry_run)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Self::uninstall_hooks_at(&Self::settings_path(), dry_run)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_test_env() -> (TempDir, PathBuf) {
+        let temp_dir = TempDir::new().unwrap();
+        let settings_path = temp_dir
+            .path()
+            .join("CodeBuddyExtension")
+            .join("settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        (temp_dir, settings_path)
+    }
+
+    fn binary_path() -> PathBuf {
+        PathBuf::from("/usr/local/bin/git-ai")
+    }
+
+    fn params() -> HookInstallerParams {
+        HookInstallerParams {
+            binary_path: binary_path(),
+        }
+    }
+
+    fn expected_cmd() -> String {
+        format!("{} {}", binary_path().display(), CODEBUDDY_PRE_TOOL_CMD)
+    }
+
+    fn read_settings(path: &Path) -> Value {
+        serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn catch_all_block(hook_type_array: &[Value]) -> Option<&Value> {
+        hook_type_array.iter().find(|b| {
+            b.get("matcher")
+                .and_then(|m| m.as_str())
+                .map(|m| m == CODEBUDDY_CATCH_ALL_MATCHER)
+                .unwrap_or(false)
+        })
+    }
+
+    fn hooks_in_catch_all<'a>(settings: &'a Value, hook_type: &str) -> Vec<&'a Value> {
+        let Some(blocks) = settings
+            .get("hooks")
+            .and_then(|h| h.get(hook_type))
+            .and_then(|v| v.as_array())
+        else {
+            return Vec::new();
+        };
+        catch_all_block(blocks)
+            .and_then(|b| b.get("hooks").and_then(|h| h.as_array()))
+            .map(|v| v.iter().collect())
+            .unwrap_or_default()
+    }
+
+    // ---- Install scenarios ----
+
+    #[test]
+    fn s1_fresh_install_creates_catch_all_block() {
+        let (_td, path) = setup_test_env();
+        fs::remove_file(&path).ok();
+
+        let diff = CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        assert!(diff.is_some(), "should produce a diff");
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let hooks = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(hooks.len(), 1, "{hook_type}: expected 1 hook in catch-all");
+            assert_eq!(
+                hooks[0].get("command").and_then(|c| c.as_str()).unwrap(),
+                expected_cmd()
+            );
+            assert_eq!(
+                hooks[0].get("type").and_then(|t| t.as_str()).unwrap(),
+                "command"
+            );
+        }
+    }
+
+    #[test]
+    fn s2_idempotent_already_on_catch_all() {
+        let (_td, path) = setup_test_env();
+        let cmd = expected_cmd();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": cmd}]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": cmd}]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let diff = CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        assert!(diff.is_none(), "should return None when already up-to-date");
+    }
+
+    #[test]
+    fn s3_migration_old_matcher_no_user_hooks() {
+        let (_td, path) = setup_test_env();
+        let cmd = expected_cmd();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": "Write|Edit|MultiEdit", "hooks": [{"type":"command","command": cmd}]}],
+                    "PostToolUse": [{"matcher": "Write|Edit|MultiEdit", "hooks": [{"type":"command","command": cmd}]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let hooks = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(hooks.len(), 1, "{hook_type}: expected git-ai in catch-all");
+
+            // Old matcher block (which only had our hook) must be removed.
+            let blocks = settings
+                .get("hooks")
+                .and_then(|h| h.get(*hook_type))
+                .and_then(|v| v.as_array())
+                .unwrap();
+            assert_eq!(
+                blocks.len(),
+                1,
+                "{hook_type}: old matcher block should be removed, only catch-all should remain"
+            );
+        }
+    }
+
+    #[test]
+    fn s4_migration_old_matcher_user_hook_preserved() {
+        let (_td, path) = setup_test_env();
+        let cmd = expected_cmd();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{
+                        "matcher": "Write|Edit|MultiEdit",
+                        "hooks": [
+                            {"type":"command","command": "echo before"},
+                            {"type":"command","command": cmd}
+                        ]
+                    }],
+                    "PostToolUse": [{
+                        "matcher": "Write|Edit|MultiEdit",
+                        "hooks": [
+                            {"type":"command","command": "prettier --write"},
+                            {"type":"command","command": cmd}
+                        ]
+                    }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let settings = read_settings(&path);
+        for (hook_type, user_cmd) in &[
+            ("PreToolUse", "echo before"),
+            ("PostToolUse", "prettier --write"),
+        ] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(catch_all.len(), 1);
+
+            let blocks = settings
+                .get("hooks")
+                .and_then(|h| h.get(*hook_type))
+                .and_then(|v| v.as_array())
+                .unwrap();
+            let old_block = blocks
+                .iter()
+                .find(|b| b.get("matcher").and_then(|m| m.as_str()) == Some("Write|Edit|MultiEdit"))
+                .expect("old matcher block should still exist");
+            let old_hooks = old_block.get("hooks").and_then(|h| h.as_array()).unwrap();
+            assert!(
+                old_hooks
+                    .iter()
+                    .any(|h| h.get("command").and_then(|c| c.as_str()) == Some(*user_cmd)),
+                "{hook_type}: user hook '{user_cmd}' should still be present"
+            );
+            assert!(
+                !old_hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(is_git_ai_checkpoint_command)
+                        .unwrap_or(false)
+                }),
+                "{hook_type}: git-ai should be removed from old matcher block"
+            );
+        }
+    }
+
+    #[test]
+    fn s5_user_catch_all_hook_preserved_alongside_git_ai() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": "my-audit-tool"}]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": "my-audit-tool"}]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(
+                catch_all.len(),
+                2,
+                "{hook_type}: should have user hook + git-ai"
+            );
+            assert_eq!(
+                catch_all[0]
+                    .get("command")
+                    .and_then(|c| c.as_str())
+                    .unwrap(),
+                "my-audit-tool",
+                "user hook should be first"
+            );
+            assert!(is_git_ai_checkpoint_command(
+                catch_all[1]
+                    .get("command")
+                    .and_then(|c| c.as_str())
+                    .unwrap()
+            ));
+        }
+    }
+
+    #[test]
+    fn s6_stale_command_upgraded_in_catch_all() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": "/old/path/git-ai checkpoint codebuddy --hook-input stdin"}]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": "/old/path/git-ai checkpoint codebuddy --hook-input stdin"}]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(catch_all.len(), 1);
+            assert_eq!(
+                catch_all[0]
+                    .get("command")
+                    .and_then(|c| c.as_str())
+                    .unwrap(),
+                expected_cmd()
+            );
+        }
+    }
+
+    #[test]
+    fn s7_dedup_two_git_ai_in_catch_all_block() {
+        let (_td, path) = setup_test_env();
+        let cmd = expected_cmd();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": cmd},
+                        {"type":"command","command": cmd}
+                    ]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": cmd},
+                        {"type":"command","command": cmd}
+                    ]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(
+                catch_all.len(),
+                1,
+                "{hook_type}: should have exactly 1 after dedup"
+            );
+        }
+    }
+
+    #[test]
+    fn s7b_does_not_clobber_sibling_preset_commands() {
+        // Regression: CodeBuddy installer must only touch its own
+        // `git-ai checkpoint codebuddy ...` lines, never a sibling preset's.
+        let (_td, path) = setup_test_env();
+        let cb_cmd = expected_cmd();
+        let claude_cmd = "/usr/local/bin/git-ai checkpoint claude --hook-input stdin";
+        let cursor_cmd = "/usr/local/bin/git-ai checkpoint cursor --hook-input stdin";
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": claude_cmd},
+                        {"type":"command","command": cursor_cmd}
+                    ]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": claude_cmd}
+                    ]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            // Sibling preset commands must still be present, our codebuddy
+            // command must be appended (not replace them).
+            let cmds: Vec<&str> = catch_all
+                .iter()
+                .filter_map(|h| h.get("command").and_then(|c| c.as_str()))
+                .collect();
+            assert!(
+                cmds.contains(&claude_cmd),
+                "{hook_type}: claude sibling command lost: {:?}",
+                cmds
+            );
+            if *hook_type == "PreToolUse" {
+                assert!(
+                    cmds.contains(&cursor_cmd),
+                    "PreToolUse: cursor sibling command lost: {:?}",
+                    cmds
+                );
+            }
+            assert!(
+                cmds.iter().any(|c| c == &cb_cmd.as_str()),
+                "{hook_type}: codebuddy command not added: {:?}",
+                cmds
+            );
+        }
+    }
+
+    #[test]
+    fn u_does_not_remove_sibling_preset_commands() {
+        // Regression: CodeBuddy uninstall must not remove sibling preset
+        // commands that happen to share `git-ai checkpoint` prefix.
+        let (_td, path) = setup_test_env();
+        let cb_cmd = expected_cmd();
+        let claude_cmd = "/usr/local/bin/git-ai checkpoint claude --hook-input stdin";
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": cb_cmd},
+                        {"type":"command","command": claude_cmd}
+                    ]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": claude_cmd}
+                    ]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::uninstall_hooks_at(&path, false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            let cmds: Vec<&str> = catch_all
+                .iter()
+                .filter_map(|h| h.get("command").and_then(|c| c.as_str()))
+                .collect();
+            assert!(
+                cmds.contains(&claude_cmd),
+                "{hook_type}: claude sibling command must survive uninstall: {:?}",
+                cmds
+            );
+            assert!(
+                !cmds.iter().any(|c| c == &cb_cmd.as_str()),
+                "{hook_type}: codebuddy command should be removed: {:?}",
+                cmds
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(codebuddy_env)]
+    fn settings_dir_respects_codebuddy_config_dir_env() {
+        // SAFETY: env mutation is process-global; serial guard via the env var name itself.
+        let dir = "/tmp/codebuddy-test-override-dir";
+        // SAFETY: only mutating in test, not used elsewhere concurrently.
+        unsafe { std::env::set_var("CODEBUDDY_CONFIG_DIR", dir) };
+        let resolved = CodeBuddyInstaller::settings_dir();
+        unsafe { std::env::remove_var("CODEBUDDY_CONFIG_DIR") };
+        assert_eq!(resolved, PathBuf::from(dir));
+    }
+
+    #[test]
+    fn s8_creates_missing_parent_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let settings_path = temp_dir
+            .path()
+            .join("missing_dir")
+            .join("CodeBuddyExtension")
+            .join("settings.json");
+        assert!(!settings_path.parent().unwrap().exists());
+
+        let result =
+            CodeBuddyInstaller::install_hooks_at(&settings_path, &params(), false).unwrap();
+
+        assert!(result.is_some(), "should report changes for fresh install");
+        assert!(settings_path.exists(), "settings.json should be created");
+    }
+
+    // ---- Uninstall scenarios ----
+
+    #[test]
+    fn u1_uninstall_from_catch_all() {
+        let (_td, path) = setup_test_env();
+        let cmd = expected_cmd();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": cmd}]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": cmd}]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let diff = CodeBuddyInstaller::uninstall_hooks_at(&path, false).unwrap();
+        assert!(diff.is_some());
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            assert!(
+                !catch_all.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(is_git_ai_checkpoint_command)
+                        .unwrap_or(false)
+                }),
+                "{hook_type}: git-ai should be removed"
+            );
+        }
+    }
+
+    #[test]
+    fn u2_uninstall_preserves_user_hook() {
+        let (_td, path) = setup_test_env();
+        let cmd = expected_cmd();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": "my-audit"},
+                        {"type":"command","command": cmd}
+                    ]}],
+                    "PostToolUse": [{"matcher": ".*", "hooks": [
+                        {"type":"command","command": "my-audit"},
+                        {"type":"command","command": cmd}
+                    ]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        CodeBuddyInstaller::uninstall_hooks_at(&path, false).unwrap();
+
+        let settings = read_settings(&path);
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            let catch_all = hooks_in_catch_all(&settings, hook_type);
+            assert_eq!(catch_all.len(), 1);
+            assert_eq!(
+                catch_all[0]
+                    .get("command")
+                    .and_then(|c| c.as_str())
+                    .unwrap(),
+                "my-audit"
+            );
+        }
+    }
+
+    #[test]
+    fn u3_noop_uninstall_when_no_git_ai() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": "echo hello"}]}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let diff = CodeBuddyInstaller::uninstall_hooks_at(&path, false).unwrap();
+        assert!(
+            diff.is_none(),
+            "should return None when nothing to uninstall"
+        );
+    }
+
+    #[test]
+    fn u4_uninstall_when_settings_missing() {
+        let (td, _path) = setup_test_env();
+        let missing = td
+            .path()
+            .join("CodeBuddyExtension")
+            .join("nonexistent.json");
+        let diff = CodeBuddyInstaller::uninstall_hooks_at(&missing, false).unwrap();
+        assert!(diff.is_none());
+    }
+
+    // ---- check_hooks scenarios ----
+
+    #[test]
+    fn c1_no_hooks_returns_not_installed() {
+        let settings = json!({});
+        let (installed, up_to_date) = CodeBuddyInstaller::hook_status(&settings);
+        assert!(!installed);
+        assert!(!up_to_date);
+    }
+
+    #[test]
+    fn c2_git_ai_in_catch_all_returns_up_to_date() {
+        let cmd = expected_cmd();
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{"matcher": ".*", "hooks": [{"type":"command","command": cmd}]}]
+            }
+        });
+        let (installed, up_to_date) = CodeBuddyInstaller::hook_status(&settings);
+        assert!(installed);
+        assert!(up_to_date);
+    }
+
+    #[test]
+    fn c3_git_ai_only_in_old_matcher_returns_installed_but_not_up_to_date() {
+        let cmd = expected_cmd();
+        let settings = json!({
+            "hooks": {
+                "PreToolUse": [{"matcher": "Write|Edit|MultiEdit", "hooks": [{"type":"command","command": cmd}]}]
+            }
+        });
+        let (installed, up_to_date) = CodeBuddyInstaller::hook_status(&settings);
+        assert!(installed);
+        assert!(!up_to_date);
+    }
+
+    #[test]
+    #[serial_test::serial(codebuddy_env)]
+    fn settings_path_uses_codebuddyextension_dir() {
+        // The CODEBUDDY_CONFIG_DIR override would override the default — make
+        // sure no concurrent test left it set.
+        // SAFETY: env mutation is process-global; serialized via codebuddy_env guard.
+        unsafe { std::env::remove_var("CODEBUDDY_CONFIG_DIR") };
+        let path = CodeBuddyInstaller::settings_path();
+        let s = path.to_string_lossy().to_string();
+        assert!(
+            s.contains("CodeBuddyExtension"),
+            "settings_path should contain CodeBuddyExtension: {}",
+            s
+        );
+        assert!(
+            s.ends_with("settings.json"),
+            "should end with settings.json: {}",
+            s
+        );
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -1,5 +1,6 @@
 mod amp;
 mod claude_code;
+mod codebuddy;
 mod codex;
 mod cursor;
 mod droid;
@@ -14,6 +15,7 @@ mod windsurf;
 
 pub use amp::AmpInstaller;
 pub use claude_code::ClaudeCodeInstaller;
+pub use codebuddy::CodeBuddyInstaller;
 pub use codex::CodexInstaller;
 pub use cursor::CursorInstaller;
 pub use droid::DroidInstaller;
@@ -32,6 +34,7 @@ use super::hook_installer::HookInstaller;
 pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
     vec![
         Box::new(ClaudeCodeInstaller),
+        Box::new(CodeBuddyInstaller),
         Box::new(CodexInstaller),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),

--- a/tests/fixtures/codebuddy-session/index.json
+++ b/tests/fixtures/codebuddy-session/index.json
@@ -1,0 +1,20 @@
+{
+  "messages": [
+    {
+      "id": "msg001",
+      "role": "user",
+      "type": "text"
+    },
+    {
+      "id": "msg002",
+      "role": "assistant",
+      "type": "text"
+    },
+    {
+      "id": "msg003",
+      "role": "user",
+      "type": "text"
+    }
+  ],
+  "requests": []
+}

--- a/tests/fixtures/codebuddy-session/messages/msg001.json
+++ b/tests/fixtures/codebuddy-session/messages/msg001.json
@@ -1,0 +1,7 @@
+{
+  "role": "user",
+  "message": "{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Write a hello world function in Python.\"}]}",
+  "id": "msg001",
+  "references": [],
+  "extra": "{\"requestId\":\"req-001\",\"modelId\":\"glm-5.0-turbo\",\"sourceContentBlocks\":[{\"type\":\"text\",\"text\":\"Write a hello world function in Python.\"}],\"traceId\":\"trace-001\"}"
+}

--- a/tests/fixtures/codebuddy-session/messages/msg002.json
+++ b/tests/fixtures/codebuddy-session/messages/msg002.json
@@ -1,0 +1,7 @@
+{
+  "role": "assistant",
+  "message": "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Here is a hello world function in Python:\\n\\ndef hello():\\n    print('Hello, world!')\"}]}",
+  "id": "msg002",
+  "references": [],
+  "extra": "{\"requestId\":\"req-001\",\"modelId\":\"glm-5.0-turbo\",\"traceId\":\"trace-001\"}"
+}

--- a/tests/fixtures/codebuddy-session/messages/msg003.json
+++ b/tests/fixtures/codebuddy-session/messages/msg003.json
@@ -1,0 +1,7 @@
+{
+  "role": "user",
+  "message": "{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Now add a docstring.\"}]}",
+  "id": "msg003",
+  "references": [],
+  "extra": "{\"requestId\":\"req-002\",\"modelId\":\"glm-5.0-turbo\",\"traceId\":\"trace-002\"}"
+}

--- a/tests/integration/codebuddy.rs
+++ b/tests/integration/codebuddy.rs
@@ -1,0 +1,221 @@
+//! Integration tests for the CodeBuddy CN preset and installer.
+//!
+//! These exercise the end-to-end flow: real `git-ai checkpoint codebuddy`
+//! invocation via the test binary, real TestRepo, real attribution checks.
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
+use git_ai::error::GitAiError;
+use serde_json::json;
+use std::fs;
+
+fn parse_codebuddy(hook_input: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+    resolve_preset("codebuddy")?.parse(hook_input, "t_test")
+}
+
+// ============================================================================
+// Preset routing tests (in-process; no TestRepo required)
+// ============================================================================
+
+#[test]
+fn test_codebuddy_preset_resolves() {
+    assert!(resolve_preset("codebuddy").is_ok());
+}
+
+#[test]
+fn test_codebuddy_preset_post_file_edit_routes_correctly() {
+    let hook_input = json!({
+        "session_id": "sess-1",
+        "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/sess-1/index.json",
+        "cwd": "/",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "/tmp/proj/file.rs"},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE"
+    })
+    .to_string();
+    let events = parse_codebuddy(&hook_input).unwrap();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ParsedHookEvent::PostFileEdit(e) => {
+            assert_eq!(e.context.agent_id.tool, "codebuddy");
+            assert_eq!(e.context.agent_id.model, "glm-5.0-turbo");
+        }
+        _ => panic!("Expected PostFileEdit"),
+    }
+}
+
+#[test]
+fn test_codebuddy_preset_pre_file_edit_routes_to_human_checkpoint() {
+    let hook_input = json!({
+        "session_id": "sess-pre",
+        "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/sess-pre/index.json",
+        "cwd": "/",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {"filePath": "/tmp/proj/file.rs"},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE"
+    })
+    .to_string();
+    let events = parse_codebuddy(&hook_input).unwrap();
+    match &events[0] {
+        ParsedHookEvent::PreFileEdit(_) => (),
+        _ => panic!("Expected PreFileEdit"),
+    }
+}
+
+// ============================================================================
+// End-to-end tests using TestRepo
+// ============================================================================
+
+#[test]
+fn test_codebuddy_e2e_post_file_edit_attributes_to_codebuddy() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("app.py");
+    fs::write(&file_path, "def hello():\n    pass\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(
+        &file_path,
+        "def hello():\n    pass\ndef world():\n    pass\n",
+    )
+    .unwrap();
+
+    // CodeBuddy CN sends cwd:"/" — repo discovery comes from the absolute filePath.
+    let hook_input = json!({
+        "session_id": "cb-e2e-1",
+        "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/cb-e2e-1/index.json",
+        "cwd": "/",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": file_path.to_string_lossy().to_string(), "new_str": "def hello():\n    pass\ndef world():\n    pass\n"},
+        "tool_response": {"type": "replace_in_file_result", "path": file_path.to_string_lossy().to_string()},
+        "generation_id": "gen-e2e-1",
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE",
+        "version": "4.7.0"
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codebuddy", "--hook-input", &hook_input])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("CodeBuddy edit").unwrap();
+
+    let mut file = repo.filename("app.py");
+    file.assert_lines_and_blame(crate::lines![
+        "def hello():".human(),
+        "    pass".human(),
+        "def world():".ai(),
+        "    pass".ai(),
+    ]);
+
+    assert!(
+        !commit.authorship_log.attestations.is_empty(),
+        "Should have AI attestations from CodeBuddy"
+    );
+    assert!(!commit.authorship_log.metadata.sessions.is_empty());
+
+    let session_record = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("Should have a session record");
+
+    assert_eq!(session_record.agent_id.tool, "codebuddy");
+    assert_eq!(session_record.agent_id.id, "cb-e2e-1");
+    assert_eq!(session_record.agent_id.model, "glm-5.0-turbo");
+}
+
+#[test]
+fn test_codebuddy_e2e_pre_file_edit_treats_subsequent_changes_as_human() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("script.py");
+    fs::write(&file_path, "x = 1\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // PreToolUse fires before the AI writes anything — captures human baseline.
+    let hook_input = json!({
+        "session_id": "cb-pre-1",
+        "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/cb-pre-1/index.json",
+        "cwd": "/",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": file_path.to_string_lossy().to_string()},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE",
+        "version": "4.7.0"
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codebuddy", "--hook-input", &hook_input])
+        .unwrap();
+
+    // User then makes manual edits without a PostToolUse — those must remain human.
+    fs::write(&file_path, "x = 1\ny = 2\n").unwrap();
+
+    let commit = repo.stage_all_and_commit("Manual follow-up").unwrap();
+
+    let mut file = repo.filename("script.py");
+    file.assert_lines_and_blame(crate::lines!["x = 1".human(), "y = 2".human(),]);
+
+    assert_eq!(
+        commit.authorship_log.attestations.len(),
+        0,
+        "PreToolUse-only should produce no AI attestations"
+    );
+}
+
+#[test]
+fn test_codebuddy_e2e_filepath_resolves_repo_when_cwd_is_root() {
+    // Specifically exercises the cwd:"/" workaround — repo discovery uses
+    // file_paths[0], not cwd.
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("nested").join("module.py");
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::write(&file_path, "# initial\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(&file_path, "# initial\n# added by codebuddy\n").unwrap();
+
+    let hook_input = json!({
+        "session_id": "cb-cwd-root",
+        "transcript_path": "/Users/u/Library/Application Support/CodeBuddyExtension/Data/x/CodeBuddyIDE/y/history/z/cb-cwd-root/index.json",
+        "cwd": "/",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": file_path.to_string_lossy().to_string()},
+        "model": "glm-5.0-turbo",
+        "client": "CodeBuddyIDE",
+        "version": "4.7.0"
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codebuddy", "--hook-input", &hook_input])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("CodeBuddy nested edit").unwrap();
+
+    let mut file = repo.filename("nested/module.py");
+    file.assert_lines_and_blame(crate::lines![
+        "# initial".human(),
+        "# added by codebuddy".ai(),
+    ]);
+
+    let session_record = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("Should have a session record");
+    assert_eq!(session_record.agent_id.tool, "codebuddy");
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -35,6 +35,7 @@ mod ci_local_skip_push;
 mod ci_partial_clone;
 mod ci_squash_rebase;
 mod claude_code;
+mod codebuddy;
 mod codex;
 mod commit_post_stats_benchmark;
 mod config_pattern_detection;

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -8,6 +8,7 @@ use insta::assert_debug_snapshot;
 const AI_AUTHOR_NAMES: &[&str] = &[
     "mock_ai",
     "claude",
+    "codebuddy",
     "continue-cli",
     "gpt",
     "copilot",

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -811,6 +811,7 @@ fn is_known_checkpoint_preset(arg: &str) -> bool {
     matches!(
         arg,
         "claude"
+            | "codebuddy"
             | "codex"
             | "continue-cli"
             | "cursor"


### PR DESCRIPTION
## Summary

Adds support for **CodeBuddy CN** (Tencent's Claude Code-compatible IDE plugin) as requested in #1035, rebased on the new agent presets architecture.

This is a fresh PR replacing #1112 (closed pre-rewrite). 

## What's added

- **`presets/codebuddy.rs`** — pure parser implementing `AgentPreset`. Extracts events from CodeBuddy CN's Claude-shaped hook payloads (`PreToolUse`/`PostToolUse`, `tool_name`, `tool_input`).
- **`mdm/agents/codebuddy.rs`** — `CodeBuddyInstaller` for `settings.json` hooks. Cross-platform (macOS / Linux / Windows). Mirrors `ClaudeCodeInstaller`'s migration, idempotency, and dedup logic.
- **Claude preset guard** — `is_codebuddy_hook_payload` rejects payloads with `client: "CodeBuddyIDE"` or transcript paths under `CodeBuddyExtension`, preventing misrouting.
- **AI_AUTHOR_NAMES** — `"codebuddy"` added so `git-ai blame` attributes CodeBuddy commits as AI.

## Key differences from Claude Code

| | Claude Code | CodeBuddy CN |
|--|------------|-------------|
| `tool_input` filepath field | `file_path` (snake_case) | `filePath` (camelCase) |
| `cwd` | Real project dir | Always `"/"` (known CodeBuddy bug) |
| Transcript layout | Single JSONL file | `index.json` + `messages/{id}.json` directory |
| Catch-all matcher | `"*"` | `".*"` (CodeBuddy requires regex) |
| Identifier | (none in payload) | `client: "CodeBuddyIDE"`, `model: "glm-5.0-turbo"` |

The `cwd: "/"` workaround leverages the new orchestrator's design: repo discovery for `PreFileEdit`/`PostFileEdit` events uses `file_paths[0]` (`worktree_root_for_path`), not `cwd`. So as long as `tool_input.filePath` is the absolute path to a file in a git repo, attribution works.

## Deferred (not in this PR)

The CodeBuddy CN transcript format (`index.json` + `messages/{id}.json` with double-encoded JSON in the `message` field) needs a dedicated reader. For v1 this PR sets `transcript_source` to point at `index.json` with `ClaudeJsonl` format as a placeholder — the existing reader simply finds no events. Hook-based AI attribution works without it. Fixtures in `tests/fixtures/codebuddy-session/` document the layout. A follow-up commit can add the dedicated reader if desired.

## Files changed

**New:**
- `src/commands/checkpoint_agent/presets/codebuddy.rs` (~280 lines including 12 unit tests)
- `src/mdm/agents/codebuddy.rs` (~640 lines including 16 unit tests covering install/uninstall/check scenarios)
- `tests/integration/codebuddy.rs` (~210 lines, 6 tests: 3 in-process routing + 3 E2E with TestRepo)
- `tests/fixtures/codebuddy-session/index.json` + `messages/msg00{1,2,3}.json`

**Modified:**
- `src/commands/checkpoint_agent/presets/claude.rs` — added `is_codebuddy_hook_payload` guard + 2 tests
- `src/commands/checkpoint_agent/presets/mod.rs` — registered preset
- `src/mdm/agents/mod.rs` — registered installer
- `tests/integration/main.rs` — registered test module
- `tests/integration/repos/test_file.rs` — added `"codebuddy"` to `AI_AUTHOR_NAMES`
- `tests/integration/repos/test_repo.rs` — added `"codebuddy"` to `is_known_checkpoint_preset` so the test harness routes args correctly

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes
- [x] All 1460 lib unit tests pass (`cargo test --lib`)
- [x] `cargo test --test integration -- codebuddy` — all 6 pass
- [x] `cargo test --test integration -- claude_code::test` — all 18 pass (verifies the new Claude guard didn't regress)
- [x] `cargo test --test integration -- windsurf::` — all 16 pass (verifies the test harness change didn't regress)
- [x] No `println!`/`dbg!` in production code
- [x] Standalone E2E: piped a sample CodeBuddy CN PreToolUse and PostToolUse hook payload through `git-ai checkpoint codebuddy --hook-input stdin` against a temp git repo; verified the codebuddy preset accepts and the claude preset rejects (with guidance message).

Closes #1035

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->