### PR TITLE
feat: skip skills installation by default, require --skills flag

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -272,6 +272,7 @@ fn print_help() {
     eprintln!("  debug              Print support/debug diagnostics");
     eprintln!("  bg                 Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
+    eprintln!("    --skills               Also install agent skill files");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");
     eprintln!("  ci                 Continuous integration utilities");
     eprintln!("    github                 GitHub CI helpers");

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -299,12 +299,16 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
     // Parse flags
     let mut dry_run = false;
     let mut verbose = false;
+    let mut install_skills = false;
     for arg in args {
         if arg == "--dry-run" || arg == "--dry-run=true" {
             dry_run = true;
         }
         if arg == "--verbose" || arg == "-v" {
             verbose = true;
+        }
+        if arg == "--skills" {
+            install_skills = true;
         }
     }
 
@@ -327,7 +331,7 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
     let params = HookInstallerParams { binary_path };
 
     // Run async operations with smol and convert result
-    let statuses = smol::block_on(async_run_install(&params, dry_run, verbose))?;
+    let statuses = smol::block_on(async_run_install(&params, dry_run, verbose, install_skills))?;
 
     // Clean up legacy envelope logs directory and related artifacts.
     // These are no longer used — all telemetry now routes through the daemon.
@@ -431,6 +435,7 @@ async fn async_run_install(
     params: &HookInstallerParams,
     dry_run: bool,
     verbose: bool,
+    install_skills: bool,
 ) -> Result<HashMap<String, InstallStatus>, GitAiError> {
     let mut any_checked = false;
     let mut has_changes = false;
@@ -604,8 +609,9 @@ async fn async_run_install(
         }
     }
 
-    // Install skills for detected agents only
-    if let Ok(result) = skills_installer::install_skills(dry_run, verbose, &installed_tools)
+    // Install skills for detected agents only (requires --skills flag)
+    if install_skills
+        && let Ok(result) = skills_installer::install_skills(dry_run, verbose, &installed_tools)
         && result.changed
     {
         has_changes = true;


### PR DESCRIPTION
## Summary

The `git-ai install` command previously installed agent skill files automatically. This change makes skills installation opt-in — users must now pass `--skills` to include them.

**Before:** `git-ai install` installs hooks + skills  
**After:** `git-ai install` installs hooks only; `git-ai install --skills` installs hooks + skills

The uninstall path is unchanged (skills are still removed on `uninstall-hooks`).

## Review & Testing Checklist for Human
- [ ] Run `git-ai install` and verify skills are NOT installed (no `~/.git-ai/skills/` created)
- [ ] Run `git-ai install --skills` and verify skills ARE installed
- [ ] Verify `git-ai install --help` / usage output shows the new `--skills` flag

### Notes
Minimal change — only the install path is gated behind the flag. Existing callers (`install.sh`, `dev.sh`, `flake.nix`) don't pass `--skills`, so they'll naturally stop installing skills.

Link to Devin session: https://app.devin.ai/sessions/aa0fa1ac6ae842128742fe8e3063369c
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->