### PR TITLE
fix(jetbrains): silence non-critical exceptions from PostHog and Sentry

### DIFF
--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/GitAiService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/GitAiService.kt
@@ -193,7 +193,7 @@ class GitAiService {
                     - curl -fsSL https://install.usegitai.com | sh
                     - Or ensure git-ai is in your PATH
                 """.trimIndent())
-                TelemetryService.getInstance().reportGitAiNotFound(
+                TelemetryService.getInstanceOrNull()?.reportGitAiNotFound(
                     exitCode = null,
                     output = null,
                     searchedPaths = lastSearchedPaths,
@@ -229,7 +229,7 @@ class GitAiService {
                     PATH: $currentPath
                     Resolved path: $gitAiPath
                 """.trimIndent())
-                TelemetryService.getInstance().reportGitAiNotFound(
+                TelemetryService.getInstanceOrNull()?.reportGitAiNotFound(
                     exitCode = process.exitValue(),
                     output = if (errorOutput.isNotEmpty()) errorOutput else output,
                     searchedPaths = lastSearchedPaths,
@@ -249,7 +249,7 @@ class GitAiService {
 
             if (version < minVersion) {
                 logger.warn("git-ai version $version is below minimum required version $minVersion")
-                TelemetryService.getInstance().reportVersionMismatch(version.toString(), minVersion.toString())
+                TelemetryService.getInstanceOrNull()?.reportVersionMismatch(version.toString(), minVersion.toString())
                 return false
             }
 
@@ -262,7 +262,7 @@ class GitAiService {
                 Searched locations: ${lastSearchedPaths.joinToString(", ")}
                 PATH: $currentPath
             """.trimIndent(), e)
-            TelemetryService.getInstance().captureError(e, mapOf(
+            TelemetryService.getInstanceOrNull()?.captureError(e, mapOf(
                 "context" to "git_ai_availability_check",
                 "searched_paths" to lastSearchedPaths.joinToString(","),
                 "current_path" to currentPath
@@ -315,7 +315,7 @@ class GitAiService {
             if (!completed) {
                 process.destroyForcibly()
                 logger.warn("git-ai checkpoint timed out")
-                TelemetryService.getInstance().reportCheckpointTimeout()
+                TelemetryService.getInstanceOrNull()?.reportCheckpointTimeout()
                 return false
             }
 
@@ -332,7 +332,7 @@ class GitAiService {
                     Stdout: $output
                     Stderr: $errorOutput
                 """.trimIndent())
-                TelemetryService.getInstance().reportCheckpointFailure(exitCode, combinedOutput)
+                TelemetryService.getInstanceOrNull()?.reportCheckpointFailure(exitCode, combinedOutput)
                 return false
             }
 
@@ -343,7 +343,7 @@ class GitAiService {
             true
         } catch (e: Exception) {
             logger.warn("Failed to create checkpoint: ${e.message}", e)
-            TelemetryService.getInstance().captureError(e, mapOf("context" to "checkpoint_creation"))
+            TelemetryService.getInstanceOrNull()?.captureError(e, mapOf("context" to "checkpoint_creation"))
             false
         }
     }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -49,11 +49,31 @@ class TelemetryService : Disposable {
         private const val PLUGIN_EVENT_TAG = "git_ai_plugin_event"
 
         fun getInstance(): TelemetryService = service()
+
+        /**
+         * Returns the TelemetryService instance or null if service instantiation fails.
+         * Use this from call sites where telemetry failures must never propagate.
+         */
+        fun getInstanceOrNull(): TelemetryService? {
+            return try {
+                service()
+            } catch (_: Throwable) {
+                null
+            }
+        }
     }
 
     init {
-        initializePostHog()
-        initializeSentry()
+        try {
+            initializePostHog()
+        } catch (_: Throwable) {
+            // Silently ignore – telemetry must never surface errors to the user
+        }
+        try {
+            initializeSentry()
+        } catch (_: Throwable) {
+            // Silently ignore – telemetry must never surface errors to the user
+        }
     }
 
     private fun initializePostHog() {
@@ -159,7 +179,11 @@ class TelemetryService : Disposable {
      * Captures the plugin startup event.
      */
     fun captureStartupEvent() {
-        captureEvent("intellij_plugin_startup", getCommonProperties())
+        try {
+            captureEvent("intellij_plugin_startup", getCommonProperties())
+        } catch (_: Throwable) {
+            // Non-critical – never surface to user
+        }
     }
 
     /**
@@ -178,89 +202,105 @@ class TelemetryService : Disposable {
         searchedPaths: List<String>,
         currentPath: String?
     ) {
-        val context = mutableMapOf<String, Any>(
-            "error_type" to "git_ai_not_found"
-        )
-        exitCode?.let { context["exit_code"] = it }
-        output?.let { context["output"] = it.take(500) }
-        if (searchedPaths.isNotEmpty()) {
-            context["searched_paths"] = searchedPaths.joinToString(",")
-        }
-        currentPath?.let { context["path_env"] = it.take(500) }
-
-        captureEvent("git_ai_error", getCommonProperties() + context)
-
-        val message = buildString {
-            append("git-ai CLI not found")
-            exitCode?.let { append(" (exit code: $it)") }
+        try {
+            val context = mutableMapOf<String, Any>(
+                "error_type" to "git_ai_not_found"
+            )
+            exitCode?.let { context["exit_code"] = it }
+            output?.let { context["output"] = it.take(500) }
             if (searchedPaths.isNotEmpty()) {
-                append(". Searched: ${searchedPaths.joinToString(", ")}")
+                context["searched_paths"] = searchedPaths.joinToString(",")
             }
+            currentPath?.let { context["path_env"] = it.take(500) }
+
+            captureEvent("git_ai_error", getCommonProperties() + context)
+
+            val message = buildString {
+                append("git-ai CLI not found")
+                exitCode?.let { append(" (exit code: $it)") }
+                if (searchedPaths.isNotEmpty()) {
+                    append(". Searched: ${searchedPaths.joinToString(", ")}")
+                }
+            }
+            captureSentryMessage(message, SentryLevel.WARNING, context)
+        } catch (_: Throwable) {
+            // Non-critical – never surface to user
         }
-        captureSentryMessage(message, SentryLevel.WARNING, context)
     }
 
     /**
      * Reports a version mismatch where git-ai is below minimum required version.
      */
     fun reportVersionMismatch(foundVersion: String, requiredVersion: String) {
-        val context = mapOf(
-            "error_type" to "version_mismatch",
-            "found_version" to foundVersion,
-            "required_version" to requiredVersion
-        )
-        captureEvent("git_ai_error", getCommonProperties() + context)
-        captureSentryMessage(
-            "git-ai version mismatch: found $foundVersion, required $requiredVersion",
-            SentryLevel.WARNING,
-            context
-        )
+        try {
+            val context = mapOf(
+                "error_type" to "version_mismatch",
+                "found_version" to foundVersion,
+                "required_version" to requiredVersion
+            )
+            captureEvent("git_ai_error", getCommonProperties() + context)
+            captureSentryMessage(
+                "git-ai version mismatch: found $foundVersion, required $requiredVersion",
+                SentryLevel.WARNING,
+                context
+            )
+        } catch (_: Throwable) {
+            // Non-critical – never surface to user
+        }
     }
 
     /**
      * Reports a checkpoint failure.
      */
     fun reportCheckpointFailure(exitCode: Int, output: String) {
-        val context = mapOf(
-            "error_type" to "checkpoint_failure",
-            "exit_code" to exitCode.toString(),
-            "output" to output.take(500) // Limit output size
-        )
-        captureEvent("git_ai_error", getCommonProperties() + context)
-        captureSentryMessage(
-            "git-ai checkpoint failed with exit code $exitCode",
-            SentryLevel.ERROR,
-            context
-        )
+        try {
+            val context = mapOf(
+                "error_type" to "checkpoint_failure",
+                "exit_code" to exitCode.toString(),
+                "output" to output.take(500) // Limit output size
+            )
+            captureEvent("git_ai_error", getCommonProperties() + context)
+            captureSentryMessage(
+                "git-ai checkpoint failed with exit code $exitCode",
+                SentryLevel.ERROR,
+                context
+            )
+        } catch (_: Throwable) {
+            // Non-critical – never surface to user
+        }
     }
 
     /**
      * Reports a checkpoint timeout (exceeded 30s).
      */
     fun reportCheckpointTimeout() {
-        val context = mapOf("error_type" to "checkpoint_timeout")
-        captureEvent("git_ai_error", getCommonProperties() + context)
-        captureSentryMessage("git-ai checkpoint timed out after 30 seconds", SentryLevel.ERROR, context)
+        try {
+            val context = mapOf("error_type" to "checkpoint_timeout")
+            captureEvent("git_ai_error", getCommonProperties() + context)
+            captureSentryMessage("git-ai checkpoint timed out after 30 seconds", SentryLevel.ERROR, context)
+        } catch (_: Throwable) {
+            // Non-critical – never surface to user
+        }
     }
 
     /**
      * Captures a general error/exception.
      */
     fun captureError(throwable: Throwable, context: Map<String, String> = emptyMap()) {
-        val eventContext = mapOf("error_type" to "exception") + context
-        captureEvent("git_ai_error", getCommonProperties() + eventContext)
+        try {
+            val eventContext = mapOf("error_type" to "exception") + context
+            captureEvent("git_ai_error", getCommonProperties() + eventContext)
 
-        if (sentryInitialized) {
-            try {
+            if (sentryInitialized) {
                 Sentry.captureException(throwable) { scope ->
                     scope.setTag(PLUGIN_EVENT_TAG, "true")
                     context.forEach { (key, value) ->
                         scope.setExtra(key, value)
                     }
                 }
-            } catch (e: Exception) {
-                logger.warn("Failed to capture exception in Sentry: ${e.message}")
             }
+        } catch (_: Throwable) {
+            // Non-critical – never surface to user
         }
     }
 
@@ -298,18 +338,16 @@ class TelemetryService : Disposable {
     override fun dispose() {
         try {
             posthog?.shutdown()
-            logger.info("PostHog shut down")
-        } catch (e: Exception) {
-            logger.warn("Error shutting down PostHog: ${e.message}")
+        } catch (_: Throwable) {
+            // Silently ignore – shutdown errors are non-critical
         }
 
         try {
             if (sentryInitialized) {
                 Sentry.close()
-                logger.info("Sentry closed")
             }
-        } catch (e: Exception) {
-            logger.warn("Error closing Sentry: ${e.message}")
+        } catch (_: Throwable) {
+            // Silently ignore – shutdown errors are non-critical
         }
     }
 }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/startup/DocumentTrackerStartupActivity.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/startup/DocumentTrackerStartupActivity.kt
@@ -16,7 +16,7 @@ class DocumentTrackerStartupActivity : ProjectActivity {
         // Request the service to trigger its initialization
         ApplicationManager.getApplication().getService(DocumentChangeTrackerService::class.java)
 
-        // Capture startup event for analytics
-        TelemetryService.getInstance().captureStartupEvent()
+        // Capture startup event for analytics (non-critical, must never throw)
+        TelemetryService.getInstanceOrNull()?.captureStartupEvent()
     }
 }


### PR DESCRIPTION
## Summary

Ensures that PostHog analytics and Sentry error reporting failures in the JetBrains plugin never surface as user-facing warnings or errors in the IDE.

**Changes:**
- Added `TelemetryService.getInstanceOrNull()` — returns null instead of throwing if the service can't be instantiated (e.g. `NoClassDefFoundError` when PostHog/Sentry classes fail to load)
- Wrapped all public `TelemetryService` methods with top-level `try/catch(Throwable)` so no telemetry operation can escape
- Switched all call sites in `GitAiService` and `DocumentTrackerStartupActivity` from `getInstance()` to `getInstanceOrNull()?.`
- Wrapped the `init` block's `initializePostHog()`/`initializeSentry()` calls individually so one failing doesn't prevent the other
- Removed noisy `logger.warn`/`logger.info` from shutdown paths

Fixes #1296

## Review & Testing Checklist for Human

- [ ] Confirm that catching `Throwable` (not just `Exception`) is acceptable — this swallows `Error` subclasses (e.g. `OutOfMemoryError`) in telemetry paths. The rationale is that a telemetry OOM should never crash the IDE plugin, but verify this aligns with your philosophy.
- [ ] Verify that fully-silent outer catches (no logging at all) are desired. Currently if something truly unexpected happens in a telemetry method, it vanishes without a trace. Consider whether at least `logger.debug` would help future debugging without user-facing noise.
- [ ] Install the plugin locally and verify no IDE error dialogs appear when PostHog/Sentry are unreachable (e.g. behind a corporate firewall or with no internet).

### Notes
- Could not run Gradle compilation locally (timeout on this machine), so CI is the first compile check for these changes.
- The inner existing try-catch blocks (in `captureEvent`, `captureSentryMessage`, etc.) still log at warn level — the new outer catches are a last-resort safety net for unexpected failures only.

Link to Devin session: https://app.devin.ai/sessions/8de35c04fd164a14a2f8c57d3f3028b2
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->