### PR TITLE
feat(agent-v1): add pre_bash_call/post_bash_call types for shell comm…

### DIFF
--- a/scripts/test-agent-preset-v1.sh
+++ b/scripts/test-agent-preset-v1.sh
@@ -29,3 +29,23 @@ echo '{
   "model": "claude-3-sonnet-20240229",
   "conversation_id": "conv_12345"
 }' | cargo run -- checkpoint agent-v1 --hook-input stdin
+
+echo -e "\n=== Pre Bash Call Checkpoint Example (before shell command) ==="
+echo '{
+  "type": "pre_bash_call",
+  "repo_working_dir": "'$(pwd)'",
+  "tool_use_id": "tu_67890",
+  "agent_name": "my-agent",
+  "model": "gpt-4",
+  "conversation_id": "conv_12345"
+}' | cargo run -- checkpoint agent-v1 --hook-input stdin
+
+echo -e "\n=== Post Bash Call Checkpoint Example (after shell command) ==="
+echo '{
+  "type": "post_bash_call",
+  "repo_working_dir": "'$(pwd)'",
+  "tool_use_id": "tu_67890",
+  "agent_name": "my-agent",
+  "model": "gpt-4",
+  "conversation_id": "conv_12345"
+}' | cargo run -- checkpoint agent-v1 --hook-input stdin

--- a/src/commands/checkpoint_agent/presets/agent_v1.rs
+++ b/src/commands/checkpoint_agent/presets/agent_v1.rs
@@ -1,4 +1,7 @@
-use super::{AgentPreset, ParsedHookEvent, PostFileEdit, PreFileEdit, PresetContext};
+use super::{
+    AgentPreset, ParsedHookEvent, PostBashCall, PostFileEdit, PreBashCall, PreFileEdit,
+    PresetContext,
+};
 use crate::authorship::working_log::AgentId;
 use crate::error::GitAiError;
 use serde::Deserialize;
@@ -12,15 +15,35 @@ pub struct AgentV1Preset;
 enum AgentV1Payload {
     Human {
         repo_working_dir: String,
+        #[serde(default, alias = "toolUseId")]
+        tool_use_id: Option<String>,
         will_edit_filepaths: Option<Vec<String>>,
         #[serde(default)]
         dirty_files: Option<HashMap<String, String>>,
     },
     AiAgent {
         repo_working_dir: String,
+        #[serde(default, alias = "toolUseId")]
+        tool_use_id: Option<String>,
         edited_filepaths: Option<Vec<String>>,
         #[serde(default)]
         dirty_files: Option<HashMap<String, String>>,
+        agent_name: String,
+        model: String,
+        conversation_id: String,
+    },
+    PreBashCall {
+        repo_working_dir: String,
+        #[serde(default, alias = "toolUseId")]
+        tool_use_id: Option<String>,
+        agent_name: String,
+        model: String,
+        conversation_id: String,
+    },
+    PostBashCall {
+        repo_working_dir: String,
+        #[serde(default, alias = "toolUseId")]
+        tool_use_id: Option<String>,
         agent_name: String,
         model: String,
         conversation_id: String,
@@ -41,6 +64,7 @@ impl AgentPreset for AgentV1Preset {
                 repo_working_dir,
                 will_edit_filepaths,
                 dirty_files,
+                tool_use_id,
             } => {
                 let cwd = PathBuf::from(&repo_working_dir);
                 let file_paths = will_edit_filepaths
@@ -67,7 +91,7 @@ impl AgentPreset for AgentV1Preset {
                     },
                     file_paths,
                     dirty_files: dirty,
-                    tool_use_id: None,
+                    tool_use_id,
                 })
             }
             AgentV1Payload::AiAgent {
@@ -77,6 +101,7 @@ impl AgentPreset for AgentV1Preset {
                 agent_name,
                 model,
                 conversation_id,
+                tool_use_id,
             } => {
                 let cwd = PathBuf::from(&repo_working_dir);
                 let file_paths = edited_filepaths
@@ -104,7 +129,54 @@ impl AgentPreset for AgentV1Preset {
                     file_paths,
                     dirty_files: dirty,
                     transcript_source: None,
-                    tool_use_id: None,
+                    tool_use_id,
+                })
+            }
+            AgentV1Payload::PreBashCall {
+                repo_working_dir,
+                tool_use_id,
+                agent_name,
+                model,
+                conversation_id,
+            } => {
+                let cwd = PathBuf::from(&repo_working_dir);
+                ParsedHookEvent::PreBashCall(PreBashCall {
+                    context: PresetContext {
+                        agent_id: AgentId {
+                            tool: agent_name,
+                            id: conversation_id.clone(),
+                            model,
+                        },
+                        external_session_id: conversation_id,
+                        trace_id: trace_id.to_string(),
+                        cwd,
+                        metadata: HashMap::new(),
+                    },
+                    tool_use_id: tool_use_id.unwrap_or_else(|| "bash".to_string()),
+                })
+            }
+            AgentV1Payload::PostBashCall {
+                repo_working_dir,
+                tool_use_id,
+                agent_name,
+                model,
+                conversation_id,
+            } => {
+                let cwd = PathBuf::from(&repo_working_dir);
+                ParsedHookEvent::PostBashCall(PostBashCall {
+                    context: PresetContext {
+                        agent_id: AgentId {
+                            tool: agent_name,
+                            id: conversation_id.clone(),
+                            model,
+                        },
+                        external_session_id: conversation_id,
+                        trace_id: trace_id.to_string(),
+                        cwd,
+                        metadata: HashMap::new(),
+                    },
+                    tool_use_id: tool_use_id.unwrap_or_else(|| "bash".to_string()),
+                    transcript_source: None,
                 })
             }
         };
