### PR TITLE
fix: include repo_url in AgentUsage event attributes

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1359,14 +1359,27 @@ fn apply_checkpoint_side_effect(request: CheckpointRequest) -> Result<(), GitAiE
     }
 
     let repo_work_dir = &request.files[0].repo_work_dir;
-    let repo = discover_repository_in_path_no_git_exec(repo_work_dir)?;
+    let repo = match discover_repository_in_path_no_git_exec(repo_work_dir) {
+        Ok(repo) => repo,
+        Err(e) => {
+            if request.checkpoint_kind.is_ai()
+                && let Some(ref agent_id) = request.agent_id
+                && crate::daemon::checkpoint::should_emit_agent_usage(agent_id)
+            {
+                let attrs = crate::daemon::checkpoint::build_agent_usage_attrs(None, agent_id);
+                let values = crate::metrics::AgentUsageValues::new();
+                crate::metrics::record(values, attrs);
+            }
+            return Err(e);
+        }
+    };
     let author = repo.git_author_identity().formatted_or_unknown();
 
     if request.checkpoint_kind.is_ai()
         && let Some(ref agent_id) = request.agent_id
         && crate::daemon::checkpoint::should_emit_agent_usage(agent_id)
     {
-        let attrs = crate::daemon::checkpoint::build_agent_usage_attrs(&repo, agent_id);
+        let attrs = crate::daemon::checkpoint::build_agent_usage_attrs(Some(&repo), agent_id);
         let values = crate::metrics::AgentUsageValues::new();
         crate::metrics::record(values, attrs);
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1358,33 +1358,18 @@ fn apply_checkpoint_side_effect(request: CheckpointRequest) -> Result<(), GitAiE
         return Ok(());
     }
 
+    let repo_work_dir = &request.files[0].repo_work_dir;
+    let repo = discover_repository_in_path_no_git_exec(repo_work_dir)?;
+    let author = repo.git_author_identity().formatted_or_unknown();
+
     if request.checkpoint_kind.is_ai()
         && let Some(ref agent_id) = request.agent_id
         && crate::daemon::checkpoint::should_emit_agent_usage(agent_id)
     {
-        let prompt_id = crate::authorship::authorship_log_serialization::generate_short_hash(
-            &agent_id.id,
-            &agent_id.tool,
-        );
-        let session_id = crate::authorship::authorship_log_serialization::generate_session_id(
-            &agent_id.id,
-            &agent_id.tool,
-        );
-        let attrs = crate::metrics::EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
-            .session_id(session_id)
-            .tool(&agent_id.tool)
-            .model(&agent_id.model)
-            .prompt_id(prompt_id)
-            .external_prompt_id(&agent_id.id)
-            .custom_attributes_map(crate::config::Config::get().custom_attributes());
-
+        let attrs = crate::daemon::checkpoint::build_agent_usage_attrs(&repo, agent_id);
         let values = crate::metrics::AgentUsageValues::new();
         crate::metrics::record(values, attrs);
     }
