### PR TITLE
fix(ci): don't misclassify squash merges as rebases on linear base branches

### DIFF
--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -80,7 +80,7 @@ impl CiContext {
                 head_ref,
                 head_sha,
                 base_ref,
-                base_sha: _,
+                base_sha,
             } => {
                 println!("Working repository is in {}", self.repo.path().display());
 
@@ -188,8 +188,35 @@ impl CiContext {
                 if original_commits.len() > 1 {
                     // Try to find the new rebased commits
                     // Walk back from merge_commit_sha the same number of commits as original
-                    let new_commits =
+                    let mut new_commits =
                         self.get_rebased_commits(merge_commit_sha, original_commits.len());
+
+                    // #1473: On a linear base branch the first-parent walk above can
+                    // return pre-existing base-branch commits instead of rebased PR
+                    // commits, making the counts match and misclassifying a squash
+                    // merge as a rebase (which then writes the PR's notes onto
+                    // unrelated base commits). Restrict the candidates to commits that
+                    // were actually introduced on top of the pre-merge base tip, i.e.
+                    // those in `base_sha..merge_commit_sha`. A squash merge introduces
+                    // exactly one such commit, so it can no longer look like a rebase.
+                    // `base_sha` may be empty (e.g. GitLab MRs); in that case we leave
+                    // the legacy behavior untouched.
+                    if !base_sha.is_empty() {
+                        let introduced: std::collections::HashSet<String> =
+                            CommitRange::new_infer_refname(
+                                &self.repo,
+                                base_sha.clone(),
+                                merge_commit_sha.to_string(),
+                                None,
+                            )
+                            .map(|r| r.all_commits())
+                            .unwrap_or_default()
+                            .into_iter()
+                            .collect();
+                        if !introduced.is_empty() {
+                            new_commits.retain(|sha| introduced.contains(sha));
+                        }
+                    }
 
                     if new_commits.len() == original_commits.len() {
                         println!(

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -196,8 +196,11 @@ impl CiContext {
                     // misclassified (PR notes then land on unrelated commits). Restrict
                     // to commits the merge actually introduced
                     // (`base_sha..merge_commit_sha`; see gitrevisions(7)) — a squash
-                    // yields exactly one, so it can't look like a rebase. An empty
-                    // `base_sha` (currently the GitLab path) keeps the legacy behavior.
+                    // yields exactly one, so it can't look like a rebase. GitHub passes
+                    // `pull_request.base.sha` and GitLab passes `diff_refs.start_sha`
+                    // (the target-branch tip at MR creation); an empty `base_sha`
+                    // (transient API failure on either path) safely skips the filter
+                    // and falls back to the pre-#1473 behavior.
                     if !base_sha.is_empty() {
                         let introduced: std::collections::HashSet<String> =
                             CommitRange::new_infer_refname(

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -18,7 +18,6 @@ pub enum CiEvent {
         head_ref: String,
         head_sha: String,
         base_ref: String,
-        #[allow(dead_code)]
         base_sha: String,
     },
 }
@@ -191,16 +190,14 @@ impl CiContext {
                     let mut new_commits =
                         self.get_rebased_commits(merge_commit_sha, original_commits.len());
 
-                    // #1473: On a linear base branch the first-parent walk above can
-                    // return pre-existing base-branch commits instead of rebased PR
-                    // commits, making the counts match and misclassifying a squash
-                    // merge as a rebase (which then writes the PR's notes onto
-                    // unrelated base commits). Restrict the candidates to commits that
-                    // were actually introduced on top of the pre-merge base tip, i.e.
-                    // those in `base_sha..merge_commit_sha`. A squash merge introduces
-                    // exactly one such commit, so it can no longer look like a rebase.
-                    // `base_sha` may be empty (e.g. GitLab MRs); in that case we leave
-                    // the legacy behavior untouched.
+                    // #1473: on a linear base branch the first-parent walk above can
+                    // return pre-existing base commits rather than rebased PR commits,
+                    // so a squash merge's count matches a rebase's and gets
+                    // misclassified (PR notes then land on unrelated commits). Restrict
+                    // to commits the merge actually introduced
+                    // (`base_sha..merge_commit_sha`; see gitrevisions(7)) — a squash
+                    // yields exactly one, so it can't look like a rebase. An empty
+                    // `base_sha` (currently the GitLab path) keeps the legacy behavior.
                     if !base_sha.is_empty() {
                         let introduced: std::collections::HashSet<String> =
                             CommitRange::new_infer_refname(

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -303,7 +303,16 @@ impl CiContext {
         expected_count: usize,
     ) -> Vec<String> {
         let mut commits = Vec::new();
-        let mut current_sha = merge_commit_sha.to_string();
+        // Resolve to a full SHA up front so the entries are comparable to the
+        // full 40-char SHAs produced by `git rev-list` (the #1473 `retain` filter
+        // in `run_with_options` compares against such a set). Callers like
+        // `git-ai ci local merge` may pass an abbreviated `merge_commit_sha`; the
+        // remaining entries already come from parent ids, which are full.
+        let mut current_sha = self
+            .repo
+            .revparse_single(merge_commit_sha)
+            .map(|obj| obj.id())
+            .unwrap_or_else(|_| merge_commit_sha.to_string());
 
         for _ in 0..expected_count {
             commits.push(current_sha.clone());

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 const GITLAB_CI_TEMPLATE_YAML: &str = include_str!("workflow_templates/gitlab.yaml");
 
-/// GitLab Merge Request from API response
+/// GitLab Merge Request from API response (list endpoint)
 #[derive(Debug, Clone, Deserialize)]
 struct GitLabMergeRequest {
     iid: u64,
@@ -19,6 +19,112 @@ struct GitLabMergeRequest {
     merge_commit_sha: Option<String>,
     squash_commit_sha: Option<String>,
     squash: Option<bool>,
+}
+
+/// Subset of the single-MR endpoint we need. The list endpoint we already
+/// hit does NOT include `diff_refs`; this struct deserializes the single-MR
+/// response so we can pull the right SHA out for `CiEvent::Merge.base_sha`.
+///
+/// GitLab notes that `diff_refs` "is empty when the merge request is created,
+/// and populates asynchronously," hence the outer `Option`.
+#[derive(Debug, Clone, Deserialize)]
+struct GitLabMergeRequestDetails {
+    diff_refs: Option<GitLabDiffRefs>,
+}
+
+/// The `diff_refs` object has three SHAs with subtly different semantics
+/// (paraphrased from <https://docs.gitlab.com/api/merge_requests/>):
+///
+/// - `base_sha`: the **merge-base** of the source and target branches —
+///   `git merge-base source target` — the historical fork point. For a
+///   long-lived branch on a fast-moving target this is far behind the
+///   current target tip.
+/// - `start_sha`: the **target branch commit used as the starting point for
+///   the diff**. Documented as "usually the same as `base_sha`," but in
+///   practice it tracks the target tip at diff render time, not the
+///   common ancestor. **This is the semantic match for GitHub's
+///   `pull_request.base.sha`** — i.e. "the target tip the MR was opened
+///   against."
+/// - `head_sha`: the source branch tip. We already get this from `mr.sha`
+///   on the list endpoint, so we don't deserialize it here.
+///
+/// The #1473 retain filter in `CiContext::run_with_options` computes
+/// `base_sha..merge_commit_sha` to find commits the MR introduced. For a
+/// squash-on-linear-main scenario with `main = B0→B1→B2→B3` and squash
+/// commit `S`, the filter needs a range that yields exactly `{S}`. Using
+/// `base_sha` (the merge-base `B0`) gives `{B1,B2,B3,S}` and lets the walk
+/// match the PR commit count again — recreating the original #1473 bug.
+/// Using `start_sha` (the target tip `B3`) gives `{S}` and squash is
+/// correctly detected.
+///
+/// So: we prefer `start_sha`; `base_sha` is a fallback for the edge cases
+/// where GitLab returns the former as null but the latter populated.
+#[derive(Debug, Clone, Deserialize)]
+struct GitLabDiffRefs {
+    base_sha: Option<String>,
+    start_sha: Option<String>,
+}
+
+/// Build and send an authenticated GET to a GitLab REST endpoint.
+///
+/// Every GitLab API call in this module shares the same shape: 30s timeout,
+/// `User-Agent: git-ai/<version>`, one of `PRIVATE-TOKEN` / `JOB-TOKEN`.
+/// Centralizing it here keeps the call sites focused on what they're after
+/// (URL + parsing) rather than re-stating transport boilerplate.
+fn gitlab_api_get(
+    endpoint: &str,
+    auth_header_name: &str,
+    auth_token: &str,
+) -> Result<crate::http::Response, String> {
+    let agent = crate::http::build_agent(Some(30));
+    let request = agent.get(endpoint).set(auth_header_name, auth_token).set(
+        "User-Agent",
+        &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
+    );
+    crate::http::send(request)
+}
+
+/// Fetch the SHA we want to feed into `CiEvent::Merge.base_sha` (the
+/// target-branch starting point of the MR), preferring `diff_refs.start_sha`
+/// over `diff_refs.base_sha`. See [`GitLabDiffRefs`] for why.
+///
+/// Returns `None` whenever anything goes wrong (transport error, non-200,
+/// malformed body, missing `diff_refs`, both SHAs null); callers fall back to
+/// the legacy empty-string behavior, which keeps GitLab safe but unprotected
+/// from the #1473 misclassification for that one MR.
+fn fetch_mr_base_sha(
+    api_url: &str,
+    auth_header_name: &str,
+    auth_token: &str,
+    project_id: &str,
+    iid: u64,
+) -> Option<String> {
+    let endpoint = format!("{}/projects/{}/merge_requests/{}", api_url, project_id, iid);
+    let resp = match gitlab_api_get(&endpoint, auth_header_name, auth_token) {
+        Ok(resp) if resp.status_code == 200 => resp,
+        _ => return None,
+    };
+    let body = String::from_utf8_lossy(resp.as_bytes());
+    let diff_refs = serde_json::from_str::<GitLabMergeRequestDetails>(&body)
+        .ok()?
+        .diff_refs?;
+
+    // Prefer start_sha (target tip at diff render = GitHub's pull_request.base.sha).
+    // Fall back to base_sha (merge-base) only if start_sha is null/missing; that
+    // produces a wider range that weakens but does not invert the retain filter.
+    if let Some(sha) = diff_refs.start_sha {
+        Some(sha)
+    } else if let Some(sha) = diff_refs.base_sha {
+        println!(
+            "[GitLab CI] Note: diff_refs.start_sha missing for MR !{}; \
+             using diff_refs.base_sha (merge-base) as fallback. \
+             The #1473 retain filter may be weakened for this MR.",
+            iid
+        );
+        Some(sha)
+    } else {
+        None
+    }
 }
 
 /// Query GitLab API for recently merged MRs and find one matching the current commit SHA.
@@ -78,12 +184,7 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     println!("[GitLab CI] Querying API: {}", endpoint);
 
-    let agent = crate::http::build_agent(Some(30));
-    let request = agent.get(&endpoint).set(auth_header_name, &auth_token).set(
-        "User-Agent",
-        &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
-    );
-    let response = crate::http::send(request)
+    let response = gitlab_api_get(&endpoint, auth_header_name, &auth_token)
         .map_err(|e| GitAiError::Generic(format!("GitLab API request failed: {}", e)))?;
 
     if response.status_code != 200 {
@@ -260,9 +361,32 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     let repo = find_repository_in_path(&clone_dir)?;
 
+    // Fetch diff_refs.base_sha from the single-MR endpoint. The list endpoint
+    // we hit earlier doesn't include diff_refs; without base_sha the #1473
+    // retain filter in CiContext::run_with_options skips, so squash merges on
+    // a linear target branch can still be misclassified as rebases. None here
+    // -> fall back to empty string (legacy behavior, no protection).
+    let base_sha = fetch_mr_base_sha(&api_url, auth_header_name, &auth_token, &project_id, mr.iid)
+        .unwrap_or_else(|| {
+            println!(
+                "[GitLab CI] Warning: could not fetch diff_refs.base_sha for MR !{}; \
+                     proceeding without the #1473 retain filter (legacy behavior)",
+                mr.iid
+            );
+            String::new()
+        });
+
     println!(
-        "[GitLab CI] Created CiContext: merge_commit_sha={}, head_sha={}, head_ref={}, base_ref={}",
-        effective_merge_sha, mr.sha, mr.source_branch, mr.target_branch
+        "[GitLab CI] Created CiContext: merge_commit_sha={}, head_sha={}, head_ref={}, base_ref={}, base_sha={}",
+        effective_merge_sha,
+        mr.sha,
+        mr.source_branch,
+        mr.target_branch,
+        if base_sha.is_empty() {
+            "(unavailable)"
+        } else {
+            &base_sha
+        }
     );
 
     Ok(Some(CiContext {
@@ -272,7 +396,7 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
             head_ref: mr.source_branch.clone(),
             head_sha: mr.sha.clone(),
             base_ref: mr.target_branch.clone(),
-            base_sha: String::new(), // Not readily available from MR API, but not used in current impl
+            base_sha,
         },
         temp_dir: PathBuf::from(clone_dir),
     }))
@@ -387,5 +511,203 @@ mod tests {
             .unwrap_or(15i64);
         unsafe { std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES") };
         assert_eq!(lookback, 15);
+    }
+
+    // ---- CiEvent::Merge.base_sha derivation from diff_refs ----
+    //
+    // We prefer `diff_refs.start_sha` (target tip at diff render, semantically
+    // equal to GitHub's `pull_request.base.sha`) over `diff_refs.base_sha`
+    // (merge-base). See the `GitLabDiffRefs` docstring for why; tests below
+    // pin the preference + fallback + every silently-absorbed failure mode.
+
+    #[test]
+    fn test_diff_refs_deserialization_happy() {
+        let json = r#"{
+            "iid": 42,
+            "diff_refs": {
+                "base_sha": "0000000000000000000000000000000000000000",
+                "head_sha": "1111111111111111111111111111111111111111",
+                "start_sha": "2222222222222222222222222222222222222222"
+            }
+        }"#;
+        let details: GitLabMergeRequestDetails = serde_json::from_str(json).unwrap();
+        let diff_refs = details.diff_refs.unwrap();
+        assert_eq!(
+            diff_refs.base_sha,
+            Some("0000000000000000000000000000000000000000".to_string())
+        );
+        assert_eq!(
+            diff_refs.start_sha,
+            Some("2222222222222222222222222222222222222222".to_string())
+        );
+    }
+
+    #[test]
+    fn test_diff_refs_deserialization_missing_diff_refs() {
+        // GitLab notes diff_refs "is empty when the merge request is created,
+        // and populates asynchronously"; absorb that as None.
+        let json = r#"{"iid": 1}"#;
+        let details: GitLabMergeRequestDetails = serde_json::from_str(json).unwrap();
+        assert!(details.diff_refs.is_none());
+    }
+
+    #[test]
+    fn test_diff_refs_deserialization_null_shas() {
+        // Both SHAs JSON-null — surface as None on both fields.
+        let json = r#"{
+            "iid": 7,
+            "diff_refs": { "base_sha": null, "start_sha": null }
+        }"#;
+        let details: GitLabMergeRequestDetails = serde_json::from_str(json).unwrap();
+        let diff_refs = details.diff_refs.unwrap();
+        assert!(diff_refs.base_sha.is_none());
+        assert!(diff_refs.start_sha.is_none());
+    }
+
+    /// Happy path: both SHAs present, we MUST pick start_sha. This is the
+    /// load-bearing test — picking base_sha here recreates the original
+    /// #1473 bug for GitLab squash MRs.
+    #[test]
+    fn test_fetch_mr_base_sha_prefers_start_sha_over_base_sha() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .match_header("PRIVATE-TOKEN", "test-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            // Distinct values so the assertion can't pass by coincidence.
+            .with_body(
+                r#"{
+                "iid": 42,
+                "diff_refs": {
+                    "base_sha":  "0000000000000000000000000000000000000000",
+                    "start_sha": "2222222222222222222222222222222222222222",
+                    "head_sha":  "1111111111111111111111111111111111111111"
+                }
+            }"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "test-token", "123", 42);
+
+        mock.assert();
+        assert_eq!(
+            result,
+            Some("2222222222222222222222222222222222222222".to_string()),
+            "must prefer start_sha (target tip) over base_sha (merge-base)"
+        );
+    }
+
+    /// Fallback: GitLab returns diff_refs with base_sha populated but
+    /// start_sha null/missing. Use base_sha and continue; the retain
+    /// filter is weakened but not broken.
+    #[test]
+    fn test_fetch_mr_base_sha_falls_back_to_base_sha_when_start_sha_missing() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body(
+                r#"{
+                "iid": 42,
+                "diff_refs": {
+                    "base_sha":  "0000000000000000000000000000000000000000",
+                    "start_sha": null
+                }
+            }"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert_eq!(
+            result,
+            Some("0000000000000000000000000000000000000000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_returns_none_when_both_shas_missing() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body(
+                r#"{
+                "iid": 42,
+                "diff_refs": { "base_sha": null, "start_sha": null }
+            }"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_404_returns_none() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(404)
+            .with_body(r#"{"message": "404 Not Found"}"#)
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(
+            result.is_none(),
+            "404 should fall through to None (caller uses empty string)"
+        );
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_malformed_body_returns_none() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body("not json")
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(result.is_none(), "non-JSON body should not panic");
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_missing_diff_refs_returns_none() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body(r#"{"iid": 42}"#)
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_with_job_token_header() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .match_header("JOB-TOKEN", "ci-job-token-value")
+            .with_status(200)
+            // start_sha present so the happy path through JOB-TOKEN auth fires.
+            .with_body(
+                r#"{"diff_refs": {"start_sha": "abc1234567890abcdef1234567890abcdef12345"}}"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "JOB-TOKEN", "ci-job-token-value", "123", 42);
+        mock.assert();
+        assert_eq!(
+            result,
+            Some("abc1234567890abcdef1234567890abcdef12345".to_string())
+        );
     }
 }

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1332,6 +1332,131 @@ fn test_ci_rebase_merge_multiple_commits_standard_human() {
     ]);
 }
 
+/// Regression test for #1473: a squash merge of a multi-commit PR onto a *linear*
+/// main branch must not be misclassified as a rebase merge.
+///
+/// The previous detection walked `N` first-parent commits back from the squash
+/// commit (where `N` = number of PR commits). On a long linear main that walk
+/// returns `N` *pre-existing base commits* rather than rebased PR commits, the
+/// count matches, and the code took the rebase path — writing the PR's authorship
+/// notes onto unrelated base commits (e.g. a teammate's / Dependabot commit).
+///
+/// Layout reproduced here:
+/// ```text
+///   main:    B0 - B1 - B2 - B3              (B1..B3 committed WITHOUT the wrapper -> no notes)
+///   feature:   \- P1 - P2 - P3              (3 AI commits, each carrying a note)
+///   squash:  B0 - B1 - B2 - B3 - S          (S = squashed P1+P2+P3, parent = B3)
+/// ```
+/// Walking 3 first-parent commits back from `S` yields `[B2, B3, S]` (len 3 == 3),
+/// which previously tripped the rebase path. Only `S` should receive a note; the
+/// unrelated base commits `B2` and `B3` must be left untouched.
+#[test]
+fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
+    use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunOptions};
+
+    let repo = direct_test_repo();
+    repo.git_og(&["config", "user.name", "Test User"]).unwrap();
+    repo.git_og(&["config", "user.email", "test@example.com"])
+        .unwrap();
+
+    // --- B0: initial commit on main (raw git -> no authorship note) ---
+    std::fs::write(repo.path().join("base.txt"), "base content\n").unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "B0 initial"]).unwrap();
+    repo.git_og(&["branch", "-M", "main"]).unwrap();
+    let b0_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- B1, B2, B3: teammate commits on main, NOT using the wrapper (no notes) ---
+    for i in 1..=3 {
+        std::fs::write(
+            repo.path().join(format!("teammate{i}.txt")),
+            format!("teammate change {i}\n"),
+        )
+        .unwrap();
+        repo.git_og(&["add", "-A"]).unwrap();
+        repo.git_og(&["commit", "-m", &format!("B{i} teammate change")])
+            .unwrap();
+    }
+    let b2_sha = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let b3_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- feature branch off B0 with 3 AI commits (each gets a note via the wrapper) ---
+    repo.git_og(&["checkout", "-b", "feature", &b0_sha])
+        .unwrap();
+
+    let mut feat = repo.filename("feature.txt");
+    feat.set_contents(crate::lines!["// P1 ai line".ai()]);
+    repo.stage_all_and_commit("P1").unwrap();
+    feat.insert_at(1, crate::lines!["// P2 ai line".ai()]);
+    repo.stage_all_and_commit("P2").unwrap();
+    feat.insert_at(2, crate::lines!["// P3 ai line".ai()]);
+    let head_sha = repo.stage_all_and_commit("P3").unwrap().commit_sha;
+
+    // --- Squash merge: GitHub creates one new commit S on top of B3 (raw git) ---
+    repo.git_og(&["checkout", "main"]).unwrap();
+    std::fs::write(
+        repo.path().join("feature.txt"),
+        "// P1 ai line\n// P2 ai line\n// P3 ai line\n",
+    )
+    .unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "Squash merge feature (#PR)"])
+        .unwrap();
+    let squash_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- Run the CI merge rewrite exactly as GitHub Actions would ---
+    let git_ai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    let event = CiEvent::Merge {
+        merge_commit_sha: squash_sha.clone(),
+        head_ref: "feature".to_string(),
+        head_sha: head_sha.clone(),
+        base_ref: "main".to_string(),
+        base_sha: b3_sha.clone(),
+    };
+
+    let ctx = CiContext::with_repository(git_ai_repo, event);
+    ctx.run_with_options(CiRunOptions {
+        skip_fetch_notes: true,
+        skip_fetch_base: true,
+        skip_push: true,
+    })
+    .expect("CI merge rewrite should succeed");
+
+    // The squash commit S should be attributed...
+    assert!(
+        repo.read_authorship_note(&squash_sha).is_some(),
+        "squash commit S ({squash_sha}) should receive the rewritten authorship note"
+    );
+
+    // ...but the unrelated base commits B2/B3 must NOT be polluted (#1473).
+    assert!(
+        repo.read_authorship_note(&b2_sha).is_none(),
+        "#1473 regression: unrelated base commit B2 ({b2_sha}) must not receive a note"
+    );
+    assert!(
+        repo.read_authorship_note(&b3_sha).is_none(),
+        "#1473 regression: unrelated base commit B3 ({b3_sha}) must not receive a note"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -1347,4 +1472,5 @@ crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_mixed_content_standard_human,
     test_ci_squash_merge_with_manual_changes_standard_human,
     test_ci_rebase_merge_multiple_commits_standard_human,
+    test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main,
 );

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1506,7 +1506,8 @@ fn test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits() {
         .to_string();
 
     // feature branch off B0 with 3 AI commits (each gets a note via the wrapper)
-    repo.git_og(&["checkout", "-b", "feature", &b0_sha]).unwrap();
+    repo.git_og(&["checkout", "-b", "feature", &b0_sha])
+        .unwrap();
     let mut feat = repo.filename("feature.txt");
     feat.set_contents(crate::lines!["// P1 ai line".ai()]);
     repo.stage_all_and_commit("P1").unwrap();

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1586,6 +1586,134 @@ fn test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits() {
     );
 }
 
+/// Regression test for the #1473 review follow-up: a genuine rebase merge must
+/// still be classified as a rebase when `--merge-commit-sha` is passed as an
+/// abbreviated SHA (as a human might via `git-ai ci local merge`).
+///
+/// The #1473 filter intersects the first-parent walk with the full SHAs from
+/// `git rev-list base_sha..merge_commit_sha`. If `get_rebased_commits` stored the
+/// merge commit verbatim (abbreviated), that entry would fail the set lookup, get
+/// dropped, drop the count below N, and the rebase would be misclassified as a
+/// squash — writing one aggregated note instead of per-commit notes. After
+/// resolving the merge SHA to its full form, each rebased commit keeps its own note.
+#[test]
+fn test_ci_local_rebase_merge_with_abbreviated_merge_sha() {
+    use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+
+    let repo = direct_test_repo();
+
+    // --- Initial commit on main ---
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+    let base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- Feature branch: two commits touching different files ---
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+    let mut file_a = repo.filename("file_a.txt");
+    file_a.set_contents(crate::lines!["ai content in file_a".ai()]);
+    let _feature_sha1 = repo.stage_all_and_commit("Add file_a").unwrap().commit_sha;
+    let mut file_b = repo.filename("file_b.txt");
+    file_b.set_contents(crate::lines!["ai content in file_b".ai()]);
+    let feature_sha2 = repo.stage_all_and_commit("Add file_b").unwrap().commit_sha;
+
+    // --- Advance main so the rebase produces new commit SHAs ---
+    repo.git_og(&["checkout", "main"]).unwrap();
+    let mut main_file = repo.filename("main_only.txt");
+    main_file.set_contents(crate::lines!["main-only content"]);
+    repo.git_og(&["add", "main_only.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Advance main"]).unwrap();
+
+    // --- Rebase feature onto main (bypassing the local hook), then ff main ---
+    repo.git_og(&["checkout", "feature"]).unwrap();
+    repo.git_og(&["rebase", "main"]).unwrap();
+    let new_sha2 = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let new_sha1 = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git_og(&["checkout", "main"]).unwrap();
+    repo.git_og(&["merge", "--ff-only", "feature"]).unwrap();
+
+    // --- Bare origin so push_authorship inside CiContext can succeed ---
+    let origin_dir = tempfile::tempdir().unwrap();
+    let origin_path = origin_dir.path().join("origin.git");
+    repo.git_og(&[
+        "clone",
+        "--bare",
+        repo.path().to_str().unwrap(),
+        origin_path.to_str().unwrap(),
+    ])
+    .unwrap();
+    repo.git_og(&["remote", "add", "origin", origin_path.to_str().unwrap()])
+        .unwrap();
+
+    // --- Run `ci local merge` with an ABBREVIATED merge-commit-sha ---
+    let abbreviated_merge_sha = &new_sha2[..12];
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "merge",
+            "--merge-commit-sha",
+            abbreviated_merge_sha,
+            "--head-ref",
+            "feature",
+            "--head-sha",
+            feature_sha2.as_str(),
+            "--base-ref",
+            "main",
+            "--base-sha",
+            base_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-fetch-base",
+        ])
+        .expect("ci local merge should succeed");
+
+    assert!(
+        output.contains("authorship rewritten successfully"),
+        "expected authorship rewritten, got: {output}"
+    );
+
+    // --- Each rebased commit must still carry its own note (rebase path kept) ---
+    let note1 = repo
+        .read_authorship_note(&new_sha1)
+        .expect("rebased commit 1 should have a note (rebase must not be misclassified as squash)");
+    let note2 = repo
+        .read_authorship_note(&new_sha2)
+        .expect("rebased commit 2 should have a note");
+
+    let files = |note: &str| -> Vec<String> {
+        AuthorshipLog::deserialize_from_string(note)
+            .unwrap()
+            .attestations
+            .iter()
+            .map(|a| a.file_path.clone())
+            .collect()
+    };
+    let files1 = files(&note1);
+    let files2 = files(&note2);
+
+    assert!(
+        files1.iter().any(|f| f.contains("file_a")) && !files1.iter().any(|f| f.contains("file_b")),
+        "rebased commit 1 should reference only file_a.txt, got: {files1:?}"
+    );
+    assert!(
+        files2.iter().any(|f| f.contains("file_b")) && !files2.iter().any(|f| f.contains("file_a")),
+        "rebased commit 2 should reference only file_b.txt, got: {files2:?}"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -1603,4 +1731,5 @@ crate::reuse_tests_in_worktree!(
     test_ci_rebase_merge_multiple_commits_standard_human,
     test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main,
     test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits,
+    test_ci_local_rebase_merge_with_abbreviated_merge_sha,
 );

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1457,6 +1457,134 @@ fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
     );
 }
 
+/// Production-path (`git-ai ci local merge`) variant of the #1473 regression.
+///
+/// Drives the exact entrypoint a GitHub Actions workflow invokes (the "CI merge
+/// rewrite action" named in the issue) instead of calling `CiContext`
+/// in-process. Same topology: a linear `main` with note-less teammate commits
+/// (raw `git`, simulating contributors not yet using the wrapper) and a
+/// 3-commit AI PR squashed on top. Only the squash commit may receive an
+/// authorship note; the unrelated base commits must stay untouched.
+#[test]
+fn test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits() {
+    let repo = direct_test_repo();
+    repo.git_og(&["config", "user.name", "Test User"]).unwrap();
+    repo.git_og(&["config", "user.email", "test@example.com"])
+        .unwrap();
+
+    // B0: initial commit on main (raw git -> no authorship note)
+    std::fs::write(repo.path().join("base.txt"), "base content\n").unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "B0 initial"]).unwrap();
+    repo.git_og(&["branch", "-M", "main"]).unwrap();
+    let b0_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // B1, B2, B3: teammate commits on main, NOT using the wrapper (no notes)
+    for i in 1..=3 {
+        std::fs::write(
+            repo.path().join(format!("teammate{i}.txt")),
+            format!("teammate change {i}\n"),
+        )
+        .unwrap();
+        repo.git_og(&["add", "-A"]).unwrap();
+        repo.git_og(&["commit", "-m", &format!("B{i} teammate change")])
+            .unwrap();
+    }
+    let b2_sha = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let b3_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // feature branch off B0 with 3 AI commits (each gets a note via the wrapper)
+    repo.git_og(&["checkout", "-b", "feature", &b0_sha]).unwrap();
+    let mut feat = repo.filename("feature.txt");
+    feat.set_contents(crate::lines!["// P1 ai line".ai()]);
+    repo.stage_all_and_commit("P1").unwrap();
+    feat.insert_at(1, crate::lines!["// P2 ai line".ai()]);
+    repo.stage_all_and_commit("P2").unwrap();
+    feat.insert_at(2, crate::lines!["// P3 ai line".ai()]);
+    let head_sha = repo.stage_all_and_commit("P3").unwrap().commit_sha;
+
+    // Squash merge: GitHub creates one new commit S on top of B3 (raw git)
+    repo.git_og(&["checkout", "main"]).unwrap();
+    std::fs::write(
+        repo.path().join("feature.txt"),
+        "// P1 ai line\n// P2 ai line\n// P3 ai line\n",
+    )
+    .unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "Squash merge feature (#PR)"])
+        .unwrap();
+    let squash_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Bare origin so `ci local merge` can push authorship
+    let origin_dir = tempfile::tempdir().unwrap();
+    let origin_path = origin_dir.path().join("origin.git");
+    repo.git_og(&[
+        "clone",
+        "--bare",
+        repo.path().to_str().unwrap(),
+        origin_path.to_str().unwrap(),
+    ])
+    .unwrap();
+    repo.git_og(&["remote", "add", "origin", origin_path.to_str().unwrap()])
+        .unwrap();
+
+    // Run the real CLI exactly as CI would after a squash merge
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "merge",
+            "--merge-commit-sha",
+            squash_sha.as_str(),
+            "--head-ref",
+            "feature",
+            "--head-sha",
+            head_sha.as_str(),
+            "--base-ref",
+            "main",
+            "--base-sha",
+            b3_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-fetch-base",
+        ])
+        .expect("ci local merge should succeed");
+
+    assert!(
+        output.contains("authorship rewritten successfully"),
+        "expected authorship rewritten, got: {output}"
+    );
+
+    // Only the squash commit S carries a note; the base commits are untouched.
+    assert!(
+        repo.read_authorship_note(&squash_sha).is_some(),
+        "squash commit S ({squash_sha}) should receive the rewritten authorship note"
+    );
+    assert!(
+        repo.read_authorship_note(&b2_sha).is_none(),
+        "#1473 regression: unrelated base commit B2 ({b2_sha}) must not receive a note"
+    );
+    assert!(
+        repo.read_authorship_note(&b3_sha).is_none(),
+        "#1473 regression: unrelated base commit B3 ({b3_sha}) must not receive a note"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -1473,4 +1601,5 @@ crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_with_manual_changes_standard_human,
     test_ci_rebase_merge_multiple_commits_standard_human,
     test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main,
+    test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits,
 );


