### PR TITLE
﻿feat: add Kilo Code agent support

### DIFF
--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -1,23 +1,20 @@
 /**
- * git-ai plugin for OpenCode
+ * git-ai plugin for OpenCode-family agents (OpenCode, Kilo Code, etc.)
  *
- * This plugin integrates git-ai with OpenCode to track AI-generated code.
+ * This plugin integrates git-ai with OpenCode-family agents to track AI-generated code.
  * It uses the tool.execute.before and tool.execute.after events to create
  * checkpoints that mark code changes as human or AI-authored.
  *
  * Installation:
  *   - Automatically installed by `git-ai install-hooks`
- *   - Or manually copy to ~/.config/opencode/plugins/git-ai.ts (global)
- *   - Or to .opencode/plugins/git-ai.ts (project-local)
  *
  * Requirements:
  *   - git-ai must be installed (path is injected at install time)
  *
  * @see https://github.com/git-ai-project/git-ai
- * @see https://opencode.ai/docs/plugins/
  */
 
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Plugin } from "__PLUGIN_PACKAGE__"
 import { dirname, isAbsolute, join } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
@@ -231,7 +228,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
             tool_name: input.tool,
             tool_input: toolInput,
           })
-          await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+          await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint __CHECKPOINT_PRESET__ --hook-input stdin`.quiet()
         } catch (error) {
           console.error("[git-ai] Failed to create human checkpoint:", String(error))
         }
@@ -254,7 +251,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
             tool_name: input.tool,
             tool_input: toolInput,
           })
-          await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+          await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint __CHECKPOINT_PRESET__ --hook-input stdin`.quiet()
         } catch (error) {
           console.error("[git-ai] Failed to create human checkpoint:", String(error))
         }
@@ -284,7 +281,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           tool_name: input.tool,
           tool_input: toolInput,
         })
