### PR TITLE
[codex] Implement streamed git-ai log renderer

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -368,7 +368,16 @@ pub fn estimate_stats_cost_for_head(
     } else {
         "4b825dc642cb6eb9a060e54bf8d69288fbee4904".to_string()
     };
-    let estimate = estimate_stats_cost(repo, &parent_sha, commit_sha, ignore_patterns)?;
+    estimate_stats_cost_for_commit_range(repo, &parent_sha, commit_sha, ignore_patterns)
+}
+
+pub fn estimate_stats_cost_for_commit_range(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    ignore_patterns: &[String],
+) -> Result<StatsSkipEstimate, GitAiError> {
+    let estimate = estimate_stats_cost(repo, parent_sha, commit_sha, ignore_patterns)?;
     Ok(StatsSkipEstimate {
         should_skip: should_skip_expensive_post_commit_stats(&estimate),
     })

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -379,19 +379,33 @@ pub fn stats_for_commit_stats(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<CommitStats, GitAiError> {
+    let authorship_log = get_authorship(repo, commit_sha);
+    stats_for_commit_stats_with_authorship(
+        repo,
+        commit_sha,
+        ignore_patterns,
+        authorship_log.as_ref(),
+    )
+}
+
+pub fn stats_for_commit_stats_with_authorship(
+    repo: &Repository,
+    commit_sha: &str,
+    ignore_patterns: &[String],
+    authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
+) -> Result<CommitStats, GitAiError> {
     use crate::commands::diff::get_diff_with_line_numbers;
 
     let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
     let parent_count = commit_obj.parent_count()?;
 
     if parent_count > 1 {
-        let authorship_log = get_authorship(repo, commit_sha);
         return stats_for_commit_stats_from_hunks(
             repo,
             commit_sha,
             ignore_patterns,
             &[],
-            authorship_log.as_ref(),
+            authorship_log,
         );
     }
 
@@ -402,15 +416,8 @@ pub fn stats_for_commit_stats(
     };
 
     let hunks = get_diff_with_line_numbers(repo, &from_ref, commit_sha)?;
-    let authorship_log = get_authorship(repo, commit_sha);
 
-    stats_for_commit_stats_from_hunks(
-        repo,
-        commit_sha,
-        ignore_patterns,
-        &hunks,
-        authorship_log.as_ref(),
-    )
+    stats_for_commit_stats_from_hunks(repo, commit_sha, ignore_patterns, &hunks, authorship_log)
 }
 
 #[doc(hidden)]

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -394,8 +394,6 @@ pub fn stats_for_commit_stats_with_authorship(
     ignore_patterns: &[String],
     authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
 ) -> Result<CommitStats, GitAiError> {
-    use crate::commands::diff::get_diff_with_line_numbers;
-
     let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
     let parent_count = commit_obj.parent_count()?;
 
@@ -409,14 +407,32 @@ pub fn stats_for_commit_stats_with_authorship(
         );
     }
 
-    let from_ref = if parent_count == 0 {
-        "4b825dc642cb6eb9a060e54bf8d69288fbee4904".to_string()
+    let parent_sha = if parent_count == 0 {
+        None
     } else {
-        commit_obj.parent(0)?.id()
+        Some(commit_obj.parent(0)?.id())
     };
 
-    let hunks = get_diff_with_line_numbers(repo, &from_ref, commit_sha)?;
+    stats_for_commit_stats_with_parent_and_authorship(
+        repo,
+        commit_sha,
+        parent_sha.as_deref(),
+        ignore_patterns,
+        authorship_log,
+    )
+}
 
+pub fn stats_for_commit_stats_with_parent_and_authorship(
+    repo: &Repository,
+    commit_sha: &str,
+    parent_sha: Option<&str>,
+    ignore_patterns: &[String],
+    authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
+) -> Result<CommitStats, GitAiError> {
+    use crate::commands::diff::get_diff_with_line_numbers;
+
+    let from_ref = parent_sha.unwrap_or("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+    let hunks = get_diff_with_line_numbers(repo, from_ref, commit_sha)?;
     stats_for_commit_stats_from_hunks(repo, commit_sha, ignore_patterns, &hunks, authorship_log)
 }
 

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -318,10 +318,8 @@ fn print_help() {
     eprintln!("    human [pathspecs...]             Untracked/legacy human checkpoint");
     eprintln!("    mock_ai [pathspecs...]           Test preset accepting optional file pathspecs");
     eprintln!("    mock_known_human [pathspecs...]  Test preset for KnownHuman checkpoints");
-    eprintln!("  log [args...]      Show commit log with AI authorship notes");
-    eprintln!(
-        "                        Proxies git log --notes=ai with all standard git log options"
-    );
+    eprintln!("  log [args...]      Show commit log with AI authorship stats");
+    eprintln!("                        Use --raw or --notes to include raw authorship note data");
     eprintln!("  blame <file>       Git blame with AI authorship overlay");
     eprintln!("  diff <commit|range>  Show diff with AI authorship annotations");
     eprintln!("    <commit>              Diff from commit's parent to commit");

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -3,6 +3,7 @@ use crate::authorship::ignore::effective_ignore_patterns;
 use crate::authorship::stats::{
     stats_for_commit_stats_with_parent_and_authorship, write_stats_to_terminal,
 };
+use crate::config::{Config, NotesBackendKind};
 use crate::error::GitAiError;
 use crate::git::repository::Repository;
 use crossterm::{
@@ -163,6 +164,7 @@ fn extract_git_global_args(args: &[String]) -> (Vec<String>, Vec<String>) {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedLogArgs {
     git_log_args: Vec<String>,
+    plain: bool,
     show_raw_notes: bool,
     oneline: bool,
     show_decorations: bool,
@@ -173,6 +175,7 @@ impl Default for ParsedLogArgs {
     fn default() -> Self {
         Self {
             git_log_args: Vec::new(),
+            plain: false,
             show_raw_notes: false,
             oneline: false,
             show_decorations: true,
@@ -189,7 +192,7 @@ impl Default for ParsedLogArgs {
 /// stats by default. Raw note content is shown only with `--raw` or `--notes`.
 pub fn handle_log(args: &[String]) -> ExitStatus {
     match run_log(args) {
-        Ok(()) => status_from_code(0),
+        Ok(status) => status,
         Err(LogError::Io(error)) if error.kind() == io::ErrorKind::BrokenPipe => {
             status_from_code(0)
         }
@@ -200,13 +203,17 @@ pub fn handle_log(args: &[String]) -> ExitStatus {
     }
 }
 
-fn run_log(args: &[String]) -> Result<(), LogError> {
+fn run_log(args: &[String]) -> Result<ExitStatus, LogError> {
     let (global_args, log_args) = extract_git_global_args(args);
     let parsed = parse_log_args(&log_args).map_err(LogError::Message)?;
 
     if parsed.help {
         print_log_help();
-        return Ok(());
+        return Ok(status_from_code(0));
+    }
+
+    if parsed.plain {
+        return run_plain_log(&global_args, &parsed.git_log_args);
     }
 
     let repository_global_args = repository_global_args(&global_args);
@@ -216,10 +223,27 @@ fn run_log(args: &[String]) -> Result<(), LogError> {
     let renderer = LogRenderer::new(repo, parsed)?;
 
     if use_pager {
-        run_pager(renderer)
+        run_pager(renderer)?;
     } else {
-        stream_to_stdout(renderer)
+        stream_to_stdout(renderer)?;
     }
+    Ok(status_from_code(0))
+}
+
+fn run_plain_log(global_args: &[String], git_log_args: &[String]) -> Result<ExitStatus, LogError> {
+    if Config::get().notes_backend_kind() != NotesBackendKind::GitNotes {
+        return Err(LogError::Message(
+            "plain git log --notes=ai only supports the git_notes backend".to_string(),
+        ));
+    }
+
+    let mut command_args = global_args.to_vec();
+    command_args.push("log".to_string());
+    command_args.push("--notes=ai".to_string());
+    command_args.extend(git_log_args.iter().cloned());
+
+    let mut child = crate::git::repository::spawn_git_passthrough(&command_args)?;
+    child.wait().map_err(LogError::Io)
 }
 
 fn repository_global_args(global_args: &[String]) -> Vec<String> {
@@ -242,6 +266,7 @@ fn parse_log_args(args: &[String]) -> Result<ParsedLogArgs, String> {
     let mut parsed = ParsedLogArgs::default();
     let mut passthrough = Vec::new();
     let mut after_double_dash = false;
+    let plain_requested = contains_plain_flag(args);
 
     for arg in args {
         if after_double_dash {
@@ -251,6 +276,16 @@ fn parse_log_args(args: &[String]) -> Result<ParsedLogArgs, String> {
 
         if arg == "--" {
             after_double_dash = true;
+            passthrough.push(arg.clone());
+            continue;
+        }
+
+        if arg == "--plain" {
+            parsed.plain = true;
+            continue;
+        }
+
+        if plain_requested {
             passthrough.push(arg.clone());
             continue;
         }
@@ -285,6 +320,12 @@ fn parse_log_args(args: &[String]) -> Result<ParsedLogArgs, String> {
     Ok(parsed)
 }
 
+fn contains_plain_flag(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--plain")
+}
+
 fn is_unsupported_render_arg(arg: &str) -> bool {
     matches!(
         arg,
@@ -311,13 +352,14 @@ fn is_unsupported_render_arg(arg: &str) -> bool {
 }
 
 fn print_log_help() {
-    println!("Usage: git-ai log [--raw|--notes] [git log filters] [--] [pathspecs...]");
+    println!("Usage: git-ai log [--raw|--notes] [--plain] [git log filters] [--] [pathspecs...]");
     println!();
     println!("Shows commit history with Git AI authorship stats.");
     println!();
     println!("Options:");
     println!("  --raw, --notes    Include raw authorship note data after the stats");
     println!("  --show-notes      Alias for --notes");
+    println!("  --plain           Run git log --notes=ai directly (git_notes backend only)");
     println!("  --oneline         Compact commit header");
     println!("  --no-decorate     Hide ref decorations");
     println!("  --no-pager        Stream output instead of opening the pager");
@@ -1286,6 +1328,32 @@ mod tests {
         let parsed = parse_log_args(&s(&["--show-notes", "--author=me"])).unwrap();
         assert!(parsed.show_raw_notes);
         assert_eq!(parsed.git_log_args, s(&["--author=me"]));
+    }
+
+    #[test]
+    fn plain_mode_consumes_only_plain_flag() {
+        let parsed =
+            parse_log_args(&s(&["--plain", "--raw", "--format=%H", "--max-count=2"])).unwrap();
+        assert!(parsed.plain);
+        assert!(!parsed.show_raw_notes);
+        assert_eq!(
+            parsed.git_log_args,
+            s(&["--raw", "--format=%H", "--max-count=2"])
+        );
+    }
+
+    #[test]
+    fn plain_pathspec_after_double_dash_is_not_interpreted() {
+        let parsed = parse_log_args(&s(&["--", "--plain"])).unwrap();
+        assert!(!parsed.plain);
+        assert_eq!(parsed.git_log_args, s(&["--", "--plain"]));
+    }
+
+    #[test]
+    fn plain_mode_allows_git_render_flags() {
+        let parsed = parse_log_args(&s(&["--plain", "--graph", "--patch"])).unwrap();
+        assert!(parsed.plain);
+        assert_eq!(parsed.git_log_args, s(&["--graph", "--patch"]));
     }
 
     #[test]

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -811,7 +811,49 @@ fn draw_pager(
 }
 
 fn truncate_for_width(line: &str, width: usize) -> String {
-    line.chars().take(width).collect()
+    let mut out = String::new();
+    let mut visible_width = 0usize;
+    let mut index = 0usize;
+    let mut saw_ansi = false;
+    let bytes = line.as_bytes();
+
+    while index < bytes.len() && visible_width < width {
+        if bytes[index] == 0x1b
+            && let Some(end) = ansi_escape_end(bytes, index)
+        {
+            out.push_str(&line[index..end]);
+            index = end;
+            saw_ansi = true;
+            continue;
+        }
+
+        let Some(ch) = line[index..].chars().next() else {
+            break;
+        };
+        out.push(ch);
+        visible_width += 1;
+        index += ch.len_utf8();
+    }
+
+    if saw_ansi {
+        out.push_str("\x1b[0m");
+    }
+
+    out
+}
+
+fn ansi_escape_end(bytes: &[u8], start: usize) -> Option<usize> {
+    if bytes.get(start) != Some(&0x1b) || bytes.get(start + 1) != Some(&b'[') {
+        return None;
+    }
+
+    for (index, byte) in bytes.iter().enumerate().skip(start + 2) {
+        if (0x40..=0x7e).contains(byte) {
+            return Some(index + 1);
+        }
+    }
+
+    None
 }
 
 fn pad_for_width(line: &str, width: usize) -> String {
@@ -1271,5 +1313,17 @@ mod tests {
             repository_global_args(&s(&["--paginate", "--no-pager", "--bare"])),
             s(&["--bare"])
         );
+    }
+
+    #[test]
+    fn truncate_for_width_preserves_ansi_escape_sequences() {
+        let truncated = truncate_for_width("\x1b[90mabcdef\x1b[0m", 3);
+        assert_eq!(truncated, "\x1b[90mabc\x1b[0m");
+    }
+
+    #[test]
+    fn truncate_for_width_does_not_cut_incomplete_ansi_reset() {
+        let truncated = truncate_for_width("\x1b[90mabc\x1b[0mdef", 3);
+        assert_eq!(truncated, "\x1b[90mabc\x1b[0m");
     }
 }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -691,46 +691,70 @@ fn run_pager(renderer: LogRenderer) -> Result<(), LogError> {
     let mut stdout = io::stdout();
     let _guard = TerminalGuard::enter(&mut stdout)?;
     let mut scroll = 0usize;
+    let mut needs_redraw = true;
+    let mut last_size: Option<(u16, u16)> = None;
 
     loop {
-        let (_width, height) = terminal::size().map_err(LogError::Io)?;
+        let (width, height) = terminal::size().map_err(LogError::Io)?;
         let viewport_height = usize::from(height.saturating_sub(1)).max(1);
-        pager.ensure_line_loaded(scroll.saturating_add(viewport_height))?;
-        draw_pager(&mut stdout, &mut pager, scroll, viewport_height)?;
+        if needs_redraw {
+            if last_size.is_some_and(|size| size != (width, height)) {
+                queue!(stdout, MoveTo(0, 0), Clear(ClearType::All)).map_err(LogError::Io)?;
+            }
+            pager.ensure_line_loaded(scroll.saturating_add(viewport_height))?;
+            draw_pager(
+                &mut stdout,
+                &mut pager,
+                scroll,
+                width,
+                height,
+                viewport_height,
+            )?;
+            last_size = Some((width, height));
+            needs_redraw = false;
+        }
 
         if !event::poll(std::time::Duration::from_millis(250)).map_err(LogError::Io)? {
             continue;
         }
 
-        let Event::Key(key) = event::read().map_err(LogError::Io)? else {
-            continue;
-        };
-
-        match key.code {
-            KeyCode::Char('q') | KeyCode::Esc => break,
-            KeyCode::Char('j') | KeyCode::Down => {
-                pager.ensure_line_loaded(scroll.saturating_add(viewport_height + 1))?;
-                if scroll + 1 < pager.line_count() {
-                    scroll += 1;
+        match event::read().map_err(LogError::Io)? {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Char('j') | KeyCode::Down => {
+                    pager.ensure_line_loaded(scroll.saturating_add(viewport_height + 1))?;
+                    if scroll + 1 < pager.line_count() {
+                        scroll += 1;
+                    }
+                    needs_redraw = true;
                 }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                scroll = scroll.saturating_sub(1);
-            }
-            KeyCode::PageDown | KeyCode::Char(' ') => {
-                let next = scroll.saturating_add(viewport_height);
-                pager.ensure_line_loaded(next.saturating_add(viewport_height))?;
-                scroll = next.min(pager.max_scroll(viewport_height));
-            }
-            KeyCode::PageUp => {
-                scroll = scroll.saturating_sub(viewport_height);
-            }
-            KeyCode::Home => {
-                scroll = 0;
-            }
-            KeyCode::End => {
-                pager.load_all()?;
-                scroll = pager.max_scroll(viewport_height);
+                KeyCode::Char('k') | KeyCode::Up => {
+                    scroll = scroll.saturating_sub(1);
+                    needs_redraw = true;
+                }
+                KeyCode::PageDown | KeyCode::Char(' ') => {
+                    let next = scroll.saturating_add(viewport_height);
+                    pager.ensure_line_loaded(next.saturating_add(viewport_height))?;
+                    scroll = next.min(pager.max_scroll(viewport_height));
+                    needs_redraw = true;
+                }
+                KeyCode::PageUp => {
+                    scroll = scroll.saturating_sub(viewport_height);
+                    needs_redraw = true;
+                }
+                KeyCode::Home => {
+                    scroll = 0;
+                    needs_redraw = true;
+                }
+                KeyCode::End => {
+                    pager.load_all()?;
+                    scroll = pager.max_scroll(viewport_height);
+                    needs_redraw = true;
+                }
+                _ => {}
+            },
+            Event::Resize(_, _) => {
+                needs_redraw = true;
             }
             _ => {}
         }
@@ -743,24 +767,23 @@ fn draw_pager(
     stdout: &mut io::Stdout,
     pager: &mut LogPager,
     scroll: usize,
+    width: u16,
+    height: u16,
     viewport_height: usize,
 ) -> Result<(), LogError> {
-    let (width, height) = terminal::size().map_err(LogError::Io)?;
-    queue!(stdout, MoveTo(0, 0), Clear(ClearType::All)).map_err(LogError::Io)?;
-
     for row in 0..viewport_height {
-        let Some(line) = pager.read_line(scroll + row)? else {
-            break;
-        };
-        queue!(
-            stdout,
-            MoveTo(0, row as u16),
-            Print(truncate_for_width(
-                line.trim_end_matches('\n'),
-                width as usize
-            ))
-        )
-        .map_err(LogError::Io)?;
+        queue!(stdout, MoveTo(0, row as u16), Clear(ClearType::CurrentLine))
+            .map_err(LogError::Io)?;
+        if let Some(line) = pager.read_line(scroll + row)? {
+            queue!(
+                stdout,
+                Print(truncate_for_width(
+                    line.trim_end_matches('\n'),
+                    width as usize
+                ))
+            )
+            .map_err(LogError::Io)?;
+        }
     }
 
     let status = if pager.is_eof() {
@@ -777,6 +800,7 @@ fn draw_pager(
     queue!(
         stdout,
         MoveTo(0, height.saturating_sub(1)),
+        Clear(ClearType::CurrentLine),
         SetAttribute(Attribute::Reverse),
         Print(pad_for_width(&status, width as usize)),
         SetAttribute(Attribute::Reset)
@@ -951,7 +975,7 @@ struct TerminalGuard;
 impl TerminalGuard {
     fn enter(stdout: &mut io::Stdout) -> Result<Self, LogError> {
         enable_raw_mode().map_err(LogError::Io)?;
-        if let Err(error) = execute!(stdout, EnterAlternateScreen, Hide) {
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, Clear(ClearType::All), Hide) {
             let _ = disable_raw_mode();
             return Err(LogError::Io(error));
         }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -1,6 +1,8 @@
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::effective_ignore_patterns;
-use crate::authorship::stats::{stats_for_commit_stats_with_authorship, write_stats_to_terminal};
+use crate::authorship::stats::{
+    stats_for_commit_stats_with_parent_and_authorship, write_stats_to_terminal,
+};
 use crate::error::GitAiError;
 use crate::git::repository::Repository;
 use crossterm::{
@@ -257,7 +259,7 @@ fn parse_log_args(args: &[String]) -> Result<ParsedLogArgs, String> {
             "--help" | "-h" => {
                 parsed.help = true;
             }
-            "--raw" | "--notes" => {
+            "--raw" | "--notes" | "--show-notes" => {
                 parsed.show_raw_notes = true;
             }
             "--oneline" => {
@@ -315,6 +317,7 @@ fn print_log_help() {
     println!();
     println!("Options:");
     println!("  --raw, --notes    Include raw authorship note data after the stats");
+    println!("  --show-notes      Alias for --notes");
     println!("  --oneline         Compact commit header");
     println!("  --no-decorate     Hide ref decorations");
     println!("  --no-pager        Stream output instead of opening the pager");
@@ -569,8 +572,12 @@ fn render_commit(
         out.push_str("\n\n");
 
         append_indented_line(&mut out, &commit.subject, 4);
-        for line in commit.body.trim_end_matches('\n').lines() {
-            append_indented_line(&mut out, line, 4);
+        let trimmed_body = commit.body.trim_end_matches('\n');
+        if !trimmed_body.is_empty() {
+            out.push('\n');
+            for line in trimmed_body.lines() {
+                append_indented_line(&mut out, line, 4);
+            }
         }
         out.push('\n');
     }
@@ -611,8 +618,14 @@ fn render_stats(
         return Err("stats skipped for merge commit".to_string());
     }
 
-    if let Ok(estimate) = crate::authorship::post_commit::estimate_stats_cost_for_head(
+    let parent_sha = parents
+        .first()
+        .map(String::as_str)
+        .unwrap_or("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+
+    if let Ok(estimate) = crate::authorship::post_commit::estimate_stats_cost_for_commit_range(
         repo,
+        parent_sha,
         commit_sha,
         ignore_patterns,
     ) && estimate.should_skip()
@@ -623,9 +636,14 @@ fn render_stats(
         ));
     }
 
-    let stats =
-        stats_for_commit_stats_with_authorship(repo, commit_sha, ignore_patterns, authorship_log)
-            .map_err(|e| format!("stats unavailable: {}", e))?;
+    let stats = stats_for_commit_stats_with_parent_and_authorship(
+        repo,
+        commit_sha,
+        parents.first().map(String::as_str),
+        ignore_patterns,
+        authorship_log,
+    )
+    .map_err(|e| format!("stats unavailable: {}", e))?;
     Ok(write_stats_to_terminal(&stats, false))
 }
 
@@ -1193,6 +1211,13 @@ mod tests {
     #[test]
     fn log_notes_flag_is_consumed() {
         let parsed = parse_log_args(&s(&["--notes", "--author=me"])).unwrap();
+        assert!(parsed.show_raw_notes);
+        assert_eq!(parsed.git_log_args, s(&["--author=me"]));
+    }
+
+    #[test]
+    fn log_show_notes_alias_is_consumed() {
+        let parsed = parse_log_args(&s(&["--show-notes", "--author=me"])).unwrap();
         assert!(parsed.show_raw_notes);
         assert_eq!(parsed.git_log_args, s(&["--author=me"]));
     }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -1,7 +1,30 @@
-use crate::config::{self, NotesBackendKind};
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::ignore::effective_ignore_patterns;
+use crate::authorship::stats::{stats_for_commit_stats_with_authorship, write_stats_to_terminal};
+use crate::error::GitAiError;
+use crate::git::repository::Repository;
+use crossterm::{
+    cursor::{Hide, MoveTo, Show},
+    event::{self, Event, KeyCode},
+    execute, queue,
+    style::{Attribute, Print, SetAttribute},
+    terminal::{
+        self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
+        enable_raw_mode,
+    },
+};
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead, BufReader, IsTerminal, Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::process::{Child, ExitStatus};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const LOG_BATCH_SIZE: usize = 24;
+const GIT_LOG_FIELD_COUNT: usize = 8;
+const GIT_LOG_FORMAT: &str = "%H%x00%P%x00%an%x00%ae%x00%aI%x00%D%x00%s%x00%b%x00";
 
 /// Extract recognized Git global flags from args so they can be placed
-/// before the `log` subcommand. Everything else passes through to `git log`.
+/// before repository discovery. Everything else is interpreted as a log arg.
 ///
 /// We deliberately skip the ambiguous short forms `-p` (paginate vs patch),
 /// `-P` (no-pager vs perl-regexp), `-C` (change-dir vs copy-detection),
@@ -85,8 +108,6 @@ fn extract_git_global_args(args: &[String]) -> (Vec<String>, Vec<String>) {
             continue;
         }
 
-        // --- Short flags that are unambiguous ---
-
         // -C is deliberately NOT extracted:
         //   git global: -C <path> (change directory before doing anything)
         //   git log:    -C (detect copies, no argument)
@@ -129,7 +150,7 @@ fn extract_git_global_args(args: &[String]) -> (Vec<String>, Vec<String>) {
         //   -C = git log copy-detection (not --git-dir/change-dir)
 
         // Everything else (including --help, --version, -h, -v, -p, -P, -C,
-        // and all git-log options) passes through to git log.
+        // and all git-log options) remains a log arg.
         rest.push(arg.clone());
         i += 1;
     }
@@ -137,66 +158,836 @@ fn extract_git_global_args(args: &[String]) -> (Vec<String>, Vec<String>) {
     (global_args, rest)
 }
 
-/// Handle the `git ai log` command by proxying to `git log --notes=ai`.
-///
-/// When `notes_backend.kind = http`, notes are not stored in `refs/notes/ai`.
-/// In that case we first materialize the local cache into a one-off ref
-/// (`refs/notes/ai-display`) via `git fast-import`, then pass both
-/// `--notes=ai-display` and `--notes=ai` to `git log` so that any notes
-/// already in the git backend are also shown.
-///
-/// All additional arguments are forwarded to `git log` as-is, allowing
-/// users to filter, format, and paginate the output just like native git log.
-///
-/// Returns the `ExitStatus` from the child `git log` process so the caller
-/// can handle telemetry and signal-aware exit.
-pub fn handle_log(args: &[String]) -> std::process::ExitStatus {
-    // Separate git-global flags from log arguments.
-    let (global_args, log_args) = extract_git_global_args(args);
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedLogArgs {
+    git_log_args: Vec<String>,
+    show_raw_notes: bool,
+    oneline: bool,
+    show_decorations: bool,
+    help: bool,
+}
 
-    // When using the HTTP backend, materialize notes into refs/notes/ai-display
-    // so git log can render them.
-    let use_display_ref = config::Config::get().notes_backend_kind() == NotesBackendKind::Http;
-    if use_display_ref && let Some(repo) = try_open_repo_for_log(&global_args) {
-        match crate::git::notes_api::materialize_notes_for_display(&repo, 500) {
-            Ok(count) => {
-                tracing::debug!(count, "log: materialized notes into refs/notes/ai-display");
-            }
-            Err(e) => {
-                tracing::debug!(%e, "log: failed to materialize notes (continuing)");
-            }
-        }
-    }
-
-    // Build: git [global_args] log --notes=ai [--notes=ai-display] [log_args...]
-    let git_cmd = config::Config::get().git_cmd().to_string();
-    let mut cmd = std::process::Command::new(&git_cmd);
-    cmd.args(&global_args);
-    cmd.arg("log");
-    cmd.arg("--notes=ai");
-    if use_display_ref {
-        cmd.arg("--notes=ai-display");
-    }
-    cmd.args(&log_args);
-
-    // Inherit stdin/stdout/stderr so the pager and terminal colors work
-    cmd.stdin(std::process::Stdio::inherit());
-    cmd.stdout(std::process::Stdio::inherit());
-    cmd.stderr(std::process::Stdio::inherit());
-
-    match cmd.status() {
-        Ok(status) => status,
-        Err(e) => {
-            eprintln!("Failed to execute git log: {}", e);
-            std::process::exit(1);
+impl Default for ParsedLogArgs {
+    fn default() -> Self {
+        Self {
+            git_log_args: Vec::new(),
+            show_raw_notes: false,
+            oneline: false,
+            show_decorations: true,
+            help: false,
         }
     }
 }
 
-/// Try to open the git repository from the given global args for use in
-/// materialization. Best-effort: returns `None` on any error.
-fn try_open_repo_for_log(global_args: &[String]) -> Option<crate::git::repository::Repository> {
-    crate::git::repository::find_repository(global_args).ok()
+/// Handle the `git ai log` command.
+///
+/// Unlike the old implementation, this does not proxy to `git log --notes=ai`.
+/// It streams commits from git with a stable machine-readable format, resolves
+/// authorship notes through the configured notes backend, and renders Git AI
+/// stats by default. Raw note content is shown only with `--raw` or `--notes`.
+pub fn handle_log(args: &[String]) -> ExitStatus {
+    match run_log(args) {
+        Ok(()) => status_from_code(0),
+        Err(LogError::Io(error)) if error.kind() == io::ErrorKind::BrokenPipe => {
+            status_from_code(0)
+        }
+        Err(error) => {
+            eprintln!("git-ai log: {}", error);
+            status_from_code(1)
+        }
+    }
+}
+
+fn run_log(args: &[String]) -> Result<(), LogError> {
+    let (global_args, log_args) = extract_git_global_args(args);
+    let parsed = parse_log_args(&log_args).map_err(LogError::Message)?;
+
+    if parsed.help {
+        print_log_help();
+        return Ok(());
+    }
+
+    let repository_global_args = repository_global_args(&global_args);
+    let repo =
+        crate::git::repository::find_repository(&repository_global_args).map_err(LogError::Git)?;
+    let use_pager = should_use_pager(&global_args);
+    let renderer = LogRenderer::new(repo, parsed)?;
+
+    if use_pager {
+        run_pager(renderer)
+    } else {
+        stream_to_stdout(renderer)
+    }
+}
+
+fn repository_global_args(global_args: &[String]) -> Vec<String> {
+    global_args
+        .iter()
+        .filter(|arg| !matches!(arg.as_str(), "--paginate" | "--no-pager"))
+        .cloned()
+        .collect()
+}
+
+fn should_use_pager(global_args: &[String]) -> bool {
+    if global_args.iter().any(|arg| arg == "--no-pager") {
+        return false;
+    }
+    let forced = global_args.iter().any(|arg| arg == "--paginate");
+    forced || std::io::stdout().is_terminal()
+}
+
+fn parse_log_args(args: &[String]) -> Result<ParsedLogArgs, String> {
+    let mut parsed = ParsedLogArgs::default();
+    let mut passthrough = Vec::new();
+    let mut after_double_dash = false;
+
+    for arg in args {
+        if after_double_dash {
+            passthrough.push(arg.clone());
+            continue;
+        }
+
+        if arg == "--" {
+            after_double_dash = true;
+            passthrough.push(arg.clone());
+            continue;
+        }
+
+        match arg.as_str() {
+            "--help" | "-h" => {
+                parsed.help = true;
+            }
+            "--raw" | "--notes" => {
+                parsed.show_raw_notes = true;
+            }
+            "--oneline" => {
+                parsed.oneline = true;
+            }
+            "--decorate" | "--decorate=short" | "--decorate=full" | "--decorate=auto" => {
+                parsed.show_decorations = true;
+            }
+            "--no-decorate" => {
+                parsed.show_decorations = false;
+            }
+            _ if is_unsupported_render_arg(arg) => {
+                return Err(format!(
+                    "unsupported git log rendering option '{}'. `git-ai log` owns rendering so it can show authorship stats; use plain `git log` for this option.",
+                    arg
+                ));
+            }
+            _ => passthrough.push(arg.clone()),
+        }
+    }
+
+    parsed.git_log_args = passthrough;
+    Ok(parsed)
+}
+
+fn is_unsupported_render_arg(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--format"
+            | "--pretty"
+            | "--graph"
+            | "--patch"
+            | "-p"
+            | "--stat"
+            | "--shortstat"
+            | "--numstat"
+            | "--name-only"
+            | "--name-status"
+            | "--check"
+            | "--summary"
+            | "--show-signature"
+            | "--cc"
+            | "-c"
+    ) || arg.starts_with("--format=")
+        || arg.starts_with("--pretty=")
+        || arg.starts_with("--notes=")
+        || arg.starts_with("--stat=")
+        || arg.starts_with("--patch=")
+}
+
+fn print_log_help() {
+    println!("Usage: git-ai log [--raw|--notes] [git log filters] [--] [pathspecs...]");
+    println!();
+    println!("Shows commit history with Git AI authorship stats.");
+    println!();
+    println!("Options:");
+    println!("  --raw, --notes    Include raw authorship note data after the stats");
+    println!("  --oneline         Compact commit header");
+    println!("  --no-decorate     Hide ref decorations");
+    println!("  --no-pager        Stream output instead of opening the pager");
+    println!();
+    println!("Common git log filters such as -n, --max-count, --author, --grep,");
+    println!("--since, --until, revisions, and pathspecs are passed through to git.");
+}
+
+struct LogRenderer {
+    repo: Repository,
+    options: ParsedLogArgs,
+    stream: CommitStream,
+    ignore_patterns: Vec<String>,
+    eof: bool,
+}
+
+impl LogRenderer {
+    fn new(repo: Repository, options: ParsedLogArgs) -> Result<Self, LogError> {
+        let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
+        let stream = CommitStream::spawn(&repo, &options.git_log_args, options.show_decorations)?;
+        Ok(Self {
+            repo,
+            options,
+            stream,
+            ignore_patterns,
+            eof: false,
+        })
+    }
+
+    fn render_next_batch(&mut self) -> Result<Vec<String>, LogError> {
+        if self.eof {
+            return Ok(Vec::new());
+        }
+
+        let mut commits = Vec::new();
+        for _ in 0..LOG_BATCH_SIZE {
+            match self.stream.next_commit()? {
+                Some(commit) => commits.push(commit),
+                None => {
+                    self.eof = true;
+                    break;
+                }
+            }
+        }
+
+        if commits.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let shas: Vec<String> = commits.iter().map(|commit| commit.sha.clone()).collect();
+        let notes = crate::git::notes_api::read_notes_batch(&self.repo, &shas)?;
+
+        Ok(commits
+            .iter()
+            .map(|commit| {
+                let note = notes.get(&commit.sha).map(String::as_str);
+                render_commit(
+                    &self.repo,
+                    commit,
+                    note,
+                    &self.options,
+                    &self.ignore_patterns,
+                )
+            })
+            .collect())
+    }
+
+    fn is_eof(&self) -> bool {
+        self.eof
+    }
+}
+
+struct CommitStream {
+    child: Option<Child>,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl CommitStream {
+    fn spawn(
+        repo: &Repository,
+        git_log_args: &[String],
+        show_decorations: bool,
+    ) -> Result<Self, LogError> {
+        let mut command_args = repo.global_args_for_exec();
+        command_args.push("log".to_string());
+        command_args.push("--no-color".to_string());
+        command_args.push("--no-notes".to_string());
+        if show_decorations {
+            command_args.push("--decorate=short".to_string());
+        } else {
+            command_args.push("--no-decorate".to_string());
+        }
+        command_args.push(format!("--format=format:{}", GIT_LOG_FORMAT));
+        command_args.extend(git_log_args.iter().cloned());
+
+        let mut child = crate::git::repository::spawn_git_stdout(&command_args)?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| LogError::Message("failed to capture git log stdout".to_string()))?;
+
+        Ok(Self {
+            child: Some(child),
+            stdout: BufReader::new(stdout),
+        })
+    }
+
+    fn next_commit(&mut self) -> Result<Option<CommitRecord>, LogError> {
+        let mut fields = Vec::with_capacity(GIT_LOG_FIELD_COUNT);
+        for field_index in 0..GIT_LOG_FIELD_COUNT {
+            match read_nul_field(&mut self.stdout)? {
+                Some(field) => fields.push(field),
+                None if field_index == 0 => {
+                    self.wait_for_git_log()?;
+                    return Ok(None);
+                }
+                None => {
+                    self.wait_for_git_log()?;
+                    return Err(LogError::Message(
+                        "malformed git log output: truncated commit record".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(Some(CommitRecord {
+            sha: normalize_commit_sha_field(&fields[0]),
+            parents: fields[1]
+                .split_whitespace()
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect(),
+            author_name: fields[2].clone(),
+            author_email: fields[3].clone(),
+            author_date: fields[4].clone(),
+            decorations: fields[5].clone(),
+            subject: fields[6].clone(),
+            body: fields[7].clone(),
+        }))
+    }
+
+    fn wait_for_git_log(&mut self) -> Result<(), LogError> {
+        let Some(mut child) = self.child.take() else {
+            return Ok(());
+        };
+        let status = child.wait().map_err(LogError::Io)?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(LogError::Message(format!(
+                "git log exited with status {}",
+                status
+            )))
+        }
+    }
+}
+
+impl Drop for CommitStream {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn read_nul_field<R: BufRead>(reader: &mut R) -> Result<Option<String>, LogError> {
+    let mut bytes = Vec::new();
+    let read = reader.read_until(0, &mut bytes).map_err(LogError::Io)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    if bytes.last() == Some(&0) {
+        bytes.pop();
+    }
+    Ok(Some(String::from_utf8_lossy(&bytes).to_string()))
+}
+
+fn normalize_commit_sha_field(field: &str) -> String {
+    field.trim_start_matches('\n').to_string()
+}
+
+#[derive(Debug, Clone)]
+struct CommitRecord {
+    sha: String,
+    parents: Vec<String>,
+    author_name: String,
+    author_email: String,
+    author_date: String,
+    decorations: String,
+    subject: String,
+    body: String,
+}
+
+fn render_commit(
+    repo: &Repository,
+    commit: &CommitRecord,
+    raw_note: Option<&str>,
+    options: &ParsedLogArgs,
+    ignore_patterns: &[String],
+) -> String {
+    let authorship_log =
+        raw_note.and_then(|note| AuthorshipLog::deserialize_from_string(note).ok());
+    let mut out = String::new();
+
+    if options.oneline {
+        out.push_str(&short_sha(&commit.sha));
+        out.push(' ');
+        out.push_str(&commit.subject);
+        if options.show_decorations && !commit.decorations.trim().is_empty() {
+            out.push(' ');
+            out.push('(');
+            out.push_str(commit.decorations.trim());
+            out.push(')');
+        }
+        out.push('\n');
+    } else {
+        out.push_str("commit ");
+        out.push_str(&commit.sha);
+        if options.show_decorations && !commit.decorations.trim().is_empty() {
+            out.push(' ');
+            out.push('(');
+            out.push_str(commit.decorations.trim());
+            out.push(')');
+        }
+        out.push('\n');
+
+        if commit.parents.len() > 1 {
+            out.push_str("Merge: ");
+            out.push_str(
+                &commit
+                    .parents
+                    .iter()
+                    .map(|sha| short_sha(sha))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            );
+            out.push('\n');
+        }
+
+        out.push_str("Author: ");
+        out.push_str(&commit.author_name);
+        if !commit.author_email.is_empty() {
+            out.push_str(" <");
+            out.push_str(&commit.author_email);
+            out.push('>');
+        }
+        out.push('\n');
+        out.push_str("Date:   ");
+        out.push_str(&commit.author_date);
+        out.push_str("\n\n");
+
+        append_indented_line(&mut out, &commit.subject, 4);
+        for line in commit.body.trim_end_matches('\n').lines() {
+            append_indented_line(&mut out, line, 4);
+        }
+        out.push('\n');
+    }
+
+    out.push_str("    Git AI stats:\n");
+    match render_stats(
+        repo,
+        &commit.sha,
+        &commit.parents,
+        authorship_log.as_ref(),
+        ignore_patterns,
+    ) {
+        Ok(stats) => append_indented_block(&mut out, &stats, 6),
+        Err(message) => append_indented_line(&mut out, &message, 6),
+    }
+
+    if options.show_raw_notes {
+        out.push('\n');
+        out.push_str("    Authorship note:\n");
+        match raw_note {
+            Some(note) if !note.trim().is_empty() => append_indented_block(&mut out, note, 6),
+            _ => append_indented_line(&mut out, "(none)", 6),
+        }
+    }
+
+    out.push('\n');
+    out
+}
+
+fn render_stats(
+    repo: &Repository,
+    commit_sha: &str,
+    parents: &[String],
+    authorship_log: Option<&AuthorshipLog>,
+    ignore_patterns: &[String],
+) -> Result<String, String> {
+    if parents.len() > 1 {
+        return Err("stats skipped for merge commit".to_string());
+    }
+
+    if let Ok(estimate) = crate::authorship::post_commit::estimate_stats_cost_for_head(
+        repo,
+        commit_sha,
+        ignore_patterns,
+    ) && estimate.should_skip()
+    {
+        return Err(format!(
+            "stats skipped for large commit; run `git-ai stats {}` to compute on demand",
+            commit_sha
+        ));
+    }
+
+    let stats =
+        stats_for_commit_stats_with_authorship(repo, commit_sha, ignore_patterns, authorship_log)
+            .map_err(|e| format!("stats unavailable: {}", e))?;
+    Ok(write_stats_to_terminal(&stats, false))
+}
+
+fn append_indented_line(out: &mut String, line: &str, spaces: usize) {
+    out.push_str(&" ".repeat(spaces));
+    out.push_str(line);
+    out.push('\n');
+}
+
+fn append_indented_block(out: &mut String, block: &str, spaces: usize) {
+    for line in block.trim_end_matches('\n').lines() {
+        append_indented_line(out, line, spaces);
+    }
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+fn stream_to_stdout(mut renderer: LogRenderer) -> Result<(), LogError> {
+    let stdout = io::stdout();
+    let mut lock = stdout.lock();
+
+    loop {
+        let rendered = renderer.render_next_batch()?;
+        if rendered.is_empty() {
+            break;
+        }
+
+        for commit in rendered {
+            match lock.write_all(commit.as_bytes()) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::BrokenPipe => return Ok(()),
+                Err(error) => return Err(LogError::Io(error)),
+            }
+        }
+        lock.flush().map_err(LogError::Io)?;
+    }
+
+    Ok(())
+}
+
+fn run_pager(renderer: LogRenderer) -> Result<(), LogError> {
+    let mut pager = LogPager::new(renderer)?;
+    let mut stdout = io::stdout();
+    let _guard = TerminalGuard::enter(&mut stdout)?;
+    let mut scroll = 0usize;
+
+    loop {
+        let (_width, height) = terminal::size().map_err(LogError::Io)?;
+        let viewport_height = usize::from(height.saturating_sub(1)).max(1);
+        pager.ensure_line_loaded(scroll.saturating_add(viewport_height))?;
+        draw_pager(&mut stdout, &mut pager, scroll, viewport_height)?;
+
+        if !event::poll(std::time::Duration::from_millis(250)).map_err(LogError::Io)? {
+            continue;
+        }
+
+        let Event::Key(key) = event::read().map_err(LogError::Io)? else {
+            continue;
+        };
+
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => break,
+            KeyCode::Char('j') | KeyCode::Down => {
+                pager.ensure_line_loaded(scroll.saturating_add(viewport_height + 1))?;
+                if scroll + 1 < pager.line_count() {
+                    scroll += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                scroll = scroll.saturating_sub(1);
+            }
+            KeyCode::PageDown | KeyCode::Char(' ') => {
+                let next = scroll.saturating_add(viewport_height);
+                pager.ensure_line_loaded(next.saturating_add(viewport_height))?;
+                scroll = next.min(pager.max_scroll(viewport_height));
+            }
+            KeyCode::PageUp => {
+                scroll = scroll.saturating_sub(viewport_height);
+            }
+            KeyCode::Home => {
+                scroll = 0;
+            }
+            KeyCode::End => {
+                pager.load_all()?;
+                scroll = pager.max_scroll(viewport_height);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn draw_pager(
+    stdout: &mut io::Stdout,
+    pager: &mut LogPager,
+    scroll: usize,
+    viewport_height: usize,
+) -> Result<(), LogError> {
+    let (width, height) = terminal::size().map_err(LogError::Io)?;
+    queue!(stdout, MoveTo(0, 0), Clear(ClearType::All)).map_err(LogError::Io)?;
+
+    for row in 0..viewport_height {
+        let Some(line) = pager.read_line(scroll + row)? else {
+            break;
+        };
+        queue!(
+            stdout,
+            MoveTo(0, row as u16),
+            Print(truncate_for_width(
+                line.trim_end_matches('\n'),
+                width as usize
+            ))
+        )
+        .map_err(LogError::Io)?;
+    }
+
+    let status = if pager.is_eof() {
+        format!(
+            " git-ai log  lines {}  q quit  ↑/↓ scroll  PgUp/PgDn page ",
+            pager.line_count()
+        )
+    } else {
+        format!(
+            " git-ai log  loaded {} lines  q quit  ↑/↓ scroll  PgUp/PgDn page ",
+            pager.line_count()
+        )
+    };
+    queue!(
+        stdout,
+        MoveTo(0, height.saturating_sub(1)),
+        SetAttribute(Attribute::Reverse),
+        Print(pad_for_width(&status, width as usize)),
+        SetAttribute(Attribute::Reset)
+    )
+    .map_err(LogError::Io)?;
+    stdout.flush().map_err(LogError::Io)?;
+    Ok(())
+}
+
+fn truncate_for_width(line: &str, width: usize) -> String {
+    line.chars().take(width).collect()
+}
+
+fn pad_for_width(line: &str, width: usize) -> String {
+    let mut value = truncate_for_width(line, width);
+    let current = value.chars().count();
+    if current < width {
+        value.push_str(&" ".repeat(width - current));
+    }
+    value
+}
+
+struct LogPager {
+    renderer: LogRenderer,
+    spool: Spool,
+}
+
+impl LogPager {
+    fn new(renderer: LogRenderer) -> Result<Self, LogError> {
+        Ok(Self {
+            renderer,
+            spool: Spool::new()?,
+        })
+    }
+
+    fn ensure_line_loaded(&mut self, line_index: usize) -> Result<(), LogError> {
+        while self.spool.line_count() <= line_index && !self.renderer.is_eof() {
+            let rendered = self.renderer.render_next_batch()?;
+            if rendered.is_empty() {
+                break;
+            }
+            for commit in rendered {
+                self.spool.append(&commit)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn load_all(&mut self) -> Result<(), LogError> {
+        while !self.renderer.is_eof() {
+            let rendered = self.renderer.render_next_batch()?;
+            if rendered.is_empty() {
+                break;
+            }
+            for commit in rendered {
+                self.spool.append(&commit)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_line(&mut self, line_index: usize) -> Result<Option<String>, LogError> {
+        self.spool.read_line(line_index)
+    }
+
+    fn line_count(&self) -> usize {
+        self.spool.line_count()
+    }
+
+    fn is_eof(&self) -> bool {
+        self.renderer.is_eof()
+    }
+
+    fn max_scroll(&self, viewport_height: usize) -> usize {
+        self.line_count().saturating_sub(viewport_height)
+    }
+}
+
+struct Spool {
+    path: PathBuf,
+    file: File,
+    line_offsets: Vec<u64>,
+    write_offset: u64,
+}
+
+impl Spool {
+    fn new() -> Result<Self, LogError> {
+        let path = unique_spool_path();
+        let file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(LogError::Io)?;
+        Ok(Self {
+            path,
+            file,
+            line_offsets: Vec::new(),
+            write_offset: 0,
+        })
+    }
+
+    fn append(&mut self, text: &str) -> Result<(), LogError> {
+        self.file
+            .seek(SeekFrom::Start(self.write_offset))
+            .map_err(LogError::Io)?;
+
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        for chunk in text.as_bytes().split_inclusive(|byte| *byte == b'\n') {
+            self.line_offsets.push(self.write_offset);
+            self.file.write_all(chunk).map_err(LogError::Io)?;
+            self.write_offset += chunk.len() as u64;
+        }
+
+        if !text.as_bytes().ends_with(b"\n") {
+            self.file.write_all(b"\n").map_err(LogError::Io)?;
+            self.write_offset += 1;
+        }
+
+        self.file.flush().map_err(LogError::Io)?;
+        Ok(())
+    }
+
+    fn read_line(&mut self, line_index: usize) -> Result<Option<String>, LogError> {
+        let Some(offset) = self.line_offsets.get(line_index).copied() else {
+            return Ok(None);
+        };
+
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .map_err(LogError::Io)?;
+        let mut bytes = Vec::new();
+        let mut buf = [0u8; 1];
+        loop {
+            let read = self.file.read(&mut buf).map_err(LogError::Io)?;
+            if read == 0 {
+                break;
+            }
+            bytes.push(buf[0]);
+            if buf[0] == b'\n' {
+                break;
+            }
+        }
+
+        Ok(Some(String::from_utf8_lossy(&bytes).to_string()))
+    }
+
+    fn line_count(&self) -> usize {
+        self.line_offsets.len()
+    }
+}
+
+impl Drop for Spool {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn unique_spool_path() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!("git-ai-log-{}-{}.tmp", std::process::id(), nanos))
+}
+
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter(stdout: &mut io::Stdout) -> Result<Self, LogError> {
+        enable_raw_mode().map_err(LogError::Io)?;
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, Hide) {
+            let _ = disable_raw_mode();
+            return Err(LogError::Io(error));
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let mut stdout = io::stdout();
+        let _ = execute!(stdout, Show, LeaveAlternateScreen);
+    }
+}
+
+#[derive(Debug)]
+enum LogError {
+    Git(GitAiError),
+    Io(io::Error),
+    Message(String),
+}
+
+impl std::fmt::Display for LogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogError::Git(error) => write!(f, "{}", error),
+            LogError::Io(error) => write!(f, "{}", error),
+            LogError::Message(message) => write!(f, "{}", message),
+        }
+    }
+}
+
+impl From<GitAiError> for LogError {
+    fn from(value: GitAiError) -> Self {
+        LogError::Git(value)
+    }
+}
+
+impl From<io::Error> for LogError {
+    fn from(value: io::Error) -> Self {
+        LogError::Io(value)
+    }
+}
+
+#[cfg(unix)]
+fn status_from_code(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+#[cfg(windows)]
+fn status_from_code(code: i32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code as u32)
 }
 
 #[cfg(test)]
@@ -390,5 +1181,46 @@ mod tests {
         ]));
         assert_eq!(global, s(&["--no-pager", "--git-dir=/repo"]));
         assert_eq!(rest, s(&["--oneline", "--", "src/", "--bare"]));
+    }
+
+    #[test]
+    fn log_raw_flag_is_consumed() {
+        let parsed = parse_log_args(&s(&["--raw", "-n", "1"])).unwrap();
+        assert!(parsed.show_raw_notes);
+        assert_eq!(parsed.git_log_args, s(&["-n", "1"]));
+    }
+
+    #[test]
+    fn log_notes_flag_is_consumed() {
+        let parsed = parse_log_args(&s(&["--notes", "--author=me"])).unwrap();
+        assert!(parsed.show_raw_notes);
+        assert_eq!(parsed.git_log_args, s(&["--author=me"]));
+    }
+
+    #[test]
+    fn oneline_is_consumed() {
+        let parsed = parse_log_args(&s(&["--oneline", "--max-count=2"])).unwrap();
+        assert!(parsed.oneline);
+        assert_eq!(parsed.git_log_args, s(&["--max-count=2"]));
+    }
+
+    #[test]
+    fn unsupported_render_flag_errors() {
+        let err = parse_log_args(&s(&["--graph"])).unwrap_err();
+        assert!(err.contains("unsupported git log rendering option"));
+    }
+
+    #[test]
+    fn pathspec_after_double_dash_is_not_interpreted() {
+        let parsed = parse_log_args(&s(&["--", "--graph"])).unwrap();
+        assert_eq!(parsed.git_log_args, s(&["--", "--graph"]));
+    }
+
+    #[test]
+    fn pager_globals_are_not_kept_for_repository_commands() {
+        assert_eq!(
+            repository_global_args(&s(&["--paginate", "--no-pager", "--bare"])),
+            s(&["--bare"])
+        );
     }
 }

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -48,6 +48,45 @@ pub fn read_note(repo: &Repository, commit_sha: &str) -> Option<String> {
     }
 }
 
+pub fn read_notes_batch(
+    repo: &Repository,
+    commit_shas: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    if commit_shas.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    match Config::get().notes_backend_kind() {
+        NotesBackendKind::Http => {
+            let mut notes = http_read_notes(commit_shas);
+
+            let missing_after_cache: Vec<String> = commit_shas
+                .iter()
+                .filter(|sha| !notes.contains_key(*sha))
+                .cloned()
+                .collect();
+            if !missing_after_cache.is_empty() {
+                notes.extend(http_fetch_and_cache_notes(&missing_after_cache));
+            }
+
+            let missing_after_http: Vec<String> = commit_shas
+                .iter()
+                .filter(|sha| !notes.contains_key(*sha))
+                .cloned()
+                .collect();
+            if !missing_after_http.is_empty()
+                && let Ok(git_notes) =
+                    crate::git::refs::notes_for_commits(repo, &missing_after_http)
+            {
+                notes.extend(git_notes);
+            }
+
+            Ok(notes)
+        }
+        NotesBackendKind::GitNotes => crate::git::refs::notes_for_commits(repo, commit_shas),
+    }
+}
+
 pub fn read_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
     match Config::get().notes_backend_kind() {
         NotesBackendKind::Http => {
@@ -504,6 +543,47 @@ fn http_read_notes(commit_shas: &[String]) -> HashMap<String, String> {
     };
     let refs: Vec<&str> = commit_shas.iter().map(|s| s.as_str()).collect();
     db_lock.get_notes(&refs).unwrap_or_default()
+}
+
+fn http_fetch_and_cache_notes(commit_shas: &[String]) -> HashMap<String, String> {
+    if commit_shas.is_empty() {
+        return HashMap::new();
+    }
+
+    let cfg = Config::fresh();
+    let Some(backend_url) = cfg.notes_backend_url().map(str::to_string) else {
+        return HashMap::new();
+    };
+
+    let ctx = crate::api::client::ApiContext::new(Some(backend_url));
+    let client = crate::api::client::ApiClient::new(ctx);
+    if !client.is_logged_in() && !client.has_api_key() {
+        return HashMap::new();
+    }
+
+    let mut fetched = HashMap::new();
+    for chunk in commit_shas.chunks(100) {
+        let refs: Vec<&str> = chunk.iter().map(String::as_str).collect();
+        match client.read_notes(&refs) {
+            Ok(response) => {
+                if response.notes.is_empty() {
+                    continue;
+                }
+                let entries: Vec<(String, String)> = response.notes.into_iter().collect();
+                if let Ok(db) = crate::notes::db::NotesDatabase::global()
+                    && let Ok(mut lock) = db.lock()
+                {
+                    let _ = lock.cache_synced_notes(&entries);
+                }
+                fetched.extend(entries);
+            }
+            Err(e) => {
+                tracing::debug!(%e, "notes batch read from HTTP backend failed");
+            }
+        }
+    }
+
+    fetched
 }
 
 fn http_check_exists(commit_shas: &[String]) -> HashSet<String> {

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -149,6 +149,41 @@ pub fn note_blob_oids_for_commits(
     note_blob_oids_for_commits_from_ref(repo, AI_AUTHORSHIP_FULL_REF, commit_shas)
 }
 
+/// Read authorship note contents for a set of commits in batch.
+///
+/// Returns a map of commit SHA -> raw note content for commits that currently
+/// have notes in `refs/notes/ai`.
+pub fn notes_for_commits(
+    repo: &Repository,
+    commit_shas: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    if commit_shas.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let note_blob_oids = note_blob_oids_for_commits(repo, commit_shas)?;
+    if note_blob_oids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let unique_blob_oids: Vec<String> = note_blob_oids
+        .values()
+        .cloned()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let blob_contents = batch_read_blob_contents(repo, &unique_blob_oids)?;
+
+    Ok(note_blob_oids
+        .into_iter()
+        .filter_map(|(commit_sha, blob_oid)| {
+            blob_contents
+                .get(&blob_oid)
+                .map(|content| (commit_sha, content.clone()))
+        })
+        .collect())
+}
+
 /// Resolve authorship note blob OIDs for a set of commits from a specific notes ref.
 ///
 /// Returns a map of commit SHA -> note blob SHA for commits that have notes on

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2660,6 +2660,33 @@ pub fn spawn_git_stdout(args: &[String]) -> Result<Child, GitAiError> {
     cmd.spawn().map_err(GitAiError::IoError)
 }
 
+/// Spawn a git command with stdin/stdout/stderr inherited from git-ai.
+///
+/// This is used when a command intentionally delegates rendering and paging
+/// behavior to git instead of consuming output internally.
+pub fn spawn_git_passthrough(args: &[String]) -> Result<Child, GitAiError> {
+    let effective_args = args_with_internal_git_profile(
+        &args_with_disabled_hooks_if_needed(args),
+        InternalGitProfile::General,
+    );
+    let mut cmd = Command::new(config::Config::get().git_cmd());
+    cmd.args(&effective_args)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+    cmd.env_remove("GIT_EXTERNAL_DIFF");
+    cmd.env_remove("GIT_DIFF_OPTS");
+
+    #[cfg(windows)]
+    {
+        if !is_interactive_terminal() {
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+    }
+
+    cmd.spawn().map_err(GitAiError::IoError)
+}
+
 /// Helper to execute a git command with an explicit internal profile.
 pub fn exec_git_with_profile(
     args: &[String],

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -17,7 +17,7 @@ use regex::Regex;
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Child, Command, Output};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[cfg(windows)]
@@ -2631,6 +2631,33 @@ pub fn exec_git_allow_nonzero_with_profile(
     }
 
     cmd.output().map_err(GitAiError::IoError)
+}
+
+/// Spawn a git command with stdout piped and stderr inherited.
+///
+/// This is used by streaming consumers that cannot call `exec_git*` without
+/// buffering all stdout in memory.
+pub fn spawn_git_stdout(args: &[String]) -> Result<Child, GitAiError> {
+    let effective_args = args_with_internal_git_profile(
+        &args_with_disabled_hooks_if_needed(args),
+        InternalGitProfile::General,
+    );
+    let mut cmd = Command::new(config::Config::get().git_cmd());
+    cmd.args(&effective_args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit());
+    cmd.env_remove("GIT_EXTERNAL_DIFF");
+    cmd.env_remove("GIT_DIFF_OPTS");
+
+    #[cfg(windows)]
+    {
+        if !is_interactive_terminal() {
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+    }
+
+    cmd.spawn().map_err(GitAiError::IoError)
 }
 
 /// Helper to execute a git command with an explicit internal profile.

--- a/tests/integration/log.rs
+++ b/tests/integration/log.rs
@@ -46,6 +46,35 @@ fn log_raw_shows_authorship_note() {
 }
 
 #[test]
+fn log_plain_proxies_git_notes_backend() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("plain.txt");
+    file.set_contents(lines!["AI plain line".ai()]);
+    repo.stage_all_and_commit("feat: plain note").unwrap();
+
+    let output = repo
+        .git_ai(&["log", "--no-pager", "--plain", "-n", "1"])
+        .expect("git-ai log --plain should proxy git log");
+
+    assert!(output.contains("feat: plain note"), "output:\n{}", output);
+    assert!(
+        output.contains("Notes (ai):"),
+        "plain output should use git's notes renderer:\n{}",
+        output
+    );
+    assert!(
+        output.contains("schema_version"),
+        "plain output should include raw git note content:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("Git AI stats:"),
+        "plain output should not use git-ai's renderer:\n{}",
+        output
+    );
+}
+
+#[test]
 fn log_multiple_commits_parse_record_boundaries() {
     let repo = TestRepo::new();
     let mut file = repo.filename("history.txt");
@@ -91,6 +120,27 @@ fn log_commit_body_is_separated_from_subject() {
         output.contains("    feat: subject\n\n    Body paragraph"),
         "body should be separated from subject:\n{}",
         output
+    );
+}
+
+#[test]
+fn log_plain_rejects_http_backend() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        });
+    });
+
+    let err = repo
+        .git_ai(&["log", "--no-pager", "--plain", "-n", "1"])
+        .expect_err("git-ai log --plain should reject HTTP notes backend");
+
+    assert!(
+        err.contains("plain git log --notes=ai only supports the git_notes backend"),
+        "error:\n{}",
+        err
     );
 }
 

--- a/tests/integration/log.rs
+++ b/tests/integration/log.rs
@@ -76,6 +76,25 @@ fn log_multiple_commits_parse_record_boundaries() {
 }
 
 #[test]
+fn log_commit_body_is_separated_from_subject() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("body.txt");
+    file.set_contents(lines!["AI body line".ai()]);
+    repo.stage_all_and_commit("feat: subject\n\nBody paragraph")
+        .unwrap();
+
+    let output = repo
+        .git_ai(&["log", "--no-pager", "-n", "1"])
+        .expect("git-ai log should render commit body");
+
+    assert!(
+        output.contains("    feat: subject\n\n    Body paragraph"),
+        "body should be separated from subject:\n{}",
+        output
+    );
+}
+
+#[test]
 fn log_http_backend_reads_notes_db_without_git_notes_ref() {
     let mut repo = TestRepo::new();
     let mut file = repo.filename("http.txt");

--- a/tests/integration/log.rs
+++ b/tests/integration/log.rs
@@ -1,0 +1,129 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::config::{NotesBackendConfig, NotesBackendKind};
+use git_ai::notes::db::NotesDatabase;
+
+#[test]
+fn log_default_shows_stats_without_raw_note() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("app.txt");
+    file.set_contents(lines!["AI-authored line".ai()]);
+    repo.stage_all_and_commit("feat: add ai line").unwrap();
+
+    let output = repo
+        .git_ai(&["log", "--no-pager", "-n", "1"])
+        .expect("git-ai log should succeed");
+
+    assert!(output.contains("feat: add ai line"), "output:\n{}", output);
+    assert!(output.contains("Git AI stats:"), "output:\n{}", output);
+    assert!(output.contains("you"), "output:\n{}", output);
+    assert!(output.contains("ai"), "output:\n{}", output);
+    assert!(
+        !output.contains("schema_version"),
+        "raw note data should be hidden by default:\n{}",
+        output
+    );
+}
+
+#[test]
+fn log_raw_shows_authorship_note() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("raw.txt");
+    file.set_contents(lines!["AI raw line".ai()]);
+    repo.stage_all_and_commit("feat: raw note").unwrap();
+
+    let output = repo
+        .git_ai(&["log", "--no-pager", "--raw", "-n", "1"])
+        .expect("git-ai log --raw should succeed");
+
+    assert!(output.contains("Git AI stats:"), "output:\n{}", output);
+    assert!(output.contains("Authorship note:"), "output:\n{}", output);
+    assert!(
+        output.contains("schema_version"),
+        "raw note content should be visible:\n{}",
+        output
+    );
+}
+
+#[test]
+fn log_multiple_commits_parse_record_boundaries() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("history.txt");
+
+    file.set_contents(lines!["first ai line".ai()]);
+    repo.stage_all_and_commit("feat: first").unwrap();
+
+    file.set_contents(lines!["first ai line".ai(), "second ai line".ai()]);
+    repo.stage_all_and_commit("feat: second").unwrap();
+
+    let output = repo
+        .git_ai(&["log", "--no-pager", "-n", "2"])
+        .expect("git-ai log should parse multiple commits");
+
+    assert!(output.contains("feat: second"), "output:\n{}", output);
+    assert!(output.contains("feat: first"), "output:\n{}", output);
+    assert_eq!(
+        output.matches("Git AI stats:").count(),
+        2,
+        "output:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("stats unavailable"),
+        "both commits should have stats:\n{}",
+        output
+    );
+}
+
+#[test]
+fn log_http_backend_reads_notes_db_without_git_notes_ref() {
+    let mut repo = TestRepo::new();
+    let mut file = repo.filename("http.txt");
+    file.set_contents(lines!["AI http line".ai()]);
+    repo.stage_all_and_commit("feat: http note").unwrap();
+
+    let sha = repo
+        .git(&["rev-parse", "HEAD"])
+        .expect("rev-parse should succeed")
+        .trim()
+        .to_string();
+    let note = repo
+        .read_authorship_note(&sha)
+        .expect("authorship note should exist before deleting refs/notes/ai");
+
+    repo.git_og(&["update-ref", "-d", "refs/notes/ai"])
+        .expect("delete refs/notes/ai");
+    assert!(
+        repo.read_authorship_note(&sha).is_none(),
+        "precondition failed: refs/notes/ai should be absent"
+    );
+
+    let notes_db_path = repo.test_home_path().join("http-log-notes.db");
+    let mut db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db");
+    db.cache_synced_notes(&[(sha.clone(), note)])
+        .expect("seed notes db");
+
+    repo.patch_git_ai_config(|patch| {
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        });
+    });
+
+    let notes_db_path_string = notes_db_path.to_string_lossy().to_string();
+    let output = repo
+        .git_ai_with_env(
+            &["log", "--no-pager", "--notes", "-n", "1"],
+            &[("GIT_AI_TEST_NOTES_DB_PATH", notes_db_path_string.as_str())],
+        )
+        .expect("git-ai log should read HTTP notes cache");
+
+    assert!(output.contains("feat: http note"), "output:\n{}", output);
+    assert!(output.contains("Git AI stats:"), "output:\n{}", output);
+    assert!(output.contains("Authorship note:"), "output:\n{}", output);
+    assert!(
+        output.contains("schema_version"),
+        "raw note content should come from notes-db:\n{}",
+        output
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -78,6 +78,7 @@ mod internal_spawn_safety;
 mod issue_1204_multi_agent;
 mod jetbrains_download;
 mod jetbrains_ide_types;
+mod log;
 mod merge_rebase;
 mod multi_repo_workspace;
 mod non_utf8_files;


### PR DESCRIPTION
## Summary
- replace `git-ai log` direct git proxying with a streamed renderer that batches commit reads and authorship note lookups
- render Git AI stats by default and show raw authorship notes only with `--raw` or `--notes`
- add batch note reads for git-notes and HTTP cache/backend paths, plus focused integration coverage

## Validation
- `task fmt`
- `task build`
- `task lint`
- `task test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->