### PR TITLE
fix(install): stop misleading extension-install nag for Cursor/Windsurf/VS Code when the editor isn't installed

### DIFF
--- a/src/mdm/agents/cursor.rs
+++ b/src/mdm/agents/cursor.rs
@@ -377,11 +377,12 @@ impl HookInstaller for CursorInstaller {
                 }
             }
         } else {
-            results.push(InstallResult {
-                changed: false,
-                diff: None,
-                message: "Cursor: Unable to automatically install extension. Please cmd+click on the following link to install: cursor:extension/git-ai.git-ai-vscode (or search for 'git-ai-vscode' in the Cursor extensions tab)".to_string(),
-            });
+            // resolve_editor_cli returned None -- the only way to reach this
+            // branch. Cursor was detected only from its config dotfiles
+            // (~/.cursor) and isn't actually installed, so there's nothing to
+            // install the extension into. Don't emit a misleading "unable to
+            // install" nag here; genuine install/check failures are already
+            // reported by the match arms above.
         }
 
         Ok(results)
@@ -403,6 +404,28 @@ mod tests {
 
     fn create_test_binary_path() -> PathBuf {
         PathBuf::from("/usr/local/bin/git-ai")
+    }
+
+    #[test]
+    fn test_install_extras_does_not_nag_when_cli_absent() {
+        // Regression: when the Cursor app/CLI isn't resolvable (e.g. only the
+        // ~/.cursor dotfiles exist), install_extras must not emit the misleading
+        // "Unable to automatically install extension" message. dry_run=true means
+        // a real install is never attempted, so this never spawns an editor.
+        let params = HookInstallerParams {
+            binary_path: create_test_binary_path(),
+        };
+        let results = CursorInstaller.install_extras(&params, true).unwrap();
+        assert!(
+            results
+                .iter()
+                .all(|r| !r.message.contains("Unable to automatically install")),
+            "unexpected extension nag: {:?}",
+            results
+                .iter()
+                .map(|r| r.message.clone())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/mdm/agents/vscode.rs
+++ b/src/mdm/agents/vscode.rs
@@ -174,11 +174,13 @@ impl HookInstaller for VSCodeInstaller {
                 }
             }
         } else {
-            results.push(InstallResult {
-                changed: false,
-                diff: None,
-                message: "VS Code: Unable to automatically install extension. Please cmd+click on the following link to install: vscode:extension/git-ai.git-ai-vscode (or navigate to https://marketplace.visualstudio.com/items?itemName=git-ai.git-ai-vscode in your browser)".to_string(),
-            });
+            // resolve_editor_cli returned None -- the only way to reach this
+            // branch. VS Code was detected only from its config dotfiles
+            // (~/.vscode) and isn't actually installed, so there's nothing to
+            // install the extension into. Don't emit a misleading "unable to
+            // install" nag here; genuine install/check failures are already
+            // reported by the match arms above. (The chat-hook settings below are
+            // configured independently of the editor CLI and still run.)
         }
 
         for settings_path in Self::settings_targets() {
@@ -275,6 +277,28 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert!(!results[0].changed);
         assert!(results[0].message.contains("manually"));
+    }
+
+    #[test]
+    fn test_install_extras_does_not_nag_when_cli_absent() {
+        // Regression: when the `code` CLI isn't resolvable (e.g. only the
+        // ~/.vscode dotfiles exist), install_extras must not emit the misleading
+        // "Unable to automatically install extension" message. dry_run=true means
+        // no real install is attempted.
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        let results = VSCodeInstaller.install_extras(&params, true).unwrap();
+        assert!(
+            results
+                .iter()
+                .all(|r| !r.message.contains("Unable to automatically install")),
+            "unexpected extension nag: {:?}",
+            results
+                .iter()
+                .map(|r| r.message.clone())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/mdm/agents/windsurf.rs
+++ b/src/mdm/agents/windsurf.rs
@@ -379,11 +379,12 @@ impl HookInstaller for WindsurfInstaller {
                 }
             }
         } else {
-            results.push(InstallResult {
-                changed: false,
-                diff: None,
-                message: "Windsurf: Unable to automatically install extension. Please cmd+click on the following link to install: windsurf:extension/git-ai.git-ai-vscode (or search for 'git-ai-vscode' in the Windsurf extensions tab)".to_string(),
-            });
+            // resolve_editor_cli returned None -- the only way to reach this
+            // branch. Windsurf was detected only from its config dotfiles
+            // (~/.codeium) and isn't actually installed, so there's nothing to
+            // install the extension into. Don't emit a misleading "unable to
+            // install" nag here; genuine install/check failures are already
+            // reported by the match arms above.
         }
 
         Ok(results)
@@ -400,5 +401,32 @@ impl HookInstaller for WindsurfInstaller {
             message: "Windsurf: Extension must be uninstalled manually through the editor"
                 .to_string(),
         }])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_install_extras_does_not_nag_when_cli_absent() {
+        // Regression: when the Windsurf app/CLI isn't resolvable (e.g. only the
+        // ~/.codeium dotfiles exist), install_extras must not emit the misleading
+        // "Unable to automatically install extension" message. dry_run=true means
+        // a real install is never attempted, so this never spawns an editor.
+        let params = HookInstallerParams {
+            binary_path: std::path::PathBuf::from("/usr/local/bin/git-ai"),
+        };
+        let results = WindsurfInstaller.install_extras(&params, true).unwrap();
+        assert!(
+            results
+                .iter()
+                .all(|r| !r.message.contains("Unable to automatically install")),
+            "unexpected extension nag: {:?}",
+            results
+                .iter()
+                .map(|r| r.message.clone())
+                .collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
## What & why

`git-ai install` / `git-ai upgrade --force` prints a misleading warning for **Cursor**, **Windsurf**, and **VS Code** even when those editors aren't installed:

```
⚠ Cursor: Unable to automatically install extension. Please cmd+click ... cursor:extension/git-ai.git-ai-vscode ...
⚠ Windsurf: Unable to automatically install extension. ...
```

The wording implies git-ai *tried and failed* to install the extension, when really the editor's app/CLI isn't present at all — there is nothing to install into. This is especially noisy when git-ai is rolled out via MDM across many machines that have leftover editor config dirs but not the editors themselves.

### Root cause

`check_hooks()` treats an editor as installed when **either** its CLI is resolvable **or** its config dotfiles exist (`~/.cursor`, `~/.codeium`, `~/.vscode`). That is correct for installing hooks (which live in those dirs), but `install_extras()` then runs unconditionally; when `resolve_editor_cli()` returns `None` it falls into an `else` branch that emits the "Unable to automatically install extension" nag — a false failure for an editor that isn't actually installed (only leftover dotfiles).

## Change

- `install_extras()` for Cursor, Windsurf, and VS Code: when the editor CLI/app isn't resolvable, skip the extension step silently instead of emitting the misleading warning. These editors install the extension via their CLI, so with no CLI/app there is nothing to install into.
- The skip is kept as an **explicit CLI-not-found `else` branch** (not a catch-all fall-through), so only the resolver-`None` case is silent — every resolvable-CLI outcome still produces its own explicit result.
- Added regression tests asserting `install_extras()` emits no "Unable to automatically install" message when the editor CLI is absent.

The genuine install-failure branch (CLI present but the install command itself failed) is intentionally left unchanged.

## Testing

- `cargo test` — new `test_install_extras_does_not_nag_when_cli_absent` (Cursor + Windsurf + VS Code) pass; existing install/mdm unit tests green.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt -- --check` clean.
- Verified live: `git-ai install --dry-run` no longer prints the nag for Cursor/Windsurf.

Fixes #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
