### PR TITLE
fix: normalize authorship notes before push

### DIFF
--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -660,7 +660,24 @@ pub fn normalize_notes_history_for_push(
     }
 
     let base_commit = base_ref.map(|base| rev_parse(repo, base)).transpose()?;
-    let local_notes = list_all_notes(repo, local_ref)?;
+    let mut notes_by_object = HashMap::new();
+    if let Some(base) = base_ref {
+        // If we use the remote tracking ref as the parent, the replacement tree
+        // must also contain any remote-only notes. Otherwise a failed pre-push
+        // merge followed by normalization could fast-forward the remote while
+        // deleting notes that only existed on the remote.
+        for (blob, object) in list_all_notes(repo, base)? {
+            notes_by_object.insert(object, blob);
+        }
+    }
+    for (blob, object) in list_all_notes(repo, local_ref)? {
+        notes_by_object.insert(object, blob);
+    }
+    let mut combined_notes: Vec<(String, String)> = notes_by_object
+        .into_iter()
+        .map(|(object, blob)| (blob, object))
+        .collect();
+    combined_notes.sort_by(|a, b| a.1.cmp(&b.1));
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
@@ -681,7 +698,7 @@ pub fn normalize_notes_history_for_push(
         stream.extend_from_slice(format!("from {}\n", base_commit).as_bytes());
     }
     stream.extend_from_slice(b"deleteall\n");
