### PR TITLE
fix(jetbrains): prevent PostHog/Sentry errors from reaching IDE error dialog

### DIFF
--- a/agent-support/intellij/build.gradle.kts
+++ b/agent-support/intellij/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 plugins {
     id("java") // Java support
@@ -116,6 +117,10 @@ intellijPlatform {
     }
 
     pluginVerification {
+        failureLevel = listOf(
+            VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+        )
         ides {
             recommended()
         }

--- a/agent-support/intellij/build.gradle.kts
+++ b/agent-support/intellij/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
-import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 plugins {
     id("java") // Java support
@@ -117,10 +116,6 @@ intellijPlatform {
     }
 
     pluginVerification {
-        failureLevel = listOf(
-            VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
-            VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
-        )
         ides {
             recommended()
         }

--- a/agent-support/intellij/gradle.properties
+++ b/agent-support/intellij/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.usegitai.plugins.jetbrains
 pluginName = Git AI
 pluginRepositoryUrl = https://github.com/git-ai-project/git-ai
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.11
+pluginVersion = 0.1.12
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.plugins.template.services
 
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
@@ -244,7 +243,8 @@ class TelemetryService : Disposable {
 
     private fun getPluginVersion(): String {
         return try {
-            PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "unknown"
+            @Suppress("UnstableApiUsage")
+            PluginManager.getPluginByClass(this::class.java)?.version ?: "unknown"
         } catch (e: Exception) {
             "unknown"
         }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -240,17 +240,19 @@ class TelemetryService : Disposable {
         }
     }
 
-    private fun getPluginVersion(): String {
-        return try {
+    private val pluginVersion: String by lazy {
+        try {
             val xml = this::class.java.classLoader
                 .getResourceAsStream("META-INF/plugin.xml")
-                ?.bufferedReader()?.readText() ?: return "unknown"
+                ?.bufferedReader()?.use { it.readText() } ?: return@lazy "unknown"
             Regex("<version>(.+?)</version>").find(xml)
                 ?.groupValues?.get(1) ?: "unknown"
         } catch (_: Exception) {
             "unknown"
         }
     }
+
+    private fun getPluginVersion(): String = pluginVersion
 
     private fun getCommonProperties(): Map<String, Any> {
         return mapOf(

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -174,7 +174,7 @@ class TelemetryService : Disposable {
         try {
             Sentry.init { options ->
                 options.dsn = SENTRY_DSN
-                options.release = getPluginVersion()
+                options.release = pluginVersion
                 options.environment = "production"
                 options.tracesSampleRate = 0.3
                 options.setTag("ide", "intellij")
@@ -252,14 +252,12 @@ class TelemetryService : Disposable {
         }
     }
 
-    private fun getPluginVersion(): String = pluginVersion
-
     private fun getCommonProperties(): Map<String, Any> {
         return mapOf(
             "ide" to "intellij",
             "ide_version" to ApplicationInfo.getInstance().fullVersion,
             "ide_build" to ApplicationInfo.getInstance().build.asString(),
-            "plugin_version" to getPluginVersion(),
+            "plugin_version" to pluginVersion,
             "os" to (System.getProperty("os.name") ?: "unknown"),
             "arch" to (System.getProperty("os.arch") ?: "unknown")
         )

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.plugins.template.services
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
@@ -243,9 +242,12 @@ class TelemetryService : Disposable {
 
     private fun getPluginVersion(): String {
         return try {
-            @Suppress("UnstableApiUsage")
-            PluginManager.getPluginByClass(this::class.java)?.version ?: "unknown"
-        } catch (e: Exception) {
+            val xml = this::class.java.classLoader
+                .getResourceAsStream("META-INF/plugin.xml")
+                ?.bufferedReader()?.readText() ?: return "unknown"
+            Regex("<version>(.+?)</version>").find(xml)
+                ?.groupValues?.get(1) ?: "unknown"
+        } catch (_: Exception) {
             "unknown"
         }
     }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.plugins.template.services
 
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.components.Service
@@ -243,7 +244,7 @@ class TelemetryService : Disposable {
 
     private fun getPluginVersion(): String {
         return try {
-            PluginManager.getPluginByClass(this::class.java)?.version ?: "unknown"
+            PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version ?: "unknown"
         } catch (e: Exception) {
             "unknown"
         }

--- a/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
+++ b/agent-support/intellij/src/main/kotlin/org/jetbrains/plugins/template/services/TelemetryService.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.posthog.java.HttpSender
 import com.posthog.java.PostHog as PostHogClient
+import com.posthog.java.PostHogLogger
 import com.posthog.java.QueueManager
 import com.posthog.java.Sender
 import com.posthog.java.shaded.org.json.JSONObject
@@ -92,8 +93,13 @@ class TelemetryService : Disposable {
                 return
             }
 
+            // Silence PostHog's JUL logger as a safety net — prevents any
+            // SEVERE-level log from reaching IntelliJ's error dialog bridge.
+            silencePostHogJulLogger()
+
             val httpSender = HttpSender.Builder(POSTHOG_API_KEY)
                 .host(POSTHOG_HOST)
+                .logger(SilentPostHogLogger)
                 .build()
             val safeSender = SafeSender(httpSender)
             val queueManager = QueueManager.Builder(safeSender).build()
@@ -104,6 +110,38 @@ class TelemetryService : Disposable {
             logger.info("PostHog initialized with distinct_id: $distinctId")
         } catch (e: Exception) {
             logger.warn("Failed to initialize PostHog: ${e.message}")
+        }
+    }
+
+    /**
+     * No-op PostHogLogger that replaces DefaultPostHogLogger to prevent
+     * PostHog's internal error logging from triggering IntelliJ's IDE
+     * Internal Errors dialog.
+     *
+     * Root cause: HttpSender.send() catches IOException internally and logs
+     * via DefaultPostHogLogger → java.util.logging.Logger.log(Level.SEVERE, ...)
+     * IntelliJ bridges JUL SEVERE to Logger.error() which shows the error
+     * dialog. The SafeSender wrapper never sees these exceptions because
+     * they are caught and logged inside HttpSender before reaching it.
+     */
+    private object SilentPostHogLogger : PostHogLogger {
+        override fun debug(message: String) {}
+        override fun info(message: String) {}
+        override fun warn(message: String) {}
+        override fun error(message: String) {}
+        override fun error(message: String, throwable: Throwable) {}
+    }
+
+    /**
+     * Silences the JUL logger used by PostHog's DefaultPostHogLogger as
+     * a belt-and-suspenders safety net alongside SilentPostHogLogger.
+     */
+    private fun silencePostHogJulLogger() {
+        try {
+            java.util.logging.Logger.getLogger("com.posthog.java.PostHog").level =
+                java.util.logging.Level.OFF
+        } catch (_: Throwable) {
+            // Best effort — ignore if JUL manipulation fails
         }
     }
 


### PR DESCRIPTION
## Summary

**PostHog errors surfacing in IDE Internal Errors dialog**

Root cause: `HttpSender.send()` catches `IOException` internally and logs via `DefaultPostHogLogger` → `java.util.logging.Logger.log(Level.SEVERE, ...)`. IntelliJ bridges JUL `SEVERE` to `Logger.error()`, which triggers the IDE error dialog. The existing `SafeSender` wrapper was ineffective because exceptions never propagate to it — they're caught and logged *inside* `HttpSender`.

Fix: provide a no-op `SilentPostHogLogger` to `HttpSender.Builder.logger()` to replace `DefaultPostHogLogger`, plus silence the JUL logger `com.posthog.java.PostHog` at `Level.OFF` as a safety net.

**Remove internal API usage in `getPluginVersion()`**

`PluginManager.getPluginByClass(Class)` is marked `@ApiStatus.Internal` in IU-262. Replaced with reading the version from `META-INF/plugin.xml` via the plugin's classloader — the Gradle plugin already patches `<version>` into plugin.xml at build time, so no internal IntelliJ APIs are needed.

Link to Devin session: https://app.devin.ai/sessions/e1696047b2f248f0b5ed92e1dcb8e8ee
Requested by: @svarlamov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->