### PR TITLE
feat: propagate tool_use_id to checkpoint telemetry events

### DIFF
--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -269,6 +269,10 @@ fn execute_pre_file_edit(e: PreFileEdit) -> Result<Vec<CheckpointRequest>, GitAi
             }
         }
     }
+    let mut metadata = e.context.metadata;
+    if let Some(tuid) = e.tool_use_id {
+        metadata.entry("tool_use_id".to_string()).or_insert(tuid);
+    }
     Ok(split_files_into_requests(
         files,
         e.context.trace_id,
@@ -276,7 +280,7 @@ fn execute_pre_file_edit(e: PreFileEdit) -> Result<Vec<CheckpointRequest>, GitAi
         None,
         PreparedPathRole::WillEdit,
         None,
-        e.context.metadata,
+        metadata,
     ))
 }
 
@@ -296,6 +300,10 @@ fn execute_post_file_edit(
         "ai_tab" => CheckpointKind::AiTab,
         _ => CheckpointKind::AiAgent,
     };
+    let mut metadata = e.context.metadata;
+    if let Some(tuid) = e.tool_use_id {
+        metadata.entry("tool_use_id".to_string()).or_insert(tuid);
+    }
     Ok(split_files_into_requests(
         files,
         e.context.trace_id,
@@ -303,7 +311,7 @@ fn execute_post_file_edit(
         Some(e.context.agent_id),
         PreparedPathRole::Edited,
         e.transcript_source,
-        e.context.metadata,
+        metadata,
     ))
 }
 
@@ -370,6 +378,10 @@ fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAi
     }
 
     let files = build_checkpoint_files(&dirty_paths)?;
+    let mut metadata = e.context.metadata;
+    metadata
+        .entry("tool_use_id".to_string())
+        .or_insert(e.tool_use_id);
     Ok(split_files_into_requests(
         files,
         e.context.trace_id,
@@ -377,7 +389,7 @@ fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAi
         None,
         PreparedPathRole::WillEdit,
         None,
-        e.context.metadata,
+        metadata,
     ))
 }
 
@@ -408,6 +420,10 @@ fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, Git
     };
 
     let files = build_checkpoint_files(&file_paths)?;
+    let mut metadata = e.context.metadata;
+    metadata
+        .entry("tool_use_id".to_string())
+        .or_insert(e.tool_use_id);
     Ok(split_files_into_requests(
         files,
         e.context.trace_id,
@@ -415,6 +431,6 @@ fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, Git
         Some(e.context.agent_id),
         PreparedPathRole::Edited,
         e.transcript_source,
-        e.context.metadata,
+        metadata,
     ))
 }

--- a/src/commands/checkpoint_agent/presets/agent_v1.rs
+++ b/src/commands/checkpoint_agent/presets/agent_v1.rs
@@ -64,6 +64,7 @@ impl AgentPreset for AgentV1Preset {
                     },
                     file_paths,
                     dirty_files: dirty,
+                    tool_use_id: None,
                 })
             }
             AgentV1Payload::AiAgent {
@@ -97,6 +98,7 @@ impl AgentPreset for AgentV1Preset {
                     file_paths,
                     dirty_files: dirty,
                     transcript_source: None,
+                    tool_use_id: None,
                 })
             }
         };

--- a/src/commands/checkpoint_agent/presets/ai_tab.rs
+++ b/src/commands/checkpoint_agent/presets/ai_tab.rs
@@ -71,6 +71,7 @@ impl AgentPreset for AiTabPreset {
                 context,
                 file_paths,
                 dirty_files,
+                tool_use_id: None,
             })
         } else {
             let file_paths = parse::pathbuf_array(&data, "edited_filepaths", cwd);
@@ -79,6 +80,7 @@ impl AgentPreset for AiTabPreset {
                 file_paths,
                 dirty_files,
                 transcript_source: None,
+                tool_use_id: None,
             })
         };
 

--- a/src/commands/checkpoint_agent/presets/amp.rs
+++ b/src/commands/checkpoint_agent/presets/amp.rs
@@ -336,6 +336,7 @@ impl AgentPreset for AmpPreset {
                 context,
                 file_paths,
                 dirty_files: None,
+                tool_use_id: tool_use_id.clone(),
             }),
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
@@ -347,6 +348,7 @@ impl AgentPreset for AmpPreset {
                 file_paths,
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: tool_use_id.clone(),
             }),
         };
 

