### PR TITLE
fix: add ApplyPatch support to Cursor preset

### DIFF
--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -358,7 +358,7 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             _ => ToolClass::Skip,
         },
         Agent::Cursor => match tool_name {
-            "Write" | "Delete" | "StrReplace" => ToolClass::FileEdit,
+            "Write" | "Delete" | "StrReplace" | "ApplyPatch" => ToolClass::FileEdit,
             "Shell" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
@@ -1303,6 +1303,10 @@ mod tests {
         assert_eq!(classify_tool(Agent::Cursor, "Delete"), ToolClass::FileEdit);
         assert_eq!(
             classify_tool(Agent::Cursor, "StrReplace"),
+            ToolClass::FileEdit
+        );
+        assert_eq!(
+            classify_tool(Agent::Cursor, "ApplyPatch"),
             ToolClass::FileEdit
         );
         assert_eq!(classify_tool(Agent::Cursor, "Shell"), ToolClass::Bash);

--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -80,14 +80,31 @@ impl AgentPreset for CursorPreset {
         // Extract the edited path from Cursor file-edit tool input.
         let file_path = cursor_file_path_from_tool_input(data.get("tool_input"));
 
+        // For ApplyPatch, extract file paths from patch text if no direct file_path.
+        let patch_paths = if file_path.is_empty() && tool_name == "ApplyPatch" {
+            extract_paths_from_patch(data.get("tool_input"))
+        } else {
+            vec![]
+        };
+
         // Resolve cwd: match file_path to workspace root, or fall back to first root.
         // For Shell tools `file_path` is empty, so this returns workspace_roots[0].
-        let cwd = resolve_repo_cwd(&file_path, &workspace_roots).ok_or_else(|| {
+        let first_path = if !file_path.is_empty() {
+            &file_path
+        } else {
+            patch_paths.first().map(|s| s.as_str()).unwrap_or("")
+        };
+        let cwd = resolve_repo_cwd(first_path, &workspace_roots).ok_or_else(|| {
             GitAiError::PresetError("No workspace root found in hook_input".to_string())
         })?;
 
         let file_paths = if !file_path.is_empty() {
             vec![parse::resolve_absolute(&file_path, &cwd)]
+        } else if !patch_paths.is_empty() {
+            patch_paths
+                .iter()
+                .map(|p| parse::resolve_absolute(p, &cwd))
+                .collect()
         } else {
             vec![]
         };
@@ -175,6 +192,33 @@ fn normalize_cursor_path(path: &str) -> String {
 #[cfg(not(windows))]
 fn normalize_cursor_path(path: &str) -> String {
     path.to_string()
+}
+
+/// Extract file paths from an ApplyPatch tool_input's patch text.
+/// Parses `*** Update File:`, `*** Add File:`, `*** Delete File:`, and `*** Move to:` prefixes.
+fn extract_paths_from_patch(tool_input: Option<&serde_json::Value>) -> Vec<String> {
+    let mut paths = Vec::new();
+    let patch_text = tool_input.and_then(|ti| {
+        ti.as_str()
+            .or_else(|| ti.get("patch").and_then(|v| v.as_str()))
+    });
+    if let Some(text) = patch_text {
+        for line in text.lines() {
+            let trimmed = line.trim();
+            let maybe_path = trimmed
+                .strip_prefix("*** Update File: ")
+                .or_else(|| trimmed.strip_prefix("*** Add File: "))
+                .or_else(|| trimmed.strip_prefix("*** Delete File: "))
+                .or_else(|| trimmed.strip_prefix("*** Move to: "));
+            if let Some(path) = maybe_path {
+                let path = path.trim();
+                if !path.is_empty() && !paths.iter().any(|existing: &String| existing == path) {
+                    paths.push(path.to_string());
+                }
+            }
+        }
+    }
+    paths
 }
 
 fn cursor_file_path_from_tool_input(tool_input: Option<&serde_json::Value>) -> String {
@@ -509,6 +553,91 @@ mod tests {
                 assert_eq!(e.tool_use_id, "bash");
             }
             _ => panic!("Expected PreBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_apply_patch_pre_file_edit() {
+        let input = json!({
+            "conversation_id": "conv-patch",
+            "workspace_roots": ["/home/user/project"],
+            "hook_event_name": "preToolUse",
+            "tool_name": "ApplyPatch",
+            "model": "claude-3-5-sonnet",
+            "tool_input": {
+                "patch": "*** Begin Patch\n*** Update File: src/example.rs\n@@\n-old\n+new\n*** End Patch\n"
+            }
+        })
+        .to_string();
+        let events = CursorPreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "cursor");
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/example.rs")]
+                );
+            }
+            _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_apply_patch_post_file_edit() {
+        let input = json!({
+            "conversation_id": "conv-patch",
+            "workspace_roots": ["/home/user/project"],
+            "hook_event_name": "postToolUse",
+            "tool_name": "ApplyPatch",
+            "model": "claude-3-5-sonnet",
+            "transcript_path": "/home/user/.cursor/transcripts/conv-patch.jsonl",
+            "tool_input": {
+                "patch": "*** Begin Patch\n*** Update File: src/main.rs\n@@\n-old line\n+new line\n*** Add File: src/new.rs\n@@\n+content\n*** End Patch\n"
+            }
+        })
+        .to_string();
+        let events = CursorPreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "cursor");
+                assert_eq!(e.file_paths.len(), 2);
+                assert_eq!(
+                    e.file_paths[0],
+                    PathBuf::from("/home/user/project/src/main.rs")
+                );
+                assert_eq!(
+                    e.file_paths[1],
+                    PathBuf::from("/home/user/project/src/new.rs")
+                );
+                assert!(e.transcript_source.is_some());
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_apply_patch_with_absolute_path_in_patch() {
+        let input = json!({
+            "conversation_id": "conv-patch",
+            "workspace_roots": ["/home/user/project"],
+            "hook_event_name": "preToolUse",
+            "tool_name": "ApplyPatch",
+            "tool_input": {
+                "patch": "*** Update File: /home/user/project/src/lib.rs\nsome diff"
+            }
+        })
+        .to_string();
+        let events = CursorPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/lib.rs")]
+                );
+            }
+            _ => panic!("Expected PreFileEdit"),
         }
     }
 

--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -195,7 +195,9 @@ fn normalize_cursor_path(path: &str) -> String {
 }
 
 /// Extract file paths from an ApplyPatch tool_input's patch text.
-/// Delegates to the shared `parse::collect_apply_patch_paths_from_text` helper.
+/// Delegates to the shared `parse::collect_apply_patch_paths_from_text` helper,
+/// then applies `normalize_cursor_path` so patch-extracted paths get the same
+/// Windows `/c:/...` -> `C:\...` normalization as JSON-field paths.
 fn extract_paths_from_patch(tool_input: Option<&serde_json::Value>) -> Vec<String> {
     let mut paths = Vec::new();
     let patch_text = tool_input.and_then(|ti| {
@@ -206,6 +208,9 @@ fn extract_paths_from_patch(tool_input: Option<&serde_json::Value>) -> Vec<Strin
         parse::collect_apply_patch_paths_from_text(text, &mut paths);
     }
     paths
+        .into_iter()
+        .map(|p| normalize_cursor_path(&p))
+        .collect()
 }
 
 fn cursor_file_path_from_tool_input(tool_input: Option<&serde_json::Value>) -> String {
@@ -622,6 +627,33 @@ mod tests {
                 assert_eq!(
                     e.file_paths,
                     vec![PathBuf::from("/home/user/project/src/lib.rs")]
+                );
+            }
+            _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_cursor_apply_patch_normalizes_windows_path() {
+        // Cursor can embed Unix-style `/c:/...` paths in patch text on Windows;
+        // patch-extracted paths must be normalized just like JSON-field paths.
+        let input = json!({
+            "conversation_id": "conv-patch",
+            "workspace_roots": ["C:\\Users\\project"],
+            "hook_event_name": "preToolUse",
+            "tool_name": "ApplyPatch",
+            "tool_input": {
+                "patch": "*** Update File: /c:/Users/project/src/main.rs\nsome diff"
+            }
+        })
+        .to_string();
+        let events = CursorPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("C:\\Users\\project\\src\\main.rs")]
                 );
             }
             _ => panic!("Expected PreFileEdit"),

--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -195,7 +195,7 @@ fn normalize_cursor_path(path: &str) -> String {
 }
 
 /// Extract file paths from an ApplyPatch tool_input's patch text.
-/// Parses `*** Update File:`, `*** Add File:`, `*** Delete File:`, and `*** Move to:` prefixes.
+/// Delegates to the shared `parse::collect_apply_patch_paths_from_text` helper.
 fn extract_paths_from_patch(tool_input: Option<&serde_json::Value>) -> Vec<String> {
     let mut paths = Vec::new();
     let patch_text = tool_input.and_then(|ti| {
@@ -203,20 +203,7 @@ fn extract_paths_from_patch(tool_input: Option<&serde_json::Value>) -> Vec<Strin
             .or_else(|| ti.get("patch").and_then(|v| v.as_str()))
     });
     if let Some(text) = patch_text {
-        for line in text.lines() {
-            let trimmed = line.trim();
-            let maybe_path = trimmed
-                .strip_prefix("*** Update File: ")
-                .or_else(|| trimmed.strip_prefix("*** Add File: "))
-                .or_else(|| trimmed.strip_prefix("*** Delete File: "))
-                .or_else(|| trimmed.strip_prefix("*** Move to: "));
-            if let Some(path) = maybe_path {
-                let path = path.trim();
-                if !path.is_empty() && !paths.iter().any(|existing: &String| existing == path) {
-                    paths.push(path.to_string());
-                }
-            }
-        }
+        parse::collect_apply_patch_paths_from_text(text, &mut paths);
     }
     paths
 }
@@ -611,7 +598,7 @@ mod tests {
                     e.file_paths[1],
                     PathBuf::from("/home/user/project/src/new.rs")
                 );
-                assert!(e.transcript_source.is_some());
+                assert!(e.stream_source.is_some());
             }
             _ => panic!("Expected PostFileEdit"),
         }

