### PR TITLE
Add Junie session start checkpoint preset

### DIFF
--- a/agent-support/junie/README.md
+++ b/agent-support/junie/README.md
@@ -1,0 +1,28 @@
+# Junie support
+
+Junie CLI currently exposes a `SessionStart` hook, but not pre-edit or post-edit file hooks. The `junie` preset uses that hook to create a human baseline checkpoint for files that are already dirty when a Junie session starts or resumes.
+
+Add this hook to `~/.junie/config.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "git-ai checkpoint junie --hook-input stdin"
+      }
+    ]
+  }
+}
+```
+
+If `git-ai` is not on your `PATH`, use the absolute path to the binary in the command.
+
+Junie sends hook input on stdin, for example:
+
+```json
+{"hook_event_name":"SessionStart","source":"startup"}
+```
+
+Because Junie does not yet expose file edit lifecycle hooks, this preset only establishes the pre-session baseline. It is designed to be extended when Junie adds richer hook events.

--- a/src/commands/checkpoint_agent/presets/junie.rs
+++ b/src/commands/checkpoint_agent/presets/junie.rs
@@ -12,6 +12,25 @@ impl JuniePreset {
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
     }
 
+    fn status_path(raw_file: &str, repo_root: &Path) -> Option<PathBuf> {
+        let raw_file = raw_file.trim();
+        if raw_file.is_empty() {
+            return None;
+        }
+
+        let raw_path = raw_file
+            .split_once(" -> ")
+            .map(|(_, destination)| destination)
+            .unwrap_or(raw_file);
+        let unescaped = crate::utils::unescape_git_path(raw_path);
+        let path = Path::new(&unescaped);
+        if path.is_absolute() {
+            Some(path.to_path_buf())
+        } else {
+            Some(repo_root.join(path))
+        }
+    }
+
     fn dirty_file_paths(cwd: &Path) -> Vec<PathBuf> {
         let repo_root = crate::git::repository::discover_repository_in_path_no_git_exec(cwd)
             .ok()
@@ -34,21 +53,7 @@ impl JuniePreset {
                 if line.len() < 4 {
                     return None;
                 }
-                let raw_file = line[3..].trim();
-                if raw_file.is_empty() {
-                    return None;
-                }
-                let unescaped = crate::utils::unescape_git_path(raw_file);
-                let file = unescaped
-                    .find(" -> ")
-                    .map(|arrow| &unescaped[arrow + 4..])
-                    .unwrap_or(unescaped.as_str());
-                let path = Path::new(file);
-                if path.is_absolute() {
-                    Some(path.to_path_buf())
-                } else {
-                    Some(repo_root.join(path))
-                }
+                Self::status_path(&line[3..], &repo_root)
             })
             .collect()
     }
@@ -123,5 +128,14 @@ mod tests {
             err.to_string()
                 .contains("Unsupported Junie hook_event_name")
         );
+    }
+
+    #[test]
+    fn test_junie_status_path_splits_rename_before_unescape() {
+        let repo_root = Path::new("/repo");
+        let path = JuniePreset::status_path("\"old name.txt\" -> \"new name.txt\"", repo_root)
+            .expect("rename destination should parse");
+
+        assert_eq!(path, repo_root.join("new name.txt"));
     }
 }