-        await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+        await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint __CHECKPOINT_PRESET__ --hook-input stdin`.quiet()
       } catch (error) {
         console.error("[git-ai] Failed to create AI checkpoint:", String(error))
       }

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -337,6 +337,11 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             "bash" | "shell" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
+        Agent::Kilo => match tool_name {
+            "edit" | "write" => ToolClass::FileEdit,
+            "bash" | "shell" => ToolClass::Bash,
+            _ => ToolClass::Skip,
+        },
         Agent::Firebender => match tool_name {
             "Write" | "Edit" | "Delete" | "RenameSymbol" | "DeleteSymbol" => ToolClass::FileEdit,
             "Bash" => ToolClass::Bash,
@@ -374,6 +379,7 @@ pub enum Agent {
     Droid,
     Amp,
     OpenCode,
+    Kilo,
     Firebender,
     Codex,
     Pi,

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -332,12 +332,7 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             "Bash" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
-        Agent::OpenCode => match tool_name {
-            "edit" | "write" => ToolClass::FileEdit,
-            "bash" | "shell" => ToolClass::Bash,
-            _ => ToolClass::Skip,
-        },
-        Agent::Kilo => match tool_name {
+        Agent::OpenCode | Agent::Kilo => match tool_name {
             "edit" | "write" => ToolClass::FileEdit,
             "bash" | "shell" => ToolClass::Bash,
             _ => ToolClass::Skip,

--- a/src/commands/checkpoint_agent/presets/kilo.rs
+++ b/src/commands/checkpoint_agent/presets/kilo.rs
@@ -1,0 +1,137 @@
+use super::opencode::{OpenCodeFamilyConfig, parse_opencode_family};
+use super::{AgentPreset, ParsedHookEvent};
+use crate::commands::checkpoint_agent::bash_tool::Agent;
+use crate::error::GitAiError;
+
+pub struct KiloPreset;
+
+pub(crate) static KILO_CONFIG: OpenCodeFamilyConfig = OpenCodeFamilyConfig {
+    tool_name: "kilo",
+    db_filename: "kilo.db",
+    data_dir_name: "kilo",
+    storage_env_var: "GIT_AI_KILO_STORAGE_PATH",
+    bash_agent: Agent::Kilo,
+};
+
+impl AgentPreset for KiloPreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        parse_opencode_family(&KILO_CONFIG, hook_input, trace_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::checkpoint_agent::presets::*;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn make_kilo_input(event: &str, tool: &str) -> String {
+        json!({
+            "hook_event_name": event,
+            "session_id": "kilo-sess-123",
+            "cwd": "/home/user/project",
+            "tool_name": tool,
+            "tool_use_id": "tu-1",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_kilo_pre_file_edit() {
+        let input = make_kilo_input("PreToolUse", "edit");
+        let events = KiloPreset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "kilo");
+                assert_eq!(e.context.external_session_id, "kilo-sess-123");
+                assert_eq!(e.context.cwd, PathBuf::from("/home/user/project"));
+                assert!(!e.file_paths.is_empty());
+            }
+            _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_kilo_post_file_edit() {
+        let input = make_kilo_input("PostToolUse", "write");
+        let events = KiloPreset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "kilo");
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_kilo_pre_bash_call() {
+        let input = make_kilo_input("PreToolUse", "bash");
+        let events = KiloPreset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.context.agent_id.tool, "kilo");
+                assert_eq!(e.tool_use_id, "tu-1");
+            }
+            _ => panic!("Expected PreBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_kilo_post_bash_call() {
+        let input = make_kilo_input("PostToolUse", "shell");
+        let events = KiloPreset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostBashCall(e) => {
+                assert_eq!(e.context.agent_id.tool, "kilo");
+                assert_eq!(e.tool_use_id, "tu-1");
+            }
+            _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_kilo_extracts_file_paths_from_tool_input() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "sess-1",
+            "cwd": "/project",
+            "tool_name": "edit",
+            "tool_input": {
+                "file_path": "src/main.rs",
+                "fspath": "/project/src/lib.rs"
+            }
+        })
+        .to_string();
+        let events = KiloPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert!(!e.file_paths.is_empty());
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_kilo_default_tool_use_id() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-1",
+            "cwd": "/project",
+            "tool_name": "bash"
+        })
+        .to_string();
+        let events = KiloPreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.tool_use_id, "bash");
+            }
+            _ => panic!("Expected PreBashCall"),
+        }
+    }
+}

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -15,6 +15,7 @@ mod human;
 mod known_human;
 mod mock_ai;
 mod mock_known_human;
+mod kilo;
 mod opencode;
 mod pi;
 mod windsurf;
@@ -161,6 +162,7 @@ pub fn resolve_preset(name: &str) -> Result<Box<dyn AgentPreset>, GitAiError> {
         "agent-v1" => Ok(Box::new(agent_v1::AgentV1Preset)),
         "droid" => Ok(Box::new(droid::DroidPreset)),
         "opencode" => Ok(Box::new(opencode::OpenCodePreset)),
+        "kilo" => Ok(Box::new(kilo::KiloPreset)),
         "pi" => Ok(Box::new(pi::PiPreset)),
         "human" => Ok(Box::new(human::HumanPreset)),
         "mock_ai" => Ok(Box::new(mock_ai::MockAiPreset)),

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -12,6 +12,230 @@ use std::path::{Path, PathBuf};
 
 pub struct OpenCodePreset;
 
+/// Configuration for OpenCode-family presets (OpenCode, Kilo Code, etc.)
+/// These tools share the same plugin API and hook input format.
+pub(crate) struct OpenCodeFamilyConfig {
+    pub tool_name: &'static str,
+    pub db_filename: &'static str,
+    pub data_dir_name: &'static str,
+    pub storage_env_var: &'static str,
+    pub bash_agent: Agent,
+}
+
+pub(crate) static OPENCODE_CONFIG: OpenCodeFamilyConfig = OpenCodeFamilyConfig {
+    tool_name: "opencode",
+    db_filename: "opencode.db",
+    data_dir_name: "opencode",
+    storage_env_var: "GIT_AI_OPENCODE_STORAGE_PATH",
+    bash_agent: Agent::OpenCode,
+};
+
+pub(crate) fn resolve_data_path(dir_name: &str) -> Result<PathBuf, GitAiError> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir().ok_or_else(|| {
+            GitAiError::Generic("Could not determine home directory".to_string())
+        })?;
+        Ok(home.join(".local").join("share").join(dir_name))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(xdg_data) = std::env::var("XDG_DATA_HOME") {
+            Ok(PathBuf::from(xdg_data).join(dir_name))
+        } else {
+            let home = dirs::home_dir().ok_or_else(|| {
+                GitAiError::Generic("Could not determine home directory".to_string())
+            })?;
+            Ok(home.join(".local").join("share").join(dir_name))
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(app_data) = std::env::var("APPDATA") {
+            Ok(PathBuf::from(app_data).join(dir_name))
+        } else if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            Ok(PathBuf::from(local_app_data).join(dir_name))
+        } else {
+            Err(GitAiError::Generic(
+                "Neither APPDATA nor LOCALAPPDATA is set".to_string(),
+            ))
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        Err(GitAiError::PresetError(format!(
+            "{} storage path not supported on this platform",
+            dir_name
+        )))
+    }
+}
+
+pub(crate) fn resolve_db_path(path: &Path, db_filename: &str) -> Option<PathBuf> {
+    if path.is_file() {
+        return path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| *name == db_filename)
+            .map(|_| path.to_path_buf());
+    }
+
+    if !path.is_dir() {
+        return None;
+    }
+
+    let direct_db = path.join(db_filename);
+    if direct_db.exists() {
+        return Some(direct_db);
+    }
+
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "storage")
+    {
+        let sibling_db = path.parent()?.join(db_filename);
+        if sibling_db.exists() {
+            return Some(sibling_db);
+        }
+    }
+
+    None
+}
+
+pub(crate) fn lookup_parent_session(db_path: &Path, session_id: &str) -> Option<String> {
+    let conn = crate::transcripts::agents::opencode::open_sqlite_readonly(db_path).ok()?;
+    conn.query_row(
+        "SELECT parent_id FROM session WHERE id = ?",
+        [session_id],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .ok()
+    .flatten()
+}
+
+pub(crate) fn resolve_family_transcript_source(
+    config: &OpenCodeFamilyConfig,
+    session_id: &str,
+) -> Option<(TranscriptSource, PathBuf)> {
+    let data_path = if let Ok(test_path) = std::env::var(config.storage_env_var) {
+        PathBuf::from(test_path)
+    } else {
+        resolve_data_path(config.data_dir_name).ok()?
+    };
+
+    // Try sqlite first
+    let db_path = resolve_db_path(&data_path, config.db_filename);
+    if let Some(db_path) = db_path {
+        let parent_id = lookup_parent_session(&db_path, session_id);
+        return Some((
+            TranscriptSource {
+                path: db_path,
+                format: TranscriptFormat::OpenCodeSqlite,
+                session_id: generate_session_id(session_id, config.tool_name),
+                external_session_id: session_id.to_string(),
+                external_parent_session_id: parent_id,
+            },
+            data_path,
+        ));
+    }
+
+    None
+}
+
+pub(crate) fn parse_opencode_family(
+    config: &OpenCodeFamilyConfig,
+    hook_input: &str,
+    trace_id: &str,
+) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+    let hook_input: OpenCodeHookInput = serde_json::from_str(hook_input)
+        .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
+
+    let is_bash = hook_input
+        .tool_name
+        .as_deref()
+        .map(|name| bash_tool::classify_tool(config.bash_agent, name) == ToolClass::Bash)
+        .unwrap_or(false);
+
+    let is_pre = hook_input.hook_event_name == "PreToolUse";
+
+    let OpenCodeHookInput {
+        hook_event_name: _,
+        session_id,
+        cwd,
+        tool_input,
+        tool_name: _,
+        tool_use_id,
+    } = hook_input;
+
+    let file_paths =
+        OpenCodePreset::extract_filepaths_from_tool_input(tool_input.as_ref(), &cwd);
+    let tool_use_id_str = tool_use_id.as_deref().unwrap_or("bash").to_string();
+
+    // Build metadata
+    let mut metadata = HashMap::new();
+    metadata.insert("session_id".to_string(), session_id.clone());
+    if let Ok(test_path) = std::env::var(config.storage_env_var) {
+        metadata.insert("__test_storage_path".to_string(), test_path);
+    }
+
+    // Resolve transcript source
+    let transcript_result = resolve_family_transcript_source(config, &session_id);
+
+    let extracted_model = transcript_result.as_ref().and_then(|(ts, _)| {
+        crate::transcripts::model_extraction::extract_model(
+            &ts.path,
+            crate::transcripts::sweep::TranscriptFormat::OpenCodeSqlite,
+            Some(session_id.as_str()),
+        )
+        .ok()
+        .flatten()
+    });
+
+    let context = PresetContext {
+        agent_id: AgentId {
+            tool: config.tool_name.to_string(),
+            id: session_id.clone(),
+            model: extracted_model.unwrap_or_else(|| "unknown".to_string()),
+        },
+        external_session_id: session_id,
+        trace_id: trace_id.to_string(),
+        cwd: PathBuf::from(&cwd),
+        metadata,
+    };
+
+    let transcript_source = transcript_result.map(|(source, _)| source);
+
+    let event = match (is_pre, is_bash) {
+        (true, true) => ParsedHookEvent::PreBashCall(PreBashCall {
+            context,
+            tool_use_id: tool_use_id_str,
+        }),
+        (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
+            context,
+            file_paths,
+            dirty_files: None,
+            tool_use_id: Some(tool_use_id_str.clone()),
+        }),
+        (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
+            context,
+            tool_use_id: tool_use_id_str,
+            transcript_source,
+        }),
+        (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {
+            context,
+            file_paths,
+            dirty_files: None,
+            transcript_source,
+            tool_use_id: Some(tool_use_id_str),
+        }),
+    };
+
+    Ok(vec![event])
+}
+
 #[derive(Debug, Deserialize)]
 struct OpenCodeHookInput {
     hook_event_name: String,
@@ -143,204 +367,11 @@ impl OpenCodePreset {
 
         Some(joined.to_string_lossy().replace('\\', "/"))
     }
-
-    fn resolve_transcript_source(session_id: &str) -> Option<(TranscriptSource, PathBuf)> {
-        let opencode_path = if let Ok(test_path) = std::env::var("GIT_AI_OPENCODE_STORAGE_PATH") {
-            PathBuf::from(test_path)
-        } else {
-            Self::opencode_data_path().ok()?
-        };
-
-        // Try sqlite first
-        let db_path = Self::resolve_sqlite_db_path(&opencode_path);
-        if let Some(db_path) = db_path {
-            let parent_id = Self::lookup_parent_session(&db_path, session_id);
-            return Some((
-                TranscriptSource {
-                    path: db_path,
-                    format: TranscriptFormat::OpenCodeSqlite,
-                    session_id: generate_session_id(session_id, "opencode"),
-                    external_session_id: session_id.to_string(),
-                    external_parent_session_id: parent_id,
-                },
-                opencode_path,
-            ));
-        }
-
-        None
-    }
-
-    fn lookup_parent_session(db_path: &Path, session_id: &str) -> Option<String> {
-        let conn = crate::transcripts::agents::opencode::open_sqlite_readonly(db_path).ok()?;
-        conn.query_row(
-            "SELECT parent_id FROM session WHERE id = ?",
-            [session_id],
-            |row| row.get::<_, Option<String>>(0),
-        )
-        .ok()
-        .flatten()
-    }
-
-    fn opencode_data_path() -> Result<PathBuf, GitAiError> {
-        #[cfg(target_os = "macos")]
-        {
-            let home = dirs::home_dir().ok_or_else(|| {
-                GitAiError::Generic("Could not determine home directory".to_string())
-            })?;
-            Ok(home.join(".local").join("share").join("opencode"))
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            if let Ok(xdg_data) = std::env::var("XDG_DATA_HOME") {
-                Ok(PathBuf::from(xdg_data).join("opencode"))
-            } else {
-                let home = dirs::home_dir().ok_or_else(|| {
-                    GitAiError::Generic("Could not determine home directory".to_string())
-                })?;
-                Ok(home.join(".local").join("share").join("opencode"))
-            }
-        }
-
-        #[cfg(target_os = "windows")]
-        {
-            if let Ok(app_data) = std::env::var("APPDATA") {
-                Ok(PathBuf::from(app_data).join("opencode"))
-            } else if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
-                Ok(PathBuf::from(local_app_data).join("opencode"))
-            } else {
-                Err(GitAiError::Generic(
-                    "Neither APPDATA nor LOCALAPPDATA is set".to_string(),
-                ))
-            }
-        }
-
-        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-        {
-            Err(GitAiError::PresetError(
-                "OpenCode storage path not supported on this platform".to_string(),
-            ))
-        }
-    }
-
-    fn resolve_sqlite_db_path(path: &Path) -> Option<PathBuf> {
-        if path.is_file() {
-            return path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .filter(|name| *name == "opencode.db")
-                .map(|_| path.to_path_buf());
-        }
-
-        if !path.is_dir() {
-            return None;
-        }
-
-        let direct_db = path.join("opencode.db");
-        if direct_db.exists() {
-            return Some(direct_db);
-        }
-
-        if path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name == "storage")
-        {
-            let sibling_db = path.parent()?.join("opencode.db");
-            if sibling_db.exists() {
-                return Some(sibling_db);
-            }
-        }
-
-        None
-    }
 }
 
 impl AgentPreset for OpenCodePreset {
     fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
-        let hook_input: OpenCodeHookInput = serde_json::from_str(hook_input)
-            .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
-
-        let is_bash = hook_input
-            .tool_name
-            .as_deref()
-            .map(|name| bash_tool::classify_tool(Agent::OpenCode, name) == ToolClass::Bash)
-            .unwrap_or(false);
-
-        let is_pre = hook_input.hook_event_name == "PreToolUse";
-
-        let OpenCodeHookInput {
-            hook_event_name: _,
-            session_id,
-            cwd,
-            tool_input,
-            tool_name: _,
-            tool_use_id,
-        } = hook_input;
-
-        let file_paths = Self::extract_filepaths_from_tool_input(tool_input.as_ref(), &cwd);
-        let tool_use_id_str = tool_use_id.as_deref().unwrap_or("bash").to_string();
-
-        // Build metadata
-        let mut metadata = HashMap::new();
-        metadata.insert("session_id".to_string(), session_id.clone());
-        if let Ok(test_path) = std::env::var("GIT_AI_OPENCODE_STORAGE_PATH") {
-            metadata.insert("__test_storage_path".to_string(), test_path);
-        }
-
-        // Resolve transcript source
-        let transcript_result = Self::resolve_transcript_source(&session_id);
-
-        let extracted_model = transcript_result.as_ref().and_then(|(ts, _)| {
-            crate::transcripts::model_extraction::extract_model(
-                &ts.path,
-                crate::transcripts::sweep::TranscriptFormat::OpenCodeSqlite,
-                Some(session_id.as_str()),
-            )
-            .ok()
-            .flatten()
-        });
-
-        let context = PresetContext {
-            agent_id: AgentId {
-                tool: "opencode".to_string(),
-                id: session_id.clone(),
-                model: extracted_model.unwrap_or_else(|| "unknown".to_string()),
-            },
-            external_session_id: session_id,
-            trace_id: trace_id.to_string(),
-            cwd: PathBuf::from(&cwd),
-            metadata,
-        };
-
-        let transcript_source = transcript_result.map(|(source, _)| source);
-
-        let event = match (is_pre, is_bash) {
-            (true, true) => ParsedHookEvent::PreBashCall(PreBashCall {
-                context,
-                tool_use_id: tool_use_id_str,
-            }),
-            (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
-                context,
-                file_paths,
-                dirty_files: None,
-                tool_use_id: Some(tool_use_id_str),
-            }),
-            (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
-                context,
-                tool_use_id: tool_use_id_str,
-                transcript_source,
-            }),
-            (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {
-                context,
-                file_paths,
-                dirty_files: None,
-                transcript_source,
-                tool_use_id: Some(tool_use_id_str),
-            }),
-        };
-
-        Ok(vec![event])
+        parse_opencode_family(&OPENCODE_CONFIG, hook_input, trace_id)
     }
 }
 

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -230,7 +230,7 @@ fn print_help() {
     eprintln!("Commands:");
     eprintln!("  checkpoint         Checkpoint working changes and attribute author");
     eprintln!(
-        "    Presets: claude, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, pi, ai_tab, firebender, human, mock_ai, mock_known_human, known_human"
+        "    Presets: claude, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, kilo, pi, ai_tab, firebender, human, mock_ai, mock_known_human, known_human"
     );
     eprintln!(
         "    --hook-input <json|stdin>   JSON payload required by presets, or 'stdin' to read from stdin"

--- a/src/mdm/agents/kilo.rs
+++ b/src/mdm/agents/kilo.rs
@@ -1,0 +1,245 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
+use crate::mdm::utils::{binary_exists, generate_diff, home_dir, write_atomic};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::opencode::{
+    OpenCodeFamilyInstallerConfig, family_plugin_path, generate_family_plugin_content,
+};
+
+pub struct KiloInstaller;
+
+static KILO_INSTALLER_CONFIG: OpenCodeFamilyInstallerConfig = OpenCodeFamilyInstallerConfig {
+    name: "Kilo Code",
+    id: "kilo",
+    process_names: &["kilo"],
+    config_dir_name: "kilo",
+    checkpoint_preset: "kilo",
+    plugin_package: "@kilocode/plugin",
+};
+
+impl KiloInstaller {
+    fn plugin_path() -> PathBuf {
+        family_plugin_path(&KILO_INSTALLER_CONFIG)
+    }
+
+    pub(crate) fn generate_plugin_content(binary_path: &std::path::Path) -> String {
+        generate_family_plugin_content(&KILO_INSTALLER_CONFIG, binary_path)
+    }
+}
+
+impl HookInstaller for KiloInstaller {
+    fn name(&self) -> &str {
+        KILO_INSTALLER_CONFIG.name
+    }
+
+    fn id(&self) -> &str {
+        KILO_INSTALLER_CONFIG.id
+    }
+
+    fn process_names(&self) -> Vec<&str> {
+        KILO_INSTALLER_CONFIG.process_names.to_vec()
+    }
+
+    fn check_hooks(&self, params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let has_binary = binary_exists("kilo");
+        let has_global_config = home_dir().join(".config").join("kilo").exists();
+        let has_local_config = Path::new(".kilo").exists();
+
+        if !has_binary && !has_global_config && !has_local_config {
+            return Ok(HookCheckResult {
+                tool_installed: false,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let plugin_path = Self::plugin_path();
+        if !plugin_path.exists() {
+            return Ok(HookCheckResult {
+                tool_installed: true,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let current_content = fs::read_to_string(&plugin_path).unwrap_or_default();
+        let expected_content = Self::generate_plugin_content(&params.binary_path);
+        let is_up_to_date = current_content.trim() == expected_content.trim();
+
+        Ok(HookCheckResult {
+            tool_installed: true,
+            hooks_installed: true,
+            hooks_up_to_date: is_up_to_date,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        let plugin_path = Self::plugin_path();
+
+        if let Some(dir) = plugin_path.parent()
+            && !dry_run
+        {
+            fs::create_dir_all(dir)?;
+        }
+
+        let existing_content = if plugin_path.exists() {
+            fs::read_to_string(&plugin_path)?
+        } else {
+            String::new()
+        };
+
+        let new_content = Self::generate_plugin_content(&params.binary_path);
+
+        if existing_content.trim() == new_content.trim() {
+            return Ok(None);
+        }
+
+        let diff_output = generate_diff(&plugin_path, &existing_content, &new_content);
+
+        if !dry_run {
+            if let Some(dir) = plugin_path.parent() {
+                fs::create_dir_all(dir)?;
+            }
+            write_atomic(&plugin_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        let plugin_path = Self::plugin_path();
+
+        if !plugin_path.exists() {
+            return Ok(None);
+        }
+
+        let existing_content = fs::read_to_string(&plugin_path)?;
+        let diff_output = generate_diff(&plugin_path, &existing_content, "");
+
+        if !dry_run {
+            fs::remove_file(&plugin_path)?;
+        }
+
+        Ok(Some(diff_output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn create_test_binary_path() -> PathBuf {
+        PathBuf::from("/usr/local/bin/git-ai")
+    }
+
+    #[test]
+    fn test_kilo_plugin_content_is_valid_typescript() {
+        let binary_path = create_test_binary_path();
+        let content = KiloInstaller::generate_plugin_content(&binary_path);
+
+        assert!(content.contains("import type { Plugin }"));
+        assert!(content.contains("@kilocode/plugin"));
+        assert!(content.contains("export const GitAiPlugin: Plugin"));
+        assert!(content.contains("\"tool.execute.before\""));
+        assert!(content.contains("\"tool.execute.after\""));
+        assert!(content.contains("checkpoint kilo"));
+        assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+        assert!(!content.contains("__CHECKPOINT_PRESET__"));
+        assert!(!content.contains("__PLUGIN_PACKAGE__"));
+    }
+
+    #[test]
+    fn test_kilo_plugin_placeholder_substitution() {
+        let binary_path = create_test_binary_path();
+        let content = KiloInstaller::generate_plugin_content(&binary_path);
+
+        assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+        assert!(content.contains(r#"const GIT_AI_BIN = "/usr/local/bin/git-ai""#));
+        assert!(content.contains("${GIT_AI_BIN} --version"));
+        assert!(content.contains("${GIT_AI_BIN} checkpoint kilo"));
+    }
+
+    #[test]
+    fn test_kilo_plugin_windows_path_escaping() {
+        let binary_path = PathBuf::from(r"C:\Users\foo\.git-ai\bin\git-ai.exe");
+        let content = KiloInstaller::generate_plugin_content(&binary_path);
+
+        assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+        assert!(
+            content.contains(r#"const GIT_AI_BIN = "C:\\Users\\foo\\.git-ai\\bin\\git-ai.exe""#)
+        );
+    }
+
+    #[test]
+    fn test_kilo_plugin_skips_if_already_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let plugin_path = temp_dir.path().join("git-ai.ts");
+        let binary_path = create_test_binary_path();
+
+        let content1 = KiloInstaller::generate_plugin_content(&binary_path);
+        fs::write(&plugin_path, &content1).unwrap();
+
+        let content2 = KiloInstaller::generate_plugin_content(&binary_path);
+        fs::write(&plugin_path, &content2).unwrap();
+
+        assert_eq!(content1, content2);
+    }
+
+    #[test]
+    fn test_kilo_plugin_updates_outdated_content() {
+        let temp_dir = TempDir::new().unwrap();
+        let plugin_path = temp_dir.path().join("git-ai.ts");
+        let binary_path = create_test_binary_path();
+
+        let old_content = "// Old plugin version\nexport const OldPlugin = {}";
+        fs::write(&plugin_path, old_content).unwrap();
+
+        let content = fs::read_to_string(&plugin_path).unwrap();
+        assert!(content.contains("OldPlugin"));
+
+        let new_content = KiloInstaller::generate_plugin_content(&binary_path);
+        fs::write(&plugin_path, &new_content).unwrap();
+
+        let content = fs::read_to_string(&plugin_path).unwrap();
+        assert!(content.contains("GitAiPlugin"));
+        assert!(!content.contains("OldPlugin"));
+    }
+
+    #[test]
+    fn test_kilo_plugin_handles_empty_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let binary_path = create_test_binary_path();
+        let plugin_path = temp_dir
+            .path()
+            .join(".config")
+            .join("kilo")
+            .join("plugins")
+            .join("git-ai.ts");
+
+        assert!(!plugin_path.parent().unwrap().exists());
+
+        if let Some(parent) = plugin_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let generated = KiloInstaller::generate_plugin_content(&binary_path);
+        fs::write(&plugin_path, &generated).unwrap();
+
+        assert!(plugin_path.exists());
+        let content = fs::read_to_string(&plugin_path).unwrap();
+        assert!(content.contains("GitAiPlugin"));
+        assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -7,6 +7,7 @@ mod firebender;
 mod gemini;
 mod github_copilot;
 mod jetbrains;
+mod kilo;
 mod opencode;
 mod pi;
 mod vscode;
@@ -21,6 +22,7 @@ pub use firebender::FirebenderInstaller;
 pub use gemini::GeminiInstaller;
 pub use github_copilot::GitHubCopilotInstaller;
 pub use jetbrains::JetBrainsInstaller;
+pub use kilo::KiloInstaller;
 pub use opencode::OpenCodeInstaller;
 pub use pi::PiInstaller;
 pub use vscode::VSCodeInstaller;
@@ -38,6 +40,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(GitHubCopilotInstaller),
         Box::new(AmpInstaller),
         Box::new(OpenCodeInstaller),
+        Box::new(KiloInstaller),
         Box::new(PiInstaller),
         Box::new(GeminiInstaller),
         Box::new(DroidInstaller),

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -4,42 +4,79 @@ use crate::mdm::utils::{binary_exists, generate_diff, home_dir, write_atomic};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-// OpenCode plugin content (TypeScript), embedded from the source file
-const OPENCODE_PLUGIN_CONTENT: &str = include_str!(concat!(
+// OpenCode plugin template (TypeScript), embedded from the source file.
+// Contains placeholders: __GIT_AI_BINARY_PATH__, __CHECKPOINT_PRESET__, __PLUGIN_PACKAGE__
+pub(crate) const OPENCODE_PLUGIN_TEMPLATE: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/agent-support/opencode/git-ai.ts"
 ));
+
+/// Configuration for OpenCode-family hook installers
+pub(crate) struct OpenCodeFamilyInstallerConfig {
+    pub name: &'static str,
+    pub id: &'static str,
+    pub process_names: &'static [&'static str],
+    pub config_dir_name: &'static str,
+    pub checkpoint_preset: &'static str,
+    pub plugin_package: &'static str,
+}
+
+pub(crate) static OPENCODE_INSTALLER_CONFIG: OpenCodeFamilyInstallerConfig =
+    OpenCodeFamilyInstallerConfig {
+        name: "OpenCode",
+        id: "opencode",
+        process_names: &["opencode"],
+        config_dir_name: "opencode",
+        checkpoint_preset: "opencode",
+        plugin_package: "@opencode-ai/plugin",
+    };
+
+/// Returns the plugin file path for an OpenCode-family agent
+pub(crate) fn family_plugin_path(config: &OpenCodeFamilyInstallerConfig) -> PathBuf {
+    home_dir()
+        .join(".config")
+        .join(config.config_dir_name)
+        .join("plugins")
+        .join("git-ai.ts")
+}
+
+/// Generates the plugin content with all placeholders substituted
+pub(crate) fn generate_family_plugin_content(
+    config: &OpenCodeFamilyInstallerConfig,
+    binary_path: &Path,
+) -> String {
+    // Escape backslashes for the TypeScript string literal (needed for Windows paths)
+    let path_str = binary_path.display().to_string().replace('\\', "\\\\");
+    OPENCODE_PLUGIN_TEMPLATE
+        .replace("__GIT_AI_BINARY_PATH__", &path_str)
+        .replace("__CHECKPOINT_PRESET__", config.checkpoint_preset)
+        .replace("__PLUGIN_PACKAGE__", config.plugin_package)
+}
 
 pub struct OpenCodeInstaller;
 
 impl OpenCodeInstaller {
     fn plugin_path() -> PathBuf {
-        home_dir()
-            .join(".config")
-            .join("opencode")
-            .join("plugins")
-            .join("git-ai.ts")
+        family_plugin_path(&OPENCODE_INSTALLER_CONFIG)
     }
 
     /// Generate plugin content with the absolute binary path substituted in
     fn generate_plugin_content(binary_path: &Path) -> String {
-        // Escape backslashes for the TypeScript string literal (needed for Windows paths)
-        let path_str = binary_path.display().to_string().replace('\\', "\\\\");
-        OPENCODE_PLUGIN_CONTENT.replace("__GIT_AI_BINARY_PATH__", &path_str)
+        generate_family_plugin_content(&OPENCODE_INSTALLER_CONFIG, binary_path)
     }
 }
 
 impl HookInstaller for OpenCodeInstaller {
     fn name(&self) -> &str {
-        "OpenCode"
+        OPENCODE_INSTALLER_CONFIG.name
     }
 
     fn id(&self) -> &str {
-        "opencode"
+        OPENCODE_INSTALLER_CONFIG.id
     }
 
     fn process_names(&self) -> Vec<&str> {
-        vec!["opencode"]
+        OPENCODE_INSTALLER_CONFIG.process_names.to_vec()
     }
 
     fn check_hooks(&self, params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
@@ -65,7 +102,7 @@ impl HookInstaller for OpenCodeInstaller {
             });
         }
 
-        // Check if plugin is up to date (compare against content with binary path substituted)
+        // Check if plugin is up to date (compare against content with all placeholders substituted)
         let current_content = fs::read_to_string(&plugin_path).unwrap_or_default();
         let expected_content = Self::generate_plugin_content(&params.binary_path);
         let is_up_to_date = current_content.trim() == expected_content.trim();
@@ -209,19 +246,21 @@ mod tests {
     }
 
     #[test]
-    fn test_opencode_plugin_content_is_valid_typescript() {
-        let content = OPENCODE_PLUGIN_CONTENT;
+    fn test_opencode_plugin_template_is_valid_typescript() {
+        let content = OPENCODE_PLUGIN_TEMPLATE;
 
         assert!(content.contains("import type { Plugin }"));
-        assert!(content.contains("@opencode-ai/plugin"));
+        // Template uses placeholder, not the literal package name
+        assert!(content.contains("__PLUGIN_PACKAGE__"));
         assert!(content.contains("export const GitAiPlugin: Plugin"));
         assert!(content.contains("\"tool.execute.before\""));
         assert!(content.contains("\"tool.execute.after\""));
         assert!(content.contains("FILE_EDIT_TOOLS"));
         assert!(content.contains("isBashTool"));
         assert!(content.contains("apply_patch"));
-        // Template contains placeholder for binary path
+        // Template contains placeholders
         assert!(content.contains("__GIT_AI_BINARY_PATH__"));
+        assert!(content.contains("__CHECKPOINT_PRESET__"));
         assert!(content.contains("hook_event_name"));
         assert!(content.contains("session_id"));
         assert!(content.contains("PreToolUse"));
@@ -233,12 +272,16 @@ mod tests {
         let binary_path = create_test_binary_path();
         let content = OpenCodeInstaller::generate_plugin_content(&binary_path);
 
-        // Placeholder should be replaced with the actual binary path in the const
+        // All placeholders should be replaced
         assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+        assert!(!content.contains("__CHECKPOINT_PRESET__"));
+        assert!(!content.contains("__PLUGIN_PACKAGE__"));
         assert!(content.contains(r#"const GIT_AI_BIN = "/usr/local/bin/git-ai""#));
         // Commands reference the const which now holds the absolute path
         assert!(content.contains("${GIT_AI_BIN} --version"));
         assert!(content.contains("${GIT_AI_BIN} checkpoint opencode"));
+        // Package should be substituted
+        assert!(content.contains("@opencode-ai/plugin"));
     }
 
     #[test]

--- a/src/transcripts/agent.rs
+++ b/src/transcripts/agent.rs
@@ -102,6 +102,7 @@ const ALL_AGENT_TYPES: &[&str] = &[
     "codex",
     "amp",
     "opencode",
+    "kilo",
     "pi",
 ];
 
@@ -123,6 +124,7 @@ pub fn get_agent(agent_type: &str) -> Option<Box<dyn Agent>> {
         "codex" => Some(Box::new(super::agents::CodexAgent::new())),
         "amp" => Some(Box::new(super::agents::AmpAgent::new())),
         "opencode" => Some(Box::new(super::agents::OpenCodeAgent::new())),
+        "kilo" => Some(Box::new(super::agents::OpenCodeAgent::new())),
         "pi" => Some(Box::new(super::agents::PiAgent::new())),
         _ => None,
     }


### PR DESCRIPTION
Kilo Code (https://kilo.ai) is a fork of OpenCode that uses the same plugin API and SQLite database schema, but stores data under different paths (~/.local/share/kilo/kilo.db) and uses its own plugin package (@kilocode/plugin).

Changes:
- Add checkpoint preset (kilo) with Kilo-specific data paths
- Add hook installer deploying plugin to ~/.config/kilo/plugins/
- Add TypeScript plugin adapted for @kilocode/plugin
- Add Agent::Kilo variant for bash tool classification
- Register transcript agent (reuses OpenCodeAgent, same DB schema)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->