--- a/src/commands/checkpoint_agent/presets/droid.rs
+++ b/src/commands/checkpoint_agent/presets/droid.rs
@@ -63,15 +63,9 @@ impl AgentPreset for DroidPreset {
                     .or_else(|| ti.get("patch").and_then(|v| v.as_str()));
 
                 if let Some(text) = patch_text {
-                    for line in text.lines() {
-                        let trimmed = line.trim();
-                        if let Some(path) = trimmed
-                            .strip_prefix("*** Update File: ")
-                            .or_else(|| trimmed.strip_prefix("*** Add File: "))
-                        {
-                            patch_paths.push(parse::resolve_absolute(path.trim(), cwd));
-                        }
-                    }
+                    let mut raw_paths = Vec::new();
+                    parse::collect_apply_patch_paths_from_text(text, &mut raw_paths);
+                    patch_paths.extend(raw_paths.iter().map(|p| parse::resolve_absolute(p, cwd)));
                 }
             }
 

--- a/src/commands/checkpoint_agent/presets/firebender.rs
+++ b/src/commands/checkpoint_agent/presets/firebender.rs
@@ -64,20 +64,7 @@ impl FirebenderPreset {
 
     fn extract_patch_paths(patch: &str) -> Vec<String> {
         let mut paths = Vec::new();
-
-        for line in patch.lines() {
-            for prefix in [
-                "*** Add File: ",
-                "*** Update File: ",
-                "*** Delete File: ",
-                "*** Move to: ",
-            ] {
-                if let Some(path) = line.strip_prefix(prefix) {
-                    Self::push_unique_path(&mut paths, path);
-                }
-            }
-        }
-
+        parse::collect_apply_patch_paths_from_text(patch, &mut paths);
         paths
     }
 

--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -425,27 +425,6 @@ fn classify_copilot_tool(tool_name: &str) -> ToolClass {
     }
 }
 
