### PR TITLE
[codex] add git debug self checks

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,7 @@
 use crate::auth::{CredentialStore, OAuthClient};
 use crate::config;
 use crate::error::GitAiError;
-use crate::git::repository::{exec_git, parse_git_var_identity};
+use crate::git::repository::current_git_committer_identity_resolution;
 use crate::http;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
@@ -63,19 +63,15 @@ fn try_load_auth_token() -> Option<String> {
 
 /// Resolve the git author identity without requiring a Repository instance.
 ///
-/// Runs `git var GIT_COMMITTER_IDENT` to get the current user's identity,
+/// Uses the shared git identity helper to get the current user's identity,
 /// respecting the full git precedence chain (env vars > config > system defaults).
 /// Falls back to the system hostname if git identity is unavailable.
 fn resolve_git_identity() -> Option<String> {
-    let args = vec!["var".to_string(), "GIT_COMMITTER_IDENT".to_string()];
-    if let Ok(output) = exec_git(&args)
-        && let Ok(stdout) = String::from_utf8(output.stdout)
-    {
-        let identity = parse_git_var_identity(&stdout);
-        if let Some(formatted) = identity.formatted() {
-            return Some(encode_for_header(&formatted));
-        }
+    let identity = current_git_committer_identity_resolution().identity;
+    if let Some(formatted) = identity.formatted() {
+        return Some(encode_for_header(&formatted));
     }
+
     resolve_fallback_identity().map(|id| encode_for_header(&id))
 }
 

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -3,7 +3,8 @@ use crate::config;
 use crate::diagnostics::{DiagnosticCheckResult, GitDiagnosticTarget};
 use crate::git::find_repository_in_path;
 use crate::git::repository::{
-    GitAuthorIdentity, GitIdentityResolution, global_git_config_committer_identity,
+    GitAuthorIdentity, GitConfigIdentityResolution, GitIdentityResolution,
+    global_git_config_identity_resolution,
 };
 use crate::process_timeout::{TimedCommandOutput, run_command_with_timeout};
 use std::env;
@@ -405,7 +406,7 @@ struct GitDebugDiagnostics {
 }
 
 struct GitCommitterIdentityInfo {
-    global_config: Result<GitAuthorIdentity, String>,
+    global_config: Result<GitConfigIdentityResolution, String>,
     repository: RepositoryCommitterIdentity,
 }
 
@@ -415,7 +416,7 @@ enum RepositoryCommitterIdentity {
 }
 
 fn collect_git_committer_identity_info() -> GitCommitterIdentityInfo {
-    let global_config = global_git_config_committer_identity().map_err(|e| e.to_string());
+    let global_config = global_git_config_identity_resolution().map_err(|e| e.to_string());
     let repository = env::current_dir()
         .map_err(|e| e.to_string())
         .and_then(|cwd| find_repository_in_path(&cwd.to_string_lossy()).map_err(|e| e.to_string()))
@@ -434,7 +435,10 @@ fn append_git_committer_identity(out: &mut String, identity: &GitCommitterIdenti
     let _ = writeln!(out, "== Git Committer Identity ==");
     let _ = writeln!(out, "Global git config identity:");
     match &identity.global_config {
-        Ok(global) => append_git_author_identity(out, global, "  "),
+        Ok(global) => {
+            append_raw_git_config_identity(out, global, "  ");
+            append_git_author_identity(out, &global.identity, "  ");
+        }
         Err(err) => {
             let _ = writeln!(out, "  <error: {}>", err);
         }
@@ -454,6 +458,18 @@ fn append_git_committer_identity(out: &mut String, identity: &GitCommitterIdenti
             let _ = writeln!(out, "  <not in repository: {}>", err);
         }
     }
+}
+
+fn append_raw_git_config_identity(
+    out: &mut String,
+    identity: &GitConfigIdentityResolution,
+    prefix: &str,
+) {
+    let raw_name = identity.raw_name.as_deref().unwrap_or("<unset>");
+    let raw_email = identity.raw_email.as_deref().unwrap_or("<unset>");
+
+    let _ = writeln!(out, "{}Raw user.name: {}", prefix, raw_name);
+    let _ = writeln!(out, "{}Raw user.email: {}", prefix, raw_email);
 }
 
 fn append_git_author_identity(out: &mut String, identity: &GitAuthorIdentity, prefix: &str) {

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -8,6 +8,13 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+const MIN_GIT_VERSION: GitVersion = GitVersion {
+    major: 2,
+    minor: 22,
+    patch: 0,
+};
+const MIN_GIT_VERSION_DISPLAY: &str = "2.22.0";
+
 pub fn handle_debug(args: &[String]) {
     if args
         .iter()
@@ -42,6 +49,7 @@ fn build_debug_report() -> String {
     let shell_git_lookup = collect_shell_git_lookup();
     let git_diagnostics = collect_git_diagnostics(&git_cmd);
     let git_version = run_command_capture(&git_cmd, &["--version"]);
+    let shell_git_version = run_command_capture("git", &["--version"]);
     let git_config = collect_git_config_dump(&git_cmd);
     let git_ai_config = collect_git_ai_config_dump();
     let platform_info = collect_platform_info();
@@ -89,12 +97,32 @@ fn build_debug_report() -> String {
             let _ = writeln!(out, "Shell git realpath: <unavailable>");
         }
     }
-    match git_version {
+    match &git_version {
         Ok(version) => {
             let _ = writeln!(out, "Git version: {}", version);
+            append_git_version_check(&mut out, "Git version check", version);
         }
         Err(err) => {
             let _ = writeln!(out, "Git version: <error: {}>", err);
+            let _ = writeln!(
+                out,
+                "Git version check: <error: unable to verify minimum version {}>",
+                MIN_GIT_VERSION_DISPLAY
+            );
+        }
+    }
+    match &shell_git_version {
+        Ok(version) => {
+            let _ = writeln!(out, "Shell git version: {}", version);
+            append_git_version_check(&mut out, "Shell git version check", version);
+        }
+        Err(err) => {
+            let _ = writeln!(out, "Shell git version: <error: {}>", err);
+            let _ = writeln!(
+                out,
+                "Shell git version check: <error: unable to verify minimum version {}>",
+                MIN_GIT_VERSION_DISPLAY
+            );
         }
     }
     let _ = writeln!(out);
@@ -310,6 +338,7 @@ fn build_debug_report() -> String {
 
 struct GitDebugDiagnostics {
     target: GitDiagnosticTarget,
+    trace2_config: DiagnosticCheckResult,
     attribution: DiagnosticCheckResult,
     trace2: DiagnosticCheckResult,
 }
@@ -323,10 +352,12 @@ fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
     targets
         .into_iter()
         .map(|target| {
+            let trace2_config = crate::diagnostics::check_trace2_global_config(&target);
             let attribution = crate::diagnostics::run_attribution_self_check(&target);
             let trace2 = crate::diagnostics::run_trace2_file_self_check(&target);
             GitDebugDiagnostics {
                 target,
+                trace2_config,
                 attribution,
                 trace2,
             }
@@ -342,6 +373,7 @@ fn append_git_diagnostics(out: &mut String, diagnostics: &[GitDebugDiagnostics])
             "{} (program: {})",
             diagnostic.target.label, diagnostic.target.program
         );
+        append_diagnostic_check(out, "Trace2 config check", &diagnostic.trace2_config, false);
         append_diagnostic_check(
             out,
             "Attribution self-check",
@@ -399,6 +431,74 @@ fn append_diagnostic_check(
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct GitVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl std::fmt::Display for GitVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+fn append_git_version_check(out: &mut String, label: &str, version_output: &str) {
+    match parse_git_version(version_output) {
+        Some(version) if version >= MIN_GIT_VERSION => {
+            let _ = writeln!(
+                out,
+                "{}: version meets or exceeds minimum version of {}",
+                label, MIN_GIT_VERSION_DISPLAY
+            );
+        }
+        Some(version) => {
+            let _ = writeln!(
+                out,
+                "{}: ERROR: detected Git version {} is below minimum version {}",
+                label, version, MIN_GIT_VERSION_DISPLAY
+            );
+        }
+        None => {
+            let _ = writeln!(
+                out,
+                "{}: <error: could not parse Git version from '{}'; minimum version is {}>",
+                label, version_output, MIN_GIT_VERSION_DISPLAY
+            );
+        }
+    }
+}
+
+fn parse_git_version(output: &str) -> Option<GitVersion> {
+    output.split_whitespace().find_map(parse_git_version_token)
+}
+
+fn parse_git_version_token(token: &str) -> Option<GitVersion> {
+    let token = token.trim_start_matches('v');
+    let mut parts = token.split('.');
+    let major = parse_leading_u32(parts.next()?)?;
+    let minor = parse_leading_u32(parts.next()?)?;
+    let patch = parts.next().map(parse_leading_u32).unwrap_or(Some(0))?;
+
+    Some(GitVersion {
+        major,
+        minor,
+        patch,
+    })
+}
+
+fn parse_leading_u32(value: &str) -> Option<u32> {
+    let digits = value
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
 }
 
 struct ShellGitLookup {
@@ -934,6 +1034,32 @@ mod tests {
     #[test]
     fn test_format_bytes() {
         assert_eq!(format_bytes(1024), "1.00 KB (1024 bytes)");
+    }
+
+    #[test]
+    fn test_parse_git_version_handles_platform_suffixes() {
+        assert_eq!(
+            parse_git_version("git version 2.54.0.windows.1"),
+            Some(GitVersion {
+                major: 2,
+                minor: 54,
+                patch: 0
+            })
+        );
+        assert_eq!(
+            parse_git_version("git version 2.39.5 (Apple Git-154)"),
+            Some(GitVersion {
+                major: 2,
+                minor: 39,
+                patch: 5
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_git_version_accepts_minimum_version() {
+        assert!(parse_git_version("git version 2.22.0").unwrap() >= MIN_GIT_VERSION);
+        assert!(parse_git_version("git version 2.21.9").unwrap() < MIN_GIT_VERSION);
     }
 
     #[test]

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -2,11 +2,12 @@ use crate::auth::{AuthState, collect_auth_status, format_unix_timestamp};
 use crate::config;
 use crate::diagnostics::{DiagnosticCheckResult, GitDiagnosticTarget};
 use crate::git::find_repository_in_path;
+use crate::process_timeout::{TimedCommandOutput, run_command_with_timeout};
 use std::env;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::time::Duration;
 
 const MIN_GIT_VERSION: GitVersion = GitVersion {
     major: 2,
@@ -14,6 +15,8 @@ const MIN_GIT_VERSION: GitVersion = GitVersion {
     patch: 0,
 };
 const MIN_GIT_VERSION_DISPLAY: &str = "2.22.0";
+const DEBUG_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
+const DEBUG_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 pub fn handle_debug(args: &[String]) {
     if args
@@ -419,11 +422,18 @@ fn append_diagnostic_check(
             let _ = writeln!(
                 out,
                 "        status: {}",
-                command
-                    .status
-                    .map(|code| code.to_string())
-                    .unwrap_or_else(|| "<unavailable>".to_string())
+                if command.timed_out {
+                    "<timeout>".to_string()
+                } else {
+                    command
+                        .status
+                        .map(|code| code.to_string())
+                        .unwrap_or_else(|| "<unavailable>".to_string())
+                }
             );
+            if command.timed_out {
+                let _ = writeln!(out, "        timed out: yes");
+            }
             if !command.stdout.trim().is_empty() {
                 let _ = writeln!(out, "        stdout:");
                 append_indented_block_with_prefix(out, &command.stdout, "          ");
@@ -595,16 +605,41 @@ fn append_indented_block_with_prefix(out: &mut String, content: &str, prefix: &s
 }
 
 fn run_command_capture(program: &str, args: &[&str]) -> Result<String, String> {
-    let output = Command::new(program)
-        .args(args)
-        .output()
-        .map_err(|e| format!("failed to execute '{}': {}", program, e))?;
+    run_command_capture_with_timeout(program, args, DEBUG_COMMAND_TIMEOUT)
+}
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+fn run_command_capture_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<String, String> {
+    let command = format_command_for_error(program, args);
+    let output =
+        run_command_with_timeout(program, args, None, timeout, DEBUG_COMMAND_POLL_INTERVAL)
+            .map_err(|e| {
+                format!(
+                    "failed to execute '{}': {}",
+                    program,
+                    strip_execute_prefix(&e)
+                )
+            })?;
+
+    if output.timed_out {
+        return Err(format_timeout_capture_error(&command, timeout, output));
+    }
+    if output.wait_error.is_some() {
+        return Err(format_wait_capture_error(&command, output));
+    }
+
+    command_output_to_result(output)
+}
+
+fn command_output_to_result(output: TimedCommandOutput) -> Result<String, String> {
+    if output.status != Some(0) {
+        let mut stderr = output.stderr.trim().to_string();
+        append_debug_diagnostics(&mut stderr, &output.diagnostics);
         let code = output
             .status
-            .code()
             .map(|c| c.to_string())
             .unwrap_or_else(|| "signal".to_string());
         if stderr.is_empty() {
@@ -613,7 +648,85 @@ fn run_command_capture(program: &str, args: &[&str]) -> Result<String, String> {
         return Err(format!("exit code {}: {}", code, stderr));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok(output.stdout)
+}
+
+fn format_timeout_capture_error(
+    command: &str,
+    timeout: Duration,
+    output: TimedCommandOutput,
+) -> String {
+    let mut message = format!(
+        "timed out after {:.1}s running '{}'",
+        timeout.as_secs_f64(),
+        command
+    );
+    append_debug_diagnostics(&mut message, &output.diagnostics);
+    if let Some(wait_error) = output.wait_error {
+        message.push_str(&format!("; failed while waiting: {}", wait_error));
+    }
+    if !output.stdout.trim().is_empty() {
+        message.push_str(&format!(
+            "; stdout before timeout: {}",
+            output.stdout.trim()
+        ));
+    }
+    if !output.stderr.trim().is_empty() {
+        message.push_str(&format!(
+            "; stderr before timeout: {}",
+            output.stderr.trim()
+        ));
+    }
+    message
+}
+
+fn format_wait_capture_error(command: &str, output: TimedCommandOutput) -> String {
+    let wait_error = output.wait_error.as_deref().unwrap_or("unknown wait error");
+    let mut message = format!("failed while waiting for '{}': {}", command, wait_error);
+    append_debug_diagnostics(&mut message, &output.diagnostics);
+    if !output.stdout.trim().is_empty() {
+        message.push_str(&format!(
+            "; stdout before wait failure: {}",
+            output.stdout.trim()
+        ));
+    }
+    if !output.stderr.trim().is_empty() {
+        message.push_str(&format!(
+            "; stderr before wait failure: {}",
+            output.stderr.trim()
+        ));
+    }
+    message
+}
+
+fn append_debug_diagnostics(message: &mut String, diagnostics: &[String]) {
+    for diagnostic in diagnostics {
+        message.push_str("; ");
+        message.push_str(diagnostic);
+    }
+}
+
+fn strip_execute_prefix(error: &str) -> &str {
+    error.strip_prefix("failed to execute: ").unwrap_or(error)
+}
+
+fn format_command_for_error(program: &str, args: &[&str]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().copied())
+        .map(shell_quote_for_error)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote_for_error(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "-_./:=@".contains(ch))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 #[derive(Default)]
@@ -1009,6 +1122,26 @@ fn redact_env_value(key: &str, value: &str) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(not(windows))]
+    fn stdout_stderr_sleep_command() -> (&'static str, Vec<&'static str>) {
+        (
+            "sh",
+            vec!["-c", "printf out; printf err >&2; exec sleep 60"],
+        )
+    }
+
+    #[cfg(windows)]
+    fn stdout_stderr_sleep_command() -> (&'static str, Vec<&'static str>) {
+        (
+            "powershell.exe",
+            vec![
+                "-NoProfile",
+                "-Command",
+                "[Console]::Out.Write('out'); [Console]::Error.Write('err'); Start-Sleep -Seconds 60",
+            ],
+        )
+    }
+
     #[test]
     fn test_redact_git_config_line_redacts_sensitive_key() {
         let line =
@@ -1134,5 +1267,21 @@ mod tests {
             realpath_for_display(&exe.display().to_string()),
             expected.display().to_string()
         );
+    }
+
+    #[test]
+    fn test_run_command_capture_with_timeout_reports_partial_output() {
+        let (program, args) = stdout_stderr_sleep_command();
+        let err = run_command_capture_with_timeout(program, &args, Duration::from_millis(300))
+            .unwrap_err();
+
+        assert!(err.contains("timed out after"), "{err}");
+        assert!(
+            err.contains("sent kill to child process")
+                || err.contains("failed to kill child process"),
+            "{err}"
+        );
+        assert!(err.contains("stdout before timeout: out"), "{err}");
+        assert!(err.contains("stderr before timeout: err"), "{err}");
     }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -17,6 +17,12 @@ const MIN_GIT_VERSION: GitVersion = GitVersion {
 const MIN_GIT_VERSION_DISPLAY: &str = "2.22.0";
 const DEBUG_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
 const DEBUG_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const SKIP_TRACE2_CHECKS_FLAG: &str = "--skip-trace2-checks";
+
+#[derive(Debug, Clone, Copy, Default)]
+struct DebugOptions {
+    skip_trace2_checks: bool,
+}
 
 pub fn handle_debug(args: &[String]) {
     if args
@@ -27,13 +33,16 @@ pub fn handle_debug(args: &[String]) {
         std::process::exit(0);
     }
 
-    if !args.is_empty() {
-        eprintln!("Error: unknown debug argument(s): {}", args.join(" "));
-        print_debug_help();
-        std::process::exit(1);
-    }
+    let options = match parse_debug_options(args) {
+        Ok(options) => options,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            print_debug_help();
+            std::process::exit(1);
+        }
+    };
 
-    let report = build_debug_report();
+    let report = build_debug_report(options);
     println!("{}", report);
 }
 
@@ -41,26 +50,64 @@ fn print_debug_help() {
     eprintln!("git-ai debug - Print diagnostic information for troubleshooting");
     eprintln!();
     eprintln!("Usage:");
-    eprintln!("  git-ai debug");
+    eprintln!("  git-ai debug [--skip-trace2-checks]");
     eprintln!("  git-ai debug --help");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!(
+        "  {}  Skip per-git Trace2 config and Trace2 file self-checks",
+        SKIP_TRACE2_CHECKS_FLAG
+    );
 }
 
-fn build_debug_report() -> String {
+fn parse_debug_options(args: &[String]) -> Result<DebugOptions, String> {
+    let mut options = DebugOptions::default();
+    for arg in args {
+        match arg.as_str() {
+            SKIP_TRACE2_CHECKS_FLAG => options.skip_trace2_checks = true,
+            unknown => return Err(format!("unknown debug argument: {}", unknown)),
+        }
+    }
+    Ok(options)
+}
+
+fn debug_progress(message: impl AsRef<str>) {
+    eprintln!(
+        "[{}] git-ai debug: {}",
+        chrono::Utc::now().to_rfc3339(),
+        message.as_ref()
+    );
+}
+
+fn build_debug_report(options: DebugOptions) -> String {
+    debug_progress("starting debug report");
     let config = config::Config::get();
     let git_cmd = config.git_cmd().to_string();
+    debug_progress("resolving configured and shell git paths");
     let git_cmd_realpath = realpath_for_display(&git_cmd);
     let shell_git_lookup = collect_shell_git_lookup();
+    debug_progress("checking daemon readiness");
     let daemon_diagnostics = crate::diagnostics::prepare_daemon_for_debug_self_checks(&git_cmd);
-    let git_diagnostics = collect_git_diagnostics(&git_cmd);
+    debug_progress(format!(
+        "daemon readiness check {}",
+        daemon_diagnostics.status.as_str()
+    ));
+    debug_progress("running git self-checks");
+    let git_diagnostics = collect_git_diagnostics(&git_cmd, options);
+    debug_progress("collecting system and configuration details");
+    debug_progress("checking git versions");
     let git_version = run_command_capture(&git_cmd, &["--version"]);
     let shell_git_version = run_command_capture("git", &["--version"]);
+    debug_progress("collecting git config");
     let git_config = collect_git_config_dump(&git_cmd);
+    debug_progress("collecting git-ai config and login state");
     let git_ai_config = collect_git_ai_config_dump();
     let platform_info = collect_platform_info();
     let hardware_info = collect_hardware_info();
     let repository_info = collect_repository_info();
     let auth_info = collect_auth_status();
     let git_environment = collect_git_environment();
+    debug_progress("debug report ready");
 
     let mut out = String::new();
     let _ = writeln!(out, "git-ai debug report");
@@ -350,21 +397,54 @@ struct GitDebugDiagnostics {
     trace2: DiagnosticCheckResult,
 }
 
-fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
+fn collect_git_diagnostics(
+    configured_git: &str,
+    options: DebugOptions,
+) -> Vec<GitDebugDiagnostics> {
     let targets = vec![
         GitDiagnosticTarget::new("configured git", configured_git),
         GitDiagnosticTarget::new("terminal git", "git"),
     ];
 
-    let trace2_configs: Vec<_> = targets
-        .iter()
-        .map(crate::diagnostics::check_trace2_global_config)
-        .collect();
+    let trace2_configs: Vec<_> = if options.skip_trace2_checks {
+        debug_progress(format!(
+            "skipping Trace2 config checks ({})",
+            SKIP_TRACE2_CHECKS_FLAG
+        ));
+        targets
+            .iter()
+            .map(|_| skipped_trace2_check("trace2 global config check skipped"))
+            .collect()
+    } else {
+        targets
+            .iter()
+            .map(|target| {
+                debug_progress(format!("checking Trace2 config for {}", target.label));
+                let result = crate::diagnostics::check_trace2_global_config(target);
+                debug_progress(format!(
+                    "Trace2 config check for {} {}",
+                    target.label,
+                    result.status.as_str()
+                ));
+                result
+            })
+            .collect()
+    };
     let attribution_handles: Vec<_> = targets
         .clone()
         .into_iter()
         .map(|target| {
-            std::thread::spawn(move || crate::diagnostics::run_attribution_self_check(&target))
+            let label = target.label.clone();
+            debug_progress(format!("starting attribution self-check for {}", label));
+            std::thread::spawn(move || {
+                let result = crate::diagnostics::run_attribution_self_check(&target);
+                debug_progress(format!(
+                    "attribution self-check for {} {}",
+                    label,
+                    result.status.as_str()
+                ));
+                result
+            })
         })
         .collect();
     let attributions: Vec<_> = attribution_handles
@@ -380,10 +460,33 @@ fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
         })
         .collect();
     // Trace2 file checks temporarily rewrite global git config, so they must remain serialized.
-    let trace2_checks: Vec<_> = targets
-        .iter()
-        .map(crate::diagnostics::run_trace2_file_self_check)
-        .collect();
+    let trace2_checks: Vec<_> = if options.skip_trace2_checks {
+        debug_progress(format!(
+            "skipping Trace2 file self-checks ({})",
+            SKIP_TRACE2_CHECKS_FLAG
+        ));
+        targets
+            .iter()
+            .map(|_| skipped_trace2_check("trace2 file self-check skipped"))
+            .collect()
+    } else {
+        targets
+            .iter()
+            .map(|target| {
+                debug_progress(format!(
+                    "starting Trace2 file self-check for {}",
+                    target.label
+                ));
+                let result = crate::diagnostics::run_trace2_file_self_check(target);
+                debug_progress(format!(
+                    "Trace2 file self-check for {} {}",
+                    target.label,
+                    result.status.as_str()
+                ));
+                result
+            })
+            .collect()
+    };
 
     targets
         .into_iter()
@@ -399,6 +502,13 @@ fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
             },
         )
         .collect()
+}
+
+fn skipped_trace2_check(summary: &str) -> DiagnosticCheckResult {
+    DiagnosticCheckResult::skipped(
+        summary,
+        vec![format!("skipped by {}", SKIP_TRACE2_CHECKS_FLAG)],
+    )
 }
 
 fn append_git_diagnostics(
@@ -1327,6 +1437,18 @@ mod tests {
         );
         assert!(err.contains("stdout before timeout: out"), "{err}");
         assert!(err.contains("stderr before timeout: err"), "{err}");
+    }
+
+    #[test]
+    fn test_parse_debug_options_accepts_skip_trace2_checks() {
+        let options = parse_debug_options(&[SKIP_TRACE2_CHECKS_FLAG.to_string()]).unwrap();
+        assert!(options.skip_trace2_checks);
+    }
+
+    #[test]
+    fn test_parse_debug_options_rejects_unknown_arg() {
+        let err = parse_debug_options(&["--wat".to_string()]).unwrap_err();
+        assert!(err.contains("unknown debug argument: --wat"), "{err}");
     }
 
     #[test]

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -2,6 +2,9 @@ use crate::auth::{AuthState, collect_auth_status, format_unix_timestamp};
 use crate::config;
 use crate::diagnostics::{DiagnosticCheckResult, GitDiagnosticTarget};
 use crate::git::find_repository_in_path;
+use crate::git::repository::{
+    GitAuthorIdentity, GitIdentityResolution, global_git_config_committer_identity,
+};
 use crate::process_timeout::{TimedCommandOutput, run_command_with_timeout};
 use std::env;
 use std::fmt::Write as _;
@@ -105,6 +108,7 @@ fn build_debug_report(options: DebugOptions) -> String {
     let platform_info = collect_platform_info();
     let hardware_info = collect_hardware_info();
     let repository_info = collect_repository_info();
+    let git_committer_identity = collect_git_committer_identity_info();
     let auth_info = collect_auth_status();
     let git_environment = collect_git_environment();
     debug_progress("debug report ready");
@@ -275,6 +279,9 @@ fn build_debug_report(options: DebugOptions) -> String {
     }
     let _ = writeln!(out);
 
+    append_git_committer_identity(&mut out, &git_committer_identity);
+    let _ = writeln!(out);
+
     append_git_diagnostics(&mut out, &daemon_diagnostics, &git_diagnostics);
     let _ = writeln!(out);
 
@@ -395,6 +402,70 @@ struct GitDebugDiagnostics {
     trace2_config: DiagnosticCheckResult,
     attribution: DiagnosticCheckResult,
     trace2: DiagnosticCheckResult,
+}
+
+struct GitCommitterIdentityInfo {
+    global_config: Result<GitAuthorIdentity, String>,
+    repository: RepositoryCommitterIdentity,
+}
+
+enum RepositoryCommitterIdentity {
+    InRepository(GitIdentityResolution),
+    NotInRepository(String),
+}
+
+fn collect_git_committer_identity_info() -> GitCommitterIdentityInfo {
+    let global_config = global_git_config_committer_identity().map_err(|e| e.to_string());
+    let repository = env::current_dir()
+        .map_err(|e| e.to_string())
+        .and_then(|cwd| find_repository_in_path(&cwd.to_string_lossy()).map_err(|e| e.to_string()))
+        .map(|repo| {
+            RepositoryCommitterIdentity::InRepository(repo.git_author_identity_resolution())
+        })
+        .unwrap_or_else(RepositoryCommitterIdentity::NotInRepository);
+
+    GitCommitterIdentityInfo {
+        global_config,
+        repository,
+    }
+}
+
+fn append_git_committer_identity(out: &mut String, identity: &GitCommitterIdentityInfo) {
+    let _ = writeln!(out, "== Git Committer Identity ==");
+    let _ = writeln!(out, "Global git config identity:");
+    match &identity.global_config {
+        Ok(global) => append_git_author_identity(out, global, "  "),
+        Err(err) => {
+            let _ = writeln!(out, "  <error: {}>", err);
+        }
+    }
+
+    let _ = writeln!(out, "Repository effective committer identity:");
+    match &identity.repository {
+        RepositoryCommitterIdentity::InRepository(resolution) => {
+            let raw = resolution
+                .raw_git_var
+                .as_deref()
+                .unwrap_or("<unavailable; git-ai used config fallback>");
+            let _ = writeln!(out, "  Raw GIT_COMMITTER_IDENT: {}", raw);
+            append_git_author_identity(out, &resolution.identity, "  ");
+        }
+        RepositoryCommitterIdentity::NotInRepository(err) => {
+            let _ = writeln!(out, "  <not in repository: {}>", err);
+        }
+    }
+}
+
+fn append_git_author_identity(out: &mut String, identity: &GitAuthorIdentity, prefix: &str) {
+    let formatted = identity
+        .formatted()
+        .unwrap_or_else(|| "<unavailable>".to_string());
+    let name = identity.name.as_deref().unwrap_or("<unavailable>");
+    let email = identity.email.as_deref().unwrap_or("<unavailable>");
+
+    let _ = writeln!(out, "{}Formatted: {}", prefix, formatted);
+    let _ = writeln!(out, "{}Parsed name: {}", prefix, name);
+    let _ = writeln!(out, "{}Parsed email: {}", prefix, email);
 }
 
 fn collect_git_diagnostics(

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -50,6 +50,7 @@ fn build_debug_report() -> String {
     let git_cmd = config.git_cmd().to_string();
     let git_cmd_realpath = realpath_for_display(&git_cmd);
     let shell_git_lookup = collect_shell_git_lookup();
+    let daemon_diagnostics = crate::diagnostics::prepare_daemon_for_debug_self_checks(&git_cmd);
     let git_diagnostics = collect_git_diagnostics(&git_cmd);
     let git_version = run_command_capture(&git_cmd, &["--version"]);
     let shell_git_version = run_command_capture("git", &["--version"]);
@@ -227,7 +228,7 @@ fn build_debug_report() -> String {
     }
     let _ = writeln!(out);
 
-    append_git_diagnostics(&mut out, &git_diagnostics);
+    append_git_diagnostics(&mut out, &daemon_diagnostics, &git_diagnostics);
     let _ = writeln!(out);
 
     let _ = writeln!(out, "== Git Config ==");
@@ -371,8 +372,14 @@ fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
         .collect()
 }
 
-fn append_git_diagnostics(out: &mut String, diagnostics: &[GitDebugDiagnostics]) {
+fn append_git_diagnostics(
+    out: &mut String,
+    daemon: &DiagnosticCheckResult,
+    diagnostics: &[GitDebugDiagnostics],
+) {
     let _ = writeln!(out, "== Git Self Checks ==");
+    let _ = writeln!(out, "daemon");
+    append_diagnostic_check(out, "Daemon check", daemon, false);
     for diagnostic in diagnostics {
         let _ = writeln!(
             out,

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -743,7 +743,9 @@ fn format_wait_capture_error(command: &str, output: TimedCommandOutput) -> Strin
 
 fn append_debug_diagnostics(message: &mut String, diagnostics: &[String]) {
     for diagnostic in diagnostics {
-        message.push_str("; ");
+        if !message.is_empty() {
+            message.push_str("; ");
+        }
         message.push_str(diagnostic);
     }
 }
@@ -1325,5 +1327,20 @@ mod tests {
         );
         assert!(err.contains("stdout before timeout: out"), "{err}");
         assert!(err.contains("stderr before timeout: err"), "{err}");
+    }
+
+    #[test]
+    fn test_command_output_to_result_formats_diagnostics_without_stderr() {
+        let err = command_output_to_result(TimedCommandOutput {
+            status: Some(1),
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+            diagnostics: vec!["output collection did not finish".to_string()],
+            wait_error: None,
+        })
+        .unwrap_err();
+
+        assert_eq!(err, "exit code 1: output collection did not finish");
     }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -1,12 +1,12 @@
 use crate::auth::{AuthState, collect_auth_status, format_unix_timestamp};
 use crate::config;
+use crate::diagnostics::{DiagnosticCheckResult, GitDiagnosticTarget};
 use crate::git::find_repository_in_path;
 use std::env;
 use std::fmt::Write as _;
-use std::process::Command;
-
-#[cfg(target_os = "linux")]
 use std::fs;
+use std::path::Path;
+use std::process::Command;
 
 pub fn handle_debug(args: &[String]) {
     if args
@@ -38,6 +38,9 @@ fn print_debug_help() {
 fn build_debug_report() -> String {
     let config = config::Config::get();
     let git_cmd = config.git_cmd().to_string();
+    let git_cmd_realpath = realpath_for_display(&git_cmd);
+    let shell_git_lookup = collect_shell_git_lookup();
+    let git_diagnostics = collect_git_diagnostics(&git_cmd);
     let git_version = run_command_capture(&git_cmd, &["--version"]);
     let git_config = collect_git_config_dump(&git_cmd);
     let git_ai_config = collect_git_ai_config_dump();
@@ -70,6 +73,22 @@ fn build_debug_report() -> String {
             .unwrap_or_else(|e| format!("<unavailable: {}>", e))
     );
     let _ = writeln!(out, "Git binary path: {}", git_cmd);
+    let _ = writeln!(out, "Git binary realpath: {}", git_cmd_realpath);
+    let _ = writeln!(
+        out,
+        "Shell git lookup command: {}",
+        shell_git_lookup.command
+    );
+    match shell_git_lookup.path {
+        Ok(ref path) => {
+            let _ = writeln!(out, "Shell git path: {}", path);
+            let _ = writeln!(out, "Shell git realpath: {}", realpath_for_display(path));
+        }
+        Err(ref err) => {
+            let _ = writeln!(out, "Shell git path: <error: {}>", err);
+            let _ = writeln!(out, "Shell git realpath: <unavailable>");
+        }
+    }
     match git_version {
         Ok(version) => {
             let _ = writeln!(out, "Git version: {}", version);
@@ -175,6 +194,9 @@ fn build_debug_report() -> String {
             }
         }
     }
+    let _ = writeln!(out);
+
+    append_git_diagnostics(&mut out, &git_diagnostics);
     let _ = writeln!(out);
 
     let _ = writeln!(out, "== Git Config ==");
@@ -286,6 +308,169 @@ fn build_debug_report() -> String {
     out
 }
 
+struct GitDebugDiagnostics {
+    target: GitDiagnosticTarget,
+    attribution: DiagnosticCheckResult,
+    trace2: DiagnosticCheckResult,
+}
+
+fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
+    let targets = vec![
+        GitDiagnosticTarget::new("configured git", configured_git),
+        GitDiagnosticTarget::new("terminal git", "git"),
+    ];
+
+    targets
+        .into_iter()
+        .map(|target| {
+            let attribution = crate::diagnostics::run_attribution_self_check(&target);
+            let trace2 = crate::diagnostics::run_trace2_file_self_check(&target);
+            GitDebugDiagnostics {
+                target,
+                attribution,
+                trace2,
+            }
+        })
+        .collect()
+}
+
+fn append_git_diagnostics(out: &mut String, diagnostics: &[GitDebugDiagnostics]) {
+    let _ = writeln!(out, "== Git Self Checks ==");
+    for diagnostic in diagnostics {
+        let _ = writeln!(
+            out,
+            "{} (program: {})",
+            diagnostic.target.label, diagnostic.target.program
+        );
+        append_diagnostic_check(
+            out,
+            "Attribution self-check",
+            &diagnostic.attribution,
+            false,
+        );
+        append_diagnostic_check(out, "Trace2 file self-check", &diagnostic.trace2, true);
+    }
+}
+
+fn append_diagnostic_check(
+    out: &mut String,
+    label: &str,
+    check: &DiagnosticCheckResult,
+    always_show_trace2: bool,
+) {
+    let _ = writeln!(
+        out,
+        "  {}: {} - {}",
+        label,
+        check.status.as_str(),
+        check.summary
+    );
+    for detail in &check.details {
+        let _ = writeln!(out, "    {}", detail);
+    }
+
+    if always_show_trace2 && let Some(trace2_json) = check.trace2_json.as_ref() {
+        let _ = writeln!(out, "    trace2 JSON received:");
+        append_indented_block_with_prefix(out, trace2_json, "      ");
+    }
+
+    if check.status == crate::diagnostics::DiagnosticStatus::Failed {
+        let _ = writeln!(out, "    command log:");
+        for command in &check.commands {
+            let _ = writeln!(out, "      $ {}", command.command);
+            if let Some(cwd) = &command.cwd {
+                let _ = writeln!(out, "        cwd: {}", cwd);
+            }
+            let _ = writeln!(
+                out,
+                "        status: {}",
+                command
+                    .status
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "<unavailable>".to_string())
+            );
+            if !command.stdout.trim().is_empty() {
+                let _ = writeln!(out, "        stdout:");
+                append_indented_block_with_prefix(out, &command.stdout, "          ");
+            }
+            if !command.stderr.trim().is_empty() {
+                let _ = writeln!(out, "        stderr:");
+                append_indented_block_with_prefix(out, &command.stderr, "          ");
+            }
+        }
+    }
+}
+
+struct ShellGitLookup {
+    command: String,
+    path: Result<String, String>,
+}
+
+fn collect_shell_git_lookup() -> ShellGitLookup {
+    #[cfg(windows)]
+    {
+        collect_windows_shell_git_lookup()
+    }
+
+    #[cfg(not(windows))]
+    {
+        collect_unix_shell_git_lookup()
+    }
+}
+
+#[cfg(not(windows))]
+fn collect_unix_shell_git_lookup() -> ShellGitLookup {
+    let shell = env::var("SHELL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "sh".to_string());
+    let command = format!("{} -lc 'which git'", shell);
+    let path = run_command_capture(&shell, &["-lc", "which git"])
+        .and_then(|output| select_lookup_path(&output));
+
+    ShellGitLookup { command, path }
+}
+
+#[cfg(windows)]
+fn collect_windows_shell_git_lookup() -> ShellGitLookup {
+    let comspec = env::var("ComSpec")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "cmd.exe".to_string());
+    let command = format!("{} /C where git", comspec);
+    let path = run_command_capture(&comspec, &["/C", "where git"])
+        .and_then(|output| select_lookup_path(&output));
+
+    ShellGitLookup { command, path }
+}
+
+fn select_lookup_path(output: &str) -> Result<String, String> {
+    let mut first_non_empty = None;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if first_non_empty.is_none() {
+            first_non_empty = Some(trimmed.to_string());
+        }
+
+        if Path::new(trimmed).exists() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    first_non_empty.ok_or_else(|| "empty output".to_string())
+}
+
+fn realpath_for_display(path: &str) -> String {
+    fs::canonicalize(path)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|e| format!("<error: {}>", e))
+}
+
 fn append_indented_block(out: &mut String, content: &str) {
     if content.trim().is_empty() {
         let _ = writeln!(out, "  <empty>");
@@ -293,6 +478,16 @@ fn append_indented_block(out: &mut String, content: &str) {
     }
     for line in content.lines() {
         let _ = writeln!(out, "  {}", line);
+    }
+}
+
+fn append_indented_block_with_prefix(out: &mut String, content: &str, prefix: &str) {
+    if content.trim().is_empty() {
+        let _ = writeln!(out, "{}<empty>", prefix);
+        return;
+    }
+    for line in content.lines() {
+        let _ = writeln!(out, "{}{}", prefix, line);
     }
 }
 
@@ -739,5 +934,35 @@ mod tests {
     #[test]
     fn test_format_bytes() {
         assert_eq!(format_bytes(1024), "1.00 KB (1024 bytes)");
+    }
+
+    #[test]
+    fn test_select_lookup_path_prefers_existing_path() {
+        let exe = env::current_exe().unwrap();
+        let output = format!("/definitely/not/git\n{}\n", exe.display());
+
+        assert_eq!(
+            select_lookup_path(&output).unwrap(),
+            exe.display().to_string()
+        );
+    }
+
+    #[test]
+    fn test_select_lookup_path_falls_back_to_first_non_empty_line() {
+        assert_eq!(
+            select_lookup_path("\n git: aliased to hub \n").unwrap(),
+            "git: aliased to hub"
+        );
+    }
+
+    #[test]
+    fn test_realpath_for_display_canonicalizes_existing_path() {
+        let exe = env::current_exe().unwrap();
+        let expected = fs::canonicalize(&exe).unwrap();
+
+        assert_eq!(
+            realpath_for_display(&exe.display().to_string()),
+            expected.display().to_string()
+        );
     }
 }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -614,15 +614,21 @@ fn run_command_capture_with_timeout(
     timeout: Duration,
 ) -> Result<String, String> {
     let command = format_command_for_error(program, args);
-    let output =
-        run_command_with_timeout(program, args, None, timeout, DEBUG_COMMAND_POLL_INTERVAL)
-            .map_err(|e| {
-                format!(
-                    "failed to execute '{}': {}",
-                    program,
-                    strip_execute_prefix(&e)
-                )
-            })?;
+    let output = run_command_with_timeout(
+        program,
+        args,
+        None,
+        timeout,
+        DEBUG_COMMAND_POLL_INTERVAL,
+        &[],
+    )
+    .map_err(|e| {
+        format!(
+            "failed to execute '{}': {}",
+            program,
+            strip_execute_prefix(&e)
+        )
+    })?;
 
     if output.timed_out {
         return Err(format_timeout_capture_error(&command, timeout, output));

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -356,19 +356,48 @@ fn collect_git_diagnostics(configured_git: &str) -> Vec<GitDebugDiagnostics> {
         GitDiagnosticTarget::new("terminal git", "git"),
     ];
 
-    targets
+    let trace2_configs: Vec<_> = targets
+        .iter()
+        .map(crate::diagnostics::check_trace2_global_config)
+        .collect();
+    let attribution_handles: Vec<_> = targets
+        .clone()
         .into_iter()
         .map(|target| {
-            let trace2_config = crate::diagnostics::check_trace2_global_config(&target);
-            let attribution = crate::diagnostics::run_attribution_self_check(&target);
-            let trace2 = crate::diagnostics::run_trace2_file_self_check(&target);
-            GitDebugDiagnostics {
+            std::thread::spawn(move || crate::diagnostics::run_attribution_self_check(&target))
+        })
+        .collect();
+    let attributions: Vec<_> = attribution_handles
+        .into_iter()
+        .map(|handle| {
+            handle.join().unwrap_or_else(|_| {
+                DiagnosticCheckResult::failed(
+                    "attribution self-check failed",
+                    vec!["attribution self-check worker panicked".to_string()],
+                    Vec::new(),
+                )
+            })
+        })
+        .collect();
+    // Trace2 file checks temporarily rewrite global git config, so they must remain serialized.
+    let trace2_checks: Vec<_> = targets
+        .iter()
+        .map(crate::diagnostics::run_trace2_file_self_check)
+        .collect();
+
+    targets
+        .into_iter()
+        .zip(trace2_configs)
+        .zip(attributions)
+        .zip(trace2_checks)
+        .map(
+            |(((target, trace2_config), attribution), trace2)| GitDebugDiagnostics {
                 target,
                 trace2_config,
                 attribution,
                 trace2,
-            }
-        })
+            },
+        )
         .collect()
 }
 

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -109,7 +109,7 @@ fn build_debug_report(options: DebugOptions) -> String {
     let platform_info = collect_platform_info();
     let hardware_info = collect_hardware_info();
     let repository_info = collect_repository_info();
-    let git_committer_identity = collect_git_committer_identity_info();
+    let git_committer_identity = collect_git_committer_identity_info(&repository_info);
     let auth_info = collect_auth_status();
     let git_environment = collect_git_environment();
     debug_progress("debug report ready");
@@ -415,15 +415,22 @@ enum RepositoryCommitterIdentity {
     NotInRepository(String),
 }
 
-fn collect_git_committer_identity_info() -> GitCommitterIdentityInfo {
+fn collect_git_committer_identity_info(
+    repository_info: &RepositoryInfo,
+) -> GitCommitterIdentityInfo {
     let global_config = global_git_config_identity_resolution().map_err(|e| e.to_string());
-    let repository = env::current_dir()
-        .map_err(|e| e.to_string())
-        .and_then(|cwd| find_repository_in_path(&cwd.to_string_lossy()).map_err(|e| e.to_string()))
-        .map(|repo| {
-            RepositoryCommitterIdentity::InRepository(repo.git_author_identity_resolution())
-        })
-        .unwrap_or_else(RepositoryCommitterIdentity::NotInRepository);
+    let repository = repository_info
+        .committer_identity
+        .clone()
+        .map(RepositoryCommitterIdentity::InRepository)
+        .unwrap_or_else(|| {
+            RepositoryCommitterIdentity::NotInRepository(
+                repository_info
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "not in repository".to_string()),
+            )
+        });
 
     GitCommitterIdentityInfo {
         global_config,
@@ -1135,6 +1142,7 @@ struct RepositoryInfo {
     head: Option<String>,
     hooks_path: Option<String>,
     remotes: Vec<(String, String)>,
+    committer_identity: Option<GitIdentityResolution>,
 }
 
 fn collect_repository_info() -> RepositoryInfo {
@@ -1155,11 +1163,13 @@ fn collect_repository_info() -> RepositoryInfo {
                 head: None,
                 hooks_path: None,
                 remotes: Vec::new(),
+                committer_identity: None,
             };
         }
     };
 
     let head = repo.head().ok();
+    let committer_identity = repo.git_author_identity_resolution();
 
     RepositoryInfo {
         in_repository: true,
@@ -1171,6 +1181,7 @@ fn collect_repository_info() -> RepositoryInfo {
         head: head.as_ref().and_then(|h| h.target().ok()),
         hooks_path: repo.config_get_str("core.hooksPath").ok().flatten(),
         remotes: repo.remotes_with_urls().unwrap_or_default(),
+        committer_identity: Some(committer_identity),
     }
 }
 

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -56,7 +56,7 @@ fn build_debug_report() -> String {
     let hardware_info = collect_hardware_info();
     let repository_info = collect_repository_info();
     let auth_info = collect_auth_status();
-    let env_overrides = collect_git_ai_env_overrides();
+    let git_environment = collect_git_environment();
 
     let mut out = String::new();
     let _ = writeln!(out, "git-ai debug report");
@@ -323,12 +323,15 @@ fn build_debug_report() -> String {
     }
     let _ = writeln!(out);
 
-    let _ = writeln!(out, "== Git AI Environment ==");
-    if env_overrides.is_empty() {
-        let _ = writeln!(out, "No GIT_AI_* environment variables are set.");
+    let _ = writeln!(out, "== Git Environment ==");
+    if git_environment.is_empty() {
+        let _ = writeln!(
+            out,
+            "No GIT_AI_*, GITAI_*, or GIT_* environment variables are set."
+        );
     } else {
-        let _ = writeln!(out, "GIT_AI_* variables set:");
-        for entry in env_overrides {
+        let _ = writeln!(out, "GIT_AI_*, GITAI_*, and GIT_* variables set:");
+        for entry in git_environment {
             let _ = writeln!(out, "  {}", entry);
         }
     }
@@ -955,9 +958,17 @@ fn collect_git_ai_config_dump() -> Result<String, String> {
     Ok(out)
 }
 
-fn collect_git_ai_env_overrides() -> Vec<String> {
-    let mut entries: Vec<(String, String)> = env::vars()
-        .filter(|(k, _)| k.starts_with("GIT_AI_"))
+fn collect_git_environment() -> Vec<String> {
+    collect_git_environment_entries(env::vars())
+}
+
+fn collect_git_environment_entries<I>(entries: I) -> Vec<String>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut entries: Vec<(String, String)> = entries
+        .into_iter()
+        .filter(|(key, _)| is_debug_git_env_key(key))
         .collect();
     entries.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -965,6 +976,10 @@ fn collect_git_ai_env_overrides() -> Vec<String> {
         .into_iter()
         .map(|(key, value)| format!("{}={}", key, redact_env_value(&key, &value)))
         .collect()
+}
+
+fn is_debug_git_env_key(key: &str) -> bool {
+    key.starts_with("GIT_AI_") || key.starts_with("GITAI_") || key.starts_with("GIT_")
 }
 
 fn redact_env_value(key: &str, value: &str) -> String {
@@ -1034,6 +1049,35 @@ mod tests {
     #[test]
     fn test_format_bytes() {
         assert_eq!(format_bytes(1024), "1.00 KB (1024 bytes)");
+    }
+
+    #[test]
+    fn test_is_debug_git_env_key_matches_git_prefixes() {
+        assert!(is_debug_git_env_key("GIT_AI_DEBUG"));
+        assert!(is_debug_git_env_key("GITAI_TEST_DB_PATH"));
+        assert!(is_debug_git_env_key("GIT_DIR"));
+        assert!(is_debug_git_env_key("GIT_TRACE2_EVENT"));
+        assert!(!is_debug_git_env_key("GITHUB_TOKEN"));
+        assert!(!is_debug_git_env_key("PATH"));
+    }
+
+    #[test]
+    fn test_collect_git_environment_entries_sorts_and_redacts() {
+        let entries = collect_git_environment_entries(vec![
+            ("OTHER".to_string(), "ignored".to_string()),
+            ("GIT_DIR".to_string(), ".git".to_string()),
+            ("GITAI_TEST_DB_PATH".to_string(), "/tmp/db".to_string()),
+            ("GIT_AI_API_KEY".to_string(), "secret".to_string()),
+        ]);
+
+        assert_eq!(
+            entries,
+            vec![
+                "GITAI_TEST_DB_PATH=/tmp/db",
+                "GIT_AI_API_KEY=[REDACTED]",
+                "GIT_DIR=.git",
+            ]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,6 +274,14 @@ impl Config {
         &self,
         remotes: Option<&Vec<(String, String)>>,
     ) -> bool {
+        if remotes.is_some_and(|remotes| {
+            remotes.iter().any(|(_, remote_url)| {
+                crate::diagnostic_sentinels::is_debug_self_check_remote_url(remote_url)
+            })
+        }) {
+            return true;
+        }
+
         // First check if repository is in exclusion list - exclusions take precedence
         if !self.exclude_repositories.is_empty()
             && let Some(remotes) = remotes

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,8 +313,28 @@ impl Config {
     /// This uses a blacklist model: empty list = share everywhere, patterns = repos to exclude.
     /// Local repositories (no remotes) are only excluded if wildcard "*" pattern is present.
     pub fn should_exclude_prompts(&self, repository: &Option<Repository>) -> bool {
+        let remotes = repository
+            .as_ref()
+            .and_then(|repo| repo.remotes_with_urls().ok());
+
+        self.should_exclude_prompts_with_remotes(remotes.as_ref())
+    }
+
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn should_exclude_prompts_with_remotes(
+        &self,
+        remotes: Option<&Vec<(String, String)>>,
+    ) -> bool {
         // Empty exclusion list = never exclude
         if self.exclude_prompts_in_repositories.is_empty() {
+            return false;
+        }
+
+        if remotes.is_some_and(|remotes| {
+            remotes.iter().any(|(_, remote_url)| {
+                crate::diagnostic_sentinels::is_debug_self_check_remote_url(remote_url)
+            })
+        }) {
             return false;
         }
 
@@ -326,11 +346,6 @@ impl Config {
         if has_wildcard {
             return true;
         }
-
-        // Fetch remotes
-        let remotes = repository
-            .as_ref()
-            .and_then(|repo| repo.remotes_with_urls().ok());
 
         match remotes {
             Some(remotes) => {
@@ -1719,6 +1734,17 @@ mod tests {
 
         // Wildcard * should also exclude repos without remotes (None case)
         assert!(config.should_exclude_prompts(&None));
+    }
+
+    #[test]
+    fn test_debug_self_check_remote_bypasses_prompt_exclusion_wildcard() {
+        let config = create_test_config_with_exclude_prompts(vec!["*".to_string()]);
+        let remotes = vec![(
+            "origin".to_string(),
+            crate::diagnostic_sentinels::DEBUG_SELF_CHECK_REMOTE_URL.to_string(),
+        )];
+
+        assert!(!config.should_exclude_prompts_with_remotes(Some(&remotes)));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -664,7 +664,7 @@ fn trace_invocation_is_definitely_read_only(
             // Only parse the subcommand for commands that need it; parsing is
             // cheap but this avoids it for the majority of clearly-read-only
             // commands like status, diff, show, etc.
-            let subcommand = if matches!(cmd, "stash" | "worktree") {
+            let subcommand = if matches!(cmd, "notes" | "stash" | "worktree") {
                 trace_argv_subcommand(argv)
             } else {
                 None

--- a/src/diagnostic_sentinels.rs
+++ b/src/diagnostic_sentinels.rs
@@ -1,0 +1,45 @@
+use std::path::{Path, PathBuf};
+
+pub const DEBUG_SELF_CHECK_REMOTE_URL: &str = "https://git-ai.invalid/debug/self-check.git";
+pub const DEBUG_SELF_CHECK_NORMALIZED_REMOTE_URL: &str = "https://git-ai.invalid/debug/self-check";
+pub const DEBUG_SELF_CHECK_DIR_NAME: &str = "debug-self-checks";
+
+pub fn is_debug_self_check_remote_url(url: &str) -> bool {
+    let trimmed = url.trim().trim_end_matches('/');
+    trimmed == DEBUG_SELF_CHECK_REMOTE_URL
+        || trimmed == DEBUG_SELF_CHECK_NORMALIZED_REMOTE_URL
+        || crate::repo_url::normalize_repo_url(trimmed)
+            .is_ok_and(|normalized| normalized == DEBUG_SELF_CHECK_NORMALIZED_REMOTE_URL)
+}
+
+pub fn debug_self_check_root() -> PathBuf {
+    crate::mdm::utils::home_dir()
+        .join(".git-ai")
+        .join("internal")
+        .join(DEBUG_SELF_CHECK_DIR_NAME)
+}
+
+pub fn path_is_in_debug_self_check_root(path: &Path) -> bool {
+    let root = debug_self_check_root();
+    let root = std::fs::canonicalize(&root).unwrap_or(root);
+    let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    path.starts_with(root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_debug_self_check_remote_url_matches_raw_and_normalized() {
+        assert!(is_debug_self_check_remote_url(
+            "https://git-ai.invalid/debug/self-check.git"
+        ));
+        assert!(is_debug_self_check_remote_url(
+            "https://git-ai.invalid/debug/self-check"
+        ));
+        assert!(!is_debug_self_check_remote_url(
+            "https://example.com/debug/self-check.git"
+        ));
+    }
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -14,6 +14,9 @@ const SELF_CHECK_FILE: &str = "git-ai-debug-self-check.txt";
 const SELF_CHECK_CONTENT_UNTRACKED: &str = "Untracked line\n";
 const SELF_CHECK_CONTENT_KNOWN_HUMAN: &str = "Untracked line\nKnown human line\n";
 const SELF_CHECK_CONTENT_AI: &str = "Untracked line\nKnown human line\nAI line\n";
+const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
+const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
+const TRACE2_EVENT_NESTING_VALUE: &str = "10";
 const CHECKPOINT_WAIT: Duration = Duration::from_secs(10);
 const NOTE_WAIT: Duration = Duration::from_secs(20);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -105,6 +108,86 @@ impl GitDiagnosticTarget {
             program: program.into(),
         }
     }
+}
+
+pub fn check_trace2_global_config(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
+    let mut commands = Vec::new();
+    let expected_target = match crate::daemon::DaemonConfig::from_env_or_default_paths() {
+        Ok(config) => config.trace2_event_target(),
+        Err(err) => {
+            return DiagnosticCheckResult::failed(
+                "trace2 global config could not be inspected",
+                trace2_config_failure_details(
+                    &format!("failed to determine expected trace2 target: {}", err),
+                    None,
+                    None,
+                    None,
+                ),
+                commands,
+            );
+        }
+    };
+
+    let event_targets =
+        read_global_git_config_values(&mut commands, &target.program, TRACE2_EVENT_TARGET_KEY);
+    let event_nesting =
+        read_global_git_config_values(&mut commands, &target.program, TRACE2_EVENT_NESTING_KEY);
+
+    let event_targets = match event_targets {
+        Ok(values) => values,
+        Err(err) => {
+            return DiagnosticCheckResult::failed(
+                "trace2 global config could not be inspected",
+                trace2_config_failure_details(&err, Some(&expected_target), None, None),
+                commands,
+            );
+        }
+    };
+    let event_nesting = match event_nesting {
+        Ok(values) => values,
+        Err(err) => {
+            return DiagnosticCheckResult::failed(
+                "trace2 global config could not be inspected",
+                trace2_config_failure_details(
+                    &err,
+                    Some(&expected_target),
+                    Some(&event_targets),
+                    None,
+                ),
+                commands,
+            );
+        }
+    };
+
+    let target_matches = event_targets.iter().any(|value| value == &expected_target);
+    let nesting_matches = event_nesting
+        .iter()
+        .any(|value| value == TRACE2_EVENT_NESTING_VALUE);
+
+    if target_matches && nesting_matches {
+        return DiagnosticCheckResult::passed(
+            "trace2 global config is configured",
+            vec![
+                format!("{}: {}", TRACE2_EVENT_TARGET_KEY, expected_target),
+                format!(
+                    "{}: {}",
+                    TRACE2_EVENT_NESTING_KEY, TRACE2_EVENT_NESTING_VALUE
+                ),
+            ],
+            commands,
+        );
+    }
+
+    DiagnosticCheckResult::failed(
+        "trace2 global config is not configured",
+        trace2_config_failure_details(
+            "trace2 is not configured for git-ai daemon mode",
+            Some(&expected_target),
+            Some(&event_targets),
+            Some(&event_nesting),
+        ),
+        commands,
+    )
 }
 
 pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
@@ -253,7 +336,7 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
                 "config",
                 "--global",
                 "--replace-all",
-                "trace2.eventTarget",
+                TRACE2_EVENT_TARGET_KEY,
                 trace_path_string.as_str(),
             ],
             None,
@@ -565,7 +648,7 @@ fn snapshot_global_trace2_event_target(
             "--global",
             "--no-includes",
             "--get-all",
-            "trace2.eventTarget",
+            TRACE2_EVENT_TARGET_KEY,
         ],
         None,
     );
@@ -581,7 +664,8 @@ fn snapshot_global_trace2_event_target(
         Vec::new()
     } else {
         let err = format!(
-            "failed to snapshot global trace2.eventTarget: status={}, stderr={}",
+            "failed to snapshot global {}: status={}, stderr={}",
+            TRACE2_EVENT_TARGET_KEY,
             format_status(record.status),
             record.stderr
         );
@@ -599,7 +683,7 @@ fn restore_global_trace2_event_target(
 ) -> Result<(), String> {
     let remove = run_logged_command(
         git_program,
-        &["config", "--global", "--unset-all", "trace2.eventTarget"],
+        &["config", "--global", "--unset-all", TRACE2_EVENT_TARGET_KEY],
         None,
     );
     let remove_ok = remove.success() || remove.status == Some(5);
@@ -607,7 +691,8 @@ fn restore_global_trace2_event_target(
         None
     } else {
         Some(format!(
-            "failed to remove temporary trace2.eventTarget: status={}, stderr={}",
+            "failed to remove temporary {}: status={}, stderr={}",
+            TRACE2_EVENT_TARGET_KEY,
             format_status(remove.status),
             remove.stderr
         ))
@@ -620,14 +705,21 @@ fn restore_global_trace2_event_target(
     for value in &snapshot.values {
         let record = run_logged_command(
             git_program,
-            &["config", "--global", "--add", "trace2.eventTarget", value],
+            &[
+                "config",
+                "--global",
+                "--add",
+                TRACE2_EVENT_TARGET_KEY,
+                value,
+            ],
             None,
         );
         let error = if record.success() {
             None
         } else {
             Some(format!(
-                "failed to restore trace2.eventTarget: status={}, stderr={}",
+                "failed to restore {}: status={}, stderr={}",
+                TRACE2_EVENT_TARGET_KEY,
                 format_status(record.status),
                 record.stderr
             ))
@@ -706,6 +798,85 @@ fn validate_trace2_command_events(
     ])
 }
 
+fn read_global_git_config_values(
+    commands: &mut Vec<CommandRecord>,
+    git_program: &str,
+    key: &str,
+) -> Result<Vec<String>, String> {
+    let record = run_logged_command(git_program, &["config", "--global", "--get-all", key], None);
+    let values = if record.success() {
+        record
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
+    } else if record.status == Some(1) {
+        Vec::new()
+    } else {
+        let err = format!(
+            "failed to read global {}: status={}, stderr={}",
+            key,
+            format_status(record.status),
+            record.stderr
+        );
+        commands.push(record);
+        return Err(err);
+    };
+    commands.push(record);
+    Ok(values)
+}
+
+fn trace2_config_failure_details(
+    reason: &str,
+    expected_target: Option<&str>,
+    actual_targets: Option<&[String]>,
+    actual_nesting: Option<&[String]>,
+) -> Vec<String> {
+    let mut details = vec![
+        format!("ERROR: {}", reason),
+        "Why this matters: git-ai daemon mode relies on Git trace2 events to match real Git commands to checkpoint and authorship state; without this config, commit/rebase/merge attribution can be missed or delayed.".to_string(),
+    ];
+
+    if let Some(expected_target) = expected_target {
+        details.push(format!(
+            "Expected {}: {}",
+            TRACE2_EVENT_TARGET_KEY, expected_target
+        ));
+    }
+    if let Some(actual_targets) = actual_targets {
+        details.push(format!(
+            "Actual {}: {}",
+            TRACE2_EVENT_TARGET_KEY,
+            format_config_values(actual_targets)
+        ));
+    }
+    details.push(format!(
+        "Expected {}: {}",
+        TRACE2_EVENT_NESTING_KEY, TRACE2_EVENT_NESTING_VALUE
+    ));
+    if let Some(actual_nesting) = actual_nesting {
+        details.push(format!(
+            "Actual {}: {}",
+            TRACE2_EVENT_NESTING_KEY,
+            format_config_values(actual_nesting)
+        ));
+    }
+
+    details.push("Common causes: `git-ai install-hooks` has not run, was run with `--dry-run`, or failed while writing global Git config.".to_string());
+    details.push("Common causes: git-ai cannot edit the same global Git config Git reads because HOME/USERPROFILE/XDG_CONFIG_HOME/GIT_CONFIG_GLOBAL points somewhere different, the global config file or parent directory is read-only or locked, permissions or ownership are wrong, or the configured git and terminal git use different config locations.".to_string());
+    details
+}
+
+fn format_config_values(values: &[String]) -> String {
+    if values.is_empty() {
+        "<missing>".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
 fn sanitize_label(label: &str) -> String {
     let sanitized = label
         .chars()
@@ -777,5 +948,38 @@ mod tests {
 
         let err = validate_trace2_command_events(trace, "init").unwrap_err();
         assert!(err.contains("missing cmd_name event for expected command"));
+    }
+
+    #[test]
+    fn test_trace2_config_failure_details_explains_missing_config() {
+        let empty = Vec::new();
+        let details = trace2_config_failure_details(
+            "trace2 is not configured for git-ai daemon mode",
+            Some("af_unix:stream:/tmp/git-ai-trace2.sock"),
+            Some(&empty),
+            Some(&empty),
+        );
+
+        assert!(details[0].contains("ERROR: trace2 is not configured"));
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("Why this matters"))
+        );
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail == "Actual trace2.eventTarget: <missing>")
+        );
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail == "Actual trace2.eventNesting: <missing>")
+        );
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("Common causes"))
+        );
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -218,6 +218,11 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         sanitize_label(&target.label),
         crate::uuid::generate_v4()
     ));
+    let trace_command_dir = debug_self_check_root().join(format!(
+        "trace2-{}-{}",
+        sanitize_label(&target.label),
+        crate::uuid::generate_v4()
+    ));
 
     let snapshot = match snapshot_global_trace2_event_target(&mut commands, &target.program) {
         Ok(snapshot) => snapshot,
@@ -234,9 +239,13 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
     let result = (|| -> Result<(Vec<String>, String), String> {
         fs::create_dir_all(&trace_dir)
             .map_err(|e| format!("failed to create {}: {}", trace_dir.display(), e))?;
+        fs::create_dir_all(&trace_command_dir)
+            .map_err(|e| format!("failed to create {}: {}", trace_command_dir.display(), e))?;
         let _ = fs::remove_file(&trace_path);
         let trace_path_string = trace_path.to_string_lossy().to_string();
 
+        // This intentionally uses global git config rather than a process-local
+        // GIT_TRACE2_EVENT override so the diagnostic exercises the install path.
         run_required(
             &mut commands,
             &target.program,
@@ -251,11 +260,18 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         )?;
         changed_global_event_target = true;
 
-        run_required(&mut commands, &target.program, &["version"], None)?;
+        // Use init rather than version: when terminal git is the git-ai proxy,
+        // read-only commands intentionally suppress trace2 before invoking real git.
+        run_required(
+            &mut commands,
+            &target.program,
+            &["init", "."],
+            Some(&trace_command_dir),
+        )?;
 
         let trace2_json = fs::read_to_string(&trace_path)
             .map_err(|e| format!("failed to read {}: {}", trace_path.display(), e))?;
-        let details = validate_trace2_version_command_events(&trace2_json)?;
+        let details = validate_trace2_command_events(&trace2_json, "init")?;
         Ok((details, trace2_json))
     })();
 
@@ -265,27 +281,36 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         Ok(())
     };
     let _ = fs::remove_file(&trace_path);
+    let _ = fs::remove_dir_all(&trace_command_dir);
 
     match (result, restore_result) {
         (Ok((mut details, trace2_json)), Ok(())) => {
             details.insert(0, format!("trace2 file: {}", trace_path.display()));
+            details.insert(1, format!("command dir: {}", trace_command_dir.display()));
             DiagnosticCheckResult::passed("trace2 file self-check completed", details, commands)
                 .with_trace2_json(Some(trace2_json))
         }
         (Ok((mut details, trace2_json)), Err(restore_err)) => {
+            details.insert(0, format!("trace2 file: {}", trace_path.display()));
+            details.insert(1, format!("command dir: {}", trace_command_dir.display()));
             details.push(format!("restore failed: {}", restore_err));
             DiagnosticCheckResult::failed("trace2 file self-check failed", details, commands)
                 .with_trace2_json(Some(trace2_json))
         }
         (Err(err), Ok(())) => DiagnosticCheckResult::failed(
             "trace2 file self-check failed",
-            vec![format!("trace2 file: {}", trace_path.display()), err],
+            vec![
+                format!("trace2 file: {}", trace_path.display()),
+                format!("command dir: {}", trace_command_dir.display()),
+                err,
+            ],
             commands,
         ),
         (Err(err), Err(restore_err)) => DiagnosticCheckResult::failed(
             "trace2 file self-check failed",
             vec![
                 format!("trace2 file: {}", trace_path.display()),
+                format!("command dir: {}", trace_command_dir.display()),
                 err,
                 format!("restore failed: {}", restore_err),
             ],
@@ -616,7 +641,10 @@ fn restore_global_trace2_event_target(
     Ok(())
 }
 
-fn validate_trace2_version_command_events(trace2_json: &str) -> Result<Vec<String>, String> {
+fn validate_trace2_command_events(
+    trace2_json: &str,
+    expected_command: &str,
+) -> Result<Vec<String>, String> {
     let mut events = Vec::new();
     for (idx, line) in trace2_json.lines().enumerate() {
         let trimmed = line.trim();
@@ -638,9 +666,9 @@ fn validate_trace2_version_command_events(trace2_json: &str) -> Result<Vec<Strin
     let has_start = events
         .iter()
         .any(|event| event.get("event").and_then(Value::as_str) == Some("start"));
-    let has_cmd_name_version = events.iter().any(|event| {
+    let has_cmd_name_expected = events.iter().any(|event| {
         event.get("event").and_then(Value::as_str) == Some("cmd_name")
-            && event.get("name").and_then(Value::as_str) == Some("version")
+            && event.get("name").and_then(Value::as_str) == Some(expected_command)
     });
     let has_exit_zero = events.iter().any(|event| {
         event.get("event").and_then(Value::as_str) == Some("exit")
@@ -654,7 +682,10 @@ fn validate_trace2_version_command_events(trace2_json: &str) -> Result<Vec<Strin
     let failures = [
         (has_version, "missing version event"),
         (has_start, "missing start event"),
-        (has_cmd_name_version, "missing cmd_name event for version"),
+        (
+            has_cmd_name_expected,
+            "missing cmd_name event for expected command",
+        ),
         (has_exit_zero, "missing exit event with code 0"),
         (has_atexit_zero, "missing atexit event with code 0"),
     ]
@@ -668,7 +699,10 @@ fn validate_trace2_version_command_events(trace2_json: &str) -> Result<Vec<Strin
 
     Ok(vec![
         format!("events: {}", events.len()),
-        "validated: version/start/cmd_name(version)/exit(0)/atexit(0)".to_string(),
+        format!(
+            "validated: version/start/cmd_name({})/exit(0)/atexit(0)",
+            expected_command
+        ),
     ])
 }
 
@@ -721,27 +755,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_validate_trace2_version_command_events_accepts_expected_events() {
+    fn test_validate_trace2_command_events_accepts_expected_events() {
         let trace = r#"{"event":"version"}
-{"event":"start","argv":["git","version"]}
-{"event":"cmd_name","name":"version"}
+{"event":"start","argv":["git","init","."]}
+{"event":"cmd_name","name":"init"}
 {"event":"exit","code":0}
 {"event":"atexit","code":0}
 "#;
 
-        let details = validate_trace2_version_command_events(trace).unwrap();
+        let details = validate_trace2_command_events(trace, "init").unwrap();
         assert!(details.iter().any(|detail| detail == "events: 5"));
     }
 
     #[test]
-    fn test_validate_trace2_version_command_events_rejects_missing_cmd_name() {
+    fn test_validate_trace2_command_events_rejects_missing_cmd_name() {
         let trace = r#"{"event":"version"}
-{"event":"start","argv":["git","version"]}
+{"event":"start","argv":["git","init","."]}
 {"event":"exit","code":0}
 {"event":"atexit","code":0}
 "#;
 
-        let err = validate_trace2_version_command_events(trace).unwrap_err();
-        assert!(err.contains("missing cmd_name event for version"));
+        let err = validate_trace2_command_events(trace, "init").unwrap_err();
+        assert!(err.contains("missing cmd_name event for expected command"));
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -4,10 +4,10 @@ use crate::diagnostic_sentinels::{
     DEBUG_SELF_CHECK_REMOTE_URL, debug_self_check_root, path_is_in_debug_self_check_root,
 };
 use crate::git::repository::discover_repository_in_path_no_git_exec;
+use crate::process_timeout::run_command_with_timeout;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::time::{Duration, Instant};
 
 const SELF_CHECK_FILE: &str = "git-ai-debug-self-check.txt";
@@ -17,8 +17,7 @@ const SELF_CHECK_CONTENT_AI: &str = "Untracked line\nKnown human line\nAI line\n
 const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
 const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
 const TRACE2_EVENT_NESTING_VALUE: &str = "10";
-const CHECKPOINT_WAIT: Duration = Duration::from_secs(10);
-const NOTE_WAIT: Duration = Duration::from_secs(20);
+const DEBUG_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,11 +42,12 @@ pub struct CommandRecord {
     pub status: Option<i32>,
     pub stdout: String,
     pub stderr: String,
+    pub timed_out: bool,
 }
 
 impl CommandRecord {
     fn success(&self) -> bool {
-        self.status == Some(0)
+        !self.timed_out && self.status == Some(0)
     }
 }
 
@@ -192,6 +192,7 @@ pub fn check_trace2_global_config(target: &GitDiagnosticTarget) -> DiagnosticChe
 
 pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
     let mut commands = Vec::new();
+    let deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
     let repo_path = debug_self_check_root().join(format!(
         "{}-{}",
         sanitize_label(&target.label),
@@ -203,70 +204,77 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         fs::create_dir_all(&repo_path)
             .map_err(|e| format!("failed to create {}: {}", repo_path.display(), e))?;
 
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["init", "."],
             Some(&repo_path),
+            deadline,
         )?;
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["config", "user.name", "Git AI Debug"],
             Some(&repo_path),
+            deadline,
         )?;
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["config", "user.email", "debug-self-check@git-ai.invalid"],
             Some(&repo_path),
+            deadline,
         )?;
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["remote", "add", "origin", DEBUG_SELF_CHECK_REMOTE_URL],
             Some(&repo_path),
+            deadline,
         )?;
 
         fs::write(&file_path, SELF_CHECK_CONTENT_UNTRACKED)
             .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
-        run_git_ai_checkpoint(&mut commands, &repo_path, "human")?;
-        wait_for_checkpoint_count(&repo_path, 1)?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "human", deadline)?;
+        wait_for_checkpoint_count(&repo_path, 1, deadline)?;
 
         fs::write(&file_path, SELF_CHECK_CONTENT_KNOWN_HUMAN)
             .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
-        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_known_human")?;
-        wait_for_checkpoint_count(&repo_path, 2)?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_known_human", deadline)?;
+        wait_for_checkpoint_count(&repo_path, 2, deadline)?;
 
         fs::write(&file_path, SELF_CHECK_CONTENT_AI)
             .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
-        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_ai")?;
-        wait_for_checkpoint_count(&repo_path, 3)?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_ai", deadline)?;
+        wait_for_checkpoint_count(&repo_path, 3, deadline)?;
 
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["add", SELF_CHECK_FILE],
             Some(&repo_path),
+            deadline,
         )?;
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["commit", "-m", "git-ai debug self check"],
             Some(&repo_path),
+            deadline,
         )?;
 
-        let commit_sha = run_required(
+        let commit_sha = run_required_until(
             &mut commands,
             &target.program,
             &["rev-parse", "HEAD"],
             Some(&repo_path),
+            deadline,
         )?
         .stdout
         .trim()
         .to_string();
 
-        let note = poll_authorship_note(&mut commands, &target.program, &repo_path)?;
+        let note = poll_authorship_note(&mut commands, &target.program, &repo_path, deadline)?;
         let mut details = validate_self_check_authorship_note(&note)?;
         details.insert(0, format!("repo: {}", repo_path.display()));
         details.insert(1, format!("commit: {}", commit_sha));
@@ -292,6 +300,7 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
 
 pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
     let mut commands = Vec::new();
+    let deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
     let trace_dir = crate::mdm::utils::home_dir()
         .join(".git-ai")
         .join("internal")
@@ -329,7 +338,7 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
 
         // This intentionally uses global git config rather than a process-local
         // GIT_TRACE2_EVENT override so the diagnostic exercises the install path.
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &[
@@ -340,16 +349,18 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
                 trace_path_string.as_str(),
             ],
             None,
+            deadline,
         )?;
         changed_global_event_target = true;
 
         // Use init rather than version: when terminal git is the git-ai proxy,
         // read-only commands intentionally suppress trace2 before invoking real git.
-        run_required(
+        run_required_until(
             &mut commands,
             &target.program,
             &["init", "."],
             Some(&trace_command_dir),
+            deadline,
         )?;
 
         let trace2_json = fs::read_to_string(&trace_path)
@@ -406,28 +417,76 @@ fn run_git_ai_checkpoint(
     commands: &mut Vec<CommandRecord>,
     repo_path: &Path,
     preset: &str,
+    deadline: Instant,
 ) -> Result<CommandRecord, String> {
     let git_ai = std::env::current_exe()
         .map_err(|e| format!("failed to resolve git-ai binary path: {}", e))?;
     let git_ai = git_ai.to_string_lossy().to_string();
-    run_required(
+    run_required_until(
         commands,
         &git_ai,
         &["checkpoint", preset, SELF_CHECK_FILE],
         Some(repo_path),
+        deadline,
     )
 }
 
-fn run_required(
+fn run_required_until(
     commands: &mut Vec<CommandRecord>,
     program: &str,
     args: &[&str],
     cwd: Option<&Path>,
+    deadline: Instant,
 ) -> Result<CommandRecord, String> {
-    let record = run_logged_command(program, args, cwd);
+    let timeout = remaining_timeout(deadline);
+    if timeout.is_zero() {
+        let record = CommandRecord {
+            command: format_command(program, args),
+            cwd: cwd.map(|p| p.display().to_string()),
+            status: None,
+            stdout: String::new(),
+            stderr: format!(
+                "self-check timed out after {:.1}s before this command could start",
+                DEBUG_CHECK_TIMEOUT.as_secs_f64()
+            ),
+            timed_out: true,
+        };
+        let error = format!("command timed out before start: {}", record.command);
+        commands.push(record);
+        return Err(error);
+    }
+
+    run_required_with_timeout(commands, program, args, cwd, timeout)
+}
+
+fn run_required_with_timeout(
+    commands: &mut Vec<CommandRecord>,
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    timeout: Duration,
+) -> Result<CommandRecord, String> {
+    let record = run_logged_command_with_timeout(program, args, cwd, timeout);
     let success = record.success();
     let error = if success {
         None
+    } else if record.timed_out {
+        let mut error = format!(
+            "command timed out: {} (timeout={:.1}s, status={})",
+            record.command,
+            timeout.as_secs_f64(),
+            format_status(record.status)
+        );
+        if let Some(cwd) = &record.cwd {
+            error.push_str(&format!(", cwd={}", cwd));
+        }
+        if !record.stdout.trim().is_empty() {
+            error.push_str(&format!(", stdout={}", record.stdout.trim()));
+        }
+        if !record.stderr.trim().is_empty() {
+            error.push_str(&format!(", stderr={}", record.stderr.trim()));
+        }
+        Some(error)
     } else {
         Some(format!(
             "command failed: {} (status={})",
@@ -443,34 +502,96 @@ fn run_required(
 }
 
 fn run_logged_command(program: &str, args: &[&str], cwd: Option<&Path>) -> CommandRecord {
-    let output = Command::new(program)
-        .args(args)
-        .current_dir(cwd.unwrap_or_else(|| Path::new(".")))
-        .output();
+    run_logged_command_with_timeout(program, args, cwd, DEBUG_CHECK_TIMEOUT)
+}
+
+fn run_logged_command_with_timeout(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    timeout: Duration,
+) -> CommandRecord {
     let command = format_command(program, args);
-    match output {
-        Ok(output) => CommandRecord {
-            command,
-            cwd: cwd.map(|p| p.display().to_string()),
-            status: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        },
+    let cwd_display = cwd.map(|p| p.display().to_string());
+    match run_command_with_timeout(program, args, cwd, timeout, POLL_INTERVAL) {
+        Ok(output) => {
+            let stderr = format_logged_stderr(
+                output.timed_out,
+                timeout,
+                output.stderr,
+                output.diagnostics,
+                output.wait_error,
+            );
+            CommandRecord {
+                command,
+                cwd: cwd_display,
+                status: output.status,
+                stdout: output.stdout,
+                stderr,
+                timed_out: output.timed_out,
+            }
+        }
         Err(e) => CommandRecord {
             command,
-            cwd: cwd.map(|p| p.display().to_string()),
+            cwd: cwd_display,
             status: None,
             stdout: String::new(),
-            stderr: format!("failed to execute: {}", e),
+            stderr: e,
+            timed_out: false,
         },
     }
 }
 
-fn wait_for_checkpoint_count(repo_path: &Path, expected_min_count: usize) -> Result<(), String> {
+fn format_logged_stderr(
+    timed_out: bool,
+    timeout: Duration,
+    process_stderr: String,
+    diagnostics: Vec<String>,
+    wait_error: Option<String>,
+) -> String {
+    let mut stderr = String::new();
+    if timed_out {
+        stderr.push_str(&format!("timed out after {:.1}s", timeout.as_secs_f64()));
+        if !process_stderr.trim().is_empty() {
+            stderr.push_str("\nstderr before timeout:\n");
+            stderr.push_str(process_stderr.trim());
+        }
+    } else {
+        stderr.push_str(process_stderr.trim());
+    }
+
+    if let Some(wait_error) = wait_error {
+        append_stderr_line(
+            &mut stderr,
+            &format!("failed while waiting for command: {}", wait_error),
+        );
+    }
+    for diagnostic in diagnostics {
+        append_stderr_line(&mut stderr, &diagnostic);
+    }
+    stderr
+}
+
+fn append_stderr_line(stderr: &mut String, line: &str) {
+    if !stderr.is_empty() {
+        stderr.push('\n');
+    }
+    stderr.push_str(line);
+}
+
+fn remaining_timeout(deadline: Instant) -> Duration {
+    deadline.saturating_duration_since(Instant::now())
+}
+
+fn wait_for_checkpoint_count(
+    repo_path: &Path,
+    expected_min_count: usize,
+    deadline: Instant,
+) -> Result<(), String> {
     let start = Instant::now();
     let mut last_error = None;
 
-    while start.elapsed() < CHECKPOINT_WAIT {
+    while Instant::now() < deadline {
         match read_checkpoint_count(repo_path) {
             Ok(count) if count >= expected_min_count => return Ok(()),
             Ok(count) => {
@@ -485,8 +606,14 @@ fn wait_for_checkpoint_count(repo_path: &Path, expected_min_count: usize) -> Res
     }
 
     Err(format!(
-        "timed out waiting for checkpoint persistence: {}",
-        last_error.unwrap_or_else(|| "no checkpoint status available".to_string())
+        "timed out after {:.1}s waiting for checkpoint persistence: {}",
+        start.elapsed().as_secs_f64(),
+        last_error.unwrap_or_else(|| {
+            format!(
+                "no checkpoint status available for repo {}",
+                repo_path.display()
+            )
+        })
     ))
 }
 
@@ -506,29 +633,43 @@ fn poll_authorship_note(
     commands: &mut Vec<CommandRecord>,
     git_program: &str,
     repo_path: &Path,
+    deadline: Instant,
 ) -> Result<String, String> {
     let start = Instant::now();
     let mut last_record = None;
 
-    while start.elapsed() < NOTE_WAIT {
-        let record = run_logged_command(
+    while Instant::now() < deadline {
+        let timeout = remaining_timeout(deadline);
+        if timeout.is_zero() {
+            break;
+        }
+        let record = run_logged_command_with_timeout(
             git_program,
             &["notes", "--ref=ai", "show", "HEAD"],
             Some(repo_path),
+            timeout,
         );
         if record.success() && !record.stdout.trim().is_empty() {
             let note = record.stdout.clone();
             commands.push(record);
             return Ok(note);
         }
+        let timed_out = record.timed_out;
         last_record = Some(record);
+        if timed_out {
+            break;
+        }
         std::thread::sleep(POLL_INTERVAL);
     }
 
     if let Some(record) = last_record {
         commands.push(record);
     }
-    Err("timed out waiting for authorship note on HEAD".to_string())
+    Err(format!(
+        "timed out after {:.1}s waiting for authorship note on HEAD in {}",
+        start.elapsed().as_secs_f64(),
+        repo_path.display()
+    ))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -925,6 +1066,26 @@ fn format_status(status: Option<i32>) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(not(windows))]
+    fn stdout_stderr_sleep_command() -> (&'static str, Vec<&'static str>) {
+        (
+            "sh",
+            vec!["-c", "printf out; printf err >&2; exec sleep 60"],
+        )
+    }
+
+    #[cfg(windows)]
+    fn stdout_stderr_sleep_command() -> (&'static str, Vec<&'static str>) {
+        (
+            "powershell.exe",
+            vec![
+                "-NoProfile",
+                "-Command",
+                "[Console]::Out.Write('out'); [Console]::Error.Write('err'); Start-Sleep -Seconds 60",
+            ],
+        )
+    }
+
     #[test]
     fn test_validate_trace2_command_events_accepts_expected_events() {
         let trace = r#"{"event":"version"}
@@ -981,5 +1142,26 @@ mod tests {
                 .iter()
                 .any(|detail| detail.contains("Common causes"))
         );
+    }
+
+    #[test]
+    fn test_run_logged_command_with_timeout_reports_partial_output() {
+        let (program, args) = stdout_stderr_sleep_command();
+        let record =
+            run_logged_command_with_timeout(program, &args, None, Duration::from_millis(300));
+
+        assert!(record.timed_out, "{record:?}");
+        assert_eq!(record.stdout, "out");
+        assert!(record.stderr.contains("timed out after"), "{record:?}");
+        assert!(
+            record.stderr.contains("sent kill to child process")
+                || record.stderr.contains("failed to kill child process"),
+            "{record:?}"
+        );
+        assert!(
+            record.stderr.contains("stderr before timeout"),
+            "{record:?}"
+        );
+        assert!(record.stderr.contains("err"), "{record:?}");
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -7,7 +7,7 @@ use crate::diagnostic_sentinels::{
 };
 use crate::git::notes_api;
 use crate::git::repository::discover_repository_in_path_no_git_exec;
-use crate::process_timeout::run_command_with_timeout_with_env;
+use crate::process_timeout::run_command_with_timeout;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -26,7 +26,6 @@ const SELF_CHECK_TRACE_ENV_REMOVE: &[&str] = &[
     "GIT_AI_WRAPPER_INVOCATION_ID",
     "GIT_TRACE2_ENV_VARS",
 ];
-const SELF_CHECK_VALIDATION_TRACE_ENV_SET: &[(&str, &str)] = &[("GIT_TRACE2_EVENT", "0")];
 const DEBUG_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 const DAEMON_CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -35,6 +34,7 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub enum DiagnosticStatus {
     Passed,
     Failed,
+    Skipped,
 }
 
 impl DiagnosticStatus {
@@ -42,6 +42,7 @@ impl DiagnosticStatus {
         match self {
             DiagnosticStatus::Passed => "passed",
             DiagnosticStatus::Failed => "failed",
+            DiagnosticStatus::Skipped => "skipped",
         }
     }
 }
@@ -96,6 +97,16 @@ impl DiagnosticCheckResult {
             summary: summary.into(),
             details,
             commands,
+            trace2_json: None,
+        }
+    }
+
+    pub(crate) fn skipped(summary: impl Into<String>, details: Vec<String>) -> Self {
+        Self {
+            status: DiagnosticStatus::Skipped,
+            summary: summary.into(),
+            details,
+            commands: Vec::new(),
             trace2_json: None,
         }
     }
@@ -404,13 +415,7 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         .trim()
         .to_string();
 
-        let note = poll_authorship_note(
-            &mut commands,
-            &target.program,
-            &repo_path,
-            &commit_sha,
-            deadline,
-        )?;
+        let note = poll_authorship_note(&repo_path, &commit_sha, deadline)?;
         let mut details = validate_self_check_authorship_note(&note)?;
         details.insert(0, format!("repo: {}", repo_path.display()));
         details.insert(1, format!("commit: {}", commit_sha));
@@ -690,26 +695,15 @@ fn run_logged_command_with_timeout(
     cwd: Option<&Path>,
     timeout: Duration,
 ) -> CommandRecord {
-    run_logged_command_with_timeout_and_env(program, args, cwd, timeout, &[])
-}
-
-fn run_logged_command_with_timeout_and_env(
-    program: &str,
-    args: &[&str],
-    cwd: Option<&Path>,
-    timeout: Duration,
-    env_set: &[(&str, &str)],
-) -> CommandRecord {
     let command = format_command(program, args);
     let cwd_display = cwd.map(|p| p.display().to_string());
-    match run_command_with_timeout_with_env(
+    match run_command_with_timeout(
         program,
         args,
         cwd,
         timeout,
         POLL_INTERVAL,
         SELF_CHECK_TRACE_ENV_REMOVE,
-        env_set,
     ) {
         Ok(output) => {
             let stderr = format_logged_stderr(
@@ -827,8 +821,6 @@ fn read_checkpoint_count(repo_path: &Path) -> Result<usize, String> {
 }
 
 fn poll_authorship_note(
-    commands: &mut Vec<CommandRecord>,
-    git_program: &str,
     repo_path: &Path,
     commit_sha: &str,
     deadline: Instant,
@@ -849,15 +841,6 @@ fn poll_authorship_note(
         }
         std::thread::sleep(POLL_INTERVAL);
     }
-
-    let diagnostic = run_logged_command_with_timeout_and_env(
-        git_program,
-        &["notes", "--ref=ai", "show", "HEAD"],
-        Some(repo_path),
-        remaining_timeout(deadline).max(POLL_INTERVAL),
-        SELF_CHECK_VALIDATION_TRACE_ENV_SET,
-    );
-    commands.push(diagnostic);
 
     Err(format!(
         "timed out after {:.1}s waiting for authorship note via {} backend for {} in {}",

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,5 +1,6 @@
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::working_log::CheckpointKind;
+use crate::daemon::control_api::{ControlRequest, FamilyStatus};
 use crate::diagnostic_sentinels::{
     DEBUG_SELF_CHECK_REMOTE_URL, debug_self_check_root, path_is_in_debug_self_check_root,
 };
@@ -8,7 +9,7 @@ use crate::process_timeout::run_command_with_timeout;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const SELF_CHECK_FILE: &str = "git-ai-debug-self-check.txt";
 const SELF_CHECK_CONTENT_UNTRACKED: &str = "Untracked line\n";
@@ -24,6 +25,7 @@ const SELF_CHECK_TRACE_ENV_REMOVE: &[&str] = &[
     "GIT_TRACE2_ENV_VARS",
 ];
 const DEBUG_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
+const DAEMON_CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,6 +114,125 @@ impl GitDiagnosticTarget {
         Self {
             label: label.into(),
             program: program.into(),
+        }
+    }
+}
+
+pub fn prepare_daemon_for_debug_self_checks(git_program: &str) -> DiagnosticCheckResult {
+    let mut commands = Vec::new();
+    let mut details = Vec::new();
+    let mut probe_deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
+
+    let config = match crate::daemon::DaemonConfig::from_env_or_default_paths() {
+        Ok(config) => config,
+        Err(err) => {
+            return DiagnosticCheckResult::failed(
+                "daemon readiness could not be inspected",
+                vec![format!("failed to determine daemon paths: {}", err)],
+                commands,
+            );
+        }
+    };
+
+    details.push(format!(
+        "control socket: {}",
+        config.control_socket_path.display()
+    ));
+    details.push(format!(
+        "trace2 socket: {}",
+        config.trace_socket_path.display()
+    ));
+    details.push(format!("lock: {}", config.lock_path.display()));
+
+    let initially_up = crate::commands::daemon::daemon_is_up(&config);
+    details.push(format!("initial daemon running: {}", initially_up));
+
+    let mut restarted = false;
+    if initially_up && daemon_binary_is_stale(&config).unwrap_or(false) {
+        details.push("running daemon was started before the current git-ai binary was written; restarting daemon".to_string());
+        if let Err(err) = crate::commands::daemon::restart_daemon(&config) {
+            details.push(format!("restart failed: {}", err));
+            return DiagnosticCheckResult::failed(
+                "daemon readiness check failed",
+                details,
+                commands,
+            );
+        }
+        restarted = true;
+        probe_deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
+    } else if !initially_up {
+        details.push("daemon was not running; starting daemon".to_string());
+        if let Err(err) = crate::commands::daemon::ensure_daemon_running(DEBUG_CHECK_TIMEOUT) {
+            details.push(format!("start failed: {}", err));
+            return DiagnosticCheckResult::failed(
+                "daemon readiness check failed",
+                details,
+                commands,
+            );
+        }
+        probe_deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
+    }
+
+    match run_daemon_trace2_ingestion_probe(&mut commands, git_program, &config, probe_deadline) {
+        Ok(mut probe_details) => {
+            details.append(&mut probe_details);
+            details.push(format!("daemon restarted: {}", restarted));
+            DiagnosticCheckResult::passed(
+                "daemon is ready for debug self-checks",
+                details,
+                commands,
+            )
+        }
+        Err(first_err) if !restarted => {
+            details.push(format!(
+                "initial trace2 daemon ingestion probe failed: {}",
+                first_err
+            ));
+            details
+                .push("restarting daemon and retrying trace2 daemon ingestion probe".to_string());
+            if let Err(restart_err) = crate::commands::daemon::restart_daemon(&config) {
+                details.push(format!("restart failed: {}", restart_err));
+                return DiagnosticCheckResult::failed(
+                    "daemon readiness check failed",
+                    details,
+                    commands,
+                );
+            }
+            restarted = true;
+
+            match run_daemon_trace2_ingestion_probe(
+                &mut commands,
+                git_program,
+                &config,
+                Instant::now() + DEBUG_CHECK_TIMEOUT,
+            ) {
+                Ok(mut probe_details) => {
+                    details.append(&mut probe_details);
+                    details.push(format!("daemon restarted: {}", restarted));
+                    DiagnosticCheckResult::passed(
+                        "daemon is ready for debug self-checks",
+                        details,
+                        commands,
+                    )
+                }
+                Err(retry_err) => {
+                    details.push(format!(
+                        "trace2 daemon ingestion probe failed after restart: {}",
+                        retry_err
+                    ));
+                    details.push(format!("daemon restarted: {}", restarted));
+                    DiagnosticCheckResult::failed(
+                        "daemon readiness check failed",
+                        details,
+                        commands,
+                    )
+                }
+            }
+        }
+        Err(err) => {
+            details.push(format!("trace2 daemon ingestion probe failed: {}", err));
+            details.push(format!("daemon restarted: {}", restarted));
+            DiagnosticCheckResult::failed("daemon readiness check failed", details, commands)
         }
     }
 }
@@ -294,6 +415,7 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         }
         Err(err) => {
             let mut details = vec![format!("repo: {}", repo_path.display()), err];
+            details.push(daemon_family_status_detail(&repo_path));
             if path_is_in_debug_self_check_root(&repo_path) {
                 details.push(
                     "failed self-check repository was left in place for inspection".to_string(),
@@ -417,6 +539,44 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
             commands,
         ),
     }
+}
+
+fn run_daemon_trace2_ingestion_probe(
+    commands: &mut Vec<CommandRecord>,
+    git_program: &str,
+    config: &crate::daemon::DaemonConfig,
+    deadline: Instant,
+) -> Result<Vec<String>, String> {
+    let probe_path =
+        debug_self_check_root().join(format!("daemon-probe-{}", crate::uuid::generate_v4()));
+
+    let result = (|| -> Result<Vec<String>, String> {
+        fs::create_dir_all(&probe_path)
+            .map_err(|e| format!("failed to create {}: {}", probe_path.display(), e))?;
+        run_required_until(
+            commands,
+            git_program,
+            &["init", "."],
+            Some(&probe_path),
+            deadline,
+        )?;
+
+        let status = wait_for_daemon_family_status(config, &probe_path, 1, deadline)?;
+        Ok(vec![
+            format!("daemon trace2 probe repo: {}", probe_path.display()),
+            format!("daemon trace2 probe latest_seq: {}", status.latest_seq),
+            format!(
+                "daemon trace2 probe last_error: {}",
+                status.last_error.unwrap_or_else(|| "<none>".to_string())
+            ),
+        ])
+    })();
+
+    if result.is_ok() {
+        let _ = fs::remove_dir_all(&probe_path);
+    }
+
+    result
 }
 
 fn run_git_ai_checkpoint(
@@ -683,6 +843,127 @@ fn poll_authorship_note(
         start.elapsed().as_secs_f64(),
         repo_path.display()
     ))
+}
+
+fn wait_for_daemon_family_status(
+    config: &crate::daemon::DaemonConfig,
+    repo_path: &Path,
+    expected_min_seq: u64,
+    deadline: Instant,
+) -> Result<FamilyStatus, String> {
+    let mut last_error = None;
+
+    while Instant::now() < deadline {
+        match read_daemon_family_status(config, repo_path) {
+            Ok(status) if status.latest_seq >= expected_min_seq => return Ok(status),
+            Ok(status) => {
+                last_error = Some(format!(
+                    "latest_seq={}, expected at least {}, last_error={}",
+                    status.latest_seq,
+                    expected_min_seq,
+                    status.last_error.as_deref().unwrap_or("<none>")
+                ));
+            }
+            Err(err) => last_error = Some(err),
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    Err(format!(
+        "timed out waiting for daemon family status: {}",
+        last_error.unwrap_or_else(|| format!("no status for {}", repo_path.display()))
+    ))
+}
+
+fn read_daemon_family_status(
+    config: &crate::daemon::DaemonConfig,
+    repo_path: &Path,
+) -> Result<FamilyStatus, String> {
+    let request = ControlRequest::StatusFamily {
+        repo_working_dir: repo_path.display().to_string(),
+    };
+    let response = crate::daemon::send_control_request_with_timeout(
+        &config.control_socket_path,
+        &request,
+        DAEMON_CONTROL_TIMEOUT,
+    )
+    .map_err(|e| e.to_string())?;
+
+    if !response.ok {
+        return Err(response
+            .error
+            .unwrap_or_else(|| "daemon status request failed".to_string()));
+    }
+
+    let data = response
+        .data
+        .ok_or_else(|| "daemon status response had no data".to_string())?;
+    serde_json::from_value::<FamilyStatus>(data).map_err(|e| e.to_string())
+}
+
+fn daemon_family_status_detail(repo_path: &Path) -> String {
+    let config = match crate::daemon::DaemonConfig::from_env_or_default_paths() {
+        Ok(config) => config,
+        Err(err) => {
+            return format!("daemon status for repo: <error: {}>", err);
+        }
+    };
+
+    match read_daemon_family_status(&config, repo_path) {
+        Ok(status) => format!(
+            "daemon status for repo: latest_seq={}, last_error={}",
+            status.latest_seq,
+            status.last_error.as_deref().unwrap_or("<none>")
+        ),
+        Err(err) => format!("daemon status for repo: <error: {}>", err),
+    }
+}
+
+fn daemon_binary_is_stale(config: &crate::daemon::DaemonConfig) -> Result<bool, String> {
+    let Some(started_at_ns) = read_daemon_started_at_ns(config)? else {
+        return Ok(false);
+    };
+    let binary_modified_ns = current_binary_modified_ns()?;
+    Ok(binary_modified_ns > started_at_ns)
+}
+
+fn read_daemon_started_at_ns(config: &crate::daemon::DaemonConfig) -> Result<Option<u128>, String> {
+    let pid_path = config.internal_dir.join("daemon").join("daemon.pid.json");
+    let contents = match fs::read_to_string(&pid_path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(format!(
+                "failed to read daemon pid metadata at {}: {}",
+                pid_path.display(),
+                err
+            ));
+        }
+    };
+    let value: Value = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
+    Ok(value
+        .get("started_at_ns")
+        .and_then(Value::as_u64)
+        .map(u128::from))
+}
+
+fn current_binary_modified_ns() -> Result<u128, String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let modified = fs::metadata(&exe)
+        .and_then(|metadata| metadata.modified())
+        .map_err(|e| format!("failed to read mtime for {}: {}", exe.display(), e))?;
+    system_time_to_unix_nanos(modified).ok_or_else(|| {
+        format!(
+            "failed to convert mtime for {} to unix timestamp",
+            exe.display()
+        )
+    })
+}
+
+fn system_time_to_unix_nanos(time: SystemTime) -> Option<u128> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_nanos())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,747 @@
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::working_log::CheckpointKind;
+use crate::diagnostic_sentinels::{
+    DEBUG_SELF_CHECK_REMOTE_URL, debug_self_check_root, path_is_in_debug_self_check_root,
+};
+use crate::git::repository::discover_repository_in_path_no_git_exec;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+const SELF_CHECK_FILE: &str = "git-ai-debug-self-check.txt";
+const SELF_CHECK_CONTENT_UNTRACKED: &str = "Untracked line\n";
+const SELF_CHECK_CONTENT_KNOWN_HUMAN: &str = "Untracked line\nKnown human line\n";
+const SELF_CHECK_CONTENT_AI: &str = "Untracked line\nKnown human line\nAI line\n";
+const CHECKPOINT_WAIT: Duration = Duration::from_secs(10);
+const NOTE_WAIT: Duration = Duration::from_secs(20);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticStatus {
+    Passed,
+    Failed,
+}
+
+impl DiagnosticStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiagnosticStatus::Passed => "passed",
+            DiagnosticStatus::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandRecord {
+    pub command: String,
+    pub cwd: Option<String>,
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl CommandRecord {
+    fn success(&self) -> bool {
+        self.status == Some(0)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiagnosticCheckResult {
+    pub status: DiagnosticStatus,
+    pub summary: String,
+    pub details: Vec<String>,
+    pub commands: Vec<CommandRecord>,
+    pub trace2_json: Option<String>,
+}
+
+impl DiagnosticCheckResult {
+    fn passed(
+        summary: impl Into<String>,
+        details: Vec<String>,
+        commands: Vec<CommandRecord>,
+    ) -> Self {
+        Self {
+            status: DiagnosticStatus::Passed,
+            summary: summary.into(),
+            details,
+            commands,
+            trace2_json: None,
+        }
+    }
+
+    fn failed(
+        summary: impl Into<String>,
+        details: Vec<String>,
+        commands: Vec<CommandRecord>,
+    ) -> Self {
+        Self {
+            status: DiagnosticStatus::Failed,
+            summary: summary.into(),
+            details,
+            commands,
+            trace2_json: None,
+        }
+    }
+
+    fn with_trace2_json(mut self, trace2_json: Option<String>) -> Self {
+        self.trace2_json = trace2_json;
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GitDiagnosticTarget {
+    pub label: String,
+    pub program: String,
+}
+
+impl GitDiagnosticTarget {
+    pub fn new(label: impl Into<String>, program: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            program: program.into(),
+        }
+    }
+}
+
+pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
+    let mut commands = Vec::new();
+    let repo_path = debug_self_check_root().join(format!(
+        "{}-{}",
+        sanitize_label(&target.label),
+        crate::uuid::generate_v4()
+    ));
+    let file_path = repo_path.join(SELF_CHECK_FILE);
+
+    let result = (|| -> Result<Vec<String>, String> {
+        fs::create_dir_all(&repo_path)
+            .map_err(|e| format!("failed to create {}: {}", repo_path.display(), e))?;
+
+        run_required(
+            &mut commands,
+            &target.program,
+            &["init", "."],
+            Some(&repo_path),
+        )?;
+        run_required(
+            &mut commands,
+            &target.program,
+            &["config", "user.name", "Git AI Debug"],
+            Some(&repo_path),
+        )?;
+        run_required(
+            &mut commands,
+            &target.program,
+            &["config", "user.email", "debug-self-check@git-ai.invalid"],
+            Some(&repo_path),
+        )?;
+        run_required(
+            &mut commands,
+            &target.program,
+            &["remote", "add", "origin", DEBUG_SELF_CHECK_REMOTE_URL],
+            Some(&repo_path),
+        )?;
+
+        fs::write(&file_path, SELF_CHECK_CONTENT_UNTRACKED)
+            .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "human")?;
+        wait_for_checkpoint_count(&repo_path, 1)?;
+
+        fs::write(&file_path, SELF_CHECK_CONTENT_KNOWN_HUMAN)
+            .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_known_human")?;
+        wait_for_checkpoint_count(&repo_path, 2)?;
+
+        fs::write(&file_path, SELF_CHECK_CONTENT_AI)
+            .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_ai")?;
+        wait_for_checkpoint_count(&repo_path, 3)?;
+
+        run_required(
+            &mut commands,
+            &target.program,
+            &["add", SELF_CHECK_FILE],
+            Some(&repo_path),
+        )?;
+        run_required(
+            &mut commands,
+            &target.program,
+            &["commit", "-m", "git-ai debug self check"],
+            Some(&repo_path),
+        )?;
+
+        let commit_sha = run_required(
+            &mut commands,
+            &target.program,
+            &["rev-parse", "HEAD"],
+            Some(&repo_path),
+        )?
+        .stdout
+        .trim()
+        .to_string();
+
+        let note = poll_authorship_note(&mut commands, &target.program, &repo_path)?;
+        let mut details = validate_self_check_authorship_note(&note)?;
+        details.insert(0, format!("repo: {}", repo_path.display()));
+        details.insert(1, format!("commit: {}", commit_sha));
+        Ok(details)
+    })();
+
+    match result {
+        Ok(details) => {
+            let _ = fs::remove_dir_all(&repo_path);
+            DiagnosticCheckResult::passed("attribution self-check completed", details, commands)
+        }
+        Err(err) => {
+            let mut details = vec![format!("repo: {}", repo_path.display()), err];
+            if path_is_in_debug_self_check_root(&repo_path) {
+                details.push(
+                    "failed self-check repository was left in place for inspection".to_string(),
+                );
+            }
+            DiagnosticCheckResult::failed("attribution self-check failed", details, commands)
+        }
+    }
+}
+
+pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
+    let mut commands = Vec::new();
+    let trace_dir = crate::mdm::utils::home_dir()
+        .join(".git-ai")
+        .join("internal")
+        .join("daemon");
+    let trace_path = trace_dir.join(format!(
+        "trace2-debug-check-{}-{}.json",
+        sanitize_label(&target.label),
+        crate::uuid::generate_v4()
+    ));
+
+    let snapshot = match snapshot_global_trace2_event_target(&mut commands, &target.program) {
+        Ok(snapshot) => snapshot,
+        Err(err) => {
+            return DiagnosticCheckResult::failed(
+                "trace2 file self-check failed",
+                vec![err],
+                commands,
+            );
+        }
+    };
+
+    let mut changed_global_event_target = false;
+    let result = (|| -> Result<(Vec<String>, String), String> {
+        fs::create_dir_all(&trace_dir)
+            .map_err(|e| format!("failed to create {}: {}", trace_dir.display(), e))?;
+        let _ = fs::remove_file(&trace_path);
+        let trace_path_string = trace_path.to_string_lossy().to_string();
+
+        run_required(
+            &mut commands,
+            &target.program,
+            &[
+                "config",
+                "--global",
+                "--replace-all",
+                "trace2.eventTarget",
+                trace_path_string.as_str(),
+            ],
+            None,
+        )?;
+        changed_global_event_target = true;
+
+        run_required(&mut commands, &target.program, &["version"], None)?;
+
+        let trace2_json = fs::read_to_string(&trace_path)
+            .map_err(|e| format!("failed to read {}: {}", trace_path.display(), e))?;
+        let details = validate_trace2_version_command_events(&trace2_json)?;
+        Ok((details, trace2_json))
+    })();
+
+    let restore_result = if changed_global_event_target {
+        restore_global_trace2_event_target(&mut commands, &target.program, &snapshot)
+    } else {
+        Ok(())
+    };
+    let _ = fs::remove_file(&trace_path);
+
+    match (result, restore_result) {
+        (Ok((mut details, trace2_json)), Ok(())) => {
+            details.insert(0, format!("trace2 file: {}", trace_path.display()));
+            DiagnosticCheckResult::passed("trace2 file self-check completed", details, commands)
+                .with_trace2_json(Some(trace2_json))
+        }
+        (Ok((mut details, trace2_json)), Err(restore_err)) => {
+            details.push(format!("restore failed: {}", restore_err));
+            DiagnosticCheckResult::failed("trace2 file self-check failed", details, commands)
+                .with_trace2_json(Some(trace2_json))
+        }
+        (Err(err), Ok(())) => DiagnosticCheckResult::failed(
+            "trace2 file self-check failed",
+            vec![format!("trace2 file: {}", trace_path.display()), err],
+            commands,
+        ),
+        (Err(err), Err(restore_err)) => DiagnosticCheckResult::failed(
+            "trace2 file self-check failed",
+            vec![
+                format!("trace2 file: {}", trace_path.display()),
+                err,
+                format!("restore failed: {}", restore_err),
+            ],
+            commands,
+        ),
+    }
+}
+
+fn run_git_ai_checkpoint(
+    commands: &mut Vec<CommandRecord>,
+    repo_path: &Path,
+    preset: &str,
+) -> Result<CommandRecord, String> {
+    let git_ai = std::env::current_exe()
+        .map_err(|e| format!("failed to resolve git-ai binary path: {}", e))?;
+    let git_ai = git_ai.to_string_lossy().to_string();
+    run_required(
+        commands,
+        &git_ai,
+        &["checkpoint", preset, SELF_CHECK_FILE],
+        Some(repo_path),
+    )
+}
+
+fn run_required(
+    commands: &mut Vec<CommandRecord>,
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+) -> Result<CommandRecord, String> {
+    let record = run_logged_command(program, args, cwd);
+    let success = record.success();
+    let error = if success {
+        None
+    } else {
+        Some(format!(
+            "command failed: {} (status={})",
+            record.command,
+            format_status(record.status)
+        ))
+    };
+    commands.push(record.clone());
+    match error {
+        Some(error) => Err(error),
+        None => Ok(record),
+    }
+}
+
+fn run_logged_command(program: &str, args: &[&str], cwd: Option<&Path>) -> CommandRecord {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(cwd.unwrap_or_else(|| Path::new(".")))
+        .output();
+    let command = format_command(program, args);
+    match output {
+        Ok(output) => CommandRecord {
+            command,
+            cwd: cwd.map(|p| p.display().to_string()),
+            status: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        },
+        Err(e) => CommandRecord {
+            command,
+            cwd: cwd.map(|p| p.display().to_string()),
+            status: None,
+            stdout: String::new(),
+            stderr: format!("failed to execute: {}", e),
+        },
+    }
+}
+
+fn wait_for_checkpoint_count(repo_path: &Path, expected_min_count: usize) -> Result<(), String> {
+    let start = Instant::now();
+    let mut last_error = None;
+
+    while start.elapsed() < CHECKPOINT_WAIT {
+        match read_checkpoint_count(repo_path) {
+            Ok(count) if count >= expected_min_count => return Ok(()),
+            Ok(count) => {
+                last_error = Some(format!(
+                    "only {} checkpoint(s) visible, expected at least {}",
+                    count, expected_min_count
+                ));
+            }
+            Err(e) => last_error = Some(e),
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    Err(format!(
+        "timed out waiting for checkpoint persistence: {}",
+        last_error.unwrap_or_else(|| "no checkpoint status available".to_string())
+    ))
+}
+
+fn read_checkpoint_count(repo_path: &Path) -> Result<usize, String> {
+    let repo = discover_repository_in_path_no_git_exec(repo_path).map_err(|e| e.to_string())?;
+    let working_log = repo
+        .storage
+        .working_log_for_base_commit("initial")
+        .map_err(|e| e.to_string())?;
+    working_log
+        .read_all_checkpoints()
+        .map(|checkpoints| checkpoints.len())
+        .map_err(|e| e.to_string())
+}
+
+fn poll_authorship_note(
+    commands: &mut Vec<CommandRecord>,
+    git_program: &str,
+    repo_path: &Path,
+) -> Result<String, String> {
+    let start = Instant::now();
+    let mut last_record = None;
+
+    while start.elapsed() < NOTE_WAIT {
+        let record = run_logged_command(
+            git_program,
+            &["notes", "--ref=ai", "show", "HEAD"],
+            Some(repo_path),
+        );
+        if record.success() && !record.stdout.trim().is_empty() {
+            let note = record.stdout.clone();
+            commands.push(record);
+            return Ok(note);
+        }
+        last_record = Some(record);
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    if let Some(record) = last_record {
+        commands.push(record);
+    }
+    Err("timed out waiting for authorship note on HEAD".to_string())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LineClassification {
+    Untracked,
+    KnownHuman,
+    Ai,
+    Unknown,
+}
+
+impl LineClassification {
+    fn as_str(self) -> &'static str {
+        match self {
+            LineClassification::Untracked => "untracked",
+            LineClassification::KnownHuman => "known_human",
+            LineClassification::Ai => "ai",
+            LineClassification::Unknown => "unknown",
+        }
+    }
+}
+
+fn validate_self_check_authorship_note(note: &str) -> Result<Vec<String>, String> {
+    let authorship = AuthorshipLog::deserialize_from_string(note)
+        .map_err(|e| format!("failed to parse authorship note: {}", e))?;
+
+    let expected = [
+        (1, LineClassification::Untracked),
+        (2, LineClassification::KnownHuman),
+        (3, LineClassification::Ai),
+    ];
+    let mut details = Vec::new();
+
+    for (line, expected_class) in expected {
+        let actual = classify_line(&authorship, SELF_CHECK_FILE, line);
+        details.push(format!(
+            "line {}: {} (expected {})",
+            line,
+            actual.as_str(),
+            expected_class.as_str()
+        ));
+        if actual != expected_class {
+            return Err(format!(
+                "unexpected attribution for line {}: got {}, expected {}\n{}",
+                line,
+                actual.as_str(),
+                expected_class.as_str(),
+                note
+            ));
+        }
+    }
+
+    Ok(details)
+}
+
+fn classify_line(authorship: &AuthorshipLog, file: &str, line: u32) -> LineClassification {
+    let Some(file_attestation) = authorship
+        .attestations
+        .iter()
+        .find(|attestation| attestation.file_path == file)
+    else {
+        return LineClassification::Untracked;
+    };
+
+    for entry in file_attestation.entries.iter().rev() {
+        if !entry.line_ranges.iter().any(|range| range.contains(line)) {
+            continue;
+        }
+
+        if entry.hash.starts_with("h_") && authorship.metadata.humans.contains_key(&entry.hash) {
+            return LineClassification::KnownHuman;
+        }
+
+        if authorship
+            .metadata
+            .prompts
+            .get(&entry.hash)
+            .is_some_and(|prompt| prompt.agent_id.tool == "mock_ai")
+        {
+            return LineClassification::Ai;
+        }
+
+        if entry.hash.starts_with("s_") {
+            let session_key = entry.hash.split("::").next().unwrap_or(&entry.hash);
+            if authorship
+                .metadata
+                .sessions
+                .get(session_key)
+                .is_some_and(|session| session.agent_id.tool == "mock_ai")
+            {
+                return LineClassification::Ai;
+            }
+        }
+
+        if entry.hash == CheckpointKind::Human.to_str() {
+            return LineClassification::Untracked;
+        }
+
+        return LineClassification::Unknown;
+    }
+
+    LineClassification::Untracked
+}
+
+#[derive(Debug, Clone, Default)]
+struct Trace2EventTargetSnapshot {
+    values: Vec<String>,
+}
+
+fn snapshot_global_trace2_event_target(
+    commands: &mut Vec<CommandRecord>,
+    git_program: &str,
+) -> Result<Trace2EventTargetSnapshot, String> {
+    let record = run_logged_command(
+        git_program,
+        &[
+            "config",
+            "--global",
+            "--no-includes",
+            "--get-all",
+            "trace2.eventTarget",
+        ],
+        None,
+    );
+    let snapshot = if record.success() {
+        record
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
+    } else if record.status == Some(1) {
+        Vec::new()
+    } else {
+        let err = format!(
+            "failed to snapshot global trace2.eventTarget: status={}, stderr={}",
+            format_status(record.status),
+            record.stderr
+        );
+        commands.push(record);
+        return Err(err);
+    };
+    commands.push(record);
+    Ok(Trace2EventTargetSnapshot { values: snapshot })
+}
+
+fn restore_global_trace2_event_target(
+    commands: &mut Vec<CommandRecord>,
+    git_program: &str,
+    snapshot: &Trace2EventTargetSnapshot,
+) -> Result<(), String> {
+    let remove = run_logged_command(
+        git_program,
+        &["config", "--global", "--unset-all", "trace2.eventTarget"],
+        None,
+    );
+    let remove_ok = remove.success() || remove.status == Some(5);
+    let remove_error = if remove_ok {
+        None
+    } else {
+        Some(format!(
+            "failed to remove temporary trace2.eventTarget: status={}, stderr={}",
+            format_status(remove.status),
+            remove.stderr
+        ))
+    };
+    commands.push(remove);
+    if let Some(error) = remove_error {
+        return Err(error);
+    }
+
+    for value in &snapshot.values {
+        let record = run_logged_command(
+            git_program,
+            &["config", "--global", "--add", "trace2.eventTarget", value],
+            None,
+        );
+        let error = if record.success() {
+            None
+        } else {
+            Some(format!(
+                "failed to restore trace2.eventTarget: status={}, stderr={}",
+                format_status(record.status),
+                record.stderr
+            ))
+        };
+        commands.push(record);
+        if let Some(error) = error {
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_trace2_version_command_events(trace2_json: &str) -> Result<Vec<String>, String> {
+    let mut events = Vec::new();
+    for (idx, line) in trace2_json.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(trimmed)
+            .map_err(|e| format!("invalid trace2 JSON on line {}: {}", idx + 1, e))?;
+        events.push(value);
+    }
+
+    if events.is_empty() {
+        return Err("trace2 file was empty".to_string());
+    }
+
+    let has_version = events
+        .iter()
+        .any(|event| event.get("event").and_then(Value::as_str) == Some("version"));
+    let has_start = events
+        .iter()
+        .any(|event| event.get("event").and_then(Value::as_str) == Some("start"));
+    let has_cmd_name_version = events.iter().any(|event| {
+        event.get("event").and_then(Value::as_str) == Some("cmd_name")
+            && event.get("name").and_then(Value::as_str) == Some("version")
+    });
+    let has_exit_zero = events.iter().any(|event| {
+        event.get("event").and_then(Value::as_str) == Some("exit")
+            && event.get("code").and_then(Value::as_i64) == Some(0)
+    });
+    let has_atexit_zero = events.iter().any(|event| {
+        event.get("event").and_then(Value::as_str) == Some("atexit")
+            && event.get("code").and_then(Value::as_i64) == Some(0)
+    });
+
+    let failures = [
+        (has_version, "missing version event"),
+        (has_start, "missing start event"),
+        (has_cmd_name_version, "missing cmd_name event for version"),
+        (has_exit_zero, "missing exit event with code 0"),
+        (has_atexit_zero, "missing atexit event with code 0"),
+    ]
+    .into_iter()
+    .filter_map(|(ok, msg)| (!ok).then_some(msg))
+    .collect::<Vec<_>>();
+
+    if !failures.is_empty() {
+        return Err(format!("unexpected trace2 events: {}", failures.join(", ")));
+    }
+
+    Ok(vec![
+        format!("events: {}", events.len()),
+        "validated: version/start/cmd_name(version)/exit(0)/atexit(0)".to_string(),
+    ])
+}
+
+fn sanitize_label(label: &str) -> String {
+    let sanitized = label
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "git".to_string()
+    } else {
+        trimmed.to_lowercase()
+    }
+}
+
+fn format_command(program: &str, args: &[&str]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().copied())
+        .map(shell_quote_for_display)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote_for_display(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || "-_./:=@".contains(ch))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+fn format_status(status: Option<i32>) -> String {
+    status
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "unavailable".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_trace2_version_command_events_accepts_expected_events() {
+        let trace = r#"{"event":"version"}
+{"event":"start","argv":["git","version"]}
+{"event":"cmd_name","name":"version"}
+{"event":"exit","code":0}
+{"event":"atexit","code":0}
+"#;
+
+        let details = validate_trace2_version_command_events(trace).unwrap();
+        assert!(details.iter().any(|detail| detail == "events: 5"));
+    }
+
+    #[test]
+    fn test_validate_trace2_version_command_events_rejects_missing_cmd_name() {
+        let trace = r#"{"event":"version"}
+{"event":"start","argv":["git","version"]}
+{"event":"exit","code":0}
+{"event":"atexit","code":0}
+"#;
+
+        let err = validate_trace2_version_command_events(trace).unwrap_err();
+        assert!(err.contains("missing cmd_name event for version"));
+    }
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,11 +1,10 @@
-use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::working_log::CheckpointKind;
+use crate::commands::blame::{BlameAnalysisResult, GitAiBlameOptions};
 use crate::config::Config;
 use crate::daemon::control_api::{ControlRequest, FamilyStatus};
 use crate::diagnostic_sentinels::{
     DEBUG_SELF_CHECK_REMOTE_URL, debug_self_check_root, path_is_in_debug_self_check_root,
 };
-use crate::git::notes_api;
 use crate::git::repository::discover_repository_in_path_no_git_exec;
 use crate::process_timeout::run_command_with_timeout;
 use serde_json::Value;
@@ -415,8 +414,7 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         .trim()
         .to_string();
 
-        let note = poll_authorship_note(&repo_path, &commit_sha, deadline)?;
-        let mut details = validate_self_check_authorship_note(&note)?;
+        let mut details = poll_self_check_attribution(&repo_path, &commit_sha, deadline)?;
         details.insert(0, format!("repo: {}", repo_path.display()));
         details.insert(1, format!("commit: {}", commit_sha));
         details.insert(
@@ -820,20 +818,23 @@ fn read_checkpoint_count(repo_path: &Path) -> Result<usize, String> {
         .map_err(|e| e.to_string())
 }
 
-fn poll_authorship_note(
+fn poll_self_check_attribution(
     repo_path: &Path,
     commit_sha: &str,
     deadline: Instant,
-) -> Result<String, String> {
+) -> Result<Vec<String>, String> {
     let start = Instant::now();
     let repo = discover_repository_in_path_no_git_exec(repo_path).map_err(|e| e.to_string())?;
     let notes_backend = Config::get().notes_backend_kind();
+    let mut last_error = None;
 
     while Instant::now() < deadline {
-        if let Some(note) = notes_api::read_note(&repo, commit_sha)
-            && !note.trim().is_empty()
-        {
-            return Ok(note);
+        match validate_self_check_blame_analysis(
+            repo.blame_analysis(SELF_CHECK_FILE, &self_check_blame_options(commit_sha))
+                .map_err(|e| e.to_string()),
+        ) {
+            Ok(details) => return Ok(details),
+            Err(err) => last_error = Some(err),
         }
 
         if remaining_timeout(deadline).is_zero() {
@@ -843,12 +844,23 @@ fn poll_authorship_note(
     }
 
     Err(format!(
-        "timed out after {:.1}s waiting for authorship note via {} backend for {} in {}",
+        "timed out after {:.1}s waiting for expected attribution via {} backend for {} in {}: {}",
         start.elapsed().as_secs_f64(),
         notes_backend,
         commit_sha,
-        repo_path.display()
+        repo_path.display(),
+        last_error.unwrap_or_else(|| "no blame analysis result available".to_string())
     ))
+}
+
+fn self_check_blame_options(commit_sha: &str) -> GitAiBlameOptions {
+    GitAiBlameOptions {
+        line_ranges: vec![(1, 3)],
+        newest_commit: Some(commit_sha.to_string()),
+        use_prompt_hashes_as_names: true,
+        return_human_authors_as_human: true,
+        ..GitAiBlameOptions::default()
+    }
 }
 
 fn wait_for_daemon_family_status(
@@ -991,10 +1003,10 @@ impl LineClassification {
     }
 }
 
-fn validate_self_check_authorship_note(note: &str) -> Result<Vec<String>, String> {
-    let authorship = AuthorshipLog::deserialize_from_string(note)
-        .map_err(|e| format!("failed to parse authorship note: {}", e))?;
-
+fn validate_self_check_blame_analysis(
+    analysis: Result<BlameAnalysisResult, String>,
+) -> Result<Vec<String>, String> {
+    let analysis = analysis.map_err(|err| format!("blame analysis failed: {}", err))?;
     let expected = [
         (1, LineClassification::Untracked),
         (2, LineClassification::KnownHuman),
@@ -1003,12 +1015,18 @@ fn validate_self_check_authorship_note(note: &str) -> Result<Vec<String>, String
     let mut details = Vec::new();
 
     for (line, expected_class) in expected {
-        let actual = classify_line(&authorship, SELF_CHECK_FILE, line);
+        let actual = classify_line(&analysis, line);
+        let raw_author = analysis
+            .line_authors
+            .get(&line)
+            .cloned()
+            .unwrap_or_else(|| "<missing>".to_string());
         details.push(format!(
-            "line {}: {} (expected {})",
+            "line {}: {} (expected {}, raw={})",
             line,
             actual.as_str(),
-            expected_class.as_str()
+            expected_class.as_str(),
+            raw_author
         ));
         if actual != expected_class {
             return Err(format!(
@@ -1016,61 +1034,51 @@ fn validate_self_check_authorship_note(note: &str) -> Result<Vec<String>, String
                 line,
                 actual.as_str(),
                 expected_class.as_str(),
-                note
+                format_blame_analysis_debug(&analysis)
             ));
         }
     }
 
+    details.push(format_blame_analysis_debug(&analysis));
     Ok(details)
 }
 
-fn classify_line(authorship: &AuthorshipLog, file: &str, line: u32) -> LineClassification {
-    let Some(file_attestation) = authorship
-        .attestations
-        .iter()
-        .find(|attestation| attestation.file_path == file)
-    else {
-        return LineClassification::Untracked;
+fn classify_line(analysis: &BlameAnalysisResult, line: u32) -> LineClassification {
+    let Some(author) = analysis.line_authors.get(&line) else {
+        return LineClassification::Unknown;
     };
 
-    for entry in file_attestation.entries.iter().rev() {
-        if !entry.line_ranges.iter().any(|range| range.contains(line)) {
-            continue;
-        }
-
-        if entry.hash.starts_with("h_") && authorship.metadata.humans.contains_key(&entry.hash) {
-            return LineClassification::KnownHuman;
-        }
-
-        if authorship
-            .metadata
-            .prompts
-            .get(&entry.hash)
-            .is_some_and(|prompt| prompt.agent_id.tool == "mock_ai")
-        {
-            return LineClassification::Ai;
-        }
-
-        if entry.hash.starts_with("s_") {
-            let session_key = entry.hash.split("::").next().unwrap_or(&entry.hash);
-            if authorship
-                .metadata
-                .sessions
-                .get(session_key)
-                .is_some_and(|session| session.agent_id.tool == "mock_ai")
-            {
-                return LineClassification::Ai;
-            }
-        }
-
-        if entry.hash == CheckpointKind::Human.to_str() {
-            return LineClassification::Untracked;
-        }
-
-        return LineClassification::Unknown;
+    if author == &CheckpointKind::Human.to_str() {
+        return LineClassification::Untracked;
     }
 
-    LineClassification::Untracked
+    if author.starts_with("h_") && analysis.humans.contains_key(author) {
+        return LineClassification::KnownHuman;
+    }
+
+    if analysis
+        .prompt_records
+        .get(author)
+        .is_some_and(|prompt| prompt.agent_id.tool == "mock_ai")
+    {
+        return LineClassification::Ai;
+    }
+
+    LineClassification::Unknown
+}
+
+fn format_blame_analysis_debug(analysis: &BlameAnalysisResult) -> String {
+    let mut prompt_keys = analysis.prompt_records.keys().cloned().collect::<Vec<_>>();
+    prompt_keys.sort();
+    let mut session_keys = analysis.session_records.keys().cloned().collect::<Vec<_>>();
+    session_keys.sort();
+    let mut human_keys = analysis.humans.keys().cloned().collect::<Vec<_>>();
+    human_keys.sort();
+
+    format!(
+        "blame analysis: line_authors={:?}, prompt_keys={:?}, session_keys={:?}, human_keys={:?}",
+        analysis.line_authors, prompt_keys, session_keys, human_keys
+    )
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -17,6 +17,12 @@ const SELF_CHECK_CONTENT_AI: &str = "Untracked line\nKnown human line\nAI line\n
 const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
 const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
 const TRACE2_EVENT_NESTING_VALUE: &str = "10";
+const SELF_CHECK_TRACE_ENV_REMOVE: &[&str] = &[
+    "GIT_TRACE2_PARENT_SID",
+    "GIT_TRACE2_PARENT_NAME",
+    "GIT_AI_WRAPPER_INVOCATION_ID",
+    "GIT_TRACE2_ENV_VARS",
+];
 const DEBUG_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -513,7 +519,14 @@ fn run_logged_command_with_timeout(
 ) -> CommandRecord {
     let command = format_command(program, args);
     let cwd_display = cwd.map(|p| p.display().to_string());
-    match run_command_with_timeout(program, args, cwd, timeout, POLL_INTERVAL) {
+    match run_command_with_timeout(
+        program,
+        args,
+        cwd,
+        timeout,
+        POLL_INTERVAL,
+        SELF_CHECK_TRACE_ENV_REMOVE,
+    ) {
         Ok(output) => {
             let stderr = format_logged_stderr(
                 output.timed_out,

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,11 +1,13 @@
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::working_log::CheckpointKind;
+use crate::config::Config;
 use crate::daemon::control_api::{ControlRequest, FamilyStatus};
 use crate::diagnostic_sentinels::{
     DEBUG_SELF_CHECK_REMOTE_URL, debug_self_check_root, path_is_in_debug_self_check_root,
 };
+use crate::git::notes_api;
 use crate::git::repository::discover_repository_in_path_no_git_exec;
-use crate::process_timeout::run_command_with_timeout;
+use crate::process_timeout::run_command_with_timeout_with_env;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -24,6 +26,7 @@ const SELF_CHECK_TRACE_ENV_REMOVE: &[&str] = &[
     "GIT_AI_WRAPPER_INVOCATION_ID",
     "GIT_TRACE2_ENV_VARS",
 ];
+const SELF_CHECK_VALIDATION_TRACE_ENV_SET: &[(&str, &str)] = &[("GIT_TRACE2_EVENT", "0")];
 const DEBUG_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 const DAEMON_CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -83,7 +86,7 @@ impl DiagnosticCheckResult {
         }
     }
 
-    fn failed(
+    pub(crate) fn failed(
         summary: impl Into<String>,
         details: Vec<String>,
         commands: Vec<CommandRecord>,
@@ -401,10 +404,20 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         .trim()
         .to_string();
 
-        let note = poll_authorship_note(&mut commands, &target.program, &repo_path, deadline)?;
+        let note = poll_authorship_note(
+            &mut commands,
+            &target.program,
+            &repo_path,
+            &commit_sha,
+            deadline,
+        )?;
         let mut details = validate_self_check_authorship_note(&note)?;
         details.insert(0, format!("repo: {}", repo_path.display()));
         details.insert(1, format!("commit: {}", commit_sha));
+        details.insert(
+            2,
+            format!("notes backend: {}", Config::get().notes_backend_kind()),
+        );
         Ok(details)
     })();
 
@@ -677,15 +690,26 @@ fn run_logged_command_with_timeout(
     cwd: Option<&Path>,
     timeout: Duration,
 ) -> CommandRecord {
+    run_logged_command_with_timeout_and_env(program, args, cwd, timeout, &[])
+}
+
+fn run_logged_command_with_timeout_and_env(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    timeout: Duration,
+    env_set: &[(&str, &str)],
+) -> CommandRecord {
     let command = format_command(program, args);
     let cwd_display = cwd.map(|p| p.display().to_string());
-    match run_command_with_timeout(
+    match run_command_with_timeout_with_env(
         program,
         args,
         cwd,
         timeout,
         POLL_INTERVAL,
         SELF_CHECK_TRACE_ENV_REMOVE,
+        env_set,
     ) {
         Ok(output) => {
             let stderr = format_logged_stderr(
@@ -806,41 +830,40 @@ fn poll_authorship_note(
     commands: &mut Vec<CommandRecord>,
     git_program: &str,
     repo_path: &Path,
+    commit_sha: &str,
     deadline: Instant,
 ) -> Result<String, String> {
     let start = Instant::now();
-    let mut last_record = None;
+    let repo = discover_repository_in_path_no_git_exec(repo_path).map_err(|e| e.to_string())?;
+    let notes_backend = Config::get().notes_backend_kind();
 
     while Instant::now() < deadline {
-        let timeout = remaining_timeout(deadline);
-        if timeout.is_zero() {
-            break;
-        }
-        let record = run_logged_command_with_timeout(
-            git_program,
-            &["notes", "--ref=ai", "show", "HEAD"],
-            Some(repo_path),
-            timeout,
-        );
-        if record.success() && !record.stdout.trim().is_empty() {
-            let note = record.stdout.clone();
-            commands.push(record);
+        if let Some(note) = notes_api::read_note(&repo, commit_sha)
+            && !note.trim().is_empty()
+        {
             return Ok(note);
         }
-        let timed_out = record.timed_out;
-        last_record = Some(record);
-        if timed_out {
+
+        if remaining_timeout(deadline).is_zero() {
             break;
         }
         std::thread::sleep(POLL_INTERVAL);
     }
 
-    if let Some(record) = last_record {
-        commands.push(record);
-    }
+    let diagnostic = run_logged_command_with_timeout_and_env(
+        git_program,
+        &["notes", "--ref=ai", "show", "HEAD"],
+        Some(repo_path),
+        remaining_timeout(deadline).max(POLL_INTERVAL),
+        SELF_CHECK_VALIDATION_TRACE_ENV_SET,
+    );
+    commands.push(diagnostic);
+
     Err(format!(
-        "timed out after {:.1}s waiting for authorship note on HEAD in {}",
+        "timed out after {:.1}s waiting for authorship note via {} backend for {} in {}",
         start.elapsed().as_secs_f64(),
+        notes_backend,
+        commit_sha,
         repo_path.display()
     ))
 }

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -44,6 +44,8 @@ pub fn is_definitely_read_only_command(command: &str) -> bool {
 /// - `git stash pop` / `git stash apply` are not
 /// - `git worktree list` is read-only
 /// - `git worktree add` / `git worktree remove` are not
+/// - `git notes show` / `git notes list` / `git notes get-ref` are read-only
+/// - `git notes add` / `git notes append` / `git notes remove` are not
 ///
 /// IDEs like Zed issue thousands of `stash list` and `worktree list` calls
 /// per minute for their git panel UI. These must be identified as read-only
@@ -53,6 +55,7 @@ pub fn is_definitely_read_only_invocation(command: &str, subcommand: Option<&str
         return true;
     }
     match command {
+        "notes" => matches!(subcommand, Some("show" | "list" | "get-ref")),
         "stash" => matches!(subcommand, Some("list" | "show")),
         "worktree" => matches!(subcommand, Some("list")),
         _ => false,
@@ -146,6 +149,32 @@ mod tests {
             Some("prune")
         ));
         assert!(!is_definitely_read_only_invocation("worktree", None));
+    }
+
+    #[test]
+    fn notes_read_only_subcommands_are_read_only_invocations() {
+        assert!(is_definitely_read_only_invocation("notes", Some("show")));
+        assert!(is_definitely_read_only_invocation("notes", Some("list")));
+        assert!(is_definitely_read_only_invocation("notes", Some("get-ref")));
+    }
+
+    #[test]
+    fn notes_mutating_subcommands_are_not_read_only_invocations() {
+        for subcommand in &[
+            None,
+            Some("add"),
+            Some("append"),
+            Some("copy"),
+            Some("edit"),
+            Some("merge"),
+            Some("prune"),
+            Some("remove"),
+        ] {
+            assert!(
+                !is_definitely_read_only_invocation("notes", *subcommand),
+                "git notes {subcommand:?} should not be read-only"
+            );
+        }
     }
 
     #[test]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -949,6 +949,13 @@ pub struct GitIdentityResolution {
     pub identity: GitAuthorIdentity,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct GitConfigIdentityResolution {
+    pub raw_name: Option<String>,
+    pub raw_email: Option<String>,
+    pub identity: GitAuthorIdentity,
+}
+
 /// Parse `git var GIT_COMMITTER_IDENT` output into name and email.
 ///
 /// The output format is: `Name <email> unix-timestamp timezone`
@@ -991,9 +998,13 @@ pub fn parse_git_var_identity(output: &str) -> GitAuthorIdentity {
 }
 
 pub fn global_git_config_committer_identity() -> Result<GitAuthorIdentity, GitAiError> {
+    Ok(global_git_config_identity_resolution()?.identity)
+}
+
+pub fn global_git_config_identity_resolution() -> Result<GitConfigIdentityResolution, GitAiError> {
     let config =
         gix_config::File::from_globals().map_err(|e| GitAiError::GixError(e.to_string()))?;
-    Ok(git_author_identity_from_config(&config))
+    Ok(git_config_identity_resolution_from_config(&config))
 }
 
 pub fn current_git_committer_identity_resolution() -> GitIdentityResolution {
@@ -1002,19 +1013,27 @@ pub fn current_git_committer_identity_resolution() -> GitIdentityResolution {
     })
 }
 
-fn git_author_identity_from_config(config: &gix_config::File<'_>) -> GitAuthorIdentity {
-    let name = config
-        .string("user.name")
-        .map(|cow| cow.to_string())
+fn git_config_identity_resolution_from_config(
+    config: &gix_config::File<'_>,
+) -> GitConfigIdentityResolution {
+    let raw_name = config.string("user.name").map(|cow| cow.to_string());
+    let raw_email = config.string("user.email").map(|cow| cow.to_string());
+    let name = raw_name
+        .as_deref()
+        .map(ToOwned::to_owned)
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.trim().to_string());
-    let email = config
-        .string("user.email")
-        .map(|cow| cow.to_string())
+    let email = raw_email
+        .as_deref()
+        .map(ToOwned::to_owned)
         .filter(|s| !s.trim().is_empty())
         .map(|s| s.trim().to_string());
 
-    GitAuthorIdentity { name, email }
+    GitConfigIdentityResolution {
+        raw_name,
+        raw_email,
+        identity: GitAuthorIdentity { name, email },
+    }
 }
 
 fn resolve_git_var_identity_with_args<F>(
@@ -1373,7 +1392,7 @@ impl Repository {
         resolve_git_var_identity_with_args(self.global_args_for_exec(), git_var, || {
             self.get_git_config_file()
                 .ok()
-                .map(|config| git_author_identity_from_config(&config))
+                .map(|config| git_config_identity_resolution_from_config(&config).identity)
                 .unwrap_or_default()
         })
     }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -943,6 +943,12 @@ impl GitAuthorIdentity {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct GitIdentityResolution {
+    pub raw_git_var: Option<String>,
+    pub identity: GitAuthorIdentity,
+}
+
 /// Parse `git var GIT_COMMITTER_IDENT` output into name and email.
 ///
 /// The output format is: `Name <email> unix-timestamp timezone`
@@ -981,6 +987,62 @@ pub fn parse_git_var_identity(output: &str) -> GitAuthorIdentity {
                 email: None,
             }
         }
+    }
+}
+
+pub fn global_git_config_committer_identity() -> Result<GitAuthorIdentity, GitAiError> {
+    let config =
+        gix_config::File::from_globals().map_err(|e| GitAiError::GixError(e.to_string()))?;
+    Ok(git_author_identity_from_config(&config))
+}
+
+pub fn current_git_committer_identity_resolution() -> GitIdentityResolution {
+    resolve_git_var_identity_with_args(Vec::new(), "GIT_COMMITTER_IDENT", || {
+        global_git_config_committer_identity().unwrap_or_default()
+    })
+}
+
+fn git_author_identity_from_config(config: &gix_config::File<'_>) -> GitAuthorIdentity {
+    let name = config
+        .string("user.name")
+        .map(|cow| cow.to_string())
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string());
+    let email = config
+        .string("user.email")
+        .map(|cow| cow.to_string())
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string());
+
+    GitAuthorIdentity { name, email }
+}
+
+fn resolve_git_var_identity_with_args<F>(
+    mut args: Vec<String>,
+    git_var: &str,
+    fallback_identity: F,
+) -> GitIdentityResolution
+where
+    F: FnOnce() -> GitAuthorIdentity,
+{
+    args.push("var".to_string());
+    args.push(git_var.to_string());
+
+    if let Ok(output) = exec_git(&args)
+        && let Ok(stdout) = String::from_utf8(output.stdout)
+    {
+        let identity = parse_git_var_identity(&stdout);
+        if identity.name.is_some() || identity.email.is_some() {
+            return GitIdentityResolution {
+                raw_git_var: Some(stdout.trim().to_string()),
+                identity,
+            };
+        }
+    }
+
+    GitIdentityResolution {
+        raw_git_var: None,
+        identity: fallback_identity(),
     }
 }
 
@@ -1284,6 +1346,10 @@ impl Repository {
             .get_or_init(|| self.resolve_git_var_identity("GIT_COMMITTER_IDENT"))
     }
 
+    pub fn git_author_identity_resolution(&self) -> GitIdentityResolution {
+        self.resolve_git_var_identity_resolution("GIT_COMMITTER_IDENT")
+    }
+
     /// Get the effective git commit author identity for this repository.
     ///
     /// Uses `git var GIT_AUTHOR_IDENT` which respects:
@@ -1300,34 +1366,16 @@ impl Repository {
 
     /// Internal: resolve git identity via the specified `git var` variable.
     fn resolve_git_var_identity(&self, git_var: &str) -> GitAuthorIdentity {
-        let mut args = self.global_args_for_exec();
-        args.push("var".to_string());
-        args.push(git_var.to_string());
+        self.resolve_git_var_identity_resolution(git_var).identity
+    }
 
-        if let Ok(output) = exec_git(&args)
-            && let Ok(stdout) = String::from_utf8(output.stdout)
-        {
-            let identity = parse_git_var_identity(&stdout);
-            if identity.name.is_some() || identity.email.is_some() {
-                return identity;
-            }
-        }
-
-        // Fall back to git config user.name / user.email
-        let name = self
-            .config_get_str("user.name")
-            .ok()
-            .flatten()
-            .filter(|s| !s.trim().is_empty())
-            .map(|s| s.trim().to_string());
-        let email = self
-            .config_get_str("user.email")
-            .ok()
-            .flatten()
-            .filter(|s| !s.trim().is_empty())
-            .map(|s| s.trim().to_string());
-
-        GitAuthorIdentity { name, email }
+    fn resolve_git_var_identity_resolution(&self, git_var: &str) -> GitIdentityResolution {
+        resolve_git_var_identity_with_args(self.global_args_for_exec(), git_var, || {
+            self.get_git_config_file()
+                .ok()
+                .map(|config| git_author_identity_from_config(&config))
+                .unwrap_or_default()
+        })
     }
 
     /// Get all config values matching a regex pattern.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod mdm;
 pub mod metrics;
 pub mod notes;
 pub mod observability;
+pub mod process_timeout;
 pub mod repo_url;
 pub mod streams;
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod ci;
 pub mod commands;
 pub mod config;
 pub mod daemon;
+pub mod diagnostic_sentinels;
+pub mod diagnostics;
 pub mod error;
 pub mod feature_flags;
 pub mod git;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -49,9 +49,25 @@ pub fn record<V: EventValues>(values: V, attrs: EventAttributes) {
     if attrs.tool == Some(Some("mock_ai".to_string())) {
         return;
     }
+    if should_ignore_debug_self_check_event(&attrs) {
+        return;
+    }
     let event = MetricEvent::new(&values, attrs.to_sparse());
     // Write directly to observability log
     crate::observability::log_metrics(vec![event]);
+}
+
+fn should_ignore_debug_self_check_event(attrs: &EventAttributes) -> bool {
+    if attrs.repo_url.as_ref().is_some_and(|repo_url| {
+        repo_url
+            .as_ref()
+            .is_some_and(|url| crate::diagnostic_sentinels::is_debug_self_check_remote_url(url))
+    }) {
+        return true;
+    }
+
+    std::env::current_dir()
+        .is_ok_and(|cwd| crate::diagnostic_sentinels::path_is_in_debug_self_check_root(&cwd))
 }
 
 #[cfg(test)]
@@ -89,6 +105,13 @@ mod tests {
         // side since log_metrics is a no-op in tests, but the guard is exercised.
         let values = events::AgentUsageValues::new();
         record(values, attrs);
+    }
+
+    #[test]
+    fn test_debug_self_check_repo_url_is_ignored() {
+        let attrs = EventAttributes::with_version("1.0.0")
+            .repo_url(crate::diagnostic_sentinels::DEBUG_SELF_CHECK_NORMALIZED_REMOTE_URL);
+        assert!(should_ignore_debug_self_check_event(&attrs));
     }
 
     /// Verify that a Committed event whose tool_model_pairs contain "mock_ai::unknown"

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -1,0 +1,243 @@
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::{Duration, Instant};
+
+const OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(200);
+const OUTPUT_DRAIN_POLL: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Clone)]
+pub(crate) struct TimedCommandOutput {
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+    pub diagnostics: Vec<String>,
+    pub wait_error: Option<String>,
+}
+
+enum OutputEvent {
+    Stdout(Vec<u8>),
+    Stderr(Vec<u8>),
+    StdoutDone,
+    StderrDone,
+    StdoutError(String),
+    StderrError(String),
+}
+
+#[derive(Default)]
+struct OutputState {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_done: bool,
+    stderr_done: bool,
+    diagnostics: Vec<String>,
+}
+
+impl OutputState {
+    fn complete(&self) -> bool {
+        self.stdout_done && self.stderr_done
+    }
+
+    fn finish(
+        self,
+        status: Option<i32>,
+        timed_out: bool,
+        wait_error: Option<String>,
+    ) -> TimedCommandOutput {
+        TimedCommandOutput {
+            status,
+            stdout: String::from_utf8_lossy(&self.stdout).trim().to_string(),
+            stderr: String::from_utf8_lossy(&self.stderr).trim().to_string(),
+            timed_out,
+            diagnostics: self.diagnostics,
+            wait_error,
+        }
+    }
+}
+
+pub(crate) fn run_command_with_timeout(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<TimedCommandOutput, String> {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to execute: {}", e))?;
+
+    let (tx, rx) = mpsc::channel();
+    let mut output = OutputState::default();
+    match child.stdout.take() {
+        Some(stdout) => spawn_output_reader(stdout, tx.clone(), true),
+        None => output.stdout_done = true,
+    }
+    match child.stderr.take() {
+        Some(stderr) => spawn_output_reader(stderr, tx.clone(), false),
+        None => output.stderr_done = true,
+    }
+    drop(tx);
+
+    let start = Instant::now();
+    loop {
+        drain_output_events(&rx, &mut output);
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                collect_output_until(
+                    &rx,
+                    &mut output,
+                    Instant::now() + OUTPUT_DRAIN_GRACE,
+                    OUTPUT_DRAIN_POLL,
+                );
+                if !output.complete() {
+                    output.diagnostics.push(
+                        "output collection did not finish after the child exited; descendant processes may still be holding stdout/stderr open".to_string(),
+                    );
+                }
+                return Ok(output.finish(status.code(), false, None));
+            }
+            Ok(None) if start.elapsed() >= timeout => {
+                let kill_result = child.kill();
+                match &kill_result {
+                    Ok(()) => output
+                        .diagnostics
+                        .push("sent kill to child process".to_string()),
+                    Err(e) => output
+                        .diagnostics
+                        .push(format!("failed to kill child process: {}", e)),
+                }
+
+                let wait_result = child.wait();
+                let status = match wait_result {
+                    Ok(status) => {
+                        output.diagnostics.push(format!(
+                            "child process exited after timeout with status {}",
+                            status
+                                .code()
+                                .map(|code| code.to_string())
+                                .unwrap_or_else(|| "signal".to_string())
+                        ));
+                        status.code()
+                    }
+                    Err(e) => {
+                        output
+                            .diagnostics
+                            .push(format!("failed to wait for child after timeout: {}", e));
+                        None
+                    }
+                };
+
+                collect_output_until(
+                    &rx,
+                    &mut output,
+                    Instant::now() + OUTPUT_DRAIN_GRACE,
+                    OUTPUT_DRAIN_POLL,
+                );
+                if !output.complete() {
+                    output.diagnostics.push(
+                        "output collection incomplete after timeout; descendant processes may still be holding stdout/stderr open".to_string(),
+                    );
+                }
+                return Ok(output.finish(status, true, None));
+            }
+            Ok(None) => {
+                std::thread::sleep(poll_interval);
+            }
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                collect_output_until(
+                    &rx,
+                    &mut output,
+                    Instant::now() + OUTPUT_DRAIN_GRACE,
+                    OUTPUT_DRAIN_POLL,
+                );
+                return Ok(output.finish(None, false, Some(e.to_string())));
+            }
+        }
+    }
+}
+
+fn spawn_output_reader<R>(mut reader: R, tx: Sender<OutputEvent>, stdout: bool)
+where
+    R: Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut buf = [0_u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let event = if stdout {
+                        OutputEvent::Stdout(buf[..n].to_vec())
+                    } else {
+                        OutputEvent::Stderr(buf[..n].to_vec())
+                    };
+                    if tx.send(event).is_err() {
+                        return;
+                    }
+                }
+                Err(e) => {
+                    let event = if stdout {
+                        OutputEvent::StdoutError(e.to_string())
+                    } else {
+                        OutputEvent::StderrError(e.to_string())
+                    };
+                    let _ = tx.send(event);
+                    return;
+                }
+            }
+        }
+
+        let event = if stdout {
+            OutputEvent::StdoutDone
+        } else {
+            OutputEvent::StderrDone
+        };
+        let _ = tx.send(event);
+    });
+}
+
+fn collect_output_until(
+    rx: &Receiver<OutputEvent>,
+    output: &mut OutputState,
+    deadline: Instant,
+    poll_interval: Duration,
+) {
+    while !output.complete() && Instant::now() < deadline {
+        drain_output_events(rx, output);
+        if output.complete() {
+            break;
+        }
+        std::thread::sleep(poll_interval);
+    }
+    drain_output_events(rx, output);
+}
+
+fn drain_output_events(rx: &Receiver<OutputEvent>, output: &mut OutputState) {
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            OutputEvent::Stdout(bytes) => output.stdout.extend(bytes),
+            OutputEvent::Stderr(bytes) => output.stderr.extend(bytes),
+            OutputEvent::StdoutDone => output.stdout_done = true,
+            OutputEvent::StderrDone => output.stderr_done = true,
+            OutputEvent::StdoutError(err) => output
+                .diagnostics
+                .push(format!("failed to read stdout: {}", err)),
+            OutputEvent::StderrError(err) => output
+                .diagnostics
+                .push(format!("failed to read stderr: {}", err)),
+        }
+    }
+}

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -251,12 +251,18 @@ fn drain_output_events(rx: &Receiver<OutputEvent>, output: &mut OutputState) {
             OutputEvent::Stderr(bytes) => output.stderr.extend(bytes),
             OutputEvent::StdoutDone => output.stdout_done = true,
             OutputEvent::StderrDone => output.stderr_done = true,
-            OutputEvent::StdoutError(err) => output
-                .diagnostics
-                .push(format!("failed to read stdout: {}", err)),
-            OutputEvent::StderrError(err) => output
-                .diagnostics
-                .push(format!("failed to read stderr: {}", err)),
+            OutputEvent::StdoutError(err) => {
+                output
+                    .diagnostics
+                    .push(format!("failed to read stdout: {}", err));
+                output.stdout_done = true;
+            }
+            OutputEvent::StderrError(err) => {
+                output
+                    .diagnostics
+                    .push(format!("failed to read stderr: {}", err));
+                output.stderr_done = true;
+            }
         }
     }
 }

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -65,18 +65,6 @@ pub(crate) fn run_command_with_timeout(
     poll_interval: Duration,
     env_remove: &[&str],
 ) -> Result<TimedCommandOutput, String> {
-    run_command_with_timeout_with_env(program, args, cwd, timeout, poll_interval, env_remove, &[])
-}
-
-pub(crate) fn run_command_with_timeout_with_env(
-    program: &str,
-    args: &[&str],
-    cwd: Option<&Path>,
-    timeout: Duration,
-    poll_interval: Duration,
-    env_remove: &[&str],
-    env_set: &[(&str, &str)],
-) -> Result<TimedCommandOutput, String> {
     let mut command = Command::new(program);
     command
         .args(args)
@@ -84,9 +72,6 @@ pub(crate) fn run_command_with_timeout_with_env(
         .stderr(Stdio::piped());
     for key in env_remove {
         command.env_remove(key);
-    }
-    for (key, value) in env_set {
-        command.env(key, value);
     }
     if let Some(cwd) = cwd {
         command.current_dir(cwd);

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -65,6 +65,18 @@ pub(crate) fn run_command_with_timeout(
     poll_interval: Duration,
     env_remove: &[&str],
 ) -> Result<TimedCommandOutput, String> {
+    run_command_with_timeout_with_env(program, args, cwd, timeout, poll_interval, env_remove, &[])
+}
+
+pub(crate) fn run_command_with_timeout_with_env(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    timeout: Duration,
+    poll_interval: Duration,
+    env_remove: &[&str],
+    env_set: &[(&str, &str)],
+) -> Result<TimedCommandOutput, String> {
     let mut command = Command::new(program);
     command
         .args(args)
@@ -72,6 +84,9 @@ pub(crate) fn run_command_with_timeout(
         .stderr(Stdio::piped());
     for key in env_remove {
         command.env_remove(key);
+    }
+    for (key, value) in env_set {
+        command.env(key, value);
     }
     if let Some(cwd) = cwd {
         command.current_dir(cwd);

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -63,12 +63,16 @@ pub(crate) fn run_command_with_timeout(
     cwd: Option<&Path>,
     timeout: Duration,
     poll_interval: Duration,
+    env_remove: &[&str],
 ) -> Result<TimedCommandOutput, String> {
     let mut command = Command::new(program);
     command
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    for key in env_remove {
+        command.env_remove(key);
+    }
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -371,7 +371,7 @@ impl DaemonProcess {
             .arg(repo_path)
             .arg("-c")
             .arg(format!("core.hooksPath={}", null_hooks))
-            .args(["notes", "--ref=ai", "list"])
+            .args(["config", "--local", "git-ai.test-readiness-probe", "1"])
             .env(
                 "GIT_TRACE2_EVENT",
                 DaemonConfig::trace2_event_target_for_path(&self.trace_socket_path),
@@ -380,14 +380,11 @@ impl DaemonProcess {
         configure_test_home_env(&mut command, &self.daemon_home);
 
         let output = command.output().map_err(|error| {
-            format!(
-                "failed to run daemon readiness probe git notes list: {}",
-                error
-            )
+            format!("failed to run daemon readiness probe git config: {}", error)
         })?;
         if !output.status.success() {
             return Err(format!(
-                "daemon readiness probe git notes list failed:\nstdout: {}\nstderr: {}",
+                "daemon readiness probe git config failed:\nstdout: {}\nstderr: {}",
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)
             ));


### PR DESCRIPTION
## Summary
- add configured-vs-terminal git diagnostics to git-ai debug, including realpath output
- add reusable attribution and trace2 self-check helpers for debug/post-install reuse
- hard-allow the sentinel self-check repo through repo filters and suppress its metrics

## Validation
- task fmt
- task build
- task test TEST_FILTER=diagnostic
- task test TEST_FILTER=debug
- task lint
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->