### PR TITLE
fix(e2e): update Codex hook verification for inline TOML format

### DIFF
--- a/.github/workflows/install-scripts-local.yml
+++ b/.github/workflows/install-scripts-local.yml
@@ -99,10 +99,10 @@ jobs:
               grep -F "checkpoint claude" "$HOME/.claude/settings.json"
               ;;
             codex)
-              # Codex writes a feature flag to config.toml and the actual hook
-              # commands to hooks.json (separate file since the hooks refactor).
-              grep -F "codex_hooks" "$HOME/.codex/config.toml"
-              grep -F "checkpoint" "$HOME/.codex/hooks.json"
+              # Codex writes inline hooks directly in config.toml (no separate hooks.json).
+              # The feature flag is [features].hooks = true.
+              grep -F 'hooks = true' "$HOME/.codex/config.toml"
+              grep -F "checkpoint codex" "$HOME/.codex/config.toml"
               ;;
             gemini)
               grep -F "checkpoint gemini" "$HOME/.gemini/settings.json"
@@ -259,12 +259,11 @@ jobs:
               if (-not (Select-String -Path $settings -Pattern "checkpoint claude")) { throw "Claude hooks not configured" }
             }
             "codex" {
-              # Codex writes a feature flag to config.toml and the actual hook
-              # commands to hooks.json (separate file since the hooks refactor).
+              # Codex writes inline hooks directly in config.toml (no separate hooks.json).
+              # The feature flag is [features].hooks = true.
               $config = Join-Path $env:USERPROFILE ".codex\config.toml"
-              if (-not (Select-String -Path $config -Pattern "codex_hooks")) { throw "Codex feature flag not set in config.toml" }
-              $hooks = Join-Path $env:USERPROFILE ".codex\hooks.json"
-              if (-not (Select-String -Path $hooks -Pattern "checkpoint")) { throw "Codex hooks not configured in hooks.json" }
+              if (-not (Select-String -Path $config -Pattern "hooks = true")) { throw "Codex hooks feature flag not set in config.toml" }
+              if (-not (Select-String -Path $config -Pattern "checkpoint codex")) { throw "Codex hooks not configured in config.toml" }
             }
             "gemini" {
               $settings = Join-Path $env:USERPROFILE ".gemini\settings.json"

--- a/scripts/nightly/verify-hook-wiring.sh
+++ b/scripts/nightly/verify-hook-wiring.sh
@@ -27,14 +27,12 @@ case "$AGENT" in
 
   codex)
     CONFIG="$HOME/.codex/config.toml"
-    HOOKS="$HOME/.codex/hooks.json"
     [ -f "$CONFIG" ] || fail "config.toml not found at $CONFIG"
-    [ -f "$HOOKS" ] || fail "hooks.json not found at $HOOKS"
-    grep -q 'codex_hooks = true' "$CONFIG" \
-      || fail "codex_hooks feature flag not enabled in $CONFIG"
-    grep -q 'checkpoint codex --hook-input stdin' "$HOOKS" \
-      || fail "checkpoint codex hook not found in $HOOKS"
-    pass "Codex hooks configured in $CONFIG and $HOOKS"
+    grep -q 'hooks = true' "$CONFIG" \
+      || fail "hooks feature flag not enabled in $CONFIG"
+    grep -q 'checkpoint codex --hook-input stdin' "$CONFIG" \
+      || fail "checkpoint codex hook not found in $CONFIG"
+    pass "Codex hooks configured in $CONFIG"
     ;;
 
   gemini)


### PR DESCRIPTION
## Summary

- Updates E2E test assertions for Codex hooks to match the new inline TOML format introduced in PR #1345
- Unix: checks for `hooks = true` and `checkpoint codex` in `config.toml` (instead of `codex_hooks` in config.toml + `checkpoint` in hooks.json)
- Windows: same pattern with `Select-String`

## Test plan

- [ ] E2E codex on ubuntu-latest passes
- [ ] E2E codex on macos-latest passes
- [ ] E2E codex on windows-latest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->