### PR TITLE
[codex] fix blank agent attribution in daemon replay

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -30,7 +30,7 @@ use crate::{
         restore_working_log_carryover, rewrite_authorship_after_commit_amend_with_snapshot,
         rewrite_authorship_if_needed,
     },
-    authorship::working_log::CheckpointKind,
+    authorship::working_log::{AgentId, CheckpointKind},
     commands::checkpoint_agent::orchestrator::CheckpointRequest,
     commands::hooks::{push_hooks, stash_hooks},
     daemon::checkpoint::PreparedPathRole,
@@ -1894,6 +1894,26 @@ fn build_human_replay_checkpoint_request(
     files: Vec<String>,
     dirty_files: HashMap<String, String>,
 ) -> CheckpointRequest {
+    build_replay_checkpoint_request(
+        repo_work_dir,
+        files,
+        dirty_files,
+        CheckpointKind::Human,
+        None,
+        PreparedPathRole::WillEdit,
+        HashMap::new(),
+    )
+}
+
+fn build_replay_checkpoint_request(
+    repo_work_dir: &str,
+    files: Vec<String>,
+    dirty_files: HashMap<String, String>,
+    checkpoint_kind: CheckpointKind,
+    agent_id: Option<AgentId>,
+    path_role: PreparedPathRole,
+    metadata: HashMap<String, String>,
+) -> CheckpointRequest {
     let base_commit = crate::commands::checkpoint_agent::orchestrator::BaseCommit::Initial;
     let repo_work_dir_path = std::path::PathBuf::from(repo_work_dir);
 
@@ -1913,12 +1933,12 @@ fn build_human_replay_checkpoint_request(
 
     CheckpointRequest {
         trace_id: crate::authorship::authorship_log_serialization::generate_trace_id(),
-        checkpoint_kind: CheckpointKind::Human,
-        agent_id: None,
+        checkpoint_kind,
+        agent_id,
         files: checkpoint_files,
-        path_role: PreparedPathRole::WillEdit,
+        path_role,
         stream_source: None,
-        metadata: std::collections::HashMap::new(),
+        metadata,
     }
 }
 
@@ -2648,17 +2668,34 @@ fn sync_pre_commit_checkpoint_for_daemon_commit(
         return Ok(());
     }
 
-    let replay_checkpoint_request = build_human_replay_checkpoint_request(
-        &repo_workdir,
-        changed_files.clone(),
-        dirty_files.clone(),
-    );
-
-    let checkpoint_kind = if active_bash.is_some() {
-        CheckpointKind::AiAgent
-    } else {
-        CheckpointKind::Human
-    };
+    let (checkpoint_kind, replay_checkpoint_request) =
+        if let Some((agent_id, metadata)) = active_bash {
+            let mut metadata = metadata.clone();
+            metadata
+                .entry("edit_kind".to_string())
+                .or_insert_with(|| "bash".to_string());
+            (
+                CheckpointKind::AiAgent,
+                build_replay_checkpoint_request(
+                    &repo_workdir,
+                    changed_files.clone(),
+                    dirty_files.clone(),
+                    CheckpointKind::AiAgent,
+                    Some(agent_id.clone()),
+                    PreparedPathRole::Edited,
+                    metadata,
+                ),
+            )
+        } else {
+            (
+                CheckpointKind::Human,
+                build_human_replay_checkpoint_request(
+                    &repo_workdir,
+                    changed_files.clone(),
+                    dirty_files.clone(),
+                ),
+            )
+        };
 
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -8948,6 +8985,50 @@ mod tests {
                 metadata: std::collections::HashMap::new(),
             }),
         }
