### PR TITLE
feat: remove inter_commit_move feature flag and all associated dead code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Signal forwarding: On Unix, the git proxy installs signal handlers (SIGTERM, SIG
 
 `Config` is a global `OnceLock` singleton accessed via `Config::get()`. It reads from `~/.git-ai/config.json`. In tests, `GIT_AI_TEST_CONFIG_PATCH` env var allows overriding specific config fields without a real config file. Feature flags follow precedence: environment vars (`GIT_AI_*` prefix via `envy`) > config file > defaults.
 
-Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `rewrite_stash` (true/true), `inter_commit_move` (false/false), `auth_keyring` (false/false).
+Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `rewrite_stash` (true/true), `auth_keyring` (false/false).
 
 ### Error handling
 

--- a/docs/superpowers/plans/2026-04-22-drop-legacy-wrapper.md
+++ b/docs/superpowers/plans/2026-04-22-drop-legacy-wrapper.md
@@ -38,7 +38,6 @@ The `define_feature_flags!` macro at lines 54-61 becomes:
 ```rust
 define_feature_flags!(
     rewrite_stash: rewrite_stash, debug = true, release = true,
-    inter_commit_move: checkpoint_inter_commit_move, debug = false, release = false,
     auth_keyring: auth_keyring, debug = false, release = false,
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,

--- a/flake.nix
+++ b/flake.nix
@@ -388,7 +388,6 @@ GITOGEOF
               let
                 knownFlags = filterAttrs (n: v: v != null) {
                   rewrite_stash = cfg.settings.featureFlags.rewriteStash;
-                  checkpoint_inter_commit_move = cfg.settings.featureFlags.interCommitMove;
                   auth_keyring = cfg.settings.featureFlags.authKeyring;
                   git_hooks_enabled = cfg.settings.featureFlags.gitHooksEnabled;
                   git_hooks_externally_managed = cfg.settings.featureFlags.gitHooksExternallyManaged;
@@ -569,14 +568,6 @@ GITOGEOF
                   '';
                 };
 
-                interCommitMove = mkOption {
-                  type = types.nullOr types.bool;
-                  default = null;
-                  description = ''
-                    Enable checkpoint inter-commit move tracking.
-                  '';
-                };
-
                 authKeyring = mkOption {
                   type = types.nullOr types.bool;
                   default = null;
@@ -683,7 +674,6 @@ GITOGEOF
               let
                 knownFlags = filterAttrs (n: v: v != null) {
                   rewrite_stash = cfg.settings.featureFlags.rewriteStash;
-                  checkpoint_inter_commit_move = cfg.settings.featureFlags.interCommitMove;
                   auth_keyring = cfg.settings.featureFlags.authKeyring;
                   git_hooks_enabled = cfg.settings.featureFlags.gitHooksEnabled;
                   git_hooks_externally_managed = cfg.settings.featureFlags.gitHooksExternallyManaged;
@@ -848,14 +838,6 @@ GITOGEOF
                   description = ''
                     Enable stash rewriting for improved AI tracking of stash
                     operations.
-                  '';
-                };
-
-                interCommitMove = mkOption {
-                  type = types.nullOr types.bool;
-                  default = null;
-                  description = ''
-                    Enable checkpoint inter-commit move tracking.
                   '';
                 };
 

--- a/scripts/benchmarks/checkpoint/benchmark_human_non_ai_checkpoint.py
+++ b/scripts/benchmarks/checkpoint/benchmark_human_non_ai_checkpoint.py
@@ -190,7 +190,6 @@ def run_scenario(
     changed_counts: list[int],
     repeats: int,
     keep_repo: bool,
-    inter_commit_move: bool,
 ) -> None:
     tmp_parent = repo_root / "tmp"
     tmp_parent.mkdir(parents=True, exist_ok=True)
@@ -200,8 +199,6 @@ def run_scenario(
 
     try:
         base_env = dict(os.environ)
-        if inter_commit_move:
-            base_env["GIT_AI_CHECKPOINT_INTER_COMMIT_MOVE"] = "true"
         perf_env = {**base_env, "GIT_AI_DEBUG_PERFORMANCE": "2"}
 
         all_results: list[RunResult] = []
@@ -308,11 +305,6 @@ def main() -> None:
         action="store_true",
         help="Keep generated benchmark repository under ./tmp for inspection.",
     )
-    parser.add_argument(
-        "--inter-commit-move",
-        action="store_true",
-        help="Enable inter-commit move feature flag (adds git blame work per file).",
-    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[3]
@@ -323,7 +315,7 @@ def main() -> None:
     print(
         "scenario: human checkpoints on non-AI-changed files "
         f"(total_files={args.total_files}, ai_seed_files={args.ai_seed_files}, "
-        f"repeats={args.repeats}, inter_commit_move={args.inter_commit_move})"
+        f"repeats={args.repeats})"
     )
     run_scenario(
         repo_root=repo_root,
@@ -333,7 +325,7 @@ def main() -> None:
         changed_counts=changed_counts,
         repeats=args.repeats,
         keep_repo=args.keep_repo,
-        inter_commit_move=args.inter_commit_move,
+
     )
 
 

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -1,7 +1,6 @@
 use crate::authorship::attribution_tracker::{
     Attribution, AttributionTracker, INITIAL_ATTRIBUTION_TS, LineAttribution,
 };
-use crate::authorship::authorship_log::PromptRecord;
 use crate::authorship::authorship_log_serialization::{
     generate_session_id, generate_short_hash, generate_trace_id,
 };
@@ -10,9 +9,7 @@ use crate::authorship::imara_diff_utils::{
 };
 use crate::authorship::working_log::CheckpointKind;
 use crate::authorship::working_log::{Checkpoint, WorkingLogEntry};
-use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
 use crate::commands::checkpoint_agent::orchestrator::CheckpointRequest;
-use crate::config::Config;
 use crate::error::GitAiError;
 use crate::git::repo_storage::PersistedWorkingLog;
 use crate::git::repository::Repository;
@@ -555,14 +552,11 @@ fn get_checkpoint_entry_for_file(
     ai_touched_files: Arc<HashSet<String>>,
     file_content_hash: String,
     author_id: Arc<String>,
-    head_commit_sha: Arc<Option<String>>,
     head_tree_id: Arc<Option<String>>,
     initial_attributions: Arc<HashMap<String, Vec<LineAttribution>>>,
     initial_snapshot_contents: Arc<HashMap<String, String>>,
     ts: u128,
 ) -> Result<Option<(WorkingLogEntry, FileLineStats)>, GitAiError> {
-    let feature_flag_inter_commit_move = Config::get().get_feature_flags().inter_commit_move;
-
     let file_start = Instant::now();
     let initial_attrs_for_file = initial_attributions
         .get(&file_path)
@@ -638,57 +632,10 @@ fn get_checkpoint_entry_for_file(
         let mut prev_line_attributions = initial_attrs_for_file.clone();
         let mut blamed_lines: HashSet<u32> = HashSet::new();
 
-        // Get blame for lines not in INITIAL
-        let blame_start = Instant::now();
-        let mut ai_blame_opts = GitAiBlameOptions::default();
-        #[allow(clippy::field_reassign_with_default)]
-        {
-            ai_blame_opts.no_output = true;
-            ai_blame_opts.return_human_authors_as_human = true;
-            ai_blame_opts.use_prompt_hashes_as_names = true;
-            ai_blame_opts.newest_commit = head_commit_sha.as_ref().clone();
-            ai_blame_opts.oldest_date = Some(*OLDEST_AI_BLAME_DATE);
-        }
-        let ai_blame = if feature_flag_inter_commit_move {
-            repo.blame(&file_path, &ai_blame_opts).ok()
-        } else {
-            // When skipping blame, default all lines to "human"
-            let total_lines = previous_content.lines().count() as u32;
-            let mut line_authors: HashMap<u32, String> = HashMap::new();
-            for line_num in 1..=total_lines {
-                line_authors.insert(line_num, CheckpointKind::Human.to_str());
-            }
-            let prompt_records: HashMap<String, PromptRecord> = HashMap::new();
-            Some((line_authors, prompt_records))
-        };
-
-        tracing::debug!(
-            "[BENCHMARK] Blame for {} took {:?}",
-            file_path,
-            blame_start.elapsed()
-        );
-
-        // Add blame results for lines NOT covered by INITIAL
-        if let Some((blames, _)) = ai_blame {
-            for (line, author) in blames {
-                blamed_lines.insert(line);
-                // Skip if INITIAL already has this line
-                if initial_covered_lines.contains(&line) {
-                    continue;
-                }
-
-                // Skip human-authored lines - they should remain human
-                if author == CheckpointKind::Human.to_str() {
-                    continue;
-                }
-
-                prev_line_attributions.push(LineAttribution {
-                    start_line: line,
-                    end_line: line,
-                    author_id: author.clone(),
-                    overrode: None,
-                });
-            }
+        // Default all previous-content lines to "human" (no cross-commit blame)
+        let prev_total_lines = previous_content.lines().count() as u32;
+        for line_num in 1..=prev_total_lines {
+            blamed_lines.insert(line_num);
         }
 
         // For AI checkpoints, attribute any lines NOT in INITIAL and NOT returned by ai_blame
@@ -862,7 +809,6 @@ async fn get_checkpoint_entries(
                 .and_then(|h| h.target().ok())
                 .and_then(|oid| repo.find_commit(oid).ok())
         });
-    let head_commit_sha = head_commit.as_ref().map(|c| c.id().to_string());
     let head_tree_id = head_commit
         .as_ref()
         .and_then(|c| c.tree().ok())
@@ -877,7 +823,6 @@ async fn get_checkpoint_entries(
     let previous_file_state_by_file = Arc::new(previous_file_state_by_file);
     let ai_touched_files = Arc::new(ai_touched_files);
     let author_id = Arc::new(author_id);
-    let head_commit_sha = Arc::new(head_commit_sha);
     let head_tree_id = Arc::new(head_tree_id);
     let initial_attributions = Arc::new(initial_attributions);
     let initial_snapshot_contents = Arc::new(initial_snapshot_contents);
@@ -893,7 +838,6 @@ async fn get_checkpoint_entries(
         let previous_file_state_by_file = Arc::clone(&previous_file_state_by_file);
         let ai_touched_files = Arc::clone(&ai_touched_files);
         let author_id = Arc::clone(&author_id);
-        let head_commit_sha = Arc::clone(&head_commit_sha);
         let head_tree_id = Arc::clone(&head_tree_id);
         let blob_sha = file_content_hashes
             .get(&file_path)
@@ -918,7 +862,6 @@ async fn get_checkpoint_entries(
                     ai_touched_files,
                     blob_sha,
                     author_id.clone(),
-                    head_commit_sha.clone(),
                     head_tree_id.clone(),
                     initial_attributions.clone(),
                     initial_snapshot_contents.clone(),

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -79,7 +79,6 @@ macro_rules! define_feature_flags {
 // Format: struct_field: file_and_env_name, debug = <bool>, release = <bool>
 define_feature_flags!(
     rewrite_stash: rewrite_stash, debug = true, release = true,
-    inter_commit_move: checkpoint_inter_commit_move, debug = false, release = false,
     auth_keyring: auth_keyring, debug = false, release = false,
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
@@ -94,7 +93,7 @@ impl FeatureFlags {
 
     /// Build FeatureFlags from environment variables
     /// Reads from GIT_AI_* prefixed environment variables
-    /// Example: GIT_AI_REWRITE_STASH=true, GIT_AI_CHECKPOINT_INTER_COMMIT_MOVE=false
+    /// Example: GIT_AI_REWRITE_STASH=true, GIT_AI_AUTH_KEYRING=false
     /// Falls back to defaults for any invalid or missing values
     #[allow(dead_code)]
     pub fn from_env() -> Self {
@@ -135,7 +134,6 @@ mod tests {
         #[cfg(debug_assertions)]
         {
             assert!(flags.rewrite_stash);
-            assert!(!flags.inter_commit_move);
             assert!(!flags.auth_keyring);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
@@ -144,7 +142,6 @@ mod tests {
         #[cfg(not(debug_assertions))]
         {
             assert!(flags.rewrite_stash);
-            assert!(!flags.inter_commit_move);
             assert!(!flags.auth_keyring);
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
@@ -156,14 +153,12 @@ mod tests {
     fn test_from_deserializable() {
         let deserializable = DeserializableFeatureFlags {
             rewrite_stash: Some(false),
-            checkpoint_inter_commit_move: Some(false),
             auth_keyring: Some(true),
             ..Default::default()
         };
 
         let flags = FeatureFlags::from_deserializable(deserializable);
         assert!(!flags.rewrite_stash);
-        assert!(!flags.inter_commit_move);
         assert!(flags.auth_keyring);
     }
 
@@ -173,14 +168,12 @@ mod tests {
         // No file flags, env should be empty
         unsafe {
             std::env::remove_var("GIT_AI_REWRITE_STASH");
-            std::env::remove_var("GIT_AI_CHECKPOINT_INTER_COMMIT_MOVE");
             std::env::remove_var("GIT_AI_AUTH_KEYRING");
         }
 
         let flags = FeatureFlags::from_env_and_file(None);
         let defaults = FeatureFlags::default();
         assert_eq!(flags.rewrite_stash, defaults.rewrite_stash);
-        assert_eq!(flags.inter_commit_move, defaults.inter_commit_move);
         assert_eq!(flags.auth_keyring, defaults.auth_keyring);
     }
 
@@ -189,7 +182,6 @@ mod tests {
     fn test_from_env_and_file_file_overrides() {
         unsafe {
             std::env::remove_var("GIT_AI_REWRITE_STASH");
-            std::env::remove_var("GIT_AI_CHECKPOINT_INTER_COMMIT_MOVE");
             std::env::remove_var("GIT_AI_AUTH_KEYRING");
         }
 
@@ -208,7 +200,6 @@ mod tests {
     fn test_serialization() {
         let flags = FeatureFlags {
             rewrite_stash: true,
-            inter_commit_move: false,
             auth_keyring: true,
             git_hooks_enabled: false,
             git_hooks_externally_managed: false,
@@ -217,7 +208,6 @@ mod tests {
 
         let serialized = serde_json::to_string(&flags).unwrap();
         assert!(serialized.contains("rewrite_stash"));
-        assert!(serialized.contains("inter_commit_move"));
         assert!(serialized.contains("auth_keyring"));
         assert!(serialized.contains("git_hooks_enabled"));
         assert!(serialized.contains("git_hooks_externally_managed"));
@@ -228,7 +218,6 @@ mod tests {
     fn test_clone_trait() {
         let flags = FeatureFlags {
             rewrite_stash: true,
-            inter_commit_move: false,
             auth_keyring: true,
             git_hooks_enabled: true,
             git_hooks_externally_managed: false,
@@ -236,7 +225,6 @@ mod tests {
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);
-        assert_eq!(cloned.inter_commit_move, flags.inter_commit_move);
         assert_eq!(cloned.auth_keyring, flags.auth_keyring);
         assert_eq!(cloned.git_hooks_enabled, flags.git_hooks_enabled);
         assert_eq!(

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -16,7 +16,6 @@ fn setup() {
     // Test that we can override feature flags
     let test_flags = FeatureFlags {
         rewrite_stash: true,
-        inter_commit_move: true,
         auth_keyring: false,
         git_hooks_enabled: false,
         git_hooks_externally_managed: false,


### PR DESCRIPTION
## Summary

Removes the `inter_commit_move` feature flag entirely. It was never enabled (debug=false, release=false) and is no longer needed.

**Changes across 7 files:**

- **`src/feature_flags.rs`**: Removed `inter_commit_move` from `define_feature_flags!` macro and all test references
- **`src/daemon/checkpoint.rs`**: Removed the blame-based cross-commit attribution branch (the `true` path that called `repo.blame()`), keeping only the existing default behavior that marks all previous-content lines as human. Cleaned up now-unused imports (`GitAiBlameOptions`, `OLDEST_AI_BLAME_DATE`, `PromptRecord`, `Config`) and the unused `head_commit_sha` parameter
- **`tests/integration/performance.rs`**: Removed `inter_commit_move` field from `FeatureFlags` struct literal
- **`flake.nix`**: Removed `interCommitMove` Nix option declarations (2 places) and `checkpoint_inter_commit_move` config mappings (2 places)
- **`scripts/benchmarks/checkpoint/benchmark_human_non_ai_checkpoint.py`**: Removed `--inter-commit-move` CLI flag and `inter_commit_move` parameter
- **`docs/superpowers/plans/2026-04-22-drop-legacy-wrapper.md`**: Removed `inter_commit_move` from example code block
- **`AGENTS.md`**: Updated feature flags documentation to remove `inter_commit_move`

## Review & Testing Checklist for Human

- [ ] Verify that the checkpoint behavior is unchanged — the removed code path was never enabled, so the kept behavior (defaulting all previous-content lines to human) was always the active path
- [ ] Confirm no config files in deployment reference `checkpoint_inter_commit_move` or `interCommitMove` that would cause errors on upgrade

### Notes

Net deletion of ~97 lines. The `head_commit_sha` parameter was also removed from `get_checkpoint_entry_for_file` since it was only used by the blame options in the removed branch.

Link to Devin session: https://app.devin.ai/sessions/493e3daabe3e4db7a2b4b023b5a42b25
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->