### PR TITLE
chore(metrics): remove dead sparse helpers and MetricEvent::with_timestamp

### DIFF
--- a/src/metrics/pos_encoded.rs
+++ b/src/metrics/pos_encoded.rs
@@ -18,7 +18,6 @@ pub type PosField<T> = Option<Option<T>>;
 /// Trait for types that can be position-encoded.
 pub trait PosEncoded: Sized + Default {
     fn to_sparse(&self) -> SparseArray;
-    #[allow(dead_code)]
     fn from_sparse(arr: &SparseArray) -> Self;
 }
 
@@ -60,7 +59,6 @@ pub fn f64_to_json(field: &PosField<f64>) -> Option<Value> {
 }
 
 /// Get a string field from a sparse array at a position.
-#[allow(dead_code)]
 pub fn sparse_get_string(arr: &SparseArray, pos: usize) -> PosField<String> {
     match arr.get(&pos.to_string()) {
         None => None,                    // not-set
@@ -71,7 +69,6 @@ pub fn sparse_get_string(arr: &SparseArray, pos: usize) -> PosField<String> {
 }
 
 /// Get a u32 field from a sparse array at a position.
-#[allow(dead_code)]
 pub fn sparse_get_u32(arr: &SparseArray, pos: usize) -> PosField<u32> {
     match arr.get(&pos.to_string()) {
         None => None,
@@ -88,23 +85,11 @@ pub fn sparse_get_u32(arr: &SparseArray, pos: usize) -> PosField<u32> {
 }
 
 /// Get a u64 field from a sparse array at a position.
-#[allow(dead_code)]
 pub fn sparse_get_u64(arr: &SparseArray, pos: usize) -> PosField<u64> {
     match arr.get(&pos.to_string()) {
         None => None,
         Some(Value::Null) => Some(None),
         Some(Value::Number(n)) => n.as_u64().map(Some),
-        Some(_) => None,
-    }
-}
-
-/// Get a f64 field from a sparse array at a position.
-#[allow(dead_code)]
-pub fn sparse_get_f64(arr: &SparseArray, pos: usize) -> PosField<f64> {
-    match arr.get(&pos.to_string()) {
-        None => None,
-        Some(Value::Null) => Some(None),
-        Some(Value::Number(n)) => n.as_f64().map(Some),
         Some(_) => None,
     }
 }
@@ -143,7 +128,6 @@ pub fn vec_u64_to_json(field: &PosField<Vec<u64>>) -> Option<Value> {
 }
 
 /// Get a `Vec<String>` field from a sparse array at a position.
-#[allow(dead_code)]
 pub fn sparse_get_vec_string(arr: &SparseArray, pos: usize) -> PosField<Vec<String>> {
     match arr.get(&pos.to_string()) {
         None => None,
@@ -160,7 +144,6 @@ pub fn sparse_get_vec_string(arr: &SparseArray, pos: usize) -> PosField<Vec<Stri
 }
 
 /// Get a `Vec<u32>` field from a sparse array at a position.
-#[allow(dead_code)]
 pub fn sparse_get_vec_u32(arr: &SparseArray, pos: usize) -> PosField<Vec<u32>> {
     match arr.get(&pos.to_string()) {
         None => None,
@@ -178,20 +161,6 @@ pub fn sparse_get_vec_u32(arr: &SparseArray, pos: usize) -> PosField<Vec<u32>> {
                     })
                 })
                 .collect();
-            Some(Some(nums))
-        }
-        Some(_) => None,
-    }
-}
-
-/// Get a `Vec<u64>` field from a sparse array at a position.
-#[allow(dead_code)]
-pub fn sparse_get_vec_u64(arr: &SparseArray, pos: usize) -> PosField<Vec<u64>> {
-    match arr.get(&pos.to_string()) {
-        None => None,
-        Some(Value::Null) => Some(None),
-        Some(Value::Array(arr)) => {
-            let nums: Vec<u64> = arr.iter().filter_map(|v| v.as_u64()).collect();
             Some(Some(nums))
         }
         Some(_) => None,
@@ -562,27 +531,6 @@ mod tests {
     }
 
     #[test]
-    fn test_sparse_get_vec_u64() {
-        let mut arr = SparseArray::new();
-        assert_eq!(sparse_get_vec_u64(&arr, 0), None);
-
-        arr.insert("0".to_string(), Value::Null);
-        assert_eq!(sparse_get_vec_u64(&arr, 0), Some(None));
-
-        arr.insert(
-            "1".to_string(),
-            Value::Array(vec![
-                Value::Number(1000000000000u64.into()),
-                Value::Number(2000000000000u64.into()),
-            ]),
-        );
-        assert_eq!(
-            sparse_get_vec_u64(&arr, 1),
-            Some(Some(vec![1000000000000u64, 2000000000000u64]))
-        );
-    }
-
-    #[test]
     fn test_sparse_set() {
         let mut arr = SparseArray::new();
 
@@ -632,6 +580,5 @@ mod tests {
         arr.insert("0".to_string(), Value::String("not an array".to_string()));
         assert_eq!(sparse_get_vec_string(&arr, 0), None);
         assert_eq!(sparse_get_vec_u32(&arr, 0), None);
-        assert_eq!(sparse_get_vec_u64(&arr, 0), None);
     }
 }

--- a/src/metrics/types.rs
+++ b/src/metrics/types.rs
@@ -32,7 +32,6 @@ pub trait EventValues: Sized {
     fn into_sparse(self) -> SparseArray {
         self.to_sparse()
     }
-    #[allow(dead_code)]
     fn from_sparse(arr: &SparseArray) -> Self;
 }
 
@@ -93,17 +92,6 @@ impl MetricEvent {
             }),
             event_id: V::event_id() as u16,
             values: values.into_sparse(),
-            attrs,
-        }
-    }
-
-    /// Create with explicit timestamp (for deserialization/testing).
-    #[allow(dead_code)]
-    pub fn with_timestamp<V: EventValues>(timestamp: u32, values: &V, attrs: SparseArray) -> Self {
-        Self {
-            timestamp,
-            event_id: V::event_id() as u16,
-            values: values.to_sparse(),
             attrs,
         }
     }
@@ -175,20 +163,6 @@ mod tests {
             event.attrs.get("0"),
             Some(&Value::String("1.0.0".to_string()))
         );
-    }
-
-    #[test]
-    fn test_metric_event_with_timestamp() {
-        use crate::metrics::events::CommittedValues;
-
-        let values = CommittedValues::new().human_additions(50);
-        let mut attrs = SparseArray::new();
-        attrs.insert("0".to_string(), Value::String("1.0.0".to_string()));
-
-        let event = MetricEvent::with_timestamp(1700000000, &values, attrs);
-
-        assert_eq!(event.timestamp, 1700000000);
-        assert_eq!(event.event_id, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

sparse_get_f64 and sparse_get_vec_u64 had no callers outside their own tests — no metric field uses f64 or Vec<u64> encoding. MetricEvent::with_timestamp was similarly only tested internally; production metrics use MetricEvent::new.

## Test plan
- [x] `task build` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->