@@ -194,6 +266,45 @@ mod tests {
     }
 
     #[test]
+    fn test_agent_v1_human_with_tool_use_id() {
+        let input = json!({
+            "type": "human",
+            "repo_working_dir": "/home/user/project",
+            "will_edit_filepaths": ["/home/user/project/src/main.rs"],
+            "tool_use_id": "tu-abc"
+        })
+        .to_string();
+        let events = AgentV1Preset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(e.tool_use_id, Some("tu-abc".to_string()));
+            }
+            _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_agent_v1_ai_agent_with_tool_use_id() {
+        let input = json!({
+            "type": "ai_agent",
+            "repo_working_dir": "/home/user/project",
+            "edited_filepaths": ["/home/user/project/src/lib.rs"],
+            "agent_name": "my-agent",
+            "model": "gpt-4",
+            "conversation_id": "conv-123",
+            "tool_use_id": "tu-xyz"
+        })
+        .to_string();
+        let events = AgentV1Preset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.tool_use_id, Some("tu-xyz".to_string()));
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
     fn test_agent_v1_invalid_json() {
         let result = AgentV1Preset.parse("not json", "t_test");
         assert!(result.is_err());
@@ -208,5 +319,89 @@ mod tests {
         .to_string();
         let result = AgentV1Preset.parse(&input, "t_test");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_agent_v1_pre_bash_call_type() {
+        let input = json!({
+            "type": "pre_bash_call",
+            "repo_working_dir": "/home/user/project",
+            "tool_use_id": "tu-123",
+            "agent_name": "my-agent",
+            "model": "gpt-4",
+            "conversation_id": "conv-456"
+        })
+        .to_string();
+        let events = AgentV1Preset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.context.agent_id.tool, "my-agent");
+                assert_eq!(e.context.agent_id.model, "gpt-4");
+                assert_eq!(e.context.external_session_id, "conv-456");
+                assert_eq!(e.context.cwd, PathBuf::from("/home/user/project"));
+                assert_eq!(e.tool_use_id, "tu-123");
+            }
+            _ => panic!("Expected PreBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_agent_v1_post_bash_call_type() {
+        let input = json!({
+            "type": "post_bash_call",
+            "repo_working_dir": "/home/user/project",
+            "tool_use_id": "tu-123",
+            "agent_name": "my-agent",
+            "model": "gpt-4",
+            "conversation_id": "conv-456"
+        })
+        .to_string();
+        let events = AgentV1Preset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostBashCall(e) => {
+                assert_eq!(e.context.agent_id.tool, "my-agent");
+                assert_eq!(e.context.agent_id.model, "gpt-4");
+                assert_eq!(e.context.external_session_id, "conv-456");
+                assert_eq!(e.context.cwd, PathBuf::from("/home/user/project"));
+                assert_eq!(e.tool_use_id, "tu-123");
+                assert!(e.transcript_source.is_none());
+            }
+            _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_agent_v1_pre_bash_call_missing_model_is_error() {
+        let input = json!({
+            "type": "pre_bash_call",
+            "repo_working_dir": "/tmp",
+            "tool_use_id": "tu-1",
+            "agent_name": "my-agent",
+            "conversation_id": "s1"
+        })
+        .to_string();
+        let result = AgentV1Preset.parse(&input, "t_test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_agent_v1_pre_bash_call_tool_use_id_defaults_to_bash() {
+        let input = json!({
+            "type": "pre_bash_call",
+            "repo_working_dir": "/tmp",
+            "agent_name": "my-agent",
+            "model": "unknown",
+            "conversation_id": "s1"
+        })
+        .to_string();
+        let events = AgentV1Preset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.tool_use_id, "bash");
+            }
+            _ => panic!("Expected PreBashCall"),
+        }
     }
 }

