### PR TITLE
[codex] Enable transcript sweep by default

### DIFF
--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -81,7 +81,7 @@ define_feature_flags!(
     rewrite_stash: rewrite_stash, debug = true, release = true,
     auth_keyring: auth_keyring, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
-    transcript_sweep: transcript_sweep, debug = true, release = false,
+    transcript_sweep: transcript_sweep, debug = true, release = true,
     checkpoint_debug_log: checkpoint_debug_log, debug = false, release = false,
 );
 
@@ -144,7 +144,7 @@ mod tests {
             assert!(flags.rewrite_stash);
             assert!(!flags.auth_keyring);
             assert!(flags.transcript_streaming);
-            assert!(!flags.transcript_sweep);
+            assert!(flags.transcript_sweep);
             assert!(!flags.checkpoint_debug_log);
         }
     }


### PR DESCRIPTION
## Summary

Enable the `transcript_sweep` feature flag by default in both debug and release builds.

## Details

- Sets the release default for `transcript_sweep` to `true`.
- Updates the default feature flag test expectation for release builds so it matches the new default.

## Validation

- `task fmt`
- `task lint`
- `task test TEST_FILTER=test_default_feature_flags`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->