### PR TITLE
Add Codex hooks.json install option

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,7 @@ use dirs;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::config::NotesBackendKind;
+use crate::config::{CodexHooksFormat, NotesBackendKind};
 use crate::git::repository::find_repository_in_path;
 
 /// Determines the type of pattern value provided
@@ -113,6 +113,7 @@ fn print_config_help() {
     println!("  default_prompt_storage       Fallback storage mode for non-included repos");
     println!("  quiet                        Suppress chart output after commits (bool)");
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
+    println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
     println!("  notes_backend.kind           Notes backend kind (git_notes/http)");
     println!("  notes_backend.backend_url    Notes backend base URL. Required when kind=http.");
     println!(
@@ -139,6 +140,7 @@ fn print_config_help() {
     println!("  git-ai config --add allow_repositories ~/projects/my-repo");
     println!("  git-ai config --add feature_flags.my_flag true");
     println!("  git-ai config --add git_ai_hooks.post_notes_updated \"./my-hook.sh\"");
+    println!("  git-ai config set codex_hooks_format hooks_json");
     println!("  git-ai config unset exclude_repositories");
     println!();
     std::process::exit(0);
@@ -329,6 +331,11 @@ fn show_all_config() -> Result<(), String> {
             .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
     );
 
+    effective_config.insert(
+        "codex_hooks_format".to_string(),
+        Value::String(runtime_config.codex_hooks_format().as_str().to_string()),
+    );
+
     // Feature flags - show effective flags with defaults applied
     let flags_value = serde_json::to_value(runtime_config.get_feature_flags())
         .unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
@@ -433,6 +440,9 @@ fn get_config_value(key: &str) -> Result<(), String> {
             "quiet" => Value::Bool(runtime_config.is_quiet()),
             "git_ai_hooks" => serde_json::to_value(runtime_config.git_ai_hooks())
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
+            "codex_hooks_format" => {
+                Value::String(runtime_config.codex_hooks_format().as_str().to_string())
+            }
             "notes_backend" => {
                 let nb = runtime_config.notes_backend();
                 let mut map = serde_json::Map::new();
@@ -643,6 +653,12 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.git_ai_hooks = Some(parse_git_ai_hooks_object(value)?);
                 crate::config::save_file_config(&file_config)?;
                 println!("[git_ai_hooks]: {}", value);
+            }
+            "codex_hooks_format" => {
+                let format = parse_codex_hooks_format(value)?;
+                file_config.codex_hooks_format = Some(format.as_str().to_string());
+                crate::config::save_file_config(&file_config)?;
+                println!("[codex_hooks_format]: {}", format.as_str());
             }
             _ => return Err(format!("Unknown config key: {}", key)),
         }
@@ -885,6 +901,13 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [git_ai_hooks]: {:?}", v);
+                }
+            }
+            "codex_hooks_format" => {
+                let old_value = file_config.codex_hooks_format.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [codex_hooks_format]: {}", v);
                 }
             }
             _ => return Err(format!("Unknown config key: {}", key)),
@@ -1213,6 +1236,17 @@ fn parse_notes_backend_kind(value: &str) -> Result<NotesBackendKind, String> {
     }
 }
 
