### PR TITLE
fix: use forward-slash Windows paths for PowerShell hook compatibility

### DIFF
--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -2,7 +2,8 @@ use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
     MIN_CLAUDE_VERSION, binary_exists, claude_config_dir, generate_diff, get_binary_version,
-    is_git_ai_checkpoint_command, parse_version, to_git_bash_path, version_meets_requirement,
+    is_git_ai_checkpoint_command, normalize_windows_path_for_shell, parse_version,
+    version_meets_requirement,
     write_atomic,
 };
 use serde_json::{Value, json};
@@ -89,7 +90,7 @@ impl ClaudeCodeInstaller {
             serde_json::from_str(&existing_content)?
         };
 
-        let binary_path_str = to_git_bash_path(&params.binary_path);
+        let binary_path_str = normalize_windows_path_for_shell(&params.binary_path);
         let pre_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_PRE_TOOL_CMD);
         let post_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_POST_TOOL_CMD);
 
@@ -376,7 +377,7 @@ impl HookInstaller for ClaudeCodeInstaller {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mdm::utils::{clean_path, to_git_bash_path};
+    use crate::mdm::utils::{clean_path, normalize_windows_path_for_shell};
     use std::fs;
     use tempfile::TempDir;
 
@@ -1182,7 +1183,7 @@ mod tests {
         let raw_path = PathBuf::from(r"\\?\C:\Users\USERNAME\.git-ai\bin\git-ai.exe");
         let binary_path = clean_path(raw_path);
 
-        let binary_path_str = to_git_bash_path(&binary_path);
+        let binary_path_str = normalize_windows_path_for_shell(&binary_path);
         let pre_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_PRE_TOOL_CMD);
         let post_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_POST_TOOL_CMD);
 
