### PR TITLE
[codex] fix OpenCode Desktop checkpointing

### DIFF
--- a/agent-support/opencode/README.md
+++ b/agent-support/opencode/README.md
@@ -17,7 +17,8 @@ Build `git-ai` (`cargo build`) and then run the `git-ai install-hooks` or `cargo
 
 ## Requirements
 
-- [git-ai](https://github.com/git-ai-project/git-ai) must be installed and available in PATH
+- [git-ai](https://github.com/git-ai-project/git-ai) must be installed through `git-ai install-hooks`; the plugin uses the absolute binary path injected at install time
+- `git` must be available in PATH for repository discovery
 - [OpenCode](https://opencode.ai) with plugin support
 
 ## How It Works
@@ -30,7 +31,7 @@ The plugin intercepts file editing operations (`edit`, `write`, `patch`, `multie
    - Session/conversation ID
    - List of edited file paths
 
-If `git-ai` is not installed or the file is not in a git repository, the plugin gracefully skips checkpoint creation without breaking OpenCode functionality.
+If `git-ai` cannot be launched or the file is not in a git repository, the plugin gracefully skips checkpoint creation without breaking OpenCode functionality. Set `GIT_AI_OPENCODE_DEBUG=1` or `GIT_AI_DEBUG=1` before launching OpenCode to log skipped checkpoint details.
 
 ## Development
 