+    }
+
+    #[test]
+    fn human_replay_checkpoint_request_has_no_agent_identity() {
+        let request = build_human_replay_checkpoint_request(
+            "/repo",
+            vec!["src/main.rs".to_string()],
+            HashMap::from([("src/main.rs".to_string(), "fn main() {}\n".to_string())]),
+        );
+
+        assert_eq!(request.checkpoint_kind, CheckpointKind::Human);
+        assert_eq!(request.agent_id, None);
+        assert_eq!(request.path_role, PreparedPathRole::WillEdit);
+        assert_eq!(request.files.len(), 1);
+        assert_eq!(
+            request.files[0].path,
+            std::path::PathBuf::from("src/main.rs")
+        );
+        assert_eq!(request.files[0].content.as_deref(), Some("fn main() {}\n"));
+    }
+
+    #[test]
+    fn ai_replay_checkpoint_request_preserves_active_bash_agent_identity() {
+        let agent_id = AgentId {
+            tool: "claude".to_string(),
+            id: "session-123".to_string(),
+            model: "opus-4".to_string(),
+        };
+        let metadata = HashMap::from([("edit_kind".to_string(), "bash".to_string())]);
+
+        let request = build_replay_checkpoint_request(
+            "/repo",
+            vec!["src/main.rs".to_string()],
+            HashMap::from([("src/main.rs".to_string(), "fn main() {}\n".to_string())]),
+            CheckpointKind::AiAgent,
+            Some(agent_id.clone()),
+            PreparedPathRole::Edited,
+            metadata.clone(),
+        );
+
+        assert_eq!(request.checkpoint_kind, CheckpointKind::AiAgent);
+        assert_eq!(request.agent_id, Some(agent_id));
+        assert_eq!(request.path_role, PreparedPathRole::Edited);
+        assert_eq!(request.metadata, metadata);
     }
 
     #[test]

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -191,6 +191,12 @@ fn execute_resolved_checkpoint(
     resolved: ResolvedCheckpointExecution,
     checkpoint_start: Instant,
 ) -> Result<(usize, usize, usize), GitAiError> {
+    if kind.is_ai() && checkpoint_request.agent_id.is_none() {
+        return Err(GitAiError::Generic(
+            "AI checkpoint is missing agent_id".to_string(),
+        ));
+    }
+
     let mut working_log = repo
         .storage
         .working_log_for_base_commit(&resolved.base_commit)?;

--- a/tests/integration/checkpoint_unit.rs
+++ b/tests/integration/checkpoint_unit.rs
@@ -268,6 +268,60 @@ fn test_checkpoint_base_override_controls_head_context_for_entry_generation() {
 }
 
 #[test]
+fn test_ai_checkpoint_without_agent_id_is_rejected() {
+    let (repo, lines_file, _) = setup_repo_with_base_commit();
+    let file_path = repo.path().join(&lines_file);
+    let base_commit = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let content = "changed without agent identity\n";
+    std::fs::write(&file_path, content).unwrap();
+
+    let checkpoint_request = CheckpointRequest {
+        trace_id: "missing-agent-regression".to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: None,
+        files: vec![CheckpointFile {
+            path: PathBuf::from(&lines_file),
+            content: Some(content.to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Sha(base_commit.clone()),
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: HashMap::new(),
+    };
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let resolved = ResolvedCheckpointExecution {
+        base_commit,
+        ts: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+        files: vec![lines_file.clone()],
+        dirty_files: HashMap::from([(lines_file, content.to_string())]),
+    };
+
+    let error = execute_resolved_checkpoint_from_daemon(
+        &gitai_repo,
+        "mock-ai",
+        CheckpointKind::AiAgent,
+        checkpoint_request,
+        resolved,
+    )
+    .expect_err("AI checkpoints must carry an agent_id");
+
+    assert!(
+        error.to_string().contains("missing agent_id"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn test_checkpoint_skips_conflicted_files() {
     // Create a repo with an initial commit
     let (repo, lines_file, _) = setup_repo_with_base_commit();


### PR DESCRIPTION
## Summary

Fix daemon commit replay so active bash-tool commits preserve the AI agent identity in the replay checkpoint request. Previously the daemon detected that a bash session was active and executed the replay as `AiAgent`, but it still passed a human-shaped `CheckpointRequest` with `agent_id: None`. The checkpoint executor then fell back to the generic checkpoint kind string, which could persist `ai_agent` into working-log line attribution and later into git notes instead of an `s_...::t_...` session/trace attestation.

## Root Cause

`sync_pre_commit_checkpoint_for_daemon_commit` was mixing two sources of truth: an out-of-band `CheckpointKind::AiAgent` argument plus an in-band `CheckpointRequest` that still said human/no-agent. The lower-level attribution code derives note author IDs from the request `agent_id`; when that identity is missing, the old fallback was `kind.to_str()`.

## Changes

- Add a replay checkpoint request builder that carries checkpoint kind, agent identity, path role, and metadata together.
- Use the active bash `AgentId` and metadata when replaying daemon commits as AI checkpoints.
- Reject AI checkpoints without `agent_id` at the executor boundary to prevent future malformed control requests from writing generic `ai_agent` attribution.
- Add regression coverage for replay request construction and missing-agent AI checkpoint rejection.

## Validation

- `task fmt`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=replay_checkpoint_request`
- `task test TEST_FILTER=test_ai_checkpoint_without_agent_id_is_rejected`
- `task lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->