### PR TITLE
test: add e2e test for issue #394 multi-user reformat AI attribution

### DIFF
--- a/tests/integration/e2e_user_scenarios.rs
+++ b/tests/integration/e2e_user_scenarios.rs
@@ -1,3 +1,4 @@
+use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::stats::CommitStats;
 use std::fs;
@@ -1208,4 +1209,83 @@ def handle_error(err):
     assert!(content.contains("get_config"));
     assert!(content.contains("log_message"));
     assert!(content.contains("handle_error"));
+}
+
+// ---------------------------------------------------------------------------
+// Test: Issue #394 — Multi-user collaboration with code reformatting and AI
+//
+// Scenario from https://github.com/git-ai-project/git-ai/issues/394:
+// 1. User test-a creates a single-line function and commits
+// 2. User test-b checkpoints, reformats + wraps that function with AI lines,
+//    checkpoints as AI, and commits
+// 3. Verify blame attribution after each commit
+// ---------------------------------------------------------------------------
+#[test]
+fn test_issue_394_multiuser_reformat_ai_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("hello.js");
+
+    // --- Commit 1: user test-a creates the file ---
+    repo.git(&["config", "user.name", "test-a"]).unwrap();
+    repo.git(&["config", "user.email", "test-a@example.com"])
+        .unwrap();
+
+    let initial = "function hello() {console.log('hello')}\n";
+    fs::write(&file_path, initial).unwrap();
+    // No checkpoints — this is a plain untracked commit
+    repo.stage_all_and_commit("Initial commit by test-a")
+        .unwrap();
+
+    let mut file = repo.filename("hello.js");
+    file.assert_committed_lines(lines![
+        "function hello() {console.log('hello')}".unattributed_human(),
+    ]);
+
+    // --- Commit 2: user test-b reformats + adds AI lines ---
+    repo.git(&["config", "user.name", "test-b"]).unwrap();
+    repo.git(&["config", "user.email", "test-b@example.com"])
+        .unwrap();
+
+    // Pre-edit checkpoint (untracked/legacy human) — mimics AI agent preset's
+    // before-edit snapshot to exclude prior changes
+    repo.git_ai(&["checkpoint", "human", "hello.js"]).unwrap();
+
+    let modified = "\
+console.log('a')
+function hello() {
+    console.log('hello')
+}
+console.log('b')
+";
+    fs::write(&file_path, modified).unwrap();
+
+    // Post-edit AI checkpoint
+    repo.git_ai(&["checkpoint", "mock_ai", "hello.js"]).unwrap();
+
+    repo.stage_all_and_commit("AI-assisted edit by test-b")
+        .unwrap();
+
+    // Verify blame: the 2 new wrapper lines should be AI, and the 3
+    // reformatted function lines' attribution is what issue #394 questions.
+    let blame_output = repo.git_ai(&["blame", "hello.js"]).unwrap();
+    eprintln!("=== git-ai blame output (issue #394) ===\n{blame_output}");
+
+    let stats = head_stats(&repo);
+    eprintln!(
+        "=== commit stats (issue #394) ===\nhuman_additions={}, ai_additions={}, ai_accepted={}",
+        stats.human_additions, stats.ai_additions, stats.ai_accepted
+    );
+
+    // Issue #394 reported 60% test-b / 40% AI (3 reformatted function lines
+    // attributed to the committer instead of AI).  Current behaviour: all 5
+    // lines are attributed to AI (the entire diff between the pre-edit and
+    // post-edit checkpoints is AI), so the original split no longer reproduces.
+    let mut file = repo.filename("hello.js");
+    file.assert_committed_lines(lines![
+        "console.log('a')".ai(),
+        "function hello() {".ai(),
+        "    console.log('hello')".ai(),
+        "}".ai(),
+        "console.log('b')".ai(),
+    ]);
 }


### PR DESCRIPTION
## Summary

Fixes #394 (by confirming it doesn't repro anymore)

Adds an e2e test that reproduces the exact scenario from #394:

1. User `test-a` creates a single-line function `function hello() {console.log('hello')}` and commits
2. User `test-b` fires a pre-edit checkpoint, reformats the function to multi-line and adds AI-generated wrapper lines (`console.log('a')` / `console.log('b')`), fires a post-edit AI checkpoint, and commits
3. Asserts blame attribution and commit stats

**Result:** The original bug (60% committer / 40% AI split, with 3 reformatted function lines attributed to test-b instead of AI) **does not reproduce**. Current behaviour attributes all 5 lines as AI (`human_additions=0, ai_additions=5, ai_accepted=5`).

## Review & Testing Checklist for Human

- [ ] Verify the test scenario matches the steps described in #394
- [ ] Confirm the assertion expectations (all 5 lines as AI) match your desired behaviour for this case

### Notes

The test uses explicit `fs::write` + manual checkpoint calls (not the `set_contents` helper) as recommended by AGENTS.md for checkpoint/attribution-focused tests.

Link to Devin session: https://app.devin.ai/sessions/1d711a75529a4be792827f70f0fbb759
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->