-
-    let repo_work_dir = &request.files[0].repo_work_dir;
-    let repo = discover_repository_in_path_no_git_exec(repo_work_dir)?;
-    let author = repo.git_author_identity().formatted_or_unknown();
 
     let resolved = resolve_checkpoint_request(&repo, &request)?;
     let Some(resolved) = resolved else {

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -87,6 +87,40 @@ pub struct ResolvedCheckpointExecution {
     pub dirty_files: HashMap<String, String>,
 }
 
+/// Build EventAttributes for AgentUsage events.
+/// Includes repo_url, branch, tool, model, session_id, prompt_id, and custom attributes.
+pub fn build_agent_usage_attrs(
+    repo: &Repository,
+    agent_id: &AgentId,
+) -> crate::metrics::EventAttributes {
+    let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
+    let session_id = generate_session_id(&agent_id.id, &agent_id.tool);
+
+    let mut attrs = crate::metrics::EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+        .session_id(session_id)
+        .tool(&agent_id.tool)
+        .model(&agent_id.model)
+        .prompt_id(prompt_id)
+        .external_prompt_id(&agent_id.id)
+        .custom_attributes_map(crate::config::Config::get().custom_attributes());
+
+    if let Ok(Some(remote_name)) = repo.get_default_remote()
+        && let Ok(remotes) = repo.remotes_with_urls()
+        && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
+        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
+    {
+        attrs = attrs.repo_url(normalized);
+    }
+
+    if let Ok(head_ref) = repo.head()
+        && let Ok(short_branch) = head_ref.shorthand()
+    {
+        attrs = attrs.branch(short_branch);
+    }
+
+    attrs
+}
+
 /// Build EventAttributes with repo metadata.
 /// Reused for both AgentUsage and Checkpoint events.
 fn build_checkpoint_attrs(

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -1,9 +1,9 @@
 use crate::authorship::attribution_tracker::{
     Attribution, AttributionTracker, INITIAL_ATTRIBUTION_TS, LineAttribution,
 };
-use crate::authorship::authorship_log_serialization::{
-    generate_session_id, generate_short_hash, generate_trace_id,
-};
+#[cfg(not(any(test, feature = "test-support")))]
+use crate::authorship::authorship_log_serialization::generate_short_hash;
+use crate::authorship::authorship_log_serialization::{generate_session_id, generate_trace_id};
 use crate::authorship::imara_diff_utils::{
     LineChangeTag, compute_line_changes, normalize_line_endings,
 };
@@ -89,19 +89,17 @@ pub struct ResolvedCheckpointExecution {
 
 /// Build EventAttributes for AgentUsage events.
 /// When repo is available, includes repo_url and branch. Always includes tool, model,
-/// session_id, prompt_id, and custom attributes.
+/// session_id, and custom attributes.
 pub fn build_agent_usage_attrs(
     repo: Option<&Repository>,
     agent_id: &AgentId,
 ) -> crate::metrics::EventAttributes {
-    let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
     let session_id = generate_session_id(&agent_id.id, &agent_id.tool);
 
     let mut attrs = crate::metrics::EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
         .session_id(session_id)
         .tool(&agent_id.tool)
         .model(&agent_id.model)
-        .prompt_id(prompt_id)
         .external_prompt_id(&agent_id.id)
         .custom_attributes_map(crate::config::Config::fresh().custom_attributes());
 
@@ -143,11 +141,9 @@ fn build_checkpoint_attrs(
 
     // Add AI-specific attributes
     if let Some(agent_id) = agent_id {
-        let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
         attrs = attrs
             .tool(&agent_id.tool)
             .model(&agent_id.model)
-            .prompt_id(prompt_id)
             .external_prompt_id(&agent_id.id);
     }
 

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -88,9 +88,10 @@ pub struct ResolvedCheckpointExecution {
 }
 
 /// Build EventAttributes for AgentUsage events.
-/// Includes repo_url, branch, tool, model, session_id, prompt_id, and custom attributes.
+/// When repo is available, includes repo_url and branch. Always includes tool, model,
+/// session_id, prompt_id, and custom attributes.
 pub fn build_agent_usage_attrs(
-    repo: &Repository,
+    repo: Option<&Repository>,
     agent_id: &AgentId,
 ) -> crate::metrics::EventAttributes {
     let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
@@ -104,18 +105,20 @@ pub fn build_agent_usage_attrs(
         .external_prompt_id(&agent_id.id)
         .custom_attributes_map(crate::config::Config::fresh().custom_attributes());
 
-    if let Ok(Some(remote_name)) = repo.get_default_remote()
-        && let Ok(remotes) = repo.remotes_with_urls()
-        && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
-        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
-    {
-        attrs = attrs.repo_url(normalized);
-    }
+    if let Some(repo) = repo {
+        if let Ok(Some(remote_name)) = repo.get_default_remote()
+            && let Ok(remotes) = repo.remotes_with_urls()
+            && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
+            && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
+        {
+            attrs = attrs.repo_url(normalized);
+        }
 
-    if let Ok(head_ref) = repo.head()
-        && let Ok(short_branch) = head_ref.shorthand()
-    {
-        attrs = attrs.branch(short_branch);
+        if let Ok(head_ref) = repo.head()
+            && let Ok(short_branch) = head_ref.shorthand()
+        {
+            attrs = attrs.branch(short_branch);
+        }
     }
 
     attrs

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -102,7 +102,7 @@ pub fn build_agent_usage_attrs(
         .model(&agent_id.model)
         .prompt_id(prompt_id)
         .external_prompt_id(&agent_id.id)
-        .custom_attributes_map(crate::config::Config::get().custom_attributes());
+        .custom_attributes_map(crate::config::Config::fresh().custom_attributes());
 
     if let Ok(Some(remote_name)) = repo.get_default_remote()
         && let Ok(remotes) = repo.remotes_with_urls()

--- a/src/metrics/attrs.rs
+++ b/src/metrics/attrs.rs
@@ -166,17 +166,7 @@ impl EventAttributes {
         self
     }
 
-    // Builder methods for prompt_id
-    pub fn prompt_id(mut self, value: impl Into<String>) -> Self {
-        self.prompt_id = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn prompt_id_null(mut self) -> Self {
-        self.prompt_id = Some(None);
-        self
-    }
+    // Position 22 (prompt_id) is TOMBSTONED - setters removed, field kept for reading legacy data.
 
     // Builder methods for external_prompt_id
     pub fn external_prompt_id(mut self, value: impl Into<String>) -> Self {
@@ -261,11 +251,7 @@ impl PosEncoded for EventAttributes {
         sparse_set(&mut map, attr_pos::BRANCH, string_to_json(&self.branch));
         sparse_set(&mut map, attr_pos::TOOL, string_to_json(&self.tool));
         sparse_set(&mut map, attr_pos::MODEL, string_to_json(&self.model));
-        sparse_set(
-            &mut map,
-            attr_pos::PROMPT_ID,
-            string_to_json(&self.prompt_id),
-        );
+        // Position 22 (PROMPT_ID) is TOMBSTONED - no longer written, only read for legacy data
         sparse_set(
             &mut map,
             attr_pos::EXTERNAL_PROMPT_ID,
@@ -318,8 +304,7 @@ mod tests {
             .base_commit_sha("base-commit-123")
             .branch("main")
             .tool("claude-code")
-            .model_null()
-            .prompt_id("prompt-123");
+            .model_null();
 
         assert_eq!(attrs.git_ai_version, Some(Some("1.0.0".to_string())));
         assert_eq!(
@@ -335,15 +320,14 @@ mod tests {
         assert_eq!(attrs.branch, Some(Some("main".to_string())));
         assert_eq!(attrs.tool, Some(Some("claude-code".to_string())));
         assert_eq!(attrs.model, Some(None)); // explicitly null
-        assert_eq!(attrs.prompt_id, Some(Some("prompt-123".to_string())));
+        assert_eq!(attrs.prompt_id, None); // tombstoned - never written
     }
 
     #[test]
     fn test_event_attributes_to_sparse() {
         let attrs = EventAttributes::with_version("1.0.0")
             .tool("test-tool")
-            .model_null()
-            .prompt_id("prompt-123");
+            .model_null();
 
         let sparse = attrs.to_sparse();
 
@@ -358,10 +342,7 @@ mod tests {
             Some(&Value::String("test-tool".to_string()))
         );
         assert_eq!(sparse.get("21"), Some(&Value::Null)); // explicitly null
-        assert_eq!(
-            sparse.get("22"),
-            Some(&Value::String("prompt-123".to_string()))
-        );
+        assert_eq!(sparse.get("22"), None); // tombstoned - never written
     }
 
     #[test]
@@ -392,7 +373,6 @@ mod tests {
             .branch("feature-branch")
             .tool("cursor")
             .model("gpt-4")
-            .prompt_id("prompt-456")
             .external_prompt_id("ext-789");
 
         assert_eq!(attrs.git_ai_version, Some(Some("1.2.3".to_string())));
@@ -406,7 +386,7 @@ mod tests {
         assert_eq!(attrs.branch, Some(Some("feature-branch".to_string())));
         assert_eq!(attrs.tool, Some(Some("cursor".to_string())));
         assert_eq!(attrs.model, Some(Some("gpt-4".to_string())));
-        assert_eq!(attrs.prompt_id, Some(Some("prompt-456".to_string())));
+        assert_eq!(attrs.prompt_id, None); // tombstoned
         assert_eq!(attrs.external_prompt_id, Some(Some("ext-789".to_string())));
     }
 
@@ -421,7 +401,6 @@ mod tests {
             .branch_null()
             .tool_null()
             .model_null()
-            .prompt_id_null()
             .external_prompt_id_null();
 
         assert_eq!(attrs.git_ai_version, Some(None));
@@ -432,7 +411,7 @@ mod tests {
         assert_eq!(attrs.branch, Some(None));
         assert_eq!(attrs.tool, Some(None));
         assert_eq!(attrs.model, Some(None));
-        assert_eq!(attrs.prompt_id, Some(None));
+        assert_eq!(attrs.prompt_id, None); // tombstoned - no setter available
         assert_eq!(attrs.external_prompt_id, Some(None));
     }
 
@@ -446,7 +425,6 @@ mod tests {
             .branch("main")
             .tool("test-tool")
             .model("test-model")
-            .prompt_id("prompt-id")
             .external_prompt_id("ext-id");
 
         let sparse = attrs.to_sparse();
@@ -477,10 +455,7 @@ mod tests {
             sparse.get("21"),
             Some(&Value::String("test-model".to_string()))
         );
-        assert_eq!(
-            sparse.get("22"),
-            Some(&Value::String("prompt-id".to_string()))
-        );
+        assert_eq!(sparse.get("22"), None); // tombstoned - never written
         assert_eq!(sparse.get("23"), Some(&Value::String("ext-id".to_string())));
     }
 

--- a/tests/integration/agent_usage_repo_url.rs
+++ b/tests/integration/agent_usage_repo_url.rs
@@ -55,8 +55,8 @@ fn test_agent_usage_attrs_include_repo_url_when_remote_exists() {
         attrs.session_id
     );
     assert!(
-        matches!(&attrs.prompt_id, Some(Some(p)) if !p.is_empty()),
-        "attrs.prompt_id should be set, got: {:?}",
+        attrs.prompt_id.is_none(),
+        "attrs.prompt_id should not be set (tombstoned), got: {:?}",
         attrs.prompt_id
     );
     assert!(
@@ -162,6 +162,39 @@ fn test_agent_usage_attrs_no_remote_still_works() {
     assert!(
         matches!(&attrs.model, Some(Some(m)) if m == "claude-opus-4-20250514"),
         "attrs.model should be set"
+    );
+}
+
+/// Verifies that credentials in the remote URL are stripped from repo_url.
+#[test]
+fn test_agent_usage_attrs_strips_credentials_from_repo_url() {
+    let repo = TestRepo::new();
+
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://oauth2:ghp_secret_token_123@github.com/private-org/secret-repo.git",
+    ])
+    .unwrap();
+
+    let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("should open repo");
+
+    let agent_id = AgentId {
+        id: "session-creds".to_string(),
+        tool: "cursor".to_string(),
+        model: "gpt-4".to_string(),
+    };
+
+    let attrs = build_agent_usage_attrs(Some(&gitai_repo), &agent_id);
+
+    assert_eq!(
+        attrs.repo_url,
+        Some(Some(
+            "https://github.com/private-org/secret-repo".to_string()
+        )),
+        "repo_url must never contain credentials"
     );
 }
 

--- a/tests/integration/agent_usage_repo_url.rs
+++ b/tests/integration/agent_usage_repo_url.rs
@@ -1,0 +1,197 @@
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::working_log::AgentId;
+use git_ai::daemon::checkpoint::build_agent_usage_attrs;
+use git_ai::git::repository as GitAiRepository;
+
+/// Verifies that `build_agent_usage_attrs` includes `repo_url` when the repo has a remote
+/// with a normalizable URL (SSH or HTTPS format).
+/// Regression test: previously, AgentUsage events were emitted before the repo was
+/// discovered, so repo_url was never set.
+#[test]
+fn test_agent_usage_attrs_include_repo_url_when_remote_exists() {
+    let repo = TestRepo::new();
+
+    // Set up an origin remote with an SSH-style URL (normalizable to HTTPS)
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:test-org/test-repo.git",
+    ])
+    .unwrap();
+
+    let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("should open repo");
+
+    let agent_id = AgentId {
+        id: "test-session-123".to_string(),
+        tool: "claude-code".to_string(),
+        model: "claude-sonnet-4-20250514".to_string(),
+    };
+
+    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+
+    // repo_url should be normalized to HTTPS
+    assert_eq!(
+        attrs.repo_url,
+        Some(Some("https://github.com/test-org/test-repo".to_string())),
+        "AgentUsage attrs must include normalized repo_url"
+    );
+
+    // Also verify tool, model, session_id are populated
+    assert!(
+        matches!(&attrs.tool, Some(Some(t)) if t == "claude-code"),
+        "attrs.tool should be 'claude-code', got: {:?}",
+        attrs.tool
+    );
+    assert!(
+        matches!(&attrs.model, Some(Some(m)) if m == "claude-sonnet-4-20250514"),
+        "attrs.model should be set, got: {:?}",
+        attrs.model
+    );
+    assert!(
+        matches!(&attrs.session_id, Some(Some(s)) if !s.is_empty()),
+        "attrs.session_id should be set, got: {:?}",
+        attrs.session_id
+    );
+    assert!(
+        matches!(&attrs.prompt_id, Some(Some(p)) if !p.is_empty()),
+        "attrs.prompt_id should be set, got: {:?}",
+        attrs.prompt_id
+    );
+    assert!(
+        matches!(&attrs.external_prompt_id, Some(Some(p)) if p == "test-session-123"),
+        "attrs.external_prompt_id should match agent_id.id, got: {:?}",
+        attrs.external_prompt_id
+    );
+}
+
+/// Verifies that `build_agent_usage_attrs` normalizes HTTPS remote URLs.
+#[test]
+fn test_agent_usage_attrs_normalizes_https_remote_url() {
+    let repo = TestRepo::new();
+
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/my-company/my-project.git",
+    ])
+    .unwrap();
+
+    let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("should open repo");
+
+    let agent_id = AgentId {
+        id: "session-456".to_string(),
+        tool: "cursor".to_string(),
+        model: "gpt-4".to_string(),
+    };
+
+    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+
+    // Should strip .git suffix
+    assert_eq!(
+        attrs.repo_url,
+        Some(Some("https://github.com/my-company/my-project".to_string())),
+        "AgentUsage attrs must normalize HTTPS repo_url (strip .git)"
+    );
+}
+
+/// Verifies that `build_agent_usage_attrs` includes `branch` when on a branch.
+#[test]
+fn test_agent_usage_attrs_include_branch() {
+    use std::fs;
+
+    let repo = TestRepo::new();
+
+    // Need at least one commit so HEAD resolves to a branch
+    fs::write(repo.path().join("init.txt"), "init\n").unwrap();
+    repo.stage_all_and_commit("initial commit").unwrap();
+
+    repo.git(&["remote", "add", "origin", "git@github.com:org/repo.git"])
+        .unwrap();
+
+    let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("should open repo");
+
+    let agent_id = AgentId {
+        id: "session-789".to_string(),
+        tool: "cursor".to_string(),
+        model: "gpt-4".to_string(),
+    };
+
+    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+
+    // branch should be "main"
+    assert_eq!(
+        attrs.branch,
+        Some(Some("main".to_string())),
+        "AgentUsage attrs must include branch"
+    );
+}
+
+/// Verifies that `build_agent_usage_attrs` gracefully handles repos without a remote.
+#[test]
+fn test_agent_usage_attrs_no_remote_still_works() {
+    let repo = TestRepo::new();
+
+    let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("should open repo");
+
+    let agent_id = AgentId {
+        id: "session-000".to_string(),
+        tool: "windsurf".to_string(),
+        model: "claude-opus-4-20250514".to_string(),
+    };
+
+    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+
+    // repo_url should NOT be set (no remote configured)
+    assert!(
+        attrs.repo_url.is_none() || matches!(&attrs.repo_url, Some(None)),
+        "AgentUsage attrs should not have repo_url when no remote exists, got: {:?}",
+        attrs.repo_url
+    );
+
+    // But tool/model/session_id should still be set
+    assert!(
+        matches!(&attrs.tool, Some(Some(t)) if t == "windsurf"),
+        "attrs.tool should be set"
+    );
+    assert!(
+        matches!(&attrs.model, Some(Some(m)) if m == "claude-opus-4-20250514"),
+        "attrs.model should be set"
+    );
+}
+
+/// Verifies that `build_agent_usage_attrs` gracefully handles repos with a local-path remote
+/// (which cannot be normalized to HTTPS).
+#[test]
+fn test_agent_usage_attrs_local_path_remote_no_repo_url() {
+    let (mirror, _upstream) = TestRepo::new_with_remote();
+
+    let gitai_repo = GitAiRepository::find_repository_in_path(mirror.path().to_str().unwrap())
+        .expect("should open repo");
+
+    let agent_id = AgentId {
+        id: "session-local".to_string(),
+        tool: "claude-code".to_string(),
+        model: "claude-sonnet-4-20250514".to_string(),
+    };
+
+    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+
+    // Local path remotes (like /tmp/...) cannot be normalized, so repo_url should be absent
+    assert!(
+        attrs.repo_url.is_none(),
+        "AgentUsage attrs should not have repo_url for local-path remotes, got: {:?}",
+        attrs.repo_url
+    );
+
+    // But other attrs should still be set correctly
+    assert!(
+        matches!(&attrs.tool, Some(Some(t)) if t == "claude-code"),
+        "attrs.tool should be set"
+    );
+}

--- a/tests/integration/agent_usage_repo_url.rs
+++ b/tests/integration/agent_usage_repo_url.rs
@@ -29,7 +29,7 @@ fn test_agent_usage_attrs_include_repo_url_when_remote_exists() {
         model: "claude-sonnet-4-20250514".to_string(),
     };
 
-    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+    let attrs = build_agent_usage_attrs(Some(&gitai_repo), &agent_id);
 
     // repo_url should be normalized to HTTPS
     assert_eq!(
@@ -88,7 +88,7 @@ fn test_agent_usage_attrs_normalizes_https_remote_url() {
         model: "gpt-4".to_string(),
     };
 
-    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+    let attrs = build_agent_usage_attrs(Some(&gitai_repo), &agent_id);
 
     // Should strip .git suffix
     assert_eq!(
@@ -121,7 +121,7 @@ fn test_agent_usage_attrs_include_branch() {
         model: "gpt-4".to_string(),
     };
 
-    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+    let attrs = build_agent_usage_attrs(Some(&gitai_repo), &agent_id);
 
     // branch should be "main"
     assert_eq!(
@@ -145,7 +145,7 @@ fn test_agent_usage_attrs_no_remote_still_works() {
         model: "claude-opus-4-20250514".to_string(),
     };
 
-    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+    let attrs = build_agent_usage_attrs(Some(&gitai_repo), &agent_id);
 
     // repo_url should NOT be set (no remote configured)
     assert!(
@@ -180,7 +180,7 @@ fn test_agent_usage_attrs_local_path_remote_no_repo_url() {
         model: "claude-sonnet-4-20250514".to_string(),
     };
 
-    let attrs = build_agent_usage_attrs(&gitai_repo, &agent_id);
+    let attrs = build_agent_usage_attrs(Some(&gitai_repo), &agent_id);
 
     // Local path remotes (like /tmp/...) cannot be normalized, so repo_url should be absent
     assert!(

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -7,6 +7,7 @@ mod test_utils;
 // Test modules (one per original test file)
 mod agent_commits_blame;
 mod agent_presets_comprehensive;
+mod agent_usage_repo_url;
 mod agent_v1;
 mod ai_reflow_attribution;
 mod ai_tab;


### PR DESCRIPTION
## Summary

- AgentUsage events were emitted **before** the repository was discovered from the checkpoint request's working directory, so `repo_url` and `branch` were never populated in the event attributes
- Moved repository discovery to occur before the AgentUsage event emission
- Extracted a dedicated `build_agent_usage_attrs()` function that properly includes `repo_url`, `branch`, and all existing fields (tool, model, session_id, prompt_id, external_prompt_id, custom_attributes)

## Test plan

- [x] Added 5 integration tests covering:
  - SSH remote URL normalization to HTTPS in AgentUsage attrs
  - HTTPS remote URL normalization (stripping `.git` suffix)
  - Branch inclusion in attrs
  - Graceful handling of repos without remotes
  - Graceful handling of local-path remotes (non-normalizable)
- [x] `task fmt` passes
- [x] `task lint` passes
- [x] Full test suite passes (2973 tests, 1 unrelated flaky timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->