--- a/src/commands/checkpoint_agent/presets/claude.rs
+++ b/src/commands/checkpoint_agent/presets/claude.rs
@@ -100,6 +100,7 @@ impl AgentPreset for ClaudePreset {
                 context,
                 file_paths: parse::file_paths_from_tool_input(&data, cwd),
                 dirty_files: None,
+                tool_use_id: Some(tool_use_id.to_string()),
             }),
             (_, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
@@ -111,6 +112,7 @@ impl AgentPreset for ClaudePreset {
                 file_paths: parse::file_paths_from_tool_input(&data, cwd),
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: Some(tool_use_id.to_string()),
             }),
         };
 

--- a/src/commands/checkpoint_agent/presets/codex.rs
+++ b/src/commands/checkpoint_agent/presets/codex.rs
@@ -148,6 +148,7 @@ impl AgentPreset for CodexPreset {
                         context,
                         file_paths: vec![],
                         dirty_files: None,
+                        tool_use_id: Some(tool_use_id.to_string()),
                     })
                 } else {
                     return Err(GitAiError::PresetError(format!(
@@ -177,6 +178,7 @@ impl AgentPreset for CodexPreset {
                         file_paths,
                         dirty_files: None,
                         transcript_source,
+                        tool_use_id: Some(tool_use_id.to_string()),
                     })
                 } else {
                     return Err(GitAiError::PresetError(format!(

--- a/src/commands/checkpoint_agent/presets/continue_cli.rs
+++ b/src/commands/checkpoint_agent/presets/continue_cli.rs
@@ -59,6 +59,7 @@ impl AgentPreset for ContinueCliPreset {
                 context,
                 file_paths: parse::file_paths_from_tool_input(&data, cwd),
                 dirty_files: None,
+                tool_use_id: Some(tool_use_id.to_string()),
             }),
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
@@ -70,6 +71,7 @@ impl AgentPreset for ContinueCliPreset {
                 file_paths: parse::file_paths_from_tool_input(&data, cwd),
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: Some(tool_use_id.to_string()),
             }),
         };
 

--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -123,37 +123,32 @@ impl AgentPreset for CursorPreset {
         });
 
         let is_pre = hook_event_name == "preToolUse";
+        let tool_use_id = parse::optional_str(&data, "tool_use_id")
+            .unwrap_or("bash")
+            .to_string();
 
         let event = match (tool_class, is_pre) {
-            (ToolClass::Bash, true) => {
-                let tool_use_id = parse::optional_str(&data, "tool_use_id")
-                    .unwrap_or("bash")
-                    .to_string();
-                ParsedHookEvent::PreBashCall(PreBashCall {
-                    context,
-                    tool_use_id,
-                })
-            }
-            (ToolClass::Bash, false) => {
-                let tool_use_id = parse::optional_str(&data, "tool_use_id")
-                    .unwrap_or("bash")
-                    .to_string();
-                ParsedHookEvent::PostBashCall(PostBashCall {
-                    context,
-                    tool_use_id,
-                    transcript_source,
-                })
-            }
+            (ToolClass::Bash, true) => ParsedHookEvent::PreBashCall(PreBashCall {
+                context,
+                tool_use_id,
+            }),
+            (ToolClass::Bash, false) => ParsedHookEvent::PostBashCall(PostBashCall {
+                context,
+                tool_use_id,
+                transcript_source,
+            }),
             (ToolClass::FileEdit, true) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
                 file_paths,
                 dirty_files: None,
+                tool_use_id: Some(tool_use_id),
             }),
             (ToolClass::FileEdit, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {
                 context,
                 file_paths,
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: Some(tool_use_id),
             }),
             (ToolClass::Skip, _) => unreachable!("Skip handled above"),
         };

--- a/src/commands/checkpoint_agent/presets/droid.rs
+++ b/src/commands/checkpoint_agent/presets/droid.rs
@@ -173,6 +173,7 @@ impl AgentPreset for DroidPreset {
                 context,
                 file_paths,
                 dirty_files: None,
+                tool_use_id: Some(tool_use_id.clone()),
             })]);
         }
 
