### PR TITLE
fix: ignore CRLF-only rewrites in attribution stats

### DIFF
--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -220,6 +220,192 @@ fn collect_line_metadata(content: &str) -> Vec<LineMetadata> {
 }
 
 #[derive(Clone, Debug)]
+struct LineEndingSpan {
+    start: usize,
+    eol_start: usize,
+    end: usize,
+}
+
+impl LineEndingSpan {
+    fn text<'a>(&self, content: &'a str) -> &'a str {
+        &content[self.start..self.eol_start]
+    }
+
+    fn eol<'a>(&self, content: &'a str) -> &'a str {
+        &content[self.eol_start..self.end]
+    }
+
+    fn logical_key(&self, content: &str) -> LogicalLineKey {
+        LogicalLineKey {
+            text: self.text(content).to_string(),
+            has_eol: self.eol_start < self.end,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct LogicalLineKey {
+    text: String,
+    has_eol: bool,
+}
+
+fn collect_line_ending_spans(content: &str) -> Vec<LineEndingSpan> {
+    let mut spans = Vec::new();
+    let bytes = content.as_bytes();
+    let mut line_start = 0usize;
+    let mut idx = 0usize;
+
+    while idx < bytes.len() {
+        let eol_len = match bytes[idx] {
+            b'\r' if idx + 1 < bytes.len() && bytes[idx + 1] == b'\n' => 2,
+            b'\r' | b'\n' => 1,
+            _ => {
+                idx += 1;
+                continue;
+            }
+        };
+
+        spans.push(LineEndingSpan {
+            start: line_start,
+            eol_start: idx,
+            end: idx + eol_len,
+        });
+        idx += eol_len;
+        line_start = idx;
+    }
+
+    if line_start < content.len() {
+        spans.push(LineEndingSpan {
+            start: line_start,
+            eol_start: content.len(),
+            end: content.len(),
+        });
+    }
+
+    spans
+}
+
+// Build a synthetic old buffer for diffing where unchanged logical lines use
+// the new buffer's line-ending bytes. This removes pure LF/CRLF churn before
+// byte attribution runs, while still treating added final newlines as edits.
+fn rewrite_line_endings_to_match(source: &str, reference: &str) -> Option<(String, Vec<usize>)> {
+    let source_spans = collect_line_ending_spans(source);
+    let reference_spans = collect_line_ending_spans(reference);
+    if source_spans.is_empty() || reference_spans.is_empty() {
+        return None;
+    }
+
+    let source_keys: Vec<LogicalLineKey> = source_spans
+        .iter()
+        .map(|span| span.logical_key(source))
+        .collect();
+    let reference_keys: Vec<LogicalLineKey> = reference_spans
+        .iter()
+        .map(|span| span.logical_key(reference))
+        .collect();
+
+    let mut matching_reference_by_source = vec![None; source_spans.len()];
+    for op in capture_diff_slices(&source_keys, &reference_keys) {
+        if let DiffOp::Equal {
+            old_index,
+            new_index,
+            len,
+        } = op
+        {
+            for offset in 0..len {
+                matching_reference_by_source[old_index + offset] = Some(new_index + offset);
+            }
+        }
+    }
+
+    let has_rewrite =
+        matching_reference_by_source
+            .iter()
+            .enumerate()
+            .any(|(source_idx, reference_idx)| {
+                let Some(reference_idx) = reference_idx else {
+                    return false;
+                };
+                should_rewrite_line_ending(
+                    source_spans[source_idx].eol(source),
+                    reference_spans[*reference_idx].eol(reference),
+                )
+            });
+    if !has_rewrite {
+        return None;
+    }
+
+    let mut rewritten = String::with_capacity(reference.len().max(source.len()));
+    let mut offset_map = vec![0usize; source.len() + 1];
+
+    for (source_idx, source_span) in source_spans.iter().enumerate() {
+        let source_eol = source_span.eol(source);
+        let target_eol = matching_reference_by_source[source_idx]
+            .map(|reference_idx| reference_spans[reference_idx].eol(reference))
+            .filter(|reference_eol| should_rewrite_line_ending(source_eol, reference_eol))
+            .unwrap_or(source_eol);
+        push_line_with_rewritten_eol(
+            source,
+            source_span,
+            target_eol,
+            &mut rewritten,
+            &mut offset_map,
+        );
+    }
+
+    offset_map[source.len()] = rewritten.len();
+    Some((rewritten, offset_map))
+}
+
+fn should_rewrite_line_ending(source_eol: &str, reference_eol: &str) -> bool {
+    !source_eol.is_empty() && !reference_eol.is_empty() && source_eol != reference_eol
+}
+
+fn push_line_with_rewritten_eol(
+    source: &str,
+    span: &LineEndingSpan,
+    target_eol: &str,
+    rewritten: &mut String,
+    offset_map: &mut [usize],
+) {
+    let output_text_start = rewritten.len();
+    rewritten.push_str(span.text(source));
+
+    for (source_offset, mapped_offset) in offset_map
+        .iter_mut()
+        .enumerate()
+        .take(span.eol_start + 1)
+        .skip(span.start)
+    {
+        *mapped_offset = output_text_start + (source_offset - span.start);
+    }
+
+    let output_eol_start = rewritten.len();
+    rewritten.push_str(target_eol);
+    for mapped_offset in offset_map
+        .iter_mut()
+        .take(span.end + 1)
+        .skip(span.eol_start + 1)
+    {
+        *mapped_offset = output_eol_start + target_eol.len();
+    }
+}
+
+fn remap_attributions_through_offset_map(
+    attributions: &[Attribution],
+    offset_map: &[usize],
+) -> Vec<Attribution> {
+    attributions
+        .iter()
+        .filter_map(|attr| {
+            let start = *offset_map.get(attr.start)?;
+            let end = *offset_map.get(attr.end)?;
+            (start < end).then(|| Attribution::new(start, end, attr.author_id.clone(), attr.ts))
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug)]
 struct Token {
     lexeme: String,
     start: usize,
@@ -569,9 +755,22 @@ impl AttributionTracker {
         let sorted_old_storage = (!is_attribution_list_sorted(old_attributions))
             .then(|| sort_attributions_for_transform(old_attributions));
         let old_attributions = sorted_old_storage.as_deref().unwrap_or(old_attributions);
+        let line_ending_rewrite_storage = rewrite_line_endings_to_match(old_content, new_content);
+        let remapped_attributions_storage =
+            line_ending_rewrite_storage.as_ref().map(|(_, offset_map)| {
+                remap_attributions_through_offset_map(old_attributions, offset_map)
+            });
+        let old_content_for_diff = line_ending_rewrite_storage
+            .as_ref()
+            .map(|(rewritten, _)| rewritten.as_str())
+            .unwrap_or(old_content);
+        let old_attributions_for_diff = remapped_attributions_storage
+            .as_deref()
+            .unwrap_or(old_attributions);
 
         // Phase 1: Compute diff
-        let diff_result = self.compute_diffs(old_content, new_content, is_ai_checkpoint)?;
+        let diff_result =
+            self.compute_diffs(old_content_for_diff, new_content, is_ai_checkpoint)?;
 
         // Phase 2: Build deletion and insertion catalogs
         let (deletions, insertions) = self.build_diff_catalog(&diff_result.diffs);
@@ -581,17 +780,21 @@ impl AttributionTracker {
             // AI formatting/refactor checkpoints should attribute rewritten regions to AI
             // instead of preserving original ownership through move detection.
             Vec::new()
-        } else if self.should_skip_move_detection(old_content, new_content, &deletions, &insertions)
-        {
+        } else if self.should_skip_move_detection(
+            old_content_for_diff,
+            new_content,
+            &deletions,
+            &insertions,
+        ) {
             Vec::new()
         } else {
-            self.detect_moves(old_content, new_content, &deletions, &insertions)
+            self.detect_moves(old_content_for_diff, new_content, &deletions, &insertions)
         };
 
         // Phase 4: Transform attributions through the diff
         let new_attributions = self.transform_attributions(
             &diff_result.diffs,
-            old_attributions,
+            old_attributions_for_diff,
             current_author,
             &insertions,
             &move_mappings,
@@ -2663,6 +2866,32 @@ mod tests {
             new,
             "Alice",
             "LF→CRLF with same content should not re-attribute to Bob",
+        );
+    }
+
+    #[test]
+    fn ai_append_after_no_final_newline_keeps_previous_ai_checkpoint_semantics() {
+        let tracker = AttributionTracker::new();
+        let old = "Base line 1\nBase line 2";
+        let new = "Base line 1\nBase line 2\nAI line\n";
+        let old_attrs = vec![Attribution::new(0, old.len(), "Alice".into(), TEST_TS)];
+
+        assert!(
+            rewrite_line_endings_to_match(old, new).is_none(),
+            "adding a final newline before appended content is a real edit, not a CR-at-EOL rewrite"
+        );
+
+        let updated = tracker
+            .update_attributions_for_checkpoint(old, new, &old_attrs, "Bob", TEST_TS + 1, true)
+            .unwrap();
+
+        let previous_final_line_start = "Base line 1\n".len();
+        let previous_final_line_end = "Base line 1\nBase line 2".len();
+        assert_range_owned_by(
+            &updated,
+            previous_final_line_start,
+            previous_final_line_end,
+            "Bob",
         );
     }
 

--- a/src/authorship/diff_ai_accepted.rs
+++ b/src/authorship/diff_ai_accepted.rs
@@ -19,7 +19,18 @@ pub fn diff_ai_accepted_stats(
     oldest_commit: Option<&str>,
     ignore_patterns: &[String],
 ) -> Result<DiffAiAcceptedStats, GitAiError> {
-    let added_lines_by_file = repo.diff_added_lines(from_ref, to_ref, None)?;
+    let diff_hunks = crate::commands::diff::get_diff_with_line_numbers_ignoring_cr_at_eol(
+        repo, from_ref, to_ref,
+    )?;
+    let mut added_lines_by_file = std::collections::HashMap::new();
+    for hunk in diff_hunks {
+        if !hunk.added_lines.is_empty() {
+            added_lines_by_file
+                .entry(hunk.file_path)
+                .or_insert_with(Vec::new)
+                .extend(hunk.added_lines);
+        }
+    }
     let ignore_matcher = build_ignore_matcher(ignore_patterns);
 
     let mut stats = DiffAiAcceptedStats::default();

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -226,8 +226,11 @@ pub fn post_commit_with_final_state(
             &parent_sha
         };
 
-        let diff_hunks =
-            crate::commands::diff::get_diff_with_line_numbers(repo, diff_base, &commit_sha)?;
+        let diff_hunks = crate::commands::diff::get_diff_with_line_numbers_ignoring_cr_at_eol(
+            repo,
+            diff_base,
+            &commit_sha,
+        )?;
 
         let computed = stats_for_commit_stats_from_hunks(
             repo,

--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -348,46 +348,19 @@ fn get_git_diff_stats_for_range(
     end_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<(u32, u32), GitAiError> {
-    // Use git diff --numstat to get diff statistics for the range
-    let mut args = repo.global_args_for_exec();
-    args.push("diff".to_string());
-    args.push("--numstat".to_string());
-    args.push(format!("{}..{}", start_sha, end_sha));
-
-    let output = exec_git_with_profile(&args, InternalGitProfile::NumstatParse)?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
+    let hunks = crate::commands::diff::get_diff_with_line_numbers_ignoring_cr_at_eol(
+        repo, start_sha, end_sha,
+    )?;
     let mut added_lines = 0u32;
     let mut deleted_lines = 0u32;
     let ignore_matcher = build_ignore_matcher(ignore_patterns);
 
-    // Parse numstat output
-    for line in stdout.lines() {
-        if line.trim().is_empty() {
+    for hunk in hunks {
+        if should_ignore_file_with_matcher(&hunk.file_path, &ignore_matcher) {
             continue;
         }
-
-        // Parse numstat format: "added\tdeleted\tfilename"
-        let parts: Vec<&str> = line.split('\t').collect();
-        if parts.len() >= 3 {
-            // Check if this file should be ignored and skip it
-            let filename = parts[2];
-            if should_ignore_file_with_matcher(filename, &ignore_matcher) {
-                continue;
-            }
-
-            // Parse added lines
-            if let Ok(added) = parts[0].parse::<u32>() {
-                added_lines += added;
-            }
-
-            // Parse deleted lines (handle "-" for binary files)
-            if parts[1] != "-"
-                && let Ok(deleted) = parts[1].parse::<u32>()
-            {
-                deleted_lines += deleted;
-            }
-        }
+        added_lines += hunk.added_lines.len() as u32;
+        deleted_lines += hunk.deleted_lines.len() as u32;
     }
 
     Ok((added_lines, deleted_lines))

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -379,7 +379,7 @@ pub fn stats_for_commit_stats(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<CommitStats, GitAiError> {
-    use crate::commands::diff::get_diff_with_line_numbers;
+    use crate::commands::diff::get_diff_with_line_numbers_ignoring_cr_at_eol;
 
     let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
     let parent_count = commit_obj.parent_count()?;
@@ -401,7 +401,7 @@ pub fn stats_for_commit_stats(
         commit_obj.parent(0)?.id()
     };
 
-    let hunks = get_diff_with_line_numbers(repo, &from_ref, commit_sha)?;
+    let hunks = get_diff_with_line_numbers_ignoring_cr_at_eol(repo, &from_ref, commit_sha)?;
     let authorship_log = get_authorship(repo, commit_sha);
 
     stats_for_commit_stats_from_hunks(
@@ -557,7 +557,7 @@ pub fn get_git_diff_stats(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<(u32, u32), GitAiError> {
-    use crate::commands::diff::get_diff_with_line_numbers;
+    use crate::commands::diff::get_diff_with_line_numbers_ignoring_cr_at_eol;
 
     let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
     let parent_count = commit_obj.parent_count()?;
@@ -575,7 +575,7 @@ pub fn get_git_diff_stats(
     };
 
     // Use the diff engine which properly handles renames with --find-renames=1%
-    let hunks = get_diff_with_line_numbers(repo, &from_ref, commit_sha)?;
+    let hunks = get_diff_with_line_numbers_ignoring_cr_at_eol(repo, &from_ref, commit_sha)?;
 
     let ignore_matcher = build_ignore_matcher(ignore_patterns);
     let mut added_lines = 0u32;

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -3,6 +3,7 @@ use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
+use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
 use crate::commands::blame::GitAiBlameOptions;
 use crate::error::GitAiError;
 use crate::git::refs::{get_authorship, show_authorship_note};
@@ -480,6 +481,15 @@ pub fn get_diff_with_line_numbers(
     parse_diff_hunks(&diff_text)
 }
 
+pub fn get_diff_with_line_numbers_ignoring_cr_at_eol(
+    repo: &Repository,
+    from: &str,
+    to: &str,
+) -> Result<Vec<DiffHunk>, GitAiError> {
+    let diff_text = get_diff_text(repo, from, to, true)?;
+    parse_diff_hunks_ignoring_cr_at_eol(&diff_text)
+}
+
 fn get_diff_text(
     repo: &Repository,
     from: &str,
@@ -503,23 +513,67 @@ fn get_diff_text(
 }
 
 fn parse_diff_hunks(diff_text: &str) -> Result<Vec<DiffHunk>, GitAiError> {
+    parse_diff_hunks_internal(diff_text, false)
+}
+
+fn parse_diff_hunks_ignoring_cr_at_eol(diff_text: &str) -> Result<Vec<DiffHunk>, GitAiError> {
+    parse_diff_hunks_internal(diff_text, true)
+}
+
+#[derive(Debug)]
+struct ParsedHunk {
+    hunk: DiffHunk,
+    deleted_no_newline: Vec<bool>,
+    added_no_newline: Vec<bool>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LastChangedLine {
+    Deleted(usize),
+    Added(usize),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CrComparableDiffLine {
+    content_without_cr: String,
+    no_newline_at_eof: bool,
+}
+
+fn parse_diff_hunks_internal(
+    diff_text: &str,
+    ignore_cr_at_eol: bool,
+) -> Result<Vec<DiffHunk>, GitAiError> {
     let mut hunks = Vec::new();
     let mut current_old_file: Option<String> = None;
     let mut current_file = String::new();
-    let mut current_hunk: Option<DiffHunk> = None;
+    let mut current_hunk: Option<ParsedHunk> = None;
     let mut old_line_cursor = 0u32;
     let mut new_line_cursor = 0u32;
+    let mut last_changed_line: Option<LastChangedLine> = None;
 
-    let flush_current_hunk = |hunks: &mut Vec<DiffHunk>, current_hunk: &mut Option<DiffHunk>| {
-        if let Some(hunk) = current_hunk.take() {
-            hunks.push(hunk);
+    let flush_current_hunk = |hunks: &mut Vec<DiffHunk>, current_hunk: &mut Option<ParsedHunk>| {
+        if let Some(mut parsed_hunk) = current_hunk.take() {
+            if ignore_cr_at_eol {
+                filter_cr_at_eol_only_changes(&mut parsed_hunk);
+                strip_trailing_cr_from_hunk_contents(&mut parsed_hunk.hunk);
+            }
+            if !parsed_hunk.hunk.deleted_lines.is_empty()
+                || !parsed_hunk.hunk.added_lines.is_empty()
+            {
+                hunks.push(parsed_hunk.hunk);
+            }
         }
     };
 
-    for line in diff_text.lines() {
-        if line.starts_with("diff --git ") {
+    for raw_line in diff_text.split_inclusive('\n') {
+        let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+        let header_line = line.strip_suffix('\r').unwrap_or(line);
+        let content_line = if ignore_cr_at_eol { line } else { header_line };
+
+        if header_line.starts_with("diff --git ") {
             flush_current_hunk(&mut hunks, &mut current_hunk);
-            if let Some((old_file, new_file)) = parse_diff_git_header_paths(line) {
+            last_changed_line = None;
+            if let Some((old_file, new_file)) = parse_diff_git_header_paths(header_line) {
                 current_old_file = Some(old_file);
                 current_file = new_file;
             } else {
@@ -530,7 +584,7 @@ fn parse_diff_hunks(diff_text: &str) -> Result<Vec<DiffHunk>, GitAiError> {
         }
 
         if current_hunk.is_none() {
-            if let Some(path_opt) = parse_old_file_path_from_minus_header_line(line) {
+            if let Some(path_opt) = parse_old_file_path_from_minus_header_line(header_line) {
                 current_old_file = path_opt;
                 if current_file.is_empty() {
                     current_file = current_old_file.clone().unwrap_or_default();
@@ -538,7 +592,7 @@ fn parse_diff_hunks(diff_text: &str) -> Result<Vec<DiffHunk>, GitAiError> {
                 continue;
             }
 
-            if let Some(path_opt) = parse_new_file_path_from_plus_header_line(line) {
+            if let Some(path_opt) = parse_new_file_path_from_plus_header_line(header_line) {
                 current_file = path_opt
                     .or_else(|| current_old_file.clone())
                     .unwrap_or_default();
@@ -546,39 +600,162 @@ fn parse_diff_hunks(diff_text: &str) -> Result<Vec<DiffHunk>, GitAiError> {
             }
         }
 
-        if line.starts_with("@@ ") {
+        if header_line.starts_with("@@ ") {
             flush_current_hunk(&mut hunks, &mut current_hunk);
+            last_changed_line = None;
             let old_file_path = current_old_file
                 .as_deref()
                 .filter(|old_path| *old_path != current_file.as_str());
-            if let Some(mut hunk) = parse_hunk_line(line, &current_file, old_file_path)? {
+            if let Some(mut hunk) = parse_hunk_line(header_line, &current_file, old_file_path)? {
                 old_line_cursor = hunk.old_start;
                 new_line_cursor = hunk.new_start;
                 hunk.deleted_lines.clear();
                 hunk.added_lines.clear();
-                current_hunk = Some(hunk);
+                current_hunk = Some(ParsedHunk {
+                    hunk,
+                    deleted_no_newline: Vec::new(),
+                    added_no_newline: Vec::new(),
+                });
             }
             continue;
         }
 
-        if let Some(hunk) = current_hunk.as_mut() {
-            if let Some(stripped) = line.strip_prefix('-') {
-                hunk.deleted_lines.push(old_line_cursor);
-                hunk.deleted_contents.push(stripped.to_string());
+        if let Some(parsed_hunk) = current_hunk.as_mut() {
+            if let Some(stripped) = content_line.strip_prefix('-') {
+                parsed_hunk.hunk.deleted_lines.push(old_line_cursor);
+                parsed_hunk.hunk.deleted_contents.push(stripped.to_string());
+                parsed_hunk.deleted_no_newline.push(false);
+                last_changed_line = Some(LastChangedLine::Deleted(
+                    parsed_hunk.deleted_no_newline.len() - 1,
+                ));
                 old_line_cursor += 1;
-            } else if let Some(stripped) = line.strip_prefix('+') {
-                hunk.added_lines.push(new_line_cursor);
-                hunk.added_contents.push(stripped.to_string());
+            } else if let Some(stripped) = content_line.strip_prefix('+') {
+                parsed_hunk.hunk.added_lines.push(new_line_cursor);
+                parsed_hunk.hunk.added_contents.push(stripped.to_string());
+                parsed_hunk.added_no_newline.push(false);
+                last_changed_line = Some(LastChangedLine::Added(
+                    parsed_hunk.added_no_newline.len() - 1,
+                ));
                 new_line_cursor += 1;
-            } else if line.starts_with(' ') {
+            } else if content_line.starts_with(' ') {
+                last_changed_line = None;
                 old_line_cursor += 1;
                 new_line_cursor += 1;
+            } else if header_line.starts_with("\\ No newline at end of file") {
+                match last_changed_line {
+                    Some(LastChangedLine::Deleted(idx)) => {
+                        if let Some(flag) = parsed_hunk.deleted_no_newline.get_mut(idx) {
+                            *flag = true;
+                        }
+                    }
+                    Some(LastChangedLine::Added(idx)) => {
+                        if let Some(flag) = parsed_hunk.added_no_newline.get_mut(idx) {
+                            *flag = true;
+                        }
+                    }
+                    None => {}
+                }
             }
         }
     }
 
     flush_current_hunk(&mut hunks, &mut current_hunk);
     Ok(hunks)
+}
+
+// Filter only paired delete/add lines whose content differs by a trailing CR.
+// Missing-final-newline markers are tracked separately so adding a newline at
+// EOF remains a real line change.
+fn filter_cr_at_eol_only_changes(parsed_hunk: &mut ParsedHunk) {
+    let deleted_keys: Vec<CrComparableDiffLine> = parsed_hunk
+        .hunk
+        .deleted_contents
+        .iter()
+        .zip(&parsed_hunk.deleted_no_newline)
+        .map(|(content, no_newline_at_eof)| CrComparableDiffLine {
+            content_without_cr: strip_trailing_cr(content).to_string(),
+            no_newline_at_eof: *no_newline_at_eof,
+        })
+        .collect();
+    let added_keys: Vec<CrComparableDiffLine> = parsed_hunk
+        .hunk
+        .added_contents
+        .iter()
+        .zip(&parsed_hunk.added_no_newline)
+        .map(|(content, no_newline_at_eof)| CrComparableDiffLine {
+            content_without_cr: strip_trailing_cr(content).to_string(),
+            no_newline_at_eof: *no_newline_at_eof,
+        })
+        .collect();
+
+    let mut remove_deleted = vec![false; deleted_keys.len()];
+    let mut remove_added = vec![false; added_keys.len()];
+    for op in capture_diff_slices(&deleted_keys, &added_keys) {
+        if let DiffOp::Equal {
+            old_index,
+            new_index,
+            len,
+        } = op
+        {
+            for offset in 0..len {
+                let deleted_idx = old_index + offset;
+                let added_idx = new_index + offset;
+                if is_cr_at_eol_only_change(
+                    &parsed_hunk.hunk.deleted_contents[deleted_idx],
+                    &parsed_hunk.hunk.added_contents[added_idx],
+                    parsed_hunk.deleted_no_newline[deleted_idx],
+                    parsed_hunk.added_no_newline[added_idx],
+                ) {
+                    remove_deleted[deleted_idx] = true;
+                    remove_added[added_idx] = true;
+                }
+            }
+        }
+    }
+
+    filter_vec_by_remove_flags(&mut parsed_hunk.hunk.deleted_lines, &remove_deleted);
+    filter_vec_by_remove_flags(&mut parsed_hunk.hunk.deleted_contents, &remove_deleted);
+    filter_vec_by_remove_flags(&mut parsed_hunk.deleted_no_newline, &remove_deleted);
+    filter_vec_by_remove_flags(&mut parsed_hunk.hunk.added_lines, &remove_added);
+    filter_vec_by_remove_flags(&mut parsed_hunk.hunk.added_contents, &remove_added);
+    filter_vec_by_remove_flags(&mut parsed_hunk.added_no_newline, &remove_added);
+}
+
+fn strip_trailing_cr_from_hunk_contents(hunk: &mut DiffHunk) {
+    for content in hunk
+        .deleted_contents
+        .iter_mut()
+        .chain(hunk.added_contents.iter_mut())
+    {
+        if content.ends_with('\r') {
+            content.pop();
+        }
+    }
+}
+
+fn is_cr_at_eol_only_change(
+    deleted_content: &str,
+    added_content: &str,
+    deleted_no_newline: bool,
+    added_no_newline: bool,
+) -> bool {
+    !deleted_no_newline
+        && !added_no_newline
+        && deleted_content != added_content
+        && strip_trailing_cr(deleted_content) == strip_trailing_cr(added_content)
+}
+
+fn strip_trailing_cr(content: &str) -> &str {
+    content.strip_suffix('\r').unwrap_or(content)
+}
+
+fn filter_vec_by_remove_flags<T>(items: &mut Vec<T>, remove_flags: &[bool]) {
+    let mut index = 0usize;
+    items.retain(|_| {
+        let keep = !remove_flags.get(index).copied().unwrap_or(false);
+        index += 1;
+        keep
+    });
 }
 
 fn normalize_diff_path_token(path: &str) -> String {

--- a/tests/integration/eol_attribution.rs
+++ b/tests/integration/eol_attribution.rs
@@ -1,0 +1,175 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::range_authorship::range_authorship;
+use git_ai::authorship::stats::stats_for_commit_stats;
+use git_ai::git::repository::{CommitRange, find_repository_in_path};
+
+const FILE_PATH: &str = "src/eol.rs";
+const LF_BASE: &str = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
+const CRLF_WITH_DELTA: &str = "fn alpha() {}\r\nfn beta() {}\r\nfn gamma() {}\r\nfn delta() {}\r\n";
+
+#[test]
+fn test_stats_lf_to_crlf_rewrite_counts_only_logical_addition() {
+    let repo = TestRepo::new();
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join(FILE_PATH), LF_BASE).unwrap();
+    repo.stage_all_and_commit("Initial LF file").unwrap();
+
+    std::fs::write(repo.path().join(FILE_PATH), CRLF_WITH_DELTA).unwrap();
+    repo.stage_all_and_commit("Rewrite to CRLF with one new line")
+        .unwrap();
+
+    let head_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let stats = stats_for_commit_stats(&gitai_repo, head_sha.trim(), &[]).unwrap();
+
+    assert_eq!(stats.git_diff_added_lines, 1);
+    assert_eq!(stats.git_diff_deleted_lines, 0);
+    assert_eq!(stats.ai_additions, 0);
+    assert_eq!(stats.ai_accepted, 0);
+    assert_eq!(stats.unknown_additions, 1);
+}
+
+#[test]
+fn test_stats_append_after_no_final_newline_still_counts_previous_line_change() {
+    let repo = TestRepo::new();
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join(FILE_PATH), "fn alpha() {}\nfn beta() {}").unwrap();
+    repo.stage_all_and_commit("Initial file without final newline")
+        .unwrap();
+
+    std::fs::write(
+        repo.path().join(FILE_PATH),
+        "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("Append after adding final newline")
+        .unwrap();
+
+    let head_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let stats = stats_for_commit_stats(&gitai_repo, head_sha.trim(), &[]).unwrap();
+
+    assert_eq!(stats.git_diff_added_lines, 2);
+    assert_eq!(stats.git_diff_deleted_lines, 1);
+}
+
+#[test]
+fn test_ai_checkpoint_lf_to_crlf_rewrite_attributes_only_new_line_to_ai() {
+    let repo = TestRepo::new();
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join(FILE_PATH), LF_BASE).unwrap();
+    repo.stage_all_and_commit("Initial LF file").unwrap();
+
+    std::fs::write(repo.path().join(FILE_PATH), CRLF_WITH_DELTA).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", FILE_PATH]).unwrap();
+    repo.stage_all_and_commit("AI adds one line while file becomes CRLF")
+        .unwrap();
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(stats.git_diff_added_lines, 1);
+    assert_eq!(stats.git_diff_deleted_lines, 0);
+    assert_eq!(stats.human_additions, 0);
+    assert_eq!(stats.unknown_additions, 0);
+    assert_eq!(stats.ai_additions, 1);
+    assert_eq!(stats.ai_accepted, 1);
+
+    repo.filename(FILE_PATH).assert_committed_lines(lines![
+        "fn alpha() {}".human(),
+        "fn beta() {}".human(),
+        "fn gamma() {}".human(),
+        "fn delta() {}".ai(),
+    ]);
+}
+
+#[test]
+fn test_ai_checkpoint_lf_to_crlf_top_insert_preserves_existing_authorship() {
+    let repo = TestRepo::new();
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join(FILE_PATH), "fn alpha() {}\nfn beta() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial LF file").unwrap();
+
+    std::fs::write(
+        repo.path().join(FILE_PATH),
+        "fn inserted() {}\r\nfn alpha() {}\r\nfn beta() {}\r\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", FILE_PATH]).unwrap();
+    repo.stage_all_and_commit("AI inserts at top while file becomes CRLF")
+        .unwrap();
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(stats.git_diff_added_lines, 1);
+    assert_eq!(stats.git_diff_deleted_lines, 0);
+    assert_eq!(stats.ai_additions, 1);
+    assert_eq!(stats.ai_accepted, 1);
+
+    repo.filename(FILE_PATH).assert_committed_lines(lines![
+        "fn inserted() {}".ai(),
+        "fn alpha() {}".human(),
+        "fn beta() {}".human(),
+    ]);
+}
+
+#[test]
+fn test_range_stats_lf_to_crlf_rewrite_counts_only_logical_addition() {
+    let repo = TestRepo::new();
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join(FILE_PATH), LF_BASE).unwrap();
+    repo.stage_all_and_commit("Initial LF file").unwrap();
+    let first_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+
+    std::fs::write(repo.path().join(FILE_PATH), CRLF_WITH_DELTA).unwrap();
+    repo.stage_all_and_commit("Rewrite to CRLF with one new line")
+        .unwrap();
+    let second_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let commit_range = CommitRange::new_infer_refname(
+        &gitai_repo,
+        first_sha.trim().to_string(),
+        second_sha.trim().to_string(),
+        Some("HEAD".to_string()),
+    )
+    .unwrap();
+    let stats = range_authorship(commit_range, false, &[], None).unwrap();
+
+    assert_eq!(stats.range_stats.git_diff_added_lines, 1);
+    assert_eq!(stats.range_stats.git_diff_deleted_lines, 0);
+}
+
+#[test]
+fn test_range_ai_accepted_lf_to_crlf_rewrite_counts_only_logical_addition() {
+    let repo = TestRepo::new();
+
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(repo.path().join(FILE_PATH), LF_BASE).unwrap();
+    repo.stage_all_and_commit("Initial LF file").unwrap();
+    let first_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+
+    std::fs::write(repo.path().join(FILE_PATH), CRLF_WITH_DELTA).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", FILE_PATH]).unwrap();
+    repo.stage_all_and_commit("AI adds one line while file becomes CRLF")
+        .unwrap();
+    let second_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let commit_range = CommitRange::new_infer_refname(
+        &gitai_repo,
+        first_sha.trim().to_string(),
+        second_sha.trim().to_string(),
+        Some("HEAD".to_string()),
+    )
+    .unwrap();
+    let stats = range_authorship(commit_range, false, &[], None).unwrap();
+
+    assert_eq!(stats.range_stats.git_diff_added_lines, 1);
+    assert_eq!(stats.range_stats.git_diff_deleted_lines, 0);
+    assert_eq!(stats.range_stats.ai_additions, 1);
+    assert_eq!(stats.range_stats.ai_accepted, 1);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -52,6 +52,7 @@ mod diff_ignore_binary;
 mod droid;
 mod e2big_post_filter;
 mod e2e_user_scenarios;
+mod eol_attribution;
 mod event_timestamp_extraction;
 mod fast_reader;
 mod fetch_notes;


### PR DESCRIPTION
## Problem

When a file switches between LF and CRLF line endings at the same time as a real edit, git can represent unchanged lines as delete/add pairs. That inflates `git-ai stats` / post-commit stats / range stats and can make unchanged existing lines look newly AI-authored.

For example, if a file has 100 existing LF lines and an AI edit adds 1 real line while the file is saved as CRLF, the old behavior could count many rewritten lines instead of the single logical addition.

## Fix

- Ignore CR-at-EOL-only delete/add pairs when building line-numbered diff hunks used by stats, post-commit stats, range stats, and diff AI accepted calculations.
- Align old attribution snapshots to matching new line-ending bytes before byte-level attribution transforms, so LF/CRLF-only rewrites do not reattribute unchanged lines.
- Preserve final-newline behavior: adding a missing final newline before appended content is still treated as a real diff, not as CRLF-only churn.

## Tests

- `cargo test --test integration eol_attribution -- --nocapture --test-threads=1`
- `cargo test --test integration stats_unit -- --nocapture`
- `cargo test --test integration range_authorship_unit -- --nocapture`
- `cargo test --test integration checkpoint_unit -- --nocapture`
- `cargo test --test integration post_commit_unit -- --nocapture`
- `cargo test attribution_tracker::tests:: -- --nocapture`
- `cargo test diff_ai_accepted -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
