### PR TITLE
fix(e2e): update verification for sessions-v2 and enable Windows daemon

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,9 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  # Async mode is now fully supported by the e2e tests: a per-test daemon
-  # is started in setup() and the wrapper polls for authorship notes.
-  GIT_AI_ASYNC_MODE: "true"
+  GIT_AI_TEST_FORCE_TTY: "1"
+  GIT_AI_POST_COMMIT_TIMEOUT_MS: "30000"
 
 jobs:
   e2e-tests:

--- a/.github/workflows/install-scripts-local.yml
+++ b/.github/workflows/install-scripts-local.yml
@@ -20,12 +20,12 @@ on:
   workflow_dispatch:
 
 env:
-  # Async mode: each Unix job starts a per-job daemon via
-  # start-async-daemon.sh which exports GIT_AI_TEST_FORCE_TTY and
-  # GIT_AI_POST_COMMIT_TIMEOUT_MS so the wrapper polls for authorship
-  # notes after commits.  Windows jobs override this to "false" because
-  # Unix-domain sockets are not available there.
-  GIT_AI_ASYNC_MODE: "true"
+  # The daemon is always required — the git proxy only performs attribution
+  # when connected to a daemon (see git_handlers.rs). Each job starts a
+  # per-job daemon via start-async-daemon.sh (Unix) or inline PowerShell
+  # (Windows, using named pipes).
+  GIT_AI_TEST_FORCE_TTY: "1"
+  GIT_AI_POST_COMMIT_TIMEOUT_MS: "30000"
 
 jobs:
   install-local-unix:
@@ -179,9 +179,6 @@ jobs:
   install-local-windows:
     name: E2E ${{ matrix.agent.name }} on windows-latest
     runs-on: windows-latest
-    env:
-      # Windows does not support Unix-domain sockets for the async daemon.
-      GIT_AI_ASYNC_MODE: "false"
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -311,6 +308,47 @@ jobs:
           & $gitAiExe install
           if ($LASTEXITCODE -ne 0) { throw "git-ai install failed with exit code $LASTEXITCODE" }
 
+      - name: Start async daemon (Windows)
+        shell: pwsh
+        env:
+          HOME: ${{ env.TEST_HOME }}
+          USERPROFILE: ${{ env.TEST_HOME }}
+          HOMEDRIVE: ${{ env.TEST_HOME_DRIVE }}
+          HOMEPATH: ${{ env.TEST_HOME_PATH }}
+        run: |
+          $installDir = Join-Path $env:USERPROFILE ".git-ai\bin"
+          $gitAiExe = Join-Path $installDir "git-ai.exe"
+          # Create daemon home with config
+          $daemonHome = Join-Path $env:RUNNER_TEMP "git-ai-daemon"
+          New-Item -ItemType Directory -Force -Path (Join-Path $daemonHome ".git-ai") | Out-Null
+          # Find the real git (not the proxy)
+          $realGit = (Get-Command git -CommandType Application | Where-Object { $_.Source -notlike "*\.git-ai\*" } | Select-Object -First 1).Source
+          if (-not $realGit) { $realGit = "C:\Program Files\Git\cmd\git.exe" }
+          $config = @{
+            git_path = $realGit
+            disable_auto_updates = $true
+            feature_flags = @{ git_hooks_enabled = $false }
+            quiet = $false
+          } | ConvertTo-Json -Depth 5
+          Set-Content -Path (Join-Path $daemonHome ".git-ai\config.json") -Value $config
+          # Export daemon env vars
+          Add-Content -Path $env:GITHUB_ENV -Value "GIT_AI_DAEMON_HOME=$daemonHome"
+          $env:GIT_AI_DAEMON_HOME = $daemonHome
+          # Start the daemon in the background
+          $proc = Start-Process -FilePath $gitAiExe -ArgumentList "bg","run" -PassThru -NoNewWindow
+          Add-Content -Path $env:GITHUB_ENV -Value "ASYNC_DAEMON_PID=$($proc.Id)"
+          # Wait for the daemon to be ready (up to 15s)
+          $waited = 0
+          while ($waited -lt 15000) {
+            # Test connectivity by running a simple command that requires the daemon
+            $testResult = & $gitAiExe bg status 2>&1
+            if ($LASTEXITCODE -eq 0) { break }
+            Start-Sleep -Milliseconds 250
+            $waited += 250
+          }
+          if ($waited -ge 15000) { throw "Daemon did not start within 15 seconds" }
+          Write-Host "Async daemon started (PID=$($proc.Id))"
+
       - name: Run synthetic agent commit (Windows)
         shell: pwsh
         env:
