### PR TITLE
feat: add authorship_note attribute to committed event metrics

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -191,11 +191,11 @@ pub fn post_commit_with_final_state(
         }
     }
 
-    let authorship_json = authorship_log
+    let authorship_note_str = authorship_log
         .serialize_to_string()
         .map_err(|_| GitAiError::Generic("Failed to serialize authorship log".to_string()))?;
 
-    notes_add(repo, &commit_sha, &authorship_json)?;
+    notes_add(repo, &commit_sha, &authorship_note_str)?;
 
     // Compute stats once (needed for both metrics and terminal output), unless preflight
     // estimate predicts this would be too expensive for the commit hook path.
@@ -227,7 +227,7 @@ pub fn post_commit_with_final_state(
             &commit_sha,
             &parent_sha,
             &human_author,
-            &authorship_log,
+            &authorship_note_str,
             &computed,
             &parent_working_log,
         );
@@ -412,7 +412,7 @@ fn record_commit_metrics(
     commit_sha: &str,
     parent_sha: &str,
     human_author: &str,
-    _authorship_log: &AuthorshipLog,
+    authorship_note: &str,
     stats: &crate::authorship::stats::CommitStats,
     checkpoints: &[Checkpoint],
 ) {
@@ -484,6 +484,8 @@ fn record_commit_metrics(
     } else {
         values.commit_subject_null().commit_body_null()
     };
+
+    let values = values.authorship_note(authorship_note);
 
     // Build attributes - start with version and extract session_id from first AI checkpoint
     // session_id links this commit to the AI agent conversation that produced it

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -221,6 +221,17 @@ pub fn post_commit_with_final_state(
 
     if skip_reason.is_none() {
         let computed = stats_for_commit_stats(repo, &commit_sha, &ignore_patterns)?;
+
+        let hunks_json = crate::commands::diff::build_diff_artifacts_with_note(
+            repo,
+            &parent_sha,
+            &commit_sha,
+            &crate::commands::diff::DiffCommandOptions::default(),
+            Some(&authorship_log),
+        )
+        .ok()
+        .and_then(|artifacts| serde_json::to_string(&artifacts.json_hunks).ok());
+
         // Record metrics only when we have full stats.
         record_commit_metrics(
             repo,
@@ -230,6 +241,7 @@ pub fn post_commit_with_final_state(
             &authorship_note_str,
             &computed,
             &parent_working_log,
+            hunks_json.as_deref(),
         );
         stats = Some(computed);
     } else {
@@ -407,6 +419,7 @@ pub fn count_line_ranges(lines: &[u32]) -> usize {
 
 /// Record metrics for a committed change.
 /// This is a best-effort operation - failures are silently ignored.
+#[allow(clippy::too_many_arguments)]
 fn record_commit_metrics(
     repo: &Repository,
     commit_sha: &str,
@@ -415,6 +428,7 @@ fn record_commit_metrics(
     authorship_note: &str,
     stats: &crate::authorship::stats::CommitStats,
     checkpoints: &[Checkpoint],
+    hunks_json: Option<&str>,
 ) {
     use crate::metrics::{CommittedValues, EventAttributes, record};
 
@@ -486,6 +500,12 @@ fn record_commit_metrics(
     };
 
     let values = values.authorship_note(authorship_note);
+
+    let values = if let Some(hunks) = hunks_json {
+        values.hunks(hunks)
+    } else {
+        values.hunks_null()
+    };
 
     // Build attributes - start with version and extract session_id from first AI checkpoint
     // session_id links this commit to the AI agent conversation that produced it

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -222,9 +222,14 @@ pub fn post_commit_with_final_state(
     if skip_reason.is_none() {
         let computed = stats_for_commit_stats(repo, &commit_sha, &ignore_patterns)?;
 
+        let diff_base_for_hunks = if parent_sha == "initial" {
+            "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+        } else {
+            &parent_sha
+        };
         let hunks_json = crate::commands::diff::build_diff_artifacts_with_note(
             repo,
-            &parent_sha,
+            diff_base_for_hunks,
             &commit_sha,
             &crate::commands::diff::DiffCommandOptions::default(),
             Some(&authorship_log),

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -2,7 +2,7 @@ use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
-use crate::authorship::stats::{stats_for_commit_stats, write_stats_to_terminal};
+use crate::authorship::stats::{stats_for_commit_stats_from_hunks, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry};
 use crate::config::Config;
@@ -220,18 +220,27 @@ pub fn post_commit_with_final_state(
     };
 
     if skip_reason.is_none() {
-        let computed = stats_for_commit_stats(repo, &commit_sha, &ignore_patterns)?;
-
-        let diff_base_for_hunks = if parent_sha == "initial" {
+        let diff_base = if parent_sha == "initial" {
             "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
         } else {
             &parent_sha
         };
-        let hunks_json = crate::commands::diff::build_diff_artifacts_with_note(
+
+        let diff_hunks =
+            crate::commands::diff::get_diff_with_line_numbers(repo, diff_base, &commit_sha)?;
+
+        let computed = stats_for_commit_stats_from_hunks(
             repo,
-            diff_base_for_hunks,
             &commit_sha,
-            &crate::commands::diff::DiffCommandOptions::default(),
+            &ignore_patterns,
+            &diff_hunks,
+            Some(&authorship_log),
+        )?;
+
+        let hunks_json = crate::commands::diff::build_diff_artifacts_from_hunks(
+            repo,
+            diff_hunks,
+            &commit_sha,
             Some(&authorship_log),
         )
         .ok()

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -379,55 +379,38 @@ pub fn stats_for_commit_stats(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<CommitStats, GitAiError> {
+    use crate::commands::diff::get_diff_with_line_numbers;
+
     let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
-
-    // Step 1: get the diff between this commit and its parent ON refname (if more than one parent)
-    // If initial than everything is additions
-    // We want the count here git shows +111 -55
-    let (git_diff_added_lines, git_diff_deleted_lines) =
-        get_git_diff_stats(repo, commit_sha, ignore_patterns)?;
-
-    // Step 2: get the authorship log for this commit
-    let authorship_log = get_authorship(repo, commit_sha);
-
-    // Step 3: get line numbers added by this specific commit, then intersect with attestations.
-    // This keeps accepted stats scoped to the target commit while avoiding expensive blame traversal.
     let parent_count = commit_obj.parent_count()?;
-    let is_merge_commit = parent_count > 1;
-    let mut added_lines_by_file: HashMap<String, Vec<u32>> = if is_merge_commit {
-        HashMap::new()
-    } else {
-        let from_ref = if parent_count == 0 {
-            "4b825dc642cb6eb9a060e54bf8d69288fbee4904".to_string()
-        } else {
-            commit_obj.parent(0)?.id()
-        };
-        repo.diff_added_lines(&from_ref, commit_sha, None)?
-    };
-    let ignore_matcher = build_ignore_matcher(ignore_patterns);
-    added_lines_by_file
-        .retain(|file_path, _| !should_ignore_file_with_matcher(file_path, &ignore_matcher));
-    for lines in added_lines_by_file.values_mut() {
-        lines.sort_unstable();
-        lines.dedup();
+
+    if parent_count > 1 {
+        let authorship_log = get_authorship(repo, commit_sha);
+        return stats_for_commit_stats_from_hunks(
+            repo,
+            commit_sha,
+            ignore_patterns,
+            &[],
+            authorship_log.as_ref(),
+        );
     }
 
-    // Step 4: derive accepted lines directly from note attestations for lines added in this commit.
-    let (ai_accepted, known_human_accepted, ai_accepted_by_tool) = accepted_lines_from_attestations(
-        authorship_log.as_ref(),
-        &added_lines_by_file,
-        is_merge_commit,
-    );
+    let from_ref = if parent_count == 0 {
+        "4b825dc642cb6eb9a060e54bf8d69288fbee4904".to_string()
+    } else {
+        commit_obj.parent(0)?.id()
+    };
 
-    // Step 5: Calculate stats from authorship log
-    Ok(stats_from_authorship_log(
+    let hunks = get_diff_with_line_numbers(repo, &from_ref, commit_sha)?;
+    let authorship_log = get_authorship(repo, commit_sha);
+
+    stats_for_commit_stats_from_hunks(
+        repo,
+        commit_sha,
+        ignore_patterns,
+        &hunks,
         authorship_log.as_ref(),
-        git_diff_added_lines,
-        git_diff_deleted_lines,
-        ai_accepted,
-        known_human_accepted,
-        &ai_accepted_by_tool,
-    ))
+    )
 }
 
 #[doc(hidden)]

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -515,6 +515,58 @@ pub fn line_range_overlap_len(range: &LineRange, added_lines: &[u32]) -> u32 {
     }
 }
 
+/// Like `stats_for_commit_stats` but accepts pre-computed diff hunks and authorship log,
+/// avoiding redundant git subprocess calls in the post-commit hook path.
+pub fn stats_for_commit_stats_from_hunks(
+    repo: &Repository,
+    commit_sha: &str,
+    ignore_patterns: &[String],
+    hunks: &[crate::commands::diff::DiffHunk],
+    authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
+) -> Result<CommitStats, GitAiError> {
+    let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
+    let parent_count = commit_obj.parent_count()?;
+    let is_merge_commit = parent_count > 1;
+
+    let ignore_matcher = build_ignore_matcher(ignore_patterns);
+
+    let mut git_diff_added_lines = 0u32;
+    let mut git_diff_deleted_lines = 0u32;
+    let mut added_lines_by_file: HashMap<String, Vec<u32>> = HashMap::new();
+
+    for hunk in hunks {
+        if should_ignore_file_with_matcher(&hunk.file_path, &ignore_matcher) {
+            continue;
+        }
+        git_diff_added_lines += hunk.added_lines.len() as u32;
+        git_diff_deleted_lines += hunk.deleted_lines.len() as u32;
+
+        if !is_merge_commit && !hunk.added_lines.is_empty() {
+            added_lines_by_file
+                .entry(hunk.file_path.clone())
+                .or_default()
+                .extend(hunk.added_lines.iter().copied());
+        }
+    }
+
+    for lines in added_lines_by_file.values_mut() {
+        lines.sort_unstable();
+        lines.dedup();
+    }
+
+    let (ai_accepted, known_human_accepted, ai_accepted_by_tool) =
+        accepted_lines_from_attestations(authorship_log, &added_lines_by_file, is_merge_commit);
+
+    Ok(stats_from_authorship_log(
+        authorship_log,
+        git_diff_added_lines,
+        git_diff_deleted_lines,
+        ai_accepted,
+        known_human_accepted,
+        &ai_accepted_by_tool,
+    ))
+}
+
 /// Get git diff statistics between commit and its parent
 /// Uses the same diff engine as git ai diff to properly handle renames
 pub fn get_git_diff_stats(

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1017,11 +1017,11 @@ fn build_line_attribution_from_note(
     }
 
     // Deleted lines: include with NoData attribution (no blame)
-    let deleted_lines_by_file = collect_lines_by_file(hunks, LineSide::Old);
-    for (file_path, lines) in &deleted_lines_by_file {
-        for line in lines {
+    // Use file_path (new name) for DiffLineKey to match build_json_hunk_segments lookup
+    for hunk in hunks {
+        for line in &hunk.deleted_lines {
             let key = DiffLineKey {
-                file: file_path.clone(),
+                file: hunk.file_path.clone(),
                 line: *line,
                 side: LineSide::Old,
             };

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1,4 +1,5 @@
 use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord, SessionRecord};
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
@@ -184,15 +185,15 @@ struct LineAttributionDetail {
 }
 
 #[derive(Debug)]
-struct DiffBuildArtifacts {
-    attributions: HashMap<DiffLineKey, Attribution>,
-    annotations_by_file: BTreeMap<String, BTreeMap<String, Vec<LineRange>>>,
-    prompts: BTreeMap<String, PromptRecord>,
-    sessions: BTreeMap<String, SessionRecord>,
-    humans: BTreeMap<String, HumanRecord>,
-    json_hunks: Vec<DiffJsonHunk>,
-    commits: BTreeMap<String, DiffCommitMetadata>,
-    included_files: HashSet<String>,
+pub struct DiffBuildArtifacts {
+    pub attributions: HashMap<DiffLineKey, Attribution>,
+    pub annotations_by_file: BTreeMap<String, BTreeMap<String, Vec<LineRange>>>,
+    pub prompts: BTreeMap<String, PromptRecord>,
+    pub sessions: BTreeMap<String, SessionRecord>,
+    pub humans: BTreeMap<String, HumanRecord>,
+    pub json_hunks: Vec<DiffJsonHunk>,
+    pub commits: BTreeMap<String, DiffCommitMetadata>,
+    pub included_files: HashSet<String>,
 }
 
 // ============================================================================
@@ -760,11 +761,21 @@ pub fn overlay_diff_attributions(
     Ok(attributions)
 }
 
-fn build_diff_artifacts(
+pub fn build_diff_artifacts(
     repo: &Repository,
     from_commit: &str,
     to_commit: &str,
     options: &DiffCommandOptions,
+) -> Result<DiffBuildArtifacts, GitAiError> {
+    build_diff_artifacts_with_note(repo, from_commit, to_commit, options, None)
+}
+
+pub fn build_diff_artifacts_with_note(
+    repo: &Repository,
+    from_commit: &str,
+    to_commit: &str,
+    options: &DiffCommandOptions,
+    authorship_log: Option<&AuthorshipLog>,
 ) -> Result<DiffBuildArtifacts, GitAiError> {
     let effective_patterns = effective_ignore_patterns(repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&effective_patterns);
@@ -786,7 +797,11 @@ fn build_diff_artifacts(
     let line_contents = build_line_content_map(&hunks);
 
     let (annotations_by_file, attributions, line_details, prompts, sessions, humans, mut commits) =
-        build_line_attribution_data(repo, from_commit, to_commit, &hunks, options)?;
+        if let Some(note) = authorship_log {
+            build_line_attribution_from_note(to_commit, &hunks, note)
+        } else {
+            build_line_attribution_data(repo, from_commit, to_commit, &hunks, options)?
+        };
 
     let json_hunks = build_json_hunks(
         repo,
@@ -890,6 +905,147 @@ fn build_line_attribution_data(
         humans,
         commits,
     ))
+}
+
+#[allow(clippy::type_complexity)]
+fn build_line_attribution_from_note(
+    to_commit: &str,
+    hunks: &[DiffHunk],
+    note: &AuthorshipLog,
+) -> (
+    BTreeMap<String, BTreeMap<String, Vec<LineRange>>>,
+    HashMap<DiffLineKey, Attribution>,
+    HashMap<DiffLineKey, LineAttributionDetail>,
+    BTreeMap<String, PromptRecord>,
+    BTreeMap<String, SessionRecord>,
+    BTreeMap<String, HumanRecord>,
+    BTreeMap<String, DiffCommitMetadata>,
+) {
+    let mut annotations_by_file: BTreeMap<String, BTreeMap<String, Vec<LineRange>>> =
+        BTreeMap::new();
+    let mut attributions: HashMap<DiffLineKey, Attribution> = HashMap::new();
+    let mut line_details: HashMap<DiffLineKey, LineAttributionDetail> = HashMap::new();
+    let prompts: BTreeMap<String, PromptRecord> = note.metadata.prompts.clone();
+    let sessions: BTreeMap<String, SessionRecord> = note.metadata.sessions.clone();
+    let humans: BTreeMap<String, HumanRecord> = note.metadata.humans.clone();
+    let commits: BTreeMap<String, DiffCommitMetadata> = BTreeMap::new();
+
+    let added_lines_by_file = collect_lines_by_file(hunks, LineSide::New);
+    for (file_path, lines) in &added_lines_by_file {
+        let file_attestation = note
+            .attestations
+            .iter()
+            .find(|fa| &fa.file_path == file_path);
+
+        let mut file_annotations: BTreeMap<String, Vec<LineRange>> = BTreeMap::new();
+
+        for line in lines {
+            let key = DiffLineKey {
+                file: file_path.clone(),
+                line: *line,
+                side: LineSide::New,
+            };
+
+            let mut found_hash: Option<&str> = None;
+            if let Some(fa) = file_attestation {
+                for entry in &fa.entries {
+                    if entry.line_ranges.iter().any(|r| r.contains(*line)) {
+                        found_hash = Some(&entry.hash);
+                        break;
+                    }
+                }
+            }
+
+            if let Some(hash) = found_hash {
+                let is_prompt = prompts.contains_key(hash) || hash.starts_with("s_");
+                let is_human = hash.starts_with("h_");
+
+                let (prompt_id, human_id, attribution) = if is_prompt {
+                    let tool = prompts
+                        .get(hash)
+                        .map(|p| p.agent_id.tool.clone())
+                        .unwrap_or_else(|| {
+                            let session_key = extract_session_id(hash);
+                            sessions
+                                .get(session_key)
+                                .map(|s| s.agent_id.tool.clone())
+                                .unwrap_or_else(|| "unknown".to_string())
+                        });
+                    (Some(hash.to_string()), None, Attribution::Ai(tool))
+                } else if is_human {
+                    (
+                        None,
+                        Some(hash.to_string()),
+                        Attribution::Human(hash.to_string()),
+                    )
+                } else {
+                    (None, None, Attribution::NoData)
+                };
+
+                if let Some(ref pid) = prompt_id {
+                    file_annotations
+                        .entry(pid.clone())
+                        .or_default()
+                        .push(LineRange::Single(*line));
+                }
+
+                attributions.insert(key.clone(), attribution);
+                line_details.insert(
+                    key,
+                    LineAttributionDetail {
+                        commit_sha: Some(to_commit.to_string()),
+                        prompt_id,
+                        human_id,
+                    },
+                );
+            } else {
+                attributions.insert(key.clone(), Attribution::NoData);
+                line_details.insert(
+                    key,
+                    LineAttributionDetail {
+                        commit_sha: Some(to_commit.to_string()),
+                        prompt_id: None,
+                        human_id: None,
+                    },
+                );
+            }
+        }
+
+        if !file_annotations.is_empty() {
+            annotations_by_file.insert(file_path.clone(), file_annotations);
+        }
+    }
+
+    // Deleted lines: include with NoData attribution (no blame)
+    let deleted_lines_by_file = collect_lines_by_file(hunks, LineSide::Old);
+    for (file_path, lines) in &deleted_lines_by_file {
+        for line in lines {
+            let key = DiffLineKey {
+                file: file_path.clone(),
+                line: *line,
+                side: LineSide::Old,
+            };
+            attributions.insert(key.clone(), Attribution::NoData);
+            line_details.insert(
+                key,
+                LineAttributionDetail {
+                    commit_sha: None,
+                    prompt_id: None,
+                    human_id: None,
+                },
+            );
+        }
+    }
+
+    (
+        annotations_by_file,
+        attributions,
+        line_details,
+        prompts,
+        sessions,
+        humans,
+        commits,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -777,6 +777,13 @@ pub fn build_diff_artifacts_with_note(
     options: &DiffCommandOptions,
     authorship_log: Option<&AuthorshipLog>,
 ) -> Result<DiffBuildArtifacts, GitAiError> {
+    let hunks = get_diff_with_line_numbers(repo, from_commit, to_commit)?;
+
+    if let Some(note) = authorship_log {
+        return build_diff_artifacts_from_hunks(repo, hunks, to_commit, Some(note));
+    }
+
+    // Slow path: no authorship log, needs blame
     let effective_patterns = effective_ignore_patterns(repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&effective_patterns);
     let diff_sections = get_diff_sections_by_file(repo, from_commit, to_commit)?;
@@ -788,7 +795,7 @@ pub fn build_diff_artifacts_with_note(
         })
         .collect();
 
-    let mut hunks = get_diff_with_line_numbers(repo, from_commit, to_commit)?;
+    let mut hunks = hunks;
     hunks.retain(|hunk| {
         !hunk.file_path.is_empty()
             && !should_ignore_file_with_matcher(&hunk.file_path, &ignore_matcher)
@@ -797,11 +804,7 @@ pub fn build_diff_artifacts_with_note(
     let line_contents = build_line_content_map(&hunks);
 
     let (annotations_by_file, attributions, line_details, prompts, sessions, humans, mut commits) =
-        if let Some(note) = authorship_log {
-            build_line_attribution_from_note(to_commit, &hunks, note)
-        } else {
-            build_line_attribution_data(repo, from_commit, to_commit, &hunks, options)?
-        };
+        build_line_attribution_data(repo, from_commit, to_commit, &hunks, options)?;
 
     let json_hunks = build_json_hunks(
         repo,

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -824,6 +824,63 @@ pub fn build_diff_artifacts_with_note(
     })
 }
 
+/// Build diff artifacts from pre-computed hunks, avoiding redundant git subprocess calls.
+/// Used by the post-commit hook path where the caller already has the hunks from a single
+/// `get_diff_with_line_numbers` call.
+pub fn build_diff_artifacts_from_hunks(
+    repo: &Repository,
+    hunks: Vec<DiffHunk>,
+    to_commit: &str,
+    authorship_log: Option<&AuthorshipLog>,
+) -> Result<DiffBuildArtifacts, GitAiError> {
+    let effective_patterns = effective_ignore_patterns(repo, &[], &[]);
+    let ignore_matcher = build_ignore_matcher(&effective_patterns);
+
+    let mut hunks = hunks;
+    hunks.retain(|hunk| {
+        !hunk.file_path.is_empty()
+            && !should_ignore_file_with_matcher(&hunk.file_path, &ignore_matcher)
+    });
+
+    let included_files: HashSet<String> = hunks.iter().map(|h| h.file_path.clone()).collect();
+    let line_contents = build_line_content_map(&hunks);
+
+    let (annotations_by_file, attributions, line_details, prompts, sessions, humans, mut commits) =
+        if let Some(note) = authorship_log {
+            build_line_attribution_from_note(to_commit, &hunks, note)
+        } else {
+            (
+                BTreeMap::new(),
+                HashMap::new(),
+                HashMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+                BTreeMap::new(),
+            )
+        };
+
+    let json_hunks = build_json_hunks(
+        repo,
+        &hunks,
+        &line_details,
+        &line_contents,
+        to_commit,
+        &mut commits,
+    )?;
+
+    Ok(DiffBuildArtifacts {
+        attributions,
+        annotations_by_file,
+        prompts,
+        sessions,
+        humans,
+        json_hunks,
+        commits,
+        included_files,
+    })
+}
+
 #[allow(clippy::type_complexity)]
 fn build_line_attribution_data(
     repo: &Repository,

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -27,6 +27,7 @@ pub mod committed_pos {
     pub const FIRST_CHECKPOINT_TS: usize = 10; // u64 (null if no checkpoints)
     pub const COMMIT_SUBJECT: usize = 11; // String
     pub const COMMIT_BODY: usize = 12; // String (null if empty)
+    pub const AUTHORSHIP_NOTE: usize = 13; // String (full serialized authorship note)
 }
 
 /// Values for Event ID 1: committed
@@ -53,6 +54,7 @@ pub mod committed_pos {
 /// | 10 | first_checkpoint_ts | u64 |
 /// | 11 | commit_subject | String |
 /// | 12 | commit_body | String |
+/// | 13 | authorship_note | String |
 #[derive(Debug, Clone, Default)]
 pub struct CommittedValues {
     // Scalar fields
@@ -69,6 +71,7 @@ pub struct CommittedValues {
     pub first_checkpoint_ts: PosField<u64>,
     pub commit_subject: PosField<String>,
     pub commit_body: PosField<String>,
+    pub authorship_note: PosField<String>,
 }
 
 impl CommittedValues {
@@ -177,6 +180,16 @@ impl CommittedValues {
         self.commit_body = Some(None);
         self
     }
+
+    pub fn authorship_note(mut self, value: impl Into<String>) -> Self {
+        self.authorship_note = Some(Some(value.into()));
+        self
+    }
+
+    pub fn authorship_note_null(mut self) -> Self {
+        self.authorship_note = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for CommittedValues {
@@ -233,6 +246,11 @@ impl PosEncoded for CommittedValues {
             committed_pos::COMMIT_BODY,
             string_to_json(&self.commit_body),
         );
+        sparse_set(
+            &mut map,
+            committed_pos::AUTHORSHIP_NOTE,
+            string_to_json(&self.authorship_note),
+        );
 
         map
     }
@@ -253,6 +271,7 @@ impl PosEncoded for CommittedValues {
             first_checkpoint_ts: sparse_get_u64(arr, committed_pos::FIRST_CHECKPOINT_TS),
             commit_subject: sparse_get_string(arr, committed_pos::COMMIT_SUBJECT),
             commit_body: sparse_get_string(arr, committed_pos::COMMIT_BODY),
+            authorship_note: sparse_get_string(arr, committed_pos::AUTHORSHIP_NOTE),
         }
     }
 }

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -28,6 +28,7 @@ pub mod committed_pos {
     pub const COMMIT_SUBJECT: usize = 11; // String
     pub const COMMIT_BODY: usize = 12; // String (null if empty)
     pub const AUTHORSHIP_NOTE: usize = 13; // String (full serialized authorship note)
+    pub const HUNKS: usize = 14; // String (JSON array of DiffJsonHunk)
 }
 
 /// Values for Event ID 1: committed
@@ -55,6 +56,7 @@ pub mod committed_pos {
 /// | 11 | commit_subject | String |
 /// | 12 | commit_body | String |
 /// | 13 | authorship_note | String |
+/// | 14 | hunks | String |
 #[derive(Debug, Clone, Default)]
 pub struct CommittedValues {
     // Scalar fields
@@ -72,6 +74,7 @@ pub struct CommittedValues {
     pub commit_subject: PosField<String>,
     pub commit_body: PosField<String>,
     pub authorship_note: PosField<String>,
+    pub hunks: PosField<String>,
 }
 
 impl CommittedValues {
@@ -190,6 +193,16 @@ impl CommittedValues {
         self.authorship_note = Some(None);
         self
     }
+
+    pub fn hunks(mut self, value: impl Into<String>) -> Self {
+        self.hunks = Some(Some(value.into()));
+        self
+    }
+
+    pub fn hunks_null(mut self) -> Self {
+        self.hunks = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for CommittedValues {
@@ -251,6 +264,7 @@ impl PosEncoded for CommittedValues {
             committed_pos::AUTHORSHIP_NOTE,
             string_to_json(&self.authorship_note),
         );
+        sparse_set(&mut map, committed_pos::HUNKS, string_to_json(&self.hunks));
 
         map
     }
@@ -272,6 +286,7 @@ impl PosEncoded for CommittedValues {
             commit_subject: sparse_get_string(arr, committed_pos::COMMIT_SUBJECT),
             commit_body: sparse_get_string(arr, committed_pos::COMMIT_BODY),
             authorship_note: sparse_get_string(arr, committed_pos::AUTHORSHIP_NOTE),
+            hunks: sparse_get_string(arr, committed_pos::HUNKS),
         }
     }
 }
@@ -798,6 +813,37 @@ mod tests {
             Some(Some("Test commit".to_string()))
         );
         assert_eq!(restored.commit_body, Some(None));
+    }
+
+    #[test]
+    fn test_committed_values_with_hunks() {
+        let hunks_json = r#"[{"commit_sha":"abc123","content_hash":"def456","hunk_kind":"addition","start_line":1,"end_line":5,"file_path":"src/main.rs"}]"#;
+        let values = CommittedValues::new().human_additions(10).hunks(hunks_json);
+
+        assert_eq!(values.hunks, Some(Some(hunks_json.to_string())));
+    }
+
+    #[test]
+    fn test_committed_values_hunks_null() {
+        let values = CommittedValues::new().hunks_null();
+        assert_eq!(values.hunks, Some(None));
+    }
+
+    #[test]
+    fn test_committed_values_hunks_roundtrip() {
+        use super::PosEncoded;
+
+        let hunks_json = r#"[{"commit_sha":"abc","content_hash":"def","hunk_kind":"addition","start_line":1,"end_line":3,"file_path":"test.rs"}]"#;
+        let original = CommittedValues::new().human_additions(5).hunks(hunks_json);
+
+        let sparse = PosEncoded::to_sparse(&original);
+        assert_eq!(
+            sparse.get("14"),
+            Some(&Value::String(hunks_json.to_string()))
+        );
+
+        let restored = <CommittedValues as PosEncoded>::from_sparse(&sparse);
+        assert_eq!(restored.hunks, Some(Some(hunks_json.to_string())));
     }
 
     #[test]

--- a/tests/commit_hunks.rs
+++ b/tests/commit_hunks.rs
@@ -1,0 +1,483 @@
+#[macro_use]
+#[path = "integration/repos/mod.rs"]
+mod repos;
+
+use git_ai::commands::diff::{DiffCommandOptions, DiffJsonHunk, build_diff_artifacts_with_note};
+use git_ai::git::repository::Repository as GitAiRepository;
+use repos::test_repo::TestRepo;
+use sha2::{Digest, Sha256};
+use std::fs;
+
+fn get_repo(test_repo: &TestRepo) -> GitAiRepository {
+    git_ai::git::find_repository_in_path(test_repo.path().to_str().unwrap())
+        .expect("Failed to find repository")
+}
+
+fn get_parent_sha(test_repo: &TestRepo) -> String {
+    match test_repo.git(&["rev-parse", "HEAD~1"]) {
+        Ok(sha) => sha.trim().to_string(),
+        // Initial commit has no parent - use empty tree
+        Err(_) => "4b825dc642cb6eb9a060e54bf8d69288fbee4904".to_string(),
+    }
+}
+
+fn compute_content_hash(lines: &[&str]) -> String {
+    let joined = lines.join("\n");
+    let mut hasher = Sha256::new();
+    hasher.update(joined.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[test]
+fn test_commit_hunks_basic_ai_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+
+    let content = "AI line 1\nAI line 2\nAI line 3\n";
+    fs::write(&file_path, content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+    let commit = repo.stage_all_and_commit("add AI lines").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    // Should have exactly one addition hunk (all lines same attribution)
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+    assert_eq!(addition_hunks.len(), 1);
+
+    let hunk = addition_hunks[0];
+    assert_eq!(hunk.file_path, "example.txt");
+    assert_eq!(hunk.hunk_kind, "addition");
+    assert_eq!(hunk.start_line, 1);
+    assert_eq!(hunk.end_line, 3);
+    assert_eq!(hunk.commit_sha, commit.commit_sha);
+
+    // Should have a prompt_id from the attestation
+    assert!(hunk.prompt_id.is_some());
+
+    // Content hash should match SHA256 of the 3 lines
+    let expected_hash = compute_content_hash(&["AI line 1", "AI line 2", "AI line 3"]);
+    assert_eq!(hunk.content_hash, expected_hash);
+
+    // No deletion hunks
+    let deletion_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "deletion")
+        .collect();
+    assert_eq!(deletion_hunks.len(), 0);
+}
+
+#[test]
+fn test_commit_hunks_mixed_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("mixed.txt");
+
+    // First: human writes lines
+    let human_content = "Human line 1\nHuman line 2\n";
+    fs::write(&file_path, human_content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "mixed.txt"])
+        .unwrap();
+
+    // Then: AI adds lines after
+    let mixed_content = "Human line 1\nHuman line 2\nAI line 1\nAI line 2\n";
+    fs::write(&file_path, mixed_content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "mixed.txt"])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("mixed commit").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    // Should have 2 hunks: human (lines 1-2) and AI (lines 3-4)
+    assert_eq!(addition_hunks.len(), 2);
+
+    // First hunk: human lines
+    let human_hunk = &addition_hunks[0];
+    assert_eq!(human_hunk.file_path, "mixed.txt");
+    assert_eq!(human_hunk.start_line, 1);
+    assert_eq!(human_hunk.end_line, 2);
+    assert!(human_hunk.human_id.is_some());
+    assert!(human_hunk.prompt_id.is_none());
+
+    // Second hunk: AI lines
+    let ai_hunk = &addition_hunks[1];
+    assert_eq!(ai_hunk.file_path, "mixed.txt");
+    assert_eq!(ai_hunk.start_line, 3);
+    assert_eq!(ai_hunk.end_line, 4);
+    assert!(ai_hunk.prompt_id.is_some());
+    assert!(ai_hunk.human_id.is_none());
+
+    // Content hashes
+    let human_hash = compute_content_hash(&["Human line 1", "Human line 2"]);
+    assert_eq!(human_hunk.content_hash, human_hash);
+
+    let ai_hash = compute_content_hash(&["AI line 1", "AI line 2"]);
+    assert_eq!(ai_hunk.content_hash, ai_hash);
+}
+
+#[test]
+fn test_commit_hunks_multiple_files() {
+    let repo = TestRepo::new();
+
+    let file_a = repo.path().join("a.txt");
+    let file_b = repo.path().join("b.txt");
+
+    fs::write(&file_a, "A line 1\nA line 2\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+
+    fs::write(&file_b, "B line 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "b.txt"])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("multi-file commit").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    assert_eq!(addition_hunks.len(), 2);
+
+    let a_hunk = addition_hunks
+        .iter()
+        .find(|h| h.file_path == "a.txt")
+        .unwrap();
+    assert_eq!(a_hunk.start_line, 1);
+    assert_eq!(a_hunk.end_line, 2);
+    assert!(a_hunk.prompt_id.is_some());
+
+    let b_hunk = addition_hunks
+        .iter()
+        .find(|h| h.file_path == "b.txt")
+        .unwrap();
+    assert_eq!(b_hunk.start_line, 1);
+    assert_eq!(b_hunk.end_line, 1);
+    assert!(b_hunk.human_id.is_some());
+}
+
+#[test]
+fn test_commit_hunks_deletions_unattributed() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("deleteme.txt");
+
+    // Initial commit with content
+    fs::write(&file_path, "Line 1\nLine 2\nLine 3\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "deleteme.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    // Second commit: delete a line
+    fs::write(&file_path, "Line 1\nLine 3\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "deleteme.txt"])
+        .unwrap();
+    let commit = repo.stage_all_and_commit("delete line 2").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let deletion_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "deletion")
+        .collect();
+
+    assert_eq!(deletion_hunks.len(), 1);
+    let del_hunk = deletion_hunks[0];
+    assert_eq!(del_hunk.file_path, "deleteme.txt");
+    assert_eq!(del_hunk.hunk_kind, "deletion");
+    assert_eq!(del_hunk.start_line, 2);
+    assert_eq!(del_hunk.end_line, 2);
+    // Deletions are not attributed
+    assert!(del_hunk.prompt_id.is_none());
+    assert!(del_hunk.human_id.is_none());
+    assert!(del_hunk.original_commit_sha.is_none());
+}
+
+#[test]
+fn test_commit_hunks_consecutive_same_attribution_merges() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("merge.txt");
+
+    // 10 consecutive AI lines should merge into one hunk
+    let content = (1..=10)
+        .map(|i| format!("AI line {}", i))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    fs::write(&file_path, &content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "merge.txt"])
+        .unwrap();
+    let commit = repo.stage_all_and_commit("consecutive AI lines").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    // All same attribution => single hunk
+    assert_eq!(addition_hunks.len(), 1);
+    assert_eq!(addition_hunks[0].start_line, 1);
+    assert_eq!(addition_hunks[0].end_line, 10);
+}
+
+#[test]
+fn test_commit_hunks_attribution_boundaries_split() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("split.txt");
+
+    // Untracked line first
+    fs::write(&file_path, "Untracked\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "split.txt"]).unwrap();
+
+    // Then AI adds
+    fs::write(&file_path, "Untracked\nAI added\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "split.txt"])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("boundary split").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    // Untracked and AI should be separate hunks
+    assert_eq!(addition_hunks.len(), 2);
+
+    // First hunk: untracked (no prompt_id, no human_id)
+    assert_eq!(addition_hunks[0].start_line, 1);
+    assert_eq!(addition_hunks[0].end_line, 1);
+    assert!(addition_hunks[0].prompt_id.is_none());
+    assert!(addition_hunks[0].human_id.is_none());
+
+    // Second hunk: AI
+    assert_eq!(addition_hunks[1].start_line, 2);
+    assert_eq!(addition_hunks[1].end_line, 2);
+    assert!(addition_hunks[1].prompt_id.is_some());
+}
+
+#[test]
+fn test_commit_hunks_session_id_extraction() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("session.txt");
+
+    fs::write(&file_path, "Session line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "session.txt"])
+        .unwrap();
+    let commit = repo.stage_all_and_commit("session test").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    assert_eq!(addition_hunks.len(), 1);
+    let hunk = addition_hunks[0];
+
+    // The mock_ai preset uses session-format attestation hashes (s_ prefix)
+    // If prompt_id starts with s_, session_id should be extracted
+    if let Some(ref pid) = hunk.prompt_id
+        && pid.starts_with("s_")
+    {
+        assert!(hunk.session_id.is_some());
+        let sid = hunk.session_id.as_ref().unwrap();
+        assert!(pid.starts_with(sid));
+    }
+}
+
+#[test]
+fn test_commit_hunks_empty_diff() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("empty.txt");
+
+    // Create file in initial commit
+    fs::write(&file_path, "content\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "empty.txt"])
+        .unwrap();
+    let first = repo.stage_all_and_commit("first").unwrap();
+
+    // Make same content commit (empty diff) by using allow-empty
+    repo.git(&["commit", "--allow-empty", "-m", "empty"])
+        .unwrap();
+    let commit_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    let git_repo = get_repo(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &first.commit_sha,
+        &commit_sha,
+        &DiffCommandOptions::default(),
+        None, // no authorship log for empty commit
+    )
+    .unwrap();
+
+    assert_eq!(artifacts.json_hunks.len(), 0);
+}
+
+#[test]
+fn test_commit_hunks_content_hash_correctness() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("hash_test.txt");
+
+    let lines = ["first line", "second line", "third line"];
+    let content = lines.join("\n") + "\n";
+    fs::write(&file_path, &content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "hash_test.txt"])
+        .unwrap();
+    let commit = repo.stage_all_and_commit("hash test").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    assert_eq!(addition_hunks.len(), 1);
+    let hunk = addition_hunks[0];
+
+    // Manually compute expected hash
+    let expected_hash = compute_content_hash(&["first line", "second line", "third line"]);
+    assert_eq!(hunk.content_hash, expected_hash);
+}
+
+#[test]
+fn test_commit_hunks_interleaved_attributions() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("interleaved.txt");
+
+    // Human writes line 1
+    fs::write(&file_path, "Human 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "interleaved.txt"])
+        .unwrap();
+
+    // AI adds lines 2-3
+    fs::write(&file_path, "Human 1\nAI 1\nAI 2\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "interleaved.txt"])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("interleaved").unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let artifacts = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let addition_hunks: Vec<&DiffJsonHunk> = artifacts
+        .json_hunks
+        .iter()
+        .filter(|h| h.hunk_kind == "addition")
+        .collect();
+
+    // Human hunk (line 1) + AI hunk (lines 2-3)
+    assert_eq!(addition_hunks.len(), 2);
+
+    assert_eq!(addition_hunks[0].start_line, 1);
+    assert_eq!(addition_hunks[0].end_line, 1);
+    assert!(addition_hunks[0].human_id.is_some());
+
+    assert_eq!(addition_hunks[1].start_line, 2);
+    assert_eq!(addition_hunks[1].end_line, 3);
+    assert!(addition_hunks[1].prompt_id.is_some());
+}

--- a/tests/commit_hunks.rs
+++ b/tests/commit_hunks.rs
@@ -4,6 +4,7 @@ mod repos;
 
 use git_ai::commands::diff::{DiffCommandOptions, DiffJsonHunk, build_diff_artifacts_with_note};
 use git_ai::git::repository::Repository as GitAiRepository;
+use repos::test_file::ExpectedLineExt;
 use repos::test_repo::TestRepo;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -38,6 +39,9 @@ fn test_commit_hunks_basic_ai_attribution() {
     repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
         .unwrap();
     let commit = repo.stage_all_and_commit("add AI lines").unwrap();
+
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(lines!["AI line 1".ai(), "AI line 2".ai(), "AI line 3".ai()]);
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
@@ -100,6 +104,14 @@ fn test_commit_hunks_mixed_attribution() {
 
     let commit = repo.stage_all_and_commit("mixed commit").unwrap();
 
+    let mut file = repo.filename("mixed.txt");
+    file.assert_committed_lines(lines![
+        "Human line 1".human(),
+        "Human line 2".human(),
+        "AI line 1".ai(),
+        "AI line 2".ai()
+    ]);
+
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
     let artifacts = build_diff_artifacts_with_note(
@@ -160,6 +172,11 @@ fn test_commit_hunks_multiple_files() {
 
     let commit = repo.stage_all_and_commit("multi-file commit").unwrap();
 
+    let mut file_a_test = repo.filename("a.txt");
+    file_a_test.assert_committed_lines(lines!["A line 1".ai(), "A line 2".ai()]);
+    let mut file_b_test = repo.filename("b.txt");
+    file_b_test.assert_committed_lines(lines!["B line 1".human()]);
+
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
     let artifacts = build_diff_artifacts_with_note(
@@ -207,11 +224,16 @@ fn test_commit_hunks_deletions_unattributed() {
         .unwrap();
     repo.stage_all_and_commit("initial").unwrap();
 
+    let mut file = repo.filename("deleteme.txt");
+    file.assert_committed_lines(lines!["Line 1".ai(), "Line 2".ai(), "Line 3".ai()]);
+
     // Second commit: delete a line
     fs::write(&file_path, "Line 1\nLine 3\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "deleteme.txt"])
         .unwrap();
     let commit = repo.stage_all_and_commit("delete line 2").unwrap();
+
+    file.assert_committed_lines(lines!["Line 1".ai(), "Line 3".ai()]);
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
@@ -258,6 +280,20 @@ fn test_commit_hunks_consecutive_same_attribution_merges() {
         .unwrap();
     let commit = repo.stage_all_and_commit("consecutive AI lines").unwrap();
 
+    let mut file = repo.filename("merge.txt");
+    file.assert_committed_lines(lines![
+        "AI line 1".ai(),
+        "AI line 2".ai(),
+        "AI line 3".ai(),
+        "AI line 4".ai(),
+        "AI line 5".ai(),
+        "AI line 6".ai(),
+        "AI line 7".ai(),
+        "AI line 8".ai(),
+        "AI line 9".ai(),
+        "AI line 10".ai()
+    ]);
+
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
     let artifacts = build_diff_artifacts_with_note(
@@ -296,6 +332,9 @@ fn test_commit_hunks_attribution_boundaries_split() {
         .unwrap();
 
     let commit = repo.stage_all_and_commit("boundary split").unwrap();
+
+    let mut file = repo.filename("split.txt");
+    file.assert_committed_lines(lines!["Untracked".unattributed_human(), "AI added".ai()]);
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
@@ -339,6 +378,9 @@ fn test_commit_hunks_session_id_extraction() {
         .unwrap();
     let commit = repo.stage_all_and_commit("session test").unwrap();
 
+    let mut file = repo.filename("session.txt");
+    file.assert_committed_lines(lines!["Session line".ai()]);
+
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
     let artifacts = build_diff_artifacts_with_note(
@@ -381,6 +423,9 @@ fn test_commit_hunks_empty_diff() {
         .unwrap();
     let first = repo.stage_all_and_commit("first").unwrap();
 
+    let mut file = repo.filename("empty.txt");
+    file.assert_committed_lines(lines!["content".ai()]);
+
     // Make same content commit (empty diff) by using allow-empty
     repo.git(&["commit", "--allow-empty", "-m", "empty"])
         .unwrap();
@@ -410,6 +455,13 @@ fn test_commit_hunks_content_hash_correctness() {
     repo.git_ai(&["checkpoint", "mock_ai", "hash_test.txt"])
         .unwrap();
     let commit = repo.stage_all_and_commit("hash test").unwrap();
+
+    let mut file = repo.filename("hash_test.txt");
+    file.assert_committed_lines(lines![
+        "first line".ai(),
+        "second line".ai(),
+        "third line".ai()
+    ]);
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
@@ -452,6 +504,9 @@ fn test_commit_hunks_interleaved_attributions() {
         .unwrap();
 
     let commit = repo.stage_all_and_commit("interleaved").unwrap();
+
+    let mut file = repo.filename("interleaved.txt");
+    file.assert_committed_lines(lines!["Human 1".human(), "AI 1".ai(), "AI 2".ai()]);
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);

--- a/tests/commit_hunks.rs
+++ b/tests/commit_hunks.rs
@@ -2,7 +2,10 @@
 #[path = "integration/repos/mod.rs"]
 mod repos;
 
-use git_ai::commands::diff::{DiffCommandOptions, DiffJsonHunk, build_diff_artifacts_with_note};
+use git_ai::commands::diff::{
+    DiffCommandOptions, DiffJsonHunk, build_diff_artifacts_from_hunks,
+    build_diff_artifacts_with_note, get_diff_with_line_numbers,
+};
 use git_ai::git::repository::Repository as GitAiRepository;
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::TestRepo;
@@ -45,11 +48,14 @@ fn test_commit_hunks_basic_ai_attribution() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+
+    // Use build_diff_artifacts_from_hunks (the optimized post-commit path)
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -83,6 +89,31 @@ fn test_commit_hunks_basic_ai_attribution() {
         .filter(|h| h.hunk_kind == "deletion")
         .collect();
     assert_eq!(deletion_hunks.len(), 0);
+
+    // Verify parity with build_diff_artifacts_with_note
+    let artifacts_old = build_diff_artifacts_with_note(
+        &git_repo,
+        &parent_sha,
+        &commit.commit_sha,
+        &DiffCommandOptions::default(),
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+    assert_eq!(artifacts.json_hunks.len(), artifacts_old.json_hunks.len());
+    for (a, b) in artifacts
+        .json_hunks
+        .iter()
+        .zip(artifacts_old.json_hunks.iter())
+    {
+        assert_eq!(a.file_path, b.file_path);
+        assert_eq!(a.hunk_kind, b.hunk_kind);
+        assert_eq!(a.start_line, b.start_line);
+        assert_eq!(a.end_line, b.end_line);
+        assert_eq!(a.content_hash, b.content_hash);
+        assert_eq!(a.prompt_id, b.prompt_id);
+        assert_eq!(a.human_id, b.human_id);
+        assert_eq!(a.commit_sha, b.commit_sha);
+    }
 }
 
 #[test]
@@ -114,11 +145,12 @@ fn test_commit_hunks_mixed_attribution() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -179,11 +211,12 @@ fn test_commit_hunks_multiple_files() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -237,11 +270,12 @@ fn test_commit_hunks_deletions_unattributed() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -296,11 +330,12 @@ fn test_commit_hunks_consecutive_same_attribution_merges() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -338,11 +373,12 @@ fn test_commit_hunks_attribution_boundaries_split() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -383,11 +419,12 @@ fn test_commit_hunks_session_id_extraction() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -432,11 +469,11 @@ fn test_commit_hunks_empty_diff() {
     let commit_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
 
     let git_repo = get_repo(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks = get_diff_with_line_numbers(&git_repo, &first.commit_sha, &commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &first.commit_sha,
+        diff_hunks,
         &commit_sha,
-        &DiffCommandOptions::default(),
         None, // no authorship log for empty commit
     )
     .unwrap();
@@ -465,11 +502,12 @@ fn test_commit_hunks_content_hash_correctness() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();
@@ -510,11 +548,12 @@ fn test_commit_hunks_interleaved_attributions() {
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
-    let artifacts = build_diff_artifacts_with_note(
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+    let artifacts = build_diff_artifacts_from_hunks(
         &git_repo,
-        &parent_sha,
+        diff_hunks,
         &commit.commit_sha,
-        &DiffCommandOptions::default(),
         Some(&commit.authorship_log),
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- Adds `authorship_note` string field at position 13 on the committed metric event — contains the full serialized authorship note (attestation section + divider + JSON metadata)
- Adds `hunks` string field at position 14 — JSON array of `DiffJsonHunk` objects matching the same structure used by `git-ai diff --json` and consumed by monorepo-artisan
- Optimizes single-commit diffs via `build_diff_artifacts_with_note` which resolves attribution from the authorship note directly (no git blame needed)
- Deleted hunks are included but not attributed (no blame for deletions)
- Renames `authorship_json` variable to `authorship_note_str` for accuracy

## Test plan
- [x] `task build` passes
- [x] `task lint` passes
- [x] `task fmt` passes
- [x] 10 new E2E tests in `tests/commit_hunks.rs` covering: basic AI attribution, mixed attribution, multiple files, deletions unattributed, consecutive merge, attribution boundary split, session ID extraction, empty diff, content hash correctness, interleaved attributions
- [x] 3 new unit tests for hunks metric field (builder, null, roundtrip)
- [ ] Full CI test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)