-    for (blob, object) in local_notes {
+    for (blob, object) in combined_notes {
         let path = notes_path_for_object(&object);
         stream.extend_from_slice(format!("M 100644 {} {}\n", blob, path).as_bytes());
     }

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -8,6 +8,8 @@ use std::collections::{HashMap, HashSet};
 // Modern refspecs without force to enable proper merging
 pub const AI_AUTHORSHIP_REFNAME: &str = "ai";
 pub const AI_AUTHORSHIP_PUSH_REFSPEC: &str = "refs/notes/ai:refs/notes/ai";
+const NOTES_UPDATE_COMMIT_MESSAGE: &str = "chore: update git-ai authorship notes";
+const NOTES_MERGE_COMMIT_MESSAGE: &str = "chore: merge git-ai authorship notes";
 
 pub fn notes_add(
     repo: &Repository,
@@ -28,6 +30,63 @@ pub fn notes_path_for_object(oid: &str) -> String {
     } else {
         format!("{}/{}", &oid[..2], &oid[2..])
     }
+}
+
+fn sanitize_fast_import_name(value: Option<&String>) -> Option<String> {
+    value
+        .map(|s| {
+            s.chars()
+                .map(|ch| match ch {
+                    '\n' | '\r' | '<' | '>' => ' ',
+                    _ => ch,
+                })
+                .collect::<String>()
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn sanitize_fast_import_email(value: Option<&String>) -> Option<String> {
+    value
+        .map(|s| {
+            s.chars()
+                .filter(|ch| !matches!(ch, '\n' | '\r' | '<' | '>' | ' '))
+                .collect::<String>()
+        })
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn append_fast_import_commit_header(
+    script: &mut Vec<u8>,
+    repo: &Repository,
+    refname: &str,
+    message: &str,
+    timestamp_secs: u64,
+) -> Result<(), GitAiError> {
+    let identity = repo.git_author_identity();
+    let email = sanitize_fast_import_email(identity.email.as_ref()).ok_or_else(|| {
+        GitAiError::Generic(
+            "Cannot write git-ai notes without a valid git committer email".to_string(),
+        )
+    })?;
+    let name = sanitize_fast_import_name(identity.name.as_ref()).unwrap_or_else(|| {
+        email
+            .split('@')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("git-ai")
+            .to_string()
+    });
+    let ident = format!("{} <{}> {} +0000", name, email, timestamp_secs);
+
+    script.extend_from_slice(format!("commit {}\n", refname).as_bytes());
+    script.extend_from_slice(format!("author {}\n", ident).as_bytes());
+    script.extend_from_slice(format!("committer {}\n", ident).as_bytes());
+    script.extend_from_slice(format!("data {}\n", message.len()).as_bytes());
+    script.extend_from_slice(message.as_bytes());
+    script.extend_from_slice(b"\n");
+    Ok(())
 }
 
 #[doc(hidden)]
@@ -215,9 +274,13 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
         script.extend_from_slice(b"\n");
     }
 
-    script.extend_from_slice(b"commit refs/notes/ai\n");
-    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
-    script.extend_from_slice(b"data 0\n");
+    append_fast_import_commit_header(
+        &mut script,
+        repo,
+        "refs/notes/ai",
+        NOTES_UPDATE_COMMIT_MESSAGE,
+        now,
+    )?;
     if let Some(existing_tip) = existing_notes_tip {
         script.extend_from_slice(format!("from {}\n", existing_tip).as_bytes());
     }
@@ -282,9 +345,13 @@ pub fn notes_add_blob_batch(
         .as_secs();
 
     let mut script = Vec::<u8>::new();
-    script.extend_from_slice(b"commit refs/notes/ai\n");
-    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
-    script.extend_from_slice(b"data 0\n");
+    append_fast_import_commit_header(
+        &mut script,
+        repo,
+        "refs/notes/ai",
+        NOTES_UPDATE_COMMIT_MESSAGE,
+        now,
+    )?;
     if let Some(existing_tip) = existing_notes_tip {
         script.extend_from_slice(format!("from {}\n", existing_tip).as_bytes());
     }
@@ -569,6 +636,131 @@ pub fn merge_notes_from_ref(repo: &Repository, source_ref: &str) -> Result<(), G
     Ok(())
 }
 
+pub fn normalize_notes_history_for_push(
+    repo: &Repository,
+    base_ref: Option<&str>,
+) -> Result<bool, GitAiError> {
+    let local_ref = "refs/notes/ai";
+    if !ref_exists(repo, local_ref) {
+        return Ok(false);
+    }
+
+    let base_ref = base_ref.filter(|base| ref_exists(repo, base));
+    if !notes_history_requires_normalization(repo, local_ref, base_ref)? {
+        return Ok(false);
+    }
+
+    let local_tree = rev_parse(repo, &format!("{}^{{tree}}", local_ref))?;
+    if let Some(base) = base_ref {
+        let base_tree = rev_parse(repo, &format!("{}^{{tree}}", base))?;
+        if local_tree == base_tree {
+            copy_ref(repo, base, local_ref)?;
+            return Ok(true);
+        }
+    }
+
+    let base_commit = base_ref.map(|base| rev_parse(repo, base)).transpose()?;
+    let local_notes = list_all_notes(repo, local_ref)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
+        .as_secs();
+
+    let temp_ref = format!("refs/notes/ai-normalize-tmp/{}", crate::uuid::generate_v4());
+    delete_ref_if_exists(repo, &temp_ref);
+
+    let mut stream = Vec::new();
+    append_fast_import_commit_header(
+        &mut stream,
+        repo,
+        &temp_ref,
+        NOTES_UPDATE_COMMIT_MESSAGE,
+        now,
+    )?;
+    if let Some(base_commit) = base_commit {
+        stream.extend_from_slice(format!("from {}\n", base_commit).as_bytes());
+    }
+    stream.extend_from_slice(b"deleteall\n");
+    for (blob, object) in local_notes {
+        let path = notes_path_for_object(&object);
+        stream.extend_from_slice(format!("M 100644 {} {}\n", blob, path).as_bytes());
+    }
+    stream.extend_from_slice(b"\n");
+
+    let mut args = repo.global_args_for_exec();
+    args.push("fast-import".to_string());
+    args.push("--quiet".to_string());
+    exec_git_stdin(&args, &stream)?;
+    copy_ref(repo, &temp_ref, local_ref)?;
+    delete_ref_if_exists(repo, &temp_ref);
+    Ok(true)
+}
+
+fn delete_ref_if_exists(repo: &Repository, refname: &str) {
+    let mut args = repo.global_args_for_exec();
+    args.push("update-ref".to_string());
+    args.push("-d".to_string());
+    args.push(refname.to_string());
+    let _ = exec_git(&args);
+}
+
+fn notes_history_requires_normalization(
+    repo: &Repository,
+    local_ref: &str,
+    base_ref: Option<&str>,
+) -> Result<bool, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.push("log".to_string());
+    args.push("--format=%ae%x09%ce%x09%s".to_string());
+    args.push(local_ref.to_string());
+    if let Some(base) = base_ref {
+        args.push("--not".to_string());
+        args.push(base.to_string());
+    }
+
+    let output = exec_git(&args)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok(stdout.lines().any(|line| {
+        let mut parts = line.splitn(3, '\t');
+        let author_email = parts.next().unwrap_or_default();
+        let committer_email = parts.next().unwrap_or_default();
+        let subject = parts.next().unwrap_or_default();
+
+        !is_git_server_safe_notes_subject(subject)
+            || is_legacy_git_ai_email(author_email)
+            || is_legacy_git_ai_email(committer_email)
+    }))
+}
+
+fn is_git_server_safe_notes_subject(subject: &str) -> bool {
+    let subject = subject.trim();
+    if subject.starts_with("feat: #") || subject.starts_with("fix: #") {
+        return true;
+    }
+
+    [
+        "docs:",
+        "style:",
+        "refactor:",
+        "perf:",
+        "test:",
+        "chore:",
+        "build:",
+        "ci:",
+        "revert:",
+        "release:",
+    ]
+    .iter()
+    .any(|prefix| subject.starts_with(prefix) && subject.len() > prefix.len())
+}
+
+fn is_legacy_git_ai_email(email: &str) -> bool {
+    matches!(
+        email.trim(),
+        "git-ai@local" | "git-ai@noreply" | "git-ai@localhost"
+    )
+}
+
 /// Fallback merge when `git notes merge -s ours` fails (e.g., due to git assertion
 /// failures on corrupted/mixed-fanout notes trees). Implements the "ours" strategy
 /// using a single `git fast-import` invocation that:
@@ -605,10 +797,20 @@ pub fn fallback_merge_notes_ours(repo: &Repository, source_ref: &str) -> Result<
     //    Emit source (remote) notes first, then local notes. fast-import uses
     //    last-writer-wins for duplicate paths, so local notes take precedence —
     //    this implements the "ours" merge strategy.
-    let mut stream = String::new();
-    stream.push_str(&format!("commit {}\n", local_ref));
-    stream.push_str("committer git-ai <git-ai@noreply> 0 +0000\n");
-    stream.push_str("data 23\nMerge notes (fallback)\n");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
+        .as_secs();
+
+    let mut stream = Vec::new();
+    append_fast_import_commit_header(
+        &mut stream,
+        repo,
+        &local_ref,
+        NOTES_MERGE_COMMIT_MESSAGE,
+        now,
+    )?;
+    let mut stream = String::from_utf8(stream)?;
     stream.push_str(&format!("from {}\n", local_commit));
     stream.push_str(&format!("merge {}\n", source_commit));
     // Start with a clean tree to avoid mixed-fanout issues

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -1,6 +1,6 @@
 use crate::git::refs::{
     AI_AUTHORSHIP_PUSH_REFSPEC, copy_ref, fallback_merge_notes_ours, merge_notes_from_ref,
-    ref_exists, tracking_ref_for_remote,
+    normalize_notes_history_for_push, ref_exists, tracking_ref_for_remote,
 };
 use crate::{
     error::GitAiError,
@@ -253,7 +253,13 @@ pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Resu
             );
         }
 
-        fetch_and_merge_tracking_notes(repository, remote_name);
+        let tracking_ref = fetch_and_merge_tracking_notes(repository, remote_name);
+        let base_ref = tracking_ref
+            .as_deref()
+            .filter(|r| ref_exists(repository, r));
+        if let Err(e) = normalize_notes_history_for_push(repository, base_ref) {
+            tracing::debug!("notes history normalization before push failed: {}", e);
+        }
 
         // Push notes without force (requires fast-forward)
         let push_args = build_authorship_push_args(repository.global_args_for_exec(), remote_name);
@@ -280,7 +286,7 @@ pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Resu
 }
 
 /// Fetch remote notes into a tracking ref and merge into local refs/notes/ai.
-fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
+fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) -> Option<String> {
     let tracking_ref = tracking_ref_for_remote(remote_name);
     let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
 
@@ -294,13 +300,13 @@ fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
 
     // Fetch is best-effort; if it fails (e.g., no remote notes yet), continue
     if exec_git(&fetch_args).is_err() {
-        return;
+        return None;
     }
 
     let local_notes_ref = "refs/notes/ai";
 
     if !ref_exists(repository, &tracking_ref) {
-        return;
+        return None;
     }
 
     if !ref_exists(repository, local_notes_ref) {
@@ -313,7 +319,7 @@ fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
         if let Err(e) = copy_ref(repository, &tracking_ref, local_notes_ref) {
             tracing::debug!("pre-push notes copy failed: {}", e);
         }
-        return;
+        return Some(tracking_ref);
     }
 
     // Both exist - merge them
@@ -331,6 +337,8 @@ fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
             tracing::debug!("pre-push fallback merge also failed: {}", e2);
         }
     }
