### PR TITLE
chore(auth,config,mdm): remove dead initialization and utility methods

### DIFF
--- a/src/auth/credentials.rs
+++ b/src/auth/credentials.rs
@@ -128,14 +128,7 @@ impl CredentialStore {
         self.backend.clear()
     }
 
-    /// Check if credentials are stored
-    #[allow(dead_code)]
-    pub fn has_credentials(&self) -> bool {
-        self.load().map(|c| c.is_some()).unwrap_or(false)
-    }
-
     /// Get the backend name (for logging/debugging)
-    #[allow(dead_code)]
     pub fn backend_name(&self) -> &'static str {
         self.backend.name()
     }
@@ -172,12 +165,10 @@ mod tests {
         let creds = make_test_credentials();
 
         // Initially empty
-        assert!(!store.has_credentials());
         assert!(store.load().unwrap().is_none());
 
         // Store
         store.store(&creds).unwrap();
-        assert!(store.has_credentials());
 
         // Load and verify
         let loaded = store.load().unwrap().unwrap();
@@ -194,7 +185,6 @@ mod tests {
 
         // Clear
         store.clear().unwrap();
-        assert!(!store.has_credentials());
         assert!(store.load().unwrap().is_none());
     }
 
@@ -220,19 +210,6 @@ mod tests {
         // Load when nothing stored should return None
         let result = store.load().unwrap();
         assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_has_credentials_with_mock() {
-        let store = CredentialStore::with_backend(Box::new(MockBackend::new()));
-
-        assert!(!store.has_credentials());
-
-        store.store(&make_test_credentials()).unwrap();
-        assert!(store.has_credentials());
-
-        store.clear().unwrap();
-        assert!(!store.has_credentials());
     }
 
     // ============= Error Handling Tests with Mock =============
@@ -265,15 +242,6 @@ mod tests {
         let result = store.clear();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Permission denied"));
-    }
-
-    #[test]
-    fn test_has_credentials_returns_false_on_load_error() {
-        let mock = MockBackend::new().fail_load("Backend unavailable");
-        let store = CredentialStore::with_backend(Box::new(mock));
-
-        // has_credentials should return false when load errors
-        assert!(!store.has_credentials());
     }
 
     // ============= Serialization Tests =============

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,13 +230,6 @@ pub struct ConfigPatch {
 }
 
 impl Config {
-    /// Initialize the global configuration exactly once.
-    /// Safe to call multiple times; subsequent calls are no-ops.
-    #[allow(dead_code)]
-    pub fn init() {
-        let _ = CONFIG.get_or_init(build_config);
-    }
-
     /// Access the global configuration. Lazily initializes if not already initialized.
     pub fn get() -> &'static Config {
         CONFIG.get_or_init(build_config)
@@ -507,7 +500,6 @@ impl Config {
     /// Only available when the `test-support` feature is enabled or in test mode.
     /// Must be `pub` to work with integration tests in the `tests/` directory.
     #[cfg(any(test, feature = "test-support"))]
-    #[allow(dead_code)]
     pub fn set_test_feature_flags(flags: FeatureFlags) {
         let mut override_flags = TEST_FEATURE_FLAGS_OVERRIDE
             .write()
@@ -519,7 +511,6 @@ impl Config {
     /// Only available when the `test-support` feature is enabled or in test mode.
     /// This should be called in test cleanup to reset to default behavior.
     #[cfg(any(test, feature = "test-support"))]
-    #[allow(dead_code)]
     pub fn clear_test_feature_flags() {
         let mut override_flags = TEST_FEATURE_FLAGS_OVERRIDE
             .write()
@@ -1173,7 +1164,6 @@ fn config_file_path() -> Option<PathBuf> {
 }
 
 /// Public accessor for config file path
-#[allow(dead_code)]
 pub fn config_file_path_public() -> Option<PathBuf> {
     config_file_path()
 }

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -86,21 +86,6 @@ define_feature_flags!(
 );
 
 impl FeatureFlags {
-    /// Build FeatureFlags from deserializable config
-    fn from_deserializable(flags: DeserializableFeatureFlags) -> Self {
-        Self::merge_with(FeatureFlags::default(), flags)
-    }
-
-    /// Build FeatureFlags from environment variables
-    /// Reads from GIT_AI_* prefixed environment variables
-    /// Example: GIT_AI_REWRITE_STASH=true, GIT_AI_AUTH_KEYRING=false
-    /// Falls back to defaults for any invalid or missing values
-    #[allow(dead_code)]
-    pub fn from_env() -> Self {
-        let env_flags = DeserializableFeatureFlags::from_env("GIT_AI_");
-        Self::from_deserializable(env_flags)
-    }
-
     /// Build FeatureFlags from both file and environment variables
     /// Precedence: Environment > File > Default
     /// - Starts with defaults
@@ -147,19 +132,6 @@ mod tests {
             assert!(flags.transcript_sweep);
             assert!(!flags.checkpoint_debug_log);
         }
-    }
-
-    #[test]
-    fn test_from_deserializable() {
-        let deserializable = DeserializableFeatureFlags {
-            rewrite_stash: Some(false),
-            auth_keyring: Some(true),
-            ..Default::default()
-        };
-
-        let flags = FeatureFlags::from_deserializable(deserializable);
-        assert!(!flags.rewrite_stash);
-        assert!(flags.auth_keyring);
     }
 
     #[test]

--- a/src/mdm/spinner.rs
+++ b/src/mdm/spinner.rs
@@ -24,16 +24,6 @@ impl Spinner {
         // Spinner starts automatically when created
     }
 
-    #[allow(dead_code)]
-    pub fn update_message(&self, message: &str) {
-        self.pb.set_message(message.to_string());
-    }
-
-    #[allow(dead_code)]
-    pub async fn wait_for(&self, duration_ms: u64) {
-        smol::Timer::after(std::time::Duration::from_millis(duration_ms)).await;
-    }
-
     pub fn success(&self, message: &str) {
         // Clear spinner and show success with green checkmark and bold green text
         self.pb.finish_and_clear();
@@ -50,13 +40,6 @@ impl Spinner {
         // Clear spinner and show error with red X and bold red text
         self.pb.finish_and_clear();
         println!("\x1b[1;31m✗ {}\x1b[0m", message);
-    }
-
-    #[allow(dead_code)]
-    pub fn skipped(&self, message: &str) {
-        // Clear spinner and show skipped with gray circle and gray text
-        self.pb.finish_and_clear();
-        println!("\x1b[90m○ {}\x1b[0m", message);
     }
 }
 
@@ -112,19 +95,6 @@ mod tests {
     fn test_spinner_error_output() {
         let spinner = Spinner::new("Processing");
         spinner.error("An error occurred");
-    }
-
-    #[test]
-    fn test_spinner_skipped_output() {
-        let spinner = Spinner::new("Processing");
-        spinner.skipped("Operation skipped");
-    }
-
-    #[test]
-    fn test_spinner_update_message() {
-        let spinner = Spinner::new("Initial message");
-        spinner.update_message("Updated message");
-        spinner.success("Done");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

CredentialStore::has_credentials: zero callers outside its own tests. Config::init: redundant with the lazy Config::get() initializer. FeatureFlags::from_env and from_deserializable: dead since from_env_and_file became the sole production entry point. Spinner::update_message, wait_for, skipped: zero callers in production.

## Test plan
- [x] `task build` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->