+fn parse_codex_hooks_format(value: &str) -> Result<CodexHooksFormat, String> {
+    match value.trim().to_lowercase().as_str() {
+        "config_toml" | "config-toml" => Ok(CodexHooksFormat::ConfigToml),
+        "hooks_json" | "hooks-json" => Ok(CodexHooksFormat::HooksJson),
+        _ => Err(format!(
+            "Invalid codex_hooks_format '{}'. Expected 'config_toml' or 'hooks_json'",
+            value
+        )),
+    }
+}
+
 /// Validate prompt_storage value
 fn validate_prompt_storage_value(value: &str) -> Result<(), String> {
     if value != "default" && value != "notes" && value != "local" {
@@ -1253,6 +1287,27 @@ mod tests {
         assert!(err.contains("default"));
         assert!(err.contains("notes"));
         assert!(err.contains("local"));
+    }
+
+    #[test]
+    fn test_codex_hooks_format_valid_values() {
+        assert_eq!(
+            parse_codex_hooks_format("config_toml").unwrap(),
+            CodexHooksFormat::ConfigToml
+        );
+        assert_eq!(
+            parse_codex_hooks_format("hooks_json").unwrap(),
+            CodexHooksFormat::HooksJson
+        );
+    }
+
+    #[test]
+    fn test_codex_hooks_format_invalid_value() {
+        let result = parse_codex_hooks_format("json");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("config_toml"));
+        assert!(err.contains("hooks_json"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,40 @@ pub struct NotesBackendConfig {
     pub backend_url: Option<String>,
 }
 
+/// Which Codex hook file git-ai should use when installing Codex hooks.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexHooksFormat {
+    /// Default: install git-ai Codex hooks inline in ~/.codex/config.toml.
+    #[default]
+    ConfigToml,
+    /// Install git-ai Codex hooks in ~/.codex/hooks.json.
+    HooksJson,
+}
+
+impl CodexHooksFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodexHooksFormat::ConfigToml => "config_toml",
+            CodexHooksFormat::HooksJson => "hooks_json",
+        }
+    }
+
+    fn from_str(input: &str) -> Option<Self> {
+        match input.trim().to_lowercase().as_str() {
+            "config_toml" | "config-toml" => Some(CodexHooksFormat::ConfigToml),
+            "hooks_json" | "hooks-json" => Some(CodexHooksFormat::HooksJson),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CodexHooksFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 /// Prompt storage mode enum for type-safe handling
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PromptStorageMode {
@@ -118,6 +152,7 @@ pub struct Config {
     allow_superuser: bool,
     custom_attributes: HashMap<String, String>,
     git_ai_hooks: HashMap<String, Vec<String>>,
+    codex_hooks_format: CodexHooksFormat,
     notes_backend: NotesBackendConfig,
     transcript_streaming_lookback_days: Option<u32>,
 }
@@ -194,6 +229,8 @@ pub struct FileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_ai_hooks: Option<HashMap<String, Vec<String>>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_hooks_format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes_backend: Option<NotesBackendConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transcript_streaming_lookback_days: Option<u32>,
@@ -223,6 +260,8 @@ pub struct ConfigPatch {
     pub custom_attributes: Option<HashMap<String, String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feature_flags: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_hooks_format: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes_backend: Option<NotesBackendConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -494,6 +533,10 @@ impl Config {
     /// Returns configured shell commands for a specific hook.
     pub fn git_ai_hook_commands(&self, hook_name: &str) -> Option<&Vec<String>> {
         self.git_ai_hooks.get(hook_name)
+    }
+
+    pub fn codex_hooks_format(&self) -> CodexHooksFormat {
+        self.codex_hooks_format
     }
 
     /// Serialize the effective runtime config into pretty JSON.
@@ -905,6 +948,21 @@ fn build_config() -> Config {
         })
         .collect::<HashMap<String, Vec<String>>>();
 
+    let codex_hooks_format = file_cfg
+        .as_ref()
+        .and_then(|c| c.codex_hooks_format.as_deref())
+        .and_then(|value| {
+            let parsed = CodexHooksFormat::from_str(value);
+            if parsed.is_none() {
+                eprintln!(
+                    "Warning: Invalid codex_hooks_format value '{}', using 'config_toml'",
+                    value
+                );
+            }
+            parsed
+        })
+        .unwrap_or_default();
+
     // Resolve notes_backend config: env vars override file config, which overrides defaults.
     let file_backend = file_cfg.as_ref().and_then(|c| c.notes_backend.clone());
     let kind_from_env = env::var("GIT_AI_NOTES_BACKEND_KIND")
@@ -958,6 +1016,7 @@ fn build_config() -> Config {
             allow_superuser,
             custom_attributes: custom_attributes.clone(),
             git_ai_hooks: git_ai_hooks.clone(),
+            codex_hooks_format,
             notes_backend,
             transcript_streaming_lookback_days,
         };
@@ -986,6 +1045,7 @@ fn build_config() -> Config {
         allow_superuser,
         custom_attributes,
         git_ai_hooks,
+        codex_hooks_format,
         notes_backend,
         transcript_streaming_lookback_days,
     }
@@ -1412,6 +1472,16 @@ fn apply_test_config_patch(config: &mut Config) {
                 deserialized,
             );
         }
+        if let Some(codex_hooks_format) = patch.codex_hooks_format {
+            if let Some(format) = CodexHooksFormat::from_str(&codex_hooks_format) {
+                config.codex_hooks_format = format;
+            } else {
+                eprintln!(
+                    "Warning: Invalid test codex_hooks_format value '{}', ignoring",
+                    codex_hooks_format
+                );
+            }
+        }
         if let Some(nb) = patch.notes_backend {
             config.notes_backend.kind = nb.kind;
             if let Some(url) = nb.backend_url {
@@ -1458,6 +1528,7 @@ mod tests {
             allow_superuser: false,
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
+            codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
         }
@@ -1660,6 +1731,7 @@ mod tests {
             allow_superuser: false,
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
+            codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
         }
@@ -1792,6 +1864,7 @@ mod tests {
             allow_superuser: false,
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
+            codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
         }

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -1,3 +1,4 @@
+use crate::config::{CodexHooksFormat, Config};
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
@@ -207,10 +208,7 @@ impl CodexInstaller {
         })
     }
 
-    fn config_with_installed_hooks(
-        config: &TomlValue,
-        binary_path: &Path,
-    ) -> Result<TomlValue, GitAiError> {
+    fn config_with_hooks_feature_enabled(config: &TomlValue) -> Result<TomlValue, GitAiError> {
         let mut merged = Self::remove_notify_if_git_ai(config)?.unwrap_or(config.clone());
         let root = merged
             .as_table_mut()
@@ -229,6 +227,18 @@ impl CodexInstaller {
                 )])),
             );
         }
+
+        Ok(merged)
+    }
+
+    fn config_with_installed_hooks(
+        config: &TomlValue,
+        binary_path: &Path,
+    ) -> Result<TomlValue, GitAiError> {
+        let mut merged = Self::config_with_hooks_feature_enabled(config)?;
+        let root = merged
+            .as_table_mut()
+            .ok_or_else(|| GitAiError::Generic("Codex config root must be a table".to_string()))?;
 
         // Add inline hooks to config.toml under [hooks] table
         let desired_command = Self::desired_command(binary_path);
@@ -556,6 +566,62 @@ impl CodexInstaller {
         Ok((merged, changed))
     }
 
+    fn hooks_json_with_installed_hooks(
+        hooks_json: &JsonValue,
+        binary_path: &Path,
+    ) -> Result<JsonValue, GitAiError> {
+        let (mut merged, _) = Self::remove_codex_hooks_from_json(hooks_json)?;
+        let root = merged.as_object_mut().ok_or_else(|| {
+            GitAiError::Generic("Codex hooks.json root must be a JSON object".to_string())
+        })?;
+        let hooks_entry = root.entry("hooks").or_insert_with(|| json!({}));
+        if !hooks_entry.is_object() {
+            *hooks_entry = json!({});
+        }
+        let hooks_obj = hooks_entry.as_object_mut().ok_or_else(|| {
+            GitAiError::Generic("Codex hooks field must be a JSON object".to_string())
+        })?;
+
+        let desired_command = Self::desired_command(binary_path);
+        for event_name in CODEX_HOOK_EVENTS {
+            let mut blocks = hooks_obj
+                .get(event_name)
+                .and_then(|value| value.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            let target_idx = blocks
+                .iter()
+                .position(|block| block.get("matcher").is_none())
+                .unwrap_or_else(|| {
+                    blocks.push(json!({ "hooks": [] }));
+                    blocks.len() - 1
+                });
+
+            if !blocks[target_idx].is_object() {
+                blocks[target_idx] = json!({ "hooks": [] });
+            }
+            let block_obj = blocks[target_idx].as_object_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex hooks.json hook block must be an object".to_string())
+            })?;
+            let hooks = block_obj.entry("hooks").or_insert_with(|| json!([]));
+            if !hooks.is_array() {
+                *hooks = json!([]);
+            }
+            let hooks_array = hooks.as_array_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex hooks.json hooks entry must be an array".to_string())
+            })?;
+            hooks_array.push(json!({
+                "type": "command",
+                "command": desired_command.clone(),
+            }));
+
+            hooks_obj.insert(event_name.to_string(), JsonValue::Array(blocks));
+        }
+
+        Ok(merged)
+    }
+
     fn hooks_json_has_any_entries(hooks_json: &JsonValue) -> bool {
         hooks_json
             .get("hooks")
@@ -629,13 +695,36 @@ impl HookInstaller for CodexInstaller {
         } else {
             TomlValue::Table(Map::new())
         };
+        let hooks_json_path = Self::hooks_json_path();
+        let hooks_json = if hooks_json_path.exists() {
+            Self::parse_hooks_json(&fs::read_to_string(&hooks_json_path)?)?
+        } else {
+            json!({})
+        };
+
+        if Config::fresh().codex_hooks_format() == CodexHooksFormat::HooksJson {
+            let config_without_notify =
+                Self::remove_notify_if_git_ai(&config)?.unwrap_or(config.clone());
+            let (config_without_inline_hooks, _) =
+                Self::remove_inline_hooks_from_config(&config_without_notify)?;
+            let desired_config =
+                Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?;
+            let desired_hooks_json =
+                Self::hooks_json_with_installed_hooks(&hooks_json, &params.binary_path)?;
+            let has_json_hooks = Self::hooks_json_has_git_ai_entries(&hooks_json);
+            let hooks_installed = Self::config_hooks_feature_enabled(&config) && has_json_hooks;
+            let hooks_up_to_date = config == desired_config && hooks_json == desired_hooks_json;
+
+            return Ok(HookCheckResult {
+                tool_installed: true,
+                hooks_installed,
+                hooks_up_to_date,
+            });
+        }
 
         let desired_config = Self::config_with_installed_hooks(&config, &params.binary_path)?;
         let has_inline_hooks = Self::config_has_inline_hooks(&config);
-        let has_legacy_hooks_json = Self::hooks_json_path().exists()
-            && Self::parse_hooks_json(&fs::read_to_string(Self::hooks_json_path())?)
-                .map(|json| Self::hooks_json_has_git_ai_entries(&json))
-                .unwrap_or(false);
+        let has_legacy_hooks_json = Self::hooks_json_has_git_ai_entries(&hooks_json);
         let hooks_installed = Self::config_hooks_feature_enabled(&config)
             && (has_inline_hooks || has_legacy_hooks_json);
         let hooks_up_to_date = config == desired_config && !has_legacy_hooks_json;
@@ -666,15 +755,68 @@ impl HookInstaller for CodexInstaller {
         };
 
         let existing_config = Self::parse_config_toml(&existing_config_content)?;
+
+        let existing_hooks_content = if hooks_json_path.exists() {
+            fs::read_to_string(&hooks_json_path)?
+        } else {
+            String::new()
+        };
+        let existing_hooks = Self::parse_hooks_json(&existing_hooks_content)?;
+
+        if Config::fresh().codex_hooks_format() == CodexHooksFormat::HooksJson {
+            let config_without_notify =
+                Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
+            let (config_without_inline_hooks, _) =
+                Self::remove_inline_hooks_from_config(&config_without_notify)?;
+            let merged_config =
+                Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?;
+            let merged_hooks =
+                Self::hooks_json_with_installed_hooks(&existing_hooks, &params.binary_path)?;
+
+            let config_changed = existing_config != merged_config;
+            let hooks_json_changed = existing_hooks != merged_hooks;
+            if !config_changed && !hooks_json_changed {
+                return Ok(None);
+            }
+
+            let mut diff_output = Vec::new();
+
+            if config_changed {
+                let new_config_content = toml::to_string_pretty(&merged_config).map_err(|e| {
+                    GitAiError::Generic(format!("Failed to serialize Codex config.toml: {e}"))
+                })?;
+                diff_output.push(generate_diff(
+                    &config_path,
+                    &existing_config_content,
+                    &new_config_content,
+                ));
+                if !dry_run {
+                    write_atomic(&config_path, new_config_content.as_bytes())?;
+                }
+            }
+
+            if hooks_json_changed {
+                let new_hooks_content = serde_json::to_string_pretty(&merged_hooks)?;
+                diff_output.push(generate_diff(
+                    &hooks_json_path,
+                    &existing_hooks_content,
+                    &new_hooks_content,
+                ));
+                if !dry_run {
+                    write_atomic(&hooks_json_path, new_hooks_content.as_bytes())?;
+                }
+            }
+
+            return Ok(Some(diff_output.join("\n")));
+        }
+
         let merged_config =
             Self::config_with_installed_hooks(&existing_config, &params.binary_path)?;
 
         // Check if legacy hooks.json needs migration
         let (hooks_json_changed, existing_hooks_content) = if hooks_json_path.exists() {
-            let content = fs::read_to_string(&hooks_json_path)?;
-            let existing_hooks = Self::parse_hooks_json(&content)?;
             let (_cleaned_hooks, changed) = Self::remove_codex_hooks_from_json(&existing_hooks)?;
-            (changed, content)
+            (changed, existing_hooks_content)
         } else {
             (false, String::new())
         };
@@ -847,6 +989,19 @@ mod tests {
                 None => std::env::remove_var("USERPROFILE"),
             }
         }
