### PR TITLE
chore(metrics): remove dead null-setter builder methods

### DIFF
--- a/src/metrics/attrs.rs
+++ b/src/metrics/attrs.rs
@@ -62,11 +62,6 @@ pub struct EventAttributes {
 }
 
 impl EventAttributes {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Create with required git_ai_version field set.
     pub fn with_version(version: impl Into<String>) -> Self {
         Self {
@@ -75,28 +70,9 @@ impl EventAttributes {
         }
     }
 
-    // Builder methods for git_ai_version
-    #[allow(dead_code)]
-    pub fn git_ai_version(mut self, value: impl Into<String>) -> Self {
-        self.git_ai_version = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn git_ai_version_null(mut self) -> Self {
-        self.git_ai_version = Some(None);
-        self
-    }
-
     // Builder methods for repo_url
     pub fn repo_url(mut self, value: impl Into<String>) -> Self {
         self.repo_url = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn repo_url_null(mut self) -> Self {
-        self.repo_url = Some(None);
         self
     }
 
@@ -106,21 +82,9 @@ impl EventAttributes {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn author_null(mut self) -> Self {
-        self.author = Some(None);
-        self
-    }
-
     // Builder methods for commit_sha
     pub fn commit_sha(mut self, value: impl Into<String>) -> Self {
         self.commit_sha = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn commit_sha_null(mut self) -> Self {
-        self.commit_sha = Some(None);
         self
     }
 
@@ -130,21 +94,9 @@ impl EventAttributes {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn base_commit_sha_null(mut self) -> Self {
-        self.base_commit_sha = Some(None);
-        self
-    }
-
     // Builder methods for branch
     pub fn branch(mut self, value: impl Into<String>) -> Self {
         self.branch = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn branch_null(mut self) -> Self {
-        self.branch = Some(None);
         self
     }
 
@@ -154,21 +106,9 @@ impl EventAttributes {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn tool_null(mut self) -> Self {
-        self.tool = Some(None);
-        self
-    }
-
     // Builder methods for model
     pub fn model(mut self, value: impl Into<String>) -> Self {
         self.model = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn model_null(mut self) -> Self {
-        self.model = Some(None);
         self
     }
 
@@ -180,21 +120,9 @@ impl EventAttributes {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn session_id_null(mut self) -> Self {
-        self.session_id = Some(None);
-        self
-    }
-
     // Builder methods for trace_id
     pub fn trace_id(mut self, value: impl Into<String>) -> Self {
         self.trace_id = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn trace_id_null(mut self) -> Self {
-        self.trace_id = Some(None);
         self
     }
 
@@ -217,12 +145,6 @@ impl EventAttributes {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn external_session_id_null(mut self) -> Self {
-        self.external_session_id = Some(None);
-        self
-    }
-
     pub fn external_session_id_opt(self, value: Option<String>) -> Self {
         match value {
             Some(v) => self.external_session_id(v),
@@ -236,12 +158,6 @@ impl EventAttributes {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn external_parent_session_id_null(mut self) -> Self {
-        self.external_parent_session_id = Some(None);
-        self
-    }
-
     pub fn external_parent_session_id_opt(self, value: Option<String>) -> Self {
         match value {
             Some(v) => self.external_parent_session_id(v),
@@ -252,12 +168,6 @@ impl EventAttributes {
     // Builder methods for custom_attributes
     pub fn custom_attributes(mut self, value: impl Into<String>) -> Self {
         self.custom_attributes = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn custom_attributes_null(mut self) -> Self {
-        self.custom_attributes = Some(None);
         self
     }
 
@@ -363,8 +273,7 @@ mod tests {
             .commit_sha("commit-123")
             .base_commit_sha("base-commit-123")
             .branch("main")
-            .tool("claude-code")
-            .model_null();
+            .tool("claude-code");
 
         assert_eq!(attrs.git_ai_version, Some(Some("1.0.0".to_string())));
         assert_eq!(
@@ -379,15 +288,13 @@ mod tests {
         );
         assert_eq!(attrs.branch, Some(Some("main".to_string())));
         assert_eq!(attrs.tool, Some(Some("claude-code".to_string())));
-        assert_eq!(attrs.model, Some(None)); // explicitly null
+        assert_eq!(attrs.model, None);
         assert_eq!(attrs.prompt_id, None); // tombstoned - never written
     }
 
     #[test]
     fn test_event_attributes_to_sparse() {
-        let attrs = EventAttributes::with_version("1.0.0")
-            .tool("test-tool")
-            .model_null();
+        let attrs = EventAttributes::with_version("1.0.0").tool("test-tool");
 
         let sparse = attrs.to_sparse();
 
@@ -401,7 +308,7 @@ mod tests {
             sparse.get("20"),
             Some(&Value::String("test-tool".to_string()))
         );
-        assert_eq!(sparse.get("21"), Some(&Value::Null)); // explicitly null
+        assert_eq!(sparse.get("21"), None); // not set
         assert_eq!(sparse.get("22"), None); // tombstoned - never written
     }
 
@@ -448,31 +355,6 @@ mod tests {
         assert_eq!(attrs.model, Some(Some("gpt-4".to_string())));
         assert_eq!(attrs.prompt_id, None); // tombstoned
         assert_eq!(attrs.external_session_id, Some(Some("ext-789".to_string())));
-    }
-
-    #[test]
-    fn test_event_attributes_all_nulls() {
-        let attrs = EventAttributes::new()
-            .git_ai_version_null()
-            .repo_url_null()
-            .author_null()
-            .commit_sha_null()
-            .base_commit_sha_null()
-            .branch_null()
-            .tool_null()
-            .model_null()
-            .external_session_id_null();
-
-        assert_eq!(attrs.git_ai_version, Some(None));
-        assert_eq!(attrs.repo_url, Some(None));
-        assert_eq!(attrs.author, Some(None));
-        assert_eq!(attrs.commit_sha, Some(None));
-        assert_eq!(attrs.base_commit_sha, Some(None));
-        assert_eq!(attrs.branch, Some(None));
-        assert_eq!(attrs.tool, Some(None));
-        assert_eq!(attrs.model, Some(None));
-        assert_eq!(attrs.prompt_id, None); // tombstoned - no setter available
-        assert_eq!(attrs.external_session_id, Some(None));
     }
 
     #[test]
@@ -523,7 +405,6 @@ mod tests {
     fn test_event_attributes_roundtrip() {
         let original = EventAttributes::with_version("2.5.0")
             .repo_url("https://gitlab.com/org/repo")
-            .author_null()
             .commit_sha("sha123")
             .tool("copilot");
 
@@ -535,7 +416,7 @@ mod tests {
             restored.repo_url,
             Some(Some("https://gitlab.com/org/repo".to_string()))
         );
-        assert_eq!(restored.author, Some(None)); // explicitly null
+        assert_eq!(restored.author, None); // not set
         assert_eq!(restored.commit_sha, Some(Some("sha123".to_string())));
         assert_eq!(restored.tool, Some(Some("copilot".to_string())));
         assert_eq!(restored.base_commit_sha, None); // not set
@@ -574,12 +455,6 @@ mod tests {
     }
 
     #[test]
-    fn test_event_attributes_git_ai_version_builder() {
-        let attrs = EventAttributes::new().git_ai_version("4.0.0");
-        assert_eq!(attrs.git_ai_version, Some(Some("4.0.0".to_string())));
-    }
-
-    #[test]
     fn test_event_attributes_sparse_positions() {
         // Verify the position constants match expected values
         use super::attr_pos::*;
@@ -606,16 +481,6 @@ mod tests {
 
         assert_eq!(attrs.session_id, Some(Some("session-123".to_string())));
         assert_eq!(attrs.trace_id, Some(Some("trace-456".to_string())));
-    }
-
-    #[test]
-    fn test_event_attributes_session_id_null() {
-        let attrs = EventAttributes::with_version("1.0.0")
-            .session_id_null()
-            .trace_id_null();
-
-        assert_eq!(attrs.session_id, Some(None));
-        assert_eq!(attrs.trace_id, Some(None));
     }
 
     #[test]
@@ -654,25 +519,6 @@ mod tests {
         assert_eq!(attrs.git_ai_version, Some(Some("2.0.0".to_string())));
         assert_eq!(attrs.session_id, Some(Some("session-123".to_string())));
         assert_eq!(attrs.trace_id, Some(None)); // null
-    }
-
-    #[test]
-    fn test_event_attributes_roundtrip_with_session_fields() {
-        let original = EventAttributes::with_version("2.5.0")
-            .session_id("session-roundtrip")
-            .trace_id_null()
-            .tool("copilot");
-
-        let sparse = original.to_sparse();
-        let restored = EventAttributes::from_sparse(&sparse);
-
-        assert_eq!(restored.git_ai_version, Some(Some("2.5.0".to_string())));
-        assert_eq!(
-            restored.session_id,
-            Some(Some("session-roundtrip".to_string()))
-        );
-        assert_eq!(restored.trace_id, Some(None)); // explicitly null
-        assert_eq!(restored.tool, Some(Some("copilot".to_string())));
     }
 
     #[test]

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -89,31 +89,13 @@ impl CommittedValues {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn human_additions_null(mut self) -> Self {
-        self.human_additions = Some(None);
-        self
-    }
-
     pub fn git_diff_deleted_lines(mut self, value: u32) -> Self {
         self.git_diff_deleted_lines = Some(Some(value));
         self
     }
 
-    #[allow(dead_code)]
-    pub fn git_diff_deleted_lines_null(mut self) -> Self {
-        self.git_diff_deleted_lines = Some(None);
-        self
-    }
-
     pub fn git_diff_added_lines(mut self, value: u32) -> Self {
         self.git_diff_added_lines = Some(Some(value));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn git_diff_added_lines_null(mut self) -> Self {
-        self.git_diff_added_lines = Some(None);
         self
     }
 
@@ -124,31 +106,13 @@ impl CommittedValues {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn tool_model_pairs_null(mut self) -> Self {
-        self.tool_model_pairs = Some(None);
-        self
-    }
-
     pub fn ai_additions(mut self, value: Vec<u32>) -> Self {
         self.ai_additions = Some(Some(value));
         self
     }
 
-    #[allow(dead_code)]
-    pub fn ai_additions_null(mut self) -> Self {
-        self.ai_additions = Some(None);
-        self
-    }
-
     pub fn ai_accepted(mut self, value: Vec<u32>) -> Self {
         self.ai_accepted = Some(Some(value));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn ai_accepted_null(mut self) -> Self {
-        self.ai_accepted = Some(None);
         self
     }
 
@@ -494,20 +458,8 @@ impl CheckpointValues {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn checkpoint_ts_null(mut self) -> Self {
-        self.checkpoint_ts = Some(None);
-        self
-    }
-
     pub fn kind(mut self, value: impl Into<String>) -> Self {
         self.kind = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn kind_null(mut self) -> Self {
-        self.kind = Some(None);
         self
     }
 
@@ -516,20 +468,8 @@ impl CheckpointValues {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn file_path_null(mut self) -> Self {
-        self.file_path = Some(None);
-        self
-    }
-
     pub fn lines_added(mut self, value: u32) -> Self {
         self.lines_added = Some(Some(value));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn lines_added_null(mut self) -> Self {
-        self.lines_added = Some(None);
         self
     }
 
@@ -538,20 +478,8 @@ impl CheckpointValues {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn lines_deleted_null(mut self) -> Self {
-        self.lines_deleted = Some(None);
-        self
-    }
-
     pub fn lines_added_sloc(mut self, value: u32) -> Self {
         self.lines_added_sloc = Some(Some(value));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn lines_added_sloc_null(mut self) -> Self {
-        self.lines_added_sloc = Some(None);
         self
     }
 
@@ -560,31 +488,13 @@ impl CheckpointValues {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn lines_deleted_sloc_null(mut self) -> Self {
-        self.lines_deleted_sloc = Some(None);
-        self
-    }
-
     pub fn external_tool_use_id(mut self, value: impl Into<String>) -> Self {
         self.external_tool_use_id = Some(Some(value.into()));
         self
     }
 
-    #[allow(dead_code)]
-    pub fn external_tool_use_id_null(mut self) -> Self {
-        self.external_tool_use_id = Some(None);
-        self
-    }
-
     pub fn edit_kind(mut self, value: impl Into<String>) -> Self {
         self.edit_kind = Some(Some(value.into()));
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn edit_kind_null(mut self) -> Self {
-        self.edit_kind = Some(None);
         self
     }
 }
@@ -761,18 +671,6 @@ mod tests {
     }
 
     #[test]
-    fn test_committed_values_null_fields() {
-        let values = CommittedValues::new()
-            .human_additions_null()
-            .git_diff_deleted_lines_null()
-            .tool_model_pairs_null();
-
-        assert_eq!(values.human_additions, Some(None));
-        assert_eq!(values.git_diff_deleted_lines, Some(None));
-        assert_eq!(values.tool_model_pairs, Some(None));
-    }
-
-    #[test]
     fn test_committed_values_with_commit_info() {
         let values = CommittedValues::new()
             .human_additions(10)
@@ -800,8 +698,7 @@ mod tests {
         let original = CommittedValues::new()
             .human_additions(25)
             .first_checkpoint_ts(1700000000)
-            .commit_subject("Test commit")
-            .commit_body_null();
+            .commit_subject("Test commit");
 
         let sparse = PosEncoded::to_sparse(&original);
         let restored = <CommittedValues as PosEncoded>::from_sparse(&sparse);
@@ -812,7 +709,7 @@ mod tests {
             restored.commit_subject,
             Some(Some("Test commit".to_string()))
         );
-        assert_eq!(restored.commit_body, Some(None));
+        assert_eq!(restored.commit_body, None);
     }
 
     #[test]
@@ -959,20 +856,6 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_values_with_nulls() {
-        let values = CheckpointValues::new()
-            .checkpoint_ts_null()
-            .kind_null()
-            .file_path_null()
-            .lines_added_null();
-
-        assert_eq!(values.checkpoint_ts, Some(None));
-        assert_eq!(values.kind, Some(None));
-        assert_eq!(values.file_path, Some(None));
-        assert_eq!(values.lines_added, Some(None));
-    }
-
-    #[test]
     fn test_checkpoint_values_to_sparse() {
         use super::PosEncoded;
 
@@ -1041,13 +924,6 @@ mod tests {
     }
 
     #[test]
-    fn test_committed_values_array_nulls() {
-        let values = CommittedValues::new().ai_accepted_null();
-
-        assert_eq!(values.ai_accepted, Some(None));
-    }
-
-    #[test]
     fn test_checkpoint_values_with_external_tool_use_id() {
         let values = CheckpointValues::new()
             .checkpoint_ts(1704067200)
@@ -1060,16 +936,6 @@ mod tests {
             values.external_tool_use_id,
             Some(Some("tool-use-123".to_string()))
         );
-    }
-
-    #[test]
-    fn test_checkpoint_values_external_tool_use_id_null() {
-        let values = CheckpointValues::new()
-            .checkpoint_ts(1704067200)
-            .kind("human")
-            .external_tool_use_id_null();
-
-        assert_eq!(values.external_tool_use_id, Some(None));
     }
 
     #[test]
@@ -1125,27 +991,6 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_values_roundtrip_with_external_tool_use_id() {
-        use super::PosEncoded;
-
-        let original = CheckpointValues::new()
-            .checkpoint_ts(1700000000)
-            .kind("ai_agent")
-            .file_path("src/lib.rs")
-            .lines_added(50)
-            .external_tool_use_id_null();
-
-        let sparse = PosEncoded::to_sparse(&original);
-        let restored = <CheckpointValues as PosEncoded>::from_sparse(&sparse);
-
-        assert_eq!(restored.checkpoint_ts, Some(Some(1700000000)));
-        assert_eq!(restored.kind, Some(Some("ai_agent".to_string())));
-        assert_eq!(restored.file_path, Some(Some("src/lib.rs".to_string())));
-        assert_eq!(restored.lines_added, Some(Some(50)));
-        assert_eq!(restored.external_tool_use_id, Some(None)); // explicitly null
-    }
-
-    #[test]
     fn test_checkpoint_values_external_tool_use_id_not_set() {
         use super::PosEncoded;
 
@@ -1168,16 +1013,6 @@ mod tests {
             .edit_kind("file_edit");
 
         assert_eq!(values.edit_kind, Some(Some("file_edit".to_string())));
-    }
-
-    #[test]
-    fn test_checkpoint_values_edit_kind_null() {
-        let values = CheckpointValues::new()
-            .checkpoint_ts(1704067200)
-            .kind("ai_agent")
-            .edit_kind_null();
-
-        assert_eq!(values.edit_kind, Some(None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

EventAttributes, CommittedValues, and CheckpointValues each had *_null() methods for sparse-encoding fields as Some(None). Methods with zero production callers are removed along with their tests. Methods called from production code (post_commit.rs, install_hooks.rs) are retained.

## Test plan
- [x] `task build` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->