### PR TITLE
chore(authorship): remove dead VirtualAttributions::add_pathspec

### DIFF
--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -243,12 +243,6 @@ impl VirtualAttributions {
         )))
     }
 
-    /// Add a single pathspec to the virtual attributions
-    #[allow(dead_code)]
-    pub async fn add_pathspec(&mut self, pathspec: &str) -> Result<(), GitAiError> {
-        self.add_pathspecs_concurrent(&[pathspec.to_string()]).await
-    }
-
     /// Add multiple pathspecs concurrently
     async fn add_pathspecs_concurrent(&mut self, pathspecs: &[String]) -> Result<(), GitAiError> {
         const MAX_CONCURRENT: usize = 30;
@@ -306,7 +300,6 @@ impl VirtualAttributions {
     }
 
     /// Get both character and line attributions for a file
-    #[allow(dead_code)]
     pub fn get_attributions(
         &self,
         file_path: &str,


### PR DESCRIPTION
## Summary

add_pathspec was a thin wrapper around add_pathspecs_concurrent with zero callers — all call sites use the concurrent variant directly. Also removes the now-unnecessary #[allow(dead_code)] suppression from get_attributions which has active callers in integration tests.

## Test plan
- [x] `task build` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->