### PR TITLE
feat: 7-day default lookback for transcript streaming

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,7 @@ pub struct Config {
     custom_attributes: HashMap<String, String>,
     git_ai_hooks: HashMap<String, Vec<String>>,
     notes_backend: NotesBackendConfig,
+    transcript_streaming_lookback_days: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
@@ -191,6 +192,8 @@ pub struct FileConfig {
     pub git_ai_hooks: Option<HashMap<String, Vec<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes_backend: Option<NotesBackendConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_streaming_lookback_days: Option<u32>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -219,6 +222,8 @@ pub struct ConfigPatch {
     pub feature_flags: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes_backend: Option<NotesBackendConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_streaming_lookback_days: Option<u32>,
 }
 
 impl Config {
@@ -465,6 +470,10 @@ impl Config {
     /// Returns true when the HTTP notes backend is active.
     pub fn notes_backend_enabled(&self) -> bool {
         matches!(self.notes_backend.kind, NotesBackendKind::Http)
+    }
+
+    pub fn transcript_streaming_lookback_days(&self) -> Option<u32> {
+        self.transcript_streaming_lookback_days
     }
 
     /// Returns true if quiet mode is enabled (suppresses chart output after commits)
@@ -762,6 +771,18 @@ fn build_config() -> Config {
             .or_else(|| file_backend.as_ref().and_then(|b| b.backend_url.clone())),
     };
 
+    // Transcript streaming lookback: env > file > default (7 days). 0 means unlimited (None).
+    let transcript_streaming_lookback_days = env::var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.transcript_streaming_lookback_days)
+        })
+        .or(Some(7))
+        .and_then(|v| if v == 0 { None } else { Some(v) });
+
     #[cfg(any(test, feature = "test-support"))]
     {
         let mut config = Config {
@@ -784,6 +805,7 @@ fn build_config() -> Config {
             custom_attributes: custom_attributes.clone(),
             git_ai_hooks: git_ai_hooks.clone(),
             notes_backend,
+            transcript_streaming_lookback_days,
         };
         apply_test_config_patch(&mut config);
         config
@@ -810,6 +832,7 @@ fn build_config() -> Config {
         custom_attributes,
         git_ai_hooks,
         notes_backend,
+        transcript_streaming_lookback_days,
     }
 }
 
@@ -1240,6 +1263,9 @@ fn apply_test_config_patch(config: &mut Config) {
                 config.notes_backend.backend_url = Some(url);
             }
         }
+        if let Some(days) = patch.transcript_streaming_lookback_days {
+            config.transcript_streaming_lookback_days = if days == 0 { None } else { Some(days) };
+        }
     }
 }
 
@@ -1277,6 +1303,7 @@ mod tests {
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
             notes_backend: NotesBackendConfig::default(),
+            transcript_streaming_lookback_days: Some(7),
         }
     }
 
@@ -1387,6 +1414,7 @@ mod tests {
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
             notes_backend: NotesBackendConfig::default(),
+            transcript_streaming_lookback_days: Some(7),
         }
     }
 
@@ -1506,6 +1534,7 @@ mod tests {
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
             notes_backend: NotesBackendConfig::default(),
+            transcript_streaming_lookback_days: Some(7),
         }
     }
 
@@ -1960,5 +1989,39 @@ mod tests {
             NotesBackendKind::Http,
             "GIT_AI_NOTES_BACKEND_KIND=http should override the default git_notes"
         );
