### PR TITLE
feat: enable gzip compression for all HTTP requests and responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,6 +3544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64",
+ "flate2",
  "log",
  "native-tls",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 libc = "0.2"
 jsonc-parser = { version = "0.32", features = ["cst"] }
 dirs = "5.0"
-ureq = { version = "2.12", default-features = false, features = ["native-tls"] }
+ureq = { version = "2.12", default-features = false, features = ["native-tls", "gzip"] }
 native-tls = "0.2"
 url = "2.5"
 glob = "0.3"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -224,7 +224,7 @@ impl ApiContext {
         Ok(url.to_string())
     }
 
-    /// Make a POST request with JSON body
+    /// Make a POST request with JSON body, gzip-compressed.
     pub fn post_json<T: serde::Serialize>(
         &self,
         endpoint: &str,
@@ -246,7 +246,7 @@ impl ApiContext {
             request = request.set("Authorization", &format!("Bearer {}", token));
         }
 
-        http::send_with_body(request, &body_json)
+        http::send_with_gzip_body(request, body_json.as_bytes())
             .map_err(|e| GitAiError::Generic(format!("HTTP request failed: {}", e)))
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,6 @@
-use std::io::Read;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use std::io::{Read, Write};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -64,6 +66,29 @@ pub fn send(request: ureq::Request) -> Result<Response, String> {
 /// Execute a ureq request with a string body.
 pub fn send_with_body(request: ureq::Request, body: &str) -> Result<Response, String> {
     match request.send_string(body) {
+        Ok(response) => read_ureq_response(response),
+        Err(ureq::Error::Status(_code, response)) => read_ureq_response(response),
+        Err(ureq::Error::Transport(err)) => Err(err.to_string()),
+    }
+}
+
+/// Gzip-compress the given bytes.
+fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, String> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(data)
+        .map_err(|e| format!("gzip compression failed: {}", e))?;
+    encoder
+        .finish()
+        .map_err(|e| format!("gzip compression failed: {}", e))
+}
+
+/// Execute a ureq request with a gzip-compressed body.
+/// Sets `Content-Encoding: gzip` so the server knows the payload is compressed.
+pub fn send_with_gzip_body(request: ureq::Request, body: &[u8]) -> Result<Response, String> {
+    let compressed = gzip_compress(body)?;
+    let request = request.set("Content-Encoding", "gzip");
+    match request.send_bytes(&compressed) {
         Ok(response) => read_ureq_response(response),
         Err(ureq::Error::Status(_code, response)) => read_ureq_response(response),
         Err(ureq::Error::Transport(err)) => Err(err.to_string()),


### PR DESCRIPTION
## Summary

Enables gzip compression across all HTTP traffic in git-ai to reduce bandwidth usage, especially for large MetricsEvents uploads.

**Response decompression (Accept-Encoding: gzip):**
- Enabled ureq's `gzip` feature, which automatically sends `Accept-Encoding: gzip` on all outgoing requests and transparently decompresses gzip-encoded responses. This is a negotiation mechanism — the server only compresses if it supports it, so this is fully backward-compatible. Uses `flate2` (already a dependency) under the hood.

**Request body compression (Content-Encoding: gzip):**
- Added `send_with_gzip_body()` in `src/http.rs` that gzip-compresses request body bytes and sets `Content-Encoding: gzip`.
- Updated `ApiContext::post_json()` to use gzip-compressed request bodies by default. This covers all API calls: metrics uploads, CAS uploads, bundle creation, etc.

**Important: Server-side support required.** The server (monorepo) needs to handle `Content-Encoding: gzip` on incoming request bodies — `NextRequest.json()` does not automatically decompress gzip-encoded bodies. A companion PR to the monorepo will add this support. The monorepo changes should be deployed first since they are backward-compatible (handle both compressed and uncompressed bodies), while this client-side change requires the server to be ready.

## Review & Testing Checklist for Human
- [ ] Verify the monorepo server-side `Content-Encoding: gzip` decompression PR is merged and deployed **before** releasing a git-ai version with these changes
- [ ] Test metrics upload (`git-ai flush-logs`) against a local server to confirm gzip request bodies are correctly received and parsed
- [ ] Confirm response decompression works by checking that API responses with `Content-Encoding: gzip` are transparently handled

### Notes
- The `flate2` crate was already a dependency (used by `zip`); enabling ureq's `gzip` feature just adds it to ureq's dependency graph with no new crate downloads.
- `send_with_body()` is preserved for non-API callers (PostHog, Sentry, OAuth) that send to third-party servers where `Content-Encoding: gzip` support isn't guaranteed.

Link to Devin session: https://app.devin.ai/sessions/4b55dc2043024ab6bc29e720cb8ea328
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->