### PR TITLE
fix: prevent daemon privilege mismatch broken state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,11 @@ openssl = { version = "0.10", features = ["vendored"] }
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.4.1"
 winreg = "0.55"
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+] }
 
 [features]
 test-support = []
@@ -63,7 +68,7 @@ rstest = "0.26"
 paste = "1.0"
 
 [target.'cfg(windows)'.dev-dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"] }
 
 [profile.dev]
 debug = 1                          # Line tables only -- smaller binaries, faster linking

--- a/docs/superpowers/plans/2026-05-08-daemon-privilege-mismatch.md
+++ b/docs/superpowers/plans/2026-05-08-daemon-privilege-mismatch.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent the daemon from entering an unrecoverable broken state when started by a privileged user and accessed by a non-privileged user.
 
-**Architecture:** Four-layer defense: (1) privilege de-escalation at daemon startup, (2) relaxed socket/lock permissions, (3) privilege mismatch detection with actionable errors, (4) dead process auto-recovery. A new `daemon_allow_root` feature flag controls whether true-root operation is permitted.
+**Architecture:** Four-layer defense: (1) privilege de-escalation at daemon startup, (2) relaxed socket/lock permissions, (3) privilege mismatch detection with actionable errors, (4) dead process auto-recovery. A new `allow_root` feature flag controls whether true-root operation is permitted.
 
 **Tech Stack:** Rust, `libc` crate (Unix privilege ops), `windows-sys` crate (Windows token APIs), existing `DaemonConfig`/`DaemonLock` infrastructure.
 
@@ -15,7 +15,7 @@
 | File | Responsibility |
 |------|---------------|
 | `src/privilege.rs` (create) | Cross-platform privilege detection and de-escalation logic |
-| `src/feature_flags.rs` (modify) | Add `daemon_allow_root` feature flag |
+| `src/feature_flags.rs` (modify) | Add `allow_root` feature flag |
 | `src/daemon.rs` (modify:8429-8435) | Call privilege check before lock acquisition in `run_daemon()` |
 | `src/daemon.rs` (modify:3456-3465) | Relax socket permissions from 0o600 to 0o660 |
 | `src/commands/daemon.rs` (modify:103-114,294-308) | Replace opaque "lock held" error with Layer 3+4 logic |
@@ -25,7 +25,7 @@
 
 ---
 
-### Task 1: Add `daemon_allow_root` Feature Flag
+### Task 1: Add `allow_root` Feature Flag
 
 **Files:**
 - Modify: `src/feature_flags.rs:80-87`
@@ -42,7 +42,7 @@ define_feature_flags!(
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = false,
-    daemon_allow_root: daemon_allow_root, debug = false, release = false,
+    allow_root: allow_root, debug = false, release = false,
 );
 ```
 
@@ -55,7 +55,7 @@ Expected: PASS (the test checks debug defaults, new flag defaults to false)
 
 ```bash
 git add src/feature_flags.rs
-git commit -m "feat: add daemon_allow_root feature flag (default false)"
+git commit -m "feat: add allow_root feature flag (default false)"
 ```
 
 ---
@@ -90,14 +90,14 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
     }
 
     // True root (no SUDO_UID). Check feature flag.
-    if Config::get().get_feature_flags().daemon_allow_root {
-        eprintln!("[git-ai] warning: daemon running as root (daemon_allow_root=true)");
+    if Config::get().get_feature_flags().allow_root {
+        eprintln!("[git-ai] warning: daemon running as root (allow_root=true)");
         return PrivilegeAction::Continue;
     }
 
     PrivilegeAction::Refuse(
         "Refusing to start daemon as root without a real user to de-escalate to. \
-         Set GIT_AI_DAEMON_ALLOW_ROOT=true or add daemon_allow_root to config feature_flags to override."
+         Set GIT_AI_ALLOW_ROOT=true or add allow_root to config feature_flags to override."
             .to_string(),
     )
 }
@@ -163,13 +163,13 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
     // We're elevated. Try to respawn with linked token.
     // If --respawned flag is set, we already tried — don't loop.
     if std::env::args().any(|a| a == "--respawned") {
-        if Config::get().get_feature_flags().daemon_allow_root {
-            eprintln!("[git-ai] warning: daemon running with administrator privileges (daemon_allow_root=true)");
+        if Config::get().get_feature_flags().allow_root {
+            eprintln!("[git-ai] warning: daemon running with administrator privileges (allow_root=true)");
             return PrivilegeAction::Continue;
         }
         return PrivilegeAction::Refuse(
             "Refusing to start daemon with administrator privileges. \
-             Set GIT_AI_DAEMON_ALLOW_ROOT=true or add daemon_allow_root to config feature_flags to override."
+             Set GIT_AI_ALLOW_ROOT=true or add allow_root to config feature_flags to override."
                 .to_string(),
         );
     }
@@ -181,16 +181,16 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
         }
         Err(e) => {
             // No linked token available (true admin, not UAC split)
-            if Config::get().get_feature_flags().daemon_allow_root {
+            if Config::get().get_feature_flags().allow_root {
                 eprintln!(
-                    "[git-ai] warning: could not de-escalate ({}), running as administrator (daemon_allow_root=true)",
+                    "[git-ai] warning: could not de-escalate ({}), running as administrator (allow_root=true)",
                     e
                 );
                 return PrivilegeAction::Continue;
             }
             PrivilegeAction::Refuse(format!(
                 "Refusing to start daemon with administrator privileges (de-escalation failed: {}). \
-                 Set GIT_AI_DAEMON_ALLOW_ROOT=true or add daemon_allow_root to config feature_flags to override.",
+                 Set GIT_AI_ALLOW_ROOT=true or add allow_root to config feature_flags to override.",
                 e
             ))
         }

--- a/docs/superpowers/plans/2026-05-08-daemon-privilege-mismatch.md
+++ b/docs/superpowers/plans/2026-05-08-daemon-privilege-mismatch.md
@@ -1,0 +1,814 @@
+# Daemon Privilege Mismatch Prevention - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the daemon from entering an unrecoverable broken state when started by a privileged user and accessed by a non-privileged user.
+
+**Architecture:** Four-layer defense: (1) privilege de-escalation at daemon startup, (2) relaxed socket/lock permissions, (3) privilege mismatch detection with actionable errors, (4) dead process auto-recovery. A new `daemon_allow_root` feature flag controls whether true-root operation is permitted.
+
+**Tech Stack:** Rust, `libc` crate (Unix privilege ops), `windows-sys` crate (Windows token APIs), existing `DaemonConfig`/`DaemonLock` infrastructure.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `src/privilege.rs` (create) | Cross-platform privilege detection and de-escalation logic |
+| `src/feature_flags.rs` (modify) | Add `daemon_allow_root` feature flag |
+| `src/daemon.rs` (modify:8429-8435) | Call privilege check before lock acquisition in `run_daemon()` |
+| `src/daemon.rs` (modify:3456-3465) | Relax socket permissions from 0o600 to 0o660 |
+| `src/commands/daemon.rs` (modify:103-114,294-308) | Replace opaque "lock held" error with Layer 3+4 logic |
+| `src/commands/daemon.rs` (modify:337-413) | Pass `--respawned` flag on Windows de-escalation respawn |
+| `Cargo.toml` (modify:47-49) | Add `windows-sys` as runtime dependency with token features |
+| `tests/repos/daemon_privilege_test.rs` (create) | Integration tests for privilege detection and stale lock recovery |
+
+---
+
+### Task 1: Add `daemon_allow_root` Feature Flag
+
+**Files:**
+- Modify: `src/feature_flags.rs:80-87`
+
+- [ ] **Step 1: Add the flag to `define_feature_flags!`**
+
+In `src/feature_flags.rs`, add the new flag after `transcript_sweep`:
+
+```rust
+define_feature_flags!(
+    rewrite_stash: rewrite_stash, debug = true, release = true,
+    auth_keyring: auth_keyring, debug = false, release = false,
+    git_hooks_enabled: git_hooks_enabled, debug = false, release = false,
+    git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
+    transcript_streaming: transcript_streaming, debug = true, release = true,
+    transcript_sweep: transcript_sweep, debug = true, release = false,
+    daemon_allow_root: daemon_allow_root, debug = false, release = false,
+);
+```
+
+- [ ] **Step 2: Run tests to verify no regressions**
+
+Run: `task test TEST_FILTER=test_default_feature_flags`
+Expected: PASS (the test checks debug defaults, new flag defaults to false)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/feature_flags.rs
+git commit -m "feat: add daemon_allow_root feature flag (default false)"
+```
+
+---
+
+### Task 2: Create `src/privilege.rs` — Unix Privilege Detection & De-escalation
+
+**Files:**
+- Create: `src/privilege.rs`
+- Modify: `src/main.rs` (add `mod privilege;`)
+
+- [ ] **Step 1: Create `src/privilege.rs` with Unix implementation**
+
+```rust
+use crate::config::Config;
+
+#[derive(Debug, PartialEq)]
+pub enum PrivilegeAction {
+    Continue,
+    Refuse(String),
+}
+
+#[cfg(unix)]
+pub fn check_and_deescalate_privileges() -> PrivilegeAction {
+    let euid = unsafe { libc::geteuid() };
+    if euid != 0 {
+        return PrivilegeAction::Continue;
+    }
+
+    // We're running as root. Try to de-escalate.
+    if let Some(action) = try_deescalate_unix() {
+        return action;
+    }
+
+    // True root (no SUDO_UID). Check feature flag.
+    if Config::get().get_feature_flags().daemon_allow_root {
+        eprintln!("[git-ai] warning: daemon running as root (daemon_allow_root=true)");
+        return PrivilegeAction::Continue;
+    }
+
+    PrivilegeAction::Refuse(
+        "Refusing to start daemon as root without a real user to de-escalate to. \
+         Set GIT_AI_DAEMON_ALLOW_ROOT=true or add daemon_allow_root to config feature_flags to override."
+            .to_string(),
+    )
+}
+
+#[cfg(unix)]
+fn try_deescalate_unix() -> Option<PrivilegeAction> {
+    let sudo_uid_str = std::env::var("SUDO_UID").ok()?;
+    let sudo_gid_str = std::env::var("SUDO_GID").ok()?;
+
+    let uid: libc::uid_t = sudo_uid_str.parse().ok()?;
+    let gid: libc::gid_t = sudo_gid_str.parse().ok()?;
+
+    if uid == 0 {
+        // SUDO_UID=0 means root sudo'd to root — nothing to de-escalate to
+        return None;
+    }
+
+    eprintln!(
+        "[git-ai] dropping root privileges to uid={} gid={}",
+        uid, gid
+    );
+
+    // Order matters: setgroups before setgid before setuid
+    unsafe {
+        if libc::setgroups(1, &gid) != 0 {
+            let err = std::io::Error::last_os_error();
+            return Some(PrivilegeAction::Refuse(format!(
+                "failed to setgroups during privilege de-escalation: {}",
+                err
+            )));
+        }
+        if libc::setgid(gid) != 0 {
+            let err = std::io::Error::last_os_error();
+            return Some(PrivilegeAction::Refuse(format!(
+                "failed to setgid({}) during privilege de-escalation: {}",
+                gid, err
+            )));
+        }
+        if libc::setuid(uid) != 0 {
+            let err = std::io::Error::last_os_error();
+            return Some(PrivilegeAction::Refuse(format!(
+                "failed to setuid({}) during privilege de-escalation: {}",
+                uid, err
+            )));
+        }
+    }
+
+    // Clear SUDO_* env vars so child processes don't think they're still elevated
+    std::env::remove_var("SUDO_UID");
+    std::env::remove_var("SUDO_GID");
+    std::env::remove_var("SUDO_USER");
+    std::env::remove_var("SUDO_COMMAND");
+
+    Some(PrivilegeAction::Continue)
+}
+
+#[cfg(windows)]
+pub fn check_and_deescalate_privileges() -> PrivilegeAction {
+    if !is_elevated_windows() {
+        return PrivilegeAction::Continue;
+    }
+
+    // We're elevated. Try to respawn with linked token.
+    // If --respawned flag is set, we already tried — don't loop.
+    if std::env::args().any(|a| a == "--respawned") {
+        if Config::get().get_feature_flags().daemon_allow_root {
+            eprintln!("[git-ai] warning: daemon running with administrator privileges (daemon_allow_root=true)");
+            return PrivilegeAction::Continue;
+        }
+        return PrivilegeAction::Refuse(
+            "Refusing to start daemon with administrator privileges. \
+             Set GIT_AI_DAEMON_ALLOW_ROOT=true or add daemon_allow_root to config feature_flags to override."
+                .to_string(),
+        );
+    }
+
+    match respawn_deescalated_windows() {
+        Ok(()) => {
+            // Parent exits — child will take over
+            std::process::exit(0);
+        }
+        Err(e) => {
+            // No linked token available (true admin, not UAC split)
+            if Config::get().get_feature_flags().daemon_allow_root {
+                eprintln!(
+                    "[git-ai] warning: could not de-escalate ({}), running as administrator (daemon_allow_root=true)",
+                    e
+                );
+                return PrivilegeAction::Continue;
+            }
+            PrivilegeAction::Refuse(format!(
+                "Refusing to start daemon with administrator privileges (de-escalation failed: {}). \
+                 Set GIT_AI_DAEMON_ALLOW_ROOT=true or add daemon_allow_root to config feature_flags to override.",
+                e
+            ))
+        }
+    }
+}
+
+#[cfg(windows)]
+fn is_elevated_windows() -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token = std::mem::zeroed();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return false;
+        }
+
+        let mut elevation: TOKEN_ELEVATION = std::mem::zeroed();
+        let mut size = 0u32;
+        let result = GetTokenInformation(
+            token,
+            TokenElevation,
+            &mut elevation as *mut _ as *mut _,
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut size,
+        );
+        CloseHandle(token);
+
+        result != 0 && elevation.TokenIsElevated != 0
+    }
+}
+
+#[cfg(windows)]
+fn respawn_deescalated_windows() -> Result<(), String> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TokenLinkedToken, TOKEN_LINKED_TOKEN, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::System::Threading::{
+        CreateProcessWithTokenW, GetCurrentProcess, OpenProcessToken,
+        LOGON_WITH_PROFILE, PROCESS_INFORMATION, STARTUPINFOW,
+    };
+
+    unsafe {
+        let mut token = std::mem::zeroed();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return Err("OpenProcessToken failed".to_string());
+        }
+
+        let mut linked: TOKEN_LINKED_TOKEN = std::mem::zeroed();
+        let mut size = 0u32;
+        let result = GetTokenInformation(
+            token,
+            TokenLinkedToken,
+            &mut linked as *mut _ as *mut _,
+            std::mem::size_of::<TOKEN_LINKED_TOKEN>() as u32,
+            &mut size,
+        );
+        CloseHandle(token);
+
+        if result == 0 {
+            return Err("no linked token available (not a UAC split-token process)".to_string());
+        }
+
+        let linked_token = linked.LinkedToken;
+
+        // Build command line: current exe + "bg run --respawned"
+        let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+        let cmd_line: Vec<u16> = format!("\"{}\" bg run --respawned", exe.display())
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+
+        let mut si: STARTUPINFOW = std::mem::zeroed();
+        si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+        let mut pi: PROCESS_INFORMATION = std::mem::zeroed();
+
+        let result = CreateProcessWithTokenW(
+            linked_token,
+            LOGON_WITH_PROFILE,
+            std::ptr::null(),
+            cmd_line.as_ptr() as *mut _,
+            0, // creation flags
+            std::ptr::null(),
+            std::ptr::null(),
+            &si,
+            &mut pi,
+        );
+
+        CloseHandle(linked_token);
+
+        if result == 0 {
+            return Err(format!(
+                "CreateProcessWithTokenW failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        Ok(())
+    }
+}
+
+/// Check if a given PID is alive, dead, or alive-but-inaccessible (privilege mismatch).
+#[derive(Debug, PartialEq)]
+pub enum PidStatus {
+    Dead,
+    Alive,
+    AliveButInaccessible,
+}
+
+#[cfg(unix)]
+pub fn check_pid_status(pid: u32) -> PidStatus {
+    let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if ret == 0 {
+        return PidStatus::Alive;
+    }
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::ESRCH) => PidStatus::Dead,
+        Some(libc::EPERM) => PidStatus::AliveButInaccessible,
+        _ => PidStatus::Dead, // treat unexpected errors as dead
+    }
+}
+
+#[cfg(windows)]
+pub fn check_pid_status(pid: u32) -> PidStatus {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle == 0 {
+            let err = std::io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(5) => PidStatus::AliveButInaccessible, // ERROR_ACCESS_DENIED
+                _ => PidStatus::Dead,
+            }
+        } else {
+            CloseHandle(handle);
+            PidStatus::Alive
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in `src/main.rs`**
+
+Add `mod privilege;` near the other module declarations in `src/main.rs`.
+
+Find the existing `mod` declarations and add:
+
+```rust
+mod privilege;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `task build`
+Expected: Successful compilation (note: Windows-specific code won't compile on macOS without `windows-sys` dep — that's expected, handled in Task 5)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/privilege.rs src/main.rs
+git commit -m "feat: add privilege detection and de-escalation module"
+```
+
+---
+
+### Task 3: Add `windows-sys` as Runtime Dependency
+
+**Files:**
+- Modify: `Cargo.toml:47-49`
+
+- [ ] **Step 1: Add `windows-sys` to Windows runtime dependencies**
+
+In `Cargo.toml`, change the `[target.'cfg(windows)'.dependencies]` section:
+
+```toml
+[target.'cfg(windows)'.dependencies]
+named_pipe = "0.4.1"
+winreg = "0.55"
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+] }
+```
+
+- [ ] **Step 2: Remove duplicate from dev-dependencies**
+
+The existing `[target.'cfg(windows)'.dev-dependencies]` entry for `windows-sys` should be updated to only keep features NOT already in the runtime dep:
+
+```toml
+[target.'cfg(windows)'.dev-dependencies]
+windows-sys = { version = "0.61", features = ["Win32_System_JobObjects"] }
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `task build`
+Expected: Successful compilation
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "deps: add windows-sys as runtime dependency for token APIs"
+```
+
+---
+
+### Task 4: Integrate Privilege Check into `run_daemon()`
+
+**Files:**
+- Modify: `src/daemon.rs:8429-8435`
+
+- [ ] **Step 1: Add privilege check before lock acquisition**
+
+In `src/daemon.rs`, in `run_daemon()`, insert the privilege check after `sanitize_git_env_for_daemon()` and before `config.ensure_parent_dirs()`:
+
+```rust
+pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction, GitAiError> {
+    sanitize_git_env_for_daemon();
+    disable_trace2_for_daemon_process();
+
+    match crate::privilege::check_and_deescalate_privileges() {
+        crate::privilege::PrivilegeAction::Continue => {}
+        crate::privilege::PrivilegeAction::Refuse(msg) => {
+            return Err(GitAiError::Generic(msg));
+        }
+    }
+
+    config.ensure_parent_dirs()?;
+    let _lock = DaemonLock::acquire(&config.lock_path)?;
+    // ... rest unchanged
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `task build`
+Expected: Successful compilation
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/daemon.rs
+git commit -m "feat: integrate privilege de-escalation into daemon startup"
+```
+
+---
+
+### Task 5: Relax Socket Permissions (Layer 2)
+
+**Files:**
+- Modify: `src/daemon.rs:3456-3465`
+
+- [ ] **Step 1: Change socket permissions from 0o600 to 0o660**
+
+In `src/daemon.rs`, modify `set_socket_owner_only()`:
+
+```rust
+#[cfg(not(windows))]
+fn set_socket_owner_only(path: &Path) -> Result<(), GitAiError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // 0o660: owner + group read/write. Since ~/.git-ai/ is user-scoped (0700),
+        // this allows same-user processes at different privilege levels to connect.
+        fs::set_permissions(path, fs::Permissions::from_mode(0o660))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `task build`
+Expected: Successful compilation
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/daemon.rs
+git commit -m "feat: relax daemon socket permissions to 0o660 for cross-privilege access"
+```
+
+---
+
+### Task 6: Implement Layer 3+4 — Privilege Mismatch Detection & Dead Process Recovery
+
+**Files:**
+- Modify: `src/commands/daemon.rs:103-114` (in `ensure_daemon_running_attached`)
+- Modify: `src/commands/daemon.rs:294-308` (in `start_daemon_detached_with_config`)
+
+- [ ] **Step 1: Add a helper function for enhanced lock-blocked diagnostics**
+
+Add this function in `src/commands/daemon.rs` (after the existing `daemon_startup_is_blocked` function around line 268):
+
+```rust
+/// When the lock is held but the daemon is not connectable, determine why and
+/// either auto-recover (stale lock from dead process) or provide an actionable error.
+fn diagnose_blocked_daemon(config: &DaemonConfig) -> Result<(), String> {
+    // Try to read PID from metadata
+    let pid = match crate::daemon::read_daemon_pid(config) {
+        Ok(pid) => pid,
+        Err(_) => {
+            // No PID metadata — can't diagnose further. Maybe stale lock from crash.
+            // Try force-removing the lock file and retrying.
+            if force_remove_stale_files(config) {
+                return Ok(()); // Caller should retry
+            }
+            return Err(format!(
+                "daemon startup blocked: lock held at {} (no PID metadata found, manual removal may be required)",
+                config.lock_path.display()
+            ));
+        }
+    };
+
+    match crate::privilege::check_pid_status(pid) {
+        crate::privilege::PidStatus::Dead => {
+            // Process is dead but lock persists (crash/reboot). Clean up and retry.
+            eprintln!(
+                "[git-ai] cleaning up stale daemon files from dead process (pid {})",
+                pid
+            );
+            if force_remove_stale_files(config) {
+                return Ok(()); // Caller should retry
+            }
+            Err(format!(
+                "daemon startup blocked: lock held at {} by dead process (pid {}), but cleanup failed — manual removal required",
+                config.lock_path.display(),
+                pid
+            ))
+        }
+        crate::privilege::PidStatus::AliveButInaccessible => {
+            // Privilege mismatch — process is alive but we can't signal it
+            #[cfg(unix)]
+            let hint = format!(
+                "Daemon (pid {}) is running as a different user. To fix:\n  sudo kill {} && rm -f \"{}\"",
+                pid, pid, config.lock_path.display()
+            );
+            #[cfg(windows)]
+            let hint = format!(
+                "Daemon (pid {}) is running with elevated privileges. Open an Administrator terminal and run:\n  git-ai bg stop",
+                pid
+            );
+            Err(hint)
+        }
+        crate::privilege::PidStatus::Alive => {
+            // Process is alive and accessible but sockets aren't responding.
+            // Could be starting up, or in a bad state.
+            Err(format!(
+                "daemon startup blocked: lock held at {} by process {} (alive but not responding on sockets)",
+                config.lock_path.display(),
+                pid
+            ))
+        }
+    }
+}
+
+fn force_remove_stale_files(config: &DaemonConfig) -> bool {
+    let mut ok = true;
+    if config.lock_path.exists() {
+        if std::fs::remove_file(&config.lock_path).is_err() {
+            ok = false;
+        }
+    }
+    // Also remove stale sockets
+    let _ = std::fs::remove_file(&config.control_socket_path);
+    let _ = std::fs::remove_file(&config.trace_socket_path);
+    ok
+}
+```
+
+- [ ] **Step 2: Replace the "lock held" error in `ensure_daemon_running_attached`**
+
+In `src/commands/daemon.rs`, replace the block at lines 109-114:
+
+Old code:
+```rust
+    if daemon_startup_is_blocked(&config) {
+        return Err(format!(
+            "daemon startup blocked: lock held at {}",
+            config.lock_path.display()
+        ));
+    }
+```
+
+New code:
+```rust
+    if daemon_startup_is_blocked(&config) {
+        diagnose_blocked_daemon(&config)?;
+        // diagnose_blocked_daemon returned Ok — stale files cleaned up, retry
+        if daemon_startup_is_blocked(&config) {
+            return Err(format!(
+                "daemon startup blocked: lock held at {} (cleanup succeeded but lock still held)",
+                config.lock_path.display()
+            ));
+        }
+    }
+```
+
+- [ ] **Step 3: Replace the "lock held" error in `start_daemon_detached_with_config`**
+
+In `src/commands/daemon.rs`, replace the block at lines 303-308:
+
+Old code:
+```rust
+    if daemon_startup_is_blocked(&config) {
+        return Err(format!(
+            "daemon startup blocked: lock held at {}",
+            config.lock_path.display()
+        ));
+    }
+```
+
+New code:
+```rust
+    if daemon_startup_is_blocked(&config) {
+        diagnose_blocked_daemon(&config)?;
+        // diagnose_blocked_daemon returned Ok — stale files cleaned up, retry
+        if daemon_startup_is_blocked(&config) {
+            return Err(format!(
+                "daemon startup blocked: lock held at {} (cleanup succeeded but lock still held)",
+                config.lock_path.display()
+            ));
+        }
+    }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `task build`
+Expected: Successful compilation
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/daemon.rs
+git commit -m "feat: add privilege mismatch detection and dead process auto-recovery"
+```
+
+---
+
+### Task 7: Pass `--respawned` on Windows De-escalation Respawn
+
+**Files:**
+- Modify: `src/commands/daemon.rs:174-178` (in `handle_run`)
+
+- [ ] **Step 1: Accept `--respawned` flag in `handle_run` without error**
+
+The `handle_run` function currently only checks for `--mode`. The `--respawned` flag is already consumed by `privilege.rs` via `std::env::args()`, so no additional handling is needed in `handle_run` itself. However, we need to make sure it doesn't trigger "unknown flag" errors if any such validation exists.
+
+Verify by reading `handle_run` — it only checks `--mode` with `has_flag`. The `--respawned` flag is passed through `std::env::args()` in `privilege.rs` and doesn't need explicit handling in daemon command parsing.
+
+No code change needed for this step. The `--respawned` flag is already part of the command line args that `privilege.rs` checks via `std::env::args().any(|a| a == "--respawned")`.
+
+- [ ] **Step 2: Verify the respawn command line in `privilege.rs` is correct**
+
+In `respawn_deescalated_windows()`, the command line is:
+```rust
+let cmd_line: Vec<u16> = format!("\"{}\" bg run --respawned", exe.display())
+```
+
+This matches what `handle_daemon` dispatches: `args[0] == "run"` → `handle_run(&args[1..])`. The `--respawned` arg ends up in `args` for `handle_run`, which ignores unknown flags (it only rejects `--mode`).
+
+No additional change needed. Mark complete.
+
+- [ ] **Step 3: Commit (skip if no changes)**
+
+No changes needed — the design already handles this correctly in the `privilege.rs` module.
+
+---
+
+### Task 8: Integration Tests
+
+**Files:**
+- Create: `tests/repos/daemon_privilege_test.rs`
+
+- [ ] **Step 1: Write test for stale lock auto-recovery (Layer 4)**
+
+This test simulates a daemon crash leaving a stale lock file, verifying that the next startup cleans up and succeeds.
+
+Create `tests/repos/daemon_privilege_test.rs`:
+
+```rust
+use crate::test_repo::TestRepo;
+use std::fs;
+
+#[test]
+fn test_stale_lock_auto_recovery() {
+    let repo = TestRepo::new();
+
+    // Start daemon normally, then stop it
+    repo.git_ai(&["bg", "start"]).unwrap();
+    repo.git_ai(&["bg", "shutdown"]).unwrap();
+
+    // Simulate a stale lock by creating the lock file manually
+    // (as if the daemon crashed without cleanup)
+    let internal_dir = repo.home_dir().join(".git-ai").join("internal").join("daemon");
+    fs::create_dir_all(&internal_dir).unwrap();
+    let lock_path = internal_dir.join("daemon.lock");
+    fs::write(&lock_path, "stale").unwrap();
+
+    // Also write a fake PID metadata pointing to a dead process
+    let pid_path = internal_dir.join("daemon.pid.json");
+    fs::write(
+        &pid_path,
+        r#"{"pid": 999999999, "started_at_ns": 0}"#,
+    )
+    .unwrap();
+
+    // Starting the daemon should auto-recover by cleaning up stale files
+    let result = repo.git_ai(&["bg", "start"]);
+    assert!(
+        result.is_ok(),
+        "daemon start should succeed after stale lock cleanup, got: {:?}",
+        result
+    );
+
+    // Verify daemon is actually running now
+    repo.git_ai(&["bg", "shutdown"]).unwrap();
+}
+```
+
+- [ ] **Step 2: Write test for PID status detection**
+
+Add to the same file:
+
+```rust
+#[test]
+fn test_check_pid_status_dead_process() {
+    use git_ai::privilege::{check_pid_status, PidStatus};
+
+    // PID 999999999 is extremely unlikely to be running
+    let status = check_pid_status(999999999);
+    assert_eq!(status, PidStatus::Dead);
+}
+
+#[test]
+fn test_check_pid_status_alive_process() {
+    use git_ai::privilege::{check_pid_status, PidStatus};
+
+    // Current process PID is definitely alive
+    let pid = std::process::id();
+    let status = check_pid_status(pid);
+    assert_eq!(status, PidStatus::Alive);
+}
+```
+
+- [ ] **Step 3: Write test for privilege check when not elevated**
+
+```rust
+#[test]
+fn test_privilege_check_not_elevated() {
+    use git_ai::privilege::{check_and_deescalate_privileges, PrivilegeAction};
+
+    // In normal test execution (not root), should return Continue
+    let action = check_and_deescalate_privileges();
+    assert_eq!(action, PrivilegeAction::Continue);
+}
+```
+
+- [ ] **Step 4: Register the test module**
+
+Add `mod daemon_privilege_test;` to `tests/repos/mod.rs`.
+
+- [ ] **Step 5: Make necessary types/functions public**
+
+In `src/privilege.rs`, ensure `check_pid_status`, `PidStatus`, `check_and_deescalate_privileges`, and `PrivilegeAction` are `pub`. In `src/main.rs` (or `src/lib.rs`), ensure `pub mod privilege;` is accessible from tests.
+
+- [ ] **Step 6: Run tests**
+
+Run: `task test TEST_FILTER=daemon_privilege`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/repos/daemon_privilege_test.rs tests/repos/mod.rs src/privilege.rs
+git commit -m "test: add integration tests for daemon privilege handling"
+```
+
+---
+
+### Task 9: Lint, Format, and Final Verification
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run formatter**
+
+Run: `task fmt`
+Expected: No errors (may format some files)
+
+- [ ] **Step 2: Run linter**
+
+Run: `task lint`
+Expected: No warnings or errors
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `task test`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit any formatting fixes**
+
+```bash
+git add -A
+git commit -m "chore: fmt and lint cleanup"
+```
+
+(Skip if no changes.)

--- a/docs/superpowers/specs/2026-05-08-daemon-privilege-mismatch-design.md
+++ b/docs/superpowers/specs/2026-05-08-daemon-privilege-mismatch-design.md
@@ -1,0 +1,191 @@
+# Daemon Privilege Mismatch Prevention
+
+## Problem
+
+When the daemon is started as a privileged user (root/administrator), non-privileged users enter an unrecoverable broken state:
+
+1. Can't connect to daemon (socket permission denied)
+2. Can't start new daemon (lock file held by privileged process)
+3. Can't kill old daemon (insufficient privileges to signal elevated process)
+
+This occurs on both macOS/Linux (sudo, root shells) and Windows (Run as Administrator, elevated terminals).
+
+## Solution: Four-Layer Defense
+
+### Layer 1: Privilege De-escalation at Startup
+
+The primary defense. Ensures the daemon always runs as the real user regardless of how it was invoked.
+
+#### Unix (macOS/Linux)
+
+On daemon startup (`run_daemon()` entry), before acquiring the lock:
+
+1. Check `geteuid() == 0`
+2. If `SUDO_UID` and `SUDO_GID` env vars exist:
+   - Call `setgroups(&[gid])` to reset supplementary groups
+   - Call `setgid(sudo_gid)` to drop group privileges
+   - Call `setuid(sudo_uid)` to drop user privileges
+   - Order matters: `setgroups` before `setgid` before `setuid` (can't change groups after dropping root)
+   - Log warning: "Dropping root privileges to user {uid}"
+3. If `geteuid() == 0` but no `SUDO_UID`:
+   - True root login (no real user to drop to)
+   - Refuse to start unless `--allow-root` flag is passed
+   - Error: "Refusing to start daemon as root without a real user to de-escalate to. Use --allow-root to override."
+
+#### Windows
+
+On daemon startup, before acquiring the lock:
+
+1. Call `OpenProcessToken(GetCurrentProcess())` + `GetTokenInformation(TokenElevation)` to detect UAC elevation
+2. If elevated:
+   - Call `GetTokenInformation(TokenLinkedToken)` to obtain the non-elevated linked token
+   - Re-spawn the daemon binary (`git-ai bg run --respawned`) using `CreateProcessWithTokenW` with the linked token
+   - Parent process waits up to 3 seconds for child to signal readiness (child acquires lock = ready)
+   - Parent exits with success
+3. If elevated but no linked token (true admin account, not UAC-elevated):
+   - Refuse to start unless `--allow-root` flag is passed
+   - Error: "Refusing to start daemon with administrator privileges. Use --allow-root to override."
+
+The `--respawned` internal flag prevents infinite re-spawn loops: if the child is still elevated after respawn (shouldn't happen, but defensively), it proceeds without another respawn attempt.
+
+### Layer 2: Socket/Lock Permission Relaxation
+
+Belt-and-suspenders for edge cases where de-escalation isn't triggered (e.g., `su` without `SUDO_UID`, partial failures).
+
+#### Unix
+
+After creating socket files and lock file:
+- `chmod 0660` on socket files (owner + group read/write)
+- `chmod 0660` on lock file
+- Since `~/.git-ai/` is already user-scoped (directory perms 0700 by default), this doesn't expand access beyond the user's home
+
+#### Windows
+
+Named pipes inherit the creating user's security descriptor by default. When creating from an elevated context (if de-escalation somehow didn't fire):
+- Explicitly set the pipe's DACL to include `GENERIC_READ | GENERIC_WRITE` for the user's non-elevated SID
+- This allows the same user's non-elevated processes to connect
+
+### Layer 3: Privilege Mismatch Detection (Actionable Error)
+
+When `daemon_startup_is_blocked()` returns true AND `daemon_is_up()` returns false — the "stuck" state:
+
+1. Read `daemon.pid.json` to get the daemon PID
+2. Determine if the process is running under a different/elevated privilege level:
+   - **Unix**: `kill(pid, 0)` → if `EPERM`, process exists but caller lacks permission. Additionally check `/proc/{pid}/status` (Linux) or use `sysctl` KERN_PROC (macOS) to read process UID.
+   - **Windows**: `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, pid)` → if access denied, attempt to read token elevation status via snapshot
+3. If privilege mismatch confirmed, show platform-specific remediation:
+   - **Unix**: `"Daemon (PID {pid}) is running as a different user (uid {owner_uid}). To fix: sudo kill {pid} && rm {lock_path}"`
+   - **Windows**: `"Daemon (PID {pid}) is running with elevated privileges. Open an Administrator terminal and run: git-ai bg stop"`
+
+### Layer 4: Dead Process Auto-Recovery
+
+Handles post-reboot or crash scenarios where lock file persists but process is gone:
+
+1. Read PID from `daemon.pid.json`
+2. Check if PID is actually alive:
+   - **Unix**: `kill(pid, 0)` returns `ESRCH` (no such process) → dead
+   - **Windows**: `OpenProcess` returns null with `ERROR_INVALID_PARAMETER` → dead
+3. If confirmed dead:
+   - Remove stale lock file
+   - Remove stale socket files
+   - Log: "Cleaned up stale daemon files from dead process {pid}"
+   - Retry normal startup
+4. If alive but inaccessible (`EPERM` / `ERROR_ACCESS_DENIED`):
+   - Fall through to Layer 3 (privilege mismatch error)
+
+## Execution Flow
+
+On every `ensure_daemon_running()` call:
+
+```
+1. Am I elevated?
+   ├─ Yes + can de-escalate → de-escalate, continue as real user
+   ├─ Yes + true root/admin + no --allow-root → refuse with error
+   └─ No → continue
+2. Try to connect to running daemon
+   ├─ Connected → done (normal path)
+   └─ Failed → continue
+3. Try to acquire lock
+   ├─ Acquired → start daemon normally
+   └─ Blocked → continue
+4. Read PID, check if daemon process is alive
+   ├─ Dead → cleanup stale files, retry from step 3
+   └─ Alive but inaccessible → continue
+5. Privilege mismatch?
+   ├─ Yes → show actionable platform-specific kill/stop command
+   └─ No → generic "daemon already running" error
+```
+
+## New CLI Interface
+
+### Flags
+
+- `git-ai bg start --allow-root` — Allow daemon startup as root/administrator without de-escalation
+- `git-ai bg run --allow-root` — Same, for direct run mode
+- `git-ai bg run --respawned` — Internal flag (Windows only) to prevent re-spawn loops after de-escalation
+
+### Config
+
+Optional `config.json` field:
+```json
+{
+  "daemon_allow_root": true
+}
+```
+
+Equivalent to always passing `--allow-root`. Intended for CI/container environments where root is expected.
+
+## Platform-Specific Implementation Notes
+
+### Unix De-escalation
+
+```
+setgroups([sudo_gid])  // must happen before setuid
+setgid(sudo_gid)       // drop group first
+setuid(sudo_uid)        // drop user last (irreversible)
+```
+
+After `setuid()`, the process cannot re-escalate. This is the standard privilege-drop pattern used by sshd, nginx, etc.
+
+### Windows Token Handling
+
+The linked token approach:
+1. `OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)`
+2. `GetTokenInformation(token, TokenLinkedToken, ...)` → gives non-elevated token handle
+3. `CreateProcessWithTokenW(linked_token, ..., "git-ai bg run --respawned", ...)`
+
+Key: `TokenLinkedToken` is only available when the process was UAC-elevated (split token). For full admin accounts without split tokens, there is no linked token — this is the "refuse unless --allow-root" case.
+
+### PID Liveness Detection
+
+| Platform | Dead | Alive (accessible) | Alive (inaccessible) |
+|----------|------|--------------------|-----------------------|
+| Unix | `kill(0)` → `ESRCH` | `kill(0)` → 0 | `kill(0)` → `EPERM` |
+| Windows | `OpenProcess` → null + `ERROR_INVALID_PARAMETER` | Success | null + `ERROR_ACCESS_DENIED` |
+
+### macOS Process UID Lookup
+
+macOS doesn't have `/proc`. Use:
+```
+sysctl CTL_KERN, KERN_PROC, KERN_PROC_PID, pid
+```
+Returns `kinfo_proc` with `kp_eproc.e_ucred.cr_uid`.
+
+## Testing Strategy
+
+- Integration tests: Use `GIT_AI_TEST_CONFIG_PATCH` with `"daemon_allow_root": true` to bypass refusal in test environments that run as root
+- Unit tests for privilege detection functions (mock `geteuid()` return values via feature flag or env var)
+- Manual testing matrix:
+  - macOS: `sudo git-ai bg start` → verify de-escalation
+  - Linux: `sudo git-ai bg start` → verify de-escalation
+  - Windows: Run as Administrator → verify linked token respawn
+  - All platforms: Simulate stale lock → verify auto-recovery
+  - All platforms: Simulate privilege mismatch → verify actionable error
+
+## Edge Cases
+
+- **Docker containers running as root**: Typically no `SUDO_UID`. Users should set `daemon_allow_root: true` in config or pass `--allow-root`.
+- **CI systems**: Same as Docker — use config flag.
+- **`su` without SUDO_UID**: De-escalation won't trigger (no env var to read). Layers 2-4 handle this: relaxed perms allow connection, and if that fails, actionable error explains the fix.
+- **Windows service context**: Not a split token, so no linked token. `--allow-root` required. Services typically run under a dedicated service account anyway.
+- **Race condition on lock cleanup (Layer 4)**: Between checking PID death and removing lock, another process could start. Mitigate by re-attempting lock acquisition immediately after cleanup — if it fails again, another process won the race (which is fine).

--- a/docs/superpowers/specs/2026-05-08-daemon-privilege-mismatch-design.md
+++ b/docs/superpowers/specs/2026-05-08-daemon-privilege-mismatch-design.md
@@ -29,7 +29,7 @@ On daemon startup (`run_daemon()` entry), before acquiring the lock:
    - Log warning: "Dropping root privileges to user {uid}"
 3. If `geteuid() == 0` but no `SUDO_UID`:
    - True root login (no real user to drop to)
-   - Refuse to start unless `daemon_allow_root` feature flag is enabled
+   - Refuse to start unless `allow_root` feature flag is enabled
    - Error: "Refusing to start daemon as root without a real user to de-escalate to. Use --allow-root to override."
 
 #### Windows
@@ -43,7 +43,7 @@ On daemon startup, before acquiring the lock:
    - Parent process waits up to 3 seconds for child to signal readiness (child acquires lock = ready)
    - Parent exits with success
 3. If elevated but no linked token (true admin account, not UAC-elevated):
-   - Refuse to start unless `daemon_allow_root` feature flag is enabled
+   - Refuse to start unless `allow_root` feature flag is enabled
    - Error: "Refusing to start daemon with administrator privileges. Use --allow-root to override."
 
 The `--respawned` internal flag prevents infinite re-spawn loops: if the child is still elevated after respawn (shouldn't happen, but defensively), it proceeds without another respawn attempt.
@@ -100,7 +100,7 @@ On every `ensure_daemon_running()` call:
 ```
 1. Am I elevated?
    ├─ Yes + can de-escalate → de-escalate, continue as real user
-   ├─ Yes + true root/admin + daemon_allow_root=false → refuse with error
+   ├─ Yes + true root/admin + allow_root=false → refuse with error
    └─ No → continue
 2. Try to connect to running daemon
    ├─ Connected → done (normal path)
@@ -118,12 +118,12 @@ On every `ensure_daemon_running()` call:
 
 ## Configuration
 
-### Feature Flag: `daemon_allow_root`
+### Feature Flag: `allow_root`
 
 Controlled via the standard feature flag system (`define_feature_flags!` macro):
 
-- **Config file**: `~/.git-ai/config.json` → `"feature_flags": { "daemon_allow_root": true }`
-- **Environment variable**: `GIT_AI_DAEMON_ALLOW_ROOT=true`
+- **Config file**: `~/.git-ai/config.json` → `"feature_flags": { "allow_root": true }`
+- **Environment variable**: `GIT_AI_ALLOW_ROOT=true`
 - **Default**: `false` (both debug and release)
 
 This is preferred over a CLI flag because:
@@ -175,7 +175,7 @@ Returns `kinfo_proc` with `kp_eproc.e_ucred.cr_uid`.
 
 ## Testing Strategy
 
-- Integration tests: Use `GIT_AI_DAEMON_ALLOW_ROOT=true` env var or `GIT_AI_TEST_CONFIG_PATCH` with feature_flags override to bypass refusal in test environments that run as root
+- Integration tests: Use `GIT_AI_ALLOW_ROOT=true` env var or `GIT_AI_TEST_CONFIG_PATCH` with feature_flags override to bypass refusal in test environments that run as root
 - Unit tests for privilege detection functions (mock `geteuid()` return values via feature flag or env var)
 - Manual testing matrix:
   - macOS: `sudo git-ai bg start` → verify de-escalation
@@ -186,8 +186,8 @@ Returns `kinfo_proc` with `kp_eproc.e_ucred.cr_uid`.
 
 ## Edge Cases
 
-- **Docker containers running as root**: Typically no `SUDO_UID`. Users should set `GIT_AI_DAEMON_ALLOW_ROOT=true` or add to config feature_flags.
-- **CI systems**: Same as Docker — use `GIT_AI_DAEMON_ALLOW_ROOT=true` env var.
+- **Docker containers running as root**: Typically no `SUDO_UID`. Users should set `GIT_AI_ALLOW_ROOT=true` or add to config feature_flags.
+- **CI systems**: Same as Docker — use `GIT_AI_ALLOW_ROOT=true` env var.
 - **`su` without SUDO_UID**: De-escalation won't trigger (no env var to read). Layers 2-4 handle this: relaxed perms allow connection, and if that fails, actionable error explains the fix.
-- **Windows service context**: Not a split token, so no linked token. `daemon_allow_root` feature flag required. Services typically run under a dedicated service account anyway.
+- **Windows service context**: Not a split token, so no linked token. `allow_root` feature flag required. Services typically run under a dedicated service account anyway.
 - **Race condition on lock cleanup (Layer 4)**: Between checking PID death and removing lock, another process could start. Mitigate by re-attempting lock acquisition immediately after cleanup — if it fails again, another process won the race (which is fine).

--- a/docs/superpowers/specs/2026-05-08-daemon-privilege-mismatch-design.md
+++ b/docs/superpowers/specs/2026-05-08-daemon-privilege-mismatch-design.md
@@ -29,7 +29,7 @@ On daemon startup (`run_daemon()` entry), before acquiring the lock:
    - Log warning: "Dropping root privileges to user {uid}"
 3. If `geteuid() == 0` but no `SUDO_UID`:
    - True root login (no real user to drop to)
-   - Refuse to start unless `--allow-root` flag is passed
+   - Refuse to start unless `daemon_allow_root` feature flag is enabled
    - Error: "Refusing to start daemon as root without a real user to de-escalate to. Use --allow-root to override."
 
 #### Windows
@@ -43,7 +43,7 @@ On daemon startup, before acquiring the lock:
    - Parent process waits up to 3 seconds for child to signal readiness (child acquires lock = ready)
    - Parent exits with success
 3. If elevated but no linked token (true admin account, not UAC-elevated):
-   - Refuse to start unless `--allow-root` flag is passed
+   - Refuse to start unless `daemon_allow_root` feature flag is enabled
    - Error: "Refusing to start daemon with administrator privileges. Use --allow-root to override."
 
 The `--respawned` internal flag prevents infinite re-spawn loops: if the child is still elevated after respawn (shouldn't happen, but defensively), it proceeds without another respawn attempt.
@@ -100,7 +100,7 @@ On every `ensure_daemon_running()` call:
 ```
 1. Am I elevated?
    ├─ Yes + can de-escalate → de-escalate, continue as real user
-   ├─ Yes + true root/admin + no --allow-root → refuse with error
+   ├─ Yes + true root/admin + daemon_allow_root=false → refuse with error
    └─ No → continue
 2. Try to connect to running daemon
    ├─ Connected → done (normal path)
@@ -116,24 +116,26 @@ On every `ensure_daemon_running()` call:
    └─ No → generic "daemon already running" error
 ```
 
-## New CLI Interface
+## Configuration
 
-### Flags
+### Feature Flag: `daemon_allow_root`
 
-- `git-ai bg start --allow-root` — Allow daemon startup as root/administrator without de-escalation
-- `git-ai bg run --allow-root` — Same, for direct run mode
-- `git-ai bg run --respawned` — Internal flag (Windows only) to prevent re-spawn loops after de-escalation
+Controlled via the standard feature flag system (`define_feature_flags!` macro):
 
-### Config
+- **Config file**: `~/.git-ai/config.json` → `"feature_flags": { "daemon_allow_root": true }`
+- **Environment variable**: `GIT_AI_DAEMON_ALLOW_ROOT=true`
+- **Default**: `false` (both debug and release)
 
-Optional `config.json` field:
-```json
-{
-  "daemon_allow_root": true
-}
-```
+This is preferred over a CLI flag because:
+1. The daemon restarts itself (after updates, on `Restart` exit action, via `ensure_daemon_running()`)
+2. All restart paths would need to thread a `--allow-root` flag through spawn logic
+3. A feature flag is read from `Config::get()` at the privilege check site — works everywhere automatically
 
-Equivalent to always passing `--allow-root`. Intended for CI/container environments where root is expected.
+Intended for CI/container environments where root is expected.
+
+### Internal Flag: `--respawned`
+
+`git-ai bg run --respawned` — Internal flag (Windows only) to prevent infinite re-spawn loops after de-escalation. Not user-facing.
 
 ## Platform-Specific Implementation Notes
 
@@ -173,7 +175,7 @@ Returns `kinfo_proc` with `kp_eproc.e_ucred.cr_uid`.
 
 ## Testing Strategy
 
-- Integration tests: Use `GIT_AI_TEST_CONFIG_PATCH` with `"daemon_allow_root": true` to bypass refusal in test environments that run as root
+- Integration tests: Use `GIT_AI_DAEMON_ALLOW_ROOT=true` env var or `GIT_AI_TEST_CONFIG_PATCH` with feature_flags override to bypass refusal in test environments that run as root
 - Unit tests for privilege detection functions (mock `geteuid()` return values via feature flag or env var)
 - Manual testing matrix:
   - macOS: `sudo git-ai bg start` → verify de-escalation
@@ -184,8 +186,8 @@ Returns `kinfo_proc` with `kp_eproc.e_ucred.cr_uid`.
 
 ## Edge Cases
 
-- **Docker containers running as root**: Typically no `SUDO_UID`. Users should set `daemon_allow_root: true` in config or pass `--allow-root`.
-- **CI systems**: Same as Docker — use config flag.
+- **Docker containers running as root**: Typically no `SUDO_UID`. Users should set `GIT_AI_DAEMON_ALLOW_ROOT=true` or add to config feature_flags.
+- **CI systems**: Same as Docker — use `GIT_AI_DAEMON_ALLOW_ROOT=true` env var.
 - **`su` without SUDO_UID**: De-escalation won't trigger (no env var to read). Layers 2-4 handle this: relaxed perms allow connection, and if that fails, actionable error explains the fix.
-- **Windows service context**: Not a split token, so no linked token. `--allow-root` required. Services typically run under a dedicated service account anyway.
+- **Windows service context**: Not a split token, so no linked token. `daemon_allow_root` feature flag required. Services typically run under a dedicated service account anyway.
 - **Race condition on lock cleanup (Layer 4)**: Between checking PID death and removing lock, another process could start. Mitigate by re-attempting lock acquisition immediately after cleanup — if it fails again, another process won the race (which is fine).

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -107,10 +107,14 @@ fn ensure_daemon_running_attached(timeout: Duration) -> Result<DaemonConfig, Str
     }
 
     if daemon_startup_is_blocked(&config) {
-        return Err(format!(
-            "daemon startup blocked: lock held at {}",
-            config.lock_path.display()
-        ));
+        diagnose_blocked_daemon(&config)?;
+        // diagnose returned Ok — stale files cleaned up. Retry.
+        if daemon_startup_is_blocked(&config) {
+            return Err(format!(
+                "daemon startup blocked: lock still held at {} after cleanup",
+                config.lock_path.display()
+            ));
+        }
     }
 
     #[cfg(not(windows))]
@@ -267,6 +271,76 @@ fn daemon_startup_is_blocked(config: &DaemonConfig) -> bool {
     }
 }
 
+/// When the lock is held but the daemon is not connectable, determine why and
+/// either auto-recover (stale lock from dead process) or provide an actionable error.
+fn diagnose_blocked_daemon(config: &DaemonConfig) -> Result<(), String> {
+    let pid = match crate::daemon::read_daemon_pid(config) {
+        Ok(pid) => pid,
+        Err(_) => {
+            // No PID metadata — stale lock from crash. Try cleanup.
+            if force_remove_stale_files(config) {
+                return Ok(());
+            }
+            return Err(format!(
+                "daemon startup blocked: lock held at {} (no PID metadata, manual removal may be required)",
+                config.lock_path.display()
+            ));
+        }
+    };
+
+    match crate::privilege::check_pid_status(pid) {
+        crate::privilege::PidStatus::Dead => {
+            eprintln!(
+                "[git-ai] cleaning up stale daemon files from dead process (pid {})",
+                pid
+            );
+            if force_remove_stale_files(config) {
+                return Ok(());
+            }
+            Err(format!(
+                "daemon startup blocked: stale lock from dead process (pid {}), cleanup failed — manual removal required: {}",
+                pid,
+                config.lock_path.display()
+            ))
+        }
+        crate::privilege::PidStatus::AliveButInaccessible => {
+            #[cfg(unix)]
+            {
+                Err(format!(
+                    "Daemon (pid {}) is running as a different user. To fix:\n  sudo kill {} && rm -f \"{}\"",
+                    pid, pid, config.lock_path.display()
+                ))
+            }
+            #[cfg(windows)]
+            {
+                Err(format!(
+                    "Daemon (pid {}) is running with elevated privileges. Open an Administrator terminal and run:\n  git-ai bg stop",
+                    pid
+                ))
+            }
+        }
+        crate::privilege::PidStatus::Alive => {
+            Err(format!(
+                "daemon startup blocked: lock held at {} by process {} (alive but not responding on sockets)",
+                config.lock_path.display(),
+                pid
+            ))
+        }
+    }
+}
+
+fn force_remove_stale_files(config: &DaemonConfig) -> bool {
+    let mut ok = true;
+    if config.lock_path.exists() {
+        if std::fs::remove_file(&config.lock_path).is_err() {
+            ok = false;
+        }
+    }
+    let _ = std::fs::remove_file(&config.control_socket_path);
+    let _ = std::fs::remove_file(&config.trace_socket_path);
+    ok
+}
+
 pub(crate) fn daemon_is_up(config: &DaemonConfig) -> bool {
     if !config.control_socket_path.exists() || !config.trace_socket_path.exists() {
         return false;
@@ -301,10 +375,13 @@ fn start_daemon_detached_with_config(
     }
 
     if daemon_startup_is_blocked(&config) {
-        return Err(format!(
-            "daemon startup blocked: lock held at {}",
-            config.lock_path.display()
-        ));
+        diagnose_blocked_daemon(&config)?;
+        if daemon_startup_is_blocked(&config) {
+            return Err(format!(
+                "daemon startup blocked: lock still held at {} after cleanup",
+                config.lock_path.display()
+            ));
+        }
     }
 
     spawn_daemon_run_detached(&config)?;

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -179,6 +179,16 @@ fn handle_run(args: &[String]) -> Result<(), String> {
     if has_flag(args, "--mode") {
         return Err("--mode is no longer supported; daemon always runs in write mode".to_string());
     }
+
+    // De-escalate privileges BEFORE resolving DaemonConfig, so paths resolve
+    // relative to the real user's HOME (not root's).
+    match crate::privilege::check_and_deescalate_privileges() {
+        crate::privilege::PrivilegeAction::Continue => {}
+        crate::privilege::PrivilegeAction::Refuse(msg) => {
+            return Err(msg);
+        }
+    }
+
     let config = daemon_config_from_env_or_default_paths()?;
     let runtime_dir = daemon_runtime_dir(&config)?;
     std::env::set_current_dir(&runtime_dir).map_err(|e| {

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -308,7 +308,9 @@ fn diagnose_blocked_daemon(config: &DaemonConfig) -> Result<(), String> {
             {
                 Err(format!(
                     "Daemon (pid {}) is running as a different user. To fix:\n  sudo kill {} && rm -f \"{}\"",
-                    pid, pid, config.lock_path.display()
+                    pid,
+                    pid,
+                    config.lock_path.display()
                 ))
             }
             #[cfg(windows)]
@@ -319,22 +321,18 @@ fn diagnose_blocked_daemon(config: &DaemonConfig) -> Result<(), String> {
                 ))
             }
         }
-        crate::privilege::PidStatus::Alive => {
-            Err(format!(
-                "daemon startup blocked: lock held at {} by process {} (alive but not responding on sockets)",
-                config.lock_path.display(),
-                pid
-            ))
-        }
+        crate::privilege::PidStatus::Alive => Err(format!(
+            "daemon startup blocked: lock held at {} by process {} (alive but not responding on sockets)",
+            config.lock_path.display(),
+            pid
+        )),
     }
 }
 
 fn force_remove_stale_files(config: &DaemonConfig) -> bool {
     let mut ok = true;
-    if config.lock_path.exists() {
-        if std::fs::remove_file(&config.lock_path).is_err() {
-            ok = false;
-        }
+    if config.lock_path.exists() && std::fs::remove_file(&config.lock_path).is_err() {
+        ok = false;
     }
     let _ = std::fs::remove_file(&config.control_socket_path);
     let _ = std::fs::remove_file(&config.trace_socket_path);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8429,6 +8429,14 @@ pub(crate) fn daemon_run_pending_self_update() -> DaemonSelfUpdateOutcome {
 pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction, GitAiError> {
     sanitize_git_env_for_daemon();
     disable_trace2_for_daemon_process();
+
+    match crate::privilege::check_and_deescalate_privileges() {
+        crate::privilege::PrivilegeAction::Continue => {}
+        crate::privilege::PrivilegeAction::Refuse(msg) => {
+            return Err(GitAiError::Generic(msg));
+        }
+    }
+
     config.ensure_parent_dirs()?;
     let _lock = DaemonLock::acquire(&config.lock_path)?;
     let _active_guard = DaemonProcessActiveGuard::enter();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3457,7 +3457,10 @@ fn set_socket_owner_only(path: &Path) -> Result<(), GitAiError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        // 0o660: allows same-user processes at different privilege levels to connect
+        // (e.g., root-started daemon accessible by non-root user). Safe because
+        // ~/.git-ai/ directory is already 0700.
+        fs::set_permissions(path, fs::Permissions::from_mode(0o660))?;
     }
     #[cfg(not(unix))]
     {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3458,8 +3458,8 @@ fn set_socket_owner_only(path: &Path) -> Result<(), GitAiError> {
     {
         use std::os::unix::fs::PermissionsExt;
         // 0o660: allows same-user processes at different privilege levels to connect
-        // (e.g., root-started daemon accessible by non-root user). Safe because
-        // ~/.git-ai/ directory is already 0700.
+        // (e.g., root-started daemon accessible by non-root user). Access is
+        // bounded by parent directory permissions (home dir / .git-ai tree).
         fs::set_permissions(path, fs::Permissions::from_mode(0o660))?;
     }
     #[cfg(not(unix))]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8432,14 +8432,6 @@ pub(crate) fn daemon_run_pending_self_update() -> DaemonSelfUpdateOutcome {
 pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction, GitAiError> {
     sanitize_git_env_for_daemon();
     disable_trace2_for_daemon_process();
-
-    match crate::privilege::check_and_deescalate_privileges() {
-        crate::privilege::PrivilegeAction::Continue => {}
-        crate::privilege::PrivilegeAction::Refuse(msg) => {
-            return Err(GitAiError::Generic(msg));
-        }
-    }
-
     config.ensure_parent_dirs()?;
     let _lock = DaemonLock::acquire(&config.lock_path)?;
     let _active_guard = DaemonProcessActiveGuard::enter();

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -84,6 +84,7 @@ define_feature_flags!(
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = false,
+    daemon_allow_root: daemon_allow_root, debug = false, release = false,
 );
 
 impl FeatureFlags {

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -209,6 +209,7 @@ mod tests {
             git_hooks_externally_managed: false,
             transcript_streaming: true,
             transcript_sweep: true,
+            daemon_allow_root: false,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -229,6 +230,7 @@ mod tests {
             git_hooks_externally_managed: false,
             transcript_streaming: true,
             transcript_sweep: true,
+            daemon_allow_root: false,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -84,7 +84,7 @@ define_feature_flags!(
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = false,
-    daemon_allow_root: daemon_allow_root, debug = false, release = false,
+    allow_root: allow_root, debug = false, release = false,
 );
 
 impl FeatureFlags {
@@ -209,7 +209,7 @@ mod tests {
             git_hooks_externally_managed: false,
             transcript_streaming: true,
             transcript_sweep: true,
-            daemon_allow_root: false,
+            allow_root: false,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -230,7 +230,7 @@ mod tests {
             git_hooks_externally_managed: false,
             transcript_streaming: true,
             transcript_sweep: true,
-            daemon_allow_root: false,
+            allow_root: false,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod http;
 pub mod mdm;
 pub mod metrics;
 pub mod observability;
+pub mod privilege;
 pub mod repo_url;
 pub mod transcripts;
 pub mod utils;

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -1,0 +1,259 @@
+use crate::config::Config;
+
+#[derive(Debug, PartialEq)]
+pub enum PrivilegeAction {
+    Continue,
+    Refuse(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PidStatus {
+    Dead,
+    Alive,
+    AliveButInaccessible,
+}
+
+#[cfg(unix)]
+pub fn check_and_deescalate_privileges() -> PrivilegeAction {
+    let euid = unsafe { libc::geteuid() };
+    if euid != 0 {
+        return PrivilegeAction::Continue;
+    }
+
+    // We are running as root. Try to de-escalate via SUDO_UID/SUDO_GID.
+    let sudo_uid = std::env::var("SUDO_UID").ok().and_then(|v| v.parse::<u32>().ok());
+    let sudo_gid = std::env::var("SUDO_GID").ok().and_then(|v| v.parse::<u32>().ok());
+
+    if let (Some(uid), Some(gid)) = (sudo_uid, sudo_gid) {
+        if uid != 0 {
+            eprintln!("[git-ai] dropping root privileges to uid={} gid={}", uid, gid);
+
+            unsafe {
+                let gid_c = gid as libc::gid_t;
+                if libc::setgroups(1, &gid_c) != 0 {
+                    return PrivilegeAction::Refuse(format!(
+                        "failed to setgroups: {}",
+                        std::io::Error::last_os_error()
+                    ));
+                }
+                if libc::setgid(gid_c) != 0 {
+                    return PrivilegeAction::Refuse(format!(
+                        "failed to setgid: {}",
+                        std::io::Error::last_os_error()
+                    ));
+                }
+                if libc::setuid(uid as libc::uid_t) != 0 {
+                    return PrivilegeAction::Refuse(format!(
+                        "failed to setuid: {}",
+                        std::io::Error::last_os_error()
+                    ));
+                }
+            }
+
+            // Clear SUDO_* env vars now that we've dropped privileges
+            unsafe {
+                std::env::remove_var("SUDO_UID");
+                std::env::remove_var("SUDO_GID");
+                std::env::remove_var("SUDO_USER");
+                std::env::remove_var("SUDO_COMMAND");
+            }
+
+            return PrivilegeAction::Continue;
+        }
+    }
+
+    // True root (SUDO_UID=0, unparseable, or absent) — check feature flag
+    let allow_root = Config::get().get_feature_flags().daemon_allow_root;
+    if allow_root {
+        eprintln!("[git-ai] WARNING: running as root with daemon_allow_root=true");
+        PrivilegeAction::Continue
+    } else {
+        PrivilegeAction::Refuse(
+            "git-ai daemon refuses to run as root. \
+             Set GIT_AI_DAEMON_ALLOW_ROOT=true to override."
+                .to_string(),
+        )
+    }
+}
+
+#[cfg(unix)]
+pub fn check_pid_status(pid: u32) -> PidStatus {
+    let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if ret == 0 {
+        return PidStatus::Alive;
+    }
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::ESRCH) => PidStatus::Dead,
+        Some(libc::EPERM) => PidStatus::AliveButInaccessible,
+        _ => PidStatus::Dead,
+    }
+}
+
+#[cfg(windows)]
+pub fn check_and_deescalate_privileges() -> PrivilegeAction {
+    if !is_elevated_windows() {
+        return PrivilegeAction::Continue;
+    }
+
+    // If --respawned is present, we already tried de-escalation
+    if std::env::args().any(|arg| arg == "--respawned") {
+        let allow_root = Config::get().get_feature_flags().daemon_allow_root;
+        if allow_root {
+            eprintln!("[git-ai] WARNING: running elevated with daemon_allow_root=true");
+            return PrivilegeAction::Continue;
+        } else {
+            return PrivilegeAction::Refuse(
+                "git-ai daemon refuses to run elevated. \
+                 Set GIT_AI_DAEMON_ALLOW_ROOT=true to override."
+                    .to_string(),
+            );
+        }
+    }
+
+    // Try to respawn de-escalated
+    match respawn_deescalated_windows() {
+        Ok(()) => {
+            // Child process spawned successfully, parent should exit
+            std::process::exit(0);
+        }
+        Err(_) => {
+            let allow_root = Config::get().get_feature_flags().daemon_allow_root;
+            if allow_root {
+                eprintln!(
+                    "[git-ai] WARNING: running elevated with daemon_allow_root=true \
+                     (de-escalation failed)"
+                );
+                PrivilegeAction::Continue
+            } else {
+                PrivilegeAction::Refuse(
+                    "git-ai daemon refuses to run elevated and de-escalation failed. \
+                     Set GIT_AI_DAEMON_ALLOW_ROOT=true to override."
+                        .to_string(),
+                )
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+pub fn check_pid_status(pid: u32) -> PidStatus {
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED};
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle != 0 {
+        unsafe { CloseHandle(handle) };
+        PidStatus::Alive
+    } else {
+        let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
+        if err == ERROR_ACCESS_DENIED {
+            PidStatus::AliveButInaccessible
+        } else {
+            PidStatus::Dead
+        }
+    }
+}
+
+#[cfg(windows)]
+fn is_elevated_windows() -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token_handle = 0;
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle) == 0 {
+            return false;
+        }
+
+        let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+        let mut return_length = 0u32;
+        let result = GetTokenInformation(
+            token_handle,
+            TokenElevation,
+            &mut elevation as *mut _ as *mut _,
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut return_length,
+        );
+        CloseHandle(token_handle);
+
+        result != 0 && elevation.TokenIsElevated != 0
+    }
+}
+
+#[cfg(windows)]
+fn respawn_deescalated_windows() -> Result<(), String> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TokenLinkedToken, TOKEN_LINKED_TOKEN, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::System::Threading::{
+        CreateProcessWithTokenW, GetCurrentProcess, OpenProcessToken, LOGON_WITH_PROFILE,
+        PROCESS_INFORMATION, STARTUPINFOW,
+    };
+
+    unsafe {
+        let mut token_handle = 0;
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle) == 0 {
+            return Err("failed to open process token".to_string());
+        }
+
+        let mut linked_token = TOKEN_LINKED_TOKEN { LinkedToken: 0 };
+        let mut return_length = 0u32;
+        let result = GetTokenInformation(
+            token_handle,
+            TokenLinkedToken,
+            &mut linked_token as *mut _ as *mut _,
+            std::mem::size_of::<TOKEN_LINKED_TOKEN>() as u32,
+            &mut return_length,
+        );
+        CloseHandle(token_handle);
+
+        if result == 0 || linked_token.LinkedToken == 0 {
+            return Err("failed to get linked token".to_string());
+        }
+
+        let exe_path = std::env::current_exe()
+            .map_err(|e| format!("failed to get current exe: {}", e))?;
+        let args: Vec<String> = std::env::args().collect();
+        let mut cmd_line = format!("\"{}\"", exe_path.display());
+        for arg in &args[1..] {
+            cmd_line.push_str(&format!(" \"{}\"", arg));
+        }
+        cmd_line.push_str(" \"--respawned\"");
+
+        let cmd_line_wide: Vec<u16> = cmd_line.encode_utf16().chain(std::iter::once(0)).collect();
+
+        let mut startup_info: STARTUPINFOW = std::mem::zeroed();
+        startup_info.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+        let mut process_info: PROCESS_INFORMATION = std::mem::zeroed();
+
+        let create_result = CreateProcessWithTokenW(
+            linked_token.LinkedToken,
+            LOGON_WITH_PROFILE,
+            std::ptr::null(),
+            cmd_line_wide.as_ptr() as *mut _,
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+            &startup_info,
+            &mut process_info,
+        );
+
+        CloseHandle(linked_token.LinkedToken);
+
+        if create_result == 0 {
+            return Err(format!(
+                "CreateProcessWithTokenW failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        CloseHandle(process_info.hProcess);
+        CloseHandle(process_info.hThread);
+        Ok(())
+    }
+}

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -257,3 +257,31 @@ fn respawn_deescalated_windows() -> Result<(), String> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_pid_status_dead_process() {
+        // PID 4_000_000_000 is impossibly high and guaranteed not running
+        assert_eq!(check_pid_status(4_000_000_000), PidStatus::Dead);
+    }
+
+    #[test]
+    fn check_pid_status_alive_process() {
+        // Current process is definitely alive
+        let pid = std::process::id();
+        assert_eq!(check_pid_status(pid), PidStatus::Alive);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn privilege_check_not_elevated() {
+        // Tests run as normal user, should return Continue
+        // (unless tests are running as root, which would be unusual)
+        if unsafe { libc::geteuid() } != 0 {
+            assert_eq!(check_and_deescalate_privileges(), PrivilegeAction::Continue);
+        }
+    }
+}

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -149,7 +149,7 @@ pub fn check_pid_status(pid: u32) -> PidStatus {
     use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
     let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    if handle != 0 {
+    if !handle.is_null() {
         unsafe { CloseHandle(handle) };
         PidStatus::Alive
     } else {
@@ -171,7 +171,7 @@ fn is_elevated_windows() -> bool {
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     unsafe {
-        let mut token_handle = 0;
+        let mut token_handle = std::ptr::null_mut();
         if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle) == 0 {
             return false;
         }
@@ -203,12 +203,14 @@ fn respawn_deescalated_windows() -> Result<(), String> {
     };
 
     unsafe {
-        let mut token_handle = 0;
+        let mut token_handle = std::ptr::null_mut();
         if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle) == 0 {
             return Err("failed to open process token".to_string());
         }
 
-        let mut linked_token = TOKEN_LINKED_TOKEN { LinkedToken: 0 };
+        let mut linked_token = TOKEN_LINKED_TOKEN {
+            LinkedToken: std::ptr::null_mut(),
+        };
         let mut return_length = 0u32;
         let result = GetTokenInformation(
             token_handle,
@@ -219,7 +221,7 @@ fn respawn_deescalated_windows() -> Result<(), String> {
         );
         CloseHandle(token_handle);
 
-        if result == 0 || linked_token.LinkedToken == 0 {
+        if result == 0 || linked_token.LinkedToken.is_null() {
             return Err("failed to get linked token".to_string());
         }
 
@@ -244,7 +246,7 @@ fn respawn_deescalated_windows() -> Result<(), String> {
             std::ptr::null(),
             cmd_line_wide.as_ptr() as *mut _,
             0,
-            std::ptr::null(),
+            std::ptr::null_mut(),
             std::ptr::null(),
             &startup_info,
             &mut process_info,

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -70,14 +70,14 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
     }
 
     // True root (SUDO_UID=0, unparseable, or absent) — check feature flag
-    let allow_root = Config::get().get_feature_flags().daemon_allow_root;
+    let allow_root = Config::get().get_feature_flags().allow_root;
     if allow_root {
-        eprintln!("[git-ai] WARNING: running as root with daemon_allow_root=true");
+        eprintln!("[git-ai] WARNING: running as root with allow_root=true");
         PrivilegeAction::Continue
     } else {
         PrivilegeAction::Refuse(
             "git-ai daemon refuses to run as root. \
-             Set GIT_AI_DAEMON_ALLOW_ROOT=true to override."
+             Set GIT_AI_ALLOW_ROOT=true to override."
                 .to_string(),
         )
     }
@@ -105,14 +105,14 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
 
     // If --respawned is present, we already tried de-escalation
     if std::env::args().any(|arg| arg == "--respawned") {
-        let allow_root = Config::get().get_feature_flags().daemon_allow_root;
+        let allow_root = Config::get().get_feature_flags().allow_root;
         if allow_root {
-            eprintln!("[git-ai] WARNING: running elevated with daemon_allow_root=true");
+            eprintln!("[git-ai] WARNING: running elevated with allow_root=true");
             return PrivilegeAction::Continue;
         } else {
             return PrivilegeAction::Refuse(
                 "git-ai daemon refuses to run elevated. \
-                 Set GIT_AI_DAEMON_ALLOW_ROOT=true to override."
+                 Set GIT_AI_ALLOW_ROOT=true to override."
                     .to_string(),
             );
         }
@@ -125,17 +125,17 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
             std::process::exit(0);
         }
         Err(_) => {
-            let allow_root = Config::get().get_feature_flags().daemon_allow_root;
+            let allow_root = Config::get().get_feature_flags().allow_root;
             if allow_root {
                 eprintln!(
-                    "[git-ai] WARNING: running elevated with daemon_allow_root=true \
+                    "[git-ai] WARNING: running elevated with allow_root=true \
                      (de-escalation failed)"
                 );
                 PrivilegeAction::Continue
             } else {
                 PrivilegeAction::Refuse(
                     "git-ai daemon refuses to run elevated and de-escalation failed. \
-                     Set GIT_AI_DAEMON_ALLOW_ROOT=true to override."
+                     Set GIT_AI_ALLOW_ROOT=true to override."
                         .to_string(),
                 )
             }

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -31,10 +31,7 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
     if let (Some(uid), Some(gid)) = (sudo_uid, sudo_gid)
         && uid != 0
     {
-        eprintln!(
-            "[git-ai] dropping root privileges to uid={} gid={}",
-            uid, gid
-        );
+        eprintln!("[git-ai] dropping root privileges to invoking user");
 
         unsafe {
             let gid_c = gid as libc::gid_t;

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -21,45 +21,52 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
     }
 
     // We are running as root. Try to de-escalate via SUDO_UID/SUDO_GID.
-    let sudo_uid = std::env::var("SUDO_UID").ok().and_then(|v| v.parse::<u32>().ok());
-    let sudo_gid = std::env::var("SUDO_GID").ok().and_then(|v| v.parse::<u32>().ok());
+    let sudo_uid = std::env::var("SUDO_UID")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok());
+    let sudo_gid = std::env::var("SUDO_GID")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok());
 
-    if let (Some(uid), Some(gid)) = (sudo_uid, sudo_gid) {
-        if uid != 0 {
-            eprintln!("[git-ai] dropping root privileges to uid={} gid={}", uid, gid);
+    if let (Some(uid), Some(gid)) = (sudo_uid, sudo_gid)
+        && uid != 0
+    {
+        eprintln!(
+            "[git-ai] dropping root privileges to uid={} gid={}",
+            uid, gid
+        );
 
-            unsafe {
-                let gid_c = gid as libc::gid_t;
-                if libc::setgroups(1, &gid_c) != 0 {
-                    return PrivilegeAction::Refuse(format!(
-                        "failed to setgroups: {}",
-                        std::io::Error::last_os_error()
-                    ));
-                }
-                if libc::setgid(gid_c) != 0 {
-                    return PrivilegeAction::Refuse(format!(
-                        "failed to setgid: {}",
-                        std::io::Error::last_os_error()
-                    ));
-                }
-                if libc::setuid(uid as libc::uid_t) != 0 {
-                    return PrivilegeAction::Refuse(format!(
-                        "failed to setuid: {}",
-                        std::io::Error::last_os_error()
-                    ));
-                }
+        unsafe {
+            let gid_c = gid as libc::gid_t;
+            if libc::setgroups(1, &gid_c) != 0 {
+                return PrivilegeAction::Refuse(format!(
+                    "failed to setgroups: {}",
+                    std::io::Error::last_os_error()
+                ));
             }
-
-            // Clear SUDO_* env vars now that we've dropped privileges
-            unsafe {
-                std::env::remove_var("SUDO_UID");
-                std::env::remove_var("SUDO_GID");
-                std::env::remove_var("SUDO_USER");
-                std::env::remove_var("SUDO_COMMAND");
+            if libc::setgid(gid_c) != 0 {
+                return PrivilegeAction::Refuse(format!(
+                    "failed to setgid: {}",
+                    std::io::Error::last_os_error()
+                ));
             }
-
-            return PrivilegeAction::Continue;
+            if libc::setuid(uid as libc::uid_t) != 0 {
+                return PrivilegeAction::Refuse(format!(
+                    "failed to setuid: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
         }
+
+        // Clear SUDO_* env vars now that we've dropped privileges
+        unsafe {
+            std::env::remove_var("SUDO_UID");
+            std::env::remove_var("SUDO_GID");
+            std::env::remove_var("SUDO_USER");
+            std::env::remove_var("SUDO_COMMAND");
+        }
+
+        return PrivilegeAction::Continue;
     }
 
     // True root (SUDO_UID=0, unparseable, or absent) — check feature flag
@@ -159,7 +166,7 @@ pub fn check_pid_status(pid: u32) -> PidStatus {
 fn is_elevated_windows() -> bool {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::Security::{
-        GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY,
+        GetTokenInformation, TOKEN_ELEVATION, TOKEN_QUERY, TokenElevation,
     };
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
@@ -188,10 +195,10 @@ fn is_elevated_windows() -> bool {
 fn respawn_deescalated_windows() -> Result<(), String> {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::Security::{
-        GetTokenInformation, TokenLinkedToken, TOKEN_LINKED_TOKEN, TOKEN_QUERY,
+        GetTokenInformation, TOKEN_LINKED_TOKEN, TOKEN_QUERY, TokenLinkedToken,
     };
     use windows_sys::Win32::System::Threading::{
-        CreateProcessWithTokenW, GetCurrentProcess, OpenProcessToken, LOGON_WITH_PROFILE,
+        CreateProcessWithTokenW, GetCurrentProcess, LOGON_WITH_PROFILE, OpenProcessToken,
         PROCESS_INFORMATION, STARTUPINFOW,
     };
 
@@ -216,8 +223,8 @@ fn respawn_deescalated_windows() -> Result<(), String> {
             return Err("failed to get linked token".to_string());
         }
 
-        let exe_path = std::env::current_exe()
-            .map_err(|e| format!("failed to get current exe: {}", e))?;
+        let exe_path =
+            std::env::current_exe().map_err(|e| format!("failed to get current exe: {}", e))?;
         let args: Vec<String> = std::env::args().collect();
         let mut cmd_line = format!("\"{}\"", exe_path.display());
         for arg in &args[1..] {

--- a/src/privilege.rs
+++ b/src/privilege.rs
@@ -58,6 +58,12 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
             }
         }
 
+        // Update HOME to the real user's home directory so DaemonConfig
+        // paths resolve correctly after de-escalation.
+        if let Some(home) = lookup_home_dir(uid) {
+            unsafe { std::env::set_var("HOME", &home) };
+        }
+
         // Clear SUDO_* env vars now that we've dropped privileges
         unsafe {
             std::env::remove_var("SUDO_UID");
@@ -81,6 +87,28 @@ pub fn check_and_deescalate_privileges() -> PrivilegeAction {
                 .to_string(),
         )
     }
+}
+
+#[cfg(unix)]
+fn lookup_home_dir(uid: u32) -> Option<String> {
+    use std::ffi::CStr;
+    let mut buf = vec![0u8; 4096];
+    let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result: *mut libc::passwd = std::ptr::null_mut();
+    let ret = unsafe {
+        libc::getpwuid_r(
+            uid as libc::uid_t,
+            &mut pwd,
+            buf.as_mut_ptr() as *mut _,
+            buf.len(),
+            &mut result,
+        )
+    };
+    if ret != 0 || result.is_null() {
+        return None;
+    }
+    let home = unsafe { CStr::from_ptr(pwd.pw_dir) };
+    home.to_str().ok().map(|s| s.to_string())
 }
 
 #[cfg(unix)]
@@ -225,8 +253,8 @@ fn respawn_deescalated_windows() -> Result<(), String> {
             return Err("failed to get linked token".to_string());
         }
 
-        let exe_path =
-            std::env::current_exe().map_err(|e| format!("failed to get current exe: {}", e))?;
+        let exe_path = crate::utils::current_git_ai_exe()
+            .map_err(|e| format!("failed to get current git-ai exe: {}", e))?;
         let args: Vec<String> = std::env::args().collect();
         let mut cmd_line = format!("\"{}\"", exe_path.display());
         for arg in &args[1..] {

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -77,6 +77,7 @@ fn configure_test_daemon_env(command: &mut Command, repo: &TestRepo) {
         daemon_control_socket_path(repo),
     );
     command.env("GIT_AI_DAEMON_TRACE_SOCKET", daemon_trace_socket_path(repo));
+    command.env("GIT_AI_ALLOW_ROOT", "true");
 }
 
 fn write_daemon_config(repo: &TestRepo) {
@@ -87,7 +88,8 @@ fn write_daemon_config(repo: &TestRepo) {
         "git_path": real_git_executable(),
         "disable_auto_updates": true,
         "feature_flags": {
-            "git_hooks_enabled": false
+            "git_hooks_enabled": false,
+            "allow_root": true
         },
         "quiet": false
     });

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -4119,7 +4119,11 @@ fn stale_lock_cleaned_up_on_start() {
         TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::NoDaemon);
 
     // Create stale lock file and fake PID metadata pointing to a dead process
-    let daemon_dir = repo.test_home_path().join(".git-ai").join("internal").join("daemon");
+    let daemon_dir = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("daemon");
     fs::create_dir_all(&daemon_dir).unwrap();
     let lock_path = daemon_dir.join("daemon.lock");
     fs::write(&lock_path, "stale").unwrap();

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -4111,3 +4111,64 @@ fn daemon_self_heals_after_socket_deletion() {
         thread::sleep(Duration::from_millis(50));
     }
 }
+
+#[test]
+#[serial]
+fn stale_lock_cleaned_up_on_start() {
+    let repo =
+        TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::NoDaemon);
+
+    // Create stale lock file and fake PID metadata pointing to a dead process
+    let daemon_dir = repo.test_home_path().join(".git-ai").join("internal").join("daemon");
+    fs::create_dir_all(&daemon_dir).unwrap();
+    let lock_path = daemon_dir.join("daemon.lock");
+    fs::write(&lock_path, "stale").unwrap();
+    let pid_path = daemon_dir.join("daemon.pid.json");
+    fs::write(&pid_path, r#"{"pid": 4000000000, "started_at_ns": 0}"#).unwrap();
+
+    // Attempt to start daemon — should auto-recover by cleaning stale files
+    let mut command = Command::new(get_binary_path());
+    command
+        .arg("bg")
+        .arg("start")
+        .current_dir(repo.path())
+        .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
+        .env("GITAI_TEST_DB_PATH", repo.test_db_path());
+    configure_test_home_env(&mut command, repo.test_home_path());
+    configure_test_daemon_env(
+        &mut command,
+        &repo.daemon_home_path(),
+        &repo.daemon_control_socket_path(),
+        &repo.daemon_trace_socket_path(),
+    );
+
+    let output = command.output().expect("failed to run bg start");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The stale lock should have been cleaned up and daemon started
+    // (or at minimum, the error should NOT be the opaque "lock held" message)
+    assert!(
+        output.status.success() || stderr.contains("cleaning up stale daemon files"),
+        "expected stale lock cleanup, got exit={} stderr={}",
+        output.status,
+        stderr
+    );
+
+    // Clean up: stop daemon if it started
+    if output.status.success() {
+        let mut stop = Command::new(get_binary_path());
+        stop.arg("bg")
+            .arg("shutdown")
+            .current_dir(repo.path())
+            .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
+            .env("GITAI_TEST_DB_PATH", repo.test_db_path());
+        configure_test_home_env(&mut stop, repo.test_home_path());
+        configure_test_daemon_env(
+            &mut stop,
+            &repo.daemon_home_path(),
+            &repo.daemon_control_socket_path(),
+            &repo.daemon_trace_socket_path(),
+        );
+        let _ = stop.output();
+    }
+}

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -400,6 +400,7 @@ fn configure_test_daemon_env(
     command.env("GIT_AI_DAEMON_HOME", daemon_home);
     command.env("GIT_AI_DAEMON_CONTROL_SOCKET", control_socket_path);
     command.env("GIT_AI_DAEMON_TRACE_SOCKET", trace_socket_path);
+    command.env("GIT_AI_ALLOW_ROOT", "true");
 }
 
 struct DaemonGuard {

--- a/tests/integration/bash_tool_benchmark.rs
+++ b/tests/integration/bash_tool_benchmark.rs
@@ -62,6 +62,7 @@ impl BenchDaemon {
             .env("GIT_AI_DAEMON_CONTROL_SOCKET", &control_socket)
             .env("GIT_AI_DAEMON_TRACE_SOCKET", &trace_socket)
             .env("GIT_AI_TEST_DB_PATH", &test_db)
+            .env("GIT_AI_ALLOW_ROOT", "true")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -21,6 +21,7 @@ fn setup() {
         git_hooks_externally_managed: false,
         transcript_streaming: true,
         transcript_sweep: true,
+        daemon_allow_root: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -21,7 +21,7 @@ fn setup() {
         git_hooks_externally_managed: false,
         transcript_streaming: true,
         transcript_sweep: true,
-        daemon_allow_root: false,
+        allow_root: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -243,6 +243,7 @@ impl DaemonProcess {
             .env("GIT_AI_DAEMON_HOME", test_home)
             .env("GIT_AI_DAEMON_CONTROL_SOCKET", &control_socket_path)
             .env("GIT_AI_DAEMON_TRACE_SOCKET", &trace_socket_path)
+            .env("GIT_AI_ALLOW_ROOT", "true")
             .stdout(Stdio::null())
             .stderr(
                 stderr_log

--- a/tests/windows_install_script.rs
+++ b/tests/windows_install_script.rs
@@ -172,6 +172,7 @@ fn configure_install_env(command: &mut Command, repo: &TestRepo) {
         "GIT_AI_DAEMON_TRACE_SOCKET",
         repo.daemon_trace_socket_path(),
     );
+    command.env("GIT_AI_ALLOW_ROOT", "true");
 }
 
 fn run_command_with_timeout(command: &mut Command, timeout: Duration) -> CommandResult {


### PR DESCRIPTION
## Summary

- Partially addresses #1041 
- Adds privilege de-escalation at daemon startup: Unix drops root via `setuid`/`setgid` when `SUDO_UID`/`SUDO_GID` detected; Windows respawns with linked (non-elevated) token via `CreateProcessWithTokenW`
- Adds `daemon_allow_root` feature flag (default false) for CI/container environments that legitimately run as root
- Relaxes daemon socket permissions from 0o600 to 0o660 so same-user processes at different privilege levels can connect
- Replaces opaque "lock held" errors with smart diagnostics: detects dead processes (auto-cleans stale files) and privilege mismatches (shows platform-specific fix commands)

## Problem

When the daemon is started as a privileged user (root/admin), non-privileged users get stuck in an unrecoverable loop: can't connect (socket perms), can't start new daemon (lock held), can't kill old daemon (insufficient privileges).

## Solution

Four-layer defense:
1. **De-escalation** — daemon drops privileges before acquiring lock
2. **Permission relaxation** — sockets accessible across privilege levels
3. **Detection** — actionable error with platform-specific fix command
4. **Recovery** — auto-cleans stale locks from dead processes

## Test plan

- [x] Unit tests for PID status detection (dead process, alive process)
- [x] Unit test for privilege check when not elevated
- [x] Integration test for stale lock auto-recovery
- [x] Full test suite passes
- [x] Lint and format pass
- [ ] CI: Ubuntu checks pass
- [ ] CI: Windows checks (linked token path exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->