+    }
+
+    fn write_git_ai_config(home: &Path, codex_hooks_format: &str) {
+        let git_ai_dir = home.join(".git-ai");
+        fs::create_dir_all(&git_ai_dir).unwrap();
+        fs::write(
+            git_ai_dir.join("config.json"),
+            serde_json::to_string_pretty(&json!({
+                "codex_hooks_format": codex_hooks_format
+            }))
+            .unwrap(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1634,6 +1789,177 @@ codex_hooks = true
                 }),
                 "git-ai hooks should be removed from hooks.json"
             );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_install_hooks_prefers_hooks_json_when_configured() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            let hooks_json_path = codex_dir.join("hooks.json");
+            fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+            fs::write(
+                &hooks_json_path,
+                serde_json::to_string_pretty(&json!({
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [
+                                    { "type": "command", "command": "echo keep" }
+                                ]
+                            }
+                        ]
+                    }
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+
+            let config_content = fs::read_to_string(&config_path).unwrap();
+            let parsed = CodexInstaller::parse_config_toml(&config_content).unwrap();
+            assert_eq!(
+                parsed
+                    .get("features")
+                    .and_then(|v| v.get("hooks"))
+                    .and_then(|v| v.as_bool()),
+                Some(true),
+                "install should still enable Codex hooks"
+            );
+            assert!(
+                !CodexInstaller::config_has_inline_hooks(&parsed),
+                "configured hooks_json format should not install git-ai inline hooks"
+            );
+
+            let hooks_content = fs::read_to_string(&hooks_json_path).unwrap();
+            let hooks_json: serde_json::Value = serde_json::from_str(&hooks_content).unwrap();
+            assert!(
+                CodexInstaller::hooks_json_has_git_ai_entries(&hooks_json),
+                "git-ai hooks should be installed into hooks.json"
+            );
+            let pre_blocks = hooks_json["hooks"]["PreToolUse"].as_array().unwrap();
+            assert!(
+                pre_blocks.iter().any(|block| {
+                    block["hooks"].as_array().is_some_and(|hooks| {
+                        hooks
+                            .iter()
+                            .any(|hook| hook["command"].as_str() == Some("echo keep"))
+                    })
+                }),
+                "existing hooks.json entries should be preserved"
+            );
+
+            let check = installer
+                .check_hooks(&params)
+                .expect("check should succeed");
+            assert!(check.tool_installed);
+            assert!(check.hooks_installed);
+            assert!(check.hooks_up_to_date);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_install_hooks_prefers_hooks_json_removes_existing_inline_git_ai_hooks() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            let hooks_json_path = codex_dir.join("hooks.json");
+            fs::write(
+                &config_path,
+                r#"
+model = "gpt-5"
+
+[features]
+hooks = true
+
+[[hooks.PreToolUse]]
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "echo keep-inline"
+
+[[hooks.PostToolUse]]
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
+
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
+"#,
+            )
+            .unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+
+            let config_content = fs::read_to_string(&config_path).unwrap();
+            let parsed = CodexInstaller::parse_config_toml(&config_content).unwrap();
+            assert!(
+                !CodexInstaller::config_has_inline_hooks(&parsed),
+                "old git-ai inline hooks should be removed in hooks_json mode"
+            );
+            let pre_blocks = parsed
+                .get("hooks")
+                .and_then(|h| h.get("PreToolUse"))
+                .and_then(|v| v.as_array())
+                .expect("custom PreToolUse block should remain");
+            assert!(
+                pre_blocks.iter().any(|block| {
+                    block
+                        .get("hooks")
+                        .and_then(|v| v.as_array())
+                        .is_some_and(|hooks| {
+                            hooks.iter().any(|hook| {
+                                hook.get("command").and_then(|v| v.as_str())
+                                    == Some("echo keep-inline")
+                            })
+                        })
+                }),
+                "non-git-ai inline hooks should be preserved"
+            );
+
+            let hooks_content = fs::read_to_string(&hooks_json_path).unwrap();
+            let hooks_json: serde_json::Value = serde_json::from_str(&hooks_content).unwrap();
+            assert!(
+                CodexInstaller::hooks_json_has_git_ai_entries(&hooks_json),
+                "git-ai hooks should be installed into hooks.json"
+            );
+
+            let check = installer
+                .check_hooks(&params)
+                .expect("check should succeed");
+            assert!(check.hooks_installed);
+            assert!(check.hooks_up_to_date);
         });
     }
 


### PR DESCRIPTION
Fixes #1538

Summary:
- Adds `codex_hooks_format` to git-ai config with default `config_toml` and opt-in `hooks_json`.
- Keeps the standard Codex install flow unchanged: git-ai still installs inline `[hooks]` in `~/.codex/config.toml` by default.
- When configured with `git-ai config set codex_hooks_format hooks_json`, installs git-ai Codex hooks into `~/.codex/hooks.json`, preserves existing JSON hooks, and removes prior git-ai inline hooks.

Tests:
- `task test TEST_FILTER=test_install_hooks_prefers_hooks_json_when_configured`
- `task test TEST_FILTER=mdm::agents::codex`
- `task test TEST_FILTER=codex_hooks_format`
- `task test`
- `task fmt`
- `task lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->