### PR TITLE
fix(ci): preserve AI authorship notes from forks (stacked on #1482)

### DIFF
--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -100,10 +100,14 @@ impl CiContext {
                 }
 
                 // If this is a fork PR, fetch notes from the fork repository
+                let mut fork_notes_fetched = false;
                 if let Some(fork_url) = fork_clone_url {
                     println!("Fetching authorship notes from fork...");
                     match Self::fetch_fork_notes(&self.repo, fork_url) {
-                        Ok(true) => println!("Fetched authorship notes from fork"),
+                        Ok(true) => {
+                            println!("Fetched authorship notes from fork");
+                            fork_notes_fetched = true;
+                        }
                         Ok(false) => println!("No authorship notes found on fork"),
                         Err(e) => {
                             println!(
@@ -138,10 +142,24 @@ impl CiContext {
                     // fork have the same SHAs. Now that we've fetched fork notes,
                     // those notes are attached to the correct commits. Just push them.
                     if fork_clone_url.is_some() {
+                        if !ref_exists(&self.repo, "refs/notes/ai") {
+                            println!(
+                                "No local authorship notes available after origin/fork fetch; skipping fork note push"
+                            );
+                            return Ok(CiRunResult::SkippedSimpleMerge);
+                        }
+
                         println!(
                             "{} has {} parents (merge commit from fork) - preserving fork notes",
                             merge_commit_sha, parent_count
                         );
+                        if fork_notes_fetched {
+                            println!("Fork notes were fetched and merged locally");
+                        } else {
+                            println!(
+                                "Using existing local authorship notes (no additional fork notes fetched)"
+                            );
+                        }
                         println!("Pushing authorship...");
                         self.repo.push_authorship("origin")?;
                         println!("Pushed authorship. Done.");

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -12,6 +12,11 @@ use crate::git::sync_authorship::fetch_authorship_notes;
 use std::fs;
 use std::path::PathBuf;
 
+#[cfg(windows)]
+const NULL_HOOKS: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_HOOKS: &str = "/dev/null";
+
 #[derive(Debug)]
 pub enum CiEvent {
     Merge {
@@ -380,7 +385,7 @@ impl CiContext {
         let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
         let mut fetch_args = repo.global_args_for_exec();
         fetch_args.push("-c".to_string());
-        fetch_args.push("core.hooksPath=/dev/null".to_string());
+        fetch_args.push(format!("core.hooksPath={}", NULL_HOOKS));
         fetch_args.push("fetch".to_string());
         fetch_args.push("--no-tags".to_string());
         fetch_args.push("--recurse-submodules=no".to_string());

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -491,5 +491,4 @@ mod tests {
         let debug_str3 = format!("{:?}", result3);
         assert!(debug_str3.contains("NoAuthorshipAvailable"));
     }
-
 }

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -80,7 +80,7 @@ impl CiContext {
                 head_ref,
                 head_sha,
                 base_ref,
-                base_sha: _,
+                base_sha,
             } => {
                 println!("Working repository is in {}", self.repo.path().display());
 
@@ -188,8 +188,35 @@ impl CiContext {
                 if original_commits.len() > 1 {
                     // Try to find the new rebased commits
                     // Walk back from merge_commit_sha the same number of commits as original
-                    let new_commits =
+                    let mut new_commits =
                         self.get_rebased_commits(merge_commit_sha, original_commits.len());
+
+                    // #1473: On a linear base branch the first-parent walk above can
+                    // return pre-existing base-branch commits instead of rebased PR
+                    // commits, making the counts match and misclassifying a squash
+                    // merge as a rebase (which then writes the PR's notes onto
+                    // unrelated base commits). Restrict the candidates to commits that
+                    // were actually introduced on top of the pre-merge base tip, i.e.
+                    // those in `base_sha..merge_commit_sha`. A squash merge introduces
+                    // exactly one such commit, so it can no longer look like a rebase.
+                    // `base_sha` may be empty (e.g. GitLab MRs); in that case we leave
+                    // the legacy behavior untouched.
+                    if !base_sha.is_empty() {
+                        let introduced: std::collections::HashSet<String> =
+                            CommitRange::new_infer_refname(
+                                &self.repo,
+                                base_sha.clone(),
+                                merge_commit_sha.to_string(),
+                                None,
+                            )
+                            .map(|r| r.all_commits())
+                            .unwrap_or_default()
+                            .into_iter()
+                            .collect();
+                        if !introduced.is_empty() {
+                            new_commits.retain(|sha| introduced.contains(sha));
+                        }
+                    }
 
                     if new_commits.len() == original_commits.len() {
                         println!(

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -132,8 +132,13 @@ impl CiContext {
                     // their fork SHAs. Import only notes for those PR commits,
                     // then push the scoped local authorship ref.
                     if fork_clone_url.is_some() {
-                        let (_source_base, original_commits) =
-                            self.original_pr_commits(head_sha, base_ref, base_sha);
+                        let (_source_base, original_commits) = self
+                            .original_pr_commits_for_merge_commit(
+                                &merge_commit,
+                                head_sha,
+                                base_ref,
+                                base_sha,
+                            );
                         let fork_notes_imported = self.import_fork_notes_for_commits(
                             fork_clone_url,
                             &original_commits,
@@ -518,6 +523,35 @@ impl CiContext {
             merge_base.map(|base| format!("merge-base {}", base)),
             vec![resolved_head],
         )
+    }
+
+    fn original_pr_commits_for_merge_commit(
+        &self,
+        merge_commit: &crate::git::repository::Commit<'_>,
+        head_sha: &str,
+        base_ref: &str,
+        base_sha: &str,
+    ) -> (Option<String>, Vec<String>) {
+        if let Ok(first_parent) = merge_commit.parent(0) {
+            let first_parent_sha = first_parent.id();
+            if let Ok(mut commits) = CommitRange::new_infer_refname(
+                &self.repo,
+                first_parent_sha.clone(),
+                head_sha.to_string(),
+                None,
+            )
+            .map(|r| r.all_commits())
+                && !commits.is_empty()
+            {
+                commits.reverse();
+                return (
+                    Some(format!("merge first-parent {}", first_parent_sha)),
+                    commits,
+                );
+            }
+        }
+
+        self.original_pr_commits(head_sha, base_ref, base_sha)
     }
 
     /// Get the rebased commits by walking back from merge_commit_sha.

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -6,7 +6,10 @@ use crate::error::GitAiError;
 use crate::git::notes_api::{
     read_authorship_v3 as get_reference_as_authorship_log_v3, read_note as show_authorship_note,
 };
-use crate::git::refs::{copy_ref, merge_notes_from_ref, ref_exists};
+use crate::git::refs::{
+    AI_AUTHORSHIP_FORK_TRACKING_REF, copy_missing_notes_for_commits_from_ref,
+    note_blob_oids_for_commits, ref_exists,
+};
 use crate::git::repository::{CommitRange, Repository, exec_git};
 use crate::git::sync_authorship::fetch_authorship_notes;
 use std::fs;
@@ -58,6 +61,7 @@ pub enum CiRunResult {
 pub struct CiRunOptions {
     pub skip_fetch_notes: bool,
     pub skip_fetch_base: bool,
+    pub skip_fetch_fork_notes: bool,
     pub skip_push: bool,
 }
 
@@ -104,25 +108,6 @@ impl CiContext {
                     println!("Fetched authorship history");
                 }
 
-                // If this is a fork PR, fetch notes from the fork repository
-                let mut fork_notes_fetched = false;
-                if let Some(fork_url) = fork_clone_url {
-                    println!("Fetching authorship notes from fork...");
-                    match Self::fetch_fork_notes(&self.repo, fork_url) {
-                        Ok(true) => {
-                            println!("Fetched authorship notes from fork");
-                            fork_notes_fetched = true;
-                        }
-                        Ok(false) => println!("No authorship notes found on fork"),
-                        Err(e) => {
-                            println!(
-                                "Warning: Failed to fetch fork notes ({}), continuing without them",
-                                e
-                            );
-                        }
-                    }
-                }
-
                 // Check if authorship already exists for this commit
                 match get_reference_as_authorship_log_v3(&self.repo, merge_commit_sha) {
                     Ok(existing_log) => {
@@ -143,13 +128,20 @@ impl CiContext {
                 let merge_commit = self.repo.find_commit(merge_commit_sha.clone())?;
                 let parent_count = merge_commit.parents().count();
                 if parent_count > 1 {
-                    // For fork PRs with merge commits, the merged commits from the
-                    // fork have the same SHAs. Now that we've fetched fork notes,
-                    // those notes are attached to the correct commits. Just push them.
+                    // For fork PRs with merge commits, the merged commits keep
+                    // their fork SHAs. Import only notes for those PR commits,
+                    // then push the scoped local authorship ref.
                     if fork_clone_url.is_some() {
-                        if !ref_exists(&self.repo, "refs/notes/ai") {
+                        let (_source_base, original_commits) =
+                            self.original_pr_commits(head_sha, base_ref, base_sha);
+                        let fork_notes_imported = self.import_fork_notes_for_commits(
+                            fork_clone_url,
+                            &original_commits,
+                            options,
+                        )?;
+                        if !self.has_notes_for_any_commit(&original_commits)? {
                             println!(
-                                "No local authorship notes available after origin/fork fetch; skipping fork note push"
+                                "No local authorship notes available for fork PR commits; skipping fork note push"
                             );
                             return Ok(CiRunResult::SkippedSimpleMerge);
                         }
@@ -158,16 +150,23 @@ impl CiContext {
                             "{} has {} parents (merge commit from fork) - preserving fork notes",
                             merge_commit_sha, parent_count
                         );
-                        if fork_notes_fetched {
-                            println!("Fork notes were fetched and merged locally");
+                        if fork_notes_imported > 0 {
+                            println!(
+                                "Imported {} fork authorship notes for PR commits",
+                                fork_notes_imported
+                            );
                         } else {
                             println!(
                                 "Using existing local authorship notes (no additional fork notes fetched)"
                             );
                         }
-                        println!("Pushing authorship...");
-                        self.repo.push_authorship("origin")?;
-                        println!("Pushed authorship. Done.");
+                        if options.skip_push {
+                            println!("Skipping authorship push (--skip-push). Done.");
+                        } else {
+                            println!("Pushing authorship...");
+                            self.repo.push_authorship("origin")?;
+                            println!("Pushed authorship. Done.");
+                        }
                         return Ok(CiRunResult::ForkNotesPreserved);
                     }
                     println!(
@@ -178,6 +177,33 @@ impl CiContext {
                 }
 
                 if merge_commit_sha == head_sha {
+                    if fork_clone_url.is_some() {
+                        let (_source_base, original_commits) =
+                            self.original_pr_commits(head_sha, base_ref, base_sha);
+                        let fork_notes_imported = self.import_fork_notes_for_commits(
+                            fork_clone_url,
+                            &original_commits,
+                            options,
+                        )?;
+                        if self.has_notes_for_any_commit(&original_commits)? {
+                            println!(
+                                "{} equals head {} (fast-forward from fork) - preserving fork notes",
+                                merge_commit_sha, head_sha
+                            );
+                            println!(
+                                "Imported {} fork authorship notes for PR commits",
+                                fork_notes_imported
+                            );
+                            if options.skip_push {
+                                println!("Skipping authorship push (--skip-push). Done.");
+                            } else {
+                                println!("Pushing authorship...");
+                                self.repo.push_authorship("origin")?;
+                                println!("Pushed authorship. Done.");
+                            }
+                            return Ok(CiRunResult::ForkNotesPreserved);
+                        }
+                    }
                     println!(
                         "{} equals head {} (fast-forward)",
                         merge_commit_sha, head_sha
@@ -211,34 +237,16 @@ impl CiContext {
                 // Detect squash vs rebase merge by counting commits
                 // For squash: N original commits → 1 merge commit
                 // For rebase: N original commits → N rebased commits
-                let merge_base = self
-                    .repo
-                    .merge_base(head_sha.to_string(), base_ref.to_string())
-                    .ok();
-
-                let original_commits = if let Some(ref base) = merge_base {
-                    let mut commits = CommitRange::new_infer_refname(
-                        &self.repo,
-                        base.clone(),
-                        head_sha.to_string(),
-                        None,
-                    )
-                    .map(|r| r.all_commits())
-                    .unwrap_or_else(|_| vec![head_sha.to_string()]);
-                    // CommitRange uses `git rev-list` which returns newest-first.
-                    // rewrite_authorship_after_rebase_v2 expects oldest-first (same as
-                    // the local rebase hook which calls .reverse() after rev-list).
-                    commits.reverse();
-                    commits
-                } else {
-                    vec![head_sha.to_string()]
-                };
+                let (original_commits_base, original_commits) =
+                    self.original_pr_commits(head_sha, base_ref, base_sha);
 
                 println!(
-                    "Original commits in PR: {} (from merge base {:?})",
+                    "Original commits in PR: {} (from {:?})",
                     original_commits.len(),
-                    merge_base
+                    original_commits_base
                 );
+
+                self.import_fork_notes_for_commits(fork_clone_url, &original_commits, options)?;
 
                 // For multi-commit PRs, check if this is a rebase merge (multiple new commits)
                 // by walking back from merge_commit_sha
@@ -354,11 +362,11 @@ impl CiContext {
         Ok(())
     }
 
-    /// Fetch authorship notes from a fork repository URL and merge them into
-    /// the local refs/notes/ai. Returns Ok(true) if notes were found and merged,
+    /// Fetch authorship notes from a fork repository URL into the fork tracking ref.
+    /// Returns Ok(true) if notes were found and fetched,
     /// Ok(false) if no notes exist on the fork.
     fn fetch_fork_notes(repo: &Repository, fork_url: &str) -> Result<bool, GitAiError> {
-        let tracking_ref = "refs/notes/ai-remote/fork";
+        let tracking_ref = AI_AUTHORSHIP_FORK_TRACKING_REF;
 
         // Check if the fork has notes
         let mut ls_remote_args = repo.global_args_for_exec();
@@ -397,19 +405,119 @@ impl CiContext {
 
         exec_git(&fetch_args)?;
 
-        // Merge fork notes into local refs/notes/ai
-        let local_notes_ref = "refs/notes/ai";
-        if ref_exists(repo, tracking_ref) {
-            if ref_exists(repo, local_notes_ref) {
-                // Both exist - merge (fork notes fill in what origin doesn't have)
-                merge_notes_from_ref(repo, tracking_ref)?;
-            } else {
-                // Only fork notes exist - copy them to local
-                copy_ref(repo, tracking_ref, local_notes_ref)?;
-            }
+        Ok(true)
+    }
+
+    fn import_fork_notes_for_commits(
+        &self,
+        fork_clone_url: &Option<String>,
+        commit_shas: &[String],
+        options: CiRunOptions,
+    ) -> Result<usize, GitAiError> {
+        let Some(fork_url) = fork_clone_url else {
+            return Ok(0);
+        };
+        if commit_shas.is_empty() {
+            println!("No PR commits found; skipping fork authorship note import");
+            return Ok(0);
         }
 
-        Ok(true)
+        let source_ref_available = if options.skip_fetch_fork_notes {
+            println!(
+                "Skipping fork authorship notes fetch; using {} if it exists",
+                AI_AUTHORSHIP_FORK_TRACKING_REF
+            );
+            ref_exists(&self.repo, AI_AUTHORSHIP_FORK_TRACKING_REF)
+        } else {
+            println!(
+                "Fetching authorship notes from fork into {}...",
+                AI_AUTHORSHIP_FORK_TRACKING_REF
+            );
+            match Self::fetch_fork_notes(&self.repo, fork_url) {
+                Ok(true) => {
+                    println!("Fetched authorship notes from fork");
+                    true
+                }
+                Ok(false) => {
+                    println!("No authorship notes found on fork");
+                    false
+                }
+                Err(e) => {
+                    println!(
+                        "Warning: Failed to fetch fork notes ({}), continuing without them",
+                        e
+                    );
+                    false
+                }
+            }
+        };
+
+        if !source_ref_available {
+            return Ok(0);
+        }
+
+        let copied = copy_missing_notes_for_commits_from_ref(
+            &self.repo,
+            AI_AUTHORSHIP_FORK_TRACKING_REF,
+            commit_shas,
+        )?;
+        println!(
+            "Imported {} fork authorship notes for {} PR commits from {}",
+            copied,
+            commit_shas.len(),
+            AI_AUTHORSHIP_FORK_TRACKING_REF
+        );
+        Ok(copied)
+    }
+
+    fn has_notes_for_any_commit(&self, commit_shas: &[String]) -> Result<bool, GitAiError> {
+        Ok(!note_blob_oids_for_commits(&self.repo, commit_shas)?.is_empty())
+    }
+
+    fn original_pr_commits(
+        &self,
+        head_sha: &str,
+        base_ref: &str,
+        base_sha: &str,
+    ) -> (Option<String>, Vec<String>) {
+        if !base_sha.is_empty()
+            && let Ok(mut commits) = CommitRange::new_infer_refname(
+                &self.repo,
+                base_sha.to_string(),
+                head_sha.to_string(),
+                None,
+            )
+            .map(|r| r.all_commits())
+            && !commits.is_empty()
+        {
+            commits.reverse();
+            return (Some(format!("base_sha {}", base_sha)), commits);
+        }
+
+        let merge_base = self
+            .repo
+            .merge_base(head_sha.to_string(), base_ref.to_string())
+            .ok();
+
+        if let Some(ref base) = merge_base
+            && let Ok(mut commits) =
+                CommitRange::new_infer_refname(&self.repo, base.clone(), head_sha.to_string(), None)
+                    .map(|r| r.all_commits())
+            && !commits.is_empty()
+        {
+            commits.reverse();
+            return (Some(format!("merge-base {}", base)), commits);
+        }
+
+        let resolved_head = self
+            .repo
+            .revparse_single(head_sha)
+            .map(|obj| obj.id())
+            .unwrap_or_else(|_| head_sha.to_string());
+        (
+            merge_base.map(|base| format!("merge-base {}", base)),
+            vec![resolved_head],
+        )
     }
 
     /// Get the rebased commits by walking back from merge_commit_sha.

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -486,4 +486,5 @@ mod tests {
         let debug_str3 = format!("{:?}", result3);
         assert!(debug_str3.contains("NoAuthorshipAvailable"));
     }
+
 }

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -196,8 +196,11 @@ impl CiContext {
                     // misclassified (PR notes then land on unrelated commits). Restrict
                     // to commits the merge actually introduced
                     // (`base_sha..merge_commit_sha`; see gitrevisions(7)) — a squash
-                    // yields exactly one, so it can't look like a rebase. An empty
-                    // `base_sha` (currently the GitLab path) keeps the legacy behavior.
+                    // yields exactly one, so it can't look like a rebase. GitHub passes
+                    // `pull_request.base.sha` and GitLab passes `diff_refs.start_sha`
+                    // (the target-branch tip at MR creation); an empty `base_sha`
+                    // (transient API failure on either path) safely skips the filter
+                    // and falls back to the pre-#1473 behavior.
                     if !base_sha.is_empty() {
                         let introduced: std::collections::HashSet<String> =
                             CommitRange::new_infer_refname(

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -18,7 +18,6 @@ pub enum CiEvent {
         head_ref: String,
         head_sha: String,
         base_ref: String,
-        #[allow(dead_code)]
         base_sha: String,
     },
 }
@@ -191,16 +190,14 @@ impl CiContext {
                     let mut new_commits =
                         self.get_rebased_commits(merge_commit_sha, original_commits.len());
 
-                    // #1473: On a linear base branch the first-parent walk above can
-                    // return pre-existing base-branch commits instead of rebased PR
-                    // commits, making the counts match and misclassifying a squash
-                    // merge as a rebase (which then writes the PR's notes onto
-                    // unrelated base commits). Restrict the candidates to commits that
-                    // were actually introduced on top of the pre-merge base tip, i.e.
-                    // those in `base_sha..merge_commit_sha`. A squash merge introduces
-                    // exactly one such commit, so it can no longer look like a rebase.
-                    // `base_sha` may be empty (e.g. GitLab MRs); in that case we leave
-                    // the legacy behavior untouched.
+                    // #1473: on a linear base branch the first-parent walk above can
+                    // return pre-existing base commits rather than rebased PR commits,
+                    // so a squash merge's count matches a rebase's and gets
+                    // misclassified (PR notes then land on unrelated commits). Restrict
+                    // to commits the merge actually introduced
+                    // (`base_sha..merge_commit_sha`; see gitrevisions(7)) — a squash
+                    // yields exactly one, so it can't look like a rebase. An empty
+                    // `base_sha` (currently the GitLab path) keeps the legacy behavior.
                     if !base_sha.is_empty() {
                         let introduced: std::collections::HashSet<String> =
                             CommitRange::new_infer_refname(

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -303,7 +303,16 @@ impl CiContext {
         expected_count: usize,
     ) -> Vec<String> {
         let mut commits = Vec::new();
-        let mut current_sha = merge_commit_sha.to_string();
+        // Resolve to a full SHA up front so the entries are comparable to the
+        // full 40-char SHAs produced by `git rev-list` (the #1473 `retain` filter
+        // in `run_with_options` compares against such a set). Callers like
+        // `git-ai ci local merge` may pass an abbreviated `merge_commit_sha`; the
+        // remaining entries already come from parent ids, which are full.
+        let mut current_sha = self
+            .repo
+            .revparse_single(merge_commit_sha)
+            .map(|obj| obj.id())
+            .unwrap_or_else(|_| merge_commit_sha.to_string());
 
         for _ in 0..expected_count {
             commits.push(current_sha.clone());

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -6,7 +6,8 @@ use crate::error::GitAiError;
 use crate::git::notes_api::{
     read_authorship_v3 as get_reference_as_authorship_log_v3, read_note as show_authorship_note,
 };
-use crate::git::repository::{CommitRange, Repository};
+use crate::git::refs::{copy_ref, merge_notes_from_ref, ref_exists};
+use crate::git::repository::{CommitRange, Repository, exec_git};
 use crate::git::sync_authorship::fetch_authorship_notes;
 use std::fs;
 use std::path::PathBuf;
@@ -19,6 +20,9 @@ pub enum CiEvent {
         head_sha: String,
         base_ref: String,
         base_sha: String,
+        /// Clone URL of the fork repository, if this PR came from a fork.
+        /// When set, notes will be fetched from the fork before processing.
+        fork_clone_url: Option<String>,
     },
 }
 
@@ -39,6 +43,8 @@ pub enum CiRunResult {
         #[allow(dead_code)]
         authorship_log: AuthorshipLog,
     },
+    /// Fork notes were fetched and preserved for a merge commit from a fork
+    ForkNotesPreserved,
     /// No AI authorship to track (pre-git-ai commits or human-only code)
     NoAuthorshipAvailable,
 }
@@ -80,6 +86,7 @@ impl CiContext {
                 head_sha,
                 base_ref,
                 base_sha,
+                fork_clone_url,
             } => {
                 println!("Working repository is in {}", self.repo.path().display());
 
@@ -90,6 +97,21 @@ impl CiContext {
                     // Ensure we have the full authorship history before checking for existing notes
                     fetch_authorship_notes(&self.repo, "origin")?;
                     println!("Fetched authorship history");
+                }
+
+                // If this is a fork PR, fetch notes from the fork repository
+                if let Some(fork_url) = fork_clone_url {
+                    println!("Fetching authorship notes from fork...");
+                    match Self::fetch_fork_notes(&self.repo, fork_url) {
+                        Ok(true) => println!("Fetched authorship notes from fork"),
+                        Ok(false) => println!("No authorship notes found on fork"),
+                        Err(e) => {
+                            println!(
+                                "Warning: Failed to fetch fork notes ({}), continuing without them",
+                                e
+                            );
+                        }
+                    }
                 }
 
                 // Check if authorship already exists for this commit
@@ -112,6 +134,19 @@ impl CiContext {
                 let merge_commit = self.repo.find_commit(merge_commit_sha.clone())?;
                 let parent_count = merge_commit.parents().count();
                 if parent_count > 1 {
+                    // For fork PRs with merge commits, the merged commits from the
+                    // fork have the same SHAs. Now that we've fetched fork notes,
+                    // those notes are attached to the correct commits. Just push them.
+                    if fork_clone_url.is_some() {
+                        println!(
+                            "{} has {} parents (merge commit from fork) - preserving fork notes",
+                            merge_commit_sha, parent_count
+                        );
+                        println!("Pushing authorship...");
+                        self.repo.push_authorship("origin")?;
+                        println!("Pushed authorship. Done.");
+                        return Ok(CiRunResult::ForkNotesPreserved);
+                    }
                     println!(
                         "{} has {} parents (simple merge)",
                         merge_commit_sha, parent_count
@@ -296,6 +331,64 @@ impl CiContext {
         Ok(())
     }
 
+    /// Fetch authorship notes from a fork repository URL and merge them into
+    /// the local refs/notes/ai. Returns Ok(true) if notes were found and merged,
+    /// Ok(false) if no notes exist on the fork.
+    fn fetch_fork_notes(repo: &Repository, fork_url: &str) -> Result<bool, GitAiError> {
+        let tracking_ref = "refs/notes/ai-remote/fork";
+
+        // Check if the fork has notes
+        let mut ls_remote_args = repo.global_args_for_exec();
+        ls_remote_args.push("ls-remote".to_string());
+        ls_remote_args.push(fork_url.to_string());
+        ls_remote_args.push("refs/notes/ai".to_string());
+
+        match exec_git(&ls_remote_args) {
+            Ok(output) => {
+                let result = String::from_utf8_lossy(&output.stdout).to_string();
+                if result.trim().is_empty() {
+                    return Ok(false);
+                }
+            }
+            Err(e) => {
+                return Err(GitAiError::Generic(format!(
+                    "Failed to check fork for authorship notes: {}",
+                    e
+                )));
+            }
+        }
+
+        // Fetch notes from the fork URL into a tracking ref
+        let fetch_refspec = format!("+refs/notes/ai:{}", tracking_ref);
+        let mut fetch_args = repo.global_args_for_exec();
+        fetch_args.push("-c".to_string());
+        fetch_args.push("core.hooksPath=/dev/null".to_string());
+        fetch_args.push("fetch".to_string());
+        fetch_args.push("--no-tags".to_string());
+        fetch_args.push("--recurse-submodules=no".to_string());
+        fetch_args.push("--no-write-fetch-head".to_string());
+        fetch_args.push("--no-write-commit-graph".to_string());
+        fetch_args.push("--no-auto-maintenance".to_string());
+        fetch_args.push(fork_url.to_string());
+        fetch_args.push(fetch_refspec);
+
+        exec_git(&fetch_args)?;
+
+        // Merge fork notes into local refs/notes/ai
+        let local_notes_ref = "refs/notes/ai";
+        if ref_exists(repo, tracking_ref) {
+            if ref_exists(repo, local_notes_ref) {
+                // Both exist - merge (fork notes fill in what origin doesn't have)
+                merge_notes_from_ref(repo, tracking_ref)?;
+            } else {
+                // Only fork notes exist - copy them to local
+                copy_ref(repo, tracking_ref, local_notes_ref)?;
+            }
+        }
+
+        Ok(true)
+    }
+
     /// Get the rebased commits by walking back from merge_commit_sha.
     /// For a rebase merge with N original commits, there should be N new commits
     /// ending at merge_commit_sha.
@@ -352,6 +445,7 @@ mod tests {
             head_sha: "def456".to_string(),
             base_ref: "main".to_string(),
             base_sha: "ghi789".to_string(),
+            fork_clone_url: None,
         };
 
         let debug_str = format!("{:?}", event);

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -63,6 +63,18 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     let base_ref = pull_request.base.ref_name;
     let clone_url = pull_request.base.repo.clone_url.clone();
 
+    // Detect fork: if head repo URL differs from base repo URL, this is a fork PR
+    let fork_clone_url = if pull_request.head.repo.clone_url != pull_request.base.repo.clone_url {
+        let fork_url = pull_request.head.repo.clone_url.clone();
+        println!(
+            "Detected fork PR: head repo {} differs from base repo {}",
+            fork_url, clone_url
+        );
+        Some(fork_url)
+    } else {
+        None
+    };
+
     let clone_dir = "git-ai-ci-clone".to_string();
 
     // Authenticate the clone URL with GITHUB_TOKEN if available
@@ -99,6 +111,18 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
         format!("pull/{}/head:refs/github/pr/{}", pr_number, pr_number),
     ])?;
 
+    // Authenticate the fork clone URL if this is a fork PR
+    let authenticated_fork_url = fork_clone_url.map(|fork_url| {
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            fork_url.replace(
+                "https://github.com/",
+                &format!("https://x-access-token:{}@github.com/", token),
+            )
+        } else {
+            fork_url
+        }
+    });
+
     let repo = find_repository_in_path(&clone_dir.clone())?;
 
     Ok(Some(CiContext {
@@ -109,6 +133,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
             head_sha: head_sha.clone(),
             base_ref: base_ref.clone(),
             base_sha: pull_request.base.sha.clone(),
+            fork_clone_url: authenticated_fork_url,
         },
         temp_dir: PathBuf::from(clone_dir),
     }))

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -79,13 +79,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     // Authenticate the clone URL with GITHUB_TOKEN if available
     let authenticated_url = if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        // Replace https://github.com/ with https://x-access-token:TOKEN@github.com/
-        // Supports both public and enterprise github instances.
-        format!(
-            "https://x-access-token:{}@{}",
-            token,
-            clone_url.strip_prefix("https://").unwrap_or(&clone_url)
-        )
+        authenticate_clone_url(&clone_url, &token)
     } else {
         clone_url
     };
@@ -114,10 +108,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     // Authenticate the fork clone URL if this is a fork PR
     let authenticated_fork_url = fork_clone_url.map(|fork_url| {
         if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-            fork_url.replace(
-                "https://github.com/",
-                &format!("https://x-access-token:{}@github.com/", token),
-            )
+            authenticate_clone_url(&fork_url, &token)
         } else {
             fork_url
         }
@@ -139,6 +130,14 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     }))
 }
 
+fn authenticate_clone_url(clone_url: &str, token: &str) -> String {
+    format!(
+        "https://x-access-token:{}@{}",
+        token,
+        clone_url.strip_prefix("https://").unwrap_or(clone_url)
+    )
+}
+
 /// Install or update the GitHub Actions workflow in the current repository
 /// Writes the embedded template to .github/workflows/git-ai.yaml at the repo root
 pub fn install_github_ci_workflow() -> Result<PathBuf, GitAiError> {
@@ -157,4 +156,25 @@ pub fn install_github_ci_workflow() -> Result<PathBuf, GitAiError> {
         .map_err(|e| GitAiError::Generic(format!("Failed to write workflow file: {}", e)))?;
 
     Ok(dest_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::authenticate_clone_url;
+
+    #[test]
+    fn test_authenticate_clone_url_supports_github_dot_com() {
+        assert_eq!(
+            authenticate_clone_url("https://github.com/acme/repo.git", "token"),
+            "https://x-access-token:token@github.com/acme/repo.git"
+        );
+    }
+
+    #[test]
+    fn test_authenticate_clone_url_supports_enterprise_hosts() {
+        assert_eq!(
+            authenticate_clone_url("https://github.example.com/acme/repo.git", "token"),
+            "https://x-access-token:token@github.example.com/acme/repo.git"
+        );
+    }
 }

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 const GITLAB_CI_TEMPLATE_YAML: &str = include_str!("workflow_templates/gitlab.yaml");
 
-/// GitLab Merge Request from API response
+/// GitLab Merge Request from API response (list endpoint)
 #[derive(Debug, Clone, Deserialize)]
 struct GitLabMergeRequest {
     iid: u64,
@@ -19,6 +19,112 @@ struct GitLabMergeRequest {
     merge_commit_sha: Option<String>,
     squash_commit_sha: Option<String>,
     squash: Option<bool>,
+}
+
+/// Subset of the single-MR endpoint we need. The list endpoint we already
+/// hit does NOT include `diff_refs`; this struct deserializes the single-MR
+/// response so we can pull the right SHA out for `CiEvent::Merge.base_sha`.
+///
+/// GitLab notes that `diff_refs` "is empty when the merge request is created,
+/// and populates asynchronously," hence the outer `Option`.
+#[derive(Debug, Clone, Deserialize)]
+struct GitLabMergeRequestDetails {
+    diff_refs: Option<GitLabDiffRefs>,
+}
+
+/// The `diff_refs` object has three SHAs with subtly different semantics
+/// (paraphrased from <https://docs.gitlab.com/api/merge_requests/>):
+///
+/// - `base_sha`: the **merge-base** of the source and target branches —
+///   `git merge-base source target` — the historical fork point. For a
+///   long-lived branch on a fast-moving target this is far behind the
+///   current target tip.
+/// - `start_sha`: the **target branch commit used as the starting point for
+///   the diff**. Documented as "usually the same as `base_sha`," but in
+///   practice it tracks the target tip at diff render time, not the
+///   common ancestor. **This is the semantic match for GitHub's
+///   `pull_request.base.sha`** — i.e. "the target tip the MR was opened
+///   against."
+/// - `head_sha`: the source branch tip. We already get this from `mr.sha`
+///   on the list endpoint, so we don't deserialize it here.
+///
+/// The #1473 retain filter in `CiContext::run_with_options` computes
+/// `base_sha..merge_commit_sha` to find commits the MR introduced. For a
+/// squash-on-linear-main scenario with `main = B0→B1→B2→B3` and squash
+/// commit `S`, the filter needs a range that yields exactly `{S}`. Using
+/// `base_sha` (the merge-base `B0`) gives `{B1,B2,B3,S}` and lets the walk
+/// match the PR commit count again — recreating the original #1473 bug.
+/// Using `start_sha` (the target tip `B3`) gives `{S}` and squash is
+/// correctly detected.
+///
+/// So: we prefer `start_sha`; `base_sha` is a fallback for the edge cases
+/// where GitLab returns the former as null but the latter populated.
+#[derive(Debug, Clone, Deserialize)]
+struct GitLabDiffRefs {
+    base_sha: Option<String>,
+    start_sha: Option<String>,
+}
+
+/// Build and send an authenticated GET to a GitLab REST endpoint.
+///
+/// Every GitLab API call in this module shares the same shape: 30s timeout,
+/// `User-Agent: git-ai/<version>`, one of `PRIVATE-TOKEN` / `JOB-TOKEN`.
+/// Centralizing it here keeps the call sites focused on what they're after
+/// (URL + parsing) rather than re-stating transport boilerplate.
+fn gitlab_api_get(
+    endpoint: &str,
+    auth_header_name: &str,
+    auth_token: &str,
+) -> Result<crate::http::Response, String> {
+    let agent = crate::http::build_agent(Some(30));
+    let request = agent.get(endpoint).set(auth_header_name, auth_token).set(
+        "User-Agent",
+        &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
+    );
+    crate::http::send(request)
+}
+
+/// Fetch the SHA we want to feed into `CiEvent::Merge.base_sha` (the
+/// target-branch starting point of the MR), preferring `diff_refs.start_sha`
+/// over `diff_refs.base_sha`. See [`GitLabDiffRefs`] for why.
+///
+/// Returns `None` whenever anything goes wrong (transport error, non-200,
+/// malformed body, missing `diff_refs`, both SHAs null); callers fall back to
+/// the legacy empty-string behavior, which keeps GitLab safe but unprotected
+/// from the #1473 misclassification for that one MR.
+fn fetch_mr_base_sha(
+    api_url: &str,
+    auth_header_name: &str,
+    auth_token: &str,
+    project_id: &str,
+    iid: u64,
+) -> Option<String> {
+    let endpoint = format!("{}/projects/{}/merge_requests/{}", api_url, project_id, iid);
+    let resp = match gitlab_api_get(&endpoint, auth_header_name, auth_token) {
+        Ok(resp) if resp.status_code == 200 => resp,
+        _ => return None,
+    };
+    let body = String::from_utf8_lossy(resp.as_bytes());
+    let diff_refs = serde_json::from_str::<GitLabMergeRequestDetails>(&body)
+        .ok()?
+        .diff_refs?;
+
+    // Prefer start_sha (target tip at diff render = GitHub's pull_request.base.sha).
+    // Fall back to base_sha (merge-base) only if start_sha is null/missing; that
+    // produces a wider range that weakens but does not invert the retain filter.
+    if let Some(sha) = diff_refs.start_sha {
+        Some(sha)
+    } else if let Some(sha) = diff_refs.base_sha {
+        println!(
+            "[GitLab CI] Note: diff_refs.start_sha missing for MR !{}; \
+             using diff_refs.base_sha (merge-base) as fallback. \
+             The #1473 retain filter may be weakened for this MR.",
+            iid
+        );
+        Some(sha)
+    } else {
+        None
+    }
 }
 
 /// Query GitLab API for recently merged MRs and find one matching the current commit SHA.
@@ -78,12 +184,7 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     println!("[GitLab CI] Querying API: {}", endpoint);
 
-    let agent = crate::http::build_agent(Some(30));
-    let request = agent.get(&endpoint).set(auth_header_name, &auth_token).set(
-        "User-Agent",
-        &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
-    );
-    let response = crate::http::send(request)
+    let response = gitlab_api_get(&endpoint, auth_header_name, &auth_token)
         .map_err(|e| GitAiError::Generic(format!("GitLab API request failed: {}", e)))?;
 
     if response.status_code != 200 {
@@ -260,9 +361,32 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     let repo = find_repository_in_path(&clone_dir)?;
 
+    // Fetch diff_refs.base_sha from the single-MR endpoint. The list endpoint
+    // we hit earlier doesn't include diff_refs; without base_sha the #1473
+    // retain filter in CiContext::run_with_options skips, so squash merges on
+    // a linear target branch can still be misclassified as rebases. None here
+    // -> fall back to empty string (legacy behavior, no protection).
+    let base_sha = fetch_mr_base_sha(&api_url, auth_header_name, &auth_token, &project_id, mr.iid)
+        .unwrap_or_else(|| {
+            println!(
+                "[GitLab CI] Warning: could not fetch diff_refs.base_sha for MR !{}; \
+                     proceeding without the #1473 retain filter (legacy behavior)",
+                mr.iid
+            );
+            String::new()
+        });
+
     println!(
-        "[GitLab CI] Created CiContext: merge_commit_sha={}, head_sha={}, head_ref={}, base_ref={}",
-        effective_merge_sha, mr.sha, mr.source_branch, mr.target_branch
+        "[GitLab CI] Created CiContext: merge_commit_sha={}, head_sha={}, head_ref={}, base_ref={}, base_sha={}",
+        effective_merge_sha,
+        mr.sha,
+        mr.source_branch,
+        mr.target_branch,
+        if base_sha.is_empty() {
+            "(unavailable)"
+        } else {
+            &base_sha
+        }
     );
 
     Ok(Some(CiContext {
@@ -272,7 +396,7 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
             head_ref: mr.source_branch.clone(),
             head_sha: mr.sha.clone(),
             base_ref: mr.target_branch.clone(),
-            base_sha: String::new(), // Not readily available from MR API, but not used in current impl
+            base_sha,
         },
         temp_dir: PathBuf::from(clone_dir),
     }))
@@ -387,5 +511,203 @@ mod tests {
             .unwrap_or(15i64);
         unsafe { std::env::remove_var("GIT_AI_CI_LOOKBACK_MINUTES") };
         assert_eq!(lookback, 15);
+    }
+
+    // ---- CiEvent::Merge.base_sha derivation from diff_refs ----
+    //
+    // We prefer `diff_refs.start_sha` (target tip at diff render, semantically
+    // equal to GitHub's `pull_request.base.sha`) over `diff_refs.base_sha`
+    // (merge-base). See the `GitLabDiffRefs` docstring for why; tests below
+    // pin the preference + fallback + every silently-absorbed failure mode.
+
+    #[test]
+    fn test_diff_refs_deserialization_happy() {
+        let json = r#"{
+            "iid": 42,
+            "diff_refs": {
+                "base_sha": "0000000000000000000000000000000000000000",
+                "head_sha": "1111111111111111111111111111111111111111",
+                "start_sha": "2222222222222222222222222222222222222222"
+            }
+        }"#;
+        let details: GitLabMergeRequestDetails = serde_json::from_str(json).unwrap();
+        let diff_refs = details.diff_refs.unwrap();
+        assert_eq!(
+            diff_refs.base_sha,
+            Some("0000000000000000000000000000000000000000".to_string())
+        );
+        assert_eq!(
+            diff_refs.start_sha,
+            Some("2222222222222222222222222222222222222222".to_string())
+        );
+    }
+
+    #[test]
+    fn test_diff_refs_deserialization_missing_diff_refs() {
+        // GitLab notes diff_refs "is empty when the merge request is created,
+        // and populates asynchronously"; absorb that as None.
+        let json = r#"{"iid": 1}"#;
+        let details: GitLabMergeRequestDetails = serde_json::from_str(json).unwrap();
+        assert!(details.diff_refs.is_none());
+    }
+
+    #[test]
+    fn test_diff_refs_deserialization_null_shas() {
+        // Both SHAs JSON-null — surface as None on both fields.
+        let json = r#"{
+            "iid": 7,
+            "diff_refs": { "base_sha": null, "start_sha": null }
+        }"#;
+        let details: GitLabMergeRequestDetails = serde_json::from_str(json).unwrap();
+        let diff_refs = details.diff_refs.unwrap();
+        assert!(diff_refs.base_sha.is_none());
+        assert!(diff_refs.start_sha.is_none());
+    }
+
+    /// Happy path: both SHAs present, we MUST pick start_sha. This is the
+    /// load-bearing test — picking base_sha here recreates the original
+    /// #1473 bug for GitLab squash MRs.
+    #[test]
+    fn test_fetch_mr_base_sha_prefers_start_sha_over_base_sha() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .match_header("PRIVATE-TOKEN", "test-token")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            // Distinct values so the assertion can't pass by coincidence.
+            .with_body(
+                r#"{
+                "iid": 42,
+                "diff_refs": {
+                    "base_sha":  "0000000000000000000000000000000000000000",
+                    "start_sha": "2222222222222222222222222222222222222222",
+                    "head_sha":  "1111111111111111111111111111111111111111"
+                }
+            }"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "test-token", "123", 42);
+
+        mock.assert();
+        assert_eq!(
+            result,
+            Some("2222222222222222222222222222222222222222".to_string()),
+            "must prefer start_sha (target tip) over base_sha (merge-base)"
+        );
+    }
+
+    /// Fallback: GitLab returns diff_refs with base_sha populated but
+    /// start_sha null/missing. Use base_sha and continue; the retain
+    /// filter is weakened but not broken.
+    #[test]
+    fn test_fetch_mr_base_sha_falls_back_to_base_sha_when_start_sha_missing() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body(
+                r#"{
+                "iid": 42,
+                "diff_refs": {
+                    "base_sha":  "0000000000000000000000000000000000000000",
+                    "start_sha": null
+                }
+            }"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert_eq!(
+            result,
+            Some("0000000000000000000000000000000000000000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_returns_none_when_both_shas_missing() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body(
+                r#"{
+                "iid": 42,
+                "diff_refs": { "base_sha": null, "start_sha": null }
+            }"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_404_returns_none() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(404)
+            .with_body(r#"{"message": "404 Not Found"}"#)
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(
+            result.is_none(),
+            "404 should fall through to None (caller uses empty string)"
+        );
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_malformed_body_returns_none() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body("not json")
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(result.is_none(), "non-JSON body should not panic");
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_missing_diff_refs_returns_none() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .with_status(200)
+            .with_body(r#"{"iid": 42}"#)
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "PRIVATE-TOKEN", "tok", "123", 42);
+        mock.assert();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fetch_mr_base_sha_with_job_token_header() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/projects/123/merge_requests/42")
+            .match_header("JOB-TOKEN", "ci-job-token-value")
+            .with_status(200)
+            // start_sha present so the happy path through JOB-TOKEN auth fires.
+            .with_body(
+                r#"{"diff_refs": {"start_sha": "abc1234567890abcdef1234567890abcdef12345"}}"#,
+            )
+            .create();
+
+        let result = fetch_mr_base_sha(&server.url(), "JOB-TOKEN", "ci-job-token-value", "123", 42);
+        mock.assert();
+        assert_eq!(
+            result,
+            Some("abc1234567890abcdef1234567890abcdef12345".to_string())
+        );
     }
 }

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -19,6 +19,14 @@ struct GitLabMergeRequest {
     merge_commit_sha: Option<String>,
     squash_commit_sha: Option<String>,
     squash: Option<bool>,
+    source_project_id: u64,
+    target_project_id: u64,
+}
+
+/// GitLab Project API response (minimal fields for fork detection)
+#[derive(Debug, Clone, Deserialize)]
+struct GitLabProject {
+    http_url_to_repo: String,
 }
 
 /// Subset of the single-MR endpoint we need. The list endpoint we already
@@ -279,6 +287,60 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
         effective_merge_sha
     );
 
+    // Detect fork: if source_project_id differs from target_project_id, this is a fork MR
+    let fork_clone_url = if mr.source_project_id != mr.target_project_id {
+        println!(
+            "[GitLab CI] Detected fork MR: source project {} differs from target project {}",
+            mr.source_project_id, mr.target_project_id
+        );
+        // Query the source project API to get its clone URL.
+        // Use the existing ureq-based HTTP wrapper to match the rest of this file
+        // (avoids pulling in the minreq crate the original PR used).
+        let source_project_endpoint = format!("{}/projects/{}", api_url, mr.source_project_id);
+        let agent = crate::http::build_agent(Some(30));
+        let request = agent
+            .get(&source_project_endpoint)
+            .set(auth_header_name, &auth_token)
+            .set(
+                "User-Agent",
+                &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
+            );
+        match crate::http::send(request) {
+            Ok(resp) if resp.status_code == 200 => {
+                let body = String::from_utf8_lossy(resp.as_bytes());
+                match serde_json::from_str::<GitLabProject>(&body) {
+                    Ok(project) => {
+                        println!("[GitLab CI] Fork clone URL: {}", project.http_url_to_repo);
+                        Some(project.http_url_to_repo)
+                    }
+                    Err(e) => {
+                        println!(
+                            "[GitLab CI] Warning: Failed to parse source project response: {}",
+                            e
+                        );
+                        None
+                    }
+                }
+            }
+            Ok(resp) => {
+                println!(
+                    "[GitLab CI] Warning: Failed to query source project (status {}), fork notes may be lost",
+                    resp.status_code
+                );
+                None
+            }
+            Err(e) => {
+                println!(
+                    "[GitLab CI] Warning: Failed to query source project: {}, fork notes may be lost",
+                    e
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Found a matching MR - clone and fetch
     let clone_dir = "git-ai-ci-clone".to_string();
     let clone_url = format!("{}/{}.git", server_url, project_path);
@@ -389,6 +451,18 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
         }
     );
 
+    // Authenticate the fork clone URL for fetching notes
+    let authenticated_fork_url = fork_clone_url.map(|fork_url| {
+        if let Ok(job_token) = std::env::var("CI_JOB_TOKEN") {
+            fork_url.replace(
+                &server_url,
+                &format!("{}://gitlab-ci-token:{}@{}", scheme, job_token, server_host),
+            )
+        } else {
+            fork_url
+        }
+    });
+
     Ok(Some(CiContext {
         repo,
         event: CiEvent::Merge {
@@ -397,6 +471,7 @@ pub fn get_gitlab_ci_context() -> Result<Option<CiContext>, GitAiError> {
             head_sha: mr.sha.clone(),
             base_ref: mr.target_branch.clone(),
             base_sha,
+            fork_clone_url: authenticated_fork_url,
         },
         temp_dir: PathBuf::from(clone_dir),
     }))

--- a/src/ci/gitlab.rs
+++ b/src/ci/gitlab.rs
@@ -498,7 +498,9 @@ mod tests {
             "sha": "abc123",
             "merge_commit_sha": "def456",
             "squash_commit_sha": null,
-            "squash": false
+            "squash": false,
+            "source_project_id": 123,
+            "target_project_id": 456
         }"#;
         let mr: GitLabMergeRequest = serde_json::from_str(json).unwrap();
         assert_eq!(mr.iid, 42);
@@ -509,6 +511,8 @@ mod tests {
         assert_eq!(mr.merge_commit_sha, Some("def456".to_string()));
         assert!(mr.squash_commit_sha.is_none());
         assert_eq!(mr.squash, Some(false));
+        assert_eq!(mr.source_project_id, 123);
+        assert_eq!(mr.target_project_id, 456);
     }
 
     #[test]
@@ -521,12 +525,16 @@ mod tests {
             "sha": "head123",
             "merge_commit_sha": "merge456",
             "squash_commit_sha": "squash789",
-            "squash": true
+            "squash": true,
+            "source_project_id": 123,
+            "target_project_id": 123
         }"#;
         let mr: GitLabMergeRequest = serde_json::from_str(json).unwrap();
         assert_eq!(mr.iid, 99);
         assert_eq!(mr.squash_commit_sha, Some("squash789".to_string()));
         assert_eq!(mr.squash, Some(true));
+        assert_eq!(mr.source_project_id, 123);
+        assert_eq!(mr.target_project_id, 123);
     }
 
     #[test]
@@ -535,7 +543,9 @@ mod tests {
             "iid": 1,
             "source_branch": "dev",
             "target_branch": "main",
-            "sha": "abc"
+            "sha": "abc",
+            "source_project_id": 999,
+            "target_project_id": 999
         }"#;
         let mr: GitLabMergeRequest = serde_json::from_str(json).unwrap();
         assert_eq!(mr.iid, 1);
@@ -543,6 +553,8 @@ mod tests {
         assert!(mr.merge_commit_sha.is_none());
         assert!(mr.squash_commit_sha.is_none());
         assert!(mr.squash.is_none());
+        assert_eq!(mr.source_project_id, 999);
+        assert_eq!(mr.target_project_id, 999);
     }
 
     #[test]

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -16,10 +16,7 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
             println!("{}: skipped simple merge (authorship preserved)", prefix);
         }
         CiRunResult::ForkNotesPreserved => {
-            println!(
-                "{}: fork notes fetched and pushed (merge commit from fork)",
-                prefix
-            );
+            println!("{}: fork notes preserved", prefix);
         }
         CiRunResult::SkippedFastForward => {
             println!("{}: skipped fast-forward merge", prefix);
@@ -209,6 +206,7 @@ fn handle_ci_local(args: &[String]) {
             let skip_fetch_all = has_bool_flag("--skip-fetch");
             let skip_fetch_notes = skip_fetch_all || has_bool_flag("--skip-fetch-notes");
             let skip_fetch_base = skip_fetch_all || has_bool_flag("--skip-fetch-base");
+            let skip_fetch_fork_notes = skip_fetch_all || has_bool_flag("--skip-fetch-fork-notes");
             let skip_push = has_bool_flag("--skip-push");
 
             // Required inputs for merge
@@ -273,6 +271,7 @@ fn handle_ci_local(args: &[String]) {
             match ctx.run_with_options(CiRunOptions {
                 skip_fetch_notes,
                 skip_fetch_base,
+                skip_fetch_fork_notes,
                 skip_push,
             }) {
                 Ok(result) => {
@@ -312,7 +311,7 @@ fn print_ci_help_and_exit() -> ! {
         "                     merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha> [--fork-clone-url <url>]"
     );
     eprintln!(
-        "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch] [--skip-push]"
+        "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch-fork-notes] [--skip-fetch] [--skip-push]"
     );
     std::process::exit(1);
 }
@@ -324,9 +323,11 @@ fn print_ci_local_help_and_exit() -> ! {
     eprintln!();
     eprintln!("Events:");
     eprintln!(
-        "  merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha>"
+        "  merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha> [--fork-clone-url <url>]"
     );
-    eprintln!("         [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch] [--skip-push]");
+    eprintln!(
+        "         [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch-fork-notes] [--skip-fetch] [--skip-push]"
+    );
     std::process::exit(1);
 }
 

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -15,6 +15,12 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
         CiRunResult::SkippedSimpleMerge => {
             println!("{}: skipped simple merge (authorship preserved)", prefix);
         }
+        CiRunResult::ForkNotesPreserved => {
+            println!(
+                "{}: fork notes fetched and pushed (merge commit from fork)",
+                prefix
+            );
+        }
         CiRunResult::SkippedFastForward => {
             println!("{}: skipped fast-forward merge", prefix);
         }
@@ -247,6 +253,8 @@ fn handle_ci_local(args: &[String]) {
                 }
             };
 
+            let fork_clone_url = flag("--fork-clone-url");
+
             let ctx = CiContext {
                 repo,
                 event: CiEvent::Merge {
@@ -255,6 +263,7 @@ fn handle_ci_local(args: &[String]) {
                     head_sha,
                     base_ref,
                     base_sha,
+                    fork_clone_url,
                 },
                 // Not used for local runs; teardown not invoked
                 temp_dir: std::path::PathBuf::from("."),
@@ -300,7 +309,7 @@ fn print_ci_help_and_exit() -> ! {
     eprintln!("                   Usage: git-ai ci local <event> [flags]");
     eprintln!("                   Events:");
     eprintln!(
-        "                     merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha>"
+        "                     merge  --merge-commit-sha <sha> --base-ref <ref> --head-ref <ref> --head-sha <sha> --base-sha <sha> [--fork-clone-url <url>]"
     );
     eprintln!(
         "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch] [--skip-push]"

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -7,6 +7,8 @@ use std::collections::{HashMap, HashSet};
 
 // Modern refspecs without force to enable proper merging
 pub const AI_AUTHORSHIP_REFNAME: &str = "ai";
+pub const AI_AUTHORSHIP_FULL_REF: &str = "refs/notes/ai";
+pub const AI_AUTHORSHIP_FORK_TRACKING_REF: &str = "refs/notes/ai-remote/fork";
 pub const AI_AUTHORSHIP_PUSH_REFSPEC: &str = "refs/notes/ai:refs/notes/ai";
 
 pub fn notes_add(
@@ -32,12 +34,22 @@ pub fn notes_path_for_object(oid: &str) -> String {
 
 #[doc(hidden)]
 pub fn flat_note_pathspec_for_commit(commit_sha: &str) -> String {
-    format!("refs/notes/ai:{}", commit_sha)
+    flat_note_pathspec_for_ref(AI_AUTHORSHIP_FULL_REF, commit_sha)
 }
 
 #[doc(hidden)]
 pub fn fanout_note_pathspec_for_commit(commit_sha: &str) -> String {
-    format!("refs/notes/ai:{}", notes_path_for_object(commit_sha))
+    fanout_note_pathspec_for_ref(AI_AUTHORSHIP_FULL_REF, commit_sha)
+}
+
+#[doc(hidden)]
+pub fn flat_note_pathspec_for_ref(notes_ref: &str, commit_sha: &str) -> String {
+    format!("{}:{}", notes_ref, commit_sha)
+}
+
+#[doc(hidden)]
+pub fn fanout_note_pathspec_for_ref(notes_ref: &str, commit_sha: &str) -> String {
+    format!("{}:{}", notes_ref, notes_path_for_object(commit_sha))
 }
 
 #[doc(hidden)]
@@ -134,6 +146,18 @@ pub fn note_blob_oids_for_commits(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, GitAiError> {
+    note_blob_oids_for_commits_from_ref(repo, AI_AUTHORSHIP_FULL_REF, commit_shas)
+}
+
+/// Resolve authorship note blob OIDs for a set of commits from a specific notes ref.
+///
+/// Returns a map of commit SHA -> note blob SHA for commits that have notes on
+/// `notes_ref`. The destination `refs/notes/ai` is not consulted.
+pub fn note_blob_oids_for_commits_from_ref(
+    repo: &Repository,
+    notes_ref: &str,
+    commit_shas: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
     if commit_shas.is_empty() {
         return Ok(HashMap::new());
     }
@@ -146,9 +170,9 @@ pub fn note_blob_oids_for_commits(
     for commit_sha in commit_shas {
         // Notes can be stored with either flat paths (<sha>) or fanout paths (<aa>/<bb...>).
         // Query both forms so this works regardless of repository note fanout state.
-        stdin_data.push_str(&flat_note_pathspec_for_commit(commit_sha));
+        stdin_data.push_str(&flat_note_pathspec_for_ref(notes_ref, commit_sha));
         stdin_data.push('\n');
-        stdin_data.push_str(&fanout_note_pathspec_for_commit(commit_sha));
+        stdin_data.push_str(&fanout_note_pathspec_for_ref(notes_ref, commit_sha));
         stdin_data.push('\n');
     }
 
@@ -171,6 +195,43 @@ pub fn note_blob_oids_for_commits(
     }
 
     Ok(result)
+}
+
+/// Copy missing notes for a bounded commit set from `source_ref` into `refs/notes/ai`.
+///
+/// This deliberately does not merge `source_ref` wholesale. The source ref may
+/// contain untrusted notes from a fork, so callers must pass the exact commits
+/// whose notes are allowed to enter the local authorship ref. Existing local
+/// notes win on conflicts, matching the `git notes merge -s ours` behavior used
+/// for trusted tracking refs.
+pub fn copy_missing_notes_for_commits_from_ref(
+    repo: &Repository,
+    source_ref: &str,
+    commit_shas: &[String],
+) -> Result<usize, GitAiError> {
+    if commit_shas.is_empty() || !ref_exists(repo, source_ref) {
+        return Ok(0);
+    }
+
+    let source_note_oids = note_blob_oids_for_commits_from_ref(repo, source_ref, commit_shas)?;
+    if source_note_oids.is_empty() {
+        return Ok(0);
+    }
+
+    let local_note_oids = note_blob_oids_for_commits(repo, commit_shas)?;
+    let entries: Vec<(String, String)> = commit_shas
+        .iter()
+        .filter(|commit_sha| !local_note_oids.contains_key(*commit_sha))
+        .filter_map(|commit_sha| {
+            source_note_oids
+                .get(commit_sha)
+                .map(|blob_oid| (commit_sha.clone(), blob_oid.clone()))
+        })
+        .collect();
+
+    let copied = entries.len();
+    notes_add_blob_batch(repo, &entries)?;
+    Ok(copied)
 }
 
 pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Result<(), GitAiError> {

--- a/tests/integration/ci_context_unit.rs
+++ b/tests/integration/ci_context_unit.rs
@@ -14,6 +14,7 @@ fn test_ci_context_with_repository() {
         head_sha: "def".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi".to_string(),
+        fork_clone_url: None,
     };
 
     let context = CiContext::with_repository(gitai_repo, event);
@@ -31,6 +32,7 @@ fn test_ci_context_teardown_empty_temp_dir() {
         head_sha: "def".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi".to_string(),
+        fork_clone_url: None,
     };
 
     let context = CiContext::with_repository(gitai_repo, event);
@@ -54,6 +56,7 @@ fn test_ci_context_teardown_with_temp_dir() {
         head_sha: "def".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi".to_string(),
+        fork_clone_url: None,
     };
 
     let context = CiContext {
@@ -113,6 +116,7 @@ fn test_get_rebased_commits_linear_history() {
         head_sha: commit3.clone(),
         base_ref: "main".to_string(),
         base_sha: commit1.clone(),
+        fork_clone_url: None,
     };
     let context = CiContext::with_repository(gitai_repo, event);
 
@@ -144,6 +148,7 @@ fn test_get_rebased_commits_more_than_available() {
         head_sha: commit.clone(),
         base_ref: "main".to_string(),
         base_sha: "base".to_string(),
+        fork_clone_url: None,
     };
     let context = CiContext::with_repository(gitai_repo, event);
 
@@ -164,6 +169,7 @@ fn test_ci_context_debug() {
         head_sha: "def".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi".to_string(),
+        fork_clone_url: None,
     };
 
     let context = CiContext::with_repository(gitai_repo, event);

--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -317,6 +317,93 @@ fn test_ci_fork_no_notes() {
     );
 }
 
+/// Test merge commit from fork with no notes anywhere.
+///
+/// If neither origin nor fork has refs/notes/ai, CI should not attempt to push
+/// notes for a fork merge commit and should skip gracefully.
+#[test]
+fn test_ci_fork_merge_commit_no_notes_skips_without_push_error() {
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code"]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream.git_og(&["commit", "-m", "Initial commit"]).unwrap();
+    let base_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create fork WITHOUT git-ai notes
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines!["// Original code", "// Added in fork via merge"]);
+    fork.git_og(&["add", "-A"]).unwrap();
+    fork.git_og(&["commit", "-m", "Add feature in fork"])
+        .unwrap();
+    let fork_head_sha = fork
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Fetch fork branch and merge with merge commit
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+    upstream
+        .git_og(&[
+            "merge",
+            "--no-ff",
+            "refs/fork/main",
+            "-m",
+            "Merge fork PR with no notes",
+        ])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha,
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha,
+            base_ref: "main".to_string(),
+            base_sha,
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+    assert!(
+        matches!(result, CiRunResult::SkippedSimpleMerge),
+        "Expected SkippedSimpleMerge for fork merge commit with no notes, got {:?}",
+        result
+    );
+}
+
 /// Test that non-fork PRs (fork_clone_url = None) still work as before.
 /// Merge commits without fork_clone_url should still be skipped.
 #[test]

--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -3,7 +3,9 @@ use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunResult};
 use git_ai::git::notes_api::read_authorship_v3 as get_reference_as_authorship_log_v3;
+use git_ai::git::refs::{notes_add, show_authorship_note};
 use git_ai::git::repository as GitAiRepository;
+use std::fs;
 
 /// Helper: set up "origin" as a self-referencing remote so fetch_authorship_notes("origin")
 /// doesn't fail. In real CI the repo is cloned from origin, so it always exists.
@@ -317,6 +319,105 @@ fn test_ci_fork_no_notes() {
     );
 }
 
+/// A fork notes ref is untrusted input. CI must import only notes attached to
+/// commits that are actually in the PR, not every note present in the fork.
+#[test]
+fn test_ci_fork_notes_ignores_notes_outside_pr_commit_range() {
+    let upstream = TestRepo::new();
+    let upstream_file = upstream.path().join("feature.js");
+
+    fs::write(&upstream_file, "// Original code\n").unwrap();
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Initial commit"])
+        .unwrap();
+    let base_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    notes_add(&fork_repo, &base_sha, "malicious note for upstream base")
+        .expect("add malicious fork note");
+
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines![
+        "// Original code",
+        "// AI feature from fork".ai(),
+        "function forkFeature() {}".ai()
+    ]);
+    let fork_commit = fork.stage_all_and_commit("Add AI feature in fork").unwrap();
+    let fork_head_sha = fork_commit.commit_sha.clone();
+
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    fs::write(
+        &upstream_file,
+        "// Original code\n// AI feature from fork\nfunction forkFeature() {}\n",
+    )
+    .unwrap();
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork PR via squash"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha.clone(),
+            base_ref: "main".to_string(),
+            base_sha: base_sha.clone(),
+            fork_clone_url: Some(fork.path().to_str().unwrap().to_string()),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+    assert!(
+        matches!(result, CiRunResult::AuthorshipRewritten { .. }),
+        "Expected AuthorshipRewritten for fork squash merge, got {:?}",
+        result
+    );
+
+    let upstream_repo_after =
+        GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+            .expect("Failed to find upstream repository");
+    assert!(
+        show_authorship_note(&upstream_repo_after, &base_sha).is_none(),
+        "malicious fork note for base commit must not be imported"
+    );
+    assert!(
+        get_reference_as_authorship_log_v3(&upstream_repo_after, &merge_sha).is_ok(),
+        "squash commit should still receive rewritten authorship from PR commit notes"
+    );
+}
+
 /// Test merge commit from fork with no notes anywhere.
 ///
 /// If neither origin nor fork has refs/notes/ai, CI should not attempt to push
@@ -575,5 +676,119 @@ fn test_ci_fork_squash_merge_multiple_commits() {
     assert!(
         !log.attestations.is_empty(),
         "Authorship log should have attestations from fork's AI code"
+    );
+}
+
+#[test]
+fn test_ci_local_merge_can_use_preloaded_fork_notes_ref() {
+    let upstream = TestRepo::new();
+    let upstream_file = upstream.path().join("app.js");
+
+    fs::write(&upstream_file, "// App v1\n").unwrap();
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Initial commit"])
+        .unwrap();
+    let base_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    notes_add(
+        &fork_repo,
+        &base_sha,
+        "malicious note outside the PR commit set",
+    )
+    .expect("add malicious fork note");
+
+    let mut fork_file = fork.filename("app.js");
+    fork_file.set_contents(lines![
+        "// App v1",
+        "// AI feature".ai(),
+        "function aiFeature() {}".ai()
+    ]);
+    let fork_commit = fork.stage_all_and_commit("Add AI feature").unwrap();
+    let fork_head_sha = fork_commit.commit_sha.clone();
+
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+    upstream
+        .git_og(&[
+            "fetch",
+            fork.path().to_str().unwrap(),
+            "+refs/notes/ai:refs/notes/ai-remote/fork",
+        ])
+        .unwrap();
+
+    fs::write(
+        &upstream_file,
+        "// App v1\n// AI feature\nfunction aiFeature() {}\n",
+    )
+    .unwrap();
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork PR via squash"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let output = upstream
+        .git_ai(&[
+            "ci",
+            "local",
+            "merge",
+            "--merge-commit-sha",
+            &merge_sha,
+            "--base-ref",
+            "main",
+            "--head-ref",
+            "main",
+            "--head-sha",
+            &fork_head_sha,
+            "--base-sha",
+            &base_sha,
+            "--fork-clone-url",
+            "https://example.invalid/fork.git",
+            "--skip-fetch-notes",
+            "--skip-fetch-base",
+            "--skip-fetch-fork-notes",
+            "--skip-push",
+        ])
+        .expect("ci local merge should use preloaded fork notes");
+
+    assert!(
+        output.contains("authorship rewritten successfully"),
+        "expected successful local CI rewrite, got:\n{}",
+        output
+    );
+
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+    assert!(
+        show_authorship_note(&upstream_repo, &base_sha).is_none(),
+        "local CI must not import unrelated notes from the preloaded fork ref"
+    );
+    assert!(
+        get_reference_as_authorship_log_v3(&upstream_repo, &merge_sha).is_ok(),
+        "local CI should rewrite authorship from preloaded fork notes"
     );
 }

--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -236,6 +236,126 @@ fn test_ci_fork_merge_commit() {
     );
 }
 
+#[test]
+fn test_ci_fork_merge_commit_preserves_non_head_pr_notes_when_base_sha_is_post_merge() {
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code", "function original() {}"]);
+    upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI feature from fork".ai(),
+        "function forkFeature() {".ai(),
+        "  return true;".ai(),
+        "}".ai()
+    ]);
+    let ai_commit = fork.stage_all_and_commit("Add AI feature in fork").unwrap();
+    let ai_commit_sha = ai_commit.commit_sha.clone();
+
+    fs::write(
+        fork.path().join("feature.js"),
+        "\
+// Original code
+function original() {}
+// AI feature from fork
+function forkFeature() {
+  return true;
+}
+// Human follow-up
+",
+    )
+    .unwrap();
+    fork.git_og(&["add", "-A"]).unwrap();
+    fork.git_og(&["commit", "-m", "Human follow-up in fork"])
+        .unwrap();
+    let fork_head_sha = fork
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    assert!(
+        get_reference_as_authorship_log_v3(&fork_repo, &ai_commit_sha).is_ok(),
+        "first fork commit should have authorship notes"
+    );
+    assert!(
+        show_authorship_note(&fork_repo, &fork_head_sha).is_none(),
+        "raw git head commit should not have an authorship note"
+    );
+
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+    upstream
+        .git_og(&[
+            "merge",
+            "--no-ff",
+            "refs/fork/main",
+            "-m",
+            "Merge fork PR (#2)",
+        ])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha.clone(),
+            base_ref: "main".to_string(),
+            // For merge commits, the first parent is the target-side boundary
+            // even if a caller passes a post-merge base ref/SHA.
+            base_sha: merge_sha,
+            fork_clone_url: Some(fork.path().to_str().unwrap().to_string()),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+    assert!(
+        matches!(result, CiRunResult::ForkNotesPreserved),
+        "Expected ForkNotesPreserved for fork merge commit, got {:?}",
+        result
+    );
+
+    let upstream_repo_after =
+        GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+            .expect("Failed to find upstream repository");
+    assert!(
+        get_reference_as_authorship_log_v3(&upstream_repo_after, &ai_commit_sha).is_ok(),
+        "non-head PR commit authorship should be preserved"
+    );
+    assert!(
+        show_authorship_note(&upstream_repo_after, &fork_head_sha).is_none(),
+        "head commit should remain without a note"
+    );
+}
+
 /// Test that CI handles fork PRs with no notes gracefully.
 ///
 /// If a fork contributor doesn't use git-ai, there are no notes to fetch.

--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -328,7 +328,9 @@ fn test_ci_fork_merge_commit_no_notes_skips_without_push_error() {
 
     file.set_contents(lines!["// Original code"]);
     upstream.git_og(&["add", "-A"]).unwrap();
-    upstream.git_og(&["commit", "-m", "Initial commit"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Initial commit"])
+        .unwrap();
     let base_sha = upstream
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()

--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -1,0 +1,490 @@
+// repos module is declared once in tests/integration/main.rs
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunResult};
+use git_ai::git::notes_api::read_authorship_v3 as get_reference_as_authorship_log_v3;
+use git_ai::git::repository as GitAiRepository;
+
+/// Helper: set up "origin" as a self-referencing remote so fetch_authorship_notes("origin")
+/// doesn't fail. In real CI the repo is cloned from origin, so it always exists.
+fn add_self_origin(repo: &TestRepo) {
+    let path = repo.path().to_str().unwrap();
+    repo.git_og(&["remote", "add", "origin", path]).ok(); // ok() in case it already exists
+}
+
+/// Test that CI preserves fork notes for a squash merge from a fork.
+///
+/// Scenario:
+/// 1. Contributor works in a fork with git-ai, creating AI-attributed code
+/// 2. Maintainer squash-merges the PR into the upstream repo
+/// 3. CI runs and should fetch notes from the fork, then rewrite them
+///    onto the squash commit
+#[test]
+fn test_ci_fork_squash_merge() {
+    // Setup: create "upstream" repo with initial commit
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code", "function original() {}"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create "fork" repo and give it the upstream's history
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    // Fork contributor adds AI code using git-ai
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI added function".ai(),
+        "function aiFeature() {".ai(),
+        "  return 'from fork';".ai(),
+        "}".ai()
+    ]);
+    let fork_commit = fork.stage_all_and_commit("Add AI feature in fork").unwrap();
+    let fork_head_sha = fork_commit.commit_sha.clone();
+
+    // Verify fork has authorship notes
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    assert!(
+        get_reference_as_authorship_log_v3(&fork_repo, &fork_head_sha).is_ok(),
+        "Fork commit should have authorship notes"
+    );
+
+    // Make the fork's commits accessible from upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Simulate squash merge in upstream: maintainer creates a squash commit.
+    // Use git_og (raw git) to avoid git-ai auto-creating notes on this commit,
+    // which simulates the real CI scenario where the squash commit has no notes.
+    file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI added function",
+        "function aiFeature() {",
+        "  return 'from fork';",
+        "}"
+    ]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork PR via squash (#1)"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI context with fork_clone_url set
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha.clone(),
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // Verify the result is AuthorshipRewritten (squash merge rewrites notes)
+    assert!(
+        matches!(result, CiRunResult::AuthorshipRewritten { .. }),
+        "Expected AuthorshipRewritten for fork squash merge, got {:?}",
+        result
+    );
+
+    // Verify authorship is preserved in the squash commit
+    file.assert_lines_and_blame(lines![
+        "// Original code".human(),
+        "function original() {}".human(),
+        "// AI added function".ai(),
+        "function aiFeature() {".ai(),
+        "  return 'from fork';".ai(),
+        "}".ai()
+    ]);
+}
+
+/// Test that CI preserves fork notes for a merge commit (non-squash, non-rebase).
+///
+/// For merge commits from forks, the merged commits keep their original SHAs.
+/// The CI should fetch notes from the fork and push them to origin.
+#[test]
+fn test_ci_fork_merge_commit() {
+    // Setup: create "upstream" repo with initial commit
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code", "function original() {}"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create "fork" as separate repo with shared history
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    // Fork contributor adds AI code
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines![
+        "// Original code",
+        "function original() {}",
+        "// AI feature from fork".ai(),
+        "function forkFeature() {".ai(),
+        "  return true;".ai(),
+        "}".ai()
+    ]);
+    let fork_commit = fork.stage_all_and_commit("Add AI feature in fork").unwrap();
+    let fork_head_sha = fork_commit.commit_sha.clone();
+
+    // Verify fork has authorship notes
+    let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
+        .expect("Failed to find fork repository");
+    assert!(
+        get_reference_as_authorship_log_v3(&fork_repo, &fork_head_sha).is_ok(),
+        "Fork commit should have authorship notes"
+    );
+
+    // Fetch fork commits and create merge commit in upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Create a merge commit (--no-ff ensures a merge commit is created)
+    upstream
+        .git_og(&[
+            "merge",
+            "--no-ff",
+            "refs/fork/main",
+            "-m",
+            "Merge fork PR (#1)",
+        ])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI context with fork_clone_url
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha.clone(),
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // For merge commits from forks, notes should be preserved (not rewritten)
+    assert!(
+        matches!(result, CiRunResult::ForkNotesPreserved),
+        "Expected ForkNotesPreserved for fork merge commit, got {:?}",
+        result
+    );
+
+    // Verify the fork commit's authorship is accessible in upstream
+    let upstream_repo2 =
+        GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+            .expect("Failed to find upstream repository");
+    let authorship_log = get_reference_as_authorship_log_v3(&upstream_repo2, &fork_head_sha);
+    assert!(
+        authorship_log.is_ok(),
+        "Fork commit's authorship should be accessible in upstream after CI run"
+    );
+}
+
+/// Test that CI handles fork PRs with no notes gracefully.
+///
+/// If a fork contributor doesn't use git-ai, there are no notes to fetch.
+/// The CI should handle this gracefully without errors.
+#[test]
+fn test_ci_fork_no_notes() {
+    // Setup upstream
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create fork WITHOUT git-ai (using git_og for all operations)
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    // Fork contributor adds code without git-ai
+    let mut fork_file = fork.filename("feature.js");
+    fork_file.set_contents(lines!["// Original code", "// Added in fork"]);
+    fork.git_og(&["add", "-A"]).unwrap();
+    fork.git_og(&["commit", "-m", "Add feature in fork"])
+        .unwrap();
+    let fork_head_sha = fork
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Fetch fork commits into upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Simulate squash merge in upstream (using raw git to avoid auto-notes)
+    file.set_contents(lines!["// Original code", "// Added in fork"]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork PR via squash"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI with fork URL
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha,
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    // Should complete without errors, even though fork has no notes
+    let result = ci_context.run().unwrap();
+    assert!(
+        matches!(result, CiRunResult::NoAuthorshipAvailable),
+        "Expected NoAuthorshipAvailable for fork with no git-ai notes, got {:?}",
+        result
+    );
+}
+
+/// Test that non-fork PRs (fork_clone_url = None) still work as before.
+/// Merge commits without fork_clone_url should still be skipped.
+#[test]
+fn test_ci_non_fork_merge_commit_still_skipped() {
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("feature.js");
+
+    file.set_contents(lines!["// Original code"]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create feature branch (same repo, not a fork)
+    upstream.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = upstream.filename("feature.js");
+    feature_file.set_contents(lines![
+        "// Original code",
+        "// Feature addition".ai(),
+        "function feature() {}".ai()
+    ]);
+    let feature_commit = upstream.stage_all_and_commit("Add feature").unwrap();
+    let feature_sha = feature_commit.commit_sha.clone();
+
+    // Merge with --no-ff to create merge commit
+    upstream.git(&["checkout", "main"]).unwrap();
+    upstream
+        .git_og(&["merge", "--no-ff", "feature", "-m", "Merge feature"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha,
+            head_ref: "feature".to_string(),
+            head_sha: feature_sha,
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: None, // Not a fork
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // Should still be SkippedSimpleMerge for non-fork merge commits
+    assert!(
+        matches!(result, CiRunResult::SkippedSimpleMerge),
+        "Expected SkippedSimpleMerge for non-fork merge commit, got {:?}",
+        result
+    );
+}
+
+/// Test squash merge from fork with multiple commits containing AI code.
+/// Verify that authorship is rewritten (fork notes are fetched and processed).
+#[test]
+fn test_ci_fork_squash_merge_multiple_commits() {
+    let upstream = TestRepo::new();
+    let mut file = upstream.filename("app.js");
+
+    file.set_contents(lines!["// App v1", ""]);
+    let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
+    upstream.git(&["branch", "-M", "main"]).unwrap();
+    add_self_origin(&upstream);
+
+    // Create fork with multiple AI commits
+    let fork = TestRepo::new();
+    let upstream_path = upstream.path().to_str().unwrap().to_string();
+    fork.git_og(&["remote", "add", "upstream", &upstream_path])
+        .unwrap();
+    fork.git_og(&["fetch", "upstream"]).unwrap();
+    fork.git_og(&["checkout", "-b", "main", "upstream/main"])
+        .unwrap();
+
+    let mut fork_file = fork.filename("app.js");
+
+    // First commit: AI adds function 1
+    fork_file.insert_at(
+        1,
+        lines!["// AI function 1".ai(), "function ai1() { }".ai()],
+    );
+    fork.stage_all_and_commit("Add AI function 1").unwrap();
+
+    // Second commit: AI adds function 2
+    fork_file.insert_at(
+        3,
+        lines!["// AI function 2".ai(), "function ai2() { }".ai()],
+    );
+    fork.stage_all_and_commit("Add AI function 2").unwrap();
+
+    // Third commit: Human adds function
+    fork_file.insert_at(5, lines!["// Human function", "function human() { }"]);
+    let fork_last_commit = fork.stage_all_and_commit("Add human function").unwrap();
+    let fork_head_sha = fork_last_commit.commit_sha.clone();
+
+    // Fetch fork commits into upstream
+    upstream
+        .git_og(&["remote", "add", "fork", fork.path().to_str().unwrap()])
+        .unwrap();
+    upstream
+        .git_og(&["fetch", "fork", "main:refs/fork/main"])
+        .unwrap();
+
+    // Simulate squash merge in upstream (using raw git to avoid auto-notes)
+    file.set_contents(lines![
+        "// App v1",
+        "// AI function 1",
+        "function ai1() { }",
+        "// AI function 2",
+        "function ai2() { }",
+        "// Human function",
+        "function human() { }"
+    ]);
+    upstream.git_og(&["add", "-A"]).unwrap();
+    upstream
+        .git_og(&["commit", "-m", "Merge fork multi-commit PR (#2)"])
+        .unwrap();
+    let merge_sha = upstream
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Run CI with fork URL
+    let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+        .expect("Failed to find upstream repository");
+
+    let fork_url = fork.path().to_str().unwrap().to_string();
+
+    let ci_context = CiContext::with_repository(
+        upstream_repo,
+        CiEvent::Merge {
+            merge_commit_sha: merge_sha.clone(),
+            head_ref: "main".to_string(),
+            head_sha: fork_head_sha,
+            base_ref: "main".to_string(),
+            base_sha: base_commit.commit_sha.clone(),
+            fork_clone_url: Some(fork_url),
+        },
+    );
+
+    let result = ci_context.run().unwrap();
+
+    // Verify fork notes were fetched and authorship was rewritten
+    assert!(
+        matches!(result, CiRunResult::AuthorshipRewritten { .. }),
+        "Expected AuthorshipRewritten for multi-commit fork squash merge, got {:?}",
+        result
+    );
+
+    // Verify authorship log exists on the merge commit
+    let upstream_repo2 =
+        GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
+            .expect("Failed to find upstream repository");
+    let authorship_log = get_reference_as_authorship_log_v3(&upstream_repo2, &merge_sha);
+    assert!(
+        authorship_log.is_ok(),
+        "Squash commit should have authorship log from fork notes"
+    );
+    let log = authorship_log.unwrap();
+    assert!(
+        !log.attestations.is_empty(),
+        "Authorship log should have attestations from fork's AI code"
+    );
+}

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -200,11 +200,17 @@ fn test_ci_required_flags_for_merge() {
 
 #[test]
 fn test_ci_optional_skip_fetch_flags_for_merge() {
-    let optional_flags = ["--skip-fetch-notes", "--skip-fetch-base", "--skip-fetch"];
+    let optional_flags = [
+        "--skip-fetch-notes",
+        "--skip-fetch-base",
+        "--skip-fetch-fork-notes",
+        "--skip-fetch",
+    ];
 
-    assert_eq!(optional_flags.len(), 3);
+    assert_eq!(optional_flags.len(), 4);
     assert!(optional_flags.contains(&"--skip-fetch-notes"));
     assert!(optional_flags.contains(&"--skip-fetch-base"));
+    assert!(optional_flags.contains(&"--skip-fetch-fork-notes"));
     assert!(optional_flags.contains(&"--skip-fetch"));
 }
 

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -72,7 +72,7 @@ fn test_ci_event_merge_structure() {
         head_sha: "def456".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi789".to_string(),
-        fork_clone_url: None,
+        fork_clone_url: Some("https://example.com/fork.git".to_string()),
     };
 
     match event {
@@ -82,13 +82,17 @@ fn test_ci_event_merge_structure() {
             head_sha,
             base_ref,
             base_sha,
-            fork_clone_url: _,
+            fork_clone_url,
         } => {
             assert_eq!(merge_commit_sha, "abc123");
             assert_eq!(head_ref, "feature");
             assert_eq!(head_sha, "def456");
             assert_eq!(base_ref, "main");
             assert_eq!(base_sha, "ghi789");
+            assert_eq!(
+                fork_clone_url,
+                Some("https://example.com/fork.git".to_string())
+            );
         }
     }
 }

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -72,6 +72,7 @@ fn test_ci_event_merge_structure() {
         head_sha: "def456".to_string(),
         base_ref: "main".to_string(),
         base_sha: "ghi789".to_string(),
+        fork_clone_url: None,
     };
 
     match event {
@@ -81,6 +82,7 @@ fn test_ci_event_merge_structure() {
             head_sha,
             base_ref,
             base_sha,
+            fork_clone_url: _,
         } => {
             assert_eq!(merge_commit_sha, "abc123");
             assert_eq!(head_ref, "feature");
@@ -331,6 +333,7 @@ fn test_ci_context_with_temp_dir() {
         head_sha: sha.clone(),
         base_ref: "main".to_string(),
         base_sha: sha.clone(),
+        fork_clone_url: None,
     };
 
     let ctx = CiContext {

--- a/tests/integration/ci_partial_clone.rs
+++ b/tests/integration/ci_partial_clone.rs
@@ -76,6 +76,7 @@ fn test_squash_merge_single_parent_not_on_base_ref() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_fetch_fork_notes: true,
         skip_push: false,
     });
 
@@ -144,6 +145,7 @@ fn test_single_commit_rebase_parent_on_base_ref() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_fetch_fork_notes: true,
         skip_push: false,
     });
 
@@ -223,6 +225,7 @@ fn test_multi_commit_squash_merge_single_parent() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_fetch_fork_notes: true,
         skip_push: false,
     });
 
@@ -312,6 +315,7 @@ fn test_regular_two_parent_merge_skipped() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_fetch_fork_notes: true,
         skip_push: false,
     });
 

--- a/tests/integration/ci_partial_clone.rs
+++ b/tests/integration/ci_partial_clone.rs
@@ -69,6 +69,7 @@ fn test_squash_merge_single_parent_not_on_base_ref() {
         head_sha: feature_sha.clone(),
         base_ref: "refs/worker/pr/test/base".to_string(),
         base_sha: feature_sha.clone(),
+        fork_clone_url: None,
     };
 
     let ctx = CiContext::with_repository(git_ai_repo, event);
@@ -136,6 +137,7 @@ fn test_single_commit_rebase_parent_on_base_ref() {
         head_sha: feature_sha.clone(),
         base_ref: "refs/worker/pr/test/base".to_string(),
         base_sha: init_sha,
+        fork_clone_url: None,
     };
 
     let ctx = CiContext::with_repository(git_ai_repo, event);
@@ -214,6 +216,7 @@ fn test_multi_commit_squash_merge_single_parent() {
         head_sha: feature_head_sha.clone(),
         base_ref: "refs/worker/pr/test/base".to_string(),
         base_sha: init_sha,
+        fork_clone_url: None,
     };
 
     let ctx = CiContext::with_repository(git_ai_repo, event);
@@ -302,6 +305,7 @@ fn test_regular_two_parent_merge_skipped() {
         head_sha: feature_sha.clone(),
         base_ref: "refs/heads/master".to_string(),
         base_sha: adv_sha,
+        fork_clone_url: None,
     };
 
     let ctx = CiContext::with_repository(git_ai_repo, event);

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1332,6 +1332,131 @@ fn test_ci_rebase_merge_multiple_commits_standard_human() {
     ]);
 }
 
+/// Regression test for #1473: a squash merge of a multi-commit PR onto a *linear*
+/// main branch must not be misclassified as a rebase merge.
+///
+/// The previous detection walked `N` first-parent commits back from the squash
+/// commit (where `N` = number of PR commits). On a long linear main that walk
+/// returns `N` *pre-existing base commits* rather than rebased PR commits, the
+/// count matches, and the code took the rebase path — writing the PR's authorship
+/// notes onto unrelated base commits (e.g. a teammate's / Dependabot commit).
+///
+/// Layout reproduced here:
+/// ```text
+///   main:    B0 - B1 - B2 - B3              (B1..B3 committed WITHOUT the wrapper -> no notes)
+///   feature:   \- P1 - P2 - P3              (3 AI commits, each carrying a note)
+///   squash:  B0 - B1 - B2 - B3 - S          (S = squashed P1+P2+P3, parent = B3)
+/// ```
+/// Walking 3 first-parent commits back from `S` yields `[B2, B3, S]` (len 3 == 3),
+/// which previously tripped the rebase path. Only `S` should receive a note; the
+/// unrelated base commits `B2` and `B3` must be left untouched.
+#[test]
+fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
+    use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunOptions};
+
+    let repo = direct_test_repo();
+    repo.git_og(&["config", "user.name", "Test User"]).unwrap();
+    repo.git_og(&["config", "user.email", "test@example.com"])
+        .unwrap();
+
+    // --- B0: initial commit on main (raw git -> no authorship note) ---
+    std::fs::write(repo.path().join("base.txt"), "base content\n").unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "B0 initial"]).unwrap();
+    repo.git_og(&["branch", "-M", "main"]).unwrap();
+    let b0_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- B1, B2, B3: teammate commits on main, NOT using the wrapper (no notes) ---
+    for i in 1..=3 {
+        std::fs::write(
+            repo.path().join(format!("teammate{i}.txt")),
+            format!("teammate change {i}\n"),
+        )
+        .unwrap();
+        repo.git_og(&["add", "-A"]).unwrap();
+        repo.git_og(&["commit", "-m", &format!("B{i} teammate change")])
+            .unwrap();
+    }
+    let b2_sha = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let b3_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- feature branch off B0 with 3 AI commits (each gets a note via the wrapper) ---
+    repo.git_og(&["checkout", "-b", "feature", &b0_sha])
+        .unwrap();
+
+    let mut feat = repo.filename("feature.txt");
+    feat.set_contents(crate::lines!["// P1 ai line".ai()]);
+    repo.stage_all_and_commit("P1").unwrap();
+    feat.insert_at(1, crate::lines!["// P2 ai line".ai()]);
+    repo.stage_all_and_commit("P2").unwrap();
+    feat.insert_at(2, crate::lines!["// P3 ai line".ai()]);
+    let head_sha = repo.stage_all_and_commit("P3").unwrap().commit_sha;
+
+    // --- Squash merge: GitHub creates one new commit S on top of B3 (raw git) ---
+    repo.git_og(&["checkout", "main"]).unwrap();
+    std::fs::write(
+        repo.path().join("feature.txt"),
+        "// P1 ai line\n// P2 ai line\n// P3 ai line\n",
+    )
+    .unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "Squash merge feature (#PR)"])
+        .unwrap();
+    let squash_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- Run the CI merge rewrite exactly as GitHub Actions would ---
+    let git_ai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("Failed to find repository");
+
+    let event = CiEvent::Merge {
+        merge_commit_sha: squash_sha.clone(),
+        head_ref: "feature".to_string(),
+        head_sha: head_sha.clone(),
+        base_ref: "main".to_string(),
+        base_sha: b3_sha.clone(),
+    };
+
+    let ctx = CiContext::with_repository(git_ai_repo, event);
+    ctx.run_with_options(CiRunOptions {
+        skip_fetch_notes: true,
+        skip_fetch_base: true,
+        skip_push: true,
+    })
+    .expect("CI merge rewrite should succeed");
+
+    // The squash commit S should be attributed...
+    assert!(
+        repo.read_authorship_note(&squash_sha).is_some(),
+        "squash commit S ({squash_sha}) should receive the rewritten authorship note"
+    );
+
+    // ...but the unrelated base commits B2/B3 must NOT be polluted (#1473).
+    assert!(
+        repo.read_authorship_note(&b2_sha).is_none(),
+        "#1473 regression: unrelated base commit B2 ({b2_sha}) must not receive a note"
+    );
+    assert!(
+        repo.read_authorship_note(&b3_sha).is_none(),
+        "#1473 regression: unrelated base commit B3 ({b3_sha}) must not receive a note"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -1347,4 +1472,5 @@ crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_mixed_content_standard_human,
     test_ci_squash_merge_with_manual_changes_standard_human,
     test_ci_rebase_merge_multiple_commits_standard_human,
+    test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main,
 );

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1506,7 +1506,8 @@ fn test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits() {
         .to_string();
 
     // feature branch off B0 with 3 AI commits (each gets a note via the wrapper)
-    repo.git_og(&["checkout", "-b", "feature", &b0_sha]).unwrap();
+    repo.git_og(&["checkout", "-b", "feature", &b0_sha])
+        .unwrap();
     let mut feat = repo.filename("feature.txt");
     feat.set_contents(crate::lines!["// P1 ai line".ai()]);
     repo.stage_all_and_commit("P1").unwrap();

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -600,6 +600,7 @@ fn test_ci_rebase_merge_commit_order_pairing() {
     let result = ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_fetch_fork_notes: true,
         skip_push: false,
     });
     assert!(
@@ -1438,6 +1439,7 @@ fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
     ctx.run_with_options(CiRunOptions {
         skip_fetch_notes: true,
         skip_fetch_base: true,
+        skip_fetch_fork_notes: true,
         skip_push: true,
     })
     .expect("CI merge rewrite should succeed");

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1586,6 +1586,134 @@ fn test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits() {
     );
 }
 
+/// Regression test for the #1473 review follow-up: a genuine rebase merge must
+/// still be classified as a rebase when `--merge-commit-sha` is passed as an
+/// abbreviated SHA (as a human might via `git-ai ci local merge`).
+///
+/// The #1473 filter intersects the first-parent walk with the full SHAs from
+/// `git rev-list base_sha..merge_commit_sha`. If `get_rebased_commits` stored the
+/// merge commit verbatim (abbreviated), that entry would fail the set lookup, get
+/// dropped, drop the count below N, and the rebase would be misclassified as a
+/// squash — writing one aggregated note instead of per-commit notes. After
+/// resolving the merge SHA to its full form, each rebased commit keeps its own note.
+#[test]
+fn test_ci_local_rebase_merge_with_abbreviated_merge_sha() {
+    use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+
+    let repo = direct_test_repo();
+
+    // --- Initial commit on main ---
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+    let base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- Feature branch: two commits touching different files ---
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+    let mut file_a = repo.filename("file_a.txt");
+    file_a.set_contents(crate::lines!["ai content in file_a".ai()]);
+    let _feature_sha1 = repo.stage_all_and_commit("Add file_a").unwrap().commit_sha;
+    let mut file_b = repo.filename("file_b.txt");
+    file_b.set_contents(crate::lines!["ai content in file_b".ai()]);
+    let feature_sha2 = repo.stage_all_and_commit("Add file_b").unwrap().commit_sha;
+
+    // --- Advance main so the rebase produces new commit SHAs ---
+    repo.git_og(&["checkout", "main"]).unwrap();
+    let mut main_file = repo.filename("main_only.txt");
+    main_file.set_contents(crate::lines!["main-only content"]);
+    repo.git_og(&["add", "main_only.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Advance main"]).unwrap();
+
+    // --- Rebase feature onto main (bypassing the local hook), then ff main ---
+    repo.git_og(&["checkout", "feature"]).unwrap();
+    repo.git_og(&["rebase", "main"]).unwrap();
+    let new_sha2 = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let new_sha1 = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git_og(&["checkout", "main"]).unwrap();
+    repo.git_og(&["merge", "--ff-only", "feature"]).unwrap();
+
+    // --- Bare origin so push_authorship inside CiContext can succeed ---
+    let origin_dir = tempfile::tempdir().unwrap();
+    let origin_path = origin_dir.path().join("origin.git");
+    repo.git_og(&[
+        "clone",
+        "--bare",
+        repo.path().to_str().unwrap(),
+        origin_path.to_str().unwrap(),
+    ])
+    .unwrap();
+    repo.git_og(&["remote", "add", "origin", origin_path.to_str().unwrap()])
+        .unwrap();
+
+    // --- Run `ci local merge` with an ABBREVIATED merge-commit-sha ---
+    let abbreviated_merge_sha = &new_sha2[..12];
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "merge",
+            "--merge-commit-sha",
+            abbreviated_merge_sha,
+            "--head-ref",
+            "feature",
+            "--head-sha",
+            feature_sha2.as_str(),
+            "--base-ref",
+            "main",
+            "--base-sha",
+            base_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-fetch-base",
+        ])
+        .expect("ci local merge should succeed");
+
+    assert!(
+        output.contains("authorship rewritten successfully"),
+        "expected authorship rewritten, got: {output}"
+    );
+
+    // --- Each rebased commit must still carry its own note (rebase path kept) ---
+    let note1 = repo
+        .read_authorship_note(&new_sha1)
+        .expect("rebased commit 1 should have a note (rebase must not be misclassified as squash)");
+    let note2 = repo
+        .read_authorship_note(&new_sha2)
+        .expect("rebased commit 2 should have a note");
+
+    let files = |note: &str| -> Vec<String> {
+        AuthorshipLog::deserialize_from_string(note)
+            .unwrap()
+            .attestations
+            .iter()
+            .map(|a| a.file_path.clone())
+            .collect()
+    };
+    let files1 = files(&note1);
+    let files2 = files(&note2);
+
+    assert!(
+        files1.iter().any(|f| f.contains("file_a")) && !files1.iter().any(|f| f.contains("file_b")),
+        "rebased commit 1 should reference only file_a.txt, got: {files1:?}"
+    );
+    assert!(
+        files2.iter().any(|f| f.contains("file_b")) && !files2.iter().any(|f| f.contains("file_a")),
+        "rebased commit 2 should reference only file_b.txt, got: {files2:?}"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -1603,4 +1731,5 @@ crate::reuse_tests_in_worktree!(
     test_ci_rebase_merge_multiple_commits_standard_human,
     test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main,
     test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits,
+    test_ci_local_rebase_merge_with_abbreviated_merge_sha,
 );

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -593,6 +593,7 @@ fn test_ci_rebase_merge_commit_order_pairing() {
         head_sha: feature_sha2.clone(),
         base_ref: "main".to_string(),
         base_sha,
+        fork_clone_url: None,
     };
 
     let ctx = CiContext::with_repository(git_ai_repo, event);
@@ -1430,6 +1431,7 @@ fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
         head_sha: head_sha.clone(),
         base_ref: "main".to_string(),
         base_sha: b3_sha.clone(),
+        fork_clone_url: None,
     };
 
     let ctx = CiContext::with_repository(git_ai_repo, event);

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1457,6 +1457,134 @@ fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
     );
 }
 
+/// Production-path (`git-ai ci local merge`) variant of the #1473 regression.
+///
+/// Drives the exact entrypoint a GitHub Actions workflow invokes (the "CI merge
+/// rewrite action" named in the issue) instead of calling `CiContext`
+/// in-process. Same topology: a linear `main` with note-less teammate commits
+/// (raw `git`, simulating contributors not yet using the wrapper) and a
+/// 3-commit AI PR squashed on top. Only the squash commit may receive an
+/// authorship note; the unrelated base commits must stay untouched.
+#[test]
+fn test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits() {
+    let repo = direct_test_repo();
+    repo.git_og(&["config", "user.name", "Test User"]).unwrap();
+    repo.git_og(&["config", "user.email", "test@example.com"])
+        .unwrap();
+
+    // B0: initial commit on main (raw git -> no authorship note)
+    std::fs::write(repo.path().join("base.txt"), "base content\n").unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "B0 initial"]).unwrap();
+    repo.git_og(&["branch", "-M", "main"]).unwrap();
+    let b0_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // B1, B2, B3: teammate commits on main, NOT using the wrapper (no notes)
+    for i in 1..=3 {
+        std::fs::write(
+            repo.path().join(format!("teammate{i}.txt")),
+            format!("teammate change {i}\n"),
+        )
+        .unwrap();
+        repo.git_og(&["add", "-A"]).unwrap();
+        repo.git_og(&["commit", "-m", &format!("B{i} teammate change")])
+            .unwrap();
+    }
+    let b2_sha = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let b3_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // feature branch off B0 with 3 AI commits (each gets a note via the wrapper)
+    repo.git_og(&["checkout", "-b", "feature", &b0_sha]).unwrap();
+    let mut feat = repo.filename("feature.txt");
+    feat.set_contents(crate::lines!["// P1 ai line".ai()]);
+    repo.stage_all_and_commit("P1").unwrap();
+    feat.insert_at(1, crate::lines!["// P2 ai line".ai()]);
+    repo.stage_all_and_commit("P2").unwrap();
+    feat.insert_at(2, crate::lines!["// P3 ai line".ai()]);
+    let head_sha = repo.stage_all_and_commit("P3").unwrap().commit_sha;
+
+    // Squash merge: GitHub creates one new commit S on top of B3 (raw git)
+    repo.git_og(&["checkout", "main"]).unwrap();
+    std::fs::write(
+        repo.path().join("feature.txt"),
+        "// P1 ai line\n// P2 ai line\n// P3 ai line\n",
+    )
+    .unwrap();
+    repo.git_og(&["add", "-A"]).unwrap();
+    repo.git_og(&["commit", "-m", "Squash merge feature (#PR)"])
+        .unwrap();
+    let squash_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Bare origin so `ci local merge` can push authorship
+    let origin_dir = tempfile::tempdir().unwrap();
+    let origin_path = origin_dir.path().join("origin.git");
+    repo.git_og(&[
+        "clone",
+        "--bare",
+        repo.path().to_str().unwrap(),
+        origin_path.to_str().unwrap(),
+    ])
+    .unwrap();
+    repo.git_og(&["remote", "add", "origin", origin_path.to_str().unwrap()])
+        .unwrap();
+
+    // Run the real CLI exactly as CI would after a squash merge
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "merge",
+            "--merge-commit-sha",
+            squash_sha.as_str(),
+            "--head-ref",
+            "feature",
+            "--head-sha",
+            head_sha.as_str(),
+            "--base-ref",
+            "main",
+            "--base-sha",
+            b3_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-fetch-base",
+        ])
+        .expect("ci local merge should succeed");
+
+    assert!(
+        output.contains("authorship rewritten successfully"),
+        "expected authorship rewritten, got: {output}"
+    );
+
+    // Only the squash commit S carries a note; the base commits are untouched.
+    assert!(
+        repo.read_authorship_note(&squash_sha).is_some(),
+        "squash commit S ({squash_sha}) should receive the rewritten authorship note"
+    );
+    assert!(
+        repo.read_authorship_note(&b2_sha).is_none(),
+        "#1473 regression: unrelated base commit B2 ({b2_sha}) must not receive a note"
+    );
+    assert!(
+        repo.read_authorship_note(&b3_sha).is_none(),
+        "#1473 regression: unrelated base commit B3 ({b3_sha}) must not receive a note"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_basic,
     test_ci_squash_merge_multiple_files,
@@ -1473,4 +1601,5 @@ crate::reuse_tests_in_worktree!(
     test_ci_squash_merge_with_manual_changes_standard_human,
     test_ci_rebase_merge_multiple_commits_standard_human,
     test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main,
+    test_ci_local_merge_squash_on_linear_main_does_not_note_base_commits,
 );

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -33,6 +33,7 @@ mod checkpoint_unit;
 mod cherry_pick;
 mod chinese_text_edits;
 mod ci_context_unit;
+mod ci_fork_notes;
 mod ci_handlers_comprehensive;
 mod ci_local_skip_fetch;
 mod ci_local_skip_push;

--- a/tests/integration/refs_unit.rs
+++ b/tests/integration/refs_unit.rs
@@ -2,10 +2,11 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::error::GitAiError;
 use git_ai::git::refs::{
-    CommitAuthorship, commits_with_authorship_notes, copy_ref, get_commits_with_notes_from_list,
+    AI_AUTHORSHIP_FORK_TRACKING_REF, CommitAuthorship, commits_with_authorship_notes,
+    copy_missing_notes_for_commits_from_ref, copy_ref, get_commits_with_notes_from_list,
     get_reference_as_authorship_log_v3, get_reference_as_working_log, grep_ai_notes,
-    merge_notes_from_ref, note_blob_oids_for_commits, notes_add, notes_add_batch,
-    notes_add_blob_batch, ref_exists, show_authorship_note,
+    merge_notes_from_ref, note_blob_oids_for_commits, note_blob_oids_for_commits_from_ref,
+    notes_add, notes_add_batch, notes_add_blob_batch, ref_exists, show_authorship_note,
 };
 use git_ai::git::repository::{exec_git, find_repository_in_path};
 use std::fs;
@@ -119,6 +120,100 @@ fn test_notes_add_blob_batch_reuses_existing_note_blob() {
     let parsed_note_b =
         get_reference_as_authorship_log_v3(&gitai_repo, &commit_b).expect("parse B");
     assert_eq!(parsed_note_b.metadata.base_commit_sha, commit_b);
+}
+
+#[test]
+fn test_copy_missing_notes_for_commits_from_ref_copies_only_requested_commits() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    repo.git_og(&["add", "."]).expect("add A");
+    repo.git_og(&["commit", "-m", "Commit A"])
+        .expect("commit A");
+    let commit_a = head_sha(&repo);
+
+    fs::write(repo.path().join("b.txt"), "b\n").unwrap();
+    repo.git_og(&["add", "."]).expect("add B");
+    repo.git_og(&["commit", "-m", "Commit B"])
+        .expect("commit B");
+    let commit_b = head_sha(&repo);
+
+    for (commit, note) in [(&commit_a, "fork-note-a"), (&commit_b, "fork-note-b")] {
+        let mut args = gitai_repo.global_args_for_exec();
+        args.extend_from_slice(&[
+            "notes".to_string(),
+            "--ref=ai-remote/fork".to_string(),
+            "add".to_string(),
+            "-f".to_string(),
+            "-m".to_string(),
+            note.to_string(),
+            commit.clone(),
+        ]);
+        exec_git(&args).expect("add source note");
+    }
+
+    let source_notes = note_blob_oids_for_commits_from_ref(
+        &gitai_repo,
+        AI_AUTHORSHIP_FORK_TRACKING_REF,
+        &[commit_a.clone(), commit_b.clone()],
+    )
+    .expect("source note oids");
+    assert_eq!(source_notes.len(), 2);
+
+    let copied = copy_missing_notes_for_commits_from_ref(
+        &gitai_repo,
+        AI_AUTHORSHIP_FORK_TRACKING_REF,
+        std::slice::from_ref(&commit_a),
+    )
+    .expect("copy scoped notes");
+
+    assert_eq!(copied, 1);
+    assert_eq!(
+        show_authorship_note(&gitai_repo, &commit_a).as_deref(),
+        Some("fork-note-a")
+    );
+    assert!(
+        show_authorship_note(&gitai_repo, &commit_b).is_none(),
+        "note for unrequested commit must not be copied"
+    );
+}
+
+#[test]
+fn test_copy_missing_notes_for_commits_from_ref_keeps_existing_local_note() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    repo.git_og(&["add", "."]).expect("add A");
+    repo.git_og(&["commit", "-m", "Commit A"])
+        .expect("commit A");
+    let commit_a = head_sha(&repo);
+
+    let mut args = gitai_repo.global_args_for_exec();
+    args.extend_from_slice(&[
+        "notes".to_string(),
+        "--ref=ai-remote/fork".to_string(),
+        "add".to_string(),
+        "-f".to_string(),
+        "-m".to_string(),
+        "fork-note".to_string(),
+        commit_a.clone(),
+    ]);
+    exec_git(&args).expect("add source note");
+
+    notes_add(&gitai_repo, &commit_a, "local-note").expect("add local note");
+
+    let copied = copy_missing_notes_for_commits_from_ref(
+        &gitai_repo,
+        AI_AUTHORSHIP_FORK_TRACKING_REF,
+        std::slice::from_ref(&commit_a),
+    )
+    .expect("copy scoped notes");
+
+    assert_eq!(copied, 0);
+    assert_eq!(
+        show_authorship_note(&gitai_repo, &commit_a).as_deref(),
+        Some("local-note")
+    );
 }
 
 #[test]


### PR DESCRIPTION
**Stacked on #1482.** Diff currently includes #1482's commits because GitHub doesn't support a cross-fork base. Once #1482 merges to `main`, this PR's diff will automatically reduce to only the additive fork-notes changes (~700 lines, 5 commits).

Picks up @Ngineer101's work from #546 (which was opened against pre-`task dev` main and has bit-rotted on conflicts), rebases it onto current main, and stacks it on top of the #1473 squash-classification fix (#1482) so the squash path doesn't misattribute fork notes onto unrelated base commits when #1473 isn't in the picture.

## Primary changes

- Adopt #546's fork-notes handling, rebased onto current main and adapted to the post-`task dev` module layout. Cherry-picks @Ngineer101's commits 1:1 where they applied; resolutions are surgical (see Reviewer walkthrough).
- Detects fork-sourced PRs/MRs in `src/ci/github.rs` and `src/ci/gitlab.rs`, fetches `refs/notes/ai` from the fork, and merges it into the local notes ref before the rewrite step.
- Adds a `--fork-clone-url <url>` flag to `git-ai ci local merge` so the new code path is exercisable from the CLI.
- New 2-parent (merge-commit-from-fork) branch returns `CiRunResult::ForkNotesPreserved` instead of the existing `SkippedSimpleMerge`, after pushing the fetched fork notes.
- Drops two cherry-pick commits from #546 that were already on main:
  - `8101f21d8 .` — re-added `sanitize_git_config_env` which now exists in `src/git/repository.rs`
  - `86354a76f Update git_hook_handlers.rs` — re-added `#[serial]` to a test that already has it on main
- Drops six unit tests from #546's `fix tests` commit that used `test_repo.repo().index()` / `find_tree()` etc. (libgit2 APIs). main has fully removed the git2 dependency. The corresponding integration coverage in `tests/integration/ci_fork_notes.rs` (added in this PR) supersedes them.

## Reviewer walkthrough

- `src/ci/ci_context.rs`:
  - Import resolution: #546 imported `get_reference_as_authorship_log_v3` and `show_authorship_note` from `crate::git::refs`; current main moved both into `crate::git::notes_api` (aliased). Kept the `notes_api` aliased imports and added a separate `crate::git::refs::{copy_ref, merge_notes_from_ref, ref_exists}` import for the helpers #546 actually needs.
  - `CiEvent::Merge` arm: #546 left `base_sha: _`; #1482 binds `base_sha` for the rebase candidate filter. Kept the bound form and added `fork_clone_url` alongside.
  - `fetch_fork_notes` and the new fork-merge-commit branch carried over verbatim from #546.
- `src/ci/gitlab.rs`:
  - #546's source-project lookup used `minreq`, which isn't a dep on main. Swapped it for the existing `crate::http` ureq-backed wrapper to match the rest of the file's GitLab API calls. Same error handling shape (`Ok(resp) if resp.status_code == 200 => ...`).
- `tests/integration/ci_fork_notes.rs`:
  - Moved from `tests/ci_fork_notes.rs` (#546's location) to `tests/integration/ci_fork_notes.rs` (current main's consolidated integration target).
  - Removed the file-level `#[macro_use] mod repos;` since `tests/integration/main.rs` declares it once at the integration-crate root. Updated the imports to `use crate::repos::test_file::ExpectedLineExt` etc.
  - Updated the `get_reference_as_authorship_log_v3` import to come from `crate::git::notes_api`.
- `tests/integration/main.rs`: registered the new `mod ci_fork_notes;` line in the alphabetically-sorted module list.
- `tests/integration/ci_partial_clone.rs`, `tests/integration/ci_context_unit.rs`, `tests/integration/ci_handlers_comprehensive.rs`, `tests/integration/ci_squash_rebase.rs`: added `fork_clone_url: None` (or `fork_clone_url: _` for destructuring patterns) to every `CiEvent::Merge` construction / match site so the rest of the test suite compiles.

## Correctness and invariants

- **Stacked ordering matters**: #1482 (squash classification fix) MUST land first. Without it, #546's fork-notes fetch hands the rewrite a populated source for a squash that's mis-detected as a rebase, and the rebase pairing writes the PR's notes onto unrelated base commits (the same failure mode that originally surfaced #1473). Stacking guarantees this ordering.
- **No-fork PRs unchanged**: `fork_clone_url` defaults to `None` everywhere it isn't explicitly set; the fork-notes fetch is a strict no-op when it's `None`. The new 2-parent branch is also gated on `fork_clone_url.is_some()`, so non-fork merge commits still take the original `SkippedSimpleMerge` path.
- **No-notes-on-fork case**: `fetch_fork_notes` probes with `git ls-remote` first; an empty result returns `Ok(false)` and CI continues without touching the local notes ref. Covered by `test_ci_fork_no_notes`.
- **Empty-notes-import**: #546's commit `fc6d5f5e5` added a check to skip importing genuinely empty notes from the fork (rather than blowing up on parse). Carried over.
- **`--skip-push` does not gate the new fork-merge-commit branch**: the new path unconditionally calls `self.repo.push_authorship("origin")`. Worth flagging — would matter for local dry-runs, not for production CI which always wants the push. Happy to gate it in a follow-up commit if reviewers prefer.

## Testing and QA

Local validation on darwin / Apple Silicon with `cargo build --bin git-ai` against this branch tip:

- `task test TEST_FILTER=ci_fork_notes` → **6/6 passing** (all of #546's new integration tests: `test_ci_fork_squash_merge`, `test_ci_fork_squash_merge_multiple_commits`, `test_ci_fork_merge_commit`, `test_ci_fork_no_notes`, `test_ci_fork_merge_commit_no_notes_skips_without_push_error`, `test_ci_non_fork_merge_commit_still_skipped`)
- `task test TEST_FILTER=ci_squash_rebase` → **34/34 passing** (includes #1482's new `test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main` and worktree variants)
- `task lint` → clean (`cargo clippy --all-targets -- -D warnings`)
- `task fmt` → clean

Shell-level end-to-end against a self-contained fork+upstream pair:

| Path | Before this PR | With this PR + `--fork-clone-url` |
|---|---|---|
| Squash merge from fork | Misclassified as rebase, fork notes never fetched | Correctly classified as squash, fork notes fetched, no garbage written to base commits |
| Rebase merge from fork | Fork notes never fetched | Fork notes fetched, all 3 rebased commits get their corresponding authorship log |
| Plain merge commit from fork | `SkippedSimpleMerge` with bogus "authorship preserved" log line | `ForkNotesPreserved` — all 3 fork commits keep attribution upstream |

One observation worth flagging from the shell runs: Path B (rebase) ends with `Error running local CI: Failed to parse authorship log` *after* the notes are successfully written and visible via `git notes --ref=ai show`. The Rust integration tests (which use real `TestRepo.set_contents` edits) all pass, so this is likely a quirk of the synthetic JSON the shell fixture builds. Worth a follow-up to confirm before relying on the exit code in production CI.

Resolves #411
Refs #1473
Refs #546
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->