### PR TITLE
fix for cursor bg agent identification 

### DIFF
--- a/src/authorship/background_agent.rs
+++ b/src/authorship/background_agent.rs
@@ -25,9 +25,12 @@ pub fn detect() -> BackgroundAgent {
         };
     }
 
-    if std::env::var("CURSOR_AGENT")
-        .map(|v| v == "1")
+    if std::env::var("HOSTNAME")
+        .map(|v| v == "cursor")
         .unwrap_or(false)
+        && std::env::var("CURSOR_AGENT")
+            .map(|v| v == "1")
+            .unwrap_or(false)
     {
         return BackgroundAgent::WithHooks {
             tool: "cursor-agent".to_string(),


### PR DESCRIPTION
This isn't strictly required, but noticed that Cursor Sandboxes also set `CURSOR_AGENT=1`. So I've tightened the check for Cursor Agent to include `HOSTNAME=cursor` 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->