--- a/tests/integration/agent_v1.rs
+++ b/tests/integration/agent_v1.rs
@@ -298,3 +298,79 @@ fn test_agent_v1_relative_dirty_files_e2e_attribution() {
         "AI added line".ai(),
     ]);
 }
+
+#[test]
+fn test_agent_v1_pre_bash_call_checkpoint() {
+    let hook_input = json!({
+        "type": "pre_bash_call",
+        "repo_working_dir": "/Users/test/project",
+        "tool_use_id": "tu-abc",
+        "agent_name": "test-agent",
+        "model": "test-model",
+        "conversation_id": "conv-789"
+    })
+    .to_string();
+
+    let events = parse_agent_v1(&hook_input).unwrap();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ParsedHookEvent::PreBashCall(e) => {
+            assert_eq!(e.context.agent_id.tool, "test-agent");
+            assert_eq!(e.context.agent_id.id, "conv-789");
+            assert_eq!(e.context.agent_id.model, "test-model");
+            assert_eq!(e.context.external_session_id, "conv-789");
+            assert_eq!(e.context.cwd, PathBuf::from("/Users/test/project"));
+            assert_eq!(e.tool_use_id, "tu-abc");
+        }
+        _ => panic!("Expected PreBashCall for pre_bash_call checkpoint"),
+    }
+}
+
+#[test]
+fn test_agent_v1_post_bash_call_checkpoint() {
+    let hook_input = json!({
+        "type": "post_bash_call",
+        "repo_working_dir": "/Users/test/project",
+        "tool_use_id": "tu-abc",
+        "agent_name": "test-agent",
+        "model": "test-model",
+        "conversation_id": "conv-789"
+    })
+    .to_string();
+
+    let events = parse_agent_v1(&hook_input).unwrap();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ParsedHookEvent::PostBashCall(e) => {
+            assert_eq!(e.context.agent_id.tool, "test-agent");
+            assert_eq!(e.context.agent_id.id, "conv-789");
+            assert_eq!(e.context.agent_id.model, "test-model");
+            assert_eq!(e.context.external_session_id, "conv-789");
+            assert_eq!(e.context.cwd, PathBuf::from("/Users/test/project"));
+            assert_eq!(e.tool_use_id, "tu-abc");
+            assert!(e.transcript_source.is_none());
+        }
+        _ => panic!("Expected PostBashCall for post_bash_call checkpoint"),
+    }
+}
+
+#[test]
+fn test_agent_v1_pre_bash_call_optional_fields_default() {
+    let hook_input = json!({
+        "type": "pre_bash_call",
+        "repo_working_dir": "/Users/test/project",
+        "agent_name": "test-agent",
+        "model": "unknown",
+        "conversation_id": "conv-789"
+    })
+    .to_string();
+
+    let events = parse_agent_v1(&hook_input).unwrap();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ParsedHookEvent::PreBashCall(e) => {
+            assert_eq!(e.tool_use_id, "bash");
+        }
+        _ => panic!("Expected PreBashCall"),
+    }
+}


### PR DESCRIPTION
The agent-v1 protocol previously only supported file-edit attribution (human/ai_agent types). This left a gap: when third-party agents execute shell commands (e.g. cargo fmt, npm install) that modify files, those changes were invisible to git-ai.

Add two new payload types to the agent-v1 protocol:
- pre_bash_call: triggers a filesystem stat snapshot before command execution
- post_bash_call: diffs against the pre-snapshot to discover changed files

These map directly to the existing PreBashCall/PostBashCall events that all built-in presets (claude, codex, cursor, etc.) already use. The orchestrator, bash_tool stat-diff engine, and daemon require no changes.

**Note: The public docs at usegitai.com/docs/cli/add-your-agent should be updated to document the new types.**

Closes #1313 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->