@@ -190,6 +191,7 @@ impl AgentPreset for DroidPreset {
             file_paths,
             dirty_files: None,
             transcript_source,
+            tool_use_id: Some(tool_use_id.clone()),
         })])
     }
 }

--- a/src/commands/checkpoint_agent/presets/firebender.rs
+++ b/src/commands/checkpoint_agent/presets/firebender.rs
@@ -216,6 +216,7 @@ impl AgentPreset for FirebenderPreset {
                 context,
                 file_paths,
                 dirty_files: dirty,
+                tool_use_id: None,
             }),
             (_, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
@@ -227,6 +228,7 @@ impl AgentPreset for FirebenderPreset {
                 file_paths,
                 dirty_files: dirty,
                 transcript_source: None,
+                tool_use_id: None,
             }),
         };
 

--- a/src/commands/checkpoint_agent/presets/gemini.rs
+++ b/src/commands/checkpoint_agent/presets/gemini.rs
@@ -65,6 +65,7 @@ impl AgentPreset for GeminiPreset {
                 context,
                 file_paths: parse::file_paths_from_tool_input(&data, cwd),
                 dirty_files: None,
+                tool_use_id: Some(tool_use_id.to_string()),
             }),
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
@@ -76,6 +77,7 @@ impl AgentPreset for GeminiPreset {
                 file_paths: parse::file_paths_from_tool_input(&data, cwd),
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: Some(tool_use_id.to_string()),
             }),
         };
 

--- a/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
@@ -88,6 +88,7 @@ pub(super) fn parse_cli_hooks(
                     context,
                     file_paths: extracted_paths,
                     dirty_files: Some(dirty_files),
+                    tool_use_id: Some(tool_use_id),
                 })]);
             }
             if extracted_paths.is_empty() {
@@ -100,6 +101,7 @@ pub(super) fn parse_cli_hooks(
                 context,
                 file_paths: extracted_paths,
                 dirty_files,
+                tool_use_id: Some(tool_use_id),
             })])
         }
         ("PostToolUse", ToolClass::FileEdit) => {
@@ -114,6 +116,7 @@ pub(super) fn parse_cli_hooks(
                 file_paths: extracted_paths,
                 dirty_files,
                 transcript_source: None,
+                tool_use_id: Some(tool_use_id),
             })])
         }
         _ => unreachable!("hook_event_name pre-validated by mod.rs fork"),

--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -68,6 +68,7 @@ pub(super) fn parse_legacy_extension_hooks(
             context,
             file_paths: will_edit_filepaths,
             dirty_files,
+            tool_use_id: None,
         })]);
     }
 
@@ -130,6 +131,7 @@ pub(super) fn parse_legacy_extension_hooks(
         file_paths: edited_filepaths,
         dirty_files,
         transcript_source,
+        tool_use_id: None,
     })])
 }
 
@@ -266,6 +268,7 @@ pub(super) fn parse_vscode_native_hooks(
                 context,
                 file_paths: extracted_paths,
                 dirty_files: Some(empty_dirty_files),
+                tool_use_id: Some(tool_use_id),
             })]);
         }
 
@@ -280,6 +283,7 @@ pub(super) fn parse_vscode_native_hooks(
             context,
             file_paths: extracted_paths,
             dirty_files,
+            tool_use_id: Some(tool_use_id),
         })]);
     }
 
@@ -304,6 +308,7 @@ pub(super) fn parse_vscode_native_hooks(
         file_paths: extracted_paths,
         dirty_files,
         transcript_source,
+        tool_use_id: Some(tool_use_id),
     })])
 }
 

--- a/src/commands/checkpoint_agent/presets/mock_ai.rs
+++ b/src/commands/checkpoint_agent/presets/mock_ai.rs
@@ -62,6 +62,7 @@ impl AgentPreset for MockAiPreset {
             file_paths,
             dirty_files: None,
             transcript_source: None,
+            tool_use_id: None,
         })])
     }
 }

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -49,6 +49,8 @@ pub struct PreFileEdit {
     pub context: PresetContext,
     pub file_paths: Vec<PathBuf>,
     pub dirty_files: Option<HashMap<PathBuf, String>>,
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +59,8 @@ pub struct PostFileEdit {
     pub file_paths: Vec<PathBuf>,
     pub dirty_files: Option<HashMap<PathBuf, String>>,
     pub transcript_source: Option<TranscriptSource>,
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -310,6 +310,7 @@ impl AgentPreset for OpenCodePreset {
                 context,
                 file_paths,
                 dirty_files: None,
+                tool_use_id: Some(tool_use_id_str),
             }),
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
@@ -321,6 +322,7 @@ impl AgentPreset for OpenCodePreset {
                 file_paths,
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: Some(tool_use_id_str),
             }),
         };
 

