### PR TITLE
fix(daemon): prevent stalled Windows clients from exhausting control-pipe workers

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -46,6 +46,7 @@ use interprocess::{
 use named_pipe::{
     ConnectingServer as WindowsConnectingServer, OpenMode as WindowsPipeOpenMode,
     PipeClient as WindowsPipeClient, PipeOptions as WindowsPipeOptions,
+    PipeServer as WindowsPipeServer,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -7866,6 +7867,7 @@ fn control_listener_loop_actor(
     #[cfg(windows)]
     {
         let mut workers = Vec::new();
+        let worker_count = windows_control_pipe_worker_count();
         let first_connecting = windows_pipe_connecting_server(&control_socket_path, true)?;
         {
             let path = control_socket_path.clone();
@@ -7881,7 +7883,7 @@ fn control_listener_loop_actor(
                 result
             }));
         }
-        for _ in 1..WINDOWS_CONTROL_PIPE_WORKERS {
+        for _ in 1..worker_count {
             let path = control_socket_path.clone();
             let coord = coordinator.clone();
             let handle = runtime_handle.clone();
@@ -7901,7 +7903,7 @@ fn control_listener_loop_actor(
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
-        wake_windows_pipe_workers(&control_socket_path, WINDOWS_CONTROL_PIPE_WORKERS);
+        wake_windows_pipe_workers(&control_socket_path, worker_count);
 
         for worker in workers {
             let result = worker
@@ -7933,6 +7935,19 @@ fn windows_pipe_connecting_server(
 }
 
 #[cfg(windows)]
+fn windows_control_pipe_worker_count() -> usize {
+    #[cfg(feature = "test-support")]
+    if let Ok(raw) = std::env::var("GIT_AI_TEST_WINDOWS_CONTROL_PIPE_WORKERS")
+        && let Ok(count) = raw.parse::<usize>()
+        && count > 0
+    {
+        return count;
+    }
+
+    WINDOWS_CONTROL_PIPE_WORKERS
+}
+
+#[cfg(windows)]
 fn wake_windows_pipe_workers(pipe_path: &Path, worker_count: usize) {
     for _ in 0..worker_count {
         let _ = WindowsPipeClient::connect_ms(pipe_path.as_os_str(), 100);
@@ -7947,7 +7962,7 @@ fn windows_control_pipe_worker_loop(
     runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), GitAiError> {
     loop {
-        let mut server = connecting.wait().map_err(|e| {
+        let server = connecting.wait().map_err(|e| {
             GitAiError::Generic(format!(
                 "failed accepting control pipe {}: {}",
                 control_socket_path.display(),
@@ -7960,27 +7975,37 @@ fn windows_control_pipe_worker_loop(
             break;
         }
 
-        {
-            let mut reader = BufReader::new(&mut server);
-            if let Err(e) = handle_control_connection_actor_reader(
-                &mut reader,
-                coordinator.clone(),
-                runtime_handle.clone(),
-            ) {
-                tracing::debug!(%e, "control connection error");
-            }
-        }
+        connecting = windows_pipe_connecting_server(&control_socket_path, false)?;
 
-        connecting = server.disconnect().map_err(|e| {
-            GitAiError::Generic(format!(
-                "failed recycling control pipe {}: {}",
-                control_socket_path.display(),
-                e
-            ))
-        })?;
+        let coord = coordinator.clone();
+        let handle = runtime_handle.clone();
+        std::thread::Builder::new()
+            .spawn(move || {
+                handle_windows_control_pipe_connection(server, coord, handle);
+            })
+            .map_err(|e| {
+                GitAiError::Generic(format!(
+                    "failed spawning control pipe handler for {}: {}",
+                    control_socket_path.display(),
+                    e
+                ))
+            })?;
     }
 
     Ok(())
+}
+
+#[cfg(windows)]
+fn handle_windows_control_pipe_connection(
+    mut server: WindowsPipeServer,
+    coordinator: Arc<ActorDaemonCoordinator>,
+    runtime_handle: tokio::runtime::Handle,
+) {
+    let mut reader = BufReader::new(&mut server);
+    if let Err(e) = handle_control_connection_actor_reader(&mut reader, coordinator, runtime_handle)
+    {
+        tracing::debug!(%e, "control connection error");
+    }
 }
 
 #[cfg(not(windows))]

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1013,6 +1013,7 @@ fn checkpoint_fails_hard_when_daemon_startup_is_blocked() {
 
 #[test]
 #[cfg(windows)]
+#[serial]
 fn daemon_windows_stalled_checkpoint_clients_do_not_block_later_control_requests() {
     let repo =
         TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::NoDaemon);

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1012,6 +1012,72 @@ fn checkpoint_fails_hard_when_daemon_startup_is_blocked() {
 }
 
 #[test]
+#[cfg(windows)]
+fn daemon_windows_stalled_checkpoint_clients_do_not_block_later_control_requests() {
+    let repo =
+        TestRepo::new_with_mode_and_daemon_scope(GitTestMode::Daemon, DaemonTestScope::NoDaemon);
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_WINDOWS_CONTROL_PIPE_WORKERS", "2"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    let control_socket = daemon_control_socket_path(&repo);
+
+    let mut stalled_clients = (0..2)
+        .map(|_| {
+            let mut command = Command::new(get_binary_path());
+            command
+                .args(["checkpoint", "codex", "--hook-input", "stdin"])
+                .current_dir(repo.path())
+                .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
+                .env("GITAI_TEST_DB_PATH", repo.test_db_path())
+                .stdin(Stdio::piped())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            configure_test_home_env(&mut command, repo.test_home_path());
+            configure_test_daemon_env(
+                &mut command,
+                &repo.daemon_home_path(),
+                &control_socket,
+                &daemon_trace_socket_path(&repo),
+            );
+            command.spawn().expect("failed to spawn stalled checkpoint")
+        })
+        .collect::<Vec<_>>();
+    thread::sleep(Duration::from_millis(250));
+
+    let (response_tx, response_rx) = mpsc::channel();
+    let request_socket = control_socket.clone();
+    let request_repo = repo_workdir_string(&repo);
+    thread::spawn(move || {
+        let _ = response_tx.send(send_control_request(
+            &request_socket,
+            &ControlRequest::StatusFamily {
+                repo_working_dir: request_repo,
+            },
+        ));
+    });
+    let response = response_rx.recv_timeout(Duration::from_secs(2));
+
+    for client in &mut stalled_clients {
+        let _ = client.kill();
+        let _ = client.wait();
+    }
+    let response = response
+        .expect("control request timed out after every original pipe worker was stalled")
+        .expect("control request failed after every original pipe worker was stalled");
+    assert!(
+        response.ok,
+        "later control request should return an ok response: {:?}",
+        response
+    );
+    daemon.shutdown();
+}
+
+#[test]
 #[serial]
 fn daemon_write_mode_applies_delegated_checkpoint_and_updates_state() {
     let repo =


### PR DESCRIPTION
## Summary

  On Windows, each daemon control-pipe worker previously handled its connected
  client inline. A client that connected but did not send a request could
  therefore occupy a worker indefinitely.

  Once all workers were stalled, later control requests blocked and commit
  attribution could fall back to Human/untracked.

  This PR:

  - Creates a replacement accepting pipe immediately after each connection.
  - Handles connected clients in detached handler threads.
  - Keeps the control-pipe accept workers available for new requests.
  - Adds a Windows regression test using two stalled checkpoint clients and
    verifies that a later control request still completes.

 ## Testing
  - [x] `task fmt`
  - [x] `task lint`
  - [x] `task test TEST_FILTER=daemon_windows_stalled_checkpoint_clients_do_not_block_later_control_requests`
  - [ ] `task test` — 1676 passed; 1 unrelated existing test failed because Windows symlink creation requires
  additional privileges
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->