### PR TITLE
uninstall skills unless --skills provided to install-hooks

### DIFF
--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -609,12 +609,16 @@ async fn async_run_install(
         }
     }
 
-    // Install skills for detected agents only (requires --skills flag)
-    if install_skills
-        && let Ok(result) = skills_installer::install_skills(dry_run, verbose, &installed_tools)
-        && result.changed
-    {
-        has_changes = true;
+    if install_skills {
+        if let Ok(result) = skills_installer::install_skills(dry_run, verbose, &installed_tools) {
+            if result.changed {
+                has_changes = true;
+            }
+        }
+    } else if let Ok(result) = skills_installer::uninstall_skills(dry_run, verbose) {
+        if result.changed {
+            has_changes = true;
+        }
     }
 
     if !any_checked {

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -610,15 +610,15 @@ async fn async_run_install(
     }
 
     if install_skills {
-        if let Ok(result) = skills_installer::install_skills(dry_run, verbose, &installed_tools) {
-            if result.changed {
-                has_changes = true;
-            }
-        }
-    } else if let Ok(result) = skills_installer::uninstall_skills(dry_run, verbose) {
-        if result.changed {
+        if let Ok(result) = skills_installer::install_skills(dry_run, verbose, &installed_tools)
+            && result.changed
+        {
             has_changes = true;
         }
+    } else if let Ok(result) = skills_installer::uninstall_skills(dry_run, verbose)
+        && result.changed
+    {
+        has_changes = true;
     }
 
     if !any_checked {


### PR DESCRIPTION
Skills will be brought back by default soon when the transcript command renovation is complete 😄 

Temporarily addresses #1307 