### PR TITLE
fix: add --no-fail-fast to CI test scripts to prevent skipping test binaries

### DIFF
--- a/scripts/ci-test-with-retry.ps1
+++ b/scripts/ci-test-with-retry.ps1
@@ -119,7 +119,7 @@ function Invoke-CargoCaptured {
 }
 
 $fullRun = Invoke-CargoCaptured `
-    -Arguments @("test", "--", "--test-threads=$TestThreads") `
+    -Arguments @("test", "--no-fail-fast", "--", "--test-threads=$TestThreads") `
     -TimeoutSeconds $FullRunTimeoutSeconds `
     -Label "cargo test"
 

--- a/scripts/ci-test-with-retry.sh
+++ b/scripts/ci-test-with-retry.sh
@@ -45,7 +45,7 @@ run_retry_with_timeout() {
 
 # Run the full test suite, capturing output
 OUTPUT_FILE=$(mktemp)
-cargo test -- --test-threads="$TEST_THREADS" 2>&1 | tee "$OUTPUT_FILE"
+cargo test --no-fail-fast -- --test-threads="$TEST_THREADS" 2>&1 | tee "$OUTPUT_FILE"
 FIRST_EXIT=${PIPESTATUS[0]}
 
 if [ "$FIRST_EXIT" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Adds `--no-fail-fast` to the initial `cargo test` invocation in both `ci-test-with-retry.sh` and `ci-test-with-retry.ps1`
- Fixes a bug where the Windows CI job randomly completes in ~10min instead of ~3hrs with most tests never actually running

## Root cause

Without `--no-fail-fast`, cargo test aborts remaining test binaries as soon as one binary has a failure. On Windows, when a flaky test in an early binary (e.g. `daemon_mode` with 46 tests) fails, cargo never runs the integration tests (~3000 tests). The retry logic then only re-runs the single flaky test, it passes, the script reports overall success, and the job exits having skipped the vast majority of the test suite.

Evidence from CI logs:
- Normal run: integration tests run 2983 tests in ~4583s 
- Flaky run: integration tests show `0 passed; 3067 filtered out; finished in 0.00s` (never executed)

## Test plan

- [x] Verify fix by running the CI workflow on this branch and confirming Windows jobs take their normal ~1.5-3hr duration
- [ ] Monitor that when a flaky test does fail, all other test binaries still complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->