+    }
+
+    #[test]
+    fn test_transcript_streaming_lookback_days_default() {
+        let config = create_test_config(vec![], vec![]);
+        assert_eq!(config.transcript_streaming_lookback_days(), Some(7));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_transcript_streaming_lookback_days_env_override() {
+        let previous = std::env::var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS").ok();
+        unsafe { std::env::set_var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS", "14") };
+        let config = build_config();
+        let result = config.transcript_streaming_lookback_days;
+        match previous {
+            Some(v) => unsafe { std::env::set_var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS", v) },
+            None => unsafe { std::env::remove_var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS") },
+        }
+        assert_eq!(result, Some(14));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_transcript_streaming_lookback_days_zero_means_unlimited() {
+        let previous = std::env::var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS").ok();
+        unsafe { std::env::set_var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS", "0") };
+        let config = build_config();
+        let result = config.transcript_streaming_lookback_days;
+        match previous {
+            Some(v) => unsafe { std::env::set_var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS", v) },
+            None => unsafe { std::env::remove_var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS") },
+        }
+        assert_eq!(result, None);
     }
 }

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -404,6 +404,13 @@ impl StreamWorker {
             .and_then(|s| s.to_str())
             .map(|s| s.to_string());
 
+        let lookback_cutoff = config::Config::get()
+            .transcript_streaming_lookback_days()
+            .map(|days| {
+                std::time::SystemTime::now()
+                    - std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60)
+            });
+
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_file() || path.extension().map(|ext| ext == "jsonl") != Some(true) {
@@ -424,6 +431,27 @@ impl StreamWorker {
             let dedup_key = (canonical.clone(), "transcript".to_string());
             if self.in_flight.contains(&dedup_key) {
                 continue;
+            }
+
+            // Only apply lookback to NEW (untracked) subagent files — already-tracked
+            // files are always processed so partial watermarks aren't abandoned.
+            let path_str = canonical.display().to_string();
+            let already_tracked = self
+                .streams_db
+                .get_stream(&session_id, "transcript", &path_str)
+                .ok()
+                .flatten()
+                .is_some();
+
+            if !already_tracked && let Some(cutoff) = lookback_cutoff {
+                let too_old = path
+                    .metadata()
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .is_some_and(|mtime| mtime < cutoff);
+                if too_old {
+                    continue;
+                }
             }
 
             // Ensure the subagent session exists in the DB

--- a/src/daemon/sweep_coordinator.rs
+++ b/src/daemon/sweep_coordinator.rs
@@ -5,6 +5,7 @@ use crate::streams::types::StreamError;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 /// Work items discovered by the sweep.
 #[derive(Debug, Clone)]
@@ -33,13 +34,25 @@ pub enum SweepItem {
 pub struct SweepCoordinator {
     streams_db: Arc<StreamsDatabase>,
     agent_registry: Vec<(String, Box<dyn Agent>)>,
+    lookback_days: Option<u32>,
 }
 
 impl SweepCoordinator {
     pub fn new(streams_db: Arc<StreamsDatabase>) -> Self {
+        let lookback_days = crate::config::Config::get().transcript_streaming_lookback_days();
         Self {
             streams_db,
             agent_registry: get_all_agents(),
+            lookback_days,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_lookback(streams_db: Arc<StreamsDatabase>, lookback_days: Option<u32>) -> Self {
+        Self {
+            streams_db,
+            agent_registry: get_all_agents(),
+            lookback_days,
         }
     }
 
@@ -128,7 +141,12 @@ impl SweepCoordinator {
                 .streams_db
                 .get_stream(&session.session_id, stream.stream_kind, &path_str)?
             {
-                None => return Ok(true),
+                None => {
+                    if !self.is_within_lookback(&path) {
+                        continue;
+                    }
+                    return Ok(true);
+                }
                 Some(existing) => {
                     if Self::is_file_stale(&path, &existing)? {
                         return Ok(true);
@@ -163,6 +181,18 @@ impl SweepCoordinator {
             stream_kind: stream.stream_kind.to_string(),
             canonical_path: path,
         }))
+    }
+
+    fn is_within_lookback(&self, path: &Path) -> bool {
+        let Some(days) = self.lookback_days else {
+            return true;
+        };
+        let cutoff =
+            SystemTime::now() - std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60);
+        match std::fs::metadata(path) {
+            Ok(meta) => meta.modified().map(|mtime| mtime >= cutoff).unwrap_or(true),
+            Err(_) => true,
+        }
     }
 
     fn is_file_stale(path: &Path, existing: &StreamRecord) -> Result<bool, StreamError> {


### PR DESCRIPTION
## Summary

- Adds a configurable lookback period (default: 7 days) to transcript streaming sweep discovery
- Files not modified within the lookback window are skipped during periodic sweeps, reducing I/O and memory usage
- Checkpoint-triggered (immediate) processing is unaffected — active sessions are always processed regardless of lookback
- Subagent transcript discovery also respects the lookback filter

## Configuration

New config option `transcript_streaming_lookback_days` (not a feature flag):
- **Config file**: `~/.git-ai/config.json` → `"transcript_streaming_lookback_days": 30`
- **Env var**: `GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS=30`
- **Default**: 7 days
- **Disable**: Set to 0 to process all history (no lookback limit)
- **Precedence**: env var > config file > default (7)

## Design decisions

- Applied at the sweep coordinator level (discovery time) for maximum efficiency — old files never get opened or read
- Fail-open: if a file cannot be stat'd, it's assumed to be within the window
- Uses file `mtime` which is cheap (single stat syscall per file, no file reads)
- The `transcript_streaming` feature flag remains `true` by default in both debug and release

## Test plan

- [x] Unit tests for lookback filtering in sweep coordinator (4 tests)
- [x] Unit tests for config resolution (3 tests: default, env override, zero=unlimited)
- [x] All 260 transcript-related tests pass
- [x] All 3029+ integration tests pass (1 known flaky unrelated)
- [x] `task lint && task fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->