--- a/src/commands/checkpoint_agent/presets/pi.rs
+++ b/src/commands/checkpoint_agent/presets/pi.rs
@@ -168,6 +168,7 @@ impl AgentPreset for PiPreset {
                     context,
                     file_paths: will_edit_filepaths.into_iter().map(PathBuf::from).collect(),
                     dirty_files: dirty,
+                    tool_use_id: tool_use_id.clone(),
                 })
             }
             PiHookEvent::AfterEdit => {
@@ -181,6 +182,7 @@ impl AgentPreset for PiPreset {
                     file_paths: edited_filepaths.into_iter().map(PathBuf::from).collect(),
                     dirty_files: dirty,
                     transcript_source,
+                    tool_use_id,
                 })
             }
             PiHookEvent::BeforeCommand => ParsedHookEvent::PreBashCall(PreBashCall {

--- a/src/commands/checkpoint_agent/presets/windsurf.rs
+++ b/src/commands/checkpoint_agent/presets/windsurf.rs
@@ -154,6 +154,7 @@ impl AgentPreset for WindsurfPreset {
                 context,
                 file_paths: file_path,
                 dirty_files: None,
+                tool_use_id: Some(execution_id.clone()),
             })
         } else {
             let file_path = tool_info
@@ -167,6 +168,7 @@ impl AgentPreset for WindsurfPreset {
                 file_paths: file_path,
                 dirty_files: None,
                 transcript_source,
+                tool_use_id: Some(execution_id),
             })
         };
 

