### PR TITLE
Fix GitHub CI previous head fetch

### DIFF
--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -822,7 +822,8 @@ fn ensure_commit_available_for_sync(
     fetch_ref: &str,
     skip_fetch: bool,
 ) -> Result<(), GitAiError> {
-    if repo.revparse_single(commit_sha).is_ok() {
+    let commit_spec = format!("{}^{{commit}}", commit_sha);
+    if repo.revparse_single(&commit_spec).is_ok() {
         return Ok(());
     }
     if skip_fetch {
@@ -842,7 +843,7 @@ fn ensure_commit_available_for_sync(
     args.push(fetch_remote.to_string());
     args.push(format!("{}:{}", commit_sha, fetch_ref));
     exec_git(&args)?;
-    repo.revparse_single(commit_sha)?;
+    repo.revparse_single(&commit_spec)?;
     Ok(())
 }
 

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -180,7 +180,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
         clone_dir.clone(),
         "rev-parse".to_string(),
         "--verify".to_string(),
-        previous_head_sha.clone(),
+        format!("{}^{{commit}}", previous_head_sha),
     ])
     .is_ok();
 
@@ -188,15 +188,20 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
         let previous_head_fetch_url = authenticated_fork_url
             .as_ref()
             .unwrap_or(&authenticated_url);
+        let previous_head_ref = format!("refs/git-ai/github/pr/{}/previous-head", pr_number);
         exec_git(&[
             "-C".to_string(),
             clone_dir.clone(),
             "fetch".to_string(),
             previous_head_fetch_url.clone(),
-            format!(
-                "{}:refs/github/pr/{}/previous",
-                previous_head_sha, pr_number
-            ),
+            previous_head_sha.clone(),
+        ])?;
+        exec_git(&[
+            "-C".to_string(),
+            clone_dir.clone(),
+            "update-ref".to_string(),
+            previous_head_ref,
+            previous_head_sha.clone(),
         ])?;
     }
 

--- a/tests/integration/ci_handlers_comprehensive.rs
+++ b/tests/integration/ci_handlers_comprehensive.rs
@@ -1,5 +1,29 @@
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{TestRepo, real_git_executable};
 use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+fn run_real_git(args: &[&str]) -> String {
+    let output = Command::new(real_git_executable())
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git {:?}: {}", args, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(
+        output.status.success(),
+        "git {:?} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+        args,
+        output.status.code(),
+        stdout,
+        stderr
+    );
+    stdout.trim().to_string()
+}
+
+fn path_str(path: &Path) -> &str {
+    path.to_str().expect("test path must be valid UTF-8")
+}
 
 // ==============================================================================
 // CI Handlers Tests - Module Structure and Types
@@ -118,6 +142,106 @@ fn test_ci_github_run_noops_when_synchronize_has_no_previous_head() {
         "Expected no-op output, got: {}",
         output
     );
+}
+
+#[test]
+fn test_ci_github_run_fetches_missing_previous_head_after_force_push() {
+    let ci_repo = TestRepo::new();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let remote_path = tmp.path().join("origin.git");
+    let work_path = tmp.path().join("work");
+    let remote = path_str(&remote_path);
+    let work = path_str(&work_path);
+
+    run_real_git(&["init", "--bare", "--initial-branch=main", remote]);
+    run_real_git(&[
+        "-C",
+        remote,
+        "config",
+        "uploadpack.allowAnySHA1InWant",
+        "true",
+    ]);
+    run_real_git(&["init", "--initial-branch=main", work]);
+    run_real_git(&["-C", work, "config", "user.name", "Test User"]);
+    run_real_git(&["-C", work, "config", "user.email", "test@example.com"]);
+
+    std::fs::write(work_path.join("file.txt"), "base\n").expect("write base");
+    run_real_git(&["-C", work, "add", "file.txt"]);
+    run_real_git(&["-C", work, "commit", "-m", "base"]);
+    let base_sha = run_real_git(&["-C", work, "rev-parse", "HEAD"]);
+    run_real_git(&["-C", work, "remote", "add", "origin", remote]);
+    run_real_git(&["-C", work, "push", "origin", "main"]);
+
+    run_real_git(&["-C", work, "checkout", "-b", "feature"]);
+    std::fs::write(work_path.join("file.txt"), "old PR head\n").expect("write old head");
+    run_real_git(&["-C", work, "commit", "-am", "old pr head"]);
+    let previous_head_sha = run_real_git(&["-C", work, "rev-parse", "HEAD"]);
+    run_real_git(&["-C", work, "push", "origin", "HEAD:refs/pull/42/head"]);
+
+    run_real_git(&["-C", work, "checkout", "-B", "feature", "main"]);
+    std::fs::write(work_path.join("file.txt"), "new PR head\n").expect("write new head");
+    run_real_git(&["-C", work, "commit", "-am", "new pr head"]);
+    let current_head_sha = run_real_git(&["-C", work, "rev-parse", "HEAD"]);
+    run_real_git(&[
+        "-C",
+        work,
+        "push",
+        "--force",
+        "origin",
+        "HEAD:refs/pull/42/head",
+    ]);
+
+    let remote_url =
+        url::Url::from_directory_path(&remote_path).expect("remote path should be file URL");
+    let mut event_file = tempfile::NamedTempFile::new().expect("event file");
+    let event = serde_json::json!({
+        "action": "synchronize",
+        "before": previous_head_sha,
+        "after": current_head_sha,
+        "pull_request": {
+            "number": 42,
+            "merged": false,
+            "merge_commit_sha": null,
+            "base": {
+                "ref": "main",
+                "sha": base_sha,
+                "repo": { "clone_url": remote_url.as_str() }
+            },
+            "head": {
+                "ref": "feature",
+                "sha": current_head_sha,
+                "repo": { "clone_url": remote_url.as_str() }
+            }
+        }
+    });
+    serde_json::to_writer(&mut event_file, &event).expect("write event");
+    event_file.flush().expect("flush event");
+
+    let output = ci_repo
+        .git_ai_with_env(
+            &["ci", "github", "run", "--no-cleanup"],
+            &[
+                ("GITHUB_EVENT_NAME", "pull_request"),
+                (
+                    "GITHUB_EVENT_PATH",
+                    event_file.path().to_str().expect("event path"),
+                ),
+            ],
+        )
+        .expect("github ci run should fetch the missing previous head");
+
+    assert!(
+        output.contains("GitHub CI: skipped non-rebase PR sync"),
+        "expected successful non-rebase sync skip, got:\n{}",
+        output
+    );
+
+    let clone_path = ci_repo.path().join("git-ai-ci-clone");
+    let clone = path_str(&clone_path);
+    let previous_commit = format!("{}^{{commit}}", previous_head_sha);
+    let resolved_previous_head =
+        run_real_git(&["-C", clone, "rev-parse", "--verify", &previous_commit]);
+    assert_eq!(resolved_previous_head, previous_head_sha);
 }
 
 // ==============================================================================


### PR DESCRIPTION
Fixes #1550

## Summary
- verify previous synchronize heads as actual commit objects before deciding they are local
- fetch missing previous heads by raw SHA and pin them under a non-conflicting git-ai ref
- apply the same commit-object check in the sync availability guard

## Test Coverage
- added an integration regression for a force-updated PR ref where the old head is only fetchable by SHA
- ran `task test`, `task lint`, and `task fmt`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->