+
+    Some(tracking_ref)
 }
 
 fn is_non_fast_forward_error(error: &GitAiError) -> bool {

--- a/tests/integration/refs_unit.rs
+++ b/tests/integration/refs_unit.rs
@@ -4,11 +4,13 @@ use git_ai::error::GitAiError;
 use git_ai::git::refs::{
     CommitAuthorship, commits_with_authorship_notes, copy_ref, get_commits_with_notes_from_list,
     get_reference_as_authorship_log_v3, get_reference_as_working_log, grep_ai_notes,
-    merge_notes_from_ref, note_blob_oids_for_commits, notes_add, notes_add_batch,
-    notes_add_blob_batch, ref_exists, show_authorship_note,
+    merge_notes_from_ref, normalize_notes_history_for_push, note_blob_oids_for_commits, notes_add,
+    notes_add_batch, notes_add_blob_batch, ref_exists, show_authorship_note,
 };
 use git_ai::git::repository::{exec_git, find_repository_in_path};
 use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
 
 // ---------------------------------------------------------------------------
 // Repo-based tests (TestRepo replaces TmpRepo)
@@ -28,6 +30,39 @@ fn head_sha(repo: &TestRepo) -> String {
         .expect("rev-parse HEAD")
         .trim()
         .to_string()
+}
+
+fn legacy_bad_notes_commit(repo: &TestRepo, notes_tree: &str, parent: Option<&str>) -> String {
+    let mut args = vec![
+        "-C".to_string(),
+        repo.path().to_str().unwrap().to_string(),
+        "commit-tree".to_string(),
+        notes_tree.to_string(),
+    ];
+    if let Some(parent) = parent {
+        args.push("-p".to_string());
+        args.push(parent.to_string());
+    }
+
+    let mut child = Command::new("git")
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "git-ai")
+        .env("GIT_AUTHOR_EMAIL", "git-ai@local")
+        .env("GIT_COMMITTER_NAME", "git-ai")
+        .env("GIT_COMMITTER_EMAIL", "git-ai@local")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn commit-tree");
+    child
+        .stdin
+        .as_mut()
+        .expect("commit-tree stdin")
+        .write_all(b"")
+        .expect("write empty message");
+    let output = child.wait_with_output().expect("wait commit-tree");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
 }
 
 #[test]
