### PR TITLE
chore(authorship): remove dead LineRange::overlaps and CheckpointKind::from_str

### DIFF
--- a/src/authorship/authorship_log.rs
+++ b/src/authorship/authorship_log.rs
@@ -24,20 +24,7 @@ impl LineRange {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn overlaps(&self, other: &LineRange) -> bool {
-        match (self, other) {
-            (LineRange::Single(l1), LineRange::Single(l2)) => l1 == l2,
-            (LineRange::Single(l), LineRange::Range(start, end)) => *l >= *start && *l <= *end,
-            (LineRange::Range(start, end), LineRange::Single(l)) => *l >= *start && *l <= *end,
-            (LineRange::Range(start1, end1), LineRange::Range(start2, end2)) => {
-                start1 <= end2 && start2 <= end1
-            }
-        }
-    }
-
     /// Remove a line or range from this range, returning the remaining parts
-    #[allow(dead_code)]
     pub fn remove(&self, to_remove: &LineRange) -> Vec<LineRange> {
         match (self, to_remove) {
             (LineRange::Single(l), LineRange::Single(r)) => {
@@ -125,7 +112,6 @@ impl LineRange {
         ranges
     }
 
-    #[allow(dead_code)]
     pub fn expand(&self) -> Vec<u32> {
         match self {
             LineRange::Single(l) => vec![*l],
@@ -137,7 +123,6 @@ impl LineRange {
     /// - For insertions: offset is positive (shift lines down/forward)
     /// - For deletions: offset is negative (shift lines up/backward)
     /// - insertion_point: the line number where the change occurred
-    #[allow(dead_code)]
     pub fn shift(&self, insertion_point: u32, offset: i32) -> Option<LineRange> {
         // Helper: apply offset to a line number, returning None if result is negative
         let apply_offset = |line: u32| -> Option<u32> {

--- a/src/authorship/working_log.rs
+++ b/src/authorship/working_log.rs
@@ -60,18 +60,6 @@ impl fmt::Display for CheckpointKind {
 }
 
 impl CheckpointKind {
-    #[allow(dead_code)]
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
-        match s {
-            "human" => CheckpointKind::Human,
-            "ai_agent" => CheckpointKind::AiAgent,
-            "ai_tab" => CheckpointKind::AiTab,
-            "known_human" => CheckpointKind::KnownHuman,
-            _ => panic!("Invalid checkpoint kind: {}", s),
-        }
-    }
-
     #[allow(clippy::wrong_self_convention)]
     pub fn to_str(&self) -> String {
         match self {
@@ -254,10 +242,6 @@ mod tests {
     fn test_checkpoint_kind_known_human_roundtrip() {
         let kind = CheckpointKind::KnownHuman;
         assert_eq!(kind.to_str(), "known_human");
-        assert_eq!(
-            CheckpointKind::from_str("known_human"),
-            CheckpointKind::KnownHuman
-        );
         // Serde round-trip
         let json = serde_json::to_string(&kind).unwrap();
         let back: CheckpointKind = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

LineRange::overlaps had zero callers — all .overlaps() calls in the codebase target LineAttribution::overlaps(u32,u32) or Attribution::overlaps(usize,usize) which have different signatures. CheckpointKind::from_str was unreachable; checkpoint kinds are matched via serde deserialization.

## Test plan
- [x] `task build` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->