### PR TITLE
[codex] add configurable upgrade timing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -803,6 +803,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve release creation time
+        id: release-created
+        run: |
+          CREATED_AT=$(gh release view "${{ steps.release-meta.outputs.tag_name }}" --json createdAt --jq '.createdAt')
+          echo "created_at=$CREATED_AT" >> "$GITHUB_OUTPUT"
+          echo "Release created_at: $CREATED_AT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate release bot token
         if: inputs.release_production == true
         id: release-bot-token
@@ -873,7 +882,8 @@ jobs:
               "ref": "dev",
               "inputs": {
                 "channel": "${{ steps.release-meta.outputs.channel_label }}",
-                "tag": "${{ steps.release-meta.outputs.tag_name }}"
+                "tag": "${{ steps.release-meta.outputs.tag_name }}",
+                "created_at": "${{ steps.release-created.outputs.created_at }}"
               }
             }'
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,9 +2,7 @@ use dirs;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::config::{
-    AuthorConfig, CodexHooksFormat, MAX_UPGRADE_JITTER_SECONDS, NotesBackendKind,
-};
+use crate::config::{AuthorConfig, CodexHooksFormat, MAX_UPGRADE_JITTER_SECONDS, NotesBackendKind};
 use crate::git::repository::find_repository_in_path;
 
 /// Determines the type of pattern value provided
@@ -113,7 +111,7 @@ fn print_config_help() {
         MAX_UPGRADE_JITTER_SECONDS
     );
     println!(
-        "  minimum_package_upgrade_age_seconds  Minimum release age before upgrading (seconds)"
+        "  minimum_package_upgrade_age_seconds  Minimum release age before upgrading (seconds; requires release created_at metadata)"
     );
     println!("  feature_flags                Feature flags (object)");
     println!("  api_base_url                 API base URL (default: https://usegitai.com)");

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,9 @@ use dirs;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::config::{AuthorConfig, CodexHooksFormat, NotesBackendKind};
+use crate::config::{
+    AuthorConfig, CodexHooksFormat, MAX_UPGRADE_JITTER_SECONDS, NotesBackendKind,
+};
 use crate::git::repository::find_repository_in_path;
 
 /// Determines the type of pattern value provided
@@ -106,6 +108,13 @@ fn print_config_help() {
     println!("  disable_version_checks       Disable version checks (bool)");
     println!("  disable_auto_updates         Disable auto updates (bool)");
     println!("  update_channel               Update channel (latest/next)");
+    println!(
+        "  upgrade_jitter_seconds       Max stable per-client seconds added to the 24h update check interval (0-{})",
+        MAX_UPGRADE_JITTER_SECONDS
+    );
+    println!(
+        "  minimum_package_upgrade_age_seconds  Minimum release age before upgrading (seconds)"
+    );
     println!("  feature_flags                Feature flags (object)");
     println!("  api_base_url                 API base URL (default: https://usegitai.com)");
     println!("  api_key                      API key for X-API-Key header");
@@ -147,6 +156,8 @@ fn print_config_help() {
     println!("  git-ai config set disable_auto_updates true");
     println!("  git-ai config set author.name \"Alice Example\"");
     println!("  git-ai config set author.email alice@example.com");
+    println!("  git-ai config set upgrade_jitter_seconds 345600");
+    println!("  git-ai config set minimum_package_upgrade_age_seconds 86400");
     println!("  git-ai config set exclude_repositories \"private/*\"");
     println!("  git-ai config set exclude_repositories .         # Uses current repo's remotes");
     println!("  git-ai config --add exclude_repositories \"temp/*\"");
@@ -305,6 +316,14 @@ fn show_all_config() -> Result<(), String> {
     effective_config.insert(
         "disable_auto_updates".to_string(),
         Value::Bool(runtime_config.auto_updates_disabled()),
+    );
+    effective_config.insert(
+        "upgrade_jitter_seconds".to_string(),
+        Value::Number(runtime_config.upgrade_jitter_seconds().into()),
+    );
+    effective_config.insert(
+        "minimum_package_upgrade_age_seconds".to_string(),
+        Value::Number(runtime_config.minimum_package_upgrade_age_seconds().into()),
     );
 
     // Optional strings
@@ -475,6 +494,12 @@ fn get_config_value(key: &str) -> Result<(), String> {
             }
             "disable_version_checks" => Value::Bool(runtime_config.version_checks_disabled()),
             "disable_auto_updates" => Value::Bool(runtime_config.auto_updates_disabled()),
+            "upgrade_jitter_seconds" => {
+                Value::Number(runtime_config.upgrade_jitter_seconds().into())
+            }
+            "minimum_package_upgrade_age_seconds" => {
+                Value::Number(runtime_config.minimum_package_upgrade_age_seconds().into())
+            }
             "update_channel" => Value::String(runtime_config.update_channel().as_str().to_string()),
             "feature_flags" => {
                 // Show effective flags with defaults applied
@@ -706,6 +731,24 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.disable_auto_updates = Some(bool_value);
                 crate::config::save_file_config(&file_config)?;
                 println!("[disable_auto_updates]: {}", bool_value);
+            }
+            "upgrade_jitter_seconds" => {
+                let seconds = parse_u64(value, "upgrade_jitter_seconds")?;
+                if seconds > MAX_UPGRADE_JITTER_SECONDS {
+                    return Err(format!(
+                        "upgrade_jitter_seconds must be between 0 and {} seconds",
+                        MAX_UPGRADE_JITTER_SECONDS
+                    ));
+                }
+                file_config.upgrade_jitter_seconds = Some(seconds);
+                crate::config::save_file_config(&file_config)?;
+                println!("[upgrade_jitter_seconds]: {}", seconds);
+            }
+            "minimum_package_upgrade_age_seconds" => {
+                let seconds = parse_u64(value, "minimum_package_upgrade_age_seconds")?;
+                file_config.minimum_package_upgrade_age_seconds = Some(seconds);
+                crate::config::save_file_config(&file_config)?;
+                println!("[minimum_package_upgrade_age_seconds]: {}", seconds);
             }
             "update_channel" => {
                 // Validate update channel
@@ -1107,6 +1150,20 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [disable_auto_updates]: {}", v);
+                }
+            }
+            "upgrade_jitter_seconds" => {
+                let old_value = file_config.upgrade_jitter_seconds.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [upgrade_jitter_seconds]: {}", v);
+                }
+            }
+            "minimum_package_upgrade_age_seconds" => {
+                let old_value = file_config.minimum_package_upgrade_age_seconds.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [minimum_package_upgrade_age_seconds]: {}", v);
                 }
             }
             "update_channel" => {
@@ -1614,6 +1671,15 @@ fn parse_bool(value: &str) -> Result<bool, String> {
     }
 }
 
