### PR TITLE
perf: cache git_author_identity globally for up to 5 minutes

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -20,7 +20,9 @@ use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 #[cfg(windows)]
 use crate::utils::CREATE_NO_WINDOW;
@@ -1091,6 +1093,11 @@ impl<'a> Iterator for References<'a> {
     }
 }
 
+const AUTHOR_IDENTITY_CACHE_TTL: Duration = Duration::from_secs(300);
+
+static AUTHOR_IDENTITY_CACHE: Mutex<Option<HashMap<PathBuf, (GitAuthorIdentity, Instant)>>> =
+    Mutex::new(None);
+
 /// The effective git author identity (name + email) for the current repository.
 ///
 /// Resolved via `git var GIT_COMMITTER_IDENT` which respects the full git precedence
@@ -1453,13 +1460,31 @@ impl Repository {
     /// system defaults.
     ///
     /// Falls back to `git config user.name` / `user.email` if `git var` fails.
-    /// The result is cached per Repository instance for performance.
+    /// The result is cached globally for up to 5 minutes (keyed by git dir) and
+    /// per Repository instance for the instance's lifetime.
     ///
     /// Use this for "who is the current user" lookups (blame, status, prompts, etc.).
     /// For commit authorship specifically, use [`Self::git_commit_author_identity`] instead.
     pub fn git_author_identity(&self) -> &GitAuthorIdentity {
-        self.cached_author_identity
-            .get_or_init(|| self.resolve_git_var_identity("GIT_COMMITTER_IDENT"))
+        self.cached_author_identity.get_or_init(|| {
+            let git_dir = self.path();
+            if let Ok(cache) = AUTHOR_IDENTITY_CACHE.lock()
+                && let Some(map) = cache.as_ref()
+                && let Some((identity, cached_at)) = map.get(git_dir)
+                && cached_at.elapsed() < AUTHOR_IDENTITY_CACHE_TTL
+            {
+                return identity.clone();
+            }
+
+            let identity = self.resolve_git_var_identity("GIT_COMMITTER_IDENT");
+
+            if let Ok(mut cache) = AUTHOR_IDENTITY_CACHE.lock() {
+                let map = cache.get_or_insert_with(HashMap::new);
+                map.insert(git_dir.to_path_buf(), (identity.clone(), Instant::now()));
+            }
+
+            identity
+        })
     }
 
     /// Get the effective git commit author identity for this repository.


### PR DESCRIPTION
## Summary

Adds a process-global cache (keyed by git dir path) with a 5-minute TTL for resolved git author identities. Previously, `git_author_identity()` was cached only per `Repository` instance via `OnceLock`, meaning each new `Repository` instance would re-spawn `git var GIT_COMMITTER_IDENT` as a subprocess. This is particularly impactful for the long-running daemon, which creates many short-lived `Repository` instances.

The global cache uses a `Mutex<Option<HashMap<PathBuf, (GitAuthorIdentity, Instant)>>>` keyed by the repository's git dir path. On cache hit (< 5 min old), the identity is cloned from the global cache into the per-instance `OnceLock`. On miss or expiry, it resolves fresh via `git var` and updates the global cache.

## Review & Testing Checklist for Human

- [ ] Verify that the 5-minute TTL is acceptable for your use case — if a user changes their git identity (e.g. `git config user.name`), it won't take effect in the daemon for up to 5 minutes
- [ ] Confirm that `git_commit_author_identity()` is intentionally **not** cached globally (it uses `GIT_AUTHOR_IDENT` which may differ per-commit context, e.g. during cherry-pick/rebase)

### Notes

- The 2 test failures (`checkpoint_non_adjacent_hunks_survive_split_commits` and `checkpoint_two_commits_preserve_ai_lines`) are pre-existing on `main` and unrelated to this change.


Link to Devin session: https://app.devin.ai/sessions/8ed48033fe8843b88b2bcba98eb7034d
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->