--- a/agent-support/opencode/README.md
+++ b/agent-support/opencode/README.md
@@ -18,7 +18,6 @@ Build `git-ai` (`cargo build`) and then run the `git-ai install-hooks` or `cargo
 ## Requirements
 
 - [git-ai](https://github.com/git-ai-project/git-ai) must be installed through `git-ai install-hooks`; the plugin uses the absolute binary path injected at install time
-- `git` must be available in PATH for repository discovery
 - [OpenCode](https://opencode.ai) with plugin support
 
 ## How It Works

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -19,7 +19,7 @@
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
-import { readFileSync, statSync } from "fs"
+import { readFile, stat } from "fs/promises"
 import { dirname, isAbsolute, join, resolve } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
@@ -274,12 +274,12 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
   // Track pending calls by callID so we can reference them in the after hook
   const pendingCalls = new Map<string, { repoDir: string; sessionID: string; toolInput: unknown }>()
 
-  const nearestExistingDirectory = (pathHint: string): string | null => {
+  const nearestExistingDirectory = async (pathHint: string): Promise<string | null> => {
     let candidate = pathHint
     while (candidate) {
       try {
-        const stat = statSync(candidate)
-        return stat.isDirectory() ? candidate : dirname(candidate)
+        const fileStat = await stat(candidate)
+        return fileStat.isDirectory() ? candidate : dirname(candidate)
       } catch (error) {
         debugLog(`failed to stat path while resolving git repo from ${candidate}`, error)
       }
@@ -294,9 +294,9 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
     return null
   }
 
-  const isGitDirPointer = (gitFilePath: string, worktreeDir: string): boolean => {
+  const isGitDirPointer = async (gitFilePath: string, worktreeDir: string): Promise<boolean> => {
     try {
-      const firstLine = readFileSync(gitFilePath, "utf8").split(/\r?\n/, 1)[0]?.trim() ?? ""
+      const firstLine = (await readFile(gitFilePath, "utf8")).split(/\r?\n/, 1)[0]?.trim() ?? ""
       if (!firstLine.toLowerCase().startsWith("gitdir:")) {
         return false
       }
@@ -309,23 +309,23 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
       const gitDirPath = isAbsolute(gitDir) || /^[a-zA-Z]:[\\/]/.test(gitDir)
         ? gitDir
         : resolve(worktreeDir, gitDir)
-      return statSync(gitDirPath).isDirectory()
+      return (await stat(gitDirPath)).isDirectory()
     } catch (error) {
       debugLog(`failed to read gitdir pointer from ${gitFilePath}`, error)
       return false
     }
   }
 
-  const hasGitMetadata = (dir: string): boolean => {
+  const hasGitMetadata = async (dir: string): Promise<boolean> => {
     const marker = join(dir, ".git")
     try {
-      const stat = statSync(marker)
-      if (stat.isDirectory()) {
+      const fileStat = await stat(marker)
+      if (fileStat.isDirectory()) {
         return true
       }
 
-      if (stat.isFile()) {
-        return isGitDirPointer(marker, dir)
+      if (fileStat.isFile()) {
+        return await isGitDirPointer(marker, dir)
       }
     } catch (error) {
       debugLog(`failed to inspect git metadata at ${marker}`, error)
@@ -335,10 +335,10 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
   }
 
   // Helper to find git repo root from a file path or directory
-  const findGitRepo = (pathHint: string): string | null => {
-    let dir = nearestExistingDirectory(pathHint)
+  const findGitRepo = async (pathHint: string): Promise<string | null> => {
+    let dir = await nearestExistingDirectory(pathHint)
     while (dir) {
-      if (hasGitMetadata(dir)) {
+      if (await hasGitMetadata(dir)) {
         return dir
       }
 
@@ -360,35 +360,35 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
     return normalizePath(cwd, defaultCwd) || defaultCwd
   }
 
-  const resolveRepoDir = (filePaths: string[], cwd?: string): string | null => {
+  const resolveRepoDir = async (filePaths: string[], cwd?: string): Promise<string | null> => {
     const seenHints = new Set<string>()
-    const findGitRepoOnce = (pathHint: string | undefined): string | null => {
+    const findGitRepoOnce = async (pathHint: string | undefined): Promise<string | null> => {
       if (!pathHint || seenHints.has(pathHint)) {
         return null
       }
 
       seenHints.add(pathHint)
-      return findGitRepo(pathHint)
+      return await findGitRepo(pathHint)
     }
 
     for (const filePath of filePaths) {
-      const repo = findGitRepoOnce(filePath)
+      const repo = await findGitRepoOnce(filePath)
       if (repo) {
         return repo
       }
     }
 
-    const fromCwd = findGitRepoOnce(cwd)
+    const fromCwd = await findGitRepoOnce(cwd)
     if (fromCwd) {
       return fromCwd
     }
 
-    const fromDefaultCwd = findGitRepoOnce(defaultCwd)
+    const fromDefaultCwd = await findGitRepoOnce(defaultCwd)
     if (fromDefaultCwd) {
       return fromDefaultCwd
     }
 
-    const fromProcessCwd = findGitRepoOnce(process.cwd())
+    const fromProcessCwd = await findGitRepoOnce(process.cwd())
     if (fromProcessCwd) {
       return fromProcessCwd
     }
@@ -458,7 +458,7 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
         const toolInput = output?.args ?? input.args
         const toolCwd = resolveCwd(extractToolCwd(asRecord(toolInput)))
         const filePaths = isTrackedEdit ? extractFilePaths(toolInput, toolCwd) : []
-        const repoDir = resolveRepoDir(filePaths, toolCwd)
+        const repoDir = await resolveRepoDir(filePaths, toolCwd)
         if (!repoDir) {
           return
         }

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -24,7 +24,7 @@ import { dirname, isAbsolute, join, resolve } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
-const CHECKPOINT_TIMEOUT_MS = 30_000
+const CHECKPOINT_TIMEOUT_MS = 10_000
 const CHECKPOINT_ARGS = ["checkpoint", "opencode", "--hook-input", "stdin"]
 
 // Tools that modify files and should be tracked
@@ -176,12 +176,29 @@ const debugLog = (message: string, error?: unknown): void => {
     return
   }
 
-  const detail = error instanceof Error
-    ? `${error.name}: ${error.message}`
-    : error === undefined
-      ? ""
-      : String(error)
-  console.error(`[git-ai opencode] ${message}${detail ? `: ${detail}` : ""}`)
+  try {
+    const detail = error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : error === undefined
+        ? ""
+        : String(error)
+    console.error(`[git-ai opencode] ${message}${detail ? `: ${detail}` : ""}`)
+  } catch {
+    // Debug logging must never be the reason a hook fails.
+  }
+}
+
+const swallowHookErrors = <Args extends unknown[]>(
+  label: string,
+  hook: (...args: Args) => Promise<void>,
+): ((...args: Args) => Promise<void>) => {
+  return async (...args) => {
+    try {
+      await hook(...args)
+    } catch (error) {
+      debugLog(label, error)
+    }
+  }
 }
 
 const runCheckpoint = (hookInput: string): Promise<void> => {
@@ -220,6 +237,9 @@ const runCheckpoint = (hookInput: string): Promise<void> => {
     const stderr: Buffer[] = []
 
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk))
+    child.stderr.on("error", (error) => {
+      debugLog("failed to read checkpoint stderr", error)
+    })
     child.stdin.on("error", () => {
       // The child may exit before stdin is fully written; close/error handling below reports failures.
     })
@@ -239,6 +259,15 @@ const runCheckpoint = (hookInput: string): Promise<void> => {
 }
 
 export const GitAiPlugin: Plugin = async (ctx) => {
+  try {
+    return createGitAiPlugin(ctx)
+  } catch (error) {
+    debugLog("failed to initialize plugin", error)
+    return {}
+  }
+}
+
+const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugin>> => {
   const { worktree, directory } = ctx
   const defaultCwd = worktree || directory || process.cwd()
 
@@ -414,8 +443,9 @@ export const GitAiPlugin: Plugin = async (ctx) => {
   }
 
   return {
-    "tool.execute.before": async (input: ToolHookInput, output?: { args?: unknown }) => {
-      try {
+    "tool.execute.before": swallowHookErrors(
+      "pre-tool checkpoint failed",
+      async (input: ToolHookInput, output?: { args?: unknown }) => {
         const toolName = hookString(input.tool)
         const isTrackedEdit = isEditTool(toolName)
         const isTrackedBash = isBashTool(toolName)
@@ -444,14 +474,12 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           tool_input: toolInput,
         })
         await runCheckpoint(hookInput)
-      } catch (error) {
-        debugLog("pre-tool checkpoint failed", error)
-        // Checkpoint failures are non-critical — never propagate to the host
-      }
-    },
+      },
+    ),
 
-    "tool.execute.after": async (input: ToolHookInput, output?: { metadata?: unknown }) => {
-      try {
+    "tool.execute.after": swallowHookErrors(
+      "post-tool checkpoint failed",
+      async (input: ToolHookInput, output?: { metadata?: unknown }) => {
         const toolName = hookString(input.tool)
         if (!isEditTool(toolName) && !isBashTool(toolName)) {
           return
@@ -479,11 +507,8 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           tool_input: toolInput,
         })
         await runCheckpoint(hookInput)
-      } catch (error) {
-        debugLog("post-tool checkpoint failed", error)
-        // Checkpoint failures are non-critical — never propagate to the host
-      }
-    },
+      },
+    ),
   }
 }
 

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -148,9 +148,6 @@ type ToolHookInput = {
   sessionID?: unknown
   callID?: unknown
   args?: unknown
-  metadata?: unknown
-  cwd?: unknown
-  workdir?: unknown
 }
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined => {
@@ -163,10 +160,9 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined => {
 
 const hookString = (value: unknown): string => typeof value === "string" ? value : ""
 
-const extractToolCwd = (inputCwd: unknown, args: Record<string, unknown> | undefined): string | undefined => {
+const extractToolCwd = (args: Record<string, unknown> | undefined): string | undefined => {
   if (typeof args?.workdir === "string") return args.workdir
   if (typeof args?.cwd === "string") return args.cwd
-  if (typeof inputCwd === "string") return inputCwd
   return undefined
 }
 
@@ -430,7 +426,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
         const callID = hookString(input.callID)
         const sessionID = hookString(input.sessionID)
         const toolInput = output?.args ?? input.args
-        const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(toolInput)))
+        const toolCwd = resolveCwd(extractToolCwd(asRecord(toolInput)))
         const filePaths = isTrackedEdit ? extractFilePaths(toolInput, toolCwd) : []
         const repoDir = resolveRepoDir(filePaths, toolCwd)
         if (!repoDir) {
@@ -470,8 +466,8 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           return
         }
 
-        const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(input.args)))
-        const metadataFilePaths = extractMetadataFilePaths(output?.metadata ?? input.metadata, toolCwd)
+        const toolCwd = resolveCwd(extractToolCwd(asRecord(input.args)))
+        const metadataFilePaths = extractMetadataFilePaths(output?.metadata, toolCwd)
         const toolInput = withMetadataFilePaths(callInfo.toolInput, metadataFilePaths)
 
         const hookInput = JSON.stringify({

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -19,12 +19,11 @@
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
-import { existsSync, statSync } from "fs"
-import { dirname, isAbsolute, join } from "path"
+import { existsSync, readFileSync, statSync } from "fs"
+import { dirname, isAbsolute, join, resolve } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
-const GIT_LOOKUP_TIMEOUT_MS = 5_000
 const CHECKPOINT_TIMEOUT_MS = 30_000
 
 // Tools that modify files and should be tracked
@@ -287,23 +286,63 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     return null
   }
 
-  // Helper to find git repo root from a file path or directory
-  const findGitRepo = async (pathHint: string): Promise<string | null> => {
-    const dir = nearestExistingDirectory(pathHint)
-    if (!dir) {
-      return null
-    }
-
+  const isGitDirPointer = (gitFilePath: string, worktreeDir: string): boolean => {
     try {
-      const result = await runCommand("git", ["-C", dir, "rev-parse", "--show-toplevel"], {
-        timeoutMs: GIT_LOOKUP_TIMEOUT_MS,
-      })
-      const repoRoot = result.stdout.trim()
-      if (repoRoot) {
-        return repoRoot
+      const firstLine = readFileSync(gitFilePath, "utf8").split(/\r?\n/, 1)[0]?.trim() ?? ""
+      if (!firstLine.toLowerCase().startsWith("gitdir:")) {
+        return false
+      }
+
+      const gitDir = firstLine.slice("gitdir:".length).trim()
+      if (!gitDir) {
+        return false
+      }
+
+      const gitDirPath = isAbsolute(gitDir) || /^[a-zA-Z]:[\\/]/.test(gitDir)
+        ? gitDir
+        : resolve(worktreeDir, gitDir)
+      return existsSync(gitDirPath)
+    } catch (error) {
+      debugLog(`failed to read gitdir pointer from ${gitFilePath}`, error)
+      return false
+    }
+  }
+
+  const hasGitMetadata = (dir: string): boolean => {
+    const marker = join(dir, ".git")
+    try {
+      if (!existsSync(marker)) {
+        return false
+      }
+
+      const stat = statSync(marker)
+      if (stat.isDirectory()) {
+        return true
+      }
+
+      if (stat.isFile()) {
+        return isGitDirPointer(marker, dir)
       }
     } catch (error) {
-      debugLog(`git repo lookup failed from ${dir}`, error)
+      debugLog(`failed to inspect git metadata at ${marker}`, error)
+    }
+
+    return false
+  }
+
+  // Helper to find git repo root from a file path or directory
+  const findGitRepo = async (pathHint: string): Promise<string | null> => {
+    let dir = nearestExistingDirectory(pathHint)
+    while (dir) {
+      if (hasGitMetadata(dir)) {
+        return dir
+      }
+
+      const parent = dirname(dir)
+      if (parent === dir) {
+        break
+      }
+      dir = parent
     }
 
     return null

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin"
+import { spawn } from "child_process"
 import { dirname, isAbsolute, join } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
@@ -139,37 +140,128 @@ const extractFilePaths = (args: unknown, cwd?: string): string[] => {
   return [...normalizedPaths]
 }
 
+type ToolHookInput = {
+  tool?: unknown
+  sessionID?: unknown
+  callID?: unknown
+  args?: unknown
+  metadata?: unknown
+  cwd?: unknown
+  workdir?: unknown
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined
+  }
+
+  return value as Record<string, unknown>
+}
+
+const hookString = (value: unknown): string => typeof value === "string" ? value : ""
+
+const debugEnabled = (): boolean => {
+  const value = process.env.GIT_AI_OPENCODE_DEBUG ?? process.env.GIT_AI_DEBUG
+  return value === "1" || value?.toLowerCase() === "true"
+}
+
+const debugLog = (message: string, error?: unknown): void => {
+  if (!debugEnabled()) {
+    return
+  }
+
+  const detail = error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : error === undefined
+      ? ""
+      : String(error)
+  console.error(`[git-ai opencode] ${message}${detail ? `: ${detail}` : ""}`)
+}
+
+const runCommand = (
+  command: string,
+  args: string[],
+  options: { cwd?: string; input?: string } = {},
+): Promise<{ stdout: string; stderr: string }> => {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (error: Error | null, output?: { stdout: string; stderr: string }): void => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      if (error) {
+        reject(error)
+      } else if (output) {
+        resolve(output)
+      }
+    }
+
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk))
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk))
+    child.stdin.on("error", () => {
+      // The child may exit before stdin is fully written; close/error handling below reports failures.
+    })
+    child.on("error", finish)
+    child.on("close", (code) => {
+      const output = {
+        stdout: Buffer.concat(stdout).toString(),
+        stderr: Buffer.concat(stderr).toString(),
+      }
+      if (code === 0) {
+        finish(null, output)
+        return
+      }
+
+      finish(new Error(`${command} ${args.join(" ")} exited with ${code}: ${output.stderr}`))
+    })
+
+    if (options.input !== undefined) {
+      child.stdin.end(options.input)
+    } else {
+      child.stdin.end()
+    }
+  })
+}
+
 export const GitAiPlugin: Plugin = async (ctx) => {
-  const { $ } = ctx
-
-  // Check if git-ai is installed
-  let gitAiInstalled = false
-  try {
-    await $`${GIT_AI_BIN} --version`.quiet()
-    gitAiInstalled = true
-  } catch {
-    // git-ai not installed, plugin will be a no-op
-  }
-
-  if (!gitAiInstalled) {
-    return {}
-  }
+  const { worktree, directory } = ctx
+  const defaultCwd = worktree || directory || process.cwd()
 
   // Track pending calls by callID so we can reference them in the after hook
   const pendingCalls = new Map<string, { repoDir: string; sessionID: string; toolInput: unknown }>()
 
   // Helper to find git repo root from a file path
   const findGitRepo = async (pathHint: string): Promise<string | null> => {
-    const candidateDirs = [pathHint, dirname(pathHint)]
+    const candidateDirs: string[] = []
+    let candidate = pathHint
+    while (candidate && !candidateDirs.includes(candidate)) {
+      candidateDirs.push(candidate)
+      const parent = dirname(candidate)
+      if (parent === candidate) {
+        break
+      }
+      candidate = parent
+    }
 
     for (const dir of candidateDirs) {
       try {
-        const result = await $`git -C ${dir} rev-parse --show-toplevel`.quiet()
-        const repoRoot = result.stdout.toString().trim()
+        const result = await runCommand("git", ["-C", dir, "rev-parse", "--show-toplevel"])
+        const repoRoot = result.stdout.trim()
         if (repoRoot) {
           return repoRoot
         }
-      } catch {
+      } catch (error) {
+        debugLog(`git repo lookup failed from ${dir}`, error)
         // try next candidate
       }
     }
@@ -177,19 +269,15 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     return null
   }
 
+  const resolveCwd = (cwd?: string): string => {
+    if (!cwd) {
+      return defaultCwd
+    }
+
+    return normalizePath(cwd, defaultCwd) || defaultCwd
+  }
+
   const resolveRepoDir = async (filePaths: string[], cwd?: string): Promise<string | null> => {
-    if (cwd) {
-      const fromCwd = await findGitRepo(cwd)
-      if (fromCwd) {
-        return fromCwd
-      }
-    }
-
-    const fromProcessCwd = await findGitRepo(process.cwd())
-    if (fromProcessCwd) {
-      return fromProcessCwd
-    }
-
     for (const filePath of filePaths) {
       const repo = await findGitRepo(filePath)
       if (repo) {
@@ -197,91 +285,166 @@ export const GitAiPlugin: Plugin = async (ctx) => {
       }
     }
 
+    if (cwd) {
+      const fromCwd = await findGitRepo(cwd)
+      if (fromCwd) {
+        return fromCwd
+      }
+    }
+
+    const fromDefaultCwd = await findGitRepo(defaultCwd)
+    if (fromDefaultCwd) {
+      return fromDefaultCwd
+    }
+
+    const fromProcessCwd = await findGitRepo(process.cwd())
+    if (fromProcessCwd) {
+      return fromProcessCwd
+    }
+
     return null
   }
 
-  const extractToolCwd = (inputCwd: unknown, outputArgs: Record<string, unknown> | undefined): string | undefined => {
-    if (typeof outputArgs?.workdir === "string") return outputArgs.workdir
-    if (typeof outputArgs?.cwd === "string") return outputArgs.cwd
+  const extractMetadataFilePaths = (metadata: unknown): string[] => {
+    if (!metadata || typeof metadata !== "object") {
+      return []
+    }
+
+    const files = (metadata as { files?: unknown }).files
+    if (!Array.isArray(files)) {
+      return []
+    }
+
+    const paths = new Set<string>()
+    for (const file of files) {
+      if (!file || typeof file !== "object") {
+        continue
+      }
+
+      const filePath = (file as { filePath?: unknown; path?: unknown }).filePath ?? (file as { path?: unknown }).path
+      if (typeof filePath === "string") {
+        const normalized = normalizePath(filePath, defaultCwd)
+        if (normalized) {
+          paths.add(normalized)
+        }
+      }
+    }
+
+    return [...paths]
+  }
+
+  const withMetadataFilePaths = (toolInput: unknown, filePaths: string[]): unknown => {
+    if (filePaths.length === 0) {
+      return toolInput
+    }
+
+    if (toolInput && typeof toolInput === "object" && !Array.isArray(toolInput)) {
+      return {
+        ...toolInput,
+        file_paths: filePaths,
+      }
+    }
+
+    return {
+      input: toolInput,
+      file_paths: filePaths,
+    }
+  }
+
+  const extractToolCwd = (inputCwd: unknown, args: Record<string, unknown> | undefined): string | undefined => {
+    if (typeof args?.workdir === "string") return args.workdir
+    if (typeof args?.cwd === "string") return args.cwd
     if (typeof inputCwd === "string") return inputCwd
     return undefined
   }
 
   return {
-    "tool.execute.before": async (input, output) => {
+    "tool.execute.before": async (input: ToolHookInput, output?: { args?: unknown }) => {
       try {
-        const toolInput = output.args
-        const toolCwd = extractToolCwd((input as { cwd?: unknown }).cwd ?? (input as { workdir?: unknown }).workdir, output.args)
+        const toolName = hookString(input.tool)
+        const callID = hookString(input.callID)
+        const sessionID = hookString(input.sessionID)
+        const toolInput = output?.args ?? input.args
+        const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(toolInput)))
 
-        if (isEditTool(input.tool)) {
+        if (isEditTool(toolName)) {
           const filePaths = extractFilePaths(toolInput, toolCwd)
           const repoDir = await resolveRepoDir(filePaths, toolCwd)
           if (!repoDir) {
             return
           }
 
-          pendingCalls.set(input.callID, { repoDir, sessionID: input.sessionID, toolInput })
+          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
 
           const hookInput = JSON.stringify({
             hook_event_name: "PreToolUse",
-            session_id: input.sessionID,
-            tool_use_id: input.callID,
+            session_id: sessionID,
+            tool_use_id: callID,
             cwd: repoDir,
-            tool_name: input.tool,
+            tool_name: toolName,
             tool_input: toolInput,
           })
-          await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], { input: hookInput })
 
-        } else if (isBashTool(input.tool)) {
+        } else if (isBashTool(toolName)) {
           const repoDir = await resolveRepoDir([], toolCwd)
           if (!repoDir) {
             return
           }
 
-          pendingCalls.set(input.callID, { repoDir, sessionID: input.sessionID, toolInput })
+          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
 
           const hookInput = JSON.stringify({
             hook_event_name: "PreToolUse",
-            session_id: input.sessionID,
-            tool_use_id: input.callID,
+            session_id: sessionID,
+            tool_use_id: callID,
             cwd: repoDir,
-            tool_name: input.tool,
+            tool_name: toolName,
             tool_input: toolInput,
           })
-          await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], { input: hookInput })
         }
-      } catch {
+      } catch (error) {
+        debugLog("pre-tool checkpoint failed", error)
         // Checkpoint failures are non-critical — never propagate to the host
       }
     },
 
-    "tool.execute.after": async (input, _output) => {
+    "tool.execute.after": async (input: ToolHookInput, output?: { metadata?: unknown }) => {
       try {
-        if (!isEditTool(input.tool) && !isBashTool(input.tool)) {
+        const toolName = hookString(input.tool)
+        if (!isEditTool(toolName) && !isBashTool(toolName)) {
           return
         }
 
-        const callInfo = pendingCalls.get(input.callID)
-        pendingCalls.delete(input.callID)
+        const callID = hookString(input.callID)
+        const callInfo = pendingCalls.get(callID)
+        pendingCalls.delete(callID)
 
-        if (!callInfo) {
+        const metadataFilePaths = extractMetadataFilePaths(output?.metadata ?? input.metadata)
+        const toolInput = callInfo?.toolInput ?? withMetadataFilePaths(input.args, metadataFilePaths)
+        const sessionID = callInfo?.sessionID ?? hookString(input.sessionID)
+        const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(input.args)))
+        const repoDir = callInfo?.repoDir ?? await resolveRepoDir(extractFilePaths(toolInput, toolCwd), toolCwd)
+        if (!repoDir) {
           return
         }
-
-        const { repoDir, sessionID, toolInput } = callInfo
 
         const hookInput = JSON.stringify({
           hook_event_name: "PostToolUse",
           session_id: sessionID,
-          tool_use_id: input.callID,
+          tool_use_id: callID,
           cwd: repoDir,
-          tool_name: input.tool,
+          tool_name: toolName,
           tool_input: toolInput,
         })
-        await $`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
-      } catch {
+        await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], { input: hookInput })
+      } catch (error) {
+        debugLog("post-tool checkpoint failed", error)
         // Checkpoint failures are non-critical — never propagate to the host
       }
     },
   }
 }
