### PR TITLE
fix: resolve pipe deadlock in notes migrate with many notes

### DIFF
--- a/src/commands/notes_migrate.rs
+++ b/src/commands/notes_migrate.rs
@@ -169,13 +169,8 @@ pub fn handle_notes_migrate(args: &[String]) {
                 total_uploaded += response.success_count;
                 total_failed += response.failure_count;
 
-                if response.failure_count > 0 {
-                    eprintln!("    commits in failed chunk:");
-                    for (sha, _) in chunk {
-                        eprintln!("      {}", sha);
-                    }
-                }
-
+                // Cache the whole chunk best-effort — the server doesn't
+                // tell us which specific entries failed.
                 cached_entries.extend_from_slice(chunk);
             }
             Err(e) => {
@@ -322,7 +317,7 @@ fn cat_file_batch(
         .wait_with_output()
         .map_err(|e| GitAiError::Generic(format!("git cat-file --batch failed: {}", e)))?;
 
-    if let Err(e) = writer_thread.join().unwrap_or(Ok(())) {
+    if let Err(e) = writer_thread.join().expect("stdin writer thread panicked") {
         return Err(GitAiError::Generic(e));
     }
 

--- a/src/commands/notes_migrate.rs
+++ b/src/commands/notes_migrate.rs
@@ -169,10 +169,13 @@ pub fn handle_notes_migrate(args: &[String]) {
                 total_uploaded += response.success_count;
                 total_failed += response.failure_count;
 
-                // 7. Persist locally as synced (cache_synced_notes).
-                // We persist the whole chunk even if the server reported some failures,
-                // because the server counts are per-entry and we can't identify which
-                // entries failed at this level. The cache is best-effort.
+                if response.failure_count > 0 {
+                    eprintln!("    commits in failed chunk:");
+                    for (sha, _) in chunk {
+                        eprintln!("      {}", sha);
+                    }
+                }
+
                 cached_entries.extend_from_slice(chunk);
             }
             Err(e) => {
@@ -294,24 +297,34 @@ fn cat_file_batch(
         .spawn()
         .map_err(|e| GitAiError::Generic(format!("failed to spawn git cat-file --batch: {}", e)))?;
 
-    // Write all blob SHAs to stdin, then close it.
-    {
-        let stdin = child.stdin.as_mut().ok_or_else(|| {
-            GitAiError::Generic("failed to open git cat-file --batch stdin".to_string())
-        })?;
-        for sha in blob_shas {
-            writeln!(stdin, "{}", sha).map_err(|e| {
-                GitAiError::Generic(format!(
+    // Take stdin out of the child so we can write in a separate thread.
+    // This avoids a pipe deadlock: with many notes, stdout fills its buffer
+    // and the child blocks on write, while the parent is still writing to
+    // stdin and blocks there too.
+    let mut stdin = child.stdin.take().ok_or_else(|| {
+        GitAiError::Generic("failed to open git cat-file --batch stdin".to_string())
+    })?;
+
+    let blob_shas_owned: Vec<String> = blob_shas.to_vec();
+    let writer_thread = std::thread::spawn(move || -> Result<(), String> {
+        for sha in &blob_shas_owned {
+            if let Err(e) = writeln!(stdin, "{}", sha) {
+                return Err(format!(
                     "failed to write to git cat-file --batch stdin: {}",
                     e
-                ))
-            })?;
+                ));
+            }
         }
-    } // stdin is dropped here, closing the pipe and signalling EOF.
+        Ok(())
+    });
 
     let output = child
         .wait_with_output()
         .map_err(|e| GitAiError::Generic(format!("git cat-file --batch failed: {}", e)))?;
+
+    if let Err(e) = writer_thread.join().unwrap_or(Ok(())) {
+        return Err(GitAiError::Generic(e));
+    }
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/commands/notes_migrate.rs
+++ b/src/commands/notes_migrate.rs
@@ -301,14 +301,9 @@ fn cat_file_batch(
     })?;
 
     let blob_shas_owned: Vec<String> = blob_shas.to_vec();
-    let writer_thread = std::thread::spawn(move || -> Result<(), String> {
+    let writer_thread = std::thread::spawn(move || -> Result<(), std::io::Error> {
         for sha in &blob_shas_owned {
-            if let Err(e) = writeln!(stdin, "{}", sha) {
-                return Err(format!(
-                    "failed to write to git cat-file --batch stdin: {}",
-                    e
-                ));
-            }
+            writeln!(stdin, "{}", sha)?;
         }
         Ok(())
     });
@@ -317,8 +312,10 @@ fn cat_file_batch(
         .wait_with_output()
         .map_err(|e| GitAiError::Generic(format!("git cat-file --batch failed: {}", e)))?;
 
-    if let Err(e) = writer_thread.join().expect("stdin writer thread panicked") {
-        return Err(GitAiError::Generic(e));
+    if let Err(e) = writer_thread.join().expect("stdin writer thread panicked")
+        && e.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(GitAiError::IoError(e));
     }
 
     if !output.status.success() {


### PR DESCRIPTION
## Summary
- Fixed pipe deadlock in `cat_file_batch` that caused `git-ai notes migrate` to hang with large numbers of notes (5000+). The parent wrote to stdin synchronously while the child wrote to stdout — when both OS pipe buffers filled, both processes blocked forever. Fix moves stdin writing to a background thread.
- Print commit SHAs when a chunk has upload failures so we can see what's failing.

## Test plan
- [x] Verified `git-ai notes migrate` no longer hangs with 5469 notes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->