### PR TITLE
feat: add transcript_sweep feature flag

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -174,7 +174,9 @@ pub fn handle_config(args: &[String]) {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
             }
-            if key == "feature_flags.transcript_streaming" {
+            if key == "feature_flags.transcript_streaming"
+                || key == "feature_flags.transcript_sweep"
+            {
                 println!("Run `git-ai bg restart` for changes to take effect.");
             }
         }

--- a/src/daemon/transcript_worker.rs
+++ b/src/daemon/transcript_worker.rs
@@ -4,6 +4,7 @@
 //! 1. **Checkpoint notifications** (Immediate priority, <100ms) - fired when `git-ai checkpoint` is called
 //! 2. **Periodic sweeps** (Low priority, every 30min) - agent-specific discovery of all sessions
 
+use crate::config;
 use crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle;
 use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, SessionEventValues};
 use crate::transcripts::db::TranscriptsDatabase;
@@ -130,6 +131,8 @@ impl TranscriptWorker {
     async fn run(mut self) {
         tracing::info!("transcript worker started");
 
+        let sweep_enabled = config::Config::get().get_feature_flags().transcript_sweep;
+
         let mut processing_ticker = interval(PROCESSING_TICK_INTERVAL);
         let mut sweep_ticker = interval(Duration::from_secs(30 * 60)); // NEW: 30 minutes
 
@@ -138,7 +141,7 @@ impl TranscriptWorker {
         sweep_ticker.tick().await;
 
         // Run initial sweep on startup
-        if let Err(e) = self.run_sweep().await {
+        if sweep_enabled && let Err(e) = self.run_sweep().await {
             tracing::error!(error = %e, "initial sweep failed");
         }
 
@@ -153,7 +156,9 @@ impl TranscriptWorker {
                     self.process_next_task().await;
                 }
                 _ = sweep_ticker.tick() => {  // NEW: sweep ticker
-                    if let Err(e) = self.run_sweep().await {
+                    if sweep_enabled
+                        && let Err(e) = self.run_sweep().await
+                    {
                         tracing::error!(error = %e, "sweep failed");
                     }
                 }

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -83,6 +83,7 @@ define_feature_flags!(
     git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
+    transcript_sweep: transcript_sweep, debug = true, release = false,
 );
 
 impl FeatureFlags {
@@ -138,6 +139,7 @@ mod tests {
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
             assert!(flags.transcript_streaming);
+            assert!(flags.transcript_sweep);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -146,6 +148,7 @@ mod tests {
             assert!(!flags.git_hooks_enabled);
             assert!(!flags.git_hooks_externally_managed);
             assert!(flags.transcript_streaming);
+            assert!(!flags.transcript_sweep);
         }
     }
 
@@ -204,6 +207,7 @@ mod tests {
             git_hooks_enabled: false,
             git_hooks_externally_managed: false,
             transcript_streaming: true,
+            transcript_sweep: true,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -212,6 +216,7 @@ mod tests {
         assert!(serialized.contains("git_hooks_enabled"));
         assert!(serialized.contains("git_hooks_externally_managed"));
         assert!(serialized.contains("transcript_streaming"));
+        assert!(serialized.contains("transcript_sweep"));
     }
 
     #[test]
@@ -222,6 +227,7 @@ mod tests {
             git_hooks_enabled: true,
             git_hooks_externally_managed: false,
             transcript_streaming: true,
+            transcript_sweep: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);
@@ -232,6 +238,7 @@ mod tests {
             flags.git_hooks_externally_managed
         );
         assert_eq!(cloned.transcript_streaming, flags.transcript_streaming);
+        assert_eq!(cloned.transcript_sweep, flags.transcript_sweep);
     }
 
     #[test]

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -20,6 +20,7 @@ fn setup() {
         git_hooks_enabled: false,
         git_hooks_externally_managed: false,
         transcript_streaming: true,
+        transcript_sweep: true,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());


### PR DESCRIPTION
## Summary
- Adds a new `transcript_sweep` feature flag (debug=true, release=false) that controls whether the transcript worker runs periodic filesystem sweep discovery
- When disabled, the worker still processes individual transcripts triggered by hook events (checkpoint notifications)
- Adds daemon restart hint when this flag is changed via `git-ai config set`

## Test plan
- [x] `task build` passes
- [x] `task lint` passes
- [x] `task fmt` passes
- [x] Feature flag unit tests pass (default, serialization, clone)
- [x] Transcript worker tests pass
- [x] Sweep e2e tests pass (11 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->