+
+export default GitAiPlugin

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -17,7 +17,7 @@
  * @see https://opencode.ai/docs/plugins/
  */
 
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Plugin, PluginInput } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
 import { existsSync, readFileSync, statSync } from "fs"
 import { dirname, isAbsolute, join, resolve } from "path"
@@ -162,6 +162,13 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined => {
 
 const hookString = (value: unknown): string => typeof value === "string" ? value : ""
 
+const extractToolCwd = (inputCwd: unknown, args: Record<string, unknown> | undefined): string | undefined => {
+  if (typeof args?.workdir === "string") return args.workdir
+  if (typeof args?.cwd === "string") return args.cwd
+  if (typeof inputCwd === "string") return inputCwd
+  return undefined
+}
+
 const debugEnabled = (): boolean => {
   const value = process.env.GIT_AI_OPENCODE_DEBUG ?? process.env.GIT_AI_DEBUG
   return value === "1" || value?.toLowerCase() === "true"
@@ -257,7 +264,146 @@ const runCommand = (
   })
 }
 
+const hasShell = (value: unknown): value is PluginInput["$"] => typeof value === "function"
+
+const createShellHooks = async (shell: PluginInput["$"]) => {
+  try {
+    await shell`${GIT_AI_BIN} --version`.quiet()
+  } catch {
+    return {}
+  }
+
+  const pendingCalls = new Map<string, { repoDir: string; sessionID: string; toolInput: unknown }>()
+
+  const findGitRepo = async (pathHint: string): Promise<string | null> => {
+    const candidateDirs = [pathHint, dirname(pathHint)]
+
+    for (const dir of candidateDirs) {
+      try {
+        const result = await shell`git -C ${dir} rev-parse --show-toplevel`.quiet()
+        const repoRoot = result.stdout.toString().trim()
+        if (repoRoot) {
+          return repoRoot
+        }
+      } catch {
+        // try next candidate
+      }
+    }
+
+    return null
+  }
+
+  const resolveRepoDir = async (filePaths: string[], cwd?: string): Promise<string | null> => {
+    if (cwd) {
+      const fromCwd = await findGitRepo(cwd)
+      if (fromCwd) {
+        return fromCwd
+      }
+    }
+
+    const fromProcessCwd = await findGitRepo(process.cwd())
+    if (fromProcessCwd) {
+      return fromProcessCwd
+    }
+
+    for (const filePath of filePaths) {
+      const repo = await findGitRepo(filePath)
+      if (repo) {
+        return repo
+      }
+    }
+
+    return null
+  }
+
+  return {
+    "tool.execute.before": async (input: ToolHookInput, output?: { args?: unknown }) => {
+      try {
+        const toolName = hookString(input.tool)
+        const callID = hookString(input.callID)
+        const sessionID = hookString(input.sessionID)
+        const toolInput = output?.args ?? input.args
+        const toolCwd = extractToolCwd(input.cwd ?? input.workdir, asRecord(toolInput))
+
+        if (isEditTool(toolName)) {
+          const filePaths = extractFilePaths(toolInput, toolCwd)
+          const repoDir = await resolveRepoDir(filePaths, toolCwd)
+          if (!repoDir) {
+            return
+          }
+
+          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
+
+          const hookInput = JSON.stringify({
+            hook_event_name: "PreToolUse",
+            session_id: sessionID,
+            tool_use_id: callID,
+            cwd: repoDir,
+            tool_name: toolName,
+            tool_input: toolInput,
+          })
+          await shell`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+
+        } else if (isBashTool(toolName)) {
+          const repoDir = await resolveRepoDir([], toolCwd)
+          if (!repoDir) {
+            return
+          }
+
+          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
+
+          const hookInput = JSON.stringify({
+            hook_event_name: "PreToolUse",
+            session_id: sessionID,
+            tool_use_id: callID,
+            cwd: repoDir,
+            tool_name: toolName,
+            tool_input: toolInput,
+          })
+          await shell`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+        }
+      } catch {
+        // Checkpoint failures are non-critical — never propagate to the host
+      }
+    },
+
+    "tool.execute.after": async (input: ToolHookInput) => {
+      try {
+        const toolName = hookString(input.tool)
+        if (!isEditTool(toolName) && !isBashTool(toolName)) {
+          return
+        }
+
+        const callID = hookString(input.callID)
+        const callInfo = pendingCalls.get(callID)
+        pendingCalls.delete(callID)
+
+        if (!callInfo) {
+          return
+        }
+
+        const hookInput = JSON.stringify({
+          hook_event_name: "PostToolUse",
+          session_id: callInfo.sessionID,
+          tool_use_id: callID,
+          cwd: callInfo.repoDir,
+          tool_name: toolName,
+          tool_input: callInfo.toolInput,
+        })
+        await shell`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
+      } catch {
+        // Checkpoint failures are non-critical — never propagate to the host
+      }
+    },
+  }
+}
+
 export const GitAiPlugin: Plugin = async (ctx) => {
+  const shell = (ctx as PluginInput & { $?: unknown }).$
+  if (hasShell(shell)) {
+    return createShellHooks(shell)
+  }
+
   const { worktree, directory } = ctx
   const defaultCwd = worktree || directory || process.cwd()
 
@@ -436,13 +582,6 @@ export const GitAiPlugin: Plugin = async (ctx) => {
       input: toolInput,
       file_paths: filePaths,
     }
-  }
-
-  const extractToolCwd = (inputCwd: unknown, args: Record<string, unknown> | undefined): string | undefined => {
-    if (typeof args?.workdir === "string") return args.workdir
-    if (typeof args?.cwd === "string") return args.cwd
-    if (typeof inputCwd === "string") return inputCwd
-    return undefined
   }
 
   return {

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -19,12 +19,13 @@
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
-import { existsSync, readFileSync, statSync } from "fs"
+import { readFileSync, statSync } from "fs"
 import { dirname, isAbsolute, join, resolve } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
 const CHECKPOINT_TIMEOUT_MS = 30_000
+const CHECKPOINT_ARGS = ["checkpoint", "opencode", "--hook-input", "stdin"]
 
 // Tools that modify files and should be tracked
 const FILE_EDIT_TOOLS = new Set([
@@ -187,21 +188,11 @@ const debugLog = (message: string, error?: unknown): void => {
   console.error(`[git-ai opencode] ${message}${detail ? `: ${detail}` : ""}`)
 }
 
-type CommandOptions = {
-  cwd?: string
-  input?: string
-  timeoutMs?: number
-}
-
-const runCommand = (
-  command: string,
-  args: string[],
-  options: CommandOptions = {},
-): Promise<{ stdout: string; stderr: string }> => {
+const runCheckpoint = (hookInput: string): Promise<void> => {
   return new Promise((resolve, reject) => {
     let settled = false
     let timeout: ReturnType<typeof setTimeout> | undefined
-    const finish = (error: Error | null, output?: { stdout: string; stderr: string }): void => {
+    const finish = (error: Error | null): void => {
       if (settled) {
         return
       }
@@ -212,55 +203,42 @@ const runCommand = (
       }
       if (error) {
         reject(error)
-      } else if (output) {
-        resolve(output)
+      } else {
+        resolve()
       }
     }
 
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      stdio: ["pipe", "pipe", "pipe"],
+    const child = spawn(GIT_AI_BIN, CHECKPOINT_ARGS, {
+      stdio: ["pipe", "ignore", "pipe"],
     })
 
-    const timeoutMs = options.timeoutMs ?? CHECKPOINT_TIMEOUT_MS
-    if (timeoutMs > 0) {
-      timeout = setTimeout(() => {
-        try {
-          child.kill("SIGTERM")
-        } catch (error) {
-          debugLog(`failed to kill timed-out command ${command}`, error)
-        }
-        finish(new Error(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms`))
-      }, timeoutMs)
-    }
+    timeout = setTimeout(() => {
+      try {
+        child.kill("SIGTERM")
+      } catch (error) {
+        debugLog("failed to kill timed-out checkpoint command", error)
+      }
+      finish(new Error(`git-ai checkpoint opencode timed out after ${CHECKPOINT_TIMEOUT_MS}ms`))
+    }, CHECKPOINT_TIMEOUT_MS)
 
