### PR TITLE
feat: add edit_kind attribute to checkpoint event metrics

### DIFF
--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -304,6 +304,9 @@ fn execute_post_file_edit(
     if let Some(tuid) = e.tool_use_id {
         metadata.entry("tool_use_id".to_string()).or_insert(tuid);
     }
+    metadata
+        .entry("edit_kind".to_string())
+        .or_insert_with(|| "file_edit".to_string());
     Ok(split_files_into_requests(
         files,
         e.context.trace_id,
@@ -427,6 +430,9 @@ fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, Git
     metadata
         .entry("tool_use_id".to_string())
         .or_insert(e.tool_use_id);
+    metadata
+        .entry("edit_kind".to_string())
+        .or_insert_with(|| "bash".to_string());
     Ok(split_files_into_requests(
         files,
         e.context.trace_id,

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -349,6 +349,11 @@ fn execute_resolved_checkpoint(
             .get("tool_use_id")
             .map(|s| s.as_str());
 
+        let edit_kind = checkpoint_request
+            .metadata
+            .get("edit_kind")
+            .map(|s| s.as_str());
+
         for (entry, file_stat) in entries.iter().zip(file_stats.iter()) {
             let mut values = crate::metrics::CheckpointValues::new()
                 .checkpoint_ts(checkpoint.timestamp)
@@ -359,9 +364,11 @@ fn execute_resolved_checkpoint(
                 .lines_added_sloc(file_stat.additions_sloc)
                 .lines_deleted_sloc(file_stat.deletions_sloc);
 
-            // Add tool_use_id if available
             if let Some(tuid) = tool_use_id {
                 values = values.external_tool_use_id(tuid);
+            }
+            if let Some(ek) = edit_kind {
+                values = values.edit_kind(ek);
             }
 
             let file_attrs = attrs.clone().author(&checkpoint.author);

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -417,6 +417,7 @@ pub mod checkpoint_pos {
     pub const LINES_ADDED_SLOC: usize = 5; // u32 - for this file
     pub const LINES_DELETED_SLOC: usize = 6; // u32 - for this file
     pub const TOOL_USE_ID: usize = 7; // String - nullable
+    pub const EDIT_KIND: usize = 8; // String - nullable ("file_edit" | "bash")
 }
 
 /// Values for Event ID 4: checkpoint
@@ -435,6 +436,7 @@ pub mod checkpoint_pos {
 /// | 5 | lines_added_sloc | u32 |
 /// | 6 | lines_deleted_sloc | u32 |
 /// | 7 | external_tool_use_id | String (nullable) |
+/// | 8 | edit_kind | String (nullable) |
 #[derive(Debug, Clone, Default)]
 pub struct CheckpointValues {
     pub checkpoint_ts: PosField<u64>,
@@ -445,6 +447,7 @@ pub struct CheckpointValues {
     pub lines_added_sloc: PosField<u32>,
     pub lines_deleted_sloc: PosField<u32>,
     pub external_tool_use_id: PosField<String>,
+    pub edit_kind: PosField<String>,
 }
 
 impl CheckpointValues {
@@ -539,6 +542,17 @@ impl CheckpointValues {
         self.external_tool_use_id = Some(None);
         self
     }
+
+    pub fn edit_kind(mut self, value: impl Into<String>) -> Self {
+        self.edit_kind = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn edit_kind_null(mut self) -> Self {
+        self.edit_kind = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for CheckpointValues {
@@ -581,6 +595,11 @@ impl PosEncoded for CheckpointValues {
             checkpoint_pos::TOOL_USE_ID,
             string_to_json(&self.external_tool_use_id),
         );
+        sparse_set(
+            &mut map,
+            checkpoint_pos::EDIT_KIND,
+            string_to_json(&self.edit_kind),
+        );
 
         map
     }
@@ -595,6 +614,7 @@ impl PosEncoded for CheckpointValues {
             lines_added_sloc: sparse_get_u32(arr, checkpoint_pos::LINES_ADDED_SLOC),
             lines_deleted_sloc: sparse_get_u32(arr, checkpoint_pos::LINES_DELETED_SLOC),
             external_tool_use_id: sparse_get_string(arr, checkpoint_pos::TOOL_USE_ID),
+            edit_kind: sparse_get_string(arr, checkpoint_pos::EDIT_KIND),
         }
     }
 }
@@ -1072,6 +1092,98 @@ mod tests {
         let values = <CheckpointValues as PosEncoded>::from_sparse(&sparse);
 
         assert_eq!(values.external_tool_use_id, None); // not set
+    }
+
+    #[test]
+    fn test_checkpoint_values_with_edit_kind() {
+        let values = CheckpointValues::new()
+            .checkpoint_ts(1704067200)
+            .kind("ai_agent")
+            .file_path("src/main.rs")
+            .edit_kind("file_edit");
+
+        assert_eq!(values.edit_kind, Some(Some("file_edit".to_string())));
+    }
+
+    #[test]
+    fn test_checkpoint_values_edit_kind_null() {
+        let values = CheckpointValues::new()
+            .checkpoint_ts(1704067200)
+            .kind("ai_agent")
+            .edit_kind_null();
+
+        assert_eq!(values.edit_kind, Some(None));
+    }
+
+    #[test]
+    fn test_checkpoint_values_to_sparse_with_edit_kind() {
+        use super::PosEncoded;
+
+        let values = CheckpointValues::new()
+            .checkpoint_ts(1700000000)
+            .kind("ai_agent")
+            .file_path("tests/test.rs")
+            .edit_kind("bash");
+
+        let sparse = PosEncoded::to_sparse(&values);
+
+        assert_eq!(sparse.get("0"), Some(&Value::Number(1700000000.into())));
+        assert_eq!(
+            sparse.get("1"),
+            Some(&Value::String("ai_agent".to_string()))
+        );
+        assert_eq!(sparse.get("8"), Some(&Value::String("bash".to_string())));
+    }
+
+    #[test]
+    fn test_checkpoint_values_from_sparse_with_edit_kind() {
+        use super::PosEncoded;
+
+        let mut sparse = SparseArray::new();
+        sparse.insert("0".to_string(), Value::Number(1704067200.into()));
+        sparse.insert("1".to_string(), Value::String("ai_agent".to_string()));
+        sparse.insert("2".to_string(), Value::String("lib.rs".to_string()));
+        sparse.insert("8".to_string(), Value::String("file_edit".to_string()));
+
+        let values = <CheckpointValues as PosEncoded>::from_sparse(&sparse);
+
+        assert_eq!(values.checkpoint_ts, Some(Some(1704067200)));
+        assert_eq!(values.kind, Some(Some("ai_agent".to_string())));
+        assert_eq!(values.edit_kind, Some(Some("file_edit".to_string())));
+    }
+
+    #[test]
+    fn test_checkpoint_values_roundtrip_with_edit_kind() {
+        use super::PosEncoded;
+
+        let original = CheckpointValues::new()
+            .checkpoint_ts(1700000000)
+            .kind("ai_agent")
+            .file_path("src/lib.rs")
+            .lines_added(50)
+            .edit_kind("bash");
+
+        let sparse = PosEncoded::to_sparse(&original);
+        let restored = <CheckpointValues as PosEncoded>::from_sparse(&sparse);
+
+        assert_eq!(restored.checkpoint_ts, Some(Some(1700000000)));
+        assert_eq!(restored.kind, Some(Some("ai_agent".to_string())));
+        assert_eq!(restored.file_path, Some(Some("src/lib.rs".to_string())));
+        assert_eq!(restored.lines_added, Some(Some(50)));
+        assert_eq!(restored.edit_kind, Some(Some("bash".to_string())));
+    }
+
+    #[test]
+    fn test_checkpoint_values_edit_kind_not_set() {
+        use super::PosEncoded;
+
+        let mut sparse = SparseArray::new();
+        sparse.insert("0".to_string(), Value::Number(1700000000.into()));
+        sparse.insert("1".to_string(), Value::String("human".to_string()));
+
+        let values = <CheckpointValues as PosEncoded>::from_sparse(&sparse);
+
+        assert_eq!(values.edit_kind, None);
     }
 }
 

--- a/tests/integration/checkpoint_telemetry.rs
+++ b/tests/integration/checkpoint_telemetry.rs
@@ -135,6 +135,137 @@ fn test_codex_bash_checkpoint_propagates_tool_use_id_to_metadata() {
     );
 }
 
+/// Verify that edit_kind="file_edit" is set for file edit checkpoints.
+#[test]
+fn test_file_edit_checkpoint_has_edit_kind_metadata() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let transcript_path = repo_root.join("session.jsonl");
+    fs::write(&transcript_path, "{}\n").unwrap();
+
+    let pre_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_use_id": "toolu_edit_kind_1",
+        "session_id": "sess-edit-kind",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy()
+        }
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &pre_hook])
+        .expect("pre checkpoint should succeed");
+
+    fs::write(&file_path, "const x = 1;\nconst y = 2;\n").unwrap();
+
+    let post_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_use_id": "toolu_edit_kind_1",
+        "session_id": "sess-edit-kind",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy()
+        }
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &post_hook])
+        .expect("post checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    let ai_checkpoint = checkpoints
+        .iter()
+        .find(|c| c.kind == git_ai::authorship::working_log::CheckpointKind::AiAgent)
+        .expect("Should have an AI agent checkpoint");
+
+    let metadata = ai_checkpoint
+        .agent_metadata
+        .as_ref()
+        .expect("AI checkpoint should have agent_metadata");
+
+    assert_eq!(
+        metadata.get("edit_kind"),
+        Some(&"file_edit".to_string()),
+        "file edit checkpoints must have edit_kind=file_edit"
+    );
+}
+
+/// Verify that edit_kind="bash" is set for bash tool checkpoints.
+#[test]
+fn test_bash_checkpoint_has_edit_kind_metadata() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    let file_path = repo_root.join("src/main.rs");
+    fs::create_dir_all(repo_root.join("src")).unwrap();
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let transcript_path = repo_root.join("codex-session.jsonl");
+    fs::write(&transcript_path, "{}\n").unwrap();
+
+    let pre_hook = json!({
+        "session_id": "codex-edit-kind-sess",
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "tu-bash-edit-kind",
+        "tool_input": {
+            "command": "echo hello"
+        },
+        "transcript_path": transcript_path.to_string_lossy()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook])
+        .expect("pre bash checkpoint should succeed");
+
+    fs::write(&file_path, "fn main() {}\nfn added() {}\n").unwrap();
+
+    let post_hook = json!({
+        "session_id": "codex-edit-kind-sess",
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "tu-bash-edit-kind",
+        "tool_input": {
+            "command": "echo hello"
+        },
+        "transcript_path": transcript_path.to_string_lossy()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook])
+        .expect("post bash checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    let ai_checkpoint = checkpoints
+        .iter()
+        .find(|c| c.kind == git_ai::authorship::working_log::CheckpointKind::AiAgent)
+        .expect("Should have an AI agent checkpoint");
+
+    let metadata = ai_checkpoint
+        .agent_metadata
+        .as_ref()
+        .expect("AI checkpoint should have agent_metadata");
+
+    assert_eq!(
+        metadata.get("edit_kind"),
+        Some(&"bash".to_string()),
+        "bash checkpoints must have edit_kind=bash"
+    );
+}
+
 /// Verify that tool_use_id propagation works for the gemini preset.
 #[test]
 fn test_gemini_file_edit_checkpoint_propagates_tool_use_id_to_metadata() {


### PR DESCRIPTION
## Summary
- Adds `edit_kind` field (position 8) to `CheckpointValues` metrics records
- AI checkpoints from file-edit tools (Write, Edit, MultiEdit, etc.) get `edit_kind="file_edit"`
- AI checkpoints from bash/shell tools get `edit_kind="bash"`
- Enables downstream analytics to differentiate how AI edits were made

## Test plan
- [x] Unit tests for builder, null, serialization, deserialization, and roundtrip
- [x] Integration tests verifying end-to-end metadata propagation for both file-edit and bash checkpoints
- [x] All existing checkpoint_telemetry tests still pass
- [x] `task lint` and `task fmt` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->