-/// Extract file paths from apply_patch text format. Called from the shared
-/// `collect_tool_paths` because apply_patch payloads embed paths in the patch
-/// text rather than in JSON keys.
-pub(super) fn collect_apply_patch_paths_from_text(raw: &str, out: &mut Vec<String>) {
-    for line in raw.lines() {
-        let trimmed = line.trim();
-        let maybe_path = trimmed
-            .strip_prefix("*** Update File: ")
-            .or_else(|| trimmed.strip_prefix("*** Add File: "))
-            .or_else(|| trimmed.strip_prefix("*** Delete File: "))
-            .or_else(|| trimmed.strip_prefix("*** Move to: "));
-
-        if let Some(path) = maybe_path {
-            let path = path.trim();
-            if !path.is_empty() && !out.iter().any(|existing| existing == path) {
-                out.push(path.to_string());
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::super::AgentPreset;
@@ -792,7 +771,7 @@ mod tests {
     fn test_collect_apply_patch_paths() {
         let text = "*** Update File: /home/user/src/main.rs\n--- some diff ---\n*** Add File: /home/user/src/new.rs\n";
         let mut paths = Vec::new();
-        collect_apply_patch_paths_from_text(text, &mut paths);
+        parse::collect_apply_patch_paths_from_text(text, &mut paths);
         assert_eq!(
             paths,
             vec!["/home/user/src/main.rs", "/home/user/src/new.rs"]

--- a/src/commands/checkpoint_agent/presets/github_copilot/mod.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/mod.rs
@@ -158,7 +158,7 @@ pub(super) fn collect_tool_paths(value: &serde_json::Value, out: &mut Vec<String
             if s.starts_with("file://") {
                 out.push(s.to_string());
             }
-            ide::collect_apply_patch_paths_from_text(s, out);
+            parse::collect_apply_patch_paths_from_text(s, out);
         }
         _ => {}
     }

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -48,24 +48,6 @@ impl OpenCodePreset {
         normalized_paths
     }
 
-    fn collect_apply_patch_paths_from_text(raw: &str, out: &mut Vec<String>) {
-        for line in raw.lines() {
-            let trimmed = line.trim();
-            let maybe_path = trimmed
-                .strip_prefix("*** Update File: ")
-                .or_else(|| trimmed.strip_prefix("*** Add File: "))
-                .or_else(|| trimmed.strip_prefix("*** Delete File: "))
-                .or_else(|| trimmed.strip_prefix("*** Move to: "));
-
-            if let Some(path) = maybe_path {
-                let path = path.trim().trim_matches('"').trim_matches('\'');
-                if !path.is_empty() && !out.iter().any(|existing| existing == path) {
-                    out.push(path.to_string());
-                }
-            }
-        }
-    }
-
     fn collect_tool_paths(value: &serde_json::Value, out: &mut Vec<String>) {
         match value {
             serde_json::Value::Object(map) => {
@@ -110,7 +92,7 @@ impl OpenCodePreset {
                 if s.starts_with("file://") {
                     out.push(s.to_string());
                 }
-                Self::collect_apply_patch_paths_from_text(s, out);
+                super::parse::collect_apply_patch_paths_from_text(s, out);
             }
             _ => {}
         }
@@ -478,7 +460,7 @@ mod tests {
     #[test]
     fn test_opencode_collect_apply_patch_paths() {
         let mut out = Vec::new();
-        OpenCodePreset::collect_apply_patch_paths_from_text(
+        super::super::parse::collect_apply_patch_paths_from_text(
             "*** Update File: src/main.rs\n*** Add File: src/new.rs",
             &mut out,
         );

--- a/src/commands/checkpoint_agent/presets/parse.rs
+++ b/src/commands/checkpoint_agent/presets/parse.rs
@@ -86,6 +86,30 @@ pub fn file_paths_from_tool_input(data: &Value, cwd: &str) -> Vec<PathBuf> {
     vec![]
 }
 
+/// Extract file paths from apply_patch / `ApplyPatch` tool text format.
+///
+/// Several presets (Codex/OpenAI-style) embed edited paths in the patch text
+/// rather than in JSON keys. Parses `*** Update File:`, `*** Add File:`,
+/// `*** Delete File:`, and `*** Move to:` prefixes, trimming surrounding
+/// whitespace and any wrapping quotes, and appends each unique path to `out`.
+pub fn collect_apply_patch_paths_from_text(raw: &str, out: &mut Vec<String>) {
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        let maybe_path = trimmed
+            .strip_prefix("*** Update File: ")
+            .or_else(|| trimmed.strip_prefix("*** Add File: "))
+            .or_else(|| trimmed.strip_prefix("*** Delete File: "))
+            .or_else(|| trimmed.strip_prefix("*** Move to: "));
+
+        if let Some(path) = maybe_path {
+            let path = path.trim().trim_matches('"').trim_matches('\'');
+            if !path.is_empty() && !out.iter().any(|existing| existing == path) {
+                out.push(path.to_string());
+            }
+        }
+    }
+}
+
 pub fn dirty_files_from_value(data: &Value, cwd: &str) -> Option<HashMap<PathBuf, String>> {
     let df = data.get("dirty_files")?;
     let obj = df.as_object()?;
@@ -216,6 +240,49 @@ mod tests {
         let data = json!({"other": "value"});
         let result = optional_str_multi(&data, &["hook_event_name", "hookEventName"]);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_collect_apply_patch_paths_from_text() {
+        let text = "\
+*** Begin Patch
+*** Update File: src/main.rs
+@@
+-old line
++new line
+*** Add File: src/new.rs
+@@
++content
+*** Delete File: src/gone.rs
+*** Move to: src/moved.rs
+*** End Patch
+";
+        let mut paths = Vec::new();
+        collect_apply_patch_paths_from_text(text, &mut paths);
+        assert_eq!(
+            paths,
+            vec![
+                "src/main.rs".to_string(),
+                "src/new.rs".to_string(),
+                "src/gone.rs".to_string(),
+                "src/moved.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_collect_apply_patch_paths_dedupes_and_trims_quotes() {
+        let text = "\
+*** Update File: \"src/main.rs\"
+*** Update File: src/main.rs
+*** Add File: 'src/other.rs'
+";
+        let mut paths = Vec::new();
+        collect_apply_patch_paths_from_text(text, &mut paths);
+        assert_eq!(
+            paths,
+            vec!["src/main.rs".to_string(), "src/other.rs".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1421

- Adds `"ApplyPatch"` to the Cursor tool classifier so it's treated as `ToolClass::FileEdit` instead of being skipped
- Extracts file paths from patch text (`*** Update File:`, `*** Add File:`, `*** Delete File:`, `*** Move to:`) — the same format already supported by Droid, Codex, OpenCode, and GitHub Copilot presets
- Resolves relative paths against workspace root, consistent with other Cursor file-edit tools

## Test plan

- [x] Unit test: `test_cursor_apply_patch_pre_file_edit` — preToolUse with patch containing `*** Update File:` produces PreFileEdit with correct path
- [x] Unit test: `test_cursor_apply_patch_post_file_edit` — postToolUse with patch containing multiple file directives extracts all paths
- [x] Unit test: `test_cursor_apply_patch_with_absolute_path_in_patch` — absolute paths in patch text are handled correctly
- [x] Unit test: `test_tool_classification_all_agents` — classifier correctly maps `ApplyPatch` to `FileEdit` for Cursor
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->