### PR TITLE
feat: add checkpoint_debug_log feature flag

### DIFF
--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -4,6 +4,7 @@ use crate::commands::checkpoint_agent::presets::{
     KnownHumanEdit, ParsedHookEvent, PostBashCall, PostFileEdit, PreBashCall, PreFileEdit,
     TranscriptSource, UntrackedEdit,
 };
+use crate::config;
 use crate::daemon::checkpoint::PreparedPathRole;
 use crate::error::GitAiError;
 use crate::git::repo_state::{
@@ -13,6 +14,7 @@ use crate::git::repository::discover_repository_in_path_no_git_exec;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,6 +40,16 @@ pub struct CheckpointRequest {
     pub path_role: PreparedPathRole,
     pub transcript_source: Option<TranscriptSource>,
     pub metadata: HashMap<String, String>,
+}
+
+#[derive(Serialize)]
+struct CheckpointDebugLogEntry<'a> {
+    timestamp: String,
+    preset_name: &'a str,
+    hook_input: &'a str,
+    trace_id: &'a str,
+    event_count: usize,
+    requests: &'a [CheckpointRequest],
 }
 
 struct RepoContext {
@@ -191,12 +203,13 @@ pub fn execute_preset_checkpoint(
     let trace_id = generate_trace_id();
     let preset = super::presets::resolve_preset(preset_name)?;
     let events = preset.parse(hook_input, &trace_id)?;
+    let events_len = events.len();
 
     if perf {
         eprintln!(
             "[perf] orchestrator: parse={:.1}ms (events={})",
             t0.elapsed().as_secs_f64() * 1000.0,
-            events.len(),
+            events_len,
         );
     }
 
@@ -215,7 +228,84 @@ pub fn execute_preset_checkpoint(
         }
         requests.extend(new_requests);
     }
+
+    if config::Config::get()
+        .get_feature_flags()
+        .checkpoint_debug_log
+    {
+        write_checkpoint_debug_log(preset_name, hook_input, &trace_id, events_len, &requests);
+    }
+
     Ok(requests)
+}
+
+fn write_checkpoint_debug_log(
+    preset_name: &str,
+    hook_input: &str,
+    trace_id: &str,
+    event_count: usize,
+    requests: &[CheckpointRequest],
+) {
+    let Some(internal_dir) = config::internal_dir_path() else {
+        return;
+    };
+
+    let log_dir = internal_dir.join("checkpoint-debug-logs");
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let log_path = log_dir.join(format!("{}.log", date));
+
+    if let Err(e) = fs::create_dir_all(&log_dir) {
+        eprintln!("[checkpoint_debug_log] failed to create dir: {}", e);
+        return;
+    }
+
+    cleanup_old_debug_logs(&log_dir);
+
+    let entry = CheckpointDebugLogEntry {
+        timestamp: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        preset_name,
+        hook_input,
+        trace_id,
+        event_count,
+        requests,
+    };
+
+    let Ok(line) = serde_json::to_string(&entry) else {
+        return;
+    };
+
+    let Ok(mut file) = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    else {
+        return;
+    };
+
+    let _ = file
+        .write_all(line.as_bytes())
+        .and_then(|_| file.write_all(b"\n"))
+        .and_then(|_| file.flush());
+}
+
+fn cleanup_old_debug_logs(log_dir: &Path) {
+    let Ok(entries) = fs::read_dir(log_dir) else {
+        return;
+    };
+
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(14);
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if let Ok(file_date) = chrono::NaiveDate::parse_from_str(stem, "%Y-%m-%d")
+            && file_date < cutoff.date_naive()
+        {
+            let _ = fs::remove_file(&path);
+        }
+    }
 }
 
 fn execute_event(

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -84,6 +84,7 @@ define_feature_flags!(
     git_hooks_externally_managed: git_hooks_externally_managed, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = false,
+    checkpoint_debug_log: checkpoint_debug_log, debug = false, release = false,
 );
 
 impl FeatureFlags {
@@ -140,6 +141,7 @@ mod tests {
             assert!(!flags.git_hooks_externally_managed);
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
+            assert!(!flags.checkpoint_debug_log);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -149,6 +151,7 @@ mod tests {
             assert!(!flags.git_hooks_externally_managed);
             assert!(flags.transcript_streaming);
             assert!(!flags.transcript_sweep);
+            assert!(!flags.checkpoint_debug_log);
         }
     }
 
@@ -208,6 +211,7 @@ mod tests {
             git_hooks_externally_managed: false,
             transcript_streaming: true,
             transcript_sweep: true,
+            checkpoint_debug_log: false,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -217,6 +221,7 @@ mod tests {
         assert!(serialized.contains("git_hooks_externally_managed"));
         assert!(serialized.contains("transcript_streaming"));
         assert!(serialized.contains("transcript_sweep"));
+        assert!(serialized.contains("checkpoint_debug_log"));
     }
 
     #[test]
@@ -228,6 +233,7 @@ mod tests {
             git_hooks_externally_managed: false,
             transcript_streaming: true,
             transcript_sweep: true,
+            checkpoint_debug_log: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.rewrite_stash, flags.rewrite_stash);
@@ -239,6 +245,7 @@ mod tests {
         );
         assert_eq!(cloned.transcript_streaming, flags.transcript_streaming);
         assert_eq!(cloned.transcript_sweep, flags.transcript_sweep);
+        assert_eq!(cloned.checkpoint_debug_log, flags.checkpoint_debug_log);
     }
 
     #[test]

--- a/tests/integration/checkpoint_debug_log.rs
+++ b/tests/integration/checkpoint_debug_log.rs
@@ -1,0 +1,94 @@
+use crate::repos::test_repo::TestRepo;
+
+#[test]
+fn test_checkpoint_debug_log_writes_when_enabled() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.feature_flags = Some(serde_json::json!({"checkpoint_debug_log": true}));
+    });
+
+    let file_path = repo.path().join("test.txt");
+    std::fs::write(&file_path, "hello\n").unwrap();
+
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.txt"])
+        .unwrap();
+
+    let log_dir = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("checkpoint-debug-logs");
+    assert!(log_dir.exists(), "checkpoint-debug-logs dir should exist");
+
+    let entries: Vec<_> = std::fs::read_dir(&log_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert_eq!(entries.len(), 1, "should have exactly one daily log file");
+
+    let content = std::fs::read_to_string(entries[0].path()).unwrap();
+    let line: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+    assert_eq!(line["preset_name"], "mock_known_human");
+    assert!(line["trace_id"].is_string());
+    assert!(line["timestamp"].is_string());
+    assert!(line["event_count"].is_number());
+    assert!(line["requests"].is_array());
+}
+
+#[test]
+fn test_checkpoint_debug_log_does_not_write_when_disabled() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("test.txt");
+    std::fs::write(&file_path, "hello\n").unwrap();
+
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.txt"])
+        .unwrap();
+
+    let log_dir = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("checkpoint-debug-logs");
+    assert!(
+        !log_dir.exists(),
+        "checkpoint-debug-logs dir should NOT exist when flag is off"
+    );
+}
+
+#[test]
+fn test_checkpoint_debug_log_appends_multiple_entries() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.feature_flags = Some(serde_json::json!({"checkpoint_debug_log": true}));
+    });
+
+    let file_path = repo.path().join("test.txt");
+    std::fs::write(&file_path, "hello\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.txt"])
+        .unwrap();
+
+    std::fs::write(&file_path, "hello\nworld\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "test.txt"]).unwrap();
+
+    let log_dir = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("checkpoint-debug-logs");
+
+    let entries: Vec<_> = std::fs::read_dir(&log_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert_eq!(entries.len(), 1);
+
+    let content = std::fs::read_to_string(entries[0].path()).unwrap();
+    let lines: Vec<&str> = content.trim().lines().collect();
+    assert_eq!(lines.len(), 2, "should have two JSONL entries");
+
+    let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(first["preset_name"], "mock_known_human");
+    assert_eq!(second["preset_name"], "mock_ai");
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -24,6 +24,7 @@ mod blame_comprehensive;
 mod blame_flags;
 mod blame_subdirectory;
 mod checkout_switch;
+mod checkpoint_debug_log;
 mod checkpoint_explicit_paths;
 mod checkpoint_perf;
 mod checkpoint_size;

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -21,6 +21,7 @@ fn setup() {
         git_hooks_externally_managed: false,
         transcript_streaming: true,
         transcript_sweep: true,
+        checkpoint_debug_log: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());


### PR DESCRIPTION
## Summary
- Adds a new `checkpoint_debug_log` feature flag (default off) that intercepts every checkpoint call at the orchestrator level and writes raw invocation data + resulting checkpoint requests to a daily append-only JSONL file at `~/.git-ai/internal/checkpoint-debug-logs/YYYY-MM-DD.log`
- Centrally managed — no per-preset implementation needed
- Automatically cleans up log files older than 14 days

## Test plan
- [x] New integration tests: `test_checkpoint_debug_log_writes_when_enabled`, `test_checkpoint_debug_log_does_not_write_when_disabled`, `test_checkpoint_debug_log_appends_multiple_entries`
- [x] Existing feature_flags unit tests updated and passing
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->