### PR TITLE
fix: serialize notes-db tests to prevent flaky Windows CI failures

### DIFF
--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -520,6 +520,7 @@ mod tests {
     /// read helper returns the cached value. This tests the private http_* helpers
     /// directly so no config override is needed.
     #[test]
+    #[serial_test::serial(notes_db_env)]
     fn http_write_then_read_uses_cache() {
         use std::env;
 
@@ -558,6 +559,7 @@ mod tests {
 
     /// http_read_notes returns a HashMap of all cached entries for requested SHAs.
     #[test]
+    #[serial_test::serial(notes_db_env)]
     fn http_read_notes_returns_multiple() {
         use std::env;
 
@@ -636,6 +638,7 @@ mod tests {
     /// with `synced = 0` and `git notes --ref=ai show <sha>` returns nothing (note
     /// is NOT written into git refs).
     #[test]
+    #[serial_test::serial(notes_db_env)]
     fn integration_http_write_note_goes_to_db_not_git() {
         use crate::git::repository::exec_git;
         use crate::git::test_utils::TmpRepo;
@@ -694,6 +697,7 @@ mod tests {
     /// notes-db cache into `refs/notes/ai-display` so that `git log --notes=ai-display`
     /// can show them.
     #[test]
+    #[serial_test::serial(notes_db_env)]
     fn integration_materialize_notes_for_display() {
         use crate::git::repository::exec_git;
         use crate::git::test_utils::TmpRepo;

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -880,10 +880,14 @@ mod tests {
     // --- database_path ---
 
     #[test]
+    #[serial_test::serial(notes_db_env)]
     fn test_database_path_contains_expected_segments() {
         // Without the test env var set we expect the path to include .git-ai/internal/notes-db
         // (this test verifies the non-override branch at the schema level; in CI the HOME is
         // always set so dirs::home_dir() returns Some).
+        unsafe {
+            std::env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
+        }
         let path = NotesDatabase::database_path().unwrap();
         let path_str = path.to_string_lossy();
         assert!(


### PR DESCRIPTION
## Summary
- 6 tests were failing on Windows CI due to race conditions on the `NotesDatabase` global singleton (`OnceLock`) and the `GIT_AI_TEST_NOTES_DB_PATH` env var
- Added `#[serial_test::serial(notes_db_env)]` to the 5 unserialized tests that manipulate this shared state (`http_write_then_read_uses_cache`, `http_read_notes_returns_multiple`, `integration_http_write_note_goes_to_db_not_git`, `integration_materialize_notes_for_display`, `test_database_path_contains_expected_segments`)
- Also clear the env var at the start of `test_database_path_contains_expected_segments` to ensure it tests the non-override branch

## Root Cause
The `NotesDatabase::global()` uses a `OnceLock` that initializes once per process. Tests running in parallel would set `GIT_AI_TEST_NOTES_DB_PATH` to different temp files, but only the first call to `global()` determines the actual DB path. This caused:
1. `http_write_then_read_uses_cache` to panic ("expected pending row") because data was in a different DB than expected
2. The panic poisoned the shared `Mutex`, cascading to 4 other tests
3. `test_database_path_contains_expected_segments` to see a leaked temp path instead of `~/.git-ai/internal/notes-db`

## Test plan
- [x] All 7 affected tests pass locally
- [x] All 49 notes-related tests pass locally
- [x] `cargo clippy --lib` clean
- [ ] Windows CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->