### PR TITLE
fix: always generate unique trace_id for each session event

### DIFF
--- a/src/daemon/transcript_worker.rs
+++ b/src/daemon/transcript_worker.rs
@@ -524,14 +524,7 @@ impl TranscriptWorker {
                                 .as_secs() as u32
                         }),
                     };
-                    let trace_id = match (&task.trace_id, &task.tool_use_id, &tid) {
-                        (Some(hook_trace_id), Some(hook_tuid), Some(event_tuid))
-                            if hook_tuid == event_tuid =>
-                        {
-                            hook_trace_id.clone()
-                        }
-                        _ => generate_trace_id(),
-                    };
+                    let trace_id = generate_trace_id();
                     let attrs_sparse = base_attrs.clone().trace_id(trace_id).to_sparse();
                     let raw_event = redact_json_secrets(raw_event);
                     MetricEvent::from_values_with_timestamp(


### PR DESCRIPTION
## Summary
- Removes trace_id sharing logic between transcript events that match a checkpoint notification's tool_use_id
- Each session event now always gets a fresh unique trace_id via `generate_trace_id()`
- Fixes silent data loss in Clickhouse where tool_use/tool_result event pairs with the same trace_id and same-second timestamps collided on the ReplacingMergeTree ORDER BY key `(org_id, user_id, session_id, trace_id, event_ts)`

## Root Cause
The transcript worker previously reused the hook's trace_id for all events whose tool_use_id matched. For Claude transcripts, both the assistant `tool_use` event and its paired user `tool_result` event share the same tool_use_id — so both got the same trace_id. When their timestamps fell within the same second (common for fast tools like Read), Clickhouse treated them as duplicates and silently dropped one during background merges.

## Test plan
- [ ] `task build` passes
- [ ] `task lint` passes  
- [ ] `task test` passes (no existing tests depend on trace_id reuse behavior)
- [ ] Verify no other code references `task.trace_id` or `task.tool_use_id` for session event trace correlation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->