@@ -1203,28 +1204,28 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_hook_commands_use_git_bash_path_on_windows() {
+    fn test_claude_hook_commands_use_forward_slash_path_on_windows() {
         let binary_path = PathBuf::from(r"C:\Users\Administrator\.git-ai\bin\git-ai.exe");
-        let binary_path_str = to_git_bash_path(&binary_path);
+        let binary_path_str = normalize_windows_path_for_shell(&binary_path);
         let pre_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_PRE_TOOL_CMD);
         let post_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_POST_TOOL_CMD);
 
         assert_eq!(
             pre_tool_cmd,
-            "/c/Users/Administrator/.git-ai/bin/git-ai.exe checkpoint claude --hook-input stdin",
-            "PreToolUse command should use git bash path format"
+            "C:/Users/Administrator/.git-ai/bin/git-ai.exe checkpoint claude --hook-input stdin",
+            "PreToolUse command should use forward-slash path format"
         );
         assert_eq!(
             post_tool_cmd,
-            "/c/Users/Administrator/.git-ai/bin/git-ai.exe checkpoint claude --hook-input stdin",
-            "PostToolUse command should use git bash path format"
+            "C:/Users/Administrator/.git-ai/bin/git-ai.exe checkpoint claude --hook-input stdin",
+            "PostToolUse command should use forward-slash path format"
         );
     }
 
     #[test]
     fn test_claude_hook_commands_preserve_unix_path() {
         let binary_path = PathBuf::from("/usr/local/bin/git-ai");
-        let binary_path_str = to_git_bash_path(&binary_path);
+        let binary_path_str = normalize_windows_path_for_shell(&binary_path);
         let pre_tool_cmd = format!("{} {}", binary_path_str, CLAUDE_PRE_TOOL_CMD);
 
         assert_eq!(

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -3,8 +3,7 @@ use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerPa
 use crate::mdm::utils::{
     MIN_CLAUDE_VERSION, binary_exists, claude_config_dir, generate_diff, get_binary_version,
     is_git_ai_checkpoint_command, normalize_windows_path_for_shell, parse_version,
-    version_meets_requirement,
-    write_atomic,
+    version_meets_requirement, write_atomic,
 };
 use serde_json::{Value, json};
 use std::fs;

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -663,30 +663,30 @@ pub fn clean_path(path: PathBuf) -> PathBuf {
     path
 }
 
-/// Convert a Windows path to git bash (MSYS/MinGW) style path.
-/// e.g. `C:\Users\Administrator\.git-ai\bin\git-ai.exe` → `/c/Users/Administrator/.git-ai/bin/git-ai.exe`
-/// This is needed because Claude Code runs hooks in git bash shell on Windows.
+/// Normalize a Windows path to use forward slashes while preserving the drive letter.
+/// e.g. `C:\Users\Administrator\.git-ai\bin\git-ai.exe` → `C:/Users/Administrator/.git-ai/bin/git-ai.exe`
+/// Forward-slash paths work in both git bash and PowerShell on Windows.
 /// Non-Windows paths (or paths that don't match `X:\...` pattern) are returned unchanged.
-pub fn to_git_bash_path(path: &Path) -> String {
+pub fn normalize_windows_path_for_shell(path: &Path) -> String {
     let s = path.to_string_lossy();
-    // Match a Windows absolute path like "C:\..." or "D:\..."
     let bytes = s.as_bytes();
+    // Match a Windows absolute path like "C:\..." or "D:\..."
     if bytes.len() >= 3
         && bytes[0].is_ascii_alphabetic()
         && bytes[1] == b':'
         && (bytes[2] == b'\\' || bytes[2] == b'/')
     {
-        let drive_letter = (bytes[0] as char).to_ascii_lowercase();
+        let drive_letter = (bytes[0] as char).to_ascii_uppercase();
         let rest = &s[2..]; // skip "C:"
-        let rest_unix = rest.replace('\\', "/");
-        return format!("/{}{}", drive_letter, rest_unix);
+        let rest_fwd = rest.replace('\\', "/");
+        return format!("{}:{}", drive_letter, rest_fwd);
     }
-    // Also handle the case where the path has no separator after the drive letter (e.g. C:foo)
+    // Handle drive-relative path (e.g. C:foo)
     if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
-        let drive_letter = (bytes[0] as char).to_ascii_lowercase();
+        let drive_letter = (bytes[0] as char).to_ascii_uppercase();
         let rest = &s[2..];
-        let rest_unix = rest.replace('\\', "/");
-        return format!("/{}/{}", drive_letter, rest_unix);
+        let rest_fwd = rest.replace('\\', "/");
+        return format!("{}:/{}", drive_letter, rest_fwd);
     }
     // For non-Windows paths, just return as-is
     s.into_owned()
@@ -1216,29 +1216,30 @@ mod tests {
     }
 
     #[test]
-    fn test_to_git_bash_path_converts_windows_path() {
+    fn test_normalize_windows_path_for_shell_converts_windows_path() {
+        // Fixes #1413: use forward-slash Windows paths that work in both git bash AND PowerShell
         let path = PathBuf::from(r"C:\Users\Administrator\.git-ai\bin\git-ai.exe");
-        let result = to_git_bash_path(&path);
+        let result = normalize_windows_path_for_shell(&path);
         assert_eq!(
-            result, "/c/Users/Administrator/.git-ai/bin/git-ai.exe",
-            "should convert Windows path to git bash format"
+            result, "C:/Users/Administrator/.git-ai/bin/git-ai.exe",
+            "should convert Windows path to forward-slash format"
         );
     }
 
     #[test]
-    fn test_to_git_bash_path_converts_different_drive_letter() {
+    fn test_normalize_windows_path_for_shell_converts_different_drive_letter() {
         let path = PathBuf::from(r"D:\Projects\code\app.exe");
-        let result = to_git_bash_path(&path);
+        let result = normalize_windows_path_for_shell(&path);
         assert_eq!(
-            result, "/d/Projects/code/app.exe",
-            "should convert D: drive path to git bash format"
+            result, "D:/Projects/code/app.exe",
+            "should convert D: drive path to forward-slash format"
         );
     }
 
     #[test]
-    fn test_to_git_bash_path_preserves_unix_path() {
+    fn test_normalize_windows_path_for_shell_preserves_unix_path() {
         let path = PathBuf::from("/usr/local/bin/git-ai");
-        let result = to_git_bash_path(&path);
+        let result = normalize_windows_path_for_shell(&path);
         assert_eq!(
             result, "/usr/local/bin/git-ai",
             "should preserve unix paths unchanged"
@@ -1246,24 +1247,24 @@ mod tests {
     }
 
     #[test]
-    fn test_to_git_bash_path_handles_extended_prefix_after_clean() {
+    fn test_normalize_windows_path_for_shell_handles_extended_prefix_after_clean() {
         // After clean_path strips \\?\ prefix, the path looks like C:\...
         let raw = PathBuf::from(r"\\?\C:\Users\USERNAME\.git-ai\bin\git-ai.exe");
         let cleaned = clean_path(raw);
-        let result = to_git_bash_path(&cleaned);
+        let result = normalize_windows_path_for_shell(&cleaned);
         assert_eq!(
-            result, "/c/Users/USERNAME/.git-ai/bin/git-ai.exe",
-            "should convert cleaned Windows path to git bash format"
+            result, "C:/Users/USERNAME/.git-ai/bin/git-ai.exe",
+            "should convert cleaned Windows path to forward-slash format"
         );
     }
 
     #[test]
-    fn test_to_git_bash_path_handles_drive_relative_path() {
+    fn test_normalize_windows_path_for_shell_handles_drive_relative_path() {
         // Drive-relative path like C:foo (no separator after colon)
         let path = PathBuf::from("C:foo");
-        let result = to_git_bash_path(&path);
+        let result = normalize_windows_path_for_shell(&path);
         assert_eq!(
-            result, "/c/foo",
+            result, "C:/foo",
             "should insert separator between drive letter and relative path"
         );
     }


### PR DESCRIPTION
Fixes #1413

## Summary

- Hook commands in `settings.json` now use `C:/Users/...` format instead of MSYS `/c/Users/...` format
- Forward-slash Windows paths work in **both** git bash and PowerShell, whereas MSYS paths only work in git bash
- Renamed `to_git_bash_path()` → `normalize_windows_path_for_shell()` to reflect actual purpose

## Context

PR #603 originally converted paths to MSYS format because Claude Code ran hooks exclusively in git bash. Since Claude Code v2.1.120+, hooks can also run in PowerShell (as fallback or explicit choice). The MSYS format `/c/Users/...` is not valid in PowerShell, breaking hook execution for users who run Claude CLI from PowerShell.

The `C:/path` format works universally because:
- **Git bash**: forwards it directly to Windows API (documented in MSYS2 filesystem paths)
- **PowerShell**: handles forward slashes natively
- **cmd**: handles forward slashes natively

## Test plan

- [x] Updated all path conversion tests to assert new format
- [x] Full test suite passes (4743 tests, 0 failures)
- [x] `task lint` and `task fmt` clean
- [ ] Verify on Windows with PowerShell: `git-ai install-hooks` then check `~/.claude/settings.json`
- [ ] Verify on Windows with git bash: hooks still execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->