@@ -58,6 +93,133 @@ fn test_notes_add_and_show_authorship_note() {
     let non_existent_content =
         show_authorship_note(&gitai_repo, "0000000000000000000000000000000000000000");
     assert!(non_existent_content.is_none());
+}
+
+#[test]
+fn test_notes_add_uses_repo_identity_and_conventional_message() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("initial.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("Initial commit")
+        .expect("Failed to create initial commit");
+    let commit_sha = head_sha(&repo);
+
+    notes_add(&gitai_repo, &commit_sha, "test authorship note")
+        .expect("Failed to add authorship note");
+
+    let metadata = repo
+        .git_og(&[
+            "log",
+            "--format=%an%n%ae%n%cn%n%ce%n%s",
+            "-1",
+            "refs/notes/ai",
+        ])
+        .expect("read notes commit metadata");
+    let lines: Vec<&str> = metadata.lines().collect();
+
+    assert_eq!(lines[0], "Test User");
+    assert_eq!(lines[1], "test@example.com");
+    assert_eq!(lines[2], "Test User");
+    assert_eq!(lines[3], "test@example.com");
+    assert_eq!(lines[4], "chore: update git-ai authorship notes");
+}
+
+#[test]
+fn test_normalize_notes_history_removes_legacy_bad_notes_commits() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("initial.txt"), "initial\n").unwrap();
+    repo.stage_all_and_commit("Initial commit")
+        .expect("Failed to create initial commit");
+    let commit_sha = head_sha(&repo);
+
+    notes_add(&gitai_repo, &commit_sha, "test authorship note")
+        .expect("Failed to add authorship note");
+
+    let notes_tree = repo
+        .git_og(&["rev-parse", "refs/notes/ai^{tree}"])
+        .expect("read notes tree")
+        .trim()
+        .to_string();
+    let legacy_bad_commit = legacy_bad_notes_commit(&repo, &notes_tree, None);
+    repo.git_og(&["update-ref", "refs/notes/ai", &legacy_bad_commit])
+        .expect("install legacy bad notes commit");
+
+    assert!(normalize_notes_history_for_push(&gitai_repo, None).expect("normalize notes history"));
+
+    let metadata = repo
+        .git_og(&[
+            "log",
+            "--format=%an%n%ae%n%cn%n%ce%n%s%n%P",
+            "-1",
+            "refs/notes/ai",
+        ])
+        .expect("read normalized notes commit metadata");
+    let lines: Vec<&str> = metadata.lines().collect();
+    assert_eq!(lines[0], "Test User");
+    assert_eq!(lines[1], "test@example.com");
+    assert_eq!(lines[2], "Test User");
+    assert_eq!(lines[3], "test@example.com");
+    assert_eq!(lines[4], "chore: update git-ai authorship notes");
+    assert_eq!(lines.get(5).copied().unwrap_or_default(), "");
+
+    let retrieved_content =
+        show_authorship_note(&gitai_repo, &commit_sha).expect("note survives normalization");
+    assert_eq!(retrieved_content, "test authorship note");
+}
+
+#[test]
+fn test_normalize_notes_history_preserves_remote_base_parent() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    repo.stage_all_and_commit("Commit A").expect("commit A");
+    let commit_a = head_sha(&repo);
+    notes_add(&gitai_repo, &commit_a, "note A").expect("add note A");
+
+    let base_ref = "refs/notes/ai-remote/origin";
+    repo.git_og(&["update-ref", base_ref, "refs/notes/ai"])
+        .expect("copy base notes ref");
+    let base_commit = repo
+        .git_og(&["rev-parse", base_ref])
+        .expect("read base notes commit")
+        .trim()
+        .to_string();
+
+    fs::write(repo.path().join("b.txt"), "b\n").unwrap();
+    repo.stage_all_and_commit("Commit B").expect("commit B");
+    let commit_b = head_sha(&repo);
+    notes_add(&gitai_repo, &commit_b, "note B").expect("add note B");
+
+    let notes_tree = repo
+        .git_og(&["rev-parse", "refs/notes/ai^{tree}"])
+        .expect("read notes tree")
+        .trim()
+        .to_string();
+    let legacy_bad_commit = legacy_bad_notes_commit(&repo, &notes_tree, Some(&base_commit));
+    repo.git_og(&["update-ref", "refs/notes/ai", &legacy_bad_commit])
+        .expect("install legacy bad notes commit with remote base parent");
+
+    assert!(
+        normalize_notes_history_for_push(&gitai_repo, Some(base_ref))
+            .expect("normalize notes history")
+    );
+
+    let metadata = repo
+        .git_og(&["log", "--format=%s%n%P", "-1", "refs/notes/ai"])
+        .expect("read normalized notes commit metadata");
+    let lines: Vec<&str> = metadata.lines().collect();
+    assert_eq!(lines[0], "chore: update git-ai authorship notes");
+    assert_eq!(lines[1], base_commit);
+
+    assert_eq!(
+        show_authorship_note(&gitai_repo, &commit_a).expect("note A survives normalization"),
+        "note A"
+    );
+    assert_eq!(
+        show_authorship_note(&gitai_repo, &commit_b).expect("note B survives normalization"),
+        "note B"
+    );
 }
 
 #[test]