--- a/tests/integration/checkpoint_telemetry.rs
+++ b/tests/integration/checkpoint_telemetry.rs
@@ -1,0 +1,201 @@
+use crate::repos::test_repo::TestRepo;
+use serde_json::json;
+use std::fs;
+
+/// Verify that tool_use_id from hook input propagates to checkpoint agent_metadata
+/// for file edit events (non-bash). This is the data that feeds external_tool_use_id
+/// in telemetry metrics.
+#[test]
+fn test_claude_file_edit_checkpoint_propagates_tool_use_id_to_metadata() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let transcript_path = repo_root.join("session.jsonl");
+    fs::write(&transcript_path, "{}\n").unwrap();
+
+    let pre_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_use_id": "toolu_01ABC123",
+        "session_id": "sess-telemetry-test",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy()
+        }
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &pre_hook])
+        .expect("pre checkpoint should succeed");
+
+    fs::write(&file_path, "const x = 1;\nconst y = 2;\n").unwrap();
+
+    let post_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_use_id": "toolu_01ABC123",
+        "session_id": "sess-telemetry-test",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy()
+        }
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &post_hook])
+        .expect("post checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    let ai_checkpoint = checkpoints
+        .iter()
+        .find(|c| c.kind == git_ai::authorship::working_log::CheckpointKind::AiAgent)
+        .expect("Should have an AI agent checkpoint");
+
+    let metadata = ai_checkpoint
+        .agent_metadata
+        .as_ref()
+        .expect("AI checkpoint should have agent_metadata");
+
+    assert_eq!(
+        metadata.get("tool_use_id"),
+        Some(&"toolu_01ABC123".to_string()),
+        "tool_use_id must propagate to agent_metadata for telemetry emission"
+    );
+}
+
+/// Verify tool_use_id propagation for bash tool events (e.g., codex preset).
+#[test]
+fn test_codex_bash_checkpoint_propagates_tool_use_id_to_metadata() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    let file_path = repo_root.join("src/main.rs");
+    fs::create_dir_all(repo_root.join("src")).unwrap();
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let transcript_path = repo_root.join("codex-session.jsonl");
+    fs::write(&transcript_path, "{}\n").unwrap();
+
+    let pre_hook = json!({
+        "session_id": "codex-telem-sess",
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "tu-bash-789xyz",
+        "tool_input": {
+            "command": "echo hello"
+        },
+        "transcript_path": transcript_path.to_string_lossy()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook])
+        .expect("pre bash checkpoint should succeed");
+
+    fs::write(&file_path, "fn main() {}\nfn added() {}\n").unwrap();
+
+    let post_hook = json!({
+        "session_id": "codex-telem-sess",
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "tu-bash-789xyz",
+        "tool_input": {
+            "command": "echo hello"
+        },
+        "transcript_path": transcript_path.to_string_lossy()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook])
+        .expect("post bash checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    let ai_checkpoint = checkpoints
+        .iter()
+        .find(|c| c.kind == git_ai::authorship::working_log::CheckpointKind::AiAgent)
+        .expect("Should have an AI agent checkpoint");
+
+    let metadata = ai_checkpoint
+        .agent_metadata
+        .as_ref()
+        .expect("AI checkpoint should have agent_metadata");
+
+    assert_eq!(
+        metadata.get("tool_use_id"),
+        Some(&"tu-bash-789xyz".to_string()),
+        "tool_use_id from bash events must propagate to agent_metadata for telemetry"
+    );
+}
+
+/// Verify that tool_use_id propagation works for the gemini preset.
+#[test]
+fn test_gemini_file_edit_checkpoint_propagates_tool_use_id_to_metadata() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    let file_path = repo_root.join("app.py");
+    fs::write(&file_path, "print('hello')\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let transcript_path = repo_root.join("gemini-session.jsonl");
+    fs::write(&transcript_path, "{}\n").unwrap();
+
+    let pre_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "WriteFile",
+        "tool_use_id": "gemini-tu-456",
+        "session_id": "gemini-sess-1",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy()
+        }
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "gemini", "--hook-input", &pre_hook])
+        .expect("gemini pre checkpoint should succeed");
+
+    fs::write(&file_path, "print('hello')\nprint('world')\n").unwrap();
+
+    let post_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "WriteFile",
+        "tool_use_id": "gemini-tu-456",
+        "session_id": "gemini-sess-1",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy()
+        }
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "gemini", "--hook-input", &post_hook])
+        .expect("gemini post checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    let ai_checkpoint = checkpoints
+        .iter()
+        .find(|c| c.kind == git_ai::authorship::working_log::CheckpointKind::AiAgent)
+        .expect("Should have an AI agent checkpoint");
+
+    let metadata = ai_checkpoint
+        .agent_metadata
+        .as_ref()
+        .expect("AI checkpoint should have agent_metadata");
+
+    assert_eq!(
+        metadata.get("tool_use_id"),
+        Some(&"gemini-tu-456".to_string()),
+        "tool_use_id must propagate for gemini preset file edit events"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -26,6 +26,7 @@ mod checkout_switch;
 mod checkpoint_explicit_paths;
 mod checkpoint_perf;
 mod checkpoint_size;
+mod checkpoint_telemetry;
 mod checkpoint_unit;
 mod cherry_pick;
 mod chinese_text_edits;


### PR DESCRIPTION
## Summary
- Add `tool_use_id: Option<String>` field to `PreFileEdit` and `PostFileEdit` structs so all presets can carry tool_use_id through to telemetry
- Inject tool_use_id into metadata centrally in the orchestrator's `execute_*` functions using `entry().or_insert()` (preserves any value already set by AMP)
- Update all 15 preset files to populate the new field — presets that parse tool_use_id from hook input now pass it through; presets without it (firebender, agent_v1, ai_tab, mock_ai) use `None`

## Context
The `external_tool_use_id` field in checkpoint metrics (position 7 in `CheckpointValues`) was only ever populated for the AMP preset. All other presets parsed `tool_use_id` from their hook JSON input but never inserted it into the `context.metadata` HashMap. The telemetry consumer at `daemon/checkpoint.rs:324` reads from `checkpoint_request.metadata.get("tool_use_id")`, so for non-AMP presets this was always `None` — making it impossible to link checkpoint events back to specific tool calls in the transcript.

## Test plan
- [x] `task build` compiles cleanly
- [x] `task lint` and `task fmt` pass with no warnings
- [x] All 172 preset unit tests pass
- [x] All 168 checkpoint integration tests pass
- [x] AMP preset behavior unchanged (entry().or_insert preserves existing metadata value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->