### PR DESCRIPTION
# fix(ci): don't misclassify squash merges as rebases on linear base branches
 
Fixes #1473.
 
## Primary changes
 
- The CI merge rewrite no longer treats a merge as a *rebase* merge merely because a first-parent walk back from the merge commit happens to yield `N` commits (where `N` is the PR's commit count). On a linear base branch that walk returns pre-existing base commits, so a **squash** merge was misclassified as a rebase and the PR's authorship notes were written onto unrelated base commits (a teammate's commit, a Dependabot bump, etc.).
- Bind the previously-ignored `base_sha` from the merge event and restrict the rebase candidates to commits that were *actually introduced by the merge* — those in `base_sha..merge_commit_sha`. A squash introduces exactly one such commit, so it no longer matches the PR commit count and correctly takes the squash path.
- Resolve `merge_commit_sha` to a full SHA in `get_rebased_commits` so the candidate set compares like-for-like with the full SHAs from `git rev-list` (a hand-typed abbreviated `--merge-commit-sha` via `git-ai ci local merge` would otherwise drop the merge commit and flip a genuine rebase to the squash path). Addresses review feedback on this PR.
- Source GitLab's `base_sha` from the MR's `diff_refs.start_sha` (preferred) or `diff_refs.base_sha` (fallback) via the single-MR endpoint, so GitLab MRs now get the same #1473 retain-filter protection as GitHub PRs. `start_sha` (the target-branch tip at diff render) is the semantic match for GitHub's `pull_request.base.sha`; `base_sha` (the merge-base / common ancestor) would produce a range wide enough to re-trigger the original #1473 bug. Falls back to the legacy empty-string behavior (with a warning logged) when the API call fails. Also extracts `gitlab_api_get` to share the agent/headers/send shape between the list-MR call already in this file and the new single-MR call. Addresses review feedback on this PR.
- Add three regression tests, and drop a now-stale `#[allow(dead_code)]` on `CiEvent::Merge.base_sha` (the field is read by this fix).
## Reviewer walkthrough
 
- `src/ci/ci_context.rs`:
  - `run_with_options` / `CiEvent::Merge` arm: `base_sha` is now bound (was `base_sha: _`). After the existing `get_rebased_commits()` walk, the candidate set is intersected with the commits in `base_sha..merge_commit_sha`, computed with the same `CommitRange` already used to derive `original_commits` just above. If that intersection drops the count below `original_commits.len()`, control falls through to the existing squash path.
  - `get_rebased_commits`: resolves `merge_commit_sha` to a full SHA up front via `revparse_single` (the remaining entries already come from full parent OIDs).
- `tests/integration/ci_squash_rebase.rs` (each also runs as a `_in_worktree` variant via `reuse_tests_in_worktree!`):
  - `test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main` — in-process `CiContext` reproduction.
  - `test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits` — same scenario through the real `git-ai ci local merge` CLI.
  - `test_ci_local_rebase_merge_with_abbreviated_merge_sha` — a genuine rebase merge driven with an abbreviated `--merge-commit-sha`, asserting each rebased commit keeps its own note (guards the full-SHA resolution above).
- `src/ci/gitlab.rs`:
  - `gitlab_api_get`: centralizes the agent + `User-Agent` + auth-header + send pattern that both the list-MR call (already in this file) and the new single-MR call need. Returns `Result<crate::http::Response, String>` so each caller still chooses its own status-code interpretation.
  - `fetch_mr_base_sha`: GETs `/projects/:id/merge_requests/:iid`, prefers `diff_refs.start_sha` (target tip — matches GitHub's `pull_request.base.sha`), falls back to `diff_refs.base_sha` (merge-base) with a logged note when `start_sha` is null. Returns `Option<String>` so every failure mode (transport, non-200, malformed JSON, missing `diff_refs`, both SHAs null) collapses cleanly to `None`. See the `GitLabDiffRefs` docstring for the concrete walk-through showing why picking `start_sha` matters.
  - `get_gitlab_ci_context`: after MR matching, calls `fetch_mr_base_sha` and feeds the result into `CiEvent::Merge.base_sha`. Logs a warning on the fallback path so the regression is visible in CI output.
## Correctness and invariants
 
- **Genuine rebase merges are unchanged**: the replayed commits are within `base_sha..merge_commit_sha`, so they survive the intersection and the rebase path (including the oldest-first positional pairing) behaves as before. `Vec::retain` preserves order, and the rebase path only runs when the filtered count still equals `original_commits.len()`, so a re-ordered or wrong-sized list can never reach it.
- **SHA formats**: the production forges always supply full 40-char SHAs (GitHub `merge_commit_sha`, GitLab CI SHA); resolving up front additionally hardens the local-CLI path against abbreviated input.
- **Fallback**: when `base_sha` is empty the candidate filter is skipped and the legacy behavior is preserved. GitLab now sources `base_sha` from `diff_refs.start_sha` (or `diff_refs.base_sha` as a degraded fallback), so empty only happens on a real failure (auth, transport, missing field on a pathological MR — GitLab's docs note that `diff_refs` "is empty when the merge request is created, and populates asynchronously"). The fallback logs a warning to surface the regression in CI output rather than failing the run — worst case is unchanged from before this PR.
- **Known residual — stale `base_sha` on advancing target**: `base_sha` is captured at PR/MR-open time (GitHub's `pull_request.base.sha`, GitLab's `diff_refs.start_sha`). If the target branch advances between PR open and merge AND the maintainer squash-merges without rebasing AND the new base commits don't already have authorship notes, the `base_sha..merge_commit_sha` range includes those advance commits and the count-match misclassification fires again on them. This is a narrower residual of the same bug class #1473 addresses, not a regression introduced by this PR. Fixing it requires either an at-merge target SHA from the forge (not supplied by either webhook) or moving from count-based to content-based strategy detection. Both are out of scope here — see the follow-up below.
- No schema, note-format, or public-API changes.
## Testing and QA
 
- Methodology: test-driven. Added a failing integration test reproducing the reported topology, confirmed it failed on the current logic, then implemented the fix and confirmed it passed. The abbreviated-SHA test likewise failed (classified as squash) until `merge_commit_sha` was resolved to a full SHA — i.e. each test was observed red before its fix.
- Topology under test: a linear `main` `B0 → B1 → B2 → B3` where `B1..B3` are committed with raw `git` (no authorship notes — contributors not yet using the wrapper), a 3-commit AI feature branch off `B0`, and a squash commit `S` on top of `B3`; the CI rewrite is run with `base_sha = B3`.
- The full `ci_squash_rebase` and `rebase` integration suites pass; the only skipped tests are the pre-existing `benchmark_*` perf tests (`#[ignore]`).
- 10 new unit tests in `src/ci/gitlab.rs` covering the GitLab change: 3 serde deserialization tests for `GitLabMergeRequestDetails` / `GitLabDiffRefs` (happy path with both SHAs populated / missing `diff_refs` / both SHAs null), plus 7 mockito-backed tests for `fetch_mr_base_sha`. The load-bearing test is `test_fetch_mr_base_sha_prefers_start_sha_over_base_sha`, which uses distinct made-up SHAs for each field so picking `base_sha` (recreating the original #1473 bug for GitLab) cannot pass by coincidence. Also covered: graceful fallback to `base_sha` when `start_sha` is null, both-null returning `None`, 404, malformed body, missing `diff_refs`, and `JOB-TOKEN` auth variant. All 17 GitLab unit tests + the 4 #1473 regression integration tests pass.
- Pre-submit: `task fmt` and `task lint` (clippy `-D warnings`) clean.
## Reproduction & evidence
 
The fix lives in a single file, so a reviewer can toggle it on/off against the committed tests and watch the classification flip. `NO_CAPTURE=true` surfaces the CI rewrite's own classification log line, which is the smoking gun.
 
```bash
# 1) With the fix (branch HEAD): the #1473 tests pass
task test TEST_FILTER=on_linear_main NO_CAPTURE=true
 
# 2) Revert ONLY the fix file to its pre-fix state (keeping the committed tests).
#    b32e00ea is the fix commit, so b32e00ea~1 is pre-fix:
git checkout b32e00ea~1 -- src/ci/ci_context.rs
task test TEST_FILTER=on_linear_main NO_CAPTURE=true
 
# 3) Restore the fix:
git checkout HEAD -- src/ci/ci_context.rs
```
 
### Before the fix — bug reproduces (squash misclassified as rebase)
 
The rewrite classifies the squash as a rebase and writes the PR's note onto the unrelated base commit `B2`:
 
```
Rewriting authorship for 1d334e90... -> cba1cca0... (squash or rebase-like merge)
Original commits in PR: 3 (from merge base Some("f9d1ec29..."))
Detected rebase merge: 3 original -> 3 new commits
...
panicked at tests/integration/ci_squash_rebase.rs:
#1473 regression: unrelated base commit B2 (4e501c8b...) must not receive a note
test result: FAILED.
```
 
### After the fix — no reproduction (correctly classified as squash)
 
Same scenario; the rewrite classifies it as a squash and notes only the squash commit `S`, leaving `B2`/`B3` untouched:
 
```
Detected squash merge: 3 original commits -> 1 merge commit
...
test ci_squash_rebase::test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main ... ok
test ci_squash_rebase::test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits ... ok
test result: ok.
```
 
The single-line contrast — `Detected rebase merge: 3 original -> 3 new commits` vs `Detected squash merge: 3 original commits -> 1 merge commit` — is exactly the misclassification described in the issue, removed.
 
## Follow-up (not in this PR)
 
The underlying design still *infers* the merge strategy from the commit graph. GitLab actually exposes an authoritative `squash` flag that we currently drop, and GitHub exposes no strategy field at all. Generalizing this into explicit, forge-aware strategy detection would be recommended but is out of scope for a bugfix. Note that this would also close the "stale `base_sha` on advancing target" residual described above — content-equivalence detection between PR commits and the walked candidates doesn't depend on the at-open base snapshot at all.
