### PR TITLE
Fix Cursor hooks with corrupted payload content

### DIFF
--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -27,8 +27,7 @@ impl AgentPreset for CursorBackgroundPreset {
 
 impl AgentPreset for CursorPreset {
     fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
-        let data: serde_json::Value = serde_json::from_str(hook_input)
-            .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
+        let data = parse_cursor_payload(hook_input)?;
 
         // conversation_id is required for session_id
         let conversation_id = parse::required_str(&data, "conversation_id")?.to_string();
@@ -213,6 +212,190 @@ fn resolve_repo_cwd(file_path: &str, workspace_roots: &[String]) -> Option<Strin
     matching_workspace_root(file_path, workspace_roots).or_else(|| workspace_roots.first().cloned())
 }
 
+fn parse_cursor_payload(hook_input: &str) -> Result<serde_json::Value, GitAiError> {
+    match serde_json::from_str(hook_input) {
+        Ok(data) => Ok(data),
+        Err(parse_error) => parse_cursor_payload_lossy(hook_input).map_err(|fallback_error| {
+            GitAiError::PresetError(format!(
+                "Invalid JSON in hook_input: {}; fallback parse failed: {}",
+                parse_error, fallback_error
+            ))
+        }),
+    }
+}
+
+fn parse_cursor_payload_lossy(hook_input: &str) -> Result<serde_json::Value, String> {
+    let tool_input_start = hook_input
+        .find("\"tool_input\"")
+        .ok_or_else(|| "tool_input not found".to_string())?;
+
+    let conversation_id = find_json_string_field(hook_input, "conversation_id", 0, false)
+        .ok_or_else(|| "conversation_id not found".to_string())?;
+    let hook_event_name = find_json_string_field(hook_input, "hook_event_name", 0, true)
+        .ok_or_else(|| "hook_event_name not found".to_string())?;
+    let tool_name = find_json_string_field(hook_input, "tool_name", 0, false)
+        .ok_or_else(|| "tool_name not found".to_string())?;
+    let workspace_roots = find_json_string_array_field(hook_input, "workspace_roots", 0, true)
+        .ok_or_else(|| "workspace_roots not found".to_string())?;
+
+    let file_path = ["file_path", "path", "filePath"]
+        .iter()
+        .find_map(|key| find_json_string_field(hook_input, key, tool_input_start, false));
+    let model = find_json_string_field(hook_input, "model", 0, false);
+    let transcript_path = find_json_string_field(hook_input, "transcript_path", 0, true);
+    let tool_use_id = find_json_string_field(hook_input, "tool_use_id", 0, true);
+
+    let mut tool_input = serde_json::Map::new();
+    if let Some(path) = file_path {
+        tool_input.insert("file_path".to_string(), serde_json::Value::String(path));
+    }
+
+    let mut data = serde_json::Map::new();
+    data.insert(
+        "conversation_id".to_string(),
+        serde_json::Value::String(conversation_id),
+    );
+    data.insert(
+        "hook_event_name".to_string(),
+        serde_json::Value::String(hook_event_name),
+    );
+    data.insert(
+        "tool_name".to_string(),
+        serde_json::Value::String(tool_name),
+    );
+    data.insert(
+        "workspace_roots".to_string(),
+        serde_json::Value::Array(
+            workspace_roots
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        ),
+    );
+    data.insert(
+        "tool_input".to_string(),
+        serde_json::Value::Object(tool_input),
+    );
+    if let Some(model) = model {
+        data.insert("model".to_string(), serde_json::Value::String(model));
+    }
+    if let Some(transcript_path) = transcript_path {
+        data.insert(
+            "transcript_path".to_string(),
+            serde_json::Value::String(transcript_path),
+        );
+    }
+    if let Some(tool_use_id) = tool_use_id {
+        data.insert(
+            "tool_use_id".to_string(),
+            serde_json::Value::String(tool_use_id),
+        );
+    }
+
+    Ok(serde_json::Value::Object(data))
+}
+
+fn find_json_string_field(
+    input: &str,
+    key: &str,
+    start: usize,
+    use_last_match: bool,
+) -> Option<String> {
+    let pattern = format!("\"{}\"", key);
+    let search = input.get(start..)?;
+    let relative_index = if use_last_match {
+        search.rfind(&pattern)?
+    } else {
+        search.find(&pattern)?
+    };
+    let key_index = start + relative_index;
+    let after_key = input.get(key_index + pattern.len()..)?;
+    let colon_index = key_index + pattern.len() + after_key.find(':')?;
+    let after_colon = input.get(colon_index + 1..)?;
+    let quote_index = colon_index + 1 + after_colon.find('"')?;
+    let end_quote_index = find_json_string_end(input, quote_index)?;
+    serde_json::from_str(input.get(quote_index..=end_quote_index)?).ok()
+}
+
+fn find_json_string_array_field(
+    input: &str,
+    key: &str,
+    start: usize,
+    use_last_match: bool,
+) -> Option<Vec<String>> {
+    let pattern = format!("\"{}\"", key);
+    let search = input.get(start..)?;
+    let relative_index = if use_last_match {
+        search.rfind(&pattern)?
+    } else {
+        search.find(&pattern)?
+    };
+    let key_index = start + relative_index;
+    let after_key = input.get(key_index + pattern.len()..)?;
+    let colon_index = key_index + pattern.len() + after_key.find(':')?;
+    let after_colon = input.get(colon_index + 1..)?;
+    let array_start = colon_index + 1 + after_colon.find('[')?;
+    let array_end = find_json_array_end(input, array_start)?;
+    serde_json::from_str(input.get(array_start..=array_end)?).ok()
+}
+
+fn find_json_string_end(input: &str, quote_index: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    if bytes.get(quote_index) != Some(&b'"') {
+        return None;
+    }
+
+    let mut escaped = false;
+    for (idx, &byte) in bytes.iter().enumerate().skip(quote_index + 1) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match byte {
+            b'\\' => escaped = true,
+            b'"' => return Some(idx),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn find_json_array_end(input: &str, array_start: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    if bytes.get(array_start) != Some(&b'[') {
+        return None;
+    }
+
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (idx, &byte) in bytes.iter().enumerate().skip(array_start) {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match byte {
+            b'"' => in_string = true,
+            b'[' => depth += 1,
+            b']' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,6 +454,29 @@ mod tests {
                     assert_eq!(ts.session_id, generate_session_id("conv-123", "cursor"));
                     assert_eq!(ts.external_session_id, "conv-123");
                 }
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_fallback_parses_corrupted_tool_input_content() {
+        let input = r#"{"conversation_id":"conv-123","generation_id":"gen-123","model":"claude-3-5-sonnet","tool_name":"Write","tool_input":{"file_path":"src/main.rs","content":"class Example {\n    void f() {\n        text1 = text1.replaceAll(\"BROKEN", \":\");\n    }\n}\n"},"duration":84.485,"tool_use_id":"tool-write-1","session_id":"conv-123","hook_event_name":"postToolUse","cursor_version":"3.5.17","workspace_roots":["/home/user/project"],"user_email":"user@example.com","transcript_path":"/home/user/.cursor/transcripts/conv-123.jsonl"}"#;
+        assert!(serde_json::from_str::<serde_json::Value>(input).is_err());
+
+        let events = CursorPreset.parse(input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "cursor");
+                assert_eq!(e.context.external_session_id, "conv-123");
+                assert_eq!(e.context.agent_id.model, "claude-3-5-sonnet");
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/main.rs")]
+                );
+                assert_eq!(e.tool_use_id.as_deref(), Some("tool-write-1"));
+                assert!(e.transcript_source.is_some());
             }
             _ => panic!("Expected PostFileEdit"),
         }


### PR DESCRIPTION
I have only observed this so far when editing large files, roughly over 2,000 lines, on Windows and in Linux SSH remote sessions. I have not been able to reproduce it on macOS. I have not confirmed whether the malformed payload can also be produced in other environments, so the fix is intentionally scoped to handling already-malformed Cursor hook input rather than adding any platform-specific behavior.


Background

Cursor hook payloads can include the full edited file content inside tool_input.content for tools such as Write / Edit. I ran into a case where the payload received by git-ai checkpoint cursor --hook-input stdin was not valid JSON, even though the top-level hook metadata was still present.

The malformed part was inside the tool content string. In that situation, the Cursor preset failed before it could read fields like conversation_id, hook_event_name, tool_name, workspace_roots, and tool_input.file_path, so the checkpoint was skipped entirely with an error similar to:

cursor preset error: Invalid JSON in hook_input: key must be a string ...

This can cause Cursor-originated edits to be missed by git-ai even though the actual file path and hook metadata are still recoverable.

Root Cause

The Cursor preset previously parsed the entire hook payload with strict JSON parsing before extracting any fields. That makes the whole checkpoint depend on tool_input.content being valid JSON-escaped text.

However, for git-ai attribution, the Cursor preset does not need to trust or consume the embedded tool_input.content. The checkpoint flow only needs the hook metadata and edited file path; the actual file contents are read from the working tree later by git-ai.

So if only the large embedded content field is malformed, failing the whole checkpoint loses useful attribution data unnecessarily.

Fix

This PR keeps the existing strict JSON parsing path unchanged for valid Cursor payloads.

If strict parsing fails, it falls back to a narrow Cursor-specific metadata extraction path that only attempts to recover the fields git-ai needs:

conversation_id
hook_event_name
tool_name
workspace_roots
tool_input.file_path / compatible path aliases
optional metadata such as model, tool_use_id, and transcript_path

The fallback intentionally does not parse or use tool_input.content.

If the required metadata cannot be recovered, the preset still returns an error and includes the original JSON parse failure, so this does not silently ignore genuinely unusable payloads.

Why this should be safe

Valid Cursor hook payloads continue to use the original strict JSON parsing behavior.

The lossy fallback is only used after strict parsing fails, and it only reconstructs the small subset of metadata already required by the existing Cursor checkpoint logic. It does not change attribution logic, file diffing, working log generation, or commit note generation.

Testing

Added a regression test with a synthetic corrupted tool_input.content payload. The test verifies that strict JSON parsing fails for the synthetic payload, while the Cursor preset still recovers the required metadata and parses the event as the expected Cursor post-file-edit checkpoint.