-    const stdout: Buffer[] = []
     const stderr: Buffer[] = []
 
-    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk))
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk))
     child.stdin.on("error", () => {
       // The child may exit before stdin is fully written; close/error handling below reports failures.
     })
     child.on("error", finish)
     child.on("close", (code) => {
-      const output = {
-        stdout: Buffer.concat(stdout).toString(),
-        stderr: Buffer.concat(stderr).toString(),
-      }
       if (code === 0) {
-        finish(null, output)
+        finish(null)
         return
       }
 
-      finish(new Error(`${command} ${args.join(" ")} exited with ${code}: ${output.stderr}`))
+      const stderrText = Buffer.concat(stderr).toString().trim()
+      finish(new Error(`git-ai checkpoint opencode exited with ${code}${stderrText ? `: ${stderrText}` : ""}`))
     })
 
-    if (options.input !== undefined) {
-      child.stdin.end(options.input)
-    } else {
-      child.stdin.end()
-    }
+    child.stdin.end(hookInput)
   })
 }
 
@@ -275,10 +253,8 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     let candidate = pathHint
     while (candidate) {
       try {
-        if (existsSync(candidate)) {
-          const stat = statSync(candidate)
-          return stat.isDirectory() ? candidate : dirname(candidate)
-        }
+        const stat = statSync(candidate)
+        return stat.isDirectory() ? candidate : dirname(candidate)
       } catch (error) {
         debugLog(`failed to stat path while resolving git repo from ${candidate}`, error)
       }
@@ -308,7 +284,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
       const gitDirPath = isAbsolute(gitDir) || /^[a-zA-Z]:[\\/]/.test(gitDir)
         ? gitDir
         : resolve(worktreeDir, gitDir)
-      return existsSync(gitDirPath)
+      return statSync(gitDirPath).isDirectory()
     } catch (error) {
       debugLog(`failed to read gitdir pointer from ${gitFilePath}`, error)
       return false
@@ -318,10 +294,6 @@ export const GitAiPlugin: Plugin = async (ctx) => {
   const hasGitMetadata = (dir: string): boolean => {
     const marker = join(dir, ".git")
     try {
-      if (!existsSync(marker)) {
-        return false
-      }
-
       const stat = statSync(marker)
       if (stat.isDirectory()) {
         return true
@@ -449,54 +421,33 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     "tool.execute.before": async (input: ToolHookInput, output?: { args?: unknown }) => {
       try {
         const toolName = hookString(input.tool)
+        const isTrackedEdit = isEditTool(toolName)
+        const isTrackedBash = isBashTool(toolName)
+        if (!isTrackedEdit && !isTrackedBash) {
+          return
+        }
+
         const callID = hookString(input.callID)
         const sessionID = hookString(input.sessionID)
         const toolInput = output?.args ?? input.args
         const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(toolInput)))
-
-        if (isEditTool(toolName)) {
-          const filePaths = extractFilePaths(toolInput, toolCwd)
-          const repoDir = resolveRepoDir(filePaths, toolCwd)
-          if (!repoDir) {
-            return
-          }
-
-          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
-
-          const hookInput = JSON.stringify({
-            hook_event_name: "PreToolUse",
-            session_id: sessionID,
-            tool_use_id: callID,
-            cwd: repoDir,
-            tool_name: toolName,
-            tool_input: toolInput,
-          })
-          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], {
-            input: hookInput,
-            timeoutMs: CHECKPOINT_TIMEOUT_MS,
-          })
-
-        } else if (isBashTool(toolName)) {
-          const repoDir = resolveRepoDir([], toolCwd)
-          if (!repoDir) {
-            return
-          }
-
-          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
-
-          const hookInput = JSON.stringify({
-            hook_event_name: "PreToolUse",
-            session_id: sessionID,
-            tool_use_id: callID,
-            cwd: repoDir,
-            tool_name: toolName,
-            tool_input: toolInput,
-          })
-          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], {
-            input: hookInput,
-            timeoutMs: CHECKPOINT_TIMEOUT_MS,
-          })
+        const filePaths = isTrackedEdit ? extractFilePaths(toolInput, toolCwd) : []
+        const repoDir = resolveRepoDir(filePaths, toolCwd)
+        if (!repoDir) {
+          return
         }
+
+        pendingCalls.set(callID, { repoDir, sessionID, toolInput })
+
+        const hookInput = JSON.stringify({
+          hook_event_name: "PreToolUse",
+          session_id: sessionID,
+          tool_use_id: callID,
+          cwd: repoDir,
+          tool_name: toolName,
+          tool_input: toolInput,
+        })
+        await runCheckpoint(hookInput)
       } catch (error) {
         debugLog("pre-tool checkpoint failed", error)
         // Checkpoint failures are non-critical — never propagate to the host
@@ -531,10 +482,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           tool_name: toolName,
           tool_input: toolInput,
         })
