### PR TITLE
chore: strip stale #[allow(dead_code)] from live functions

### DIFF
--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -285,7 +285,6 @@ impl AttributionTracker {
     }
 
     /// Create a new attribution tracker with custom configuration
-    #[allow(dead_code)]
     pub fn with_config(config: AttributionConfig) -> Self {
         AttributionTracker { config }
     }

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -94,7 +94,6 @@ pub struct CiContext {
 
 impl CiContext {
     /// Create a CiContext with an existing repository (no automatic cleanup)
-    #[allow(dead_code)]
     pub fn with_repository(repo: Repository, event: CiEvent) -> Self {
         CiContext {
             repo,

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -90,7 +90,6 @@ impl InstallResult {
         }
     }
 
-    #[allow(dead_code)]
     pub fn with_warning(mut self, warning: impl Into<String>) -> Self {
         self.warnings.push(warning.into());
         self

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -306,7 +306,6 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
 /// Batch-attach existing note blobs to commits without rewriting blob contents.
 ///
 /// Each entry is (commit_sha, existing_note_blob_oid).
-#[allow(dead_code)]
 pub fn notes_add_blob_batch(
     repo: &Repository,
     entries: &[(String, String)],
@@ -531,7 +530,6 @@ pub fn get_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipL
     Some(authorship_log)
 }
 
-#[allow(dead_code)]
 pub fn get_reference_as_working_log(
     repo: &Repository,
     commit_sha: &str,

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -294,7 +294,6 @@ impl PersistedWorkingLog {
         Ok(fs::read_to_string(blob_path)?)
     }
 
-    #[allow(dead_code)]
     pub fn persist_file_version(&self, content: &str) -> Result<String, GitAiError> {
         // Create SHA256 hash of the content
         let mut hasher = Sha256::new();
@@ -558,7 +557,6 @@ impl PersistedWorkingLog {
         Ok(touched_files)
     }
 
-    #[allow(dead_code)]
     pub fn all_ai_touched_files(&self) -> Result<HashSet<String>, GitAiError> {
         let checkpoints = self.read_all_checkpoints()?;
         let mut touched_files = HashSet::new();

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -709,7 +709,6 @@ impl<'a> Tree<'a> {
         self.oid.clone()
     }
 
-    #[allow(dead_code)]
     #[allow(clippy::should_implement_trait)]
     pub fn clone(&self) -> Tree<'a> {
         Tree {
@@ -791,7 +790,6 @@ pub struct Blob<'a> {
 }
 
 impl<'a> Blob<'a> {
-    #[allow(dead_code)]
     pub fn id(&self) -> String {
         self.oid.clone()
     }
@@ -1393,7 +1391,6 @@ impl Repository {
     }
 
     // Write an in-memory buffer to the ODB as a blob.
-    #[allow(dead_code)]
     pub fn remote_head(&self, remote_name: &str) -> Result<String, GitAiError> {
         let mut args = self.global_args_for_exec();
         args.push("symbolic-ref".to_string());
@@ -1446,7 +1443,6 @@ impl Repository {
         Ok(remotes.first().map(|s| s.to_string()))
     }
 
-    #[allow(dead_code)]
     pub fn push_authorship(&self, remote_name: &str) -> Result<(), GitAiError> {
         push_authorship_notes(self, remote_name)
     }
@@ -1568,7 +1564,6 @@ impl Repository {
 
     /// Get the content of a file at a specific commit
     /// Uses `git show <commit>:<path>` for efficient single-call retrieval
-    #[allow(dead_code)]
     pub fn get_file_content(
         &self,
         file_path: &str,
@@ -2302,7 +2297,6 @@ fn repository_object_hash_kind_for_path_no_git_exec(
     }
 }
 
-#[allow(dead_code)]
 pub fn from_bare_repository(git_dir: &Path) -> Result<Repository, GitAiError> {
     let workdir = git_dir
         .parent()

--- a/src/mdm/hook_installer.rs
+++ b/src/mdm/hook_installer.rs
@@ -15,7 +15,6 @@ pub struct HookCheckResult {
     /// Whether hooks are installed
     pub hooks_installed: bool,
     /// Whether hooks are up to date
-    #[allow(dead_code)]
     pub hooks_up_to_date: bool,
 }
 

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -48,7 +48,6 @@ pub fn log_performance(
 }
 
 /// Log a message to Sentry (info, warning, etc.) (via daemon telemetry worker)
-#[allow(dead_code)]
 pub fn log_message(message: &str, level: &str, context: Option<serde_json::Value>) {
     let envelope = crate::daemon::TelemetryEnvelope::Message {
         timestamp: chrono::Utc::now().to_rfc3339(),


### PR DESCRIPTION
## Summary

These suppressions were correct when added but became stale as callers were added or tests were written. Affects: log_message, with_warning, notes_add_blob_batch, get_reference_as_working_log, persist_file_version, Blob::id, remote_head, push_authorship, get_file_content, from_bare_repository, CiContext::with_repository, AttributionTracker::with_config.

## Test plan
- [x] `task build` passes
- [x] `task lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->