### PR TITLE
fix: resolve relative dirty_files paths in agent-v1 and known_human presets

### DIFF
--- a/agent-support/intellij/build.gradle.kts
+++ b/agent-support/intellij/build.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
         plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
         // Development-only plugins for testing (not release dependencies)
-        plugin("com.github.copilot", "1.6.1-243")
+        plugin("com.github.copilot", "1.9.1-251")
         plugin("org.jetbrains.junie", "253.819.54")
 
         // Module Dependencies. Uses `platformBundledModules` property from the gradle.properties file for bundled IntelliJ Platform modules.

--- a/agent-support/intellij/gradle.properties
+++ b/agent-support/intellij/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.usegitai.plugins.jetbrains
 pluginName = Git AI
 pluginRepositoryUrl = https://github.com/git-ai-project/git-ai
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.8
+pluginVersion = 0.1.9
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/agent-support/intellij/gradle.properties
+++ b/agent-support/intellij/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.usegitai.plugins.jetbrains
 pluginName = Git AI
 pluginRepositoryUrl = https://github.com/git-ai-project/git-ai
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.9
+pluginVersion = 0.1.10
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.plugins.template.services
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
@@ -158,7 +158,7 @@ class TelemetryService : Disposable {
             val pluginIdClass = Class.forName("com.intellij.openapi.extensions.PluginId")
             val getIdMethod = pluginIdClass.getMethod("getId", String::class.java)
             val pluginId = getIdMethod.invoke(null, PLUGIN_ID) as? PluginId
-            pluginId?.let { PluginManagerCore.getPlugin(it)?.version } ?: "unknown"
+            pluginId?.let { PluginManager.getPlugin(it)?.version } ?: "unknown"
         } catch (e: Exception) {
             "unknown"
         }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -6,8 +6,11 @@ import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
-import com.intellij.openapi.extensions.PluginId
+import com.posthog.java.HttpSender
 import com.posthog.java.PostHog as PostHogClient
+import com.posthog.java.QueueManager
+import com.posthog.java.Sender
+import com.posthog.java.shaded.org.json.JSONObject
 import io.sentry.Hint
 import io.sentry.Sentry
 import io.sentry.SentryEvent
@@ -84,13 +87,44 @@ class TelemetryService : Disposable {
                 return
             }
 
-            posthog = PostHogClient.Builder(POSTHOG_API_KEY)
+            val httpSender = HttpSender.Builder(POSTHOG_API_KEY)
                 .host(POSTHOG_HOST)
+                .build()
+            val safeSender = SafeSender(httpSender)
+            val queueManager = QueueManager.Builder(safeSender).build()
+
+            posthog = PostHogClient.BuilderWithCustomQueueManager(queueManager, safeSender)
                 .build()
 
             logger.info("PostHog initialized with distinct_id: $distinctId")
         } catch (e: Exception) {
             logger.warn("Failed to initialize PostHog: ${e.message}")
+        }
+    }
+
+    /**
+     * Wraps a PostHog Sender to prevent network exceptions from propagating
+     * as uncaught exceptions on the QueueManager background thread.
+     */
+    private class SafeSender(private val delegate: Sender) : Sender {
+        private val logger = com.intellij.openapi.diagnostic.Logger.getInstance(SafeSender::class.java)
+
+        override fun send(messages: List<JSONObject>): Boolean? {
+            return try {
+                delegate.send(messages)
+            } catch (e: Exception) {
+                logger.info("PostHog send failed (non-critical): ${e.javaClass.simpleName}")
+                null
+            }
+        }
+
+        override fun post(url: String, body: String): JSONObject? {
+            return try {
+                delegate.post(url, body)
+            } catch (e: Exception) {
+                logger.info("PostHog post failed (non-critical): ${e.javaClass.simpleName}")
+                null
+            }
         }
     }
 
