### PR TITLE
fix(telemetry): stash events to SQLite when server returns HTTP 200 with errors

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -329,10 +329,19 @@ fn flush_metrics(events: &[MetricEvent]) {
     for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
         if should_upload && !upload_failed && std::time::Instant::now() < deadline {
             let batch = MetricsBatch::new(chunk.to_vec());
-            if client.upload_metrics(&batch).is_ok() {
-                continue;
+            match client.upload_metrics(&batch) {
+                Ok(response) if response.errors.is_empty() => continue,
+                Ok(_) => {
+                    // Server returned 200 but reported partial errors — stash the
+                    // whole chunk so flush_metrics_db can replay it. Without this,
+                    // events are permanently lost: the daemon treats any 200 as
+                    // success and never writes to SQLite.
+                    upload_failed = true;
+                }
+                Err(_) => {
+                    upload_failed = true;
+                }
             }
-            upload_failed = true;
         }
         store_metrics_in_db(chunk);
     }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -3,6 +3,7 @@
 //! Runs inside the daemon process using tokio. Accumulates telemetry envelopes
 //! and CAS payloads, then flushes them to their destinations every 3 seconds.
 
+use crate::api::metrics::MetricsUploadError;
 use crate::api::{ApiClient, ApiContext, CasObject, CasUploadRequest};
 use crate::config::{Config, get_or_create_distinct_id};
 use crate::daemon::control_api::{CasSyncPayload, TelemetryEnvelope};
@@ -331,12 +332,19 @@ fn flush_metrics(events: &[MetricEvent]) {
             let batch = MetricsBatch::new(chunk.to_vec());
             match client.upload_metrics(&batch) {
                 Ok(response) if response.errors.is_empty() => continue,
-                Ok(_) => {
-                    // Server returned 200 but reported partial errors — stash the
-                    // whole chunk so flush_metrics_db can replay it. Without this,
-                    // events are permanently lost: the daemon treats any 200 as
-                    // success and never writes to SQLite.
-                    upload_failed = true;
+                Ok(response) => {
+                    // Server returned 200 but reported partial errors. Stash only
+                    // the failed events so flush_metrics_db can replay them once;
+                    // that replay path treats remaining validation errors as
+                    // terminal to avoid retrying bad events forever.
+                    if let Some(failed_events) =
+                        failed_metric_events_for_retry(chunk, &response.errors)
+                    {
+                        store_metrics_in_db(&failed_events);
+                    } else {
+                        store_metrics_in_db(chunk);
+                    }
+                    continue;
                 }
                 Err(_) => {
                     upload_failed = true;
@@ -345,6 +353,33 @@ fn flush_metrics(events: &[MetricEvent]) {
         }
         store_metrics_in_db(chunk);
     }
+}
+
+fn failed_metric_events_for_retry(
+    events: &[MetricEvent],
+    errors: &[MetricsUploadError],
+) -> Option<Vec<MetricEvent>> {
+    let mut seen_indices = std::collections::HashSet::with_capacity(errors.len());
+    let mut failed_events = Vec::with_capacity(errors.len().min(events.len()));
+
+    for error in errors {
+        if !seen_indices.insert(error.index) {
+            continue;
+        }
+
+        let Some(event) = events.get(error.index) else {
+            tracing::warn!(
+                error_index = error.index,
+                batch_len = events.len(),
+                "telemetry: metrics upload response referenced out-of-range event index"
+            );
+            return None;
+        };
+
+        failed_events.push(event.clone());
+    }
+
+    Some(failed_events)
 }
 
 fn store_metrics_in_db(events: &[MetricEvent]) {
@@ -773,5 +808,53 @@ impl SentryClient {
         } else {
             Err(format!("Sentry returned status {}", status).into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metric_event(event_id: u16) -> MetricEvent {
+        MetricEvent {
+            timestamp: event_id as u32,
+            event_id,
+            values: Default::default(),
+            attrs: Default::default(),
+        }
+    }
+
+    fn upload_error(index: usize) -> MetricsUploadError {
+        MetricsUploadError {
+            index,
+            error: "failed".to_string(),
+        }
+    }
+
+    #[test]
+    fn failed_metric_events_for_retry_selects_only_failed_indices() {
+        let events = vec![metric_event(1), metric_event(2), metric_event(3)];
+        let failed = failed_metric_events_for_retry(&events, &[upload_error(2), upload_error(0)])
+            .expect("valid indices");
+
+        let event_ids: Vec<u16> = failed.iter().map(|event| event.event_id).collect();
+        assert_eq!(event_ids, vec![3, 1]);
+    }
+
+    #[test]
+    fn failed_metric_events_for_retry_deduplicates_indices() {
+        let events = vec![metric_event(1), metric_event(2), metric_event(3)];
+        let failed = failed_metric_events_for_retry(&events, &[upload_error(1), upload_error(1)])
+            .expect("valid indices");
+
+        let event_ids: Vec<u16> = failed.iter().map(|event| event.event_id).collect();
+        assert_eq!(event_ids, vec![2]);
+    }
+
+    #[test]
+    fn failed_metric_events_for_retry_returns_none_for_invalid_index() {
+        let events = vec![metric_event(1), metric_event(2)];
+
+        assert!(failed_metric_events_for_retry(&events, &[upload_error(2)]).is_none());
     }
 }


### PR DESCRIPTION
## Summary

`flush_metrics` in `src/daemon/telemetry_worker.rs` treats any HTTP 200 response as a successful upload and advances without stashing events to SQLite. However, the metrics endpoint can return 200 with a non-empty `errors` array in the body, indicating partial or full failure to process the batch. In that case, the current code silently discards the affected events — they are never written to the local stash, so `flush_metrics_db` has nothing to replay and the data is permanently lost.

- Changed `if client.upload_metrics(&batch).is_ok()` to a `match` that distinguishes between `Ok(response)` with an empty `errors` vec (true success → `continue`) and `Ok(response)` with non-empty errors (partial failure → fall through to `upload_failed = true`)
- Network/serialisation errors (`Err(_)`) continue to behave as before

## Root cause

```rust
// Before — any 200 is treated as success:
if client.upload_metrics(&batch).is_ok() {
    continue;
}
upload_failed = true;

// After — only a 200 with no errors skips the stash:
match client.upload_metrics(&batch) {
    Ok(response) if response.errors.is_empty() => continue,
    Ok(_) => {
        // Server returned 200 but reported partial errors — stash the
        // whole chunk so flush_metrics_db can replay it.
        upload_failed = true;
    }
    Err(_) => {
        upload_failed = true;
    }
}
```

## Impact

Without this fix, any batch where the server returns 200 + non-empty `errors` results in **permanent data loss**: the daemon never writes the events to SQLite, so they cannot be replayed on the next sync cycle.

## Testing

- `cargo check` passes cleanly on aarch64-apple-darwin
- Existing test suite unaffected (no logic changes to the happy path)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->