### PR TITLE
[codex] Remove smol runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,125 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,19 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -500,15 +368,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -887,27 +746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,19 +925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,7 +1057,6 @@ dependencies = [
  "serde_json_canonicalizer",
  "serial_test",
  "sha2",
- "smol",
  "tempfile",
  "tokio",
  "toml",
@@ -2541,12 +2365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,17 +2501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,20 +2532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3436,23 +3229,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-net",
- "async-process",
- "blocking",
- "futures-lite",
-]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ sha2 = "0.10"
 imara-diff = "0.2"
 chrono = { version = "0.4.44", default-features = false, features = ["serde", "clock", "std"] }
 indicatif = "0.18"
-smol = "2.0"
 futures = "0.3"
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time", "macros"] }
 tracing = "0.1"

--- a/docs/pr-1153-review-findings.md
+++ b/docs/pr-1153-review-findings.md
@@ -231,13 +231,13 @@ different trace IDs exist for the same logical checkpoint call.
 
 ---
 
-### M6: `smol::block_on` nested inside tokio async context
+### M6: Secondary runtime blocking nested inside tokio async context
 
 **File**: `src/daemon/checkpoint.rs:240, 409`
 
-Checkpoint execution uses `smol::block_on` for concurrent file processing. This blocks
-the tokio worker thread. The daemon serializes checkpoints per-family so only one is
-blocked at a time per repo, but multiple repos can saturate the thread pool.
+Checkpoint execution used a secondary runtime for concurrent file processing. This
+blocked the tokio worker thread. The daemon serializes checkpoints per-family so only
+one is blocked at a time per repo, but multiple repos can saturate the thread pool.
 
 ---
 

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -469,7 +469,7 @@ pub fn post_commit_amend(
             })
             .unwrap_or(false);
 
