### PR TITLE
feat: populate repo_url on Session Event metrics

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7446,9 +7446,16 @@ impl ActorDaemonCoordinator {
                         .unwrap_or_else(|| "unknown".to_string());
                     let trace_id = request.trace_id.clone();
 
+                    let repo_work_dir = request.files.first().map(|f| f.repo_work_dir.clone());
+
                     if let Some(db) = &self.transcripts_db
-                        && let Err(e) =
-                            Self::ensure_session_exists(db, &session_id, &tool, transcript_source)
+                        && let Err(e) = Self::ensure_session_exists(
+                            db,
+                            &session_id,
+                            &tool,
+                            transcript_source,
+                            repo_work_dir.as_deref(),
+                        )
                     {
                         tracing::warn!(session_id = %session_id, error = %e, "failed to ensure session exists");
                     }
@@ -7458,6 +7465,7 @@ impl ActorDaemonCoordinator {
                         tool,
                         trace_id,
                         transcript_source.path.clone(),
+                        repo_work_dir,
                     );
                 }
 
@@ -7605,6 +7613,7 @@ impl ActorDaemonCoordinator {
         session_id: &str,
         tool: &str,
         transcript_source: &crate::commands::checkpoint_agent::presets::TranscriptSource,
+        repo_work_dir: Option<&std::path::Path>,
     ) -> Result<(), String> {
         // Check if session exists
         if db
@@ -7655,6 +7664,7 @@ impl ActorDaemonCoordinator {
             last_modified: None,
             processing_errors: 0,
             last_error: None,
+            repo_work_dir: repo_work_dir.map(|p| p.display().to_string()),
         };
 
         db.insert_session(&record).map_err(|e| e.to_string())?;

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -104,12 +104,8 @@ pub fn build_agent_usage_attrs(
         .custom_attributes_map(crate::config::Config::fresh().custom_attributes());
 
     if let Some(repo) = repo {
-        if let Ok(Some(remote_name)) = repo.get_default_remote()
-            && let Ok(remotes) = repo.remotes_with_urls()
-            && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
-            && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
-        {
-            attrs = attrs.repo_url(normalized);
+        if let Some(url) = crate::repo_url::resolve_repo_url_from_repo(repo) {
+            attrs = attrs.repo_url(url);
         }
 
         if let Ok(head_ref) = repo.head()
@@ -151,12 +147,8 @@ fn build_checkpoint_attrs(
     attrs = attrs.custom_attributes_map(crate::config::Config::fresh().custom_attributes());
 
     // Add repo URL
-    if let Ok(Some(remote_name)) = repo.get_default_remote()
-        && let Ok(remotes) = repo.remotes_with_urls()
-        && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
-        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
-    {
-        attrs = attrs.repo_url(normalized);
+    if let Some(url) = crate::repo_url::resolve_repo_url_from_repo(repo) {
+        attrs = attrs.repo_url(url);
     }
 
     // Add branch

--- a/src/daemon/sweep_coordinator.rs
+++ b/src/daemon/sweep_coordinator.rs
@@ -97,6 +97,12 @@ impl SweepCoordinator {
 
     fn insert_new_session(&self, session: &DiscoveredSession) -> Result<(), TranscriptError> {
         let now = Utc::now().timestamp();
+
+        let agent = crate::transcripts::agent::get_agent(&session.tool);
+        let inferred_cwd = agent
+            .as_ref()
+            .and_then(|a| a.infer_cwd(&session.transcript_path));
+
         let record = SessionRecord {
             session_id: session.session_id.clone(),
             tool: session.tool.clone(),
@@ -112,6 +118,7 @@ impl SweepCoordinator {
             last_modified: None,
             processing_errors: 0,
             last_error: None,
+            repo_work_dir: inferred_cwd.map(|p| p.display().to_string()),
         };
 
         self.transcripts_db.insert_session(&record)?;

--- a/src/daemon/transcript_worker.rs
+++ b/src/daemon/transcript_worker.rs
@@ -38,6 +38,7 @@ pub(super) struct ProcessingTask {
     pub(super) tool: String,
     pub(super) trace_id: Option<String>,
     pub(super) canonical_path: PathBuf,
+    pub(super) repo_work_dir: Option<PathBuf>,
     pub(super) retry_count: u32,
     #[cfg_attr(test, serde(skip))]
     pub(super) next_retry_at: Option<std::time::Instant>,
@@ -74,12 +75,14 @@ impl TranscriptWorkerHandle {
         tool: String,
         trace_id: String,
         transcript_path: PathBuf,
+        repo_work_dir: Option<PathBuf>,
     ) {
         let notification = CheckpointNotification {
             session_id,
             tool,
             trace_id,
             transcript_path,
+            repo_work_dir,
         };
         let _ = self.checkpoint_tx.send(notification);
     }
@@ -91,6 +94,7 @@ struct CheckpointNotification {
     tool: String,
     trace_id: String,
     transcript_path: PathBuf,
+    repo_work_dir: Option<PathBuf>,
 }
 
 /// Worker that processes transcript changes.
@@ -193,6 +197,7 @@ impl TranscriptWorker {
                 tool: session.tool,
                 trace_id: None,
                 canonical_path: session.canonical_path,
+                repo_work_dir: None,
                 retry_count: 0,
                 next_retry_at: None,
             });
@@ -217,6 +222,7 @@ impl TranscriptWorker {
             tool: notification.tool,
             trace_id: Some(notification.trace_id),
             canonical_path,
+            repo_work_dir: notification.repo_work_dir,
             retry_count: 0,
             next_retry_at: None,
         });
@@ -319,12 +325,33 @@ impl TranscriptWorker {
             .external_parent_session_id
             .as_ref()
             .map(|ext_pid| generate_session_id(ext_pid, &session.tool));
-        let base_attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+
+        // Resolve repo_work_dir with priority: task (hook) > DB > infer from transcript
+        let resolved_work_dir = task
+            .repo_work_dir
+            .clone()
+            .or_else(|| session.repo_work_dir.as_ref().map(PathBuf::from))
+            .or_else(|| agent.infer_cwd(&path));
+
+        // Persist inferred cwd to DB if session didn't already have one
+        if session.repo_work_dir.is_none()
+            && let Some(ref work_dir) = resolved_work_dir
+        {
+            let _ = db.update_repo_work_dir(&session.session_id, &work_dir.display().to_string());
+        }
+
+        let mut base_attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
             .session_id(session.session_id.clone())
             .tool(&session.tool)
             .external_session_id(session.external_session_id.clone())
             .external_parent_session_id_opt(session.external_parent_session_id.clone())
             .parent_session_id_opt(parent_session_id);
+
+        if let Some(ref work_dir) = resolved_work_dir
+            && let Some(url) = crate::repo_url::resolve_repo_url_from_path(work_dir)
+        {
+            base_attrs = base_attrs.repo_url(url);
+        }
 
         loop {
             let batch = agent.read_incremental(&path, current_watermark, &session.session_id)?;

--- a/src/daemon/transcript_worker_tests.rs
+++ b/src/daemon/transcript_worker_tests.rs
@@ -14,6 +14,7 @@ fn test_priority_queue_ordering_immediate_first() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 0,
         next_retry_at: None,
     });
@@ -23,6 +24,7 @@ fn test_priority_queue_ordering_immediate_first() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 0,
         next_retry_at: None,
     });
@@ -55,6 +57,7 @@ fn test_priority_queue_ordering_multiple_same_priority() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 0,
         next_retry_at: None,
     });
@@ -64,6 +67,7 @@ fn test_priority_queue_ordering_multiple_same_priority() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 0,
         next_retry_at: None,
     });
@@ -73,6 +77,7 @@ fn test_priority_queue_ordering_multiple_same_priority() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 0,
         next_retry_at: None,
     });
