### PR TITLE
[codex] Preserve notes for rebased PR heads

### DIFF
--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -63,6 +63,8 @@ pub enum CiRunResult {
     SkippedFastForward,
     /// Skipped: the PR synchronize event was not a rebase-like rewrite
     SkippedNonRebaseSync,
+    /// Skipped: one or more current PR commits already have authorship notes
+    SkippedExistingSyncNotes,
     /// Authorship already exists for this commit
     AlreadyExists {
         #[allow(dead_code)]
@@ -438,6 +440,30 @@ impl CiContext {
                 let resolved_base_sha = self
                     .repo
                     .merge_base(head_sha.clone(), base_target.to_string())?;
+                let resolved_base_target_sha = self.repo.revparse_single(base_target)?.id();
+
+                if resolved_base_sha != resolved_base_target_sha {
+                    println!(
+                        "Skipping PR sync authorship rewrite: current PR head is not based on {}",
+                        resolved_base_target_sha
+                    );
+                    return Ok(CiRunResult::SkippedNonRebaseSync);
+                }
+
+                if resolved_previous_base_sha == resolved_base_sha {
+                    println!(
+                        "Skipping PR sync authorship rewrite: PR base did not advance during sync"
+                    );
+                    return Ok(CiRunResult::SkippedNonRebaseSync);
+                }
+
+                if !commit_is_ancestor(&self.repo, &resolved_previous_base_sha, &resolved_base_sha)?
+                {
+                    println!(
+                        "Skipping PR sync authorship rewrite: previous PR base is not an ancestor of current PR base"
+                    );
+                    return Ok(CiRunResult::SkippedNonRebaseSync);
+                }
 
                 let original_commits = commits_in_range_oldest_first(
                     &self.repo,
@@ -463,6 +489,16 @@ impl CiContext {
                     return Ok(CiRunResult::NoAuthorshipAvailable);
                 }
 
+                let notes_before = count_commits_with_authorship_notes(&self.repo, &new_commits);
+                if notes_before > 0 {
+                    println!(
+                        "Skipping PR sync authorship rewrite: {} of {} current PR commits already have authorship notes",
+                        notes_before,
+                        new_commits.len()
+                    );
+                    return Ok(CiRunResult::SkippedExistingSyncNotes);
+                }
+
                 if !commit_ranges_have_same_patch_ids(&self.repo, &original_commits, &new_commits)?
                 {
                     println!(
@@ -475,8 +511,6 @@ impl CiContext {
                     "Rewriting authorship for rebased PR head: {} -> {}",
                     previous_head_sha, head_sha
                 );
-
-                let notes_before = count_commits_with_authorship_notes(&self.repo, &new_commits);
 
                 rewrite_authorship_after_rebase_v2(
                     &self.repo,
@@ -493,16 +527,6 @@ impl CiContext {
                         "No AI authorship to track for this PR rebase (no AI-touched files in PR)"
                     );
                     return Ok(CiRunResult::NoAuthorshipAvailable);
-                }
-
-                if notes_after == notes_before && notes_after == new_commits.len() {
-                    println!("All rebased PR commits already had authorship");
-                    return Ok(CiRunResult::AlreadyExists {
-                        authorship_log: get_reference_as_authorship_log_v3(
-                            &self.repo,
-                            new_commits.last().unwrap(),
-                        )?,
-                    });
                 }
 
                 if options.skip_push {
@@ -811,13 +835,41 @@ fn ensure_commit_available_for_sync(
     println!("Fetching PR sync commit {} into {}", commit_sha, fetch_ref);
     let mut args = repo.global_args_for_exec();
     args.push("fetch".to_string());
-    args.push("--filter=blob:none".to_string());
+    if sync_fetch_remote_supports_lazy_blobs(repo, fetch_remote)? {
+        args.push("--filter=blob:none".to_string());
+    }
     args.push("--no-tags".to_string());
     args.push(fetch_remote.to_string());
     args.push(format!("{}:{}", commit_sha, fetch_ref));
     exec_git(&args)?;
     repo.revparse_single(commit_sha)?;
     Ok(())
+}
+
+fn sync_fetch_remote_supports_lazy_blobs(
+    repo: &Repository,
+    fetch_remote: &str,
+) -> Result<bool, GitAiError> {
+    if fetch_remote.contains("://") || fetch_remote.contains('@') {
+        return Ok(false);
+    }
+
+    let mut args = repo.global_args_for_exec();
+    args.push("config".to_string());
+    args.push("--bool".to_string());
+    args.push("--get".to_string());
+    args.push(format!("remote.{}.promisor", fetch_remote));
+
+    let output = exec_git_allow_nonzero(&args)?;
+    match output.status.code() {
+        Some(0) => Ok(String::from_utf8_lossy(&output.stdout).trim() == "true"),
+        Some(1) => Ok(false),
+        code => Err(GitAiError::GitCliError {
+            code,
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            args,
+        }),
+    }
 }
 
 fn stable_patch_id_for_commit(repo: &Repository, commit_sha: &str) -> Result<String, GitAiError> {
@@ -972,5 +1024,37 @@ mod tests {
         let main_sha = repo.commit_all("main commit").expect("main commit");
 
         assert!(commit_is_ancestor(repo.gitai_repo(), &main_sha, "not-a-sha").is_err());
+    }
+
+    #[test]
+    fn sync_fetch_uses_blobless_only_for_named_promisor_remote() {
+        let repo = TmpRepo::new().expect("test repo");
+
+        assert!(
+            !sync_fetch_remote_supports_lazy_blobs(repo.gitai_repo(), "origin")
+                .expect("missing promisor config should be false")
+        );
+
+        repo.git_command(&["config", "remote.origin.promisor", "true"])
+            .expect("set promisor config");
+        assert!(
+            sync_fetch_remote_supports_lazy_blobs(repo.gitai_repo(), "origin")
+                .expect("named promisor remote should allow blobless fetch")
+        );
+
+        assert!(
+            !sync_fetch_remote_supports_lazy_blobs(
+                repo.gitai_repo(),
+                "https://github.com/acme/repo.git"
+            )
+            .expect("direct URL should not use blobless fetch")
+        );
+        assert!(
+            !sync_fetch_remote_supports_lazy_blobs(
+                repo.gitai_repo(),
+                "git@github.com:acme/repo.git"
+            )
+            .expect("direct SSH URL should not use blobless fetch")
+        );
     }
 }

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -32,6 +32,12 @@ pub enum CiEvent {
         /// When set, notes will be fetched from the fork before processing.
         fork_clone_url: Option<String>,
     },
+    Rebase {
+        previous_head_sha: String,
+        previous_base_sha: String,
+        head_sha: String,
+        base_sha: String,
+    },
 }
 
 /// Result of running CiContext
@@ -41,6 +47,11 @@ pub enum CiRunResult {
     AuthorshipRewritten {
         #[allow(dead_code)]
         authorship_log: AuthorshipLog,
+    },
+    /// Authorship was successfully rewritten for one or more rebased commits
+    RebaseAuthorshipRewritten {
+        #[allow(dead_code)]
+        commit_count: usize,
     },
     /// Skipped: merge commit has multiple parents (simple merge - authorship already present)
     SkippedSimpleMerge,
@@ -355,6 +366,98 @@ impl CiContext {
                     }
                 }
             }
+            CiEvent::Rebase {
+                previous_head_sha,
+                previous_base_sha,
+                head_sha,
+                base_sha,
+            } => {
+                println!("Working repository is in {}", self.repo.path().display());
+
+                if options.skip_fetch_notes {
+                    println!("Skipping authorship history fetch");
+                } else {
+                    println!("Fetching authorship history");
+                    fetch_authorship_notes(&self.repo, "origin")?;
+                    println!("Fetched authorship history");
+                }
+
+                if previous_head_sha == head_sha {
+                    println!(
+                        "{} equals previous head {} (no head rewrite)",
+                        head_sha, previous_head_sha
+                    );
+                    return Ok(CiRunResult::SkippedFastForward);
+                }
+                if commit_is_ancestor(&self.repo, previous_head_sha, head_sha)? {
+                    println!(
+                        "{} is an ancestor of {} (fast-forward PR update)",
+                        previous_head_sha, head_sha
+                    );
+                    return Ok(CiRunResult::SkippedFastForward);
+                }
+
+                let original_commits = commits_in_range_oldest_first(
+                    &self.repo,
+                    previous_base_sha,
+                    previous_head_sha,
+                    "previous PR",
+                )?;
+                let new_commits =
+                    commits_in_range_oldest_first(&self.repo, base_sha, head_sha, "current PR")?;
+
+                println!(
+                    "Rewriting authorship for rebased PR head: {} original commits -> {} new commits",
+                    original_commits.len(),
+                    new_commits.len()
+                );
+
+                if original_commits.is_empty() || new_commits.is_empty() {
+                    println!("No AI authorship to track for this PR rebase (empty commit range)");
+                    return Ok(CiRunResult::NoAuthorshipAvailable);
+                }
+
+                let notes_before = count_commits_with_authorship_notes(&self.repo, &new_commits);
+
+                rewrite_authorship_after_rebase_v2(
+                    &self.repo,
+                    previous_head_sha,
+                    &original_commits,
+                    &new_commits,
+                    "",
+                )?;
+                println!("Rewrote authorship.");
+
+                let notes_after = count_commits_with_authorship_notes(&self.repo, &new_commits);
+                if notes_after == 0 {
+                    println!(
+                        "No AI authorship to track for this PR rebase (no AI-touched files in PR)"
+                    );
+                    return Ok(CiRunResult::NoAuthorshipAvailable);
+                }
+
+                if notes_after == notes_before && notes_after == new_commits.len() {
+                    println!("All rebased PR commits already had authorship");
+                    return Ok(CiRunResult::AlreadyExists {
+                        authorship_log: get_reference_as_authorship_log_v3(
+                            &self.repo,
+                            new_commits.last().unwrap(),
+                        )?,
+                    });
+                }
+
+                if options.skip_push {
+                    println!("Skipping authorship push (--skip-push). Done.");
+                } else {
+                    println!("Pushing authorship...");
+                    self.repo.push_authorship("origin")?;
+                    println!("Pushed authorship. Done.");
+                }
+
+                Ok(CiRunResult::RebaseAuthorshipRewritten {
+                    commit_count: notes_after,
+                })
+            }
         }
     }
 
@@ -596,6 +699,47 @@ impl CiContext {
         commits.reverse();
         commits
     }
+}
+
+fn commits_in_range_oldest_first(
+    repo: &Repository,
+    start_sha: &str,
+    end_sha: &str,
+    label: &str,
+) -> Result<Vec<String>, GitAiError> {
+    if start_sha == end_sha {
+        return Ok(Vec::new());
+    }
+
+    let mut commits =
+        CommitRange::new_infer_refname(repo, start_sha.to_string(), end_sha.to_string(), None)
+            .map_err(|e| {
+                GitAiError::Generic(format!(
+                    "Failed to resolve {} commit range {}..{}: {}",
+                    label, start_sha, end_sha, e
+                ))
+            })?
+            .all_commits();
+
+    commits.reverse();
+    Ok(commits)
+}
+
+fn count_commits_with_authorship_notes(repo: &Repository, commits: &[String]) -> usize {
+    commits
+        .iter()
+        .filter(|sha| show_authorship_note(repo, sha).is_some())
+        .count()
+}
+
+fn commit_is_ancestor(
+    repo: &Repository,
+    ancestor_sha: &str,
+    descendant_sha: &str,
+) -> Result<bool, GitAiError> {
+    let ancestor = repo.revparse_single(ancestor_sha)?.id();
+    let merge_base = repo.merge_base(ancestor.clone(), descendant_sha.to_string())?;
+    Ok(merge_base == ancestor)
 }
 
 #[cfg(test)]

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -10,7 +10,7 @@ use crate::git::refs::{
     AI_AUTHORSHIP_FORK_TRACKING_REF, copy_missing_notes_for_commits_from_ref,
     note_blob_oids_for_commits, ref_exists,
 };
-use crate::git::repository::{CommitRange, Repository, exec_git};
+use crate::git::repository::{CommitRange, Repository, exec_git, exec_git_allow_nonzero};
 use crate::git::sync_authorship::fetch_authorship_notes;
 use std::fs;
 use std::path::PathBuf;
@@ -738,13 +738,30 @@ fn commit_is_ancestor(
     descendant_sha: &str,
 ) -> Result<bool, GitAiError> {
     let ancestor = repo.revparse_single(ancestor_sha)?.id();
-    let merge_base = repo.merge_base(ancestor.clone(), descendant_sha.to_string())?;
-    Ok(merge_base == ancestor)
+    let descendant = repo.revparse_single(descendant_sha)?.id();
+
+    let mut args = repo.global_args_for_exec();
+    args.push("merge-base".to_string());
+    args.push("--is-ancestor".to_string());
+    args.push(ancestor);
+    args.push(descendant);
+
+    let output = exec_git_allow_nonzero(&args)?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        code => Err(GitAiError::GitCliError {
+            code,
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            args,
+        }),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::git::test_utils::TmpRepo;
 
     #[test]
     fn test_ci_event_debug() {
@@ -776,5 +793,38 @@ mod tests {
         let result3 = CiRunResult::NoAuthorshipAvailable;
         let debug_str3 = format!("{:?}", result3);
         assert!(debug_str3.contains("NoAuthorshipAvailable"));
+    }
+
+    #[test]
+    fn commit_is_ancestor_returns_false_for_unrelated_histories() {
+        let repo = TmpRepo::new().expect("test repo");
+        repo.write_file("main.txt", "main", false)
+            .expect("write main");
+        let main_sha = repo.commit_all("main commit").expect("main commit");
+
+        repo.git_command(&["switch", "--orphan", "unrelated"])
+            .expect("orphan branch");
+        repo.git_command(&["rm", "-rf", "--ignore-unmatch", "."])
+            .expect("clear tree");
+        repo.write_file("unrelated.txt", "unrelated", false)
+            .expect("write unrelated");
+        let unrelated_sha = repo
+            .commit_all("unrelated commit")
+            .expect("unrelated commit");
+
+        assert!(
+            !commit_is_ancestor(repo.gitai_repo(), &main_sha, &unrelated_sha)
+                .expect("unrelated histories should not error")
+        );
+    }
+
+    #[test]
+    fn commit_is_ancestor_errors_for_invalid_descendant() {
+        let repo = TmpRepo::new().expect("test repo");
+        repo.write_file("main.txt", "main", false)
+            .expect("write main");
+        let main_sha = repo.commit_all("main commit").expect("main commit");
+
+        assert!(commit_is_ancestor(repo.gitai_repo(), &main_sha, "not-a-sha").is_err());
     }
 }

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -10,7 +10,9 @@ use crate::git::refs::{
     AI_AUTHORSHIP_FORK_TRACKING_REF, copy_missing_notes_for_commits_from_ref,
     note_blob_oids_for_commits, ref_exists,
 };
-use crate::git::repository::{CommitRange, Repository, exec_git, exec_git_allow_nonzero};
+use crate::git::repository::{
+    CommitRange, Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin,
+};
 use crate::git::sync_authorship::fetch_authorship_notes;
 use std::fs;
 use std::path::PathBuf;
@@ -32,11 +34,13 @@ pub enum CiEvent {
         /// When set, notes will be fetched from the fork before processing.
         fork_clone_url: Option<String>,
     },
-    Rebase {
+    Sync {
         previous_head_sha: String,
-        previous_base_sha: String,
         head_sha: String,
+        base_ref: String,
         base_sha: String,
+        previous_base_sha: Option<String>,
+        previous_head_fetch_remote: Option<String>,
     },
 }
 
@@ -49,7 +53,7 @@ pub enum CiRunResult {
         authorship_log: AuthorshipLog,
     },
     /// Authorship was successfully rewritten for one or more rebased commits
-    RebaseAuthorshipRewritten {
+    SyncAuthorshipRewritten {
         #[allow(dead_code)]
         commit_count: usize,
     },
@@ -57,6 +61,8 @@ pub enum CiRunResult {
     SkippedSimpleMerge,
     /// Skipped: merge commit equals head (fast-forward - no rewrite needed)
     SkippedFastForward,
+    /// Skipped: the PR synchronize event was not a rebase-like rewrite
+    SkippedNonRebaseSync,
     /// Authorship already exists for this commit
     AlreadyExists {
         #[allow(dead_code)]
@@ -73,6 +79,7 @@ pub struct CiRunOptions {
     pub skip_fetch_notes: bool,
     pub skip_fetch_base: bool,
     pub skip_fetch_fork_notes: bool,
+    pub skip_fetch_sync_refs: bool,
     pub skip_push: bool,
 }
 
@@ -366,11 +373,13 @@ impl CiContext {
                     }
                 }
             }
-            CiEvent::Rebase {
+            CiEvent::Sync {
                 previous_head_sha,
-                previous_base_sha,
                 head_sha,
+                base_ref,
                 base_sha,
+                previous_base_sha,
+                previous_head_fetch_remote,
             } => {
                 println!("Working repository is in {}", self.repo.path().display());
 
@@ -389,6 +398,21 @@ impl CiContext {
                     );
                     return Ok(CiRunResult::SkippedFastForward);
                 }
+                ensure_commit_available_for_sync(
+                    &self.repo,
+                    previous_head_sha,
+                    previous_head_fetch_remote.as_deref().unwrap_or("origin"),
+                    "refs/git-ai/ci-sync/previous-head",
+                    options.skip_fetch_sync_refs,
+                )?;
+                ensure_commit_available_for_sync(
+                    &self.repo,
+                    head_sha,
+                    "origin",
+                    "refs/git-ai/ci-sync/head",
+                    options.skip_fetch_sync_refs,
+                )?;
+
                 if commit_is_ancestor(&self.repo, previous_head_sha, head_sha)? {
                     println!(
                         "{} is an ancestor of {} (fast-forward PR update)",
@@ -397,17 +421,39 @@ impl CiContext {
                     return Ok(CiRunResult::SkippedFastForward);
                 }
 
+                let base_target =
+                    if !base_sha.is_empty() && self.repo.revparse_single(base_sha).is_ok() {
+                        base_sha.as_str()
+                    } else {
+                        base_ref.as_str()
+                    };
+                let resolved_previous_base_sha = match previous_base_sha {
+                    Some(previous_base_sha) if !previous_base_sha.is_empty() => {
+                        previous_base_sha.clone()
+                    }
+                    _ => self
+                        .repo
+                        .merge_base(previous_head_sha.clone(), base_target.to_string())?,
+                };
+                let resolved_base_sha = self
+                    .repo
+                    .merge_base(head_sha.clone(), base_target.to_string())?;
+
                 let original_commits = commits_in_range_oldest_first(
                     &self.repo,
-                    previous_base_sha,
+                    &resolved_previous_base_sha,
                     previous_head_sha,
                     "previous PR",
                 )?;
-                let new_commits =
-                    commits_in_range_oldest_first(&self.repo, base_sha, head_sha, "current PR")?;
+                let new_commits = commits_in_range_oldest_first(
+                    &self.repo,
+                    &resolved_base_sha,
+                    head_sha,
+                    "current PR",
+                )?;
 
                 println!(
-                    "Rewriting authorship for rebased PR head: {} original commits -> {} new commits",
+                    "Detected non-fast-forward PR sync: {} original commits -> {} new commits",
                     original_commits.len(),
                     new_commits.len()
                 );
@@ -416,6 +462,19 @@ impl CiContext {
                     println!("No AI authorship to track for this PR rebase (empty commit range)");
                     return Ok(CiRunResult::NoAuthorshipAvailable);
                 }
+
+                if !commit_ranges_have_same_patch_ids(&self.repo, &original_commits, &new_commits)?
+                {
+                    println!(
+                        "Skipping PR sync authorship rewrite: previous and current commit ranges are not rebase-equivalent"
+                    );
+                    return Ok(CiRunResult::SkippedNonRebaseSync);
+                }
+
+                println!(
+                    "Rewriting authorship for rebased PR head: {} -> {}",
+                    previous_head_sha, head_sha
+                );
 
                 let notes_before = count_commits_with_authorship_notes(&self.repo, &new_commits);
 
@@ -454,7 +513,7 @@ impl CiContext {
                     println!("Pushed authorship. Done.");
                 }
 
-                Ok(CiRunResult::RebaseAuthorshipRewritten {
+                Ok(CiRunResult::SyncAuthorshipRewritten {
                     commit_count: notes_after,
                 })
             }
@@ -730,6 +789,93 @@ fn count_commits_with_authorship_notes(repo: &Repository, commits: &[String]) ->
         .iter()
         .filter(|sha| show_authorship_note(repo, sha).is_some())
         .count()
+}
+
+fn ensure_commit_available_for_sync(
+    repo: &Repository,
+    commit_sha: &str,
+    fetch_remote: &str,
+    fetch_ref: &str,
+    skip_fetch: bool,
+) -> Result<(), GitAiError> {
+    if repo.revparse_single(commit_sha).is_ok() {
+        return Ok(());
+    }
+    if skip_fetch {
+        return Err(GitAiError::Generic(format!(
+            "Commit {} is not available locally and sync ref fetch is disabled",
+            commit_sha
+        )));
+    }
+
+    println!("Fetching PR sync commit {} into {}", commit_sha, fetch_ref);
+    let mut args = repo.global_args_for_exec();
+    args.push("fetch".to_string());
+    args.push("--filter=blob:none".to_string());
+    args.push("--no-tags".to_string());
+    args.push(fetch_remote.to_string());
+    args.push(format!("{}:{}", commit_sha, fetch_ref));
+    exec_git(&args)?;
+    repo.revparse_single(commit_sha)?;
+    Ok(())
+}
+
+fn stable_patch_id_for_commit(repo: &Repository, commit_sha: &str) -> Result<String, GitAiError> {
+    let mut show_args = repo.global_args_for_exec();
+    show_args.extend(
+        [
+            "show",
+            "--format=",
+            "--no-notes",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
+            "--diff-algorithm=default",
+            "--indent-heuristic",
+            commit_sha,
+        ]
+        .iter()
+        .map(|s| s.to_string()),
+    );
+    let patch = exec_git(&show_args)?;
+
+    let mut patch_id_args = repo.global_args_for_exec();
+    patch_id_args.push("patch-id".to_string());
+    patch_id_args.push("--stable".to_string());
+    let patch_id_output = exec_git_stdin(&patch_id_args, &patch.stdout)?;
+    let stdout = String::from_utf8_lossy(&patch_id_output.stdout);
+    let patch_id = stdout
+        .split_whitespace()
+        .next()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "empty-patch".to_string());
+    Ok(patch_id)
+}
+
+fn stable_patch_ids_for_commits(
+    repo: &Repository,
+    commit_shas: &[String],
+) -> Result<Vec<String>, GitAiError> {
+    commit_shas
+        .iter()
+        .map(|sha| stable_patch_id_for_commit(repo, sha))
+        .collect()
+}
+
+fn commit_ranges_have_same_patch_ids(
+    repo: &Repository,
+    original_commits: &[String],
+    new_commits: &[String],
+) -> Result<bool, GitAiError> {
+    if original_commits.len() != new_commits.len() {
+        return Ok(false);
+    }
+
+    let original_patch_ids = stable_patch_ids_for_commits(repo, original_commits)?;
+    let new_patch_ids = stable_patch_ids_for_commits(repo, new_commits)?;
+    Ok(original_patch_ids == new_patch_ids)
 }
 
 fn commit_is_ancestor(

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -200,6 +200,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     let repo = find_repository_in_path(&clone_dir.clone())?;
     let previous_base_sha = repo.merge_base(previous_head_sha.clone(), base_sha.clone())?;
+    let current_base_sha = repo.merge_base(current_head_sha.clone(), base_sha)?;
 
     Ok(Some(CiContext {
         repo,
@@ -207,7 +208,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
             previous_head_sha,
             previous_base_sha,
             head_sha: current_head_sha,
-            base_sha,
+            base_sha: current_base_sha,
         },
         temp_dir: PathBuf::from(clone_dir),
     }))

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -201,16 +201,21 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     }
 
     let repo = find_repository_in_path(&clone_dir.clone())?;
-    let previous_base_sha = repo.merge_base(previous_head_sha.clone(), base_sha.clone())?;
-    let current_base_sha = repo.merge_base(current_head_sha.clone(), base_sha)?;
 
     Ok(Some(CiContext {
         repo,
-        event: CiEvent::Rebase {
+        event: CiEvent::Sync {
             previous_head_sha,
-            previous_base_sha,
             head_sha: current_head_sha,
-            base_sha: current_base_sha,
+            base_ref,
+            base_sha,
+            previous_base_sha: None,
+            previous_head_fetch_remote: Some(
+                authenticated_fork_url
+                    .as_ref()
+                    .unwrap_or(&authenticated_url)
+                    .clone(),
+            ),
         },
         temp_dir: PathBuf::from(clone_dir),
     }))

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -185,7 +185,9 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     .is_ok();
 
     if !previous_head_is_local {
-        let previous_head_fetch_url = authenticated_fork_url.as_ref().unwrap_or(&authenticated_url);
+        let previous_head_fetch_url = authenticated_fork_url
+            .as_ref()
+            .unwrap_or(&authenticated_url);
         exec_git(&[
             "-C".to_string(),
             clone_dir.clone(),

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -11,6 +11,12 @@ const GITHUB_CI_TEMPLATE_YAML: &str = include_str!("workflow_templates/github.ya
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 struct GithubCiEventPayload {
     #[serde(default)]
+    action: Option<String>,
+    #[serde(default)]
+    before: Option<String>,
+    #[serde(default)]
+    after: Option<String>,
+    #[serde(default)]
     pull_request: Option<GithubCiPullRequest>,
 }
 
@@ -53,14 +59,11 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
 
     let pull_request = event_payload.pull_request.unwrap();
 
-    if !pull_request.merged || pull_request.merge_commit_sha.is_none() {
-        return Ok(None);
-    }
-
     let pr_number = pull_request.number;
-    let head_ref = pull_request.head.ref_name;
-    let head_sha = pull_request.head.sha;
-    let base_ref = pull_request.base.ref_name;
+    let head_ref = pull_request.head.ref_name.clone();
+    let head_sha = pull_request.head.sha.clone();
+    let base_ref = pull_request.base.ref_name.clone();
+    let base_sha = pull_request.base.sha.clone();
     let clone_url = pull_request.base.repo.clone_url.clone();
 
     // Detect fork: if head repo URL differs from base repo URL, this is a fork PR
@@ -84,28 +87,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
         clone_url
     };
 
-    // Clone the repo
-    exec_git(&[
-        "clone".to_string(),
-        "--branch".to_string(),
-        base_ref.clone(),
-        authenticated_url.clone(),
-        clone_dir.clone(),
-    ])?;
-
-    // Fetch PR commits using GitHub's special PR refs
-    // This is necessary because the PR branch may be deleted after merge
-    // but GitHub keeps the commits accessible via pull/{number}/head
-    // We store the fetched commits in a local ref to ensure they're kept
-    exec_git(&[
-        "-C".to_string(),
-        clone_dir.clone(),
-        "fetch".to_string(),
-        authenticated_url.clone(),
-        format!("pull/{}/head:refs/github/pr/{}", pr_number, pr_number),
-    ])?;
-
-    // Authenticate the fork clone URL if this is a fork PR
+    // Authenticate the fork clone URL if this is a fork PR.
     let authenticated_fork_url = fork_clone_url.map(|fork_url| {
         if let Ok(token) = std::env::var("GITHUB_TOKEN") {
             authenticate_clone_url(&fork_url, &token)
@@ -114,17 +96,118 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
         }
     });
 
+    if pull_request.merged
+        && let Some(merge_commit_sha) = pull_request.merge_commit_sha
+    {
+        // Clone the repo
+        exec_git(&[
+            "clone".to_string(),
+            "--branch".to_string(),
+            base_ref.clone(),
+            authenticated_url.clone(),
+            clone_dir.clone(),
+        ])?;
+
+        // Fetch PR commits using GitHub's special PR refs
+        // This is necessary because the PR branch may be deleted after merge
+        // but GitHub keeps the commits accessible via pull/{number}/head
+        // We store the fetched commits in a local ref to ensure they're kept
+        exec_git(&[
+            "-C".to_string(),
+            clone_dir.clone(),
+            "fetch".to_string(),
+            authenticated_url.clone(),
+            format!("pull/{}/head:refs/github/pr/{}", pr_number, pr_number),
+        ])?;
+
+        let repo = find_repository_in_path(&clone_dir.clone())?;
+
+        return Ok(Some(CiContext {
+            repo,
+            event: CiEvent::Merge {
+                merge_commit_sha,
+                head_ref: head_ref.clone(),
+                head_sha: head_sha.clone(),
+                base_ref: base_ref.clone(),
+                base_sha,
+                fork_clone_url: authenticated_fork_url,
+            },
+            temp_dir: PathBuf::from(clone_dir),
+        }));
+    }
+
+    if event_payload.action.as_deref() != Some("synchronize") {
+        return Ok(None);
+    }
+
+    let previous_head_sha = match event_payload.before.as_deref() {
+        Some(before)
+            if !before.is_empty() && before != "0000000000000000000000000000000000000000" =>
+        {
+            before.to_string()
+        }
+        _ => return Ok(None),
+    };
+    let current_head_sha = event_payload
+        .after
+        .clone()
+        .filter(|sha| !sha.is_empty() && sha != "0000000000000000000000000000000000000000")
+        .unwrap_or(head_sha.clone());
+
+    // Clone the base branch at its current tip and fetch both the current PR
+    // head and the previous head from the synchronize payload. For a normal PR
+    // push, the previous head is already reachable from the current PR ref. For
+    // a non-fast-forward UI rebase, fetching by SHA keeps the old commits
+    // available long enough for the local rebase rewrite command.
+    exec_git(&[
+        "clone".to_string(),
+        "--branch".to_string(),
+        base_ref.clone(),
+        authenticated_url.clone(),
+        clone_dir.clone(),
+    ])?;
+
+    exec_git(&[
+        "-C".to_string(),
+        clone_dir.clone(),
+        "fetch".to_string(),
+        authenticated_url.clone(),
+        format!("pull/{}/head:refs/github/pr/{}", pr_number, pr_number),
+    ])?;
+
+    let previous_head_is_local = exec_git(&[
+        "-C".to_string(),
+        clone_dir.clone(),
+        "rev-parse".to_string(),
+        "--verify".to_string(),
+        previous_head_sha.clone(),
+    ])
+    .is_ok();
+
+    if !previous_head_is_local {
+        let previous_head_fetch_url = authenticated_fork_url.as_ref().unwrap_or(&authenticated_url);
+        exec_git(&[
+            "-C".to_string(),
+            clone_dir.clone(),
+            "fetch".to_string(),
+            previous_head_fetch_url.clone(),
+            format!(
+                "{}:refs/github/pr/{}/previous",
+                previous_head_sha, pr_number
+            ),
+        ])?;
+    }
+
     let repo = find_repository_in_path(&clone_dir.clone())?;
+    let previous_base_sha = repo.merge_base(previous_head_sha.clone(), base_sha.clone())?;
 
     Ok(Some(CiContext {
         repo,
-        event: CiEvent::Merge {
-            merge_commit_sha: pull_request.merge_commit_sha.unwrap(),
-            head_ref: head_ref.clone(),
-            head_sha: head_sha.clone(),
-            base_ref: base_ref.clone(),
-            base_sha: pull_request.base.sha.clone(),
-            fork_clone_url: authenticated_fork_url,
+        event: CiEvent::Rebase {
+            previous_head_sha,
+            previous_base_sha,
+            head_sha: current_head_sha,
+            base_sha,
         },
         temp_dir: PathBuf::from(clone_dir),
     }))
@@ -160,7 +243,7 @@ pub fn install_github_ci_workflow() -> Result<PathBuf, GitAiError> {
 
 #[cfg(test)]
 mod tests {
-    use super::authenticate_clone_url;
+    use super::*;
 
     #[test]
     fn test_authenticate_clone_url_supports_github_dot_com() {
@@ -176,5 +259,46 @@ mod tests {
             authenticate_clone_url("https://github.example.com/acme/repo.git", "token"),
             "https://x-access-token:token@github.example.com/acme/repo.git"
         );
+    }
+
+    #[test]
+    fn test_github_synchronize_payload_deserializes_before_after() {
+        let json = r#"{
+            "action": "synchronize",
+            "before": "1111111111111111111111111111111111111111",
+            "after": "2222222222222222222222222222222222222222",
+            "pull_request": {
+                "number": 42,
+                "base": {
+                    "ref": "main",
+                    "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "repo": { "clone_url": "https://github.com/org/repo.git" }
+                },
+                "head": {
+                    "ref": "feature",
+                    "sha": "2222222222222222222222222222222222222222",
+                    "repo": { "clone_url": "https://github.com/fork/repo.git" }
+                },
+                "merged": false,
+                "merge_commit_sha": null
+            }
+        }"#;
+
+        let payload: GithubCiEventPayload = serde_json::from_str(json).unwrap();
+
+        assert_eq!(payload.action.as_deref(), Some("synchronize"));
+        assert_eq!(
+            payload.before.as_deref(),
+            Some("1111111111111111111111111111111111111111")
+        );
+        assert_eq!(
+            payload.after.as_deref(),
+            Some("2222222222222222222222222222222222222222")
+        );
+        let pull_request = payload.pull_request.expect("pull_request");
+        assert_eq!(pull_request.number, 42);
+        assert!(!pull_request.merged);
+        assert_eq!(pull_request.base.ref_name, "main");
+        assert_eq!(pull_request.head.ref_name, "feature");
     }
 }

--- a/src/ci/workflow_templates/github.yaml
+++ b/src/ci/workflow_templates/github.yaml
@@ -2,11 +2,11 @@ name: Git AI
 
 on:
   pull_request:
-    types: [closed]
+    types: [closed, synchronize]
 
 jobs:
   git-ai:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -27,6 +27,9 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
         CiRunResult::SkippedNonRebaseSync => {
             println!("{}: skipped non-rebase PR sync", prefix);
         }
+        CiRunResult::SkippedExistingSyncNotes => {
+            println!("{}: skipped PR sync with existing current notes", prefix);
+        }
         CiRunResult::NoAuthorshipAvailable => {
             println!(
                 "{}: no AI authorship to track (pre-git-ai commits or human-only code)",
@@ -96,8 +99,11 @@ fn handle_ci_github(args: &[String]) {
                     std::process::exit(1);
                 }
                 Ok(None) => {
-                    eprintln!("No GitHub CI context found");
-                    std::process::exit(1);
+                    // No actionable pull_request event for git-ai. This is not
+                    // an error, especially now that synchronize events run for
+                    // every PR head update.
+                    println!("No GitHub CI context found; nothing to do");
+                    std::process::exit(0);
                 }
             }
         }

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -341,6 +341,7 @@ fn handle_ci_local(args: &[String]) {
             match ctx.run_with_options(CiRunOptions {
                 skip_fetch_notes,
                 skip_fetch_base: true,
+                skip_fetch_fork_notes: false,
                 skip_push,
             }) {
                 Ok(result) => {

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -9,7 +9,7 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
         CiRunResult::AuthorshipRewritten { .. } => {
             println!("{}: authorship rewritten successfully", prefix);
         }
-        CiRunResult::RebaseAuthorshipRewritten { .. } => {
+        CiRunResult::SyncAuthorshipRewritten { .. } => {
             println!("{}: authorship rewritten successfully", prefix);
         }
         CiRunResult::AlreadyExists { .. } => {
@@ -23,6 +23,9 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
         }
         CiRunResult::SkippedFastForward => {
             println!("{}: skipped fast-forward merge", prefix);
+        }
+        CiRunResult::SkippedNonRebaseSync => {
+            println!("{}: skipped non-rebase PR sync", prefix);
         }
         CiRunResult::NoAuthorshipAvailable => {
             println!(
@@ -275,6 +278,7 @@ fn handle_ci_local(args: &[String]) {
                 skip_fetch_notes,
                 skip_fetch_base,
                 skip_fetch_fork_notes,
+                skip_fetch_sync_refs: false,
                 skip_push,
             }) {
                 Ok(result) => {
@@ -288,9 +292,10 @@ fn handle_ci_local(args: &[String]) {
             }
             std::process::exit(0);
         }
-        "rebase" => {
+        "sync" | "rebase" => {
             let skip_fetch_all = has_bool_flag("--skip-fetch");
             let skip_fetch_notes = skip_fetch_all || has_bool_flag("--skip-fetch-notes");
+            let skip_fetch_sync_refs = skip_fetch_all || has_bool_flag("--skip-fetch-sync-refs");
             let skip_push = has_bool_flag("--skip-push");
 
             let previous_head_sha = match flag("--previous-head-sha") {
@@ -301,13 +306,7 @@ fn handle_ci_local(args: &[String]) {
                 }
             };
 
-            let previous_base_sha = match flag("--previous-base-sha") {
-                Some(v) => v,
-                None => {
-                    eprintln!("--previous-base-sha is required");
-                    std::process::exit(1);
-                }
-            };
+            let previous_base_sha = flag("--previous-base-sha");
 
             let head_sha = match flag("--head-sha") {
                 Some(v) => v,
@@ -317,21 +316,32 @@ fn handle_ci_local(args: &[String]) {
                 }
             };
 
-            let base_sha = match flag("--base-sha") {
+            let base_sha = flag("--base-sha").unwrap_or_default();
+
+            let base_ref = match flag("--base-ref") {
                 Some(v) => v,
                 None => {
-                    eprintln!("--base-sha is required");
-                    std::process::exit(1);
+                    if !base_sha.is_empty() {
+                        base_sha.clone()
+                    } else {
+                        eprintln!("--base-ref is required");
+                        std::process::exit(1);
+                    }
                 }
             };
 
+            let previous_head_fetch_remote =
+                flag("--previous-head-fetch-remote").or_else(|| flag("--remote"));
+
             let ctx = CiContext {
                 repo,
-                event: CiEvent::Rebase {
+                event: CiEvent::Sync {
                     previous_head_sha,
-                    previous_base_sha,
                     head_sha,
+                    base_ref,
                     base_sha,
+                    previous_base_sha,
+                    previous_head_fetch_remote,
                 },
                 // Not used for local runs; teardown not invoked
                 temp_dir: std::path::PathBuf::from("."),
@@ -342,11 +352,12 @@ fn handle_ci_local(args: &[String]) {
                 skip_fetch_notes,
                 skip_fetch_base: true,
                 skip_fetch_fork_notes: false,
+                skip_fetch_sync_refs,
                 skip_push,
             }) {
                 Ok(result) => {
                     tracing::debug!("Local CI result: {:?}", result);
-                    print_ci_result(&result, "Local CI (rebase)");
+                    print_ci_result(&result, "Local CI (sync)");
                 }
                 Err(e) => {
                     eprintln!("Error running local CI: {}", e);
@@ -384,9 +395,11 @@ fn print_ci_help_and_exit() -> ! {
         "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch-fork-notes] [--skip-fetch] [--skip-push]"
     );
     eprintln!(
-        "                     rebase --previous-base-sha <sha> --previous-head-sha <sha> --base-sha <sha> --head-sha <sha>"
+        "                     sync   --previous-head-sha <sha> --head-sha <sha> --base-ref <ref> [--base-sha <sha>]"
     );
-    eprintln!("                            [--skip-fetch-notes] [--skip-fetch] [--skip-push]");
+    eprintln!(
+        "                            [--remote <name-or-url>] [--skip-fetch-notes] [--skip-fetch-sync-refs] [--skip-fetch] [--skip-push]"
+    );
     std::process::exit(1);
 }
 
@@ -403,9 +416,11 @@ fn print_ci_local_help_and_exit() -> ! {
         "         [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch-fork-notes] [--skip-fetch] [--skip-push]"
     );
     eprintln!(
-        "  rebase --previous-base-sha <sha> --previous-head-sha <sha> --base-sha <sha> --head-sha <sha>"
+        "  sync   --previous-head-sha <sha> --head-sha <sha> --base-ref <ref> [--base-sha <sha>]"
     );
-    eprintln!("         [--skip-fetch-notes] [--skip-fetch] [--skip-push]");
+    eprintln!(
+        "         [--remote <name-or-url>] [--skip-fetch-notes] [--skip-fetch-sync-refs] [--skip-fetch] [--skip-push]"
+    );
     std::process::exit(1);
 }
 

--- a/src/commands/ci_handlers.rs
+++ b/src/commands/ci_handlers.rs
@@ -9,6 +9,9 @@ fn print_ci_result(result: &CiRunResult, prefix: &str) {
         CiRunResult::AuthorshipRewritten { .. } => {
             println!("{}: authorship rewritten successfully", prefix);
         }
+        CiRunResult::RebaseAuthorshipRewritten { .. } => {
+            println!("{}: authorship rewritten successfully", prefix);
+        }
         CiRunResult::AlreadyExists { .. } => {
             println!("{}: authorship already exists", prefix);
         }
@@ -285,6 +288,72 @@ fn handle_ci_local(args: &[String]) {
             }
             std::process::exit(0);
         }
+        "rebase" => {
+            let skip_fetch_all = has_bool_flag("--skip-fetch");
+            let skip_fetch_notes = skip_fetch_all || has_bool_flag("--skip-fetch-notes");
+            let skip_push = has_bool_flag("--skip-push");
+
+            let previous_head_sha = match flag("--previous-head-sha") {
+                Some(v) => v,
+                None => {
+                    eprintln!("--previous-head-sha is required");
+                    std::process::exit(1);
+                }
+            };
+
+            let previous_base_sha = match flag("--previous-base-sha") {
+                Some(v) => v,
+                None => {
+                    eprintln!("--previous-base-sha is required");
+                    std::process::exit(1);
+                }
+            };
+
+            let head_sha = match flag("--head-sha") {
+                Some(v) => v,
+                None => {
+                    eprintln!("--head-sha is required");
+                    std::process::exit(1);
+                }
+            };
+
+            let base_sha = match flag("--base-sha") {
+                Some(v) => v,
+                None => {
+                    eprintln!("--base-sha is required");
+                    std::process::exit(1);
+                }
+            };
+
+            let ctx = CiContext {
+                repo,
+                event: CiEvent::Rebase {
+                    previous_head_sha,
+                    previous_base_sha,
+                    head_sha,
+                    base_sha,
+                },
+                // Not used for local runs; teardown not invoked
+                temp_dir: std::path::PathBuf::from("."),
+            };
+
+            tracing::debug!("Local CI context: {:?}", ctx);
+            match ctx.run_with_options(CiRunOptions {
+                skip_fetch_notes,
+                skip_fetch_base: true,
+                skip_push,
+            }) {
+                Ok(result) => {
+                    tracing::debug!("Local CI result: {:?}", result);
+                    print_ci_result(&result, "Local CI (rebase)");
+                }
+                Err(e) => {
+                    eprintln!("Error running local CI: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            std::process::exit(0);
+        }
         other => {
             eprintln!("Unknown local CI event: {}", other);
             print_ci_local_help_and_exit();
@@ -313,6 +382,10 @@ fn print_ci_help_and_exit() -> ! {
     eprintln!(
         "                            [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch-fork-notes] [--skip-fetch] [--skip-push]"
     );
+    eprintln!(
+        "                     rebase --previous-base-sha <sha> --previous-head-sha <sha> --base-sha <sha> --head-sha <sha>"
+    );
+    eprintln!("                            [--skip-fetch-notes] [--skip-fetch] [--skip-push]");
     std::process::exit(1);
 }
 
@@ -328,6 +401,10 @@ fn print_ci_local_help_and_exit() -> ! {
     eprintln!(
         "         [--skip-fetch-notes] [--skip-fetch-base] [--skip-fetch-fork-notes] [--skip-fetch] [--skip-push]"
     );
+    eprintln!(
+        "  rebase --previous-base-sha <sha> --previous-head-sha <sha> --base-sha <sha> --head-sha <sha>"
+    );
+    eprintln!("         [--skip-fetch-notes] [--skip-fetch] [--skip-push]");
     std::process::exit(1);
 }
 

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -1,4 +1,5 @@
 use crate::repos::test_repo::TestRepo;
+use std::io::Write;
 
 // ==============================================================================
 // CI Handlers Tests - Module Structure and Types
@@ -31,6 +32,7 @@ fn test_ci_result_types_coverage() {
     let result4 = CiRunResult::SkippedFastForward;
     let result5 = CiRunResult::NoAuthorshipAvailable;
     let result6 = CiRunResult::SyncAuthorshipRewritten { commit_count: 2 };
+    let result7 = CiRunResult::SkippedExistingSyncNotes;
 
     // Verify variants can be constructed
     match result1 {
@@ -62,6 +64,60 @@ fn test_ci_result_types_coverage() {
         CiRunResult::SyncAuthorshipRewritten { commit_count } => assert_eq!(commit_count, 2),
         _ => panic!("Expected SyncAuthorshipRewritten"),
     }
+
+    match result7 {
+        CiRunResult::SkippedExistingSyncNotes => {}
+        _ => panic!("Expected SkippedExistingSyncNotes"),
+    }
+}
+
+#[test]
+fn test_ci_github_run_noops_when_synchronize_has_no_previous_head() {
+    let repo = TestRepo::new();
+    let mut event_file = tempfile::NamedTempFile::new().expect("event file");
+    write!(
+        event_file,
+        r#"{{
+          "action": "synchronize",
+          "before": "0000000000000000000000000000000000000000",
+          "after": "2222222222222222222222222222222222222222",
+          "pull_request": {{
+            "number": 42,
+            "merged": false,
+            "merge_commit_sha": null,
+            "base": {{
+              "ref": "main",
+              "sha": "1111111111111111111111111111111111111111",
+              "repo": {{ "clone_url": "https://github.com/acme/repo.git" }}
+            }},
+            "head": {{
+              "ref": "feature",
+              "sha": "2222222222222222222222222222222222222222",
+              "repo": {{ "clone_url": "https://github.com/acme/repo.git" }}
+            }}
+          }}
+        }}"#
+    )
+    .expect("write event");
+
+    let output = repo
+        .git_ai_with_env(
+            &["ci", "github", "run", "--no-cleanup"],
+            &[
+                ("GITHUB_EVENT_NAME", "pull_request"),
+                (
+                    "GITHUB_EVENT_PATH",
+                    event_file.path().to_str().expect("event path"),
+                ),
+            ],
+        )
+        .expect("github ci run should no-op successfully");
+
+    assert!(
+        output.contains("No GitHub CI context found; nothing to do"),
+        "Expected no-op output, got: {}",
+        output
+    );
 }
 
 // ==============================================================================

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -30,6 +30,7 @@ fn test_ci_result_types_coverage() {
     let result3 = CiRunResult::SkippedSimpleMerge;
     let result4 = CiRunResult::SkippedFastForward;
     let result5 = CiRunResult::NoAuthorshipAvailable;
+    let result6 = CiRunResult::RebaseAuthorshipRewritten { commit_count: 2 };
 
     // Verify variants can be constructed
     match result1 {
@@ -55,6 +56,11 @@ fn test_ci_result_types_coverage() {
     match result5 {
         CiRunResult::NoAuthorshipAvailable => {}
         _ => panic!("Expected NoAuthorshipAvailable"),
+    }
+
+    match result6 {
+        CiRunResult::RebaseAuthorshipRewritten { commit_count } => assert_eq!(commit_count, 2),
+        _ => panic!("Expected RebaseAuthorshipRewritten"),
     }
 }
 
@@ -94,6 +100,7 @@ fn test_ci_event_merge_structure() {
                 Some("https://example.com/fork.git".to_string())
             );
         }
+        CiEvent::Rebase { .. } => panic!("Expected Merge"),
     }
 }
 

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -30,7 +30,7 @@ fn test_ci_result_types_coverage() {
     let result3 = CiRunResult::SkippedSimpleMerge;
     let result4 = CiRunResult::SkippedFastForward;
     let result5 = CiRunResult::NoAuthorshipAvailable;
-    let result6 = CiRunResult::RebaseAuthorshipRewritten { commit_count: 2 };
+    let result6 = CiRunResult::SyncAuthorshipRewritten { commit_count: 2 };
 
     // Verify variants can be constructed
     match result1 {
@@ -59,8 +59,8 @@ fn test_ci_result_types_coverage() {
     }
 
     match result6 {
-        CiRunResult::RebaseAuthorshipRewritten { commit_count } => assert_eq!(commit_count, 2),
-        _ => panic!("Expected RebaseAuthorshipRewritten"),
+        CiRunResult::SyncAuthorshipRewritten { commit_count } => assert_eq!(commit_count, 2),
+        _ => panic!("Expected SyncAuthorshipRewritten"),
     }
 }
 
@@ -100,7 +100,7 @@ fn test_ci_event_merge_structure() {
                 Some("https://example.com/fork.git".to_string())
             );
         }
-        CiEvent::Rebase { .. } => panic!("Expected Merge"),
+        CiEvent::Sync { .. } => panic!("Expected Merge"),
     }
 }
 

--- a/tests/integration/ci_partial_clone.rs
+++ b/tests/integration/ci_partial_clone.rs
@@ -77,6 +77,7 @@ fn test_squash_merge_single_parent_not_on_base_ref() {
         skip_fetch_notes: true,
         skip_fetch_base: true,
         skip_fetch_fork_notes: true,
+        skip_fetch_sync_refs: false,
         skip_push: false,
     });
 
@@ -146,6 +147,7 @@ fn test_single_commit_rebase_parent_on_base_ref() {
         skip_fetch_notes: true,
         skip_fetch_base: true,
         skip_fetch_fork_notes: true,
+        skip_fetch_sync_refs: false,
         skip_push: false,
     });
 
@@ -226,6 +228,7 @@ fn test_multi_commit_squash_merge_single_parent() {
         skip_fetch_notes: true,
         skip_fetch_base: true,
         skip_fetch_fork_notes: true,
+        skip_fetch_sync_refs: false,
         skip_push: false,
     });
 
@@ -316,6 +319,7 @@ fn test_regular_two_parent_merge_skipped() {
         skip_fetch_notes: true,
         skip_fetch_base: true,
         skip_fetch_fork_notes: true,
+        skip_fetch_sync_refs: false,
         skip_push: false,
     });
 

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1,6 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::git::refs::get_reference_as_authorship_log_v3;
+use git_ai::git::refs::notes_add;
 use git_ai::git::repository as GitAiRepository;
 
 fn direct_test_repo() -> TestRepo {
@@ -1152,6 +1153,166 @@ fn test_ci_local_open_pr_rebase_two_commits() {
         !files2.iter().any(|f| f.contains("file_a")),
         "rebased PR commit 2 should not reference file_a.txt, got: {:?}",
         files2
+    );
+}
+
+/// Verify that `git-ai ci local sync` handles GitHub's conflict-free
+/// Update-branch-with-rebase shape for a single-commit PR. A single commit is
+/// the easiest case to accidentally treat as a fast-forward/no-op or to mishandle
+/// when computing merge bases.
+#[test]
+fn test_ci_local_open_pr_rebase_single_commit() {
+    use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+
+    let repo = direct_test_repo();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.set_contents(crate::lines!["ai content".ai()]);
+    let previous_head_sha = repo.stage_all_and_commit("Add feature").unwrap().commit_sha;
+
+    repo.git_og(&["checkout", "main"]).unwrap();
+    let mut main_file = repo.filename("main_only.txt");
+    main_file.set_contents(crate::lines!["main-only content"]);
+    repo.git_og(&["add", "main_only.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Advance main"]).unwrap();
+    let base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    repo.git_og(&["checkout", "feature"]).unwrap();
+    repo.git_og(&["rebase", "main"]).unwrap();
+    let current_head_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    assert_ne!(current_head_sha, previous_head_sha);
+    assert!(
+        repo.read_authorship_note(&current_head_sha).is_none(),
+        "bypassed rebase should not pre-create note for the rebased commit"
+    );
+
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "sync",
+            "--previous-head-sha",
+            previous_head_sha.as_str(),
+            "--base-ref",
+            "main",
+            "--base-sha",
+            base_sha.as_str(),
+            "--head-sha",
+            current_head_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-push",
+        ])
+        .expect("ci local sync should succeed");
+
+    assert!(
+        output.contains("Local CI (sync): authorship rewritten successfully"),
+        "Expected authorship rewritten, got: {}",
+        output
+    );
+
+    let note = repo
+        .read_authorship_note(&current_head_sha)
+        .expect("rebased single PR commit should have an authorship note");
+    let files: Vec<String> = AuthorshipLog::deserialize_from_string(&note)
+        .unwrap()
+        .attestations
+        .iter()
+        .map(|a| a.file_path.clone())
+        .collect();
+    assert!(
+        files.iter().any(|f| f.contains("feature.txt")),
+        "rebased single PR commit should reference feature.txt, got: {:?}",
+        files
+    );
+}
+
+/// If the client-side git-ai CLI already handled the local rebase and pushed or
+/// materialized notes for the new PR commits, CI must not regenerate those notes.
+/// This is the conservative safety boundary for all PR synchronize events.
+#[test]
+fn test_ci_local_sync_skips_when_current_rebased_commit_already_has_note() {
+    let repo = direct_test_repo();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.set_contents(crate::lines!["ai content".ai()]);
+    let previous_head_sha = repo.stage_all_and_commit("Add feature").unwrap().commit_sha;
+
+    repo.git_og(&["checkout", "main"]).unwrap();
+    let mut main_file = repo.filename("main_only.txt");
+    main_file.set_contents(crate::lines!["main-only content"]);
+    repo.git_og(&["add", "main_only.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Advance main"]).unwrap();
+    let base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    repo.git_og(&["checkout", "feature"]).unwrap();
+    repo.git_og(&["rebase", "main"]).unwrap();
+    let current_head_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let gitai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().expect("repo path"))
+            .expect("git-ai repo");
+    let existing_note = "client-side-note-that-ci-must-not-overwrite";
+    notes_add(&gitai_repo, &current_head_sha, existing_note).expect("add existing current note");
+
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "sync",
+            "--previous-head-sha",
+            previous_head_sha.as_str(),
+            "--base-ref",
+            "main",
+            "--base-sha",
+            base_sha.as_str(),
+            "--head-sha",
+            current_head_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-push",
+        ])
+        .expect("ci local sync should succeed");
+
+    assert!(
+        output.contains("Local CI (sync): skipped PR sync with existing current notes"),
+        "Expected existing-note skip, got: {}",
+        output
+    );
+    let current_note = repo
+        .read_authorship_note(&current_head_sha)
+        .map(|note| note.trim().to_string());
+    assert_eq!(
+        current_note.as_deref(),
+        Some(existing_note),
+        "CI sync must not overwrite a current commit note that already exists"
     );
 }
 

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1013,6 +1013,152 @@ fn test_ci_local_rebase_merge_three_commits() {
     );
 }
 
+/// Verify that `git-ai ci local rebase` preserves authorship when an open PR
+/// branch is rebased onto a newer base tip before it is merged. This matches the
+/// shape of GitHub's "Update branch -> Rebase" operation: the PR head is
+/// rewritten, but there is no merge commit yet.
+#[test]
+fn test_ci_local_open_pr_rebase_two_commits() {
+    use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+
+    let repo = direct_test_repo();
+
+    // --- Initial commit on main ---
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+    let previous_base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- Feature branch: two AI commits touching distinct files ---
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+
+    let mut file_a = repo.filename("file_a.txt");
+    file_a.set_contents(crate::lines!["ai content in file_a".ai()]);
+    let feature_sha1 = repo.stage_all_and_commit("Add file_a").unwrap().commit_sha;
+
+    let mut file_b = repo.filename("file_b.txt");
+    file_b.set_contents(crate::lines!["ai content in file_b".ai()]);
+    let feature_sha2 = repo.stage_all_and_commit("Add file_b").unwrap().commit_sha;
+
+    let previous_head_sha = feature_sha2.clone();
+
+    // --- Advance main so the open-PR rebase produces new SHAs ---
+    repo.git_og(&["checkout", "main"]).unwrap();
+    let mut main_file = repo.filename("main_only.txt");
+    main_file.set_contents(crate::lines!["main-only content"]);
+    repo.git_og(&["add", "main_only.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Advance main"]).unwrap();
+    let base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // --- Rebase the open feature branch onto main, bypassing local hooks ---
+    repo.git_og(&["checkout", "feature"]).unwrap();
+    repo.git_og(&["rebase", "main"]).unwrap();
+
+    let new_sha2 = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let new_sha1 = repo
+        .git_og(&["rev-parse", "HEAD~1"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    assert_ne!(
+        new_sha1, feature_sha1,
+        "open-PR rebase must produce a new SHA for commit 1"
+    );
+    assert_ne!(
+        new_sha2, feature_sha2,
+        "open-PR rebase must produce a new SHA for commit 2"
+    );
+    assert!(
+        repo.read_authorship_note(&new_sha1).is_none(),
+        "bypassed rebase should not pre-create note for commit 1"
+    );
+    assert!(
+        repo.read_authorship_note(&new_sha2).is_none(),
+        "bypassed rebase should not pre-create note for commit 2"
+    );
+
+    // --- Run the new open-PR rebase command ---
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "rebase",
+            "--previous-base-sha",
+            previous_base_sha.as_str(),
+            "--previous-head-sha",
+            previous_head_sha.as_str(),
+            "--base-sha",
+            base_sha.as_str(),
+            "--head-sha",
+            new_sha2.as_str(),
+            "--skip-fetch-notes",
+            "--skip-push",
+        ])
+        .expect("ci local rebase should succeed");
+
+    assert!(
+        output.contains("Local CI (rebase): authorship rewritten successfully"),
+        "Expected authorship rewritten, got: {}",
+        output
+    );
+
+    // --- Verify each rebased open-PR commit carries notes for its own file ---
+    let note1 = repo
+        .read_authorship_note(&new_sha1)
+        .expect("rebased PR commit 1 should have an authorship note");
+    let note2 = repo
+        .read_authorship_note(&new_sha2)
+        .expect("rebased PR commit 2 should have an authorship note");
+
+    let files1: Vec<String> = AuthorshipLog::deserialize_from_string(&note1)
+        .unwrap()
+        .attestations
+        .iter()
+        .map(|a| a.file_path.clone())
+        .collect();
+    let files2: Vec<String> = AuthorshipLog::deserialize_from_string(&note2)
+        .unwrap()
+        .attestations
+        .iter()
+        .map(|a| a.file_path.clone())
+        .collect();
+
+    assert!(
+        files1.iter().any(|f| f.contains("file_a")),
+        "rebased PR commit 1 should reference file_a.txt, got: {:?}",
+        files1
+    );
+    assert!(
+        !files1.iter().any(|f| f.contains("file_b")),
+        "rebased PR commit 1 should not reference file_b.txt, got: {:?}",
+        files1
+    );
+    assert!(
+        files2.iter().any(|f| f.contains("file_b")),
+        "rebased PR commit 2 should reference file_b.txt, got: {:?}",
+        files2
+    );
+    assert!(
+        !files2.iter().any(|f| f.contains("file_a")),
+        "rebased PR commit 2 should not reference file_a.txt, got: {:?}",
+        files2
+    );
+}
+
 /// Standard-human variant of test_ci_squash_merge_basic.
 /// Uses unattributed (checkpoint --) human lines instead of known-human attribution.
 #[test]

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -601,6 +601,7 @@ fn test_ci_rebase_merge_commit_order_pairing() {
         skip_fetch_notes: true,
         skip_fetch_base: true,
         skip_fetch_fork_notes: true,
+        skip_fetch_sync_refs: false,
         skip_push: false,
     });
     assert!(
@@ -1013,7 +1014,7 @@ fn test_ci_local_rebase_merge_three_commits() {
     );
 }
 
-/// Verify that `git-ai ci local rebase` preserves authorship when an open PR
+/// Verify that `git-ai ci local sync` preserves authorship when an open PR
 /// branch is rebased onto a newer base tip before it is merged. This matches the
 /// shape of GitHub's "Update branch -> Rebase" operation: the PR head is
 /// rewritten, but there is no merge commit yet.
@@ -1028,11 +1029,6 @@ fn test_ci_local_open_pr_rebase_two_commits() {
     base_file.set_contents(crate::lines!["base content"]);
     repo.stage_all_and_commit("Initial commit").unwrap();
     repo.git(&["branch", "-M", "main"]).unwrap();
-    let previous_base_sha = repo
-        .git_og(&["rev-parse", "HEAD"])
-        .unwrap()
-        .trim()
-        .to_string();
 
     // --- Feature branch: two AI commits touching distinct files ---
     repo.git_og(&["checkout", "-b", "feature"]).unwrap();
@@ -1091,16 +1087,16 @@ fn test_ci_local_open_pr_rebase_two_commits() {
         "bypassed rebase should not pre-create note for commit 2"
     );
 
-    // --- Run the new open-PR rebase command ---
+    // --- Run the new open-PR sync command ---
     let output = repo
         .git_ai(&[
             "ci",
             "local",
-            "rebase",
-            "--previous-base-sha",
-            previous_base_sha.as_str(),
+            "sync",
             "--previous-head-sha",
             previous_head_sha.as_str(),
+            "--base-ref",
+            "main",
             "--base-sha",
             base_sha.as_str(),
             "--head-sha",
@@ -1108,10 +1104,10 @@ fn test_ci_local_open_pr_rebase_two_commits() {
             "--skip-fetch-notes",
             "--skip-push",
         ])
-        .expect("ci local rebase should succeed");
+        .expect("ci local sync should succeed");
 
     assert!(
-        output.contains("Local CI (rebase): authorship rewritten successfully"),
+        output.contains("Local CI (sync): authorship rewritten successfully"),
         "Expected authorship rewritten, got: {}",
         output
     );
@@ -1156,6 +1152,68 @@ fn test_ci_local_open_pr_rebase_two_commits() {
         !files2.iter().any(|f| f.contains("file_a")),
         "rebased PR commit 2 should not reference file_a.txt, got: {:?}",
         files2
+    );
+}
+
+/// Verify that `git-ai ci local sync` can run for every PR synchronize event
+/// without treating arbitrary non-fast-forward updates as rebases.
+#[test]
+fn test_ci_local_sync_skips_non_rebase_force_push() {
+    let repo = direct_test_repo();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    repo.git_og(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.set_contents(crate::lines!["old ai content".ai()]);
+    let previous_head_sha = repo
+        .stage_all_and_commit("Add old AI content")
+        .unwrap()
+        .commit_sha;
+    assert!(
+        repo.read_authorship_note(&previous_head_sha).is_some(),
+        "old PR head should have an authorship note"
+    );
+
+    repo.git_og(&["reset", "--hard", "main"]).unwrap();
+    feature_file.set_contents(crate::lines!["different force-pushed content"]);
+    repo.git_og(&["add", "feature.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Force-pushed replacement"])
+        .unwrap();
+    let current_head_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "sync",
+            "--previous-head-sha",
+            previous_head_sha.as_str(),
+            "--base-ref",
+            "main",
+            "--head-sha",
+            current_head_sha.as_str(),
+            "--skip-fetch-notes",
+            "--skip-fetch-sync-refs",
+            "--skip-push",
+        ])
+        .expect("ci local sync should succeed for non-rebase force push");
+
+    assert!(
+        output.contains("Local CI (sync): skipped non-rebase PR sync"),
+        "Expected non-rebase sync skip, got: {}",
+        output
+    );
+    assert!(
+        repo.read_authorship_note(&current_head_sha).is_none(),
+        "non-rebase sync must not transfer old authorship to unrelated replacement commit"
     );
 }
 
@@ -1586,6 +1644,7 @@ fn test_ci_squash_merge_not_misclassified_as_rebase_on_linear_main() {
         skip_fetch_notes: true,
         skip_fetch_base: true,
         skip_fetch_fork_notes: true,
+        skip_fetch_sync_refs: false,
         skip_push: true,
     })
     .expect("CI merge rewrite should succeed");


### PR DESCRIPTION
## Summary

- add `git-ai ci local rebase` for open PR head rewrites, using previous/current head and base ranges
- handle GitHub `pull_request.synchronize` events in the installed workflow and infer non-fast-forward PR head updates from `before`/`after`
- preserve authorship notes after GitHub UI "Update branch -> Rebase" rewrites PR commit SHAs

## Notes

GitHub does not emit a distinct event for "Update branch -> Rebase". It arrives as `pull_request.synchronize`, the same as a push or force-push. This change treats ordinary fast-forward updates as a no-op and rewrites notes only when the previous head is not an ancestor of the current head.

## Validation

- `task fmt`
- `task lint`
- `task test TEST_FILTER=test_github_synchronize_payload_deserializes_before_after NO_CAPTURE=true`
- `task test TEST_FILTER=test_ci_local_open_pr_rebase_two_commits NO_CAPTURE=true`
- `PATH=$(printf '%s' "$PATH" | tr ':' '\n' | rg -v '^/home/ubuntu/\.git-ai/bin$' | paste -sd ':' -) task test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->