-        await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], {
-          input: hookInput,
-          timeoutMs: CHECKPOINT_TIMEOUT_MS,
-        })
+        await runCheckpoint(hookInput)
       } catch (error) {
         debugLog("post-tool checkpoint failed", error)
         // Checkpoint failures are non-critical — never propagate to the host

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -17,7 +17,7 @@
  * @see https://opencode.ai/docs/plugins/
  */
 
-import type { Plugin, PluginInput } from "@opencode-ai/plugin"
+import type { Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
 import { existsSync, readFileSync, statSync } from "fs"
 import { dirname, isAbsolute, join, resolve } from "path"
@@ -264,146 +264,7 @@ const runCommand = (
   })
 }
 
-const hasShell = (value: unknown): value is PluginInput["$"] => typeof value === "function"
-
-const createShellHooks = async (shell: PluginInput["$"]) => {
-  try {
-    await shell`${GIT_AI_BIN} --version`.quiet()
-  } catch {
-    return {}
-  }
-
-  const pendingCalls = new Map<string, { repoDir: string; sessionID: string; toolInput: unknown }>()
-
-  const findGitRepo = async (pathHint: string): Promise<string | null> => {
-    const candidateDirs = [pathHint, dirname(pathHint)]
-
-    for (const dir of candidateDirs) {
-      try {
-        const result = await shell`git -C ${dir} rev-parse --show-toplevel`.quiet()
-        const repoRoot = result.stdout.toString().trim()
-        if (repoRoot) {
-          return repoRoot
-        }
-      } catch {
-        // try next candidate
-      }
-    }
-
-    return null
-  }
-
-  const resolveRepoDir = async (filePaths: string[], cwd?: string): Promise<string | null> => {
-    if (cwd) {
-      const fromCwd = await findGitRepo(cwd)
-      if (fromCwd) {
-        return fromCwd
-      }
-    }
-
-    const fromProcessCwd = await findGitRepo(process.cwd())
-    if (fromProcessCwd) {
-      return fromProcessCwd
-    }
-
-    for (const filePath of filePaths) {
-      const repo = await findGitRepo(filePath)
-      if (repo) {
-        return repo
-      }
-    }
-
-    return null
-  }
-
-  return {
-    "tool.execute.before": async (input: ToolHookInput, output?: { args?: unknown }) => {
-      try {
-        const toolName = hookString(input.tool)
-        const callID = hookString(input.callID)
-        const sessionID = hookString(input.sessionID)
-        const toolInput = output?.args ?? input.args
-        const toolCwd = extractToolCwd(input.cwd ?? input.workdir, asRecord(toolInput))
-
-        if (isEditTool(toolName)) {
-          const filePaths = extractFilePaths(toolInput, toolCwd)
-          const repoDir = await resolveRepoDir(filePaths, toolCwd)
-          if (!repoDir) {
-            return
-          }
-
-          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
-
-          const hookInput = JSON.stringify({
-            hook_event_name: "PreToolUse",
-            session_id: sessionID,
-            tool_use_id: callID,
-            cwd: repoDir,
-            tool_name: toolName,
-            tool_input: toolInput,
-          })
-          await shell`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
-
-        } else if (isBashTool(toolName)) {
-          const repoDir = await resolveRepoDir([], toolCwd)
-          if (!repoDir) {
-            return
-          }
-
-          pendingCalls.set(callID, { repoDir, sessionID, toolInput })
-
-          const hookInput = JSON.stringify({
-            hook_event_name: "PreToolUse",
-            session_id: sessionID,
-            tool_use_id: callID,
-            cwd: repoDir,
-            tool_name: toolName,
-            tool_input: toolInput,
-          })
-          await shell`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
-        }
-      } catch {
-        // Checkpoint failures are non-critical — never propagate to the host
-      }
-    },
-
-    "tool.execute.after": async (input: ToolHookInput) => {
-      try {
-        const toolName = hookString(input.tool)
-        if (!isEditTool(toolName) && !isBashTool(toolName)) {
-          return
-        }
-
-        const callID = hookString(input.callID)
-        const callInfo = pendingCalls.get(callID)
-        pendingCalls.delete(callID)
-
-        if (!callInfo) {
-          return
-        }
-
-        const hookInput = JSON.stringify({
-          hook_event_name: "PostToolUse",
-          session_id: callInfo.sessionID,
-          tool_use_id: callID,
-          cwd: callInfo.repoDir,
-          tool_name: toolName,
-          tool_input: callInfo.toolInput,
-        })
-        await shell`echo ${hookInput} | ${GIT_AI_BIN} checkpoint opencode --hook-input stdin`.quiet()
-      } catch {
-        // Checkpoint failures are non-critical — never propagate to the host
-      }
-    },
-  }
-}
-
 export const GitAiPlugin: Plugin = async (ctx) => {
-  const shell = (ctx as PluginInput & { $?: unknown }).$
-  if (hasShell(shell)) {
-    return createShellHooks(shell)
-  }
-
   const { worktree, directory } = ctx
   const defaultCwd = worktree || directory || process.cwd()
 
@@ -477,7 +338,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
   }
 
   // Helper to find git repo root from a file path or directory