-    let working_va = smol::block_on(async {
+    let working_va = crate::tokio_runtime::block_on(async {
         VirtualAttributions::from_working_log_for_commit_snapshot(
             repo.clone(),
             original_commit.to_string(),

--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -226,7 +226,7 @@ fn create_authorship_log_for_range(
         tracing::debug!("Start is empty tree - using only end commit attributions");
 
         let repo_clone = repo.clone();
-        let mut end_va = smol::block_on(async {
+        let mut end_va = crate::tokio_runtime::block_on(async {
             VirtualAttributions::new_for_base_commit(
                 repo_clone,
                 end_sha.to_string(),
@@ -258,7 +258,7 @@ fn create_authorship_log_for_range(
     // avoiding expensive traversal of the entire repository history
     let repo_clone = repo.clone();
     let start_sha_limit = Some(start_sha.to_string());
-    let mut start_va = smol::block_on(async {
+    let mut start_va = crate::tokio_runtime::block_on(async {
         VirtualAttributions::new_for_base_commit(
             repo_clone,
             start_sha.to_string(),
@@ -272,7 +272,7 @@ fn create_authorship_log_for_range(
     // Pass start_sha as blame_start_commit to limit blame scope to the range
     let repo_clone = repo.clone();
     let start_sha_limit = Some(start_sha.to_string());
-    let mut end_va = smol::block_on(async {
+    let mut end_va = crate::tokio_runtime::block_on(async {
         VirtualAttributions::new_for_base_commit(
             repo_clone,
             end_sha.to_string(),

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -128,7 +128,7 @@ impl VirtualAttributions {
     ) -> Result<Vec<(String, String, PromptRecord)>, GitAiError> {
         const MAX_CONCURRENT: usize = 30;
 
-        let semaphore = Arc::new(smol::lock::Semaphore::new(MAX_CONCURRENT));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT));
         let mut tasks = Vec::new();
 
         for missing_id in missing_ids {
@@ -136,17 +136,18 @@ impl VirtualAttributions {
             let repo = self.repo.clone();
             let semaphore = Arc::clone(&semaphore);
 
-            let task = smol::spawn(async move {
-                // Acquire semaphore permit to limit concurrency
-                let _permit = semaphore.acquire().await;
+            let task = async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("prompt lookup semaphore was closed");
 
-                // Wrap blocking git operations in smol::unblock
-                smol::unblock(move || {
+                crate::tokio_runtime::spawn_blocking_result(move || {
                     Self::find_prompt_in_history_static(&repo, &missing_id)
-                        .map(|(commit_sha, prompt)| (missing_id.clone(), commit_sha, prompt))
+                        .map(|(commit_sha, prompt)| (missing_id, commit_sha, prompt))
                 })
                 .await
-            });
+            };
 
             tasks.push(task);
         }
@@ -199,7 +200,7 @@ impl VirtualAttributions {
     ) -> Result<Vec<(String, SessionRecord)>, GitAiError> {
         const MAX_CONCURRENT: usize = 30;
 
-        let semaphore = Arc::new(smol::lock::Semaphore::new(MAX_CONCURRENT));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT));
         let mut tasks = Vec::new();
 
         for missing_id in missing_ids {
@@ -207,14 +208,17 @@ impl VirtualAttributions {
             let repo = self.repo.clone();
             let semaphore = Arc::clone(&semaphore);
 
-            let task = smol::spawn(async move {
-                let _permit = semaphore.acquire().await;
-                smol::unblock(move || {
+            let task = async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("session lookup semaphore was closed");
+                crate::tokio_runtime::spawn_blocking_result(move || {
                     Self::find_session_in_history_static(&repo, &missing_id)
                         .map(|record| (missing_id, record))
                 })
                 .await
-            });
+            };
 
             tasks.push(task);
         }
@@ -254,7 +258,7 @@ impl VirtualAttributions {
     async fn add_pathspecs_concurrent(&mut self, pathspecs: &[String]) -> Result<(), GitAiError> {
         const MAX_CONCURRENT: usize = 30;
 
-        let semaphore = Arc::new(smol::lock::Semaphore::new(MAX_CONCURRENT));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT));
         let mut tasks = Vec::new();
 
         for pathspec in pathspecs {
@@ -265,12 +269,13 @@ impl VirtualAttributions {
             let blame_start_commit = self.blame_start_commit.clone();
             let semaphore = Arc::clone(&semaphore);
 
-            let task = smol::spawn(async move {
-                // Acquire semaphore permit to limit concurrency
-                let _permit = semaphore.acquire().await;
+            let task = async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("virtual attribution semaphore was closed");
 
-                // Wrap blocking git operations in smol::unblock
-                smol::unblock(move || {
+                crate::tokio_runtime::spawn_blocking_result(move || {
                     compute_attributions_for_file(
                         &repo,
                         &base_commit,
@@ -280,7 +285,7 @@ impl VirtualAttributions {
                     )
                 })
                 .await
-            });
+            };
 
             tasks.push(task);
         }

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -323,8 +323,8 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
     persist_install_config(&binary_path, options.dry_run)?;
     let params = HookInstallerParams { binary_path };
 
-    // Run async operations with smol and convert result
-    let statuses = smol::block_on(async_run_install(&params, &options))?;
+    // Run async operations and convert result.
+    let statuses = crate::tokio_runtime::block_on(async_run_install(&params, &options))?;
 
     // Clean up legacy envelope logs directory and related artifacts.
     // These are no longer used — all telemetry now routes through the daemon.
@@ -452,8 +452,8 @@ pub fn run_uninstall(args: &[String]) -> Result<HashMap<String, String>, GitAiEr
     let binary_path = get_current_binary_path()?;
     let params = HookInstallerParams { binary_path };
 
-    // Run async operations with smol and convert result
-    let statuses = smol::block_on(async_run_uninstall(&params, dry_run, verbose))?;
+    // Run async operations and convert result.
+    let statuses = crate::tokio_runtime::block_on(async_run_uninstall(&params, dry_run, verbose))?;
     Ok(to_hashmap(statuses))
 }
 

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -264,7 +264,7 @@ fn execute_resolved_checkpoint(
     let trace_id = checkpoint_request.trace_id.clone();
 
     let entries_start = Instant::now();
-    let (entries, file_stats) = smol::block_on(get_checkpoint_entries(
+    let (entries, file_stats) = crate::tokio_runtime::block_on(get_checkpoint_entries(
         kind,
         author,
         repo,
@@ -439,21 +439,24 @@ fn save_current_file_states(
 
     let blobs_dir = working_log.dir.join("blobs");
     let dirty_files = working_log.dirty_files.clone();
+    let files = files.to_vec();
 
-    let file_content_hashes = smol::block_on(async {
-        let semaphore = Arc::new(smol::lock::Semaphore::new(8));
+    let file_content_hashes = crate::tokio_runtime::block_on(async {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(8));
         let blobs_dir = Arc::new(blobs_dir);
         let dirty_files = Arc::new(dirty_files);
 
-        let futures = files.iter().map(|file_path| {
-            let file_path = file_path.clone();
+        let mut futures = Vec::with_capacity(files.len());
+        for file_path in files {
             let blobs_dir = Arc::clone(&blobs_dir);
             let dirty_files = Arc::clone(&dirty_files);
             let semaphore = Arc::clone(&semaphore);
 
-            async move {
-                // Acquire semaphore permit
-                let _permit = semaphore.acquire().await;
+            futures.push(async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("file state semaphore was closed");
 
                 // Read file content - check dirty_files first, then filesystem
                 let content = if let Some(ref dirty_map) = *dirty_files {
@@ -468,21 +471,24 @@ fn save_current_file_states(
                     ))
                 })?;
 
-                // Create SHA256 hash of the content
-                let mut hasher = Sha256::new();
-                hasher.update(content.as_bytes());
-                let sha = format!("{:x}", hasher.finalize());
+                crate::tokio_runtime::spawn_blocking_result(move || {
+                    // Create SHA256 hash of the content
+                    let mut hasher = Sha256::new();
+                    hasher.update(content.as_bytes());
+                    let sha = format!("{:x}", hasher.finalize());
 
-                // Ensure blobs directory exists
-                std::fs::create_dir_all(&*blobs_dir)?;
+                    // Ensure blobs directory exists
+                    std::fs::create_dir_all(&*blobs_dir)?;
 
-                // Write content to blob file
-                let blob_path = blobs_dir.join(&sha);
-                std::fs::write(blob_path, content)?;
+                    // Write content to blob file
+                    let blob_path = blobs_dir.join(&sha);
+                    std::fs::write(blob_path, content)?;
 
-                Ok::<(String, String), GitAiError>((file_path, sha))
-            }
-        });
+                    Ok::<(String, String), GitAiError>((file_path, sha))
+                })
+                .await
+            });
+        }
 
         // Collect results from all concurrent operations
         let results: Vec<Result<(String, String), GitAiError>> =
@@ -864,7 +870,7 @@ async fn get_checkpoint_entries(
     const MAX_CONCURRENT: usize = 30;
 
     // Create a semaphore to limit concurrent tasks
-    let semaphore = Arc::new(smol::lock::Semaphore::new(MAX_CONCURRENT));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT));
 
     // Move other repeated allocations outside the loop
     let previous_file_state_by_file = Arc::new(previous_file_state_by_file);
@@ -896,12 +902,13 @@ async fn get_checkpoint_entries(
         let parent_note_attributions = Arc::clone(&parent_note_attributions);
         let semaphore = Arc::clone(&semaphore);
 
-        let task = smol::spawn(async move {
-            // Acquire semaphore permit to limit concurrency
-            let _permit = semaphore.acquire().await;
+        let task = async move {
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .expect("checkpoint entry semaphore was closed");
 
-            // Wrap all the blocking git operations in smol::unblock
-            smol::unblock(move || {
+            crate::tokio_runtime::spawn_blocking_result(move || {
                 get_checkpoint_entry_for_file(
                     file_path,
                     kind,
@@ -919,7 +926,7 @@ async fn get_checkpoint_entries(
                 )
             })
             .await
-        });
+        };
 
         tasks.push(task);
     }

--- a/src/git/authorship_traversal.rs
+++ b/src/git/authorship_traversal.rs
@@ -16,7 +16,7 @@ pub async fn load_ai_touched_files_for_commits(
 ) -> Result<HashSet<String>, GitAiError> {
     let repo = repo.clone();
 
-    smol::unblock(move || {
+    crate::tokio_runtime::spawn_blocking_result(move || {
         if commit_shas.is_empty() {
             return Ok(HashSet::new());
         }
@@ -204,95 +204,89 @@ mod tests {
     use crate::git::{find_repository_in_path, sync_authorship::fetch_authorship_notes};
     use std::time::Instant;
 
-    #[test]
-    fn test_load_ai_touched_files_for_specific_commits() {
-        smol::block_on(async {
-            let repo = find_repository_in_path(".").unwrap();
+    #[tokio::test]
+    async fn test_load_ai_touched_files_for_specific_commits() {
+        let repo = find_repository_in_path(".").unwrap();
 
-            fetch_authorship_notes(&repo, "origin").unwrap();
+        fetch_authorship_notes(&repo, "origin").unwrap();
 
-            // Get all notes to find commits that have notes attached
-            let global_args = repo.global_args_for_exec();
-            let all_notes = get_notes_list(&global_args).unwrap();
+        // Get all notes to find commits that have notes attached
+        let global_args = repo.global_args_for_exec();
+        let all_notes = get_notes_list(&global_args).unwrap();
 
-            if all_notes.len() < 3 {
-                println!(
-                    "Skipping test: only {} notes available, need at least 3",
-                    all_notes.len()
-                );
-                return;
-            }
-
-            // Pick 3 commits that have notes
-            let selected_commits: Vec<String> = all_notes
-                .iter()
-                .take(3)
-                .map(|(_, commit_sha)| commit_sha.clone())
-                .collect();
-
-            println!("Testing with commits: {:?}", selected_commits);
-
-            let start = Instant::now();
-            let files = load_ai_touched_files_for_commits(&repo, selected_commits.clone())
-                .await
-                .unwrap();
-            let elapsed = start.elapsed();
-
+        if all_notes.len() < 3 {
             println!(
-                "Found {} unique AI-touched files from 3 commits in {:?}",
-                files.len(),
-                elapsed
+                "Skipping test: only {} notes available, need at least 3",
+                all_notes.len()
             );
+            return;
+        }
 
-            // Show the files found
-            let mut sorted_files: Vec<_> = files.iter().collect();
-            sorted_files.sort();
-            for file in sorted_files.iter() {
-                println!("  {}", file);
-            }
+        // Pick 3 commits that have notes
+        let selected_commits: Vec<String> = all_notes
+            .iter()
+            .take(3)
+            .map(|(_, commit_sha)| commit_sha.clone())
+            .collect();
 
-            // Verify we got some results (since we picked commits with notes)
-            assert!(
-                !files.is_empty(),
-                "Should find files from commits with notes"
-            );
-        });
+        println!("Testing with commits: {:?}", selected_commits);
+
+        let start = Instant::now();
+        let files = load_ai_touched_files_for_commits(&repo, selected_commits.clone())
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        println!(
+            "Found {} unique AI-touched files from 3 commits in {:?}",
+            files.len(),
+            elapsed
+        );
+
+        // Show the files found
+        let mut sorted_files: Vec<_> = files.iter().collect();
+        sorted_files.sort();
+        for file in sorted_files.iter() {
+            println!("  {}", file);
+        }
+
+        // Verify we got some results (since we picked commits with notes)
+        assert!(
+            !files.is_empty(),
+            "Should find files from commits with notes"
+        );
     }
 
-    #[test]
-    fn test_load_ai_touched_files_for_nonexistent_commit() {
-        smol::block_on(async {
-            let repo = find_repository_in_path(".").unwrap();
+    #[tokio::test]
+    async fn test_load_ai_touched_files_for_nonexistent_commit() {
+        let repo = find_repository_in_path(".").unwrap();
 
-            // Use a fake SHA that doesn't exist
-            let fake_commits = vec![
-                "0000000000000000000000000000000000000000".to_string(),
-                "1111111111111111111111111111111111111111".to_string(),
-            ];
+        // Use a fake SHA that doesn't exist
+        let fake_commits = vec![
+            "0000000000000000000000000000000000000000".to_string(),
+            "1111111111111111111111111111111111111111".to_string(),
+        ];
 
-            let files = load_ai_touched_files_for_commits(&repo, fake_commits)
-                .await
-                .unwrap();
+        let files = load_ai_touched_files_for_commits(&repo, fake_commits)
+            .await
+            .unwrap();
 
-            // Should return empty set, not crash
-            assert!(
-                files.is_empty(),
-                "Should return empty set for non-existent commits"
-            );
-        });
+        // Should return empty set, not crash
+        assert!(
+            files.is_empty(),
+            "Should return empty set for non-existent commits"
+        );
     }
 
-    #[test]
-    fn test_load_ai_touched_files_empty_commits() {
-        smol::block_on(async {
-            let repo = find_repository_in_path(".").unwrap();
+    #[tokio::test]
+    async fn test_load_ai_touched_files_empty_commits() {
+        let repo = find_repository_in_path(".").unwrap();
 
-            let files = load_ai_touched_files_for_commits(&repo, vec![])
-                .await
-                .unwrap();
+        let files = load_ai_touched_files_for_commits(&repo, vec![])
+            .await
+            .unwrap();
 
-            assert!(files.is_empty(), "Should return empty set for empty input");
-        });
+        assert!(files.is_empty(), "Should return empty set for empty input");
     }
 
     #[test]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1640,7 +1640,7 @@ impl Repository {
         const MAX_CONCURRENT: usize = 30;
 
         let repo_global_args = self.global_args_for_exec();
-        let semaphore = Arc::new(smol::lock::Semaphore::new(MAX_CONCURRENT));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT));
 
         let futures: Vec<_> = file_paths
             .iter()
@@ -1652,17 +1652,23 @@ impl Repository {
                 let semaphore = semaphore.clone();
 
                 async move {
-                    let _permit = semaphore.acquire().await;
-                    let result = exec_git(&args).and_then(|output| {
-                        String::from_utf8(output.stdout)
-                            .map_err(|e| GitAiError::Utf8Error(e.utf8_error()))
-                    });
+                    let _permit = semaphore
+                        .acquire_owned()
+                        .await
+                        .expect("staged file semaphore was closed");
+                    let result = crate::tokio_runtime::spawn_blocking_result(move || {
+                        exec_git(&args).and_then(|output| {
+                            String::from_utf8(output.stdout)
+                                .map_err(|e| GitAiError::Utf8Error(e.utf8_error()))
+                        })
+                    })
+                    .await;
                     (file_path, result)
                 }
             })
             .collect();
 
-        let results = smol::block_on(async { join_all(futures).await });
+        let results = crate::tokio_runtime::block_on(async { join_all(futures).await });
 
         let mut staged_files = HashMap::new();
         for (file_path, result) in results {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,6 @@ pub mod observability;
 pub mod process_timeout;
 pub mod repo_url;
 pub mod streams;
+pub mod tokio_runtime;
 pub mod utils;
 pub mod uuid;

--- a/src/mdm/spinner.rs
+++ b/src/mdm/spinner.rs
@@ -31,7 +31,7 @@ impl Spinner {
 
     #[allow(dead_code)]
     pub async fn wait_for(&self, duration_ms: u64) {
-        smol::Timer::after(std::time::Duration::from_millis(duration_ms)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(duration_ms)).await;
     }
 
     pub fn success(&self, message: &str) {

--- a/src/tokio_runtime.rs
+++ b/src/tokio_runtime.rs
@@ -1,0 +1,37 @@
+use std::future::Future;
+
+use crate::error::GitAiError;
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create Tokio runtime")
+}
+
+pub fn block_on<F>(future: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::scope(|scope| {
+            scope
+                .spawn(move || runtime().block_on(future))
+                .join()
+                .expect("Tokio helper thread panicked")
+        })
+    } else {
+        runtime().block_on(future)
+    }
+}
+
+pub async fn spawn_blocking_result<F, T>(task: F) -> Result<T, GitAiError>
+where
+    F: FnOnce() -> Result<T, GitAiError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(task)
+        .await
+        .map_err(|err| GitAiError::Generic(format!("Tokio blocking task failed: {err}")))?
+}

--- a/tests/integration/virtual_attribution_unit.rs
+++ b/tests/integration/virtual_attribution_unit.rs
@@ -31,7 +31,7 @@ fn test_virtual_attributions() {
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
 
     // Create VirtualAttributions using the temp repo
-    let virtual_attributions = smol::block_on(async {
+    let virtual_attributions = git_ai::tokio_runtime::block_on(async {
         VirtualAttributions::new_for_base_commit(
             gitai_repo.clone(),
             commit_sha.clone(),


### PR DESCRIPTION
## Summary

- Remove the `smol` dependency and stale lockfile entries.
- Route synchronous async wait points through a shared Tokio runtime helper.
- Replace bounded `smol` task/unblock usage with Tokio semaphores and `spawn_blocking`.
- Update tests and stale docs so repo-wide runtime references are gone.

## Validation

- `cargo check --all-targets`
- `task fmt`
- `task lint`
- `task test TEST_FILTER=rebase_realworld::test_human_conflict_python_pipeline_mixed_baseline_c3_conflict` after one transient full-suite daemon timeout
- `task test` clean rerun
- `rg -n "\\bsmol\\b|smol::" -S Cargo.toml Cargo.lock src tests docs` returns no matches

## Notes

The initial full `task test` run had one daemon completion timeout in `rebase_realworld::test_human_conflict_python_pipeline_mixed_baseline_c3_conflict`; the exact test passed on rerun and the subsequent full suite passed cleanly.