+fn parse_u64(value: &str, key: &str) -> Result<u64, String> {
+    value.parse::<u64>().map_err(|_| {
+        format!(
+            "Invalid value for {}: '{}'. Expected a non-negative integer",
+            key, value
+        )
+    })
+}
+
 fn parse_value(value: &str) -> Result<Value, String> {
     // Try to parse as JSON first
     if let Ok(json_value) = serde_json::from_str::<Value>(value) {
@@ -2104,6 +2170,22 @@ mod tests {
     #[test]
     fn test_parse_bool_empty_string() {
         assert!(parse_bool("").is_err());
+    }
+
+    #[test]
+    fn test_parse_u64_valid() {
+        assert_eq!(parse_u64("0", "upgrade_jitter_seconds").unwrap(), 0);
+        assert_eq!(
+            parse_u64("86400", "minimum_package_upgrade_age_seconds").unwrap(),
+            86400
+        );
+    }
+
+    #[test]
+    fn test_parse_u64_invalid() {
+        assert!(parse_u64("-1", "upgrade_jitter_seconds").is_err());
+        assert!(parse_u64("1.5", "upgrade_jitter_seconds").is_err());
+        assert!(parse_u64("abc", "upgrade_jitter_seconds").is_err());
     }
 
     #[test]

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -49,6 +49,7 @@ unsafe extern "system" {
 }
 
 const UPDATE_CHECK_INTERVAL_HOURS: u64 = 24;
+const UPDATE_CHECK_INTERVAL_SECS: u64 = UPDATE_CHECK_INTERVAL_HOURS * 3600;
 const GIT_AI_RELEASE_ENV: &str = "GIT_AI_RELEASE_TAG";
 #[cfg(windows)]
 const GIT_AI_RESTART_DAEMON_AFTER_INSTALL_ENV: &str = "GIT_AI_RESTART_DAEMON_AFTER_INSTALL";
@@ -64,6 +65,7 @@ enum UpgradeAction {
     UpgradeAvailable,
     AlreadyLatest,
     RunningNewerVersion,
+    ReleaseTooNew,
     ForceReinstall,
 }
 
@@ -73,6 +75,7 @@ impl UpgradeAction {
             UpgradeAction::UpgradeAvailable => "upgrade_available",
             UpgradeAction::AlreadyLatest => "already_latest",
             UpgradeAction::RunningNewerVersion => "running_newer_version",
+            UpgradeAction::ReleaseTooNew => "release_too_new",
             UpgradeAction::ForceReinstall => "force_reinstall",
         }
     }
@@ -83,11 +86,18 @@ struct ChannelRelease {
     tag: String,
     semver: String,
     checksum: String,
+    created_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UpdateCache {
     last_checked_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    next_check_after: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    upgrade_jitter_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    minimum_package_upgrade_age_seconds: Option<u64>,
     available_tag: Option<String>,
     available_semver: Option<String>,
     channel: String,
@@ -97,6 +107,9 @@ impl UpdateCache {
     fn new(channel: UpdateChannel) -> Self {
         Self {
             last_checked_at: 0,
+            next_check_after: None,
+            upgrade_jitter_seconds: None,
+            minimum_package_upgrade_age_seconds: None,
             available_tag: None,
             available_semver: None,
             channel: channel.as_str().to_string(),
@@ -116,6 +129,7 @@ impl UpdateCache {
 struct ChannelInfo {
     version: String,
     checksum: String,
+    created_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -156,6 +170,61 @@ fn current_timestamp() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_else(|_| Duration::from_secs(0))
         .as_secs()
+}
+
+fn deterministic_upgrade_jitter_seconds(
+    distinct_id: &str,
+    channel: UpdateChannel,
+    max_jitter_seconds: u64,
+) -> u64 {
+    if max_jitter_seconds == 0 {
+        return 0;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(distinct_id.as_bytes());
+    hasher.update(channel.as_str().as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    u64::from_le_bytes(bytes) % (max_jitter_seconds + 1)
+}
+
+fn upgrade_jitter_distinct_id() -> String {
+    #[cfg(test)]
+    if let Ok(distinct_id) = std::env::var("GIT_AI_TEST_DISTINCT_ID") {
+        return distinct_id;
+    }
+
+    config::get_or_create_distinct_id()
+}
+
+fn regular_next_check_after_for_distinct_id(
+    last_checked_at: u64,
+    channel: UpdateChannel,
+    upgrade_jitter_seconds: u64,
+    distinct_id: &str,
+) -> u64 {
+    last_checked_at
+        .saturating_add(UPDATE_CHECK_INTERVAL_SECS)
+        .saturating_add(deterministic_upgrade_jitter_seconds(
+            distinct_id,
+            channel,
+            upgrade_jitter_seconds,
+        ))
+}
+
+fn regular_next_check_after(
+    last_checked_at: u64,
+    channel: UpdateChannel,
+    upgrade_jitter_seconds: u64,
+) -> u64 {
+    regular_next_check_after_for_distinct_id(
+        last_checked_at,
+        channel,
+        upgrade_jitter_seconds,
+        &upgrade_jitter_distinct_id(),
+    )
 }
 
 #[cfg(windows)]
@@ -267,7 +336,12 @@ fn windows_process_entry_template() -> ProcessEntry32W {
     }
 }
 
-fn should_check_for_updates(channel: UpdateChannel, cache: Option<&UpdateCache>) -> bool {
+fn should_check_for_updates(
+    channel: UpdateChannel,
+    cache: Option<&UpdateCache>,
+    upgrade_jitter_seconds: u64,
+    minimum_package_upgrade_age_seconds: u64,
+) -> bool {
     let now = current_timestamp();
     match cache {
         Some(cache) if cache.last_checked_at > 0 => {
@@ -275,8 +349,19 @@ fn should_check_for_updates(channel: UpdateChannel, cache: Option<&UpdateCache>)
             if !cache.matches_channel(channel) {
                 return true;
             }
-            let elapsed = now.saturating_sub(cache.last_checked_at);
-            elapsed > UPDATE_CHECK_INTERVAL_HOURS * 3600
+
+            let next_check_after = cache
+                .next_check_after
+                .filter(|_| {
+                    cache.upgrade_jitter_seconds == Some(upgrade_jitter_seconds)
+                        && cache.minimum_package_upgrade_age_seconds
+                            == Some(minimum_package_upgrade_age_seconds)
+                })
+                .unwrap_or_else(|| {
+                    regular_next_check_after(cache.last_checked_at, channel, upgrade_jitter_seconds)
+                });
+
+            now >= next_check_after
         }
         _ => true,
     }
@@ -290,7 +375,40 @@ fn semver_from_tag(tag: &str) -> String {
     trimmed.split(['-', '+']).next().unwrap_or("").to_string()
 }
 
-fn determine_action(force: bool, release: &ChannelRelease, current_version: &str) -> UpgradeAction {
+fn release_meets_minimum_age(
+    release: &ChannelRelease,
+    minimum_package_upgrade_age_seconds: u64,
+    now: u64,
+) -> bool {
+    if minimum_package_upgrade_age_seconds == 0 {
+        return true;
+    }
+
+    release.created_at.is_some_and(|created_at| {
+        now.saturating_sub(created_at) >= minimum_package_upgrade_age_seconds
+    })
+}
+
+fn release_age_eligible_at(
+    release: &ChannelRelease,
+    minimum_package_upgrade_age_seconds: u64,
+) -> Option<u64> {
+    if minimum_package_upgrade_age_seconds == 0 {
+        None
+    } else {
+        release
+            .created_at
+            .map(|created_at| created_at.saturating_add(minimum_package_upgrade_age_seconds))
+    }
+}
+
+fn determine_action_at(
+    force: bool,
+    release: &ChannelRelease,
+    current_version: &str,
+    minimum_package_upgrade_age_seconds: u64,
+    now: u64,
+) -> UpgradeAction {
     if force {
         return UpgradeAction::ForceReinstall;
     }
@@ -298,15 +416,60 @@ fn determine_action(force: bool, release: &ChannelRelease, current_version: &str
     if release.semver == current_version {
         UpgradeAction::AlreadyLatest
     } else if is_newer_version(&release.semver, current_version) {
-        UpgradeAction::UpgradeAvailable
+        if release_meets_minimum_age(release, minimum_package_upgrade_age_seconds, now) {
+            UpgradeAction::UpgradeAvailable
+        } else {
+            UpgradeAction::ReleaseTooNew
+        }
     } else {
         UpgradeAction::RunningNewerVersion
     }
 }
 
-fn persist_update_state(channel: UpdateChannel, release: Option<&ChannelRelease>) {
+fn determine_action(
+    force: bool,
+    release: &ChannelRelease,
+    current_version: &str,
+    minimum_package_upgrade_age_seconds: u64,
+) -> UpgradeAction {
+    determine_action_at(
+        force,
+        release,
+        current_version,
+        minimum_package_upgrade_age_seconds,
+        current_timestamp(),
+    )
+}
+
+fn persist_update_state(
+    channel: UpdateChannel,
+    release: Option<&ChannelRelease>,
+    upgrade_jitter_seconds: u64,
+    minimum_package_upgrade_age_seconds: u64,
+) {
+    persist_update_state_with_next_check(
+        channel,
+        release,
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
+        None,
+    );
+}
+
+fn persist_update_state_with_next_check(
+    channel: UpdateChannel,
+    release: Option<&ChannelRelease>,
+    upgrade_jitter_seconds: u64,
+    minimum_package_upgrade_age_seconds: u64,
+    next_check_after: Option<u64>,
+) {
     let mut cache = UpdateCache::new(channel);
     cache.last_checked_at = current_timestamp();
+    cache.next_check_after = Some(next_check_after.unwrap_or_else(|| {
+        regular_next_check_after(cache.last_checked_at, channel, upgrade_jitter_seconds)
+    }));
+    cache.upgrade_jitter_seconds = Some(upgrade_jitter_seconds);
+    cache.minimum_package_upgrade_age_seconds = Some(minimum_package_upgrade_age_seconds);
     if let Some(release) = release {
         cache.available_tag = Some(release.tag.clone());
         cache.available_semver = Some(release.semver.clone());
@@ -315,8 +478,14 @@ fn persist_update_state(channel: UpdateChannel, release: Option<&ChannelRelease>
 }
 
 pub(crate) fn clear_cached_update_state() {
-    let channel = config::Config::fresh().update_channel();
-    persist_update_state(channel, None);
+    let config = config::Config::fresh();
+    let channel = config.update_channel();
+    persist_update_state(
+        channel,
+        None,
+        config.upgrade_jitter_seconds(),
+        config.minimum_package_upgrade_age_seconds(),
+    );
 }
 
 fn releases_endpoint() -> &'static str {
@@ -479,11 +648,36 @@ fn release_from_response(
         return Err("Checksum not found in response".to_string());
     }
 
+    let created_at = channel_info
+        .created_at
+        .as_deref()
+        .map(parse_release_created_at)
+        .transpose()?;
+
     Ok(ChannelRelease {
         tag,
         semver,
         checksum,
+        created_at,
     })
+}
+
+fn parse_release_created_at(value: &str) -> Result<u64, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("Release created_at is empty".to_string());
+    }
+
+    if let Ok(seconds) = trimmed.parse::<u64>() {
+        return Ok(seconds);
+    }
+
+    let timestamp = chrono::DateTime::parse_from_rfc3339(trimmed)
+        .map_err(|e| format!("Invalid release created_at '{}': {}", value, e))?
+        .timestamp();
+
+    u64::try_from(timestamp)
+        .map_err(|_| format!("Release created_at '{}' is before Unix epoch", value))
 }
 
 #[cfg(test)]
@@ -679,7 +873,14 @@ fn run_impl(force: bool, background: bool) {
     let config = config::Config::fresh();
     let channel = config.update_channel();
     let skip_install = background && config.auto_updates_disabled();
-    let _ = run_impl_with_url(force, config.api_base_url(), channel, skip_install);
+    let _ = run_impl_with_url(
+        force,
+        config.api_base_url(),
+        channel,
+        skip_install,
+        config.minimum_package_upgrade_age_seconds(),
+        config.upgrade_jitter_seconds(),
+    );
 }
 
 fn run_impl_with_url(
@@ -687,6 +888,8 @@ fn run_impl_with_url(
     api_base_url: &str,
     channel: UpdateChannel,
     skip_install: bool,
+    minimum_package_upgrade_age_seconds: u64,
+    upgrade_jitter_seconds: u64,
 ) -> UpgradeAction {
     let current_version = env!("CARGO_PKG_VERSION");
 
@@ -709,9 +912,25 @@ fn run_impl_with_url(
     );
     println!();
 
-    let action = determine_action(force, &release, current_version);
+    let action = determine_action(
+        force,
+        &release,
+        current_version,
+        minimum_package_upgrade_age_seconds,
+    );
     let cache_release = matches!(action, UpgradeAction::UpgradeAvailable);
-    persist_update_state(channel, cache_release.then_some(&release));
+    let next_check_after = if matches!(action, UpgradeAction::ReleaseTooNew) {
+        release_age_eligible_at(&release, minimum_package_upgrade_age_seconds)
+    } else {
+        None
+    };
+    persist_update_state_with_next_check(
+        channel,
+        cache_release.then_some(&release),
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
+        next_check_after,
+    );
 
     log_message(
         "checked_for_update",
@@ -737,6 +956,22 @@ fn run_impl_with_url(
             println!("(This usually means you're running a development build)");
             println!();
             println!("To reinstall the selected release anyway, run:");
+            println!("  \x1b[1;36mgit-ai upgrade --force\x1b[0m");
+            return action;
+        }
+        UpgradeAction::ReleaseTooNew => {
+            println!("The selected release is newer than your minimum package upgrade age.");
+            println!(
+                "Configured minimum age: {} seconds",
+                minimum_package_upgrade_age_seconds
+            );
+            if let Some(created_at) = release.created_at {
+                println!("Release created_at: {}", created_at);
+            } else {
+                println!("Release created_at is missing from the releases API response.");
+            }
+            println!();
+            println!("To install it anyway, run:");
             println!("  \x1b[1;36mgit-ai upgrade --force\x1b[0m");
             return action;
         }
@@ -857,6 +1092,8 @@ pub fn maybe_schedule_background_update_check() {
     }
 
     let channel = config.update_channel();
+    let upgrade_jitter_seconds = config.upgrade_jitter_seconds();
+    let minimum_package_upgrade_age_seconds = config.minimum_package_upgrade_age_seconds();
     let cache = read_update_cache();
 
     if config.auto_updates_disabled()
@@ -867,7 +1104,12 @@ pub fn maybe_schedule_background_update_check() {
         print_cached_notice(cache);
     }
 
-    if !should_check_for_updates(channel, cache.as_ref()) {
+    if !should_check_for_updates(
+        channel,
+        cache.as_ref(),
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
+    ) {
         return;
     }
 
@@ -918,6 +1160,8 @@ pub fn check_and_install_update_if_available() -> Result<DaemonUpdateCheckResult
 
     let channel = config.update_channel();
     let api_base_url = config.api_base_url();
+    let minimum_package_upgrade_age_seconds = config.minimum_package_upgrade_age_seconds();
+    let upgrade_jitter_seconds = config.upgrade_jitter_seconds();
 
     // Read the cache that check_for_update_available() populated earlier.
     // We intentionally skip should_check_for_updates() here because the
@@ -936,11 +1180,27 @@ pub fn check_and_install_update_if_available() -> Result<DaemonUpdateCheckResult
     // Re-fetch the release to get the tag needed for the installer.
     let release = fetch_release_for_channel(api_base_url, channel)?;
     let current_version = env!("CARGO_PKG_VERSION");
-    let action = determine_action(false, &release, current_version);
+    let action = determine_action(
+        false,
+        &release,
+        current_version,
+        minimum_package_upgrade_age_seconds,
+    );
 
     if action != UpgradeAction::UpgradeAvailable {
         // Cache was stale or version changed between check and install.
-        persist_update_state(channel, None);
+        let next_check_after = if matches!(action, UpgradeAction::ReleaseTooNew) {
+            release_age_eligible_at(&release, minimum_package_upgrade_age_seconds)
+        } else {
+            None
+        };
+        persist_update_state_with_next_check(
+            channel,
+            None,
+            upgrade_jitter_seconds,
+            minimum_package_upgrade_age_seconds,
+            next_check_after,
+        );
         return Ok(DaemonUpdateCheckResult::NoUpdate);
     }
 
@@ -962,7 +1222,12 @@ pub fn check_and_install_update_if_available() -> Result<DaemonUpdateCheckResult
     run_install_script(&script_content, &release.tag, true)?;
 
     // Clear the cached update now that we've installed it.
-    persist_update_state(channel, None);
+    persist_update_state(
+        channel,
+        None,
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
+    );
 
     log_message(
         "daemon_upgraded",
@@ -991,9 +1256,16 @@ pub fn check_for_update_available() -> Result<DaemonUpdateCheckResult, String> {
 
     let channel = config.update_channel();
     let api_base_url = config.api_base_url();
+    let minimum_package_upgrade_age_seconds = config.minimum_package_upgrade_age_seconds();
+    let upgrade_jitter_seconds = config.upgrade_jitter_seconds();
     let cache = read_update_cache();
 
-    if !should_check_for_updates(channel, cache.as_ref()) {
+    if !should_check_for_updates(
+        channel,
+        cache.as_ref(),
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
+    ) {
         // Even if it's not time to re-check, an earlier check may have found an update.
         if let Some(ref c) = cache
             && c.matches_channel(channel)
@@ -1007,9 +1279,25 @@ pub fn check_for_update_available() -> Result<DaemonUpdateCheckResult, String> {
 
     let release = fetch_release_for_channel(api_base_url, channel)?;
     let current_version = env!("CARGO_PKG_VERSION");
-    let action = determine_action(false, &release, current_version);
+    let action = determine_action(
+        false,
+        &release,
+        current_version,
+        minimum_package_upgrade_age_seconds,
+    );
     let cache_release = matches!(action, UpgradeAction::UpgradeAvailable);
-    persist_update_state(channel, cache_release.then_some(&release));
+    let next_check_after = if matches!(action, UpgradeAction::ReleaseTooNew) {
+        release_age_eligible_at(&release, minimum_package_upgrade_age_seconds)
+    } else {
+        None
+    };
+    persist_update_state_with_next_check(
+        channel,
+        cache_release.then_some(&release),
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
+        next_check_after,
+    );
 
     log_message(
         "checked_for_update",
@@ -1146,6 +1434,8 @@ mod tests {
             )),
             UpdateChannel::Latest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::UpgradeAvailable);
 
@@ -1159,6 +1449,8 @@ mod tests {
             &mock_url(&same_version_payload),
             UpdateChannel::Latest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::AlreadyLatest);
 
@@ -1168,6 +1460,8 @@ mod tests {
             &mock_url(&same_version_payload),
             UpdateChannel::Latest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::ForceReinstall);
 
@@ -1180,6 +1474,8 @@ mod tests {
             )),
             UpdateChannel::Latest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::RunningNewerVersion);
 
@@ -1192,8 +1488,41 @@ mod tests {
             )),
             UpdateChannel::Latest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::ForceReinstall);
+
+        clear_test_cache_dir();
+    }
+
+    #[test]
+    #[serial]
+    fn test_run_impl_with_url_release_too_new_sets_next_check_after() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        set_test_cache_dir(&temp_dir);
+
+        let test_checksum = "a".repeat(64);
+        let created_at = current_timestamp().saturating_sub(60);
+        let minimum_age = 3600;
+        let payload = format!(
+            r#"{{"channels":{{"latest":{{"version":"v999.0.0","checksum":"{}","created_at":"{}"}}}}}}"#,
+            test_checksum, created_at
+        );
+
+        let action = run_impl_with_url(
+            false,
+            &format!("mock://{}", payload),
+            UpdateChannel::Latest,
+            true,
+            minimum_age,
+            0,
+        );
+
+        assert_eq!(action, UpgradeAction::ReleaseTooNew);
+        let cache = read_update_cache().unwrap();
+        assert!(!cache.update_available());
+        assert_eq!(cache.next_check_after, Some(created_at + minimum_age));
 
         clear_test_cache_dir();
     }
@@ -1217,6 +1546,8 @@ mod tests {
             )),
             UpdateChannel::EnterpriseLatest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::UpgradeAvailable);
 
@@ -1230,6 +1561,8 @@ mod tests {
             &mock_url(&same_version_payload),
             UpdateChannel::EnterpriseLatest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::AlreadyLatest);
 
@@ -1239,6 +1572,8 @@ mod tests {
             &mock_url(&same_version_payload),
             UpdateChannel::EnterpriseLatest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::ForceReinstall);
 
@@ -1251,6 +1586,8 @@ mod tests {
             )),
             UpdateChannel::EnterpriseLatest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::RunningNewerVersion);
 
@@ -1263,6 +1600,8 @@ mod tests {
             )),
             UpdateChannel::EnterpriseLatest,
             true,
+            0,
+            0,
         );
         assert_eq!(action, UpgradeAction::ForceReinstall);
 
@@ -1276,17 +1615,21 @@ mod tests {
         cache.last_checked_at = now;
         assert!(!should_check_for_updates(
             UpdateChannel::Latest,
-            Some(&cache)
+            Some(&cache),
+            0,
+            0
         ));
 
         let stale_offset = (UPDATE_CHECK_INTERVAL_HOURS * 3600) + 10;
         cache.last_checked_at = now.saturating_sub(stale_offset);
         assert!(should_check_for_updates(
             UpdateChannel::Latest,
-            Some(&cache)
+            Some(&cache),
+            0,
+            0
         ));
 
-        assert!(should_check_for_updates(UpdateChannel::Latest, None));
+        assert!(should_check_for_updates(UpdateChannel::Latest, None, 0, 0));
     }
 
     #[test]
@@ -1298,11 +1641,110 @@ mod tests {
         // Cache matches channel - should respect interval
         assert!(!should_check_for_updates(
             UpdateChannel::Latest,
-            Some(&cache)
+            Some(&cache),
+            0,
+            0
         ));
 
         // Cache doesn't match channel - should check for updates
-        assert!(should_check_for_updates(UpdateChannel::Next, Some(&cache)));
+        assert!(should_check_for_updates(
+            UpdateChannel::Next,
+            Some(&cache),
+            0,
+            0
+        ));
+    }
+
+    #[test]
+    fn test_should_check_for_updates_respects_next_check_after() {
+        let now = current_timestamp();
+        let mut cache = UpdateCache::new(UpdateChannel::Latest);
+        cache.last_checked_at = now.saturating_sub(UPDATE_CHECK_INTERVAL_SECS + 3600 + 10);
+        cache.next_check_after = Some(now + 60);
+        cache.upgrade_jitter_seconds = Some(3600);
+        cache.minimum_package_upgrade_age_seconds = Some(0);
+
+        assert!(!should_check_for_updates(
+            UpdateChannel::Latest,
+            Some(&cache),
+            3600,
+            0
+        ));
+
+        cache.next_check_after = Some(now.saturating_sub(1));
+        assert!(should_check_for_updates(
+            UpdateChannel::Latest,
+            Some(&cache),
+            3600,
+            0
+        ));
+    }
+
+    #[test]
+    fn test_regular_next_check_after_uses_distinct_id_and_last_checked_at() {
+        let distinct_id = "stable-client-id";
+        let last_checked_at = 1_000_000;
+        let max_jitter = 3600;
+        let jitter =
+            deterministic_upgrade_jitter_seconds(distinct_id, UpdateChannel::Latest, max_jitter);
+
+        assert_eq!(
+            regular_next_check_after_for_distinct_id(
+                last_checked_at,
+                UpdateChannel::Latest,
+                max_jitter,
+                distinct_id,
+            ),
+            last_checked_at + UPDATE_CHECK_INTERVAL_SECS + jitter
+        );
+        assert_eq!(
+            deterministic_upgrade_jitter_seconds(distinct_id, UpdateChannel::Latest, max_jitter),
+            deterministic_upgrade_jitter_seconds(distinct_id, UpdateChannel::Latest, max_jitter)
+        );
+        assert!(jitter <= max_jitter);
+        assert_eq!(
+            regular_next_check_after_for_distinct_id(
+                last_checked_at + 123,
+                UpdateChannel::Latest,
+                max_jitter,
+                distinct_id,
+            ),
+            last_checked_at + 123 + UPDATE_CHECK_INTERVAL_SECS + jitter
+        );
+    }
+
+    #[test]
+    fn test_should_check_for_updates_ignores_next_check_after_when_jitter_changes() {
+        let now = current_timestamp();
+        let mut cache = UpdateCache::new(UpdateChannel::Latest);
+        cache.last_checked_at = now.saturating_sub(UPDATE_CHECK_INTERVAL_SECS + 10);
+        cache.next_check_after = Some(now + 60 * 60);
+        cache.upgrade_jitter_seconds = Some(3600);
+        cache.minimum_package_upgrade_age_seconds = Some(0);
+
+        assert!(should_check_for_updates(
+            UpdateChannel::Latest,
+            Some(&cache),
+            0,
+            0
+        ));
+    }
+
+    #[test]
+    fn test_should_check_for_updates_ignores_next_check_after_when_minimum_age_changes() {
+        let now = current_timestamp();
+        let mut cache = UpdateCache::new(UpdateChannel::Latest);
+        cache.last_checked_at = now.saturating_sub(UPDATE_CHECK_INTERVAL_SECS + 3600 + 10);
+        cache.next_check_after = Some(now + 60 * 60);
+        cache.upgrade_jitter_seconds = Some(3600);
+        cache.minimum_package_upgrade_age_seconds = Some(86_400);
+
+        assert!(should_check_for_updates(
+            UpdateChannel::Latest,
+            Some(&cache),
+            3600,
+            0
+        ));
     }
 
     #[test]
@@ -1401,6 +1843,8 @@ mod tests {
     fn test_update_cache_new() {
         let cache = UpdateCache::new(UpdateChannel::Latest);
         assert_eq!(cache.last_checked_at, 0);
+        assert_eq!(cache.next_check_after, None);
+        assert_eq!(cache.upgrade_jitter_seconds, None);
         assert!(cache.available_tag.is_none());
         assert!(cache.available_semver.is_none());
         assert_eq!(cache.channel, "latest");
@@ -1430,8 +1874,9 @@ mod tests {
             tag: "v1.0.0".to_string(),
             semver: "1.0.0".to_string(),
             checksum: "abc".to_string(),
+            created_at: None,
         };
-        let action = determine_action(true, &release, "1.0.0");
+        let action = determine_action(true, &release, "1.0.0", 0);
         assert_eq!(action, UpgradeAction::ForceReinstall);
     }
 
@@ -1441,8 +1886,9 @@ mod tests {
             tag: "v1.0.0".to_string(),
             semver: "1.0.0".to_string(),
             checksum: "abc".to_string(),
+            created_at: None,
         };
-        let action = determine_action(false, &release, "1.0.0");
+        let action = determine_action(false, &release, "1.0.0", 0);
         assert_eq!(action, UpgradeAction::AlreadyLatest);
     }
 
@@ -1452,9 +1898,60 @@ mod tests {
             tag: "v2.0.0".to_string(),
             semver: "2.0.0".to_string(),
             checksum: "abc".to_string(),
+            created_at: None,
         };
-        let action = determine_action(false, &release, "1.0.0");
+        let action = determine_action(false, &release, "1.0.0", 0);
         assert_eq!(action, UpgradeAction::UpgradeAvailable);
+    }
+
+    #[test]
+    fn test_determine_action_release_too_new() {
+        let now = 2_000_000;
+        let release = ChannelRelease {
+            tag: "v2.0.0".to_string(),
+            semver: "2.0.0".to_string(),
+            checksum: "abc".to_string(),
+            created_at: Some(now - 60),
+        };
+        let action = determine_action_at(false, &release, "1.0.0", 120, now);
+        assert_eq!(action, UpgradeAction::ReleaseTooNew);
+    }
+
+    #[test]
+    fn test_determine_action_release_old_enough() {
+        let now = 2_000_000;
+        let release = ChannelRelease {
+            tag: "v2.0.0".to_string(),
+            semver: "2.0.0".to_string(),
+            checksum: "abc".to_string(),
+            created_at: Some(now - 121),
+        };
+        let action = determine_action_at(false, &release, "1.0.0", 120, now);
+        assert_eq!(action, UpgradeAction::UpgradeAvailable);
+    }
+
+    #[test]
+    fn test_determine_action_release_missing_created_at_blocks_minimum_age() {
+        let release = ChannelRelease {
+            tag: "v2.0.0".to_string(),
+            semver: "2.0.0".to_string(),
+            checksum: "abc".to_string(),
+            created_at: None,
+        };
+        let action = determine_action_at(false, &release, "1.0.0", 120, 2_000_000);
+        assert_eq!(action, UpgradeAction::ReleaseTooNew);
+    }
+
+    #[test]
+    fn test_determine_action_force_bypasses_minimum_age() {
+        let release = ChannelRelease {
+            tag: "v2.0.0".to_string(),
+            semver: "2.0.0".to_string(),
+            checksum: "abc".to_string(),
+            created_at: Some(2_000_000),
+        };
+        let action = determine_action_at(true, &release, "1.0.0", 120, 2_000_000);
+        assert_eq!(action, UpgradeAction::ForceReinstall);
     }
 
     #[test]
@@ -1463,8 +1960,9 @@ mod tests {
             tag: "v1.0.0".to_string(),
             semver: "1.0.0".to_string(),
             checksum: "abc".to_string(),
+            created_at: None,
         };
-        let action = determine_action(false, &release, "2.0.0");
+        let action = determine_action(false, &release, "2.0.0", 0);
         assert_eq!(action, UpgradeAction::RunningNewerVersion);
     }
 
@@ -1479,6 +1977,7 @@ mod tests {
             UpgradeAction::RunningNewerVersion.to_string(),
             "running_newer_version"
         );
+        assert_eq!(UpgradeAction::ReleaseTooNew.to_string(), "release_too_new");
         assert_eq!(UpgradeAction::ForceReinstall.to_string(), "force_reinstall");
     }
 
@@ -1571,6 +2070,7 @@ mod tests {
             ChannelInfo {
                 version: "".to_string(),
                 checksum: "abc123".to_string(),
+                created_at: None,
             },
         );
         let releases = ReleasesResponse { channels };
@@ -1587,6 +2087,7 @@ mod tests {
             ChannelInfo {
                 version: "v1.0.0".to_string(),
                 checksum: "".to_string(),
+                created_at: None,
             },
         );
         let releases = ReleasesResponse { channels };
@@ -1603,6 +2104,7 @@ mod tests {
             ChannelInfo {
                 version: "v-invalid-version".to_string(),
                 checksum: "abc123".to_string(),
+                created_at: None,
             },
         );
         let releases = ReleasesResponse { channels };
@@ -1619,6 +2121,7 @@ mod tests {
             ChannelInfo {
                 version: "v1.2.3".to_string(),
                 checksum: "abc123def456".to_string(),
+                created_at: Some("2026-06-05T23:09:48.000Z".to_string()),
             },
         );
         let releases = ReleasesResponse { channels };
@@ -1628,24 +2131,62 @@ mod tests {
         assert_eq!(release.tag, "v1.2.3");
         assert_eq!(release.semver, "1.2.3");
         assert_eq!(release.checksum, "abc123def456");
+        assert_eq!(release.created_at, Some(1780700988));
+    }
+
+    #[test]
+    fn test_release_from_response_created_at_unix_seconds() {
+        let mut channels = HashMap::new();
+        channels.insert(
+            "latest".to_string(),
+            ChannelInfo {
+                version: "v1.2.3".to_string(),
+                checksum: "abc123def456".to_string(),
+                created_at: Some("1780700988".to_string()),
+            },
+        );
+        let release =
+            release_from_response(ReleasesResponse { channels }, UpdateChannel::Latest).unwrap();
+        assert_eq!(release.created_at, Some(1780700988));
+    }
+
+    #[test]
+    fn test_release_from_response_invalid_created_at() {
+        let mut channels = HashMap::new();
+        channels.insert(
+            "latest".to_string(),
+            ChannelInfo {
+                version: "v1.2.3".to_string(),
+                checksum: "abc123def456".to_string(),
+                created_at: Some("not-a-date".to_string()),
+            },
+        );
+        let result = release_from_response(ReleasesResponse { channels }, UpdateChannel::Latest);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid release created_at"));
     }
 
     #[test]
     fn test_should_check_for_updates_no_cache() {
-        assert!(should_check_for_updates(UpdateChannel::Latest, None));
+        assert!(should_check_for_updates(UpdateChannel::Latest, None, 0, 0));
     }
 
     #[test]
     fn test_should_check_for_updates_zero_last_checked() {
         let cache = UpdateCache {
             last_checked_at: 0,
+            next_check_after: None,
+            upgrade_jitter_seconds: None,
+            minimum_package_upgrade_age_seconds: None,
             available_tag: None,
             available_semver: None,
             channel: "latest".to_string(),
         };
         assert!(should_check_for_updates(
             UpdateChannel::Latest,
-            Some(&cache)
+            Some(&cache),
+            0,
+            0
         ));
     }
 
@@ -1654,11 +2195,19 @@ mod tests {
         let now = current_timestamp();
         let cache = UpdateCache {
             last_checked_at: now,
+            next_check_after: None,
+            upgrade_jitter_seconds: None,
+            minimum_package_upgrade_age_seconds: None,
             available_tag: None,
             available_semver: None,
             channel: "latest".to_string(),
         };
-        assert!(should_check_for_updates(UpdateChannel::Next, Some(&cache)));
+        assert!(should_check_for_updates(
+            UpdateChannel::Next,
+            Some(&cache),
+            0,
+            0
+        ));
     }
 
     #[test]
@@ -1666,6 +2215,9 @@ mod tests {
         // Test serialization/deserialization without file I/O
         let mut cache = UpdateCache::new(UpdateChannel::Latest);
         cache.last_checked_at = 1234567890;
+        cache.next_check_after = Some(1234567890 + UPDATE_CHECK_INTERVAL_SECS);
+        cache.upgrade_jitter_seconds = Some(3600);
+        cache.minimum_package_upgrade_age_seconds = Some(86_400);
         cache.available_tag = Some("v1.0.0".to_string());
         cache.available_semver = Some("1.0.0".to_string());
 
@@ -1673,6 +2225,15 @@ mod tests {
         let deserialized: UpdateCache = serde_json::from_slice(&json).unwrap();
 
         assert_eq!(deserialized.last_checked_at, 1234567890);
+        assert_eq!(
+            deserialized.next_check_after,
+            Some(1234567890 + UPDATE_CHECK_INTERVAL_SECS)
+        );
+        assert_eq!(deserialized.upgrade_jitter_seconds, Some(3600));
+        assert_eq!(
+            deserialized.minimum_package_upgrade_age_seconds,
+            Some(86_400)
+        );
         assert_eq!(deserialized.available_tag, Some("v1.0.0".to_string()));
         assert_eq!(deserialized.available_semver, Some("1.0.0".to_string()));
         assert_eq!(deserialized.channel, "latest");
@@ -1686,6 +2247,7 @@ mod tests {
             tag: "v1.5.0".to_string(),
             semver: "1.5.0".to_string(),
             checksum: "test".to_string(),
+            created_at: None,
         };
 
         // Manually construct what persist_update_state would create
@@ -1751,11 +2313,11 @@ mod tests {
         let release =
             fetch_release_for_channel(&format!("mock://{}", mock_payload), UpdateChannel::Latest)
                 .unwrap();
-        let action = determine_action(false, &release, env!("CARGO_PKG_VERSION"));
+        let action = determine_action(false, &release, env!("CARGO_PKG_VERSION"), 0);
         assert_eq!(action, UpgradeAction::UpgradeAvailable);
 
         // Persist and verify the cache reflects the available update.
-        persist_update_state(UpdateChannel::Latest, Some(&release));
+        persist_update_state(UpdateChannel::Latest, Some(&release), 0, 0);
         let cache = read_update_cache().unwrap();
         assert!(cache.update_available());
         assert_eq!(cache.available_semver.as_deref(), Some("999.0.0"));
@@ -1774,7 +2336,7 @@ mod tests {
         let release =
             fetch_release_for_channel(&format!("mock://{}", mock_payload), UpdateChannel::Latest)
                 .unwrap();
-        let action = determine_action(false, &release, current);
+        let action = determine_action(false, &release, current, 0);
         assert_eq!(action, UpgradeAction::AlreadyLatest);
 
         // When the action is AlreadyLatest, persist_update_state is called with None.
@@ -1792,7 +2354,9 @@ mod tests {
         cache.last_checked_at = current_timestamp();
         assert!(!should_check_for_updates(
             UpdateChannel::Latest,
-            Some(&cache)
+            Some(&cache),
+            0,
+            0
         ));
     }
 

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -648,11 +648,8 @@ fn release_from_response(
         return Err("Checksum not found in response".to_string());
     }
 
-    let created_at = channel_info
-        .created_at
-        .as_deref()
-        .map(parse_release_created_at)
-        .transpose()?;
+    let created_at =
+        parse_optional_release_created_at(channel_info.created_at.as_deref(), channel, &tag);
 
     Ok(ChannelRelease {
         tag,
@@ -678,6 +675,60 @@ fn parse_release_created_at(value: &str) -> Result<u64, String> {
 
     u64::try_from(timestamp)
         .map_err(|_| format!("Release created_at '{}' is before Unix epoch", value))
+}
+
+fn parse_optional_release_created_at(
+    value: Option<&str>,
+    channel: UpdateChannel,
+    tag: &str,
+) -> Option<u64> {
+    let value = value?;
+    match parse_release_created_at(value) {
+        Ok(created_at) => Some(created_at),
+        Err(err) => {
+            eprintln!("Warning: {}", err);
+            log_message(
+                "invalid_release_created_at",
+                "warning",
+                Some(serde_json::json!({
+                    "channel": channel.as_str(),
+                    "release_tag": tag,
+                    "created_at": value,
+                    "error": err,
+                })),
+            );
+            None
+        }
+    }
+}
+
+fn log_release_age_gate_block(
+    release: &ChannelRelease,
+    current_version: &str,
+    api_base_url: &str,
+    channel: UpdateChannel,
+    minimum_package_upgrade_age_seconds: u64,
+) {
+    let missing_created_at = release.created_at.is_none();
+    log_message(
+        "upgrade_blocked_by_minimum_package_age",
+        if missing_created_at {
+            "warning"
+        } else {
+            "info"
+        },
+        Some(serde_json::json!({
+            "current_version": current_version,
+            "api_base_url": api_base_url,
+            "channel": channel.as_str(),
+            "release_tag": release.tag,
+            "release_semver": release.semver,
+            "release_created_at": release.created_at,
+            "minimum_package_upgrade_age_seconds": minimum_package_upgrade_age_seconds,
+            "missing_release_created_at": missing_created_at,
+            "reason": if missing_created_at { "missing_release_created_at" } else { "release_too_young" },
+        })),
+    );
 }
 
 #[cfg(test)]
@@ -942,6 +993,15 @@ fn run_impl_with_url(
             "result": action.to_string()
         })),
     );
+    if matches!(action, UpgradeAction::ReleaseTooNew) {
+        log_release_age_gate_block(
+            &release,
+            current_version,
+            api_base_url,
+            channel,
+            minimum_package_upgrade_age_seconds,
+        );
+    }
 
     match action {
         UpgradeAction::AlreadyLatest => {
@@ -1194,6 +1254,15 @@ pub fn check_and_install_update_if_available() -> Result<DaemonUpdateCheckResult
         } else {
             None
         };
+        if matches!(action, UpgradeAction::ReleaseTooNew) {
+            log_release_age_gate_block(
+                &release,
+                current_version,
+                api_base_url,
+                channel,
+                minimum_package_upgrade_age_seconds,
+            );
+        }
         persist_update_state_with_next_check(
             channel,
             None,
@@ -1309,6 +1378,15 @@ pub fn check_for_update_available() -> Result<DaemonUpdateCheckResult, String> {
             "result": action.to_string()
         })),
     );
+    if matches!(action, UpgradeAction::ReleaseTooNew) {
+        log_release_age_gate_block(
+            &release,
+            current_version,
+            api_base_url,
+            channel,
+            minimum_package_upgrade_age_seconds,
+        );
+    }
 
     if action == UpgradeAction::UpgradeAvailable && !config.auto_updates_disabled() {
         Ok(DaemonUpdateCheckResult::UpdateReady)
@@ -2151,7 +2229,7 @@ mod tests {
     }
 
     #[test]
-    fn test_release_from_response_invalid_created_at() {
+    fn test_release_from_response_invalid_created_at_is_ignored() {
         let mut channels = HashMap::new();
         channels.insert(
             "latest".to_string(),
@@ -2161,9 +2239,9 @@ mod tests {
                 created_at: Some("not-a-date".to_string()),
             },
         );
-        let result = release_from_response(ReleasesResponse { channels }, UpdateChannel::Latest);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid release created_at"));
+        let release =
+            release_from_response(ReleasesResponse { channels }, UpdateChannel::Latest).unwrap();
+        assert_eq!(release.created_at, None);
     }
 
     #[test]

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -129,7 +129,7 @@ impl UpdateCache {
 struct ChannelInfo {
     version: String,
     checksum: String,
-    created_at: Option<String>,
+    created_at: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -465,9 +465,13 @@ fn persist_update_state_with_next_check(
 ) {
     let mut cache = UpdateCache::new(channel);
     cache.last_checked_at = current_timestamp();
-    cache.next_check_after = Some(next_check_after.unwrap_or_else(|| {
-        regular_next_check_after(cache.last_checked_at, channel, upgrade_jitter_seconds)
-    }));
+    let regular_after =
+        regular_next_check_after(cache.last_checked_at, channel, upgrade_jitter_seconds);
+    cache.next_check_after = Some(
+        next_check_after
+            .map(|next_check_after| next_check_after.max(regular_after))
+            .unwrap_or(regular_after),
+    );
     cache.upgrade_jitter_seconds = Some(upgrade_jitter_seconds);
     cache.minimum_package_upgrade_age_seconds = Some(minimum_package_upgrade_age_seconds);
     if let Some(release) = release {
@@ -649,7 +653,7 @@ fn release_from_response(
     }
 
     let created_at =
-        parse_optional_release_created_at(channel_info.created_at.as_deref(), channel, &tag);
+        parse_optional_release_created_at(channel_info.created_at.as_ref(), channel, &tag);
 
     Ok(ChannelRelease {
         tag,
@@ -677,14 +681,31 @@ fn parse_release_created_at(value: &str) -> Result<u64, String> {
         .map_err(|_| format!("Release created_at '{}' is before Unix epoch", value))
 }
 
+fn parse_release_created_at_value(value: &serde_json::Value) -> Result<Option<u64>, String> {
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(value) => parse_release_created_at(value).map(Some),
+        serde_json::Value::Number(value) => value.as_u64().map(Some).ok_or_else(|| {
+            format!(
+                "Invalid release created_at '{}': expected non-negative Unix seconds",
+                value
+            )
+        }),
+        _ => Err(format!(
+            "Invalid release created_at '{}': expected ISO-8601 string or Unix seconds",
+            value
+        )),
+    }
+}
+
 fn parse_optional_release_created_at(
-    value: Option<&str>,
+    value: Option<&serde_json::Value>,
     channel: UpdateChannel,
     tag: &str,
 ) -> Option<u64> {
     let value = value?;
-    match parse_release_created_at(value) {
-        Ok(created_at) => Some(created_at),
+    match parse_release_created_at_value(value) {
+        Ok(created_at) => created_at,
         Err(err) => {
             eprintln!("Warning: {}", err);
             log_message(
@@ -1600,7 +1621,14 @@ mod tests {
         assert_eq!(action, UpgradeAction::ReleaseTooNew);
         let cache = read_update_cache().unwrap();
         assert!(!cache.update_available());
-        assert_eq!(cache.next_check_after, Some(created_at + minimum_age));
+        let next_check_after = cache.next_check_after.unwrap();
+        assert!(
+            next_check_after
+                >= cache
+                    .last_checked_at
+                    .saturating_add(UPDATE_CHECK_INTERVAL_SECS)
+        );
+        assert!(next_check_after > created_at + minimum_age);
 
         clear_test_cache_dir();
     }
@@ -2199,7 +2227,7 @@ mod tests {
             ChannelInfo {
                 version: "v1.2.3".to_string(),
                 checksum: "abc123def456".to_string(),
-                created_at: Some("2026-06-05T23:09:48.000Z".to_string()),
+                created_at: Some(serde_json::json!("2026-06-05T23:09:48.000Z")),
             },
         );
         let releases = ReleasesResponse { channels };
@@ -2213,14 +2241,30 @@ mod tests {
     }
 
     #[test]
-    fn test_release_from_response_created_at_unix_seconds() {
+    fn test_release_from_response_created_at_unix_seconds_string() {
         let mut channels = HashMap::new();
         channels.insert(
             "latest".to_string(),
             ChannelInfo {
                 version: "v1.2.3".to_string(),
                 checksum: "abc123def456".to_string(),
-                created_at: Some("1780700988".to_string()),
+                created_at: Some(serde_json::json!("1780700988")),
+            },
+        );
+        let release =
+            release_from_response(ReleasesResponse { channels }, UpdateChannel::Latest).unwrap();
+        assert_eq!(release.created_at, Some(1780700988));
+    }
+
+    #[test]
+    fn test_release_from_response_created_at_unix_seconds_number() {
+        let mut channels = HashMap::new();
+        channels.insert(
+            "latest".to_string(),
+            ChannelInfo {
+                version: "v1.2.3".to_string(),
+                checksum: "abc123def456".to_string(),
+                created_at: Some(serde_json::json!(1780700988_u64)),
             },
         );
         let release =
@@ -2236,7 +2280,23 @@ mod tests {
             ChannelInfo {
                 version: "v1.2.3".to_string(),
                 checksum: "abc123def456".to_string(),
-                created_at: Some("not-a-date".to_string()),
+                created_at: Some(serde_json::json!("not-a-date")),
+            },
+        );
+        let release =
+            release_from_response(ReleasesResponse { channels }, UpdateChannel::Latest).unwrap();
+        assert_eq!(release.created_at, None);
+    }
+
+    #[test]
+    fn test_release_from_response_invalid_created_at_type_is_ignored() {
+        let mut channels = HashMap::new();
+        channels.insert(
+            "latest".to_string(),
+            ChannelInfo {
+                version: "v1.2.3".to_string(),
+                checksum: "abc123def456".to_string(),
+                created_at: Some(serde_json::json!({"unexpected": true})),
             },
         );
         let release =

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@ pub const DEFAULT_API_BASE_URL: &str = "https://usegitai.com";
 pub const DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES: usize = 3 * 1024 * 1024;
 pub const DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES: usize = 32 * 1024 * 1024;
 pub const DEFAULT_MAX_CHECKPOINT_TOTAL_LINES: usize = 500_000;
+/// Jitter is added on top of the 24h update interval. Four days of jitter
+/// keeps checks within the requested 24h..5d window.
+pub const MAX_UPGRADE_JITTER_SECONDS: u64 = 4 * 24 * 60 * 60;
 
 /// Which backend to use for storing authorship notes.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -170,6 +173,8 @@ pub struct Config {
     disable_version_checks: bool,
     disable_auto_updates: bool,
     update_channel: UpdateChannel,
+    upgrade_jitter_seconds: u64,
+    minimum_package_upgrade_age_seconds: u64,
     feature_flags: FeatureFlags,
     api_base_url: String,
     prompt_storage: String,
@@ -242,6 +247,10 @@ pub struct FileConfig {
     pub disable_auto_updates: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_channel: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upgrade_jitter_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum_package_upgrade_age_seconds: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feature_flags: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -319,6 +328,10 @@ pub struct ConfigPatch {
     pub disable_version_checks: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disable_auto_updates: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upgrade_jitter_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum_package_upgrade_age_seconds: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_storage: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -533,6 +546,14 @@ impl Config {
 
     pub fn update_channel(&self) -> UpdateChannel {
         self.update_channel
+    }
+
+    pub fn upgrade_jitter_seconds(&self) -> u64 {
+        self.upgrade_jitter_seconds
+    }
+
+    pub fn minimum_package_upgrade_age_seconds(&self) -> u64 {
+        self.minimum_package_upgrade_age_seconds
     }
 
     pub fn feature_flags(&self) -> &FeatureFlags {
@@ -946,6 +967,18 @@ fn author_config_file_fingerprint(path: &Path) -> Option<AuthorConfigFileFingerp
     })
 }
 
+fn normalize_upgrade_jitter_seconds(value: u64) -> u64 {
+    if value > MAX_UPGRADE_JITTER_SECONDS {
+        eprintln!(
+            "Warning: upgrade_jitter_seconds cannot exceed {} seconds; using {}",
+            MAX_UPGRADE_JITTER_SECONDS, MAX_UPGRADE_JITTER_SECONDS
+        );
+        MAX_UPGRADE_JITTER_SECONDS
+    } else {
+        value
+    }
+}
+
 fn build_config() -> Config {
     let file_cfg = load_file_config();
     let exclude_prompts_in_repositories = file_cfg
@@ -1039,6 +1072,16 @@ fn build_config() -> Config {
         .and_then(|c| c.update_channel.as_deref())
         .and_then(UpdateChannel::from_str)
         .unwrap_or_default();
+    let upgrade_jitter_seconds = normalize_upgrade_jitter_seconds(
+        file_cfg
+            .as_ref()
+            .and_then(|c| c.upgrade_jitter_seconds)
+            .unwrap_or(0),
+    );
+    let minimum_package_upgrade_age_seconds = file_cfg
+        .as_ref()
+        .and_then(|c| c.minimum_package_upgrade_age_seconds)
+        .unwrap_or(0);
 
     let git_path = resolve_git_path(&file_cfg);
 
@@ -1224,6 +1267,8 @@ fn build_config() -> Config {
             disable_version_checks,
             disable_auto_updates,
             update_channel,
+            upgrade_jitter_seconds,
+            minimum_package_upgrade_age_seconds,
             feature_flags,
             api_base_url,
             prompt_storage,
@@ -1257,6 +1302,8 @@ fn build_config() -> Config {
         disable_version_checks,
         disable_auto_updates,
         update_channel,
+        upgrade_jitter_seconds,
+        minimum_package_upgrade_age_seconds,
         feature_flags,
         api_base_url,
         prompt_storage,
@@ -1673,6 +1720,14 @@ fn apply_test_config_patch(config: &mut Config) {
         if let Some(disable_auto_updates) = patch.disable_auto_updates {
             config.disable_auto_updates = disable_auto_updates;
         }
+        if let Some(upgrade_jitter_seconds) = patch.upgrade_jitter_seconds {
+            config.upgrade_jitter_seconds =
+                normalize_upgrade_jitter_seconds(upgrade_jitter_seconds);
+        }
+        if let Some(minimum_package_upgrade_age_seconds) = patch.minimum_package_upgrade_age_seconds
+        {
+            config.minimum_package_upgrade_age_seconds = minimum_package_upgrade_age_seconds;
+        }
         if let Some(prompt_storage) = patch.prompt_storage {
             // Validate the value
             if matches!(prompt_storage.as_str(), "default" | "notes" | "local") {
@@ -1756,6 +1811,8 @@ mod tests {
             disable_version_checks: false,
             disable_auto_updates: false,
             update_channel: UpdateChannel::Latest,
+            upgrade_jitter_seconds: 0,
+            minimum_package_upgrade_age_seconds: 0,
             feature_flags: FeatureFlags::default(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             prompt_storage: "default".to_string(),
@@ -2001,6 +2058,8 @@ mod tests {
             disable_version_checks: false,
             disable_auto_updates: false,
             update_channel: UpdateChannel::Latest,
+            upgrade_jitter_seconds: 0,
+            minimum_package_upgrade_age_seconds: 0,
             feature_flags: FeatureFlags::default(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             prompt_storage: "default".to_string(),
@@ -2149,6 +2208,8 @@ mod tests {
             disable_version_checks: false,
             disable_auto_updates: false,
             update_channel: UpdateChannel::Latest,
+            upgrade_jitter_seconds: 0,
+            minimum_package_upgrade_age_seconds: 0,
             feature_flags: FeatureFlags::default(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             prompt_storage: prompt_storage.to_string(),
@@ -2375,6 +2436,13 @@ mod tests {
         let mut config = create_test_config(vec![], vec![]);
         config.quiet = true;
         assert!(config.is_quiet());
+    }
+
+    #[test]
+    fn test_upgrade_timing_defaults_are_disabled() {
+        let config = create_test_config(vec![], vec![]);
+        assert_eq!(config.upgrade_jitter_seconds(), 0);
+        assert_eq!(config.minimum_package_upgrade_age_seconds(), 0);
     }
 
     #[test]

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -284,6 +284,8 @@ fn fully_populated_file_config() -> FileConfig {
         disable_version_checks: Some(true),
         disable_auto_updates: Some(true),
         update_channel: Some("latest".to_string()),
+        upgrade_jitter_seconds: Some(345_600),
+        minimum_package_upgrade_age_seconds: Some(86_400),
         feature_flags: Some(serde_json::json!({"transcript_sweep": true})),
         api_base_url: Some("https://usegitai.com".to_string()),
         prompt_storage: Some("default".to_string()),


### PR DESCRIPTION
## Summary
- add config keys for stable per-client upgrade jitter and minimum package upgrade age
- parse release created_at from the releases API and gate upgrades until releases are old enough
- send release created_at through the git-ai release workflow when dispatching monorepo release-channel updates

## Validation
- cargo test commands::upgrade
- cargo test commands::config
- cargo test --lib
- cargo check --all-targets
- git diff --check