@@ -406,24 +444,40 @@ jobs:
             throw "Verification failed: wrong schema_version"
           }
           Write-Log "PASS: schema_version = $schema"
-          # ── 4. Prompts non-empty ──────────────────────────────────────────────
-          $promptCount = ($metaJson.prompts | Get-Member -MemberType NoteProperty).Count
-          if ($promptCount -lt 1) {
-            Write-Log "FAIL: No prompt sessions in authorship note — checkpoint data was not stored"
-            $lines | Set-Content -Path $log
-            throw "Verification failed: no prompts recorded"
+          # ── 4. Sessions non-empty ─────────────────────────────────────────────
+          $promptCount = 0
+          if ($metaJson.prompts) {
+            $promptCount = ($metaJson.prompts | Get-Member -MemberType NoteProperty).Count
           }
-          Write-Log "PASS: $promptCount prompt session(s) recorded"
+          $sessionCount = 0
+          if ($metaJson.sessions) {
+            $sessionCount = ($metaJson.sessions | Get-Member -MemberType NoteProperty).Count
+          }
+          $totalCount = $promptCount + $sessionCount
+          if ($totalCount -lt 1) {
+            Write-Log "FAIL: No prompt/session entries in authorship note — checkpoint data was not stored"
+            $lines | Set-Content -Path $log
+            throw "Verification failed: no prompts or sessions recorded"
+          }
+          Write-Log "PASS: $totalCount AI session(s) recorded"
           # ── 5. Transcript messages ────────────────────────────────────────────
           $msgCount = 0
-          foreach ($key in ($metaJson.prompts | Get-Member -MemberType NoteProperty).Name) {
-            $record = $metaJson.prompts.$key
-            if ($record.messages) { $msgCount += $record.messages.Count }
+          if ($metaJson.prompts) {
+            foreach ($key in ($metaJson.prompts | Get-Member -MemberType NoteProperty).Name) {
+              $record = $metaJson.prompts.$key
+              if ($record.messages) { $msgCount += $record.messages.Count }
+            }
+          }
+          if ($metaJson.sessions) {
+            foreach ($key in ($metaJson.sessions | Get-Member -MemberType NoteProperty).Name) {
+              $record = $metaJson.sessions.$key
+              if ($record.messages) { $msgCount += $record.messages.Count }
+            }
           }
           if ($msgCount -gt 0) {
             Write-Log "PASS: Transcript captured: $msgCount message(s) recorded"
           } else {
-            Write-Log "WARN: No transcript messages in authorship note — conversation capture is only available in live agent runs, not synthetic checkpoints"
+            Write-Log "WARN: No transcript messages — sessions format does not embed transcripts inline"
           }
           # ── 6. git-ai stats reports AI additions ──────────────────────────────
           $statsRaw = & $gitAiExe stats HEAD --json 2>&1
@@ -466,6 +520,27 @@ jobs:
           }
           $lines | Set-Content -Path $log
           Write-Log "=== Synthetic attribution verification COMPLETE: $agent ==="
+
+      - name: Stop async daemon (Windows)
+        if: always()
+        shell: pwsh
+        env:
+          HOME: ${{ env.TEST_HOME }}
+          USERPROFILE: ${{ env.TEST_HOME }}
+          HOMEDRIVE: ${{ env.TEST_HOME_DRIVE }}
+          HOMEPATH: ${{ env.TEST_HOME_PATH }}
+        run: |
+          $installDir = Join-Path $env:USERPROFILE ".git-ai\bin"
+          $gitAiExe = Join-Path $installDir "git-ai.exe"
+          if (Test-Path $gitAiExe) {
+            & $gitAiExe bg shutdown 2>&1 | Out-Null
+          }
+          if ($env:ASYNC_DAEMON_PID) {
+            $proc = Get-Process -Id $env:ASYNC_DAEMON_PID -ErrorAction SilentlyContinue
+            if ($proc) {
+              $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+          }
 
       - name: Upload E2E test results
         if: always()

--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -20,11 +20,6 @@ on:
 env:
   GIT_AI_DEBUG: "1"
   CARGO_INCREMENTAL: "0"
-  # Async mode: each job starts a per-job daemon via
-  # start-async-daemon.sh which exports GIT_AI_TEST_FORCE_TTY and
-  # GIT_AI_POST_COMMIT_TIMEOUT_MS so the wrapper polls for authorship
-  # notes after commits.
-  GIT_AI_ASYNC_MODE: "true"
 
 jobs:
   # ── Version Resolution ─────────────────────────────────────────────────────

--- a/scripts/nightly/test-synthetic-checkpoint.sh
+++ b/scripts/nightly/test-synthetic-checkpoint.sh
@@ -60,7 +60,7 @@ pass "Commit created successfully"
 
 # Verify authorship note was generated
 if git notes --ref=ai show HEAD 2>/dev/null \
-    | grep -qiE "authorship|schema_version|prompts"; then
+    | grep -qiE "authorship|schema_version|prompts|sessions"; then
   pass "Authorship note found on HEAD"
 else
   fail "No authorship note found on HEAD (post-commit hook may not have fired)"

--- a/scripts/nightly/verify-attribution.sh
+++ b/scripts/nightly/verify-attribution.sh
@@ -92,12 +92,18 @@ SCHEMA=$(python3 -c "import json, sys; d=json.load(open(sys.argv[1])); print(d.g
 
 pass "schema_version = $SCHEMA"
 
-# ── 6. Prompts non-empty ──────────────────────────────────────────────────────
-PROMPT_COUNT=$(python3 -c "import json, sys; d=json.load(open(sys.argv[1])); print(len(d.get('prompts', {})))" "$META_JSON")
-[ "$PROMPT_COUNT" -gt 0 ] \
-  || fail "No prompt sessions recorded in authorship note — agent hooks did not capture activity (check hook wiring with verify-hook-wiring.sh)"
+# ── 6. Sessions non-empty ─────────────────────────────────────────────────────
+SESSION_COUNT=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+prompts = len(d.get('prompts', {}))
+sessions = len(d.get('sessions', {}))
+print(prompts + sessions)
+" "$META_JSON")
+[ "$SESSION_COUNT" -gt 0 ] \
+  || fail "No prompt/session entries recorded in authorship note — agent hooks did not capture activity (check hook wiring with verify-hook-wiring.sh)"
 
-pass "$PROMPT_COUNT prompt session(s) recorded"
+pass "$SESSION_COUNT AI session(s) recorded"
 
 # ── 7. Agent identification ────────────────────────────────────────────────────
 AGENT_MATCH=$(python3 - "$META_JSON" "$AGENT" <<'PYEOF'
@@ -106,7 +112,8 @@ import json, sys
 meta = json.load(open(sys.argv[1]))
 agent = sys.argv[2].lower()
 
-for record in meta.get("prompts", {}).values():
+all_records = list(meta.get("prompts", {}).values()) + list(meta.get("sessions", {}).values())
+for record in all_records:
     tool = str(record.get("agent_id", {}).get("tool", "")).lower()
     # Fuzzy match: "claude" matches "claude_code", "gemini" matches "gemini_cli", etc.
     if tool and (agent in tool or tool in agent):
@@ -114,7 +121,7 @@ for record in meta.get("prompts", {}).values():
         sys.exit(0)
 
 # Print what we did find for debugging
-tools = [str(r.get("agent_id", {}).get("tool", "")) for r in meta.get("prompts", {}).values()]
+tools = [str(r.get("agent_id", {}).get("tool", "")) for r in all_records]
 print(f"not_found (found tools: {tools})", file=sys.stderr)
 print("not_found")
 PYEOF
@@ -130,7 +137,7 @@ fi
 MSG_COUNT=$(python3 -c "
 import json, sys
 d = json.load(open(sys.argv[1]))
-total = sum(len(r.get('messages', [])) for r in d.get('prompts', {}).values())
+total = sum(len(r.get('messages', [])) for r in list(d.get('prompts', {}).values()) + list(d.get('sessions', {}).values()))
 print(total)
 " "$META_JSON")
 

--- a/scripts/nightly/verify-synthetic-attribution.sh
+++ b/scripts/nightly/verify-synthetic-attribution.sh
@@ -77,24 +77,30 @@ SCHEMA=$(python3 -c "import json, sys; d=json.load(open(sys.argv[1])); print(d.g
 
 pass "schema_version = $SCHEMA"
 
-# ── 4. Prompts non-empty ──────────────────────────────────────────────────────
-PROMPT_COUNT=$(python3 -c "import json, sys; d=json.load(open(sys.argv[1])); print(len(d.get('prompts', {})))" "$META_JSON")
-[ "$PROMPT_COUNT" -gt 0 ] \
-  || fail "No prompt sessions in authorship note — synthetic checkpoint data was not stored (check git-ai checkpoint pipeline)"
+# ── 4. Sessions non-empty ─────────────────────────────────────────────────────
+SESSION_COUNT=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+prompts = len(d.get('prompts', {}))
+sessions = len(d.get('sessions', {}))
+print(prompts + sessions)
+" "$META_JSON")
+[ "$SESSION_COUNT" -gt 0 ] \
+  || fail "No prompt/session entries in authorship note — synthetic checkpoint data was not stored (check git-ai checkpoint pipeline)"
 
-pass "$PROMPT_COUNT prompt session(s) recorded"
+pass "$SESSION_COUNT AI session(s) recorded"
 
 # ── 5. Transcript messages captured ───────────────────────────────────────────
 MSG_COUNT=$(python3 -c "
 import json, sys
 d = json.load(open(sys.argv[1]))
-total = sum(len(r.get('messages', [])) for r in d.get('prompts', {}).values())
+total = sum(len(r.get('messages', [])) for r in list(d.get('prompts', {}).values()) + list(d.get('sessions', {}).values()))
 print(total)
 " "$META_JSON")
 if [ "$MSG_COUNT" -gt 0 ]; then
-  pass "Transcript captured: $MSG_COUNT message(s) recorded across all prompt sessions"
+  pass "Transcript captured: $MSG_COUNT message(s) recorded across all sessions"
 else
-  warn "No transcript messages in authorship note — conversation capture is only available in live agent runs, not synthetic checkpoints"
+  warn "No transcript messages in authorship note — sessions format does not embed transcripts inline"
 fi
 
 # ── 6. git-ai stats reports AI additions ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Updates all E2E verification scripts to check `metadata.sessions` (sessions-v2 format) instead of only `metadata.prompts` which is now always empty
- Enables the daemon on Windows (previously disabled with `GIT_AI_ASYNC_MODE=false`) — the daemon supports Windows via named pipes and is required for the git proxy to perform attribution
- Removes stale `GIT_AI_ASYNC_MODE` env var from all workflows

## Root Causes Fixed

1. **sessions-v2 migration** moved AI attribution data from `prompts` to `sessions` in authorship notes, but verification scripts only checked `prompts`
2. **Windows had no daemon** — `GIT_AI_ASYNC_MODE=false` prevented daemon startup, causing the git proxy to skip attribution entirely (`git_handlers.rs:112-115` falls through to passthrough when daemon is not connected)

## Test plan

- [x] Local: `verify-synthetic-attribution.sh` passes against fresh synthetic checkpoint
- [x] Local: `verify-attribution.sh` passes  
- [x] CI: All 12 E2E jobs pass (4 agents × 3 platforms): https://github.com/git-ai-project/git-ai/actions/runs/25406096863
- [x] CI: Nightly agent integration Tier 1 passes: https://github.com/git-ai-project/git-ai/actions/runs/25406411254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->