@@ -102,6 +107,7 @@ fn test_retry_delay_prevents_immediate_reprocessing() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 1,
         next_retry_at: Some(next_retry_at),
     };
@@ -144,6 +150,7 @@ fn test_retry_delay_allows_processing_after_delay() {
         tool: "test".to_string(),
         trace_id: None,
         canonical_path: PathBuf::from("/test"),
+        repo_work_dir: None,
         retry_count: 1,
         next_retry_at: Some(past_retry_at),
     };

--- a/src/repo_url.rs
+++ b/src/repo_url.rs
@@ -78,6 +78,28 @@ fn normalize_ssh_url(host: &str, path: &str) -> Result<String, String> {
     Ok(canonical)
 }
 
+/// Resolve a normalized repo URL from an already-opened Repository.
+///
+/// Finds the default remote and normalizes its URL to canonical HTTPS format.
+/// Returns None if there is no remote or the URL cannot be normalized.
+pub fn resolve_repo_url_from_repo(repo: &crate::git::repository::Repository) -> Option<String> {
+    let remote_name = repo.get_default_remote().ok()??;
+    let remotes = repo.remotes_with_urls().ok()?;
+    let (_, url) = remotes.into_iter().find(|(n, _)| n == &remote_name)?;
+    normalize_repo_url(&url).ok()
+}
+
+/// Resolve a normalized repo URL from a filesystem path.
+///
+/// Opens the git repository at `work_dir` (or discovers it by walking up),
+/// finds the default remote, and normalizes its URL to canonical HTTPS format.
+/// Returns None if the path is not in a git repo, has no remote, or the URL
+/// cannot be normalized.
+pub fn resolve_repo_url_from_path(work_dir: &std::path::Path) -> Option<String> {
+    let repo = crate::git::repository::discover_repository_in_path_no_git_exec(work_dir).ok()?;
+    resolve_repo_url_from_repo(&repo)
+}
+
 #[cfg(test)]
 mod tests {
     use super::normalize_repo_url;

--- a/src/transcripts/agent.rs
+++ b/src/transcripts/agent.rs
@@ -50,6 +50,14 @@ pub trait Agent: Send + Sync {
     ) -> (Option<String>, Option<String>, Option<String>) {
         (None, None, None)
     }
+
+    /// Infer the working directory from the transcript file content.
+    ///
+    /// Reads the first few lines of the transcript looking for a `cwd` field.
+    /// Returns None if the agent format doesn't include cwd or it can't be found.
+    fn infer_cwd(&self, _transcript_path: &Path) -> Option<std::path::PathBuf> {
+        None
+    }
 }
 
 const ALL_AGENT_TYPES: &[&str] = &[

--- a/src/transcripts/agents/claude.rs
+++ b/src/transcripts/agents/claude.rs
@@ -271,6 +271,29 @@ impl Agent for ClaudeAgent {
 
         (event_id, parent_id, tool_use_id)
     }
+
+    fn infer_cwd(&self, transcript_path: &Path) -> Option<PathBuf> {
+        use std::fs::File;
+        use std::io::{BufRead, BufReader};
+
+        let file = File::open(transcript_path).ok()?;
+        let reader = BufReader::new(file);
+
+        // Check up to 50 lines for a top-level "cwd" field
+        for line in reader.lines().take(50) {
+            let line = line.ok()?;
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(&line)
+                && let Some(cwd) = obj.get("cwd").and_then(|v| v.as_str())
+                && !cwd.is_empty()
+            {
+                return Some(PathBuf::from(cwd));
+            }
+        }
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/transcripts/agents/claude.rs
+++ b/src/transcripts/agents/claude.rs
@@ -281,7 +281,7 @@ impl Agent for ClaudeAgent {
 
         // Check up to 50 lines for a top-level "cwd" field
         for line in reader.lines().take(50) {
-            let line = line.ok()?;
+            let Ok(line) = line else { continue };
             if line.is_empty() {
                 continue;
             }

--- a/src/transcripts/agents/codex.rs
+++ b/src/transcripts/agents/codex.rs
@@ -262,6 +262,34 @@ impl Agent for CodexAgent {
             new_watermark,
         })
     }
+
+    fn infer_cwd(&self, transcript_path: &Path) -> Option<PathBuf> {
+        use std::fs::File;
+        use std::io::{BufRead, BufReader};
+
+        let file = File::open(transcript_path).ok()?;
+        let reader = BufReader::new(file);
+
+        // Codex has cwd in session_meta or turn_context payload events
+        for line in reader.lines().take(20) {
+            let line = line.ok()?;
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(&line) {
+                // Check payload.cwd (session_meta and turn_context)
+                if let Some(cwd) = obj
+                    .get("payload")
+                    .and_then(|p| p.get("cwd"))
+                    .and_then(|v| v.as_str())
+                    && !cwd.is_empty()
+                {
+                    return Some(PathBuf::from(cwd));
+                }
+            }
+        }
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/transcripts/agents/codex.rs
+++ b/src/transcripts/agents/codex.rs
@@ -272,7 +272,7 @@ impl Agent for CodexAgent {
 
         // Codex has cwd in session_meta or turn_context payload events
         for line in reader.lines().take(20) {
-            let line = line.ok()?;
+            let Ok(line) = line else { continue };
             if line.is_empty() {
                 continue;
             }

--- a/src/transcripts/db.rs
+++ b/src/transcripts/db.rs
@@ -78,6 +78,12 @@ const MIGRATIONS: &[&str] = &[
 
     INSERT INTO schema_version (version) VALUES (2);
     "#,
+    // Version 3: Add repo_work_dir column for session-level repo context.
+    r#"
+    ALTER TABLE sessions ADD COLUMN repo_work_dir TEXT;
+
+    INSERT INTO schema_version (version) VALUES (3);
+    "#,
 ];
 
 /// Record representing a session in the database.
@@ -97,6 +103,7 @@ pub struct SessionRecord {
     pub last_modified: Option<i64>,
     pub processing_errors: i64,
     pub last_error: Option<String>,
+    pub repo_work_dir: Option<String>,
 }
 
 /// SQLite database for transcript tracking.
@@ -209,8 +216,8 @@ impl TranscriptsDatabase {
                 watermark_type, watermark_value, external_session_id,
                 external_parent_session_id,
                 first_seen_at, last_processed_at, last_known_size, last_modified,
-                processing_errors, last_error
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                processing_errors, last_error, repo_work_dir
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             "#,
             params![
                 record.session_id,
@@ -227,6 +234,7 @@ impl TranscriptsDatabase {
                 record.last_modified,
                 record.processing_errors,
                 record.last_error,
+                record.repo_work_dir,
             ],
         )
         .map_err(|e| TranscriptError::Fatal {
@@ -253,6 +261,7 @@ impl TranscriptsDatabase {
             last_modified: row.get(11)?,
             processing_errors: row.get(12)?,
             last_error: row.get(13)?,
+            repo_work_dir: row.get(14)?,
         })
     }
 
@@ -268,7 +277,7 @@ impl TranscriptsDatabase {
                    watermark_type, watermark_value, external_session_id,
                    external_parent_session_id,
                    first_seen_at, last_processed_at, last_known_size, last_modified,
-                   processing_errors, last_error
+                   processing_errors, last_error, repo_work_dir
             FROM sessions WHERE session_id = ?1
             "#,
             params![session_id],
@@ -340,6 +349,28 @@ impl TranscriptsDatabase {
         Ok(())
     }
 
+    /// Update the repo_work_dir for a session.
+    pub fn update_repo_work_dir(
+        &self,
+        session_id: &str,
+        repo_work_dir: &str,
+    ) -> Result<(), TranscriptError> {
+        let conn = self
+            .conn
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        conn.execute(
+            "UPDATE sessions SET repo_work_dir = ?1 WHERE session_id = ?2",
+            params![repo_work_dir, session_id],
+        )
+        .map_err(|e| TranscriptError::Fatal {
+            message: format!("Failed to update repo_work_dir: {}", e),
+        })?;
+
+        Ok(())
+    }
+
     /// Record an error for a session.
     pub fn record_error(
         &self,
@@ -406,7 +437,7 @@ impl TranscriptsDatabase {
                    watermark_type, watermark_value, external_session_id,
                    external_parent_session_id,
                    first_seen_at, last_processed_at, last_known_size, last_modified,
-                   processing_errors, last_error
+                   processing_errors, last_error, repo_work_dir
             FROM sessions
             "#,
             )
@@ -459,6 +490,7 @@ mod tests {
             last_modified: Some(1704067200),
             processing_errors: 0,
             last_error: None,
+            repo_work_dir: None,
         }
     }
 
@@ -590,6 +622,7 @@ mod tests {
             last_modified: None,
             processing_errors: 0,
             last_error: None,
+            repo_work_dir: None,
         };
 
         db.insert_session(&session).unwrap();
@@ -598,6 +631,7 @@ mod tests {
         assert_eq!(retrieved.external_session_id, "session-null");
         assert_eq!(retrieved.last_modified, None);
         assert_eq!(retrieved.last_error, None);
+        assert_eq!(retrieved.repo_work_dir, None);
     }
 
     #[test]
@@ -613,7 +647,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, 2); // Current schema version
+        assert_eq!(version, 3); // Current schema version
     }
 
     #[test]

--- a/src/transcripts/db.rs
+++ b/src/transcripts/db.rs
@@ -360,13 +360,20 @@ impl TranscriptsDatabase {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
-        conn.execute(
-            "UPDATE sessions SET repo_work_dir = ?1 WHERE session_id = ?2",
-            params![repo_work_dir, session_id],
-        )
-        .map_err(|e| TranscriptError::Fatal {
-            message: format!("Failed to update repo_work_dir: {}", e),
-        })?;
+        let rows_changed = conn
+            .execute(
+                "UPDATE sessions SET repo_work_dir = ?1 WHERE session_id = ?2",
+                params![repo_work_dir, session_id],
+            )
+            .map_err(|e| TranscriptError::Fatal {
+                message: format!("Failed to update repo_work_dir: {}", e),
+            })?;
+
+        if rows_changed == 0 {
+            return Err(TranscriptError::Fatal {
+                message: format!("Session not found: {}", session_id),
+            });
+        }
 
         Ok(())
     }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -106,6 +106,7 @@ mod repo_storage_unit;
 mod repository_unit;
 mod reset;
 mod secrets_benchmark;
+mod session_event_repo_url;
 mod sessions_backwards_compat;
 mod sessions_cutover;
 mod show_prompt;

--- a/tests/integration/session_event_repo_url.rs
+++ b/tests/integration/session_event_repo_url.rs
@@ -1,0 +1,809 @@
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::{EventAttributes, MetricEvent, PosEncoded, SessionEventValues};
+use git_ai::repo_url::resolve_repo_url_from_path;
+use git_ai::transcripts::agent::Agent;
+use git_ai::transcripts::agents::ClaudeAgent;
+use git_ai::transcripts::watermark::ByteOffsetWatermark;
+use git_ai::transcripts::{SessionRecord, TranscriptsDatabase};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+// === Helper functions ===
+
+fn write_claude_transcript_with_cwd(path: &Path, cwd: &str) {
+    let events = [
+        json!({"type":"user","message":{"content":"hello","role":"user"},
+               "uuid":"u1","parentUuid":null,"cwd":cwd,"sessionId":"test-sess",
+               "timestamp":"2026-05-01T00:00:00Z"}),
+        json!({"type":"assistant","message":{"model":"claude-opus-4-6","id":"msg1","role":"assistant",
+               "content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
+               "usage":{"input_tokens":1,"output_tokens":1}},
+               "uuid":"a1","parentUuid":"u1","cwd":cwd,"sessionId":"test-sess",
+               "timestamp":"2026-05-01T00:00:01Z"}),
+    ];
+    let content: String = events.iter().map(|e| format!("{}\n", e)).collect();
+    fs::write(path, content).unwrap();
+}
+
+fn write_claude_transcript_without_cwd(path: &Path) {
+    let events = [
+        json!({"type":"user","message":{"content":"hello","role":"user"},
+               "uuid":"u1","parentUuid":null,"sessionId":"test-sess",
+               "timestamp":"2026-05-01T00:00:00Z"}),
+        json!({"type":"assistant","message":{"model":"claude-opus-4-6","id":"msg1","role":"assistant",
+               "content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",
+               "usage":{"input_tokens":1,"output_tokens":1}},
+               "uuid":"a1","parentUuid":"u1","sessionId":"test-sess",
+               "timestamp":"2026-05-01T00:00:01Z"}),
+    ];
+    let content: String = events.iter().map(|e| format!("{}\n", e)).collect();
+    fs::write(path, content).unwrap();
+}
+
+fn write_claude_transcript_cwd_on_later_line(path: &Path, cwd: &str) {
+    let events = [
+        json!({"type":"last-prompt","leafUuid":"abc","sessionId":"test-sess"}),
+        json!({"type":"permission-mode","permissionMode":"default","sessionId":"test-sess"}),
+        json!({"type":"user","message":{"content":"hello","role":"user"},
+               "uuid":"u1","parentUuid":null,"cwd":cwd,"sessionId":"test-sess",
+               "timestamp":"2026-05-01T00:00:00Z"}),
+    ];
+    let content: String = events.iter().map(|e| format!("{}\n", e)).collect();
+    fs::write(path, content).unwrap();
+}
+
+fn setup_test_db(dir: &Path) -> TranscriptsDatabase {
+    let db_path = dir.join("transcripts.db");
+    TranscriptsDatabase::open(&db_path).unwrap()
+}
+
+fn make_session_record(
+    session_id: &str,
+    tool: &str,
+    transcript_path: &Path,
+    repo_work_dir: Option<&str>,
+) -> SessionRecord {
+    SessionRecord {
+        session_id: session_id.to_string(),
+        tool: tool.to_string(),
+        transcript_path: transcript_path.display().to_string(),
+        transcript_format: "ClaudeJsonl".to_string(),
+        watermark_type: "ByteOffset".to_string(),
+        watermark_value: "0".to_string(),
+        external_session_id: format!("ext-{}", session_id),
+        external_parent_session_id: None,
+        first_seen_at: chrono::Utc::now().timestamp(),
+        last_processed_at: 0,
+        last_known_size: 0,
+        last_modified: None,
+        processing_errors: 0,
+        last_error: None,
+        repo_work_dir: repo_work_dir.map(|s| s.to_string()),
+    }
+}
+
+// === Test Group 1: resolve_repo_url_from_path utility ===
+
+#[test]
+fn test_resolve_repo_url_from_path_ssh_remote() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:org/project.git"])
+        .unwrap();
+    let result = resolve_repo_url_from_path(repo.path());
+    assert_eq!(
+        result,
+        Some("https://github.com/org/project".to_string()),
+        "SSH remote must be normalized to HTTPS"
+    );
+}
+
+#[test]
+fn test_resolve_repo_url_from_path_https_remote() {
+    let repo = TestRepo::new();
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/org/project.git",
+    ])
+    .unwrap();
+    let result = resolve_repo_url_from_path(repo.path());
+    assert_eq!(
+        result,
+        Some("https://github.com/org/project".to_string()),
+        "HTTPS remote must strip .git suffix"
+    );
+}
+
+#[test]
+fn test_resolve_repo_url_from_path_no_remote() {
+    let repo = TestRepo::new();
+    let result = resolve_repo_url_from_path(repo.path());
+    assert_eq!(result, None, "Must return None when repo has no remote");
+}
+
+#[test]
+fn test_resolve_repo_url_from_path_not_a_repo() {
+    let temp_dir = TempDir::new().unwrap();
+    let result = resolve_repo_url_from_path(temp_dir.path());
+    assert_eq!(result, None, "Must return None for non-repo directory");
+}
+
+#[test]
+fn test_resolve_repo_url_from_path_strips_credentials() {
+    let repo = TestRepo::new();
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://user:token@github.com/org/project.git",
+    ])
+    .unwrap();
+    let result = resolve_repo_url_from_path(repo.path());
+    assert_eq!(
+        result,
+        Some("https://github.com/org/project".to_string()),
+        "Credentials must be stripped from repo_url"
+    );
+}
+
+#[test]
+fn test_resolve_repo_url_from_path_from_subdirectory() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:org/project.git"])
+        .unwrap();
+    let subdir = repo.path().join("src/deep/nested");
+    fs::create_dir_all(&subdir).unwrap();
+    let result = resolve_repo_url_from_path(&subdir);
+    assert_eq!(
+        result,
+        Some("https://github.com/org/project".to_string()),
+        "Must resolve repo_url from subdirectory"
+    );
+}
+
+// === Test Group 2: Claude infer_cwd ===
+
+#[test]
+fn test_claude_infer_cwd_from_user_event() {
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, "/Users/dev/my-project");
+    let agent = ClaudeAgent::new();
+    let result = agent.infer_cwd(&transcript);
+    assert_eq!(
+        result,
+        Some(PathBuf::from("/Users/dev/my-project")),
+        "Must extract cwd from Claude transcript user event"
+    );
+}
+
+#[test]
+fn test_claude_infer_cwd_no_cwd_in_transcript() {
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_without_cwd(&transcript);
+    let agent = ClaudeAgent::new();
+    let result = agent.infer_cwd(&transcript);
+    assert_eq!(
+        result, None,
+        "Must return None when transcript has no cwd field"
+    );
+}
+
+#[test]
+fn test_claude_infer_cwd_empty_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    fs::write(&transcript, "").unwrap();
+    let agent = ClaudeAgent::new();
+    let result = agent.infer_cwd(&transcript);
+    assert_eq!(result, None, "Must return None for empty transcript file");
+}
+
+#[test]
+fn test_claude_infer_cwd_missing_file() {
+    let agent = ClaudeAgent::new();
+    let result = agent.infer_cwd(Path::new("/nonexistent/path/session.jsonl"));
+    assert_eq!(
+        result, None,
+        "Must return None for non-existent file without panicking"
+    );
+}
+
+#[test]
+fn test_claude_infer_cwd_not_on_first_line() {
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_cwd_on_later_line(&transcript, "/home/user/repo");
+    let agent = ClaudeAgent::new();
+    let result = agent.infer_cwd(&transcript);
+    assert_eq!(
+        result,
+        Some(PathBuf::from("/home/user/repo")),
+        "Must find cwd even when first event lacks it"
+    );
+}
+
+// === Test Group 3: DB schema and repo_work_dir persistence ===
+
+#[test]
+fn test_db_new_schema_has_repo_work_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let transcript = temp_dir.path().join("t.jsonl");
+    fs::write(&transcript, "").unwrap();
+
+    let record = make_session_record("test-1", "claude", &transcript, Some("/Users/dev/project"));
+    db.insert_session(&record).unwrap();
+    let retrieved = db.get_session("test-1").unwrap().unwrap();
+    assert_eq!(
+        retrieved.repo_work_dir,
+        Some("/Users/dev/project".to_string()),
+        "repo_work_dir must round-trip through insert/get"
+    );
+}
+
+#[test]
+fn test_db_insert_session_without_repo_work_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let transcript = temp_dir.path().join("t.jsonl");
+    fs::write(&transcript, "").unwrap();
+
+    let record = make_session_record("test-2", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+    let retrieved = db.get_session("test-2").unwrap().unwrap();
+    assert_eq!(
+        retrieved.repo_work_dir, None,
+        "repo_work_dir must be None when not provided"
+    );
+}
+
+#[test]
+fn test_db_update_repo_work_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let transcript = temp_dir.path().join("t.jsonl");
+    fs::write(&transcript, "").unwrap();
+
+    let record = make_session_record("test-3", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+
+    db.update_repo_work_dir("test-3", "/Users/dev/my-project")
+        .unwrap();
+    let retrieved = db.get_session("test-3").unwrap().unwrap();
+    assert_eq!(
+        retrieved.repo_work_dir,
+        Some("/Users/dev/my-project".to_string()),
+        "update_repo_work_dir must set the column"
+    );
+}
+
+// === Test Group 4: Session Event repo_url from Hook Path ===
+
+#[test]
+fn test_session_events_include_repo_url_from_hook_triggered_checkpoint() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:acme/app.git"])
+        .unwrap();
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo.path().to_str().unwrap());
+
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record(
+        "test-hook-sess",
+        "claude",
+        &transcript,
+        Some(repo.path().to_str().unwrap()),
+    );
+    db.insert_session(&record).unwrap();
+
+    let session = db.get_session("test-hook-sess").unwrap().unwrap();
+    let repo_work_dir = session.repo_work_dir.as_ref().map(PathBuf::from);
+    let resolved_repo_url = repo_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    assert_eq!(
+        resolved_repo_url,
+        Some("https://github.com/acme/app".to_string()),
+        "Session events from hook-triggered checkpoints MUST include repo_url"
+    );
+
+    // Build attrs and verify
+    let mut base_attrs = EventAttributes::with_version("test")
+        .session_id(session.session_id.clone())
+        .tool(&session.tool)
+        .external_session_id(session.external_session_id.clone());
+    if let Some(url) = &resolved_repo_url {
+        base_attrs = base_attrs.repo_url(url.clone());
+    }
+    let sparse = base_attrs.to_sparse();
+    let attrs = EventAttributes::from_sparse(&sparse);
+
+    assert_eq!(
+        attrs.repo_url,
+        Some(Some("https://github.com/acme/app".to_string())),
+        "EventAttributes must carry repo_url through sparse encoding"
+    );
+    assert_eq!(attrs.tool, Some(Some("claude".to_string())));
+    assert_eq!(attrs.session_id, Some(Some("test-hook-sess".to_string())));
+}
+
+#[test]
+fn test_session_events_no_repo_url_when_no_remote() {
+    let repo = TestRepo::new();
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo.path().to_str().unwrap());
+
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record(
+        "test-no-remote",
+        "claude",
+        &transcript,
+        Some(repo.path().to_str().unwrap()),
+    );
+    db.insert_session(&record).unwrap();
+
+    let session = db.get_session("test-no-remote").unwrap().unwrap();
+    let repo_work_dir = session.repo_work_dir.as_ref().map(PathBuf::from);
+    let resolved = repo_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    assert_eq!(
+        resolved, None,
+        "repo_url must be None when repo has no remote"
+    );
+}
+
+#[test]
+fn test_session_events_no_repo_url_when_no_work_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_without_cwd(&transcript);
+
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record("test-no-workdir", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+
+    let session = db.get_session("test-no-workdir").unwrap().unwrap();
+    assert_eq!(session.repo_work_dir, None);
+
+    let resolved = None::<PathBuf>
+        .as_ref()
+        .and_then(|p: &PathBuf| resolve_repo_url_from_path(p));
+    assert_eq!(
+        resolved, None,
+        "repo_url must be None when no work_dir and no cwd inference"
+    );
+}
+
+// === Test Group 5: Session Event repo_url from Sweep Path (cwd inference) ===
+
+#[test]
+fn test_session_events_repo_url_from_sweep_inferred_cwd() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:team/service.git"])
+        .unwrap();
+
+    let transcript = repo.path().join("transcript.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo.path().to_str().unwrap());
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record("test-sweep-sess", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+
+    let session = db.get_session("test-sweep-sess").unwrap().unwrap();
+    assert_eq!(
+        session.repo_work_dir, None,
+        "Sweep should not have repo_work_dir initially"
+    );
+
+    let agent = ClaudeAgent::new();
+    let inferred_cwd = agent.infer_cwd(&PathBuf::from(&session.transcript_path));
+    assert_eq!(
+        inferred_cwd,
+        Some(repo.path().to_path_buf()),
+        "Claude agent must infer cwd from transcript"
+    );
+
+    let resolved = inferred_cwd
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+    assert_eq!(
+        resolved,
+        Some("https://github.com/team/service".to_string()),
+        "Sweep-discovered sessions MUST resolve repo_url when cwd is inferable"
+    );
+}
+
+#[test]
+fn test_inferred_cwd_persisted_to_db() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:a/b.git"])
+        .unwrap();
+
+    let transcript = repo.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo.path().to_str().unwrap());
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record("test-persist", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+
+    let agent = ClaudeAgent::new();
+    let inferred = agent.infer_cwd(&transcript).unwrap();
+    db.update_repo_work_dir("test-persist", &inferred.display().to_string())
+        .unwrap();
+
+    let session = db.get_session("test-persist").unwrap().unwrap();
+    assert_eq!(
+        session.repo_work_dir,
+        Some(repo.path().display().to_string()),
+        "Inferred cwd must be persisted to DB for future processing cycles"
+    );
+}
+
+// === Test Group 6: Priority Resolution (hook > DB > infer) ===
+
+#[test]
+fn test_repo_work_dir_priority_hook_wins_over_db() {
+    let repo_a = TestRepo::new();
+    repo_a
+        .git(&["remote", "add", "origin", "git@github.com:org/old.git"])
+        .unwrap();
+    let repo_b = TestRepo::new();
+    repo_b
+        .git(&["remote", "add", "origin", "git@github.com:org/new.git"])
+        .unwrap();
+
+    let transcript = repo_b.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo_b.path().to_str().unwrap());
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record(
+        "test-priority",
+        "claude",
+        &transcript,
+        Some(repo_a.path().to_str().unwrap()),
+    );
+    db.insert_session(&record).unwrap();
+
+    // Hook provides repo_b's path (should take priority)
+    let task_repo_work_dir = Some(repo_b.path().to_path_buf());
+    let session = db.get_session("test-priority").unwrap().unwrap();
+    let db_repo_work_dir = session.repo_work_dir.as_ref().map(PathBuf::from);
+
+    // Resolution order: task > db > infer
+    let resolved_work_dir = task_repo_work_dir.or(db_repo_work_dir);
+    let resolved_url = resolved_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    assert_eq!(
+        resolved_url,
+        Some("https://github.com/org/new".to_string()),
+        "Hook-provided repo_work_dir MUST take priority over DB-stored value"
+    );
+}
+
+#[test]
+fn test_repo_work_dir_priority_db_used_when_no_hook() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:org/stored.git"])
+        .unwrap();
+
+    let transcript = repo.path().join("session.jsonl");
+    write_claude_transcript_without_cwd(&transcript);
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record(
+        "test-db-prio",
+        "claude",
+        &transcript,
+        Some(repo.path().to_str().unwrap()),
+    );
+    db.insert_session(&record).unwrap();
+
+    let task_repo_work_dir: Option<PathBuf> = None;
+    let session = db.get_session("test-db-prio").unwrap().unwrap();
+    let db_repo_work_dir = session.repo_work_dir.as_ref().map(PathBuf::from);
+
+    let resolved_work_dir = task_repo_work_dir.or(db_repo_work_dir);
+    let resolved_url = resolved_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    assert_eq!(
+        resolved_url,
+        Some("https://github.com/org/stored".to_string()),
+        "DB-stored repo_work_dir must be used when no hook value present"
+    );
+}
+
+#[test]
+fn test_repo_work_dir_priority_infer_fallback() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:org/inferred.git"])
+        .unwrap();
+
+    let transcript = repo.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo.path().to_str().unwrap());
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+    let record = make_session_record("test-infer-prio", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+
+    let task_repo_work_dir: Option<PathBuf> = None;
+    let session = db.get_session("test-infer-prio").unwrap().unwrap();
+    let db_repo_work_dir = session.repo_work_dir.as_ref().map(PathBuf::from);
+
+    let agent = ClaudeAgent::new();
+    let inferred_cwd = agent.infer_cwd(&PathBuf::from(&session.transcript_path));
+
+    let resolved_work_dir = task_repo_work_dir.or(db_repo_work_dir).or(inferred_cwd);
+    let resolved_url = resolved_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    assert_eq!(
+        resolved_url,
+        Some("https://github.com/org/inferred".to_string()),
+        "infer_cwd must be used as fallback when hook and DB are both None"
+    );
+}
+
+// === Test Group 7: Agents without cwd inference ===
+
+#[test]
+fn test_cursor_infer_cwd_returns_none() {
+    use git_ai::transcripts::agents::CursorAgent;
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    fs::write(&transcript, r#"{"type":"user","message":{"content":"hi"}}"#).unwrap();
+    let agent = CursorAgent::new();
+    assert_eq!(
+        agent.infer_cwd(&transcript),
+        None,
+        "CursorAgent must return None for infer_cwd (no cwd in format)"
+    );
+}
+
+#[test]
+fn test_copilot_infer_cwd_returns_none() {
+    use git_ai::transcripts::agents::CopilotAgent;
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.json");
+    fs::write(&transcript, r#"{"messages":[]}"#).unwrap();
+    let agent = CopilotAgent::new();
+    assert_eq!(
+        agent.infer_cwd(&transcript),
+        None,
+        "CopilotAgent must return None for infer_cwd"
+    );
+}
+
+// === Test Group 8: Full E2E pipeline with repo_url ===
+
+#[test]
+fn test_full_pipeline_session_events_carry_repo_url() {
+    let repo = TestRepo::new();
+    repo.git(&["remote", "add", "origin", "git@github.com:myorg/myrepo.git"])
+        .unwrap();
+
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_with_cwd(&transcript, repo.path().to_str().unwrap());
+
+    let record = make_session_record(
+        "pipeline-test",
+        "claude",
+        &transcript,
+        Some(repo.path().to_str().unwrap()),
+    );
+    db.insert_session(&record).unwrap();
+
+    // Replicate process_session_blocking logic
+    let retrieved = db.get_session("pipeline-test").unwrap().unwrap();
+    let agent = ClaudeAgent::new();
+    let watermark = Box::new(ByteOffsetWatermark::new(0));
+    let batch = agent
+        .read_incremental(
+            &PathBuf::from(&retrieved.transcript_path),
+            watermark,
+            &retrieved.session_id,
+        )
+        .unwrap();
+
+    // Resolve repo_url
+    let repo_work_dir = retrieved.repo_work_dir.as_ref().map(PathBuf::from);
+    let resolved_url = repo_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    // Build attrs
+    let mut base_attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+        .session_id(retrieved.session_id.clone())
+        .tool(&retrieved.tool)
+        .external_session_id(retrieved.external_session_id.clone())
+        .external_parent_session_id_opt(retrieved.external_parent_session_id.clone());
+    if let Some(ref url) = resolved_url {
+        base_attrs = base_attrs.repo_url(url.clone());
+    }
+
+    // Build events
+    let metric_events: Vec<MetricEvent> = batch
+        .events
+        .into_iter()
+        .map(|raw_event| {
+            let (eid, pid, tid) = agent.extract_event_ids(&raw_event);
+            let sparse = base_attrs
+                .clone()
+                .trace_id("test-trace".to_string())
+                .to_sparse();
+            MetricEvent::from_values(
+                SessionEventValues::with_ids(raw_event, eid, pid, tid),
+                sparse,
+            )
+        })
+        .collect();
+
+    assert!(
+        !metric_events.is_empty(),
+        "Should have produced session events"
+    );
+
+    // STRICT: Every single event must have repo_url
+    for (i, event) in metric_events.iter().enumerate() {
+        let attrs = EventAttributes::from_sparse(&event.attrs);
+        assert_eq!(
+            attrs.repo_url,
+            Some(Some("https://github.com/myorg/myrepo".to_string())),
+            "Event {} must have repo_url set",
+            i
+        );
+        assert_eq!(
+            attrs.tool,
+            Some(Some("claude".to_string())),
+            "Event {} must have tool set",
+            i
+        );
+        assert_eq!(
+            attrs.session_id,
+            Some(Some("pipeline-test".to_string())),
+            "Event {} must have session_id set",
+            i
+        );
+    }
+}
+
+#[test]
+fn test_full_pipeline_session_events_no_repo_url_when_unavailable() {
+    let temp_dir = TempDir::new().unwrap();
+    let db = setup_test_db(temp_dir.path());
+
+    let transcript = temp_dir.path().join("session.jsonl");
+    write_claude_transcript_without_cwd(&transcript);
+
+    let record = make_session_record("no-repo-test", "claude", &transcript, None);
+    db.insert_session(&record).unwrap();
+
+    let retrieved = db.get_session("no-repo-test").unwrap().unwrap();
+    let agent = ClaudeAgent::new();
+    let watermark = Box::new(ByteOffsetWatermark::new(0));
+    let batch = agent
+        .read_incremental(
+            &PathBuf::from(&retrieved.transcript_path),
+            watermark,
+            &retrieved.session_id,
+        )
+        .unwrap();
+
+    let repo_work_dir = retrieved.repo_work_dir.as_ref().map(PathBuf::from);
+    let inferred = agent.infer_cwd(&PathBuf::from(&retrieved.transcript_path));
+    let resolved_work_dir = repo_work_dir.or(inferred);
+    let resolved_url = resolved_work_dir
+        .as_ref()
+        .and_then(|p| resolve_repo_url_from_path(p));
+
+    assert_eq!(
+        resolved_url, None,
+        "No repo_url should be resolved when unavailable"
+    );
+
+    // Build attrs without repo_url
+    let base_attrs = EventAttributes::with_version("test")
+        .session_id(retrieved.session_id.clone())
+        .tool(&retrieved.tool);
+
+    let metric_events: Vec<MetricEvent> = batch
+        .events
+        .into_iter()
+        .map(|raw_event| {
+            let (eid, pid, tid) = agent.extract_event_ids(&raw_event);
+            let sparse = base_attrs.clone().to_sparse();
+            MetricEvent::from_values(
+                SessionEventValues::with_ids(raw_event, eid, pid, tid),
+                sparse,
+            )
+        })
+        .collect();
+
+    assert!(!metric_events.is_empty(), "Should have produced events");
+
+    for (i, event) in metric_events.iter().enumerate() {
+        let attrs = EventAttributes::from_sparse(&event.attrs);
+        assert!(
+            attrs.repo_url.is_none() || matches!(&attrs.repo_url, Some(None)),
+            "Event {} must NOT have repo_url when unavailable, got: {:?}",
+            i,
+            attrs.repo_url
+        );
+    }
+}
+
+// === Test Group 9: Codex infer_cwd ===
+
+#[test]
+fn test_codex_infer_cwd_from_session_meta() {
+    use git_ai::transcripts::agents::CodexAgent;
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    let events = [
+        json!({"timestamp":"2026-02-11T05:53:33.335Z","type":"session_meta",
+               "payload":{"id":"019c4b43","timestamp":"2026-02-11T05:53:33.266Z",
+                          "cwd":"/Users/test/projects/my-app","originator":"Codex Desktop",
+                          "cli_version":"0.99.0","source":"vscode","model_provider":"openai"}}),
+        json!({"timestamp":"2026-02-11T05:53:33.340Z","type":"turn_context",
+               "payload":{"turn_id":"turn-1","cwd":"/Users/test/projects/my-app",
+                          "model":"gpt-5.1-codex"}}),
+    ];
+    let content: String = events.iter().map(|e| format!("{}\n", e)).collect();
+    fs::write(&transcript, content).unwrap();
+
+    let agent = CodexAgent::new();
+    let result = agent.infer_cwd(&transcript);
+    assert_eq!(
+        result,
+        Some(PathBuf::from("/Users/test/projects/my-app")),
+        "CodexAgent must extract cwd from session_meta payload"
+    );
+}
+
+#[test]
+fn test_codex_infer_cwd_no_cwd() {
+    use git_ai::transcripts::agents::CodexAgent;
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    let events = [
+        json!({"timestamp":"2026-02-11T05:53:33.335Z","type":"message",
+                             "payload":{"role":"user","content":"hello"}}),
+    ];
+    let content: String = events.iter().map(|e| format!("{}\n", e)).collect();
+    fs::write(&transcript, content).unwrap();
+
+    let agent = CodexAgent::new();
+    let result = agent.infer_cwd(&transcript);
+    assert_eq!(
+        result, None,
+        "CodexAgent must return None when no cwd in payload"
+    );
+}

--- a/tests/integration/sweep_e2e.rs
+++ b/tests/integration/sweep_e2e.rs
@@ -281,6 +281,7 @@ fn test_sweep_deduplication_via_session_id() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
     db.insert_session(&record).unwrap();
 
@@ -322,6 +323,7 @@ fn test_behind_detection_on_file_growth() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
     db.insert_session(&record).unwrap();
 
@@ -400,6 +402,7 @@ fn test_watermark_persistence_after_processing() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
     db.insert_session(&record).unwrap();
 

--- a/tests/integration/transcripts_e2e.rs
+++ b/tests/integration/transcripts_e2e.rs
@@ -52,6 +52,7 @@ fn test_session_database_basic() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
 
     // Insert
@@ -156,6 +157,7 @@ fn test_multiple_sessions_isolation() {
             last_modified: None,
             processing_errors: 0,
             last_error: None,
+            repo_work_dir: None,
         };
         db.insert_session(&session).unwrap();
     }
@@ -200,6 +202,7 @@ fn test_database_persistence() {
             last_modified: None,
             processing_errors: 0,
             last_error: None,
+            repo_work_dir: None,
         };
         db.insert_session(&session).unwrap();
     }
