### PR TITLE
feat: include uncommitted blame attribution

### DIFF
--- a/agent-support/vscode/src/blame-service.ts
+++ b/agent-support/vscode/src/blame-service.ts
@@ -119,7 +119,7 @@ export class BlameService {
         'working-log',
         `checkpoints=${await this.statFileToken(path.join(workingLogPath, 'checkpoints.jsonl'))}`,
         `initial=${await this.statFileToken(path.join(workingLogPath, 'INITIAL'))}`,
-        `blobs=${await this.statDirectoryToken(path.join(workingLogPath, 'blobs'))}`,
+        `blobs=${await this.statBlobsDirectoryToken(path.join(workingLogPath, 'blobs'))}`,
       ].join(':');
     } catch (error) {
       console.warn('[git-ai] Failed to compute working log cache token:', error);
@@ -147,21 +147,10 @@ export class BlameService {
     }
   }
 
-  private async statDirectoryToken(directoryPath: string): Promise<string> {
+  private async statBlobsDirectoryToken(directoryPath: string): Promise<string> {
     try {
-      const entries = await fs.readdir(directoryPath, { withFileTypes: true });
-      const tokens: string[] = [];
-
-      for (const entry of entries) {
-        if (!entry.isFile()) {
-          continue;
-        }
-
-        const entryPath = path.join(directoryPath, entry.name);
-        tokens.push(`${entry.name}=${await this.statFileToken(entryPath)}`);
-      }
-
-      return tokens.length > 0 ? tokens.sort().join(',') : 'empty';
+      const stat = await fs.stat(directoryPath, { bigint: true });
+      return `dir:${stat.mtimeNs}`;
     } catch (error) {
       if (this.isMissingPathError(error)) {
         return 'missing';

--- a/agent-support/vscode/src/blame-service.ts
+++ b/agent-support/vscode/src/blame-service.ts
@@ -1,8 +1,13 @@
 import * as vscode from "vscode";
-import { spawn } from "child_process";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { execFile, spawn } from "child_process";
+import { promisify } from "util";
 import { BlameQueue } from "./blame-queue";
 import { findRepoForFile, getGitRepoRoot } from "./utils/git-api";
 import { getGitAiBinary, resolveGitAiBinary } from "./utils/binary-path";
+
+const execFileAsync = promisify(execFile);
 
 export interface BlameMetadata {
   is_logged_in: boolean;
@@ -54,7 +59,7 @@ export interface BlameResult {
 
 /**
  * Service for executing git-ai blame and managing blame results.
- * Uses an LRU cache keyed by file path + content hash + HEAD commit SHA.
+ * Uses an LRU cache keyed by file path + content hash + HEAD commit SHA + working log state.
  */
 export class BlameService {
   private static readonly TIMEOUT_MS = 30000; // 30 second timeout
@@ -82,11 +87,91 @@ export class BlameService {
   }
   
   /**
-   * Generate a cache key from file path, content, and commit SHA.
+   * Generate a cache key from file path, content, commit SHA, and working log state.
    */
-  private getContentCacheKey(filePath: string, content: string, commitSha: string): string {
+  private getContentCacheKey(
+    filePath: string,
+    content: string,
+    commitSha: string,
+    workingLogToken: string
+  ): string {
     const contentHash = this.hashContent(content);
-    return `${filePath}:${commitSha}:${contentHash}`;
+    return `${filePath}:${commitSha}:${contentHash}:${workingLogToken}`;
+  }
+
+  private async getWorkingLogCacheToken(cwd: string | null, headCommit: string): Promise<string> {
+    if (!cwd) {
+      return `working-log:uncached:${Date.now()}`;
+    }
+
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['rev-parse', '--git-path', `ai/working_logs/${headCommit}`],
+        { cwd, timeout: 5000 }
+      );
+      const workingLogPath = this.resolveGitPath(cwd, String(stdout).trim());
+      if (!workingLogPath) {
+        return 'working-log:missing';
+      }
+
+      return [
+        'working-log',
+        `checkpoints=${await this.statFileToken(path.join(workingLogPath, 'checkpoints.jsonl'))}`,
+        `initial=${await this.statFileToken(path.join(workingLogPath, 'INITIAL'))}`,
+        `blobs=${await this.statDirectoryToken(path.join(workingLogPath, 'blobs'))}`,
+      ].join(':');
+    } catch (error) {
+      console.warn('[git-ai] Failed to compute working log cache token:', error);
+      return `working-log:uncached:${Date.now()}`;
+    }
+  }
+
+  private resolveGitPath(cwd: string, gitPath: string): string | null {
+    if (!gitPath) {
+      return null;
+    }
+
+    return path.isAbsolute(gitPath) ? gitPath : path.join(cwd, gitPath);
+  }
+
+  private async statFileToken(filePath: string): Promise<string> {
+    try {
+      const stat = await fs.stat(filePath, { bigint: true });
+      return `${stat.mtimeNs}:${stat.size}`;
+    } catch (error) {
+      if (this.isMissingPathError(error)) {
+        return 'missing';
+      }
+      throw error;
+    }
+  }
+
+  private async statDirectoryToken(directoryPath: string): Promise<string> {
+    try {
+      const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+      const tokens: string[] = [];
+
+      for (const entry of entries) {
+        if (!entry.isFile()) {
+          continue;
+        }
+
+        const entryPath = path.join(directoryPath, entry.name);
+        tokens.push(`${entry.name}=${await this.statFileToken(entryPath)}`);
+      }
+
+      return tokens.length > 0 ? tokens.sort().join(',') : 'empty';
+    } catch (error) {
+      if (this.isMissingPathError(error)) {
+        return 'missing';
+      }
+      throw error;
+    }
+  }
+
+  private isMissingPathError(error: unknown): boolean {
+    return error instanceof Error && 'code' in error && error.code === 'ENOENT';
   }
   
   /**
@@ -156,7 +241,8 @@ export class BlameService {
 
     // Get current content for cache key and to pass to git-ai
     const content = document.getText();
-    const cacheKey = this.getContentCacheKey(document.uri.fsPath, content, headCommit);
+    const workingLogToken = await this.getWorkingLogCacheToken(gitRepoRoot, headCommit);
+    const cacheKey = this.getContentCacheKey(document.uri.fsPath, content, headCommit, workingLogToken);
 
     // Check LRU cache first
     const cached = this.getFromCache(cacheKey);
@@ -239,7 +325,7 @@ export class BlameService {
 
       // Use --contents - to read file contents from stdin
       // This allows git-ai to properly shift AI attributions for dirty files
-      const args = ['blame', '--json', '--contents', '-', filePath];
+      const args = ['blame', '--json', '--include-uncommitted', '--contents', '-', filePath];
       const binary = getGitAiBinary();
       console.log('[git-ai] Spawning blame:', { binary, args, cwd });
       const proc = spawn(binary, args, {

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1,6 +1,7 @@
 use crate::auth::CredentialStore;
 use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord};
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::CheckpointKind;
 use crate::error::GitAiError;
 use crate::git::refs::get_reference_as_authorship_log_v3;
@@ -160,6 +161,9 @@ pub struct GitAiBlameOptions {
     // Mark lines from commits without authorship logs as "Unknown"
     pub mark_unknown: bool,
 
+    // Include working-tree attribution for uncommitted lines from checkpoint working logs
+    pub include_uncommitted: bool,
+
     // Show prompt hashes inline and dump prompts when piped
     pub show_prompt: bool,
 
@@ -211,6 +215,7 @@ impl Default for GitAiBlameOptions {
             ignore_whitespace: false,
             json: false,
             mark_unknown: false,
+            include_uncommitted: false,
             show_prompt: false,
             split_hunks_by_ai_author: true,
         }
@@ -286,7 +291,7 @@ impl Repository {
         // and use prompt hashes as names so we can correlate with prompt_records.
         if options.json {
             let mut opts = options.clone();
-            if opts.newest_commit.is_none() {
+            if opts.newest_commit.is_none() && !opts.include_uncommitted {
                 opts.newest_commit = Some("HEAD".to_string());
             }
             opts.use_prompt_hashes_as_names = true;
@@ -393,6 +398,7 @@ impl Repository {
     fn run_blame_analysis_pipeline(
         &self,
         relative_file_path: &str,
+        file_content_snapshot: &str,
         line_ranges: &[(u32, u32)],
         options: &GitAiBlameOptions,
     ) -> Result<
@@ -409,14 +415,30 @@ impl Repository {
 
         // Step 2: Overlay AI authorship information.
         let (
-            line_authors,
-            prompt_records,
-            session_records,
-            humans,
+            mut line_authors,
+            mut prompt_records,
+            mut session_records,
+            mut humans,
             authorship_logs,
             prompt_commits,
             commits_with_notes,
         ) = overlay_ai_authorship(self, &blame_hunks, relative_file_path, options)?;
+
+        if options.include_uncommitted {
+            let mut overlay_targets = UncommittedOverlayTargets {
+                line_authors: &mut line_authors,
+                prompt_records: &mut prompt_records,
+                session_records: &mut session_records,
+                humans: &mut humans,
+            };
+            overlay_uncommitted_authorship(
+                self,
+                relative_file_path,
+                file_content_snapshot,
+                &blame_hunks,
+                &mut overlay_targets,
+            )?;
+        }
 
         Ok((
             BlameAnalysisResult {
@@ -546,6 +568,7 @@ impl Repository {
         let (analysis, authorship_logs, prompt_commits, commits_with_notes) = self
             .run_blame_analysis_pipeline(
                 &request.relative_file_path,
+                &request.file_content,
                 &request.line_ranges,
                 &request.options,
             )?;
@@ -615,6 +638,7 @@ impl Repository {
         let (analysis, _authorship_logs, _prompt_commits, _commits_with_notes) = self
             .run_blame_analysis_pipeline(
                 &request.relative_file_path,
+                &request.file_content,
                 &request.line_ranges,
                 &request.options,
             )?;
@@ -1259,6 +1283,102 @@ fn overlay_ai_authorship(
         prompt_commits_vec,
         commits_with_notes,
     ))
+}
+
+fn is_uncommitted_blame_sha(commit_sha: &str) -> bool {
+    !commit_sha.is_empty() && commit_sha.chars().all(|c| c == '0')
+}
+
+fn prompt_record_from_session_author_id(
+    author_id: &str,
+    sessions: &BTreeMap<String, SessionRecord>,
+) -> Option<PromptRecord> {
+    let session_key = author_id.split("::").next().unwrap_or(author_id);
+    let session = sessions.get(session_key)?;
+    Some(PromptRecord {
+        agent_id: session.agent_id.clone(),
+        human_author: session.human_author.clone(),
+        // Uncommitted session prompts do not have stable line stats until commit time.
+        total_additions: 0,
+        total_deletions: 0,
+        accepted_lines: 0,
+        overriden_lines: 0,
+        custom_attributes: session.custom_attributes.clone(),
+        messages_url: None,
+    })
+}
+
+struct UncommittedOverlayTargets<'a> {
+    line_authors: &'a mut HashMap<u32, String>,
+    prompt_records: &'a mut HashMap<String, PromptRecord>,
+    session_records: &'a mut HashMap<String, SessionRecord>,
+    humans: &'a mut BTreeMap<String, HumanRecord>,
+}
+
+fn overlay_uncommitted_authorship(
+    repo: &Repository,
+    relative_file_path: &str,
+    file_content_snapshot: &str,
+    blame_hunks: &[BlameHunk],
+    targets: &mut UncommittedOverlayTargets<'_>,
+) -> Result<(), GitAiError> {
+    let uncommitted_lines: HashSet<u32> = blame_hunks
+        .iter()
+        .filter(|hunk| is_uncommitted_blame_sha(&hunk.commit_sha))
+        .flat_map(|hunk| hunk.range.0..=hunk.range.1)
+        .collect();
+    if uncommitted_lines.is_empty() {
+        return Ok(());
+    }
+
+    let head_sha = repo.head()?.target()?;
+    let default_user = repo.git_author_identity().formatted_or_unknown();
+    let final_state_snapshot = HashMap::from([(
+        relative_file_path.to_string(),
+        file_content_snapshot.to_string(),
+    )]);
+    let working_va = VirtualAttributions::from_working_log_snapshot(
+        repo.clone(),
+        head_sha.clone(),
+        Some(default_user),
+        &final_state_snapshot,
+    )?;
+    let pathspecs = HashSet::from([relative_file_path.to_string()]);
+    let (_authorship_log, initial) = working_va.to_authorship_log_and_initial_working_log(
+        repo,
+        &head_sha,
+        &head_sha,
+        Some(&pathspecs),
+        Some(&final_state_snapshot),
+    )?;
+
+    targets.prompt_records.extend(initial.prompts.clone());
+    targets.session_records.extend(initial.sessions.clone());
+    targets.humans.extend(initial.humans.clone());
+
+    if let Some(line_attrs) = initial.files.get(relative_file_path) {
+        for attr in line_attrs {
+            if attr.author_id.starts_with("s_")
+                && !targets.prompt_records.contains_key(&attr.author_id)
+                && let Some(prompt_record) =
+                    prompt_record_from_session_author_id(&attr.author_id, &initial.sessions)
+            {
+                targets
+                    .prompt_records
+                    .insert(attr.author_id.clone(), prompt_record);
+            }
+
+            for line_num in attr.start_line..=attr.end_line {
+                if uncommitted_lines.contains(&line_num) {
+                    targets
+                        .line_authors
+                        .insert(line_num, attr.author_id.clone());
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Metadata about user's auth state and git identity
@@ -2174,6 +2294,12 @@ pub fn parse_blame_args(args: &[String]) -> Result<(String, GitAiBlameOptions), 
             // Mark unknown authorship
             "--mark-unknown" => {
                 options.mark_unknown = true;
+                i += 1;
+            }
+
+            // Include checkpoint-backed attribution for uncommitted lines
+            "--include-uncommitted" => {
+                options.include_uncommitted = true;
                 i += 1;
             }
 

--- a/tests/integration/blame_comprehensive.rs
+++ b/tests/integration/blame_comprehensive.rs
@@ -26,6 +26,7 @@ use git_ai::authorship::working_log::AgentId;
 use git_ai::commands::blame::GitAiBlameOptions;
 use git_ai::git::refs::notes_add;
 use git_ai::git::repository as GitAiRepository;
+use std::fs;
 
 // =============================================================================
 // Happy Path Tests - Successful blame operations with AI authorship
@@ -167,6 +168,107 @@ fn test_blame_success_json_format() {
 
     assert!(json["lines"].is_object());
     assert!(json["prompts"].is_object());
+}
+
+#[test]
+fn test_blame_json_include_uncommitted_shows_ai_attribution() {
+    let repo = TestRepo::new();
+    let path = repo.path().join("uncommitted.txt");
+
+    fs::write(&path, "committed line\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+
+    repo.git_ai(&["checkpoint", "human", "uncommitted.txt"])
+        .unwrap();
+    fs::write(&path, "committed line\nai new line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "uncommitted.txt"])
+        .unwrap();
+
+    let without_flag = repo
+        .git_ai(&["blame", "--json", "uncommitted.txt"])
+        .unwrap();
+    let without_flag_json: serde_json::Value =
+        serde_json::from_str(&without_flag).expect("plain JSON blame should be valid JSON");
+    assert!(
+        without_flag_json["lines"]
+            .as_object()
+            .expect("lines should be object")
+            .is_empty(),
+        "plain JSON blame should preserve the existing HEAD-only behavior"
+    );
+
+    let with_flag = repo
+        .git_ai(&[
+            "blame",
+            "--include-uncommitted",
+            "--json",
+            "uncommitted.txt",
+        ])
+        .unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&with_flag).expect("include-uncommitted JSON should be valid JSON");
+
+    let lines = json["lines"].as_object().expect("lines should be object");
+    let prompts = json["prompts"]
+        .as_object()
+        .expect("prompts should be object");
+    let prompt_id = lines.get("2").and_then(|v| v.as_str()).expect(
+        "uncommitted AI line should map to a prompt/session id using committed blame JSON shape",
+    );
+    let prompt = prompts
+        .get(prompt_id)
+        .expect("referenced uncommitted prompt should be included");
+
+    assert_eq!(prompt["agent_id"]["tool"], "mock_ai");
+    assert_eq!(
+        prompt["commits"]
+            .as_array()
+            .expect("commits should be array")
+            .len(),
+        0,
+        "uncommitted prompt records should not invent a commit sha"
+    );
+}
+
+#[test]
+fn test_blame_json_include_uncommitted_uses_contents_buffer() {
+    let repo = TestRepo::new();
+    let path = repo.path().join("buffer.txt");
+
+    fs::write(&path, "committed line\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+
+    repo.git_ai(&["checkpoint", "human", "buffer.txt"]).unwrap();
+    fs::write(&path, "committed line\nai new line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "buffer.txt"])
+        .unwrap();
+
+    let buffer = "committed line\nai new line\nbuffer-only unknown line\n";
+    let output = repo
+        .git_ai_with_stdin(
+            &[
+                "blame",
+                "--include-uncommitted",
+                "--json",
+                "--contents",
+                "-",
+                "buffer.txt",
+            ],
+            buffer.as_bytes(),
+        )
+        .unwrap();
+    let json: serde_json::Value =
+        serde_json::from_str(&output).expect("contents JSON blame should be valid JSON");
+
+    let lines = json["lines"].as_object().expect("lines should be object");
+    assert!(
+        lines.contains_key("2"),
+        "checkpoint-backed AI line should be attributed in the supplied buffer"
+    );
+    assert!(
+        !lines.contains_key("3"),
+        "buffer-only line without checkpoint data should not be guessed as AI"
+    );
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds `git-ai blame --include-uncommitted` so JSON blame can overlay checkpoint-backed working-log attribution for uncommitted lines.
- Keeps existing `git-ai blame --json` behavior HEAD-only unless the new flag is provided.
- Uses the in-memory `--contents -` snapshot when calculating uncommitted attribution, so editor integrations can pass the current buffer without mutating working logs.
- Updates the VS Code extension blame call to request uncommitted attribution for hover/gutter display.
- Adds integration coverage for uncommitted AI attribution and buffer-only lines without checkpoint data.

Resolves #1284

## Test plan

- [x] `task fmt`
- [x] `task lint`
- [x] `task test TEST_FILTER=blame_json_include_uncommitted NO_CAPTURE=true`
- [x] `task test TEST_FILTER=blame`
- [x] Manual CLI smoke test for `git-ai blame --json --include-uncommitted --contents - demo.txt` verifying checkpoint-backed lines appear and buffer-only lines are not guessed