@@ -153,12 +187,7 @@ class TelemetryService : Disposable {
 
     private fun getPluginVersion(): String {
         return try {
-            // Use reflection to call PluginId.getId() to avoid Kotlin companion object
-            // bytecode that doesn't exist in older IntelliJ versions (pre-252)
-            val pluginIdClass = Class.forName("com.intellij.openapi.extensions.PluginId")
-            val getIdMethod = pluginIdClass.getMethod("getId", String::class.java)
-            val pluginId = getIdMethod.invoke(null, PLUGIN_ID) as? PluginId
-            pluginId?.let { PluginManager.getPlugin(it)?.version } ?: "unknown"
+            PluginManager.getPluginByClass(this::class.java)?.version ?: "unknown"
         } catch (e: Exception) {
             "unknown"
         }

--- a/src/commands/checkpoint_agent/presets/agent_v1.rs
+++ b/src/commands/checkpoint_agent/presets/agent_v1.rs
@@ -48,8 +48,11 @@ impl AgentPreset for AgentV1Preset {
                     .into_iter()
                     .map(|p| super::parse::resolve_absolute(&p, &repo_working_dir))
                     .collect();
-                let dirty = dirty_files
-                    .map(|df| df.into_iter().map(|(k, v)| (PathBuf::from(k), v)).collect());
+                let dirty = dirty_files.map(|df| {
+                    df.into_iter()
+                        .map(|(k, v)| (super::parse::resolve_absolute(&k, &repo_working_dir), v))
+                        .collect()
+                });
                 ParsedHookEvent::PreFileEdit(PreFileEdit {
                     context: PresetContext {
                         agent_id: AgentId {
@@ -81,8 +84,11 @@ impl AgentPreset for AgentV1Preset {
                     .into_iter()
                     .map(|p| super::parse::resolve_absolute(&p, &repo_working_dir))
                     .collect();
-                let dirty = dirty_files
-                    .map(|df| df.into_iter().map(|(k, v)| (PathBuf::from(k), v)).collect());
+                let dirty = dirty_files.map(|df| {
+                    df.into_iter()
+                        .map(|(k, v)| (super::parse::resolve_absolute(&k, &repo_working_dir), v))
+                        .collect()
+                });
                 ParsedHookEvent::PostFileEdit(PostFileEdit {
                     context: PresetContext {
                         agent_id: AgentId {

--- a/src/commands/checkpoint_agent/presets/known_human.rs
+++ b/src/commands/checkpoint_agent/presets/known_human.rs
@@ -35,16 +35,20 @@ impl AgentPreset for KnownHumanPreset {
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
                 });
 
+                let cwd_str = cwd.to_str().unwrap_or(".");
+
                 let file_paths = data["edited_filepaths"]
                     .as_array()
                     .map(|arr| {
                         arr.iter()
-                            .filter_map(|x| x.as_str().map(PathBuf::from))
+                            .filter_map(|x| {
+                                x.as_str()
+                                    .map(|s| super::parse::resolve_absolute(s, cwd_str))
+                            })
                             .collect()
                     })
                     .unwrap_or_default();
 
-                let cwd_str = cwd.to_str().unwrap_or(".");
                 let dirty_files = data["dirty_files"].as_object().map(|obj| {
                     obj.iter()
                         .filter_map(|(k, v)| {

--- a/src/commands/checkpoint_agent/presets/known_human.rs
+++ b/src/commands/checkpoint_agent/presets/known_human.rs
@@ -44,9 +44,14 @@ impl AgentPreset for KnownHumanPreset {
                     })
                     .unwrap_or_default();
 
+                let cwd_str = cwd.to_str().unwrap_or(".");
                 let dirty_files = data["dirty_files"].as_object().map(|obj| {
                     obj.iter()
-                        .filter_map(|(k, v)| v.as_str().map(|s| (PathBuf::from(k), s.to_string())))
+                        .filter_map(|(k, v)| {
+                            v.as_str().map(|s| {
+                                (super::parse::resolve_absolute(k, cwd_str), s.to_string())
+                            })
+                        })
                         .collect::<HashMap<PathBuf, String>>()
                 });
 

--- a/tests/integration/agent_v1.rs
+++ b/tests/integration/agent_v1.rs
@@ -1,5 +1,8 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
 use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
 use serde_json::json;
+use std::fs;
 use std::path::PathBuf;
 
 fn parse_agent_v1(hook_input: &str) -> Result<Vec<ParsedHookEvent>, git_ai::error::GitAiError> {
@@ -178,4 +181,119 @@ fn test_agent_v1_dirty_files_multiple_files() {
         }
         _ => panic!("Expected PostFileEdit"),
     }
+}
+
+#[test]
+fn test_agent_v1_dirty_files_relative_paths_resolved_to_absolute() {
+    let hook_input = json!({
+        "type": "human",
+        "repo_working_dir": "/Users/test/project",
+        "will_edit_filepaths": ["src/main.rs"],
+        "dirty_files": {
+            "src/main.rs": "fn main() {}"
+        }
+    })
+    .to_string();
+
+    let events = parse_agent_v1(&hook_input).unwrap();
+    match &events[0] {
+        ParsedHookEvent::PreFileEdit(e) => {
+            assert_eq!(
+                e.file_paths,
+                vec![PathBuf::from("/Users/test/project/src/main.rs")]
+            );
+            let dirty_files = e.dirty_files.as_ref().unwrap();
+            assert!(
+                dirty_files.contains_key(&PathBuf::from("/Users/test/project/src/main.rs")),
+                "dirty_files keys should be resolved to absolute paths"
+            );
+        }
+        _ => panic!("Expected PreFileEdit"),
+    }
+
+    let hook_input = json!({
+        "type": "ai_agent",
+        "repo_working_dir": "/Users/test/project",
+        "edited_filepaths": ["src/main.rs"],
+        "agent_name": "github-copilot-jetbrains",
+        "model": "unknown",
+        "conversation_id": "session-1",
+        "dirty_files": {
+            "src/main.rs": "fn main() { println!(\"hello\"); }"
+        }
+    })
+    .to_string();
+
+    let events = parse_agent_v1(&hook_input).unwrap();
+    match &events[0] {
+        ParsedHookEvent::PostFileEdit(e) => {
+            assert_eq!(
+                e.file_paths,
+                vec![PathBuf::from("/Users/test/project/src/main.rs")]
+            );
+            let dirty_files = e.dirty_files.as_ref().unwrap();
+            assert!(
+                dirty_files.contains_key(&PathBuf::from("/Users/test/project/src/main.rs")),
+                "dirty_files keys should be resolved to absolute paths"
+            );
+        }
+        _ => panic!("Expected PostFileEdit"),
+    }
+}
+
+/// Regression test: JetBrains plugin sends relative paths in dirty_files via agent-v1.
+/// Without resolving to absolute, the dirty_files content override silently fails and
+/// AI attribution is lost because the checkpoint reads stale disk content instead.
+#[test]
+fn test_agent_v1_relative_dirty_files_e2e_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("test.txt");
+
+    fs::write(&file_path, "original line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // Simulate JetBrains plugin flow: sends relative paths in dirty_files
+    let repo_dir = repo.path().to_string_lossy().to_string();
+
+    // 1. Pre-edit (human) checkpoint with relative path + dirty_files
+    let pre_edit_content = "original line\n";
+    let human_payload = json!({
+        "type": "human",
+        "repo_working_dir": repo_dir,
+        "will_edit_filepaths": ["test.txt"],
+        "dirty_files": {
+            "test.txt": pre_edit_content
+        }
+    })
+    .to_string();
+    repo.git_ai(&["checkpoint", "agent-v1", "--hook-input", &human_payload])
+        .unwrap();
+
+    // 2. AI edits the file
+    let post_edit_content = "original line\nAI added line\n";
+    fs::write(&file_path, post_edit_content).unwrap();
+
+    // 3. Post-edit (ai_agent) checkpoint with relative path + dirty_files
+    let ai_payload = json!({
+        "type": "ai_agent",
+        "repo_working_dir": repo_dir,
+        "edited_filepaths": ["test.txt"],
+        "agent_name": "github-copilot-jetbrains",
+        "model": "unknown",
+        "conversation_id": "session-123",
+        "dirty_files": {
+            "test.txt": post_edit_content
+        }
+    })
+    .to_string();
+    repo.git_ai(&["checkpoint", "agent-v1", "--hook-input", &ai_payload])
+        .unwrap();
+
+    // 4. Commit and verify attribution
+    repo.stage_all_and_commit("AI edit").unwrap();
+    let mut file = repo.filename("test.txt");
+    file.assert_committed_lines(crate::lines![
+        "original line".unattributed_human(),
+        "AI added line".ai(),
+    ]);
 }

--- a/tests/integration/agent_v1.rs
+++ b/tests/integration/agent_v1.rs
@@ -251,6 +251,10 @@ fn test_agent_v1_relative_dirty_files_e2e_attribution() {
 
     fs::write(&file_path, "original line\n").unwrap();
     repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("test.txt");
+    file.assert_committed_lines(crate::lines![
+        "original line".unattributed_human(),
+    ]);
 
     // Simulate JetBrains plugin flow: sends relative paths in dirty_files
     let repo_dir = repo.path().to_string_lossy().to_string();
@@ -291,7 +295,6 @@ fn test_agent_v1_relative_dirty_files_e2e_attribution() {
 
     // 4. Commit and verify attribution
     repo.stage_all_and_commit("AI edit").unwrap();
-    let mut file = repo.filename("test.txt");
     file.assert_committed_lines(crate::lines![
         "original line".unattributed_human(),
         "AI added line".ai(),

--- a/tests/integration/agent_v1.rs
+++ b/tests/integration/agent_v1.rs
@@ -252,9 +252,7 @@ fn test_agent_v1_relative_dirty_files_e2e_attribution() {
     fs::write(&file_path, "original line\n").unwrap();
     repo.stage_all_and_commit("Initial commit").unwrap();
     let mut file = repo.filename("test.txt");
-    file.assert_committed_lines(crate::lines![
-        "original line".unattributed_human(),
-    ]);
+    file.assert_committed_lines(crate::lines!["original line".unattributed_human(),]);
 
     // Simulate JetBrains plugin flow: sends relative paths in dirty_files
     let repo_dir = repo.path().to_string_lossy().to_string();


### PR DESCRIPTION
Fixes #1403 #1391

## Summary

- Fix silent dirty_files path mismatch in `agent-v1` and `known_human` checkpoint presets — relative keys were never matching absolute `CheckpointFile.path`, causing content overrides to be ignored
- This caused AI attribution loss when the JetBrains plugin sent checkpoints with relative paths (the norm for that plugin)
- Apply `resolve_absolute()` to dirty_files keys, matching how `file_paths` are already handled
- Add regression tests (unit + e2e) exercising relative dirty_files paths
- Bump JetBrains dev dependency copilot plugin version

## Root Cause

`build_checkpoint_files` requires and produces absolute paths. The orchestrator's `dirty.get(&f.path)` lookup uses these absolute paths as keys. But `agent_v1.rs` stored dirty_files keys via `PathBuf::from(k)` without resolving — so relative keys like `"test.txt"` never matched absolute keys like `"/path/to/repo/test.txt"`. The content override silently failed and git-ai fell back to reading from disk.

## Test plan

- [x] `task test TEST_FILTER=agent_v1` — all 7 tests pass (including 2 new regression tests)
- [x] `task test TEST_FILTER=pending_ai_edit` — all 10 suppression tests pass
- [x] `task lint && task fmt` — clean
- [x] Manual verification with JetBrains + GitHub Copilot: AI attribution preserved in working log

🤖 Generated with [Claude Code](https://claude.com/claude-code)