@@ -236,6 +239,7 @@ fn test_error_tracking() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
 
     db.insert_session(&session).unwrap();
@@ -277,6 +281,7 @@ fn test_full_pipeline_claude_session_ids_flow_through() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
     db.insert_session(&session).unwrap();
 
@@ -365,6 +370,7 @@ fn test_full_pipeline_opencode_session_ids_flow_through() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
     db.insert_session(&session).unwrap();
 
@@ -446,6 +452,7 @@ fn test_subagent_session_record_has_parent_link() {
         last_modified: None,
         processing_errors: 0,
         last_error: None,
+        repo_work_dir: None,
     };
     db.insert_session(&session).unwrap();
 


### PR DESCRIPTION
## Summary

- Session Event metrics never had `repo_url` set. This adds repo_url resolution through three sources with priority ordering: hook-provided `repo_work_dir` > DB-persisted value > agent transcript `cwd` inference.
- Adds `resolve_repo_url_from_path` / `resolve_repo_url_from_repo` utilities, DB schema v3 migration (adds `repo_work_dir` column), and `infer_cwd()` on the Agent trait (implemented for Claude and Codex agents).
- Comprehensive 28-test suite covering all resolution paths, priority ordering, persistence, and negative cases.

## Changes

- `src/repo_url.rs` — New `resolve_repo_url_from_path` and `resolve_repo_url_from_repo` utilities
- `src/transcripts/db.rs` — Schema v3 migration: `repo_work_dir TEXT` column, `update_repo_work_dir()` method
- `src/transcripts/agent.rs` — `infer_cwd()` default method on Agent trait
- `src/transcripts/agents/claude.rs` — Claude `infer_cwd`: extracts `cwd` from JSONL events (first 50 lines)
- `src/transcripts/agents/codex.rs` — Codex `infer_cwd`: extracts `payload.cwd` from session_meta/turn_context
- `src/daemon/transcript_worker.rs` — repo_url resolution in `process_session_blocking`, propagation through `CheckpointNotification`/`ProcessingTask`
- `src/daemon.rs` — Passes `repo_work_dir` from checkpoint request to `ensure_session_exists` and `notify_checkpoint`
- `src/daemon/checkpoint.rs` — Refactored to use shared `resolve_repo_url_from_repo` utility
- `src/daemon/sweep_coordinator.rs` — Infers cwd at session discovery time

## Test plan

- [x] 28 new integration tests covering:
  - `resolve_repo_url_from_path` utility (SSH, HTTPS, no remote, non-repo, credentials, subdirectory)
  - Claude `infer_cwd` (user event, no cwd, empty file, missing file, cwd on later line)
  - Codex `infer_cwd` (session_meta payload, no cwd)
  - DB schema migration (`repo_work_dir` insert/update/null handling)
  - Session event `repo_url` from hook path (positive + negative)
  - Session event `repo_url` from sweep cwd inference
  - Priority resolution (hook > DB > infer)
  - Negative tests for agents without cwd inference (Cursor, Copilot)
  - Full pipeline E2E event construction
- [x] Full test suite passes (3027 pass, 2 pre-existing graphite failures unrelated to this PR)
- [x] `task lint` clean
- [x] `task fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->