--- a/tests/integration/refs_unit.rs
+++ b/tests/integration/refs_unit.rs
@@ -223,6 +223,66 @@ fn test_normalize_notes_history_preserves_remote_base_parent() {
 }
 
 #[test]
+fn test_normalize_notes_history_keeps_remote_only_notes_when_using_base_parent() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("remote.txt"), "remote\n").unwrap();
+    repo.stage_all_and_commit("Remote commit")
+        .expect("remote commit");
+    let remote_commit = head_sha(&repo);
+    notes_add(&gitai_repo, &remote_commit, "remote-only note").expect("add remote note");
+
+    let base_ref = "refs/notes/ai-remote/origin";
+    repo.git_og(&["update-ref", base_ref, "refs/notes/ai"])
+        .expect("copy remote notes ref");
+    let base_commit = repo
+        .git_og(&["rev-parse", base_ref])
+        .expect("read base notes commit")
+        .trim()
+        .to_string();
+
+    fs::write(repo.path().join("local.txt"), "local\n").unwrap();
+    repo.stage_all_and_commit("Local commit")
+        .expect("local commit");
+    let local_commit = head_sha(&repo);
+
+    // Simulate the hazardous state from a failed pre-push notes merge:
+    // the fetched tracking ref has a remote-only note, while local refs/notes/ai
+    // has legacy metadata and only the local note. Normalization must not create
+    // a fast-forward commit on top of the tracking ref that drops the remote note.
+    notes_add(&gitai_repo, &local_commit, "local note").expect("add local note");
+    let notes_tree = repo
+        .git_og(&["rev-parse", "refs/notes/ai^{tree}"])
+        .expect("read local notes tree")
+        .trim()
+        .to_string();
+    let legacy_bad_commit = legacy_bad_notes_commit(&repo, &notes_tree, None);
+    repo.git_og(&["update-ref", "refs/notes/ai", &legacy_bad_commit])
+        .expect("install local-only legacy notes commit");
+
+    assert!(
+        normalize_notes_history_for_push(&gitai_repo, Some(base_ref))
+            .expect("normalize notes history")
+    );
+
+    let metadata = repo
+        .git_og(&["log", "--format=%s%n%P", "-1", "refs/notes/ai"])
+        .expect("read normalized notes metadata");
+    let lines: Vec<&str> = metadata.lines().collect();
+    assert_eq!(lines[0], "chore: update git-ai authorship notes");
+    assert_eq!(lines[1], base_commit);
+
+    assert_eq!(
+        show_authorship_note(&gitai_repo, &remote_commit).expect("remote note survives"),
+        "remote-only note"
+    );
+    assert_eq!(
+        show_authorship_note(&gitai_repo, &local_commit).expect("local note survives"),
+        "local note"
+    );
+}
+
+#[test]
 fn test_notes_add_batch_writes_multiple_notes() {
     let (repo, gitai_repo) = repo_with_handle();
 


### PR DESCRIPTION
## Summary

Fixes #1376.

Some repositories can reject pushes to `refs/notes/ai` when the notes history contains legacy git-ai generated commits with placeholder identities such as `git-ai@local` or empty/non-conventional commit messages. This can leave authorship notes unable to sync even though the note contents themselves are valid.

This change:

- writes new `refs/notes/ai` fast-import commits with the repository's configured Git identity and a conventional `chore:` subject
- normalizes legacy local notes history before pushing authorship notes, preserving the current notes tree and the fetched remote base when available
- updates fallback notes merge commits to use the same safe metadata path
- adds coverage for safe notes commit metadata and history normalization

## Verification

- `cargo fmt --check`
- `cargo build --bin git-ai`
- `cargo test --test integration refs_unit:: -- --nocapture`
- `cargo test --test integration push_authorship_notes -- --nocapture`
- `cargo test --test integration 'fetch_notes::' -- --nocapture`
- `cargo test --test notes_sync_regression -- --nocapture`
- local end-to-end simulation with a bare remote pre-receive hook rejecting legacy notes identities and non-conventional notes subjects

Note: `cargo test --test integration fetch_notes -- --nocapture` also selects an unrelated `ci_local_skip_fetch` worktree test on this machine; that one failed because the installed Git does not support `git worktree add --orphan`. The targeted `fetch_notes::` tests passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->