-  const findGitRepo = async (pathHint: string): Promise<string | null> => {
+  const findGitRepo = (pathHint: string): string | null => {
     let dir = nearestExistingDirectory(pathHint)
     while (dir) {
       if (hasGitMetadata(dir)) {
@@ -502,9 +363,9 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     return normalizePath(cwd, defaultCwd) || defaultCwd
   }
 
-  const resolveRepoDir = async (filePaths: string[], cwd?: string): Promise<string | null> => {
+  const resolveRepoDir = (filePaths: string[], cwd?: string): string | null => {
     const seenHints = new Set<string>()
-    const findGitRepoOnce = async (pathHint: string | undefined): Promise<string | null> => {
+    const findGitRepoOnce = (pathHint: string | undefined): string | null => {
       if (!pathHint || seenHints.has(pathHint)) {
         return null
       }
@@ -514,23 +375,23 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     }
 
     for (const filePath of filePaths) {
-      const repo = await findGitRepoOnce(filePath)
+      const repo = findGitRepoOnce(filePath)
       if (repo) {
         return repo
       }
     }
 
-    const fromCwd = await findGitRepoOnce(cwd)
+    const fromCwd = findGitRepoOnce(cwd)
     if (fromCwd) {
       return fromCwd
     }
 
-    const fromDefaultCwd = await findGitRepoOnce(defaultCwd)
+    const fromDefaultCwd = findGitRepoOnce(defaultCwd)
     if (fromDefaultCwd) {
       return fromDefaultCwd
     }
 
-    const fromProcessCwd = await findGitRepoOnce(process.cwd())
+    const fromProcessCwd = findGitRepoOnce(process.cwd())
     if (fromProcessCwd) {
       return fromProcessCwd
     }
@@ -595,7 +456,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
 
         if (isEditTool(toolName)) {
           const filePaths = extractFilePaths(toolInput, toolCwd)
-          const repoDir = await resolveRepoDir(filePaths, toolCwd)
+          const repoDir = resolveRepoDir(filePaths, toolCwd)
           if (!repoDir) {
             return
           }
@@ -616,7 +477,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           })
 
         } else if (isBashTool(toolName)) {
-          const repoDir = await resolveRepoDir([], toolCwd)
+          const repoDir = resolveRepoDir([], toolCwd)
           if (!repoDir) {
             return
           }

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -24,6 +24,8 @@ import { dirname, isAbsolute, join } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
+const GIT_LOOKUP_TIMEOUT_MS = 5_000
+const CHECKPOINT_TIMEOUT_MS = 30_000
 
 // Tools that modify files and should be tracked
 const FILE_EDIT_TOOLS = new Set([
@@ -179,19 +181,29 @@ const debugLog = (message: string, error?: unknown): void => {
   console.error(`[git-ai opencode] ${message}${detail ? `: ${detail}` : ""}`)
 }
 
+type CommandOptions = {
+  cwd?: string
+  input?: string
+  timeoutMs?: number
+}
+
 const runCommand = (
   command: string,
   args: string[],
-  options: { cwd?: string; input?: string } = {},
+  options: CommandOptions = {},
 ): Promise<{ stdout: string; stderr: string }> => {
   return new Promise((resolve, reject) => {
     let settled = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
     const finish = (error: Error | null, output?: { stdout: string; stderr: string }): void => {
       if (settled) {
         return
       }
 
       settled = true
+      if (timeout) {
+        clearTimeout(timeout)
+      }
       if (error) {
         reject(error)
       } else if (output) {
@@ -203,6 +215,18 @@ const runCommand = (
       cwd: options.cwd,
       stdio: ["pipe", "pipe", "pipe"],
     })
+
+    const timeoutMs = options.timeoutMs ?? CHECKPOINT_TIMEOUT_MS
+    if (timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        try {
+          child.kill("SIGTERM")
+        } catch (error) {
+          debugLog(`failed to kill timed-out command ${command}`, error)
+        }
+        finish(new Error(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
+    }
 
     const stdout: Buffer[] = []
     const stderr: Buffer[] = []
@@ -271,7 +295,9 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     }
 
     try {
-      const result = await runCommand("git", ["-C", dir, "rev-parse", "--show-toplevel"])
+      const result = await runCommand("git", ["-C", dir, "rev-parse", "--show-toplevel"], {
+        timeoutMs: GIT_LOOKUP_TIMEOUT_MS,
+      })
       const repoRoot = result.stdout.trim()
       if (repoRoot) {
         return repoRoot
@@ -406,7 +432,10 @@ export const GitAiPlugin: Plugin = async (ctx) => {
             tool_name: toolName,
             tool_input: toolInput,
           })
-          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], { input: hookInput })
+          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], {
+            input: hookInput,
+            timeoutMs: CHECKPOINT_TIMEOUT_MS,
+          })
 
         } else if (isBashTool(toolName)) {
           const repoDir = await resolveRepoDir([], toolCwd)
@@ -424,7 +453,10 @@ export const GitAiPlugin: Plugin = async (ctx) => {
             tool_name: toolName,
             tool_input: toolInput,
           })
-          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], { input: hookInput })
+          await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], {
+            input: hookInput,
+            timeoutMs: CHECKPOINT_TIMEOUT_MS,
+          })
         }
       } catch (error) {
         debugLog("pre-tool checkpoint failed", error)
@@ -460,7 +492,10 @@ export const GitAiPlugin: Plugin = async (ctx) => {
           tool_name: toolName,
           tool_input: toolInput,
         })
-        await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], { input: hookInput })
+        await runCommand(GIT_AI_BIN, ["checkpoint", "opencode", "--hook-input", "stdin"], {
+          input: hookInput,
+          timeoutMs: CHECKPOINT_TIMEOUT_MS,
+        })
       } catch (error) {
         debugLog("post-tool checkpoint failed", error)
         // Checkpoint failures are non-critical — never propagate to the host

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -19,6 +19,7 @@
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
+import { existsSync, statSync } from "fs"
 import { dirname, isAbsolute, join } from "path"
 
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
@@ -240,12 +241,18 @@ export const GitAiPlugin: Plugin = async (ctx) => {
   // Track pending calls by callID so we can reference them in the after hook
   const pendingCalls = new Map<string, { repoDir: string; sessionID: string; toolInput: unknown }>()
 
-  // Helper to find git repo root from a file path
-  const findGitRepo = async (pathHint: string): Promise<string | null> => {
-    const candidateDirs: string[] = []
+  const nearestExistingDirectory = (pathHint: string): string | null => {
     let candidate = pathHint
-    while (candidate && !candidateDirs.includes(candidate)) {
-      candidateDirs.push(candidate)
+    while (candidate) {
+      try {
+        if (existsSync(candidate)) {
+          const stat = statSync(candidate)
+          return stat.isDirectory() ? candidate : dirname(candidate)
+        }
+      } catch (error) {
+        debugLog(`failed to stat path while resolving git repo from ${candidate}`, error)
+      }
+
       const parent = dirname(candidate)
       if (parent === candidate) {
         break
@@ -253,17 +260,24 @@ export const GitAiPlugin: Plugin = async (ctx) => {
       candidate = parent
     }
 
-    for (const dir of candidateDirs) {
-      try {
-        const result = await runCommand("git", ["-C", dir, "rev-parse", "--show-toplevel"])
-        const repoRoot = result.stdout.trim()
-        if (repoRoot) {
-          return repoRoot
-        }
-      } catch (error) {
-        debugLog(`git repo lookup failed from ${dir}`, error)
-        // try next candidate
+    return null
+  }
+
+  // Helper to find git repo root from a file path or directory
+  const findGitRepo = async (pathHint: string): Promise<string | null> => {
+    const dir = nearestExistingDirectory(pathHint)
+    if (!dir) {
+      return null
+    }
+
+    try {
+      const result = await runCommand("git", ["-C", dir, "rev-parse", "--show-toplevel"])
+      const repoRoot = result.stdout.trim()
+      if (repoRoot) {
+        return repoRoot
       }
+    } catch (error) {
+      debugLog(`git repo lookup failed from ${dir}`, error)
     }
 
     return null
@@ -278,26 +292,34 @@ export const GitAiPlugin: Plugin = async (ctx) => {
   }
 
   const resolveRepoDir = async (filePaths: string[], cwd?: string): Promise<string | null> => {
+    const seenHints = new Set<string>()
+    const findGitRepoOnce = async (pathHint: string | undefined): Promise<string | null> => {
+      if (!pathHint || seenHints.has(pathHint)) {
+        return null
+      }
+
+      seenHints.add(pathHint)
+      return findGitRepo(pathHint)
+    }
+
     for (const filePath of filePaths) {
-      const repo = await findGitRepo(filePath)
+      const repo = await findGitRepoOnce(filePath)
       if (repo) {
         return repo
       }
     }
 
-    if (cwd) {
-      const fromCwd = await findGitRepo(cwd)
-      if (fromCwd) {
-        return fromCwd
-      }
+    const fromCwd = await findGitRepoOnce(cwd)
+    if (fromCwd) {
+      return fromCwd
     }
 
-    const fromDefaultCwd = await findGitRepo(defaultCwd)
+    const fromDefaultCwd = await findGitRepoOnce(defaultCwd)
     if (fromDefaultCwd) {
       return fromDefaultCwd
     }
 
-    const fromProcessCwd = await findGitRepo(process.cwd())
+    const fromProcessCwd = await findGitRepoOnce(process.cwd())
     if (fromProcessCwd) {
       return fromProcessCwd
     }
@@ -305,7 +327,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
     return null
   }
 
-  const extractMetadataFilePaths = (metadata: unknown): string[] => {
+  const extractMetadataFilePaths = (metadata: unknown, cwd?: string): string[] => {
     if (!metadata || typeof metadata !== "object") {
       return []
     }
@@ -323,7 +345,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
 
       const filePath = (file as { filePath?: unknown; path?: unknown }).filePath ?? (file as { path?: unknown }).path
       if (typeof filePath === "string") {
-        const normalized = normalizePath(filePath, defaultCwd)
+        const normalized = normalizePath(filePath, cwd ?? defaultCwd)
         if (normalized) {
           paths.add(normalized)
         }
@@ -421,20 +443,20 @@ export const GitAiPlugin: Plugin = async (ctx) => {
         const callInfo = pendingCalls.get(callID)
         pendingCalls.delete(callID)
 
-        const metadataFilePaths = extractMetadataFilePaths(output?.metadata ?? input.metadata)
-        const toolInput = callInfo?.toolInput ?? withMetadataFilePaths(input.args, metadataFilePaths)
-        const sessionID = callInfo?.sessionID ?? hookString(input.sessionID)
-        const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(input.args)))
-        const repoDir = callInfo?.repoDir ?? await resolveRepoDir(extractFilePaths(toolInput, toolCwd), toolCwd)
-        if (!repoDir) {
+        if (!callInfo) {
+          debugLog(`skipping post-tool checkpoint without matching pre-tool call for ${callID}`)
           return
         }
 
+        const toolCwd = resolveCwd(extractToolCwd(input.cwd ?? input.workdir, asRecord(input.args)))
+        const metadataFilePaths = extractMetadataFilePaths(output?.metadata ?? input.metadata, toolCwd)
+        const toolInput = withMetadataFilePaths(callInfo.toolInput, metadataFilePaths)
+
         const hookInput = JSON.stringify({
           hook_event_name: "PostToolUse",
-          session_id: sessionID,
+          session_id: callInfo.sessionID,
           tool_use_id: callID,
-          cwd: repoDir,
+          cwd: callInfo.repoDir,
           tool_name: toolName,
           tool_input: toolInput,
         })

--- a/agent-support/opencode/package-lock.json
+++ b/agent-support/opencode/package-lock.json
@@ -9,28 +9,111 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.3"
+        "@opencode-ai/plugin": "1.15.13"
       },
       "devDependencies": {
         "@types/node": "^25.x",
         "typescript": "^5.8.3"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.3.tgz",
-      "integrity": "sha512-Ob/3tVSIeuMRJBr2O23RtrnC5djRe01Lglx+TwGEmjrH9yDBJ2tftegYLnNEjRoMuzITgq9LD8168p4pzv+U/A==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.13.tgz",
+      "integrity": "sha512-NFwZGhmxIPijtfz9swPJXDmhOpq4UWP8WjEE7GEMr7FwtJrK/hv6v36nFimed5+OKk+pQCrTJn/vhRW7Io72IA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.3",
+        "@opencode-ai/sdk": "1.15.13",
+        "effect": "4.0.0-beta.66",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.97",
-        "@opentui/solid": ">=0.1.97"
+        "@opentui/core": ">=0.2.16",
+        "@opentui/keymap": ">=0.2.16",
+        "@opentui/solid": ">=0.2.16"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -39,13 +122,19 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.3.tgz",
-      "integrity": "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==",
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.13.tgz",
+      "integrity": "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.1",
@@ -71,11 +160,134 @@
         "node": ">= 8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.66",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.66.tgz",
+      "integrity": "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -85,6 +297,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -105,6 +333,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/typescript": {
@@ -128,6 +365,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -141,6 +391,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/agent-support/opencode/package.json
+++ b/agent-support/opencode/package.json
@@ -8,11 +8,10 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "1.4.3"
+    "@opencode-ai/plugin": "1.15.13"
   },
   "devDependencies": {
     "@types/node": "^25.x",
     "typescript": "^5.8.3"
   }
 }
-

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -215,6 +215,8 @@ mod tests {
         assert!(content.contains("import type { Plugin }"));
         assert!(content.contains("@opencode-ai/plugin"));
         assert!(content.contains("export const GitAiPlugin: Plugin"));
+        assert!(content.contains("export default GitAiPlugin"));
+        assert!(content.contains("child_process"));
         assert!(content.contains("\"tool.execute.before\""));
         assert!(content.contains("\"tool.execute.after\""));
         assert!(content.contains("FILE_EDIT_TOOLS"));
@@ -236,9 +238,10 @@ mod tests {
         // Placeholder should be replaced with the actual binary path in the const
         assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
         assert!(content.contains(r#"const GIT_AI_BIN = "/usr/local/bin/git-ai""#));
-        // Commands reference the const which now holds the absolute path
-        assert!(content.contains("${GIT_AI_BIN} --version"));
-        assert!(content.contains("${GIT_AI_BIN} checkpoint opencode"));
+        // Commands reference the const through spawn(), which works in OpenCode CLI and Desktop.
+        assert!(content.contains("runCommand(GIT_AI_BIN"));
+        assert!(content.contains(r#""checkpoint", "opencode", "--hook-input", "stdin""#));
+        assert!(!content.contains("Bun.$"));
     }
 
     #[test]

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -212,7 +212,7 @@ mod tests {
     fn test_opencode_plugin_content_is_valid_typescript() {
         let content = OPENCODE_PLUGIN_CONTENT;
 
-        assert!(content.contains("import type { Plugin }"));
+        assert!(content.contains("import type { Plugin, PluginInput }"));
         assert!(content.contains("@opencode-ai/plugin"));
         assert!(content.contains("export const GitAiPlugin: Plugin"));
         assert!(content.contains("export default GitAiPlugin"));

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -212,7 +212,7 @@ mod tests {
     fn test_opencode_plugin_content_is_valid_typescript() {
         let content = OPENCODE_PLUGIN_CONTENT;
 
-        assert!(content.contains("import type { Plugin, PluginInput }"));
+        assert!(content.contains("import type { Plugin }"));
         assert!(content.contains("@opencode-ai/plugin"));
         assert!(content.contains("export const GitAiPlugin: Plugin"));
         assert!(content.contains("export default GitAiPlugin"));

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -238,8 +238,8 @@ mod tests {
         // Placeholder should be replaced with the actual binary path in the const
         assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
         assert!(content.contains(r#"const GIT_AI_BIN = "/usr/local/bin/git-ai""#));
-        // Commands reference the const through spawn(), which works in OpenCode CLI and Desktop.
-        assert!(content.contains("runCommand(GIT_AI_BIN"));
+        // Checkpoint execution uses spawn(), which works in OpenCode CLI and Desktop.
+        assert!(content.contains("spawn(GIT_AI_BIN"));
         assert!(content.contains(r#""checkpoint", "opencode", "--hook-input", "stdin""#));
         assert!(!content.contains("Bun.$"));
     }


### PR DESCRIPTION
## Summary

Fix OpenCode Desktop checkpointing by removing the plugin dependency on `Bun.$` and using Node `child_process.spawn` for repository discovery and `git-ai checkpoint` calls. OpenCode Desktop runs plugins in a Node sidecar where `Bun.$` is unavailable, while the CLI provides Bun support.

Also improves repo selection for edits outside the active OpenCode session directory, adds a default plugin export, and documents opt-in debug logging for skipped checkpoints.

## Validation

- `npm run type-check`
- `task test TEST_FILTER=opencode`
- `task fmt`
- `task lint`
- live OpenCode Desktop edit of `/Users/svarlamov/projects/testing-git-mar-28/jokes-june-3-extra-4.csv` produced Human and AiAgent checkpoints for the target repo