--- a/src/commands/checkpoint_agent/presets/junie.rs
+++ b/src/commands/checkpoint_agent/presets/junie.rs
@@ -1,0 +1,127 @@
+use super::{AgentPreset, ParsedHookEvent, UntrackedEdit, parse};
+use crate::error::GitAiError;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub struct JuniePreset;
+
+impl JuniePreset {
+    fn current_cwd(data: &serde_json::Value) -> PathBuf {
+        parse::optional_str(data, "cwd")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+    }
+
+    fn dirty_file_paths(cwd: &Path) -> Vec<PathBuf> {
+        let repo_root = crate::git::repository::discover_repository_in_path_no_git_exec(cwd)
+            .ok()
+            .and_then(|repo| repo.workdir().ok())
+            .unwrap_or_else(|| cwd.to_path_buf());
+
+        let output = Command::new(crate::config::Config::get().git_cmd())
+            .args(["status", "--porcelain", "-uall"])
+            .current_dir(cwd)
+            .output()
+            .ok();
+
+        let Some(output) = output else {
+            return vec![];
+        };
+
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| {
+                if line.len() < 4 {
+                    return None;
+                }
+                let raw_file = line[3..].trim();
+                if raw_file.is_empty() {
+                    return None;
+                }
+                let unescaped = crate::utils::unescape_git_path(raw_file);
+                let file = unescaped
+                    .find(" -> ")
+                    .map(|arrow| &unescaped[arrow + 4..])
+                    .unwrap_or(unescaped.as_str());
+                let path = Path::new(file);
+                if path.is_absolute() {
+                    Some(path.to_path_buf())
+                } else {
+                    Some(repo_root.join(path))
+                }
+            })
+            .collect()
+    }
+}
+
+impl AgentPreset for JuniePreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        let data: serde_json::Value = serde_json::from_str(hook_input)
+            .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
+
+        let hook_event = parse::required_str(&data, "hook_event_name")?;
+        if hook_event != "SessionStart" {
+            return Err(GitAiError::PresetError(format!(
+                "Unsupported Junie hook_event_name: {hook_event}"
+            )));
+        }
+
+        let source = parse::required_str(&data, "source")?;
+        if !matches!(source, "startup" | "resume") {
+            return Err(GitAiError::PresetError(format!(
+                "Unsupported Junie source: {source}"
+            )));
+        }
+
+        let cwd = Self::current_cwd(&data);
+        let file_paths = Self::dirty_file_paths(&cwd);
+
+        Ok(vec![ParsedHookEvent::UntrackedEdit(UntrackedEdit {
+            trace_id: trace_id.to_string(),
+            cwd,
+            file_paths,
+        })])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::checkpoint_agent::presets::ParsedHookEvent;
+    use serde_json::json;
+
+    #[test]
+    fn test_junie_session_start_uses_cwd_from_payload() {
+        let input = json!({
+            "hook_event_name": "SessionStart",
+            "source": "resume",
+            "cwd": "/tmp/project"
+        })
+        .to_string();
+
+        let events = JuniePreset.parse(&input, "t_test").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::UntrackedEdit(edit) => {
+                assert_eq!(edit.trace_id, "t_test");
+                assert_eq!(edit.cwd, PathBuf::from("/tmp/project"));
+            }
+            _ => panic!("Expected UntrackedEdit"),
+        }
+    }
+
+    #[test]
+    fn test_junie_rejects_non_session_start_events() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "source": "startup"
+        })
+        .to_string();
+
+        let err = JuniePreset.parse(&input, "t_test").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unsupported Junie hook_event_name")
+        );
+    }
+}

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -12,6 +12,7 @@ mod firebender;
 mod gemini;
 mod github_copilot;
 mod human;
+mod junie;
 mod known_human;
 mod mock_ai;
 mod mock_known_human;
@@ -162,6 +163,7 @@ pub fn resolve_preset(name: &str) -> Result<Box<dyn AgentPreset>, GitAiError> {
         "droid" => Ok(Box::new(droid::DroidPreset)),
         "opencode" => Ok(Box::new(opencode::OpenCodePreset)),
         "pi" => Ok(Box::new(pi::PiPreset)),
+        "junie" => Ok(Box::new(junie::JuniePreset)),
         "human" => Ok(Box::new(human::HumanPreset)),
         "mock_ai" => Ok(Box::new(mock_ai::MockAiPreset)),
         "known_human" => Ok(Box::new(known_human::KnownHumanPreset)),

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -310,7 +310,7 @@ fn print_help() {
     eprintln!("Commands:");
     eprintln!("  checkpoint         Checkpoint working changes and attribute author");
     eprintln!(
-        "    Presets: claude, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, pi, ai_tab, firebender, human, mock_ai, mock_known_human, known_human"
+        "    Presets: claude, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, pi, junie, ai_tab, firebender, human, mock_ai, mock_known_human, known_human"
     );
     eprintln!(
         "    --hook-input <json|stdin>   JSON payload required by presets, or 'stdin' to read from stdin"

--- a/tests/integration/junie.rs
+++ b/tests/integration/junie.rs
@@ -1,0 +1,86 @@
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::working_log::CheckpointKind;
+use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
+use serde_json::json;
+use std::fs;
+use std::path::PathBuf;
+
+fn parse_junie(hook_input: &str) -> Result<Vec<ParsedHookEvent>, git_ai::error::GitAiError> {
+    resolve_preset("junie")?.parse(hook_input, "t_test")
+}
+
+#[test]
+fn test_junie_session_start_returns_untracked_edit_event() {
+    let hook_input = json!({
+        "hook_event_name": "SessionStart",
+        "source": "startup",
+        "cwd": "/Users/test/project"
+    })
+    .to_string();
+
+    let events = parse_junie(&hook_input).expect("Junie SessionStart should parse");
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ParsedHookEvent::UntrackedEdit(edit) => {
+            assert_eq!(edit.trace_id, "t_test");
+            assert_eq!(edit.cwd, PathBuf::from("/Users/test/project"));
+        }
+        _ => panic!("Expected UntrackedEdit for Junie SessionStart"),
+    }
+}
+
+#[test]
+fn test_junie_rejects_unsupported_source() {
+    let hook_input = json!({
+        "hook_event_name": "SessionStart",
+        "source": "clear"
+    })
+    .to_string();
+
+    let result = parse_junie(&hook_input);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported Junie source")
+    );
+}
+
+#[test]
+fn test_junie_session_start_checkpoints_dirty_files_as_human_baseline() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("existing.txt"), "base\n").expect("write base file");
+    repo.stage_all_and_commit("initial commit")
+        .expect("initial commit should succeed");
+
+    let src_dir = repo.path().join("src");
+    fs::create_dir_all(&src_dir).expect("create src directory");
+    fs::write(src_dir.join("main.rs"), "fn main() {}\n").expect("write dirty file");
+
+    let hook_input = json!({
+        "hook_event_name": "SessionStart",
+        "source": "startup"
+    })
+    .to_string();
+
+    repo.git_ai_with_stdin(
+        &["checkpoint", "junie", "--hook-input", "stdin"],
+        hook_input.as_bytes(),
+    )
+    .expect("Junie checkpoint should succeed");
+
+    let checkpoints = repo
+        .current_working_logs()
+        .read_all_checkpoints()
+        .expect("checkpoints should be readable");
+    let latest = checkpoints.last().expect("Junie checkpoint should exist");
+    assert_eq!(latest.kind, CheckpointKind::Human);
+    assert!(
+        latest
+            .entries
+            .iter()
+            .any(|entry| entry.file == "src/main.rs"),
+        "Junie SessionStart should baseline current dirty files"
+    );
+}

--- a/tests/integration/junie.rs
+++ b/tests/integration/junie.rs
@@ -84,3 +84,43 @@ fn test_junie_session_start_checkpoints_dirty_files_as_human_baseline() {
         "Junie SessionStart should baseline current dirty files"
     );
 }
+
+#[test]
+fn test_junie_session_start_checkpoints_quoted_rename_destination() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("old name.txt"), "base\n").expect("write base file");
+    repo.stage_all_and_commit("initial commit")
+        .expect("initial commit should succeed");
+    repo.git(&["mv", "old name.txt", "new name.txt"])
+        .expect("rename should succeed");
+
+    let hook_input = json!({
+        "hook_event_name": "SessionStart",
+        "source": "resume"
+    })
+    .to_string();
+
+    repo.git_ai_with_stdin(
+        &["checkpoint", "junie", "--hook-input", "stdin"],
+        hook_input.as_bytes(),
+    )
+    .expect("Junie checkpoint should succeed");
+
+    let checkpoints = repo
+        .current_working_logs()
+        .read_all_checkpoints()
+        .expect("checkpoints should be readable");
+    let latest = checkpoints.last().expect("Junie checkpoint should exist");
+    assert_eq!(latest.kind, CheckpointKind::Human);
+    assert!(
+        latest
+            .entries
+            .iter()
+            .any(|entry| entry.file == "new name.txt"),
+        "Junie SessionStart should baseline renamed destination paths"
+    );
+    assert!(
+        latest.entries.iter().all(|entry| !entry.file.contains('"')),
+        "Junie rename paths should not include stray quote characters"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -77,6 +77,7 @@ mod internal_spawn_safety;
 mod issue_1204_multi_agent;
 mod jetbrains_download;
 mod jetbrains_ide_types;
+mod junie;
 mod merge_rebase;
 mod multi_repo_workspace;
 mod non_utf8_files;

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -832,6 +832,7 @@ fn is_known_checkpoint_preset(arg: &str) -> bool {
             | "windsurf"
             | "opencode"
             | "pi"
+            | "junie"
             | "ai_tab"
             | "firebender"
             | "mock_ai"


### PR DESCRIPTION
## Summary
- add a `junie` checkpoint preset for Junie `SessionStart` hook input
- baseline current dirty files as an untracked human checkpoint on `startup` or `resume`
- document `~/.junie/config.json` hook setup and add Junie parser/e2e coverage

## Limitation
- Junie currently exposes only `SessionStart`, so this establishes the pre-session baseline only.

## Validation
- `cargo fmt -- --check`
- `cargo test junie --lib`
- `cargo test --test integration junie`
- `cargo clippy --all-targets --features test-support -- -D warnings`
- `git diff --check`
- `git diff --cached | gitleaks stdin --no-banner --redact --exit-code 1`

Fixes #1437.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->