### PR TITLE
Add git-ai author config override

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,7 @@
 use crate::auth::{CredentialStore, OAuthClient};
 use crate::config;
 use crate::error::GitAiError;
-use crate::git::repository::current_git_committer_identity_resolution;
+use crate::git::repository::{current_git_committer_identity_resolution, parse_git_var_identity};
 use crate::http;
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
@@ -61,18 +61,25 @@ fn try_load_auth_token() -> Option<String> {
     // Mutex guard is automatically released when _guard is dropped
 }
 
-/// Resolve the git author identity without requiring a Repository instance.
+/// Resolve the git-ai effective author identity without requiring a Repository instance.
 ///
 /// Uses the shared git identity helper to get the current user's identity,
-/// respecting the full git precedence chain (env vars > config > system defaults).
+/// respecting the full git precedence chain (env vars > config > system defaults),
+/// then overlays any configured git-ai author fields.
 /// Falls back to the system hostname if git identity is unavailable.
 fn resolve_git_identity() -> Option<String> {
-    let identity = current_git_committer_identity_resolution().identity;
+    let author_config = config::Config::fresh_author_cached();
+    let identity = current_git_committer_identity_resolution()
+        .identity
+        .with_author_config(&author_config);
     if let Some(formatted) = identity.formatted() {
         return Some(encode_for_header(&formatted));
     }
 
-    resolve_fallback_identity().map(|id| encode_for_header(&id))
+    resolve_fallback_identity()
+        .map(|id| parse_git_var_identity(&id).with_author_config(&author_config))
+        .and_then(|identity| identity.formatted())
+        .map(|id| encode_for_header(&id))
 }
 
 /// Build a fallback identity matching git's format: `"Username <username@hostname>"`.

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -1401,7 +1401,7 @@ fn output_json_format(
         .map(|creds| !creds.is_refresh_token_expired())
         .unwrap_or(false);
 
-    let current_user = repo.git_author_identity().formatted();
+    let current_user = repo.effective_author_identity().formatted();
 
     let output = JsonBlameOutput {
         lines: lines_map,

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,7 @@ use dirs;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::config::{CodexHooksFormat, NotesBackendKind};
+use crate::config::{AuthorConfig, CodexHooksFormat, NotesBackendKind};
 use crate::git::repository::find_repository_in_path;
 
 /// Determines the type of pattern value provided
@@ -108,6 +108,8 @@ fn print_config_help() {
     println!("  update_channel               Update channel (latest/next)");
     println!("  feature_flags                Feature flags (object)");
     println!("  api_key                      API key for X-API-Key header");
+    println!("  author.name                  git-ai author display name override");
+    println!("  author.email                 git-ai author email override");
     println!("  prompt_storage               Prompt storage mode (default/notes/local)");
     println!("  include_prompts_in_repositories  Repos to include for prompt storage (array)");
     println!("  default_prompt_storage       Fallback storage mode for non-included repos");
@@ -134,6 +136,8 @@ fn print_config_help() {
     println!("Examples:");
     println!("  git-ai config exclude_repositories");
     println!("  git-ai config set disable_auto_updates true");
+    println!("  git-ai config set author.name \"Alice Example\"");
+    println!("  git-ai config set author.email alice@example.com");
     println!("  git-ai config set exclude_repositories \"private/*\"");
     println!("  git-ai config set exclude_repositories .         # Uses current repo's remotes");
     println!("  git-ai config --add exclude_repositories \"temp/*\"");
@@ -326,6 +330,12 @@ fn show_all_config() -> Result<(), String> {
     effective_config.insert("quiet".to_string(), Value::Bool(runtime_config.is_quiet()));
 
     effective_config.insert(
+        "author".to_string(),
+        serde_json::to_value(runtime_config.author())
+            .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
+    );
+
+    effective_config.insert(
         "git_ai_hooks".to_string(),
         serde_json::to_value(runtime_config.git_ai_hooks())
             .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
@@ -438,6 +448,8 @@ fn get_config_value(key: &str) -> Result<(), String> {
                 }
             }
             "quiet" => Value::Bool(runtime_config.is_quiet()),
+            "author" => serde_json::to_value(runtime_config.author())
+                .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
             "git_ai_hooks" => serde_json::to_value(runtime_config.git_ai_hooks())
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
             "codex_hooks_format" => {
@@ -510,8 +522,32 @@ fn get_config_value(key: &str) -> Result<(), String> {
         return Ok(());
     }
 
+    if key_path[0] == "author" {
+        if key_path.len() != 2 {
+            return Err("author requires a field name (author.name or author.email)".to_string());
+        }
+        let author = runtime_config.author();
+        let value = match key_path[1].as_str() {
+            "name" => author
+                .name
+                .as_ref()
+                .map(|name| Value::String(name.clone()))
+                .unwrap_or(Value::Null),
+            "email" => author
+                .email
+                .as_ref()
+                .map(|email| Value::String(email.clone()))
+                .unwrap_or(Value::Null),
+            other => return Err(format!("Unknown author field: {}", other)),
+        };
+        let json = serde_json::to_string_pretty(&value)
+            .map_err(|e| format!("Failed to serialize value: {}", e))?;
+        println!("{}", json);
+        return Ok(());
+    }
+
     Err(
-        "Nested keys are only supported for feature_flags, git_ai_hooks, and notes_backend"
+        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, and author"
             .to_string(),
     )
 }
@@ -646,6 +682,26 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 crate::config::save_file_config(&file_config)?;
                 println!("[quiet]: {}", bool_value);
             }
+            "author" => {
+                if add_mode {
+                    return Err(
+                        "Cannot use --add with author. Use author.name or author.email."
+                            .to_string(),
+                    );
+                }
+                let author = parse_author_config_object(value)?;
+                file_config.author = if author.is_empty() {
+                    None
+                } else {
+                    Some(author.clone())
+                };
+                crate::config::save_file_config(&file_config)?;
+                println!(
+                    "[author]: {}",
+                    serde_json::to_string(&author)
+                        .map_err(|e| format!("Failed to serialize author: {}", e))?
+                );
+            }
             "git_ai_hooks" => {
                 if add_mode {
                     return Err("Cannot use --add with git_ai_hooks at top level. Use dot notation: git_ai_hooks.post_notes_updated".to_string());
@@ -778,8 +834,33 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
         return Ok(());
     }
 
+    if key_path[0] == "author" {
+        if add_mode {
+            return Err("Cannot use --add with author fields".to_string());
+        }
+        if key_path.len() != 2 {
+            return Err("author requires a field name (author.name or author.email)".to_string());
+        }
+
+        let mut author = file_config.author.clone().unwrap_or_default().normalized();
+        let normalized_value = value.trim().to_string();
+        if normalized_value.is_empty() {
+            return Err(format!("author.{} cannot be empty", key_path[1]));
+        }
+        match key_path[1].as_str() {
+            "name" => author.name = Some(normalized_value.clone()),
+            "email" => author.email = Some(normalized_value.clone()),
+            other => return Err(format!("Unknown author field: {}", other)),
+        }
+
+        file_config.author = Some(author);
+        crate::config::save_file_config(&file_config)?;
+        println!("[author.{}]: {}", key_path[1], normalized_value);
+        return Ok(());
+    }
+
     Err(
-        "Nested keys are only supported for feature_flags, git_ai_hooks, and notes_backend"
+        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, and author"
             .to_string(),
     )
 }
@@ -894,6 +975,17 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [quiet]: {}", v);
+                }
+            }
+            "author" => {
+                let old_value = file_config.author.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!(
+                        "- [author]: {}",
+                        serde_json::to_string(&v)
+                            .map_err(|e| format!("Failed to serialize author: {}", e))?
+                    );
                 }
             }
             "git_ai_hooks" => {
@@ -1031,8 +1123,32 @@ fn unset_config_value(key: &str) -> Result<(), String> {
         return Ok(());
     }
 
+    if key_path[0] == "author" {
+        if key_path.len() != 2 {
+            return Err("author requires a field name (author.name or author.email)".to_string());
+        }
+
+        let mut author = file_config.author.clone().unwrap_or_default().normalized();
+        let old_value = match key_path[1].as_str() {
+            "name" => author.name.take(),
+            "email" => author.email.take(),
+            other => return Err(format!("Unknown author field: {}", other)),
+        };
+
+        file_config.author = if author.is_empty() {
+            None
+        } else {
+            Some(author)
+        };
+        crate::config::save_file_config(&file_config)?;
+        if let Some(v) = old_value {
+            println!("- [author.{}]: {}", key_path[1], v);
+        }
+        return Ok(());
+    }
+
     Err(
-        "Nested keys are only supported for feature_flags, git_ai_hooks, and notes_backend"
+        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, and author"
             .to_string(),
     )
 }
@@ -1213,6 +1329,18 @@ fn parse_value(value: &str) -> Result<Value, String> {
 
     // Otherwise treat as string
     Ok(Value::String(value.to_string()))
+}
+
+fn parse_author_config_object(value: &str) -> Result<AuthorConfig, String> {
+    let parsed: Value =
+        serde_json::from_str(value).map_err(|e| format!("Invalid JSON for author: {}", e))?;
+    if !parsed.is_object() {
+        return Err("author must be a JSON object".to_string());
+    }
+
+    serde_json::from_value::<AuthorConfig>(parsed)
+        .map(AuthorConfig::normalized)
+        .map_err(|e| format!("Invalid author config: {}", e))
 }
 
 /// Mask an API key for display (show first 4 and last 4 chars if long enough)
@@ -1404,6 +1532,21 @@ mod tests {
     fn test_parse_value_plain_string() {
         let result = parse_value("plain text").unwrap();
         assert_eq!(result, Value::String("plain text".to_string()));
+    }
+
+    #[test]
+    fn test_parse_author_config_object() {
+        let author =
+            parse_author_config_object(r#"{"name":"  Alice Example  ","email":"a@example.com"}"#)
+                .unwrap();
+        assert_eq!(author.name.as_deref(), Some("Alice Example"));
+        assert_eq!(author.email.as_deref(), Some("a@example.com"));
+    }
+
+    #[test]
+    fn test_parse_author_config_object_rejects_non_object() {
+        let err = parse_author_config_object(r#""Alice""#).unwrap_err();
+        assert!(err.contains("author must be a JSON object"));
     }
 
     #[test]

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -408,6 +408,7 @@ struct GitDebugDiagnostics {
 struct GitCommitterIdentityInfo {
     global_config: Result<GitConfigIdentityResolution, String>,
     repository: RepositoryCommitterIdentity,
+    author_config: config::AuthorConfig,
 }
 
 enum RepositoryCommitterIdentity {
@@ -419,6 +420,7 @@ fn collect_git_committer_identity_info(
     repository_info: &RepositoryInfo,
 ) -> GitCommitterIdentityInfo {
     let global_config = global_git_config_identity_resolution().map_err(|e| e.to_string());
+    let author_config = config::Config::fresh_author_cached();
     let repository = repository_info
         .committer_identity
         .clone()
@@ -435,6 +437,7 @@ fn collect_git_committer_identity_info(
     GitCommitterIdentityInfo {
         global_config,
         repository,
+        author_config,
     }
 }
 
@@ -465,6 +468,22 @@ fn append_git_committer_identity(out: &mut String, identity: &GitCommitterIdenti
             let _ = writeln!(out, "  <not in repository: {}>", err);
         }
     }
+
+    let _ = writeln!(out, "Git AI author config override:");
+    append_author_config(out, &identity.author_config, "  ");
+
+    let _ = writeln!(out, "Git AI effective author identity:");
+    match &identity.repository {
+        RepositoryCommitterIdentity::InRepository(resolution) => {
+            let effective_author = resolution
+                .identity
+                .with_author_config(&identity.author_config);
+            append_git_author_identity(out, &effective_author, "  ");
+        }
+        RepositoryCommitterIdentity::NotInRepository(err) => {
+            let _ = writeln!(out, "  <not in repository: {}>", err);
+        }
+    }
 }
 
 fn append_raw_git_config_identity(
@@ -489,6 +508,14 @@ fn append_git_author_identity(out: &mut String, identity: &GitAuthorIdentity, pr
     let _ = writeln!(out, "{}Formatted: {}", prefix, formatted);
     let _ = writeln!(out, "{}Parsed name: {}", prefix, name);
     let _ = writeln!(out, "{}Parsed email: {}", prefix, email);
+}
+
+fn append_author_config(out: &mut String, author: &config::AuthorConfig, prefix: &str) {
+    let name = author.name.as_deref().unwrap_or("<unset>");
+    let email = author.email.as_deref().unwrap_or("<unset>");
+
+    let _ = writeln!(out, "{}author.name: {}", prefix, name);
+    let _ = writeln!(out, "{}author.email: {}", prefix, email);
 }
 
 fn collect_git_diagnostics(
@@ -1547,6 +1574,43 @@ mod tests {
     fn test_parse_debug_options_rejects_unknown_arg() {
         let err = parse_debug_options(&["--wat".to_string()]).unwrap_err();
         assert!(err.contains("unknown debug argument: --wat"), "{err}");
+    }
+
+    #[test]
+    fn test_append_git_committer_identity_includes_effective_author() {
+        let identity = GitCommitterIdentityInfo {
+            global_config: Ok(GitConfigIdentityResolution {
+                raw_name: Some("Git User".to_string()),
+                raw_email: Some("git@example.com".to_string()),
+                identity: GitAuthorIdentity {
+                    name: Some("Git User".to_string()),
+                    email: Some("git@example.com".to_string()),
+                },
+            }),
+            repository: RepositoryCommitterIdentity::InRepository(GitIdentityResolution {
+                raw_git_var: Some("Git User <git@example.com> 1234567890 +0000".to_string()),
+                identity: GitAuthorIdentity {
+                    name: Some("Git User".to_string()),
+                    email: Some("git@example.com".to_string()),
+                },
+            }),
+            author_config: config::AuthorConfig {
+                name: Some("Config User".to_string()),
+                email: None,
+            },
+        };
+
+        let mut out = String::new();
+        append_git_committer_identity(&mut out, &identity);
+
+        assert!(out.contains("Git AI author config override:"), "{out}");
+        assert!(out.contains("  author.name: Config User"), "{out}");
+        assert!(out.contains("  author.email: <unset>"), "{out}");
+        assert!(out.contains("Git AI effective author identity:"), "{out}");
+        assert!(
+            out.contains("  Formatted: Config User <git@example.com>"),
+            "{out}"
+        );
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -50,7 +50,7 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
     let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&ignore_patterns);
 
-    let default_user_name = repo.git_author_identity().formatted_or_unknown();
+    let default_user_name = repo.effective_author_identity().formatted_or_unknown();
 
     let head = repo.head()?;
     let head_sha = head.target()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::env;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use glob::Pattern;
 use serde::{Deserialize, Serialize, Serializer};
@@ -50,6 +52,29 @@ pub struct NotesBackendConfig {
     pub kind: NotesBackendKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend_url: Option<String>,
+}
+
+/// Optional git-ai author override for authorship metadata.
+///
+/// Any unset field falls back to the effective Git committer identity.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AuthorConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
+
+impl AuthorConfig {
+    pub fn normalized(mut self) -> Self {
+        self.name = normalize_optional_string(self.name);
+        self.email = normalize_optional_string(self.email);
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none() && self.email.is_none()
+    }
 }
 
 /// Which Codex hook file git-ai should use when installing Codex hooks.
@@ -150,6 +175,7 @@ pub struct Config {
     api_key: Option<String>,
     quiet: bool,
     allow_superuser: bool,
+    author: AuthorConfig,
     custom_attributes: HashMap<String, String>,
     git_ai_hooks: HashMap<String, Vec<String>>,
     codex_hooks_format: CodexHooksFormat,
@@ -225,6 +251,8 @@ pub struct FileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_superuser: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<AuthorConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_attributes: Option<HashMap<String, String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git_ai_hooks: Option<HashMap<String, Vec<String>>>,
@@ -237,6 +265,31 @@ pub struct FileConfig {
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
+
+const AUTHOR_CONFIG_CACHE_TTL: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuthorConfigCacheKey {
+    config_path: Option<PathBuf>,
+    config_fingerprint: Option<AuthorConfigFileFingerprint>,
+    #[cfg(any(test, feature = "test-support"))]
+    test_patch: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AuthorConfigFileFingerprint {
+    len: u64,
+    hash: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CachedAuthorConfig {
+    key: AuthorConfigCacheKey,
+    loaded_at: Instant,
+    author: AuthorConfig,
+}
+
+static AUTHOR_CONFIG_CACHE: OnceLock<Mutex<Option<CachedAuthorConfig>>> = OnceLock::new();
 
 #[cfg(any(test, feature = "test-support"))]
 static TEST_FEATURE_FLAGS_OVERRIDE: RwLock<Option<FeatureFlags>> = RwLock::new(None);
@@ -256,6 +309,8 @@ pub struct ConfigPatch {
     pub disable_auto_updates: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_storage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<AuthorConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_attributes: Option<HashMap<String, String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -287,6 +342,44 @@ impl Config {
     /// config updates (for example, prompt sharing/privacy toggles).
     pub fn fresh() -> Self {
         build_config()
+    }
+
+    /// Return the fresh author override with a short process-local TTL.
+    ///
+    /// Author identity is consulted in hot paths such as checkpoint bursts and
+    /// daemon replay. This avoids the global `Config::get()` singleton while
+    /// still bounding repeated config file reads during a burst of operations.
+    pub fn fresh_author_cached() -> AuthorConfig {
+        let key = author_config_cache_key();
+        let now = Instant::now();
+        let cache = AUTHOR_CONFIG_CACHE.get_or_init(|| Mutex::new(None));
+        if let Ok(mut guard) = cache.lock() {
+            if let Some(cached) = guard.as_ref()
+                && cached.key == key
+                && now.duration_since(cached.loaded_at) < AUTHOR_CONFIG_CACHE_TTL
+            {
+                return cached.author.clone();
+            }
+
+            let author = build_config().author;
+            *guard = Some(CachedAuthorConfig {
+                key,
+                loaded_at: now,
+                author: author.clone(),
+            });
+            return author;
+        }
+
+        build_config().author
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn clear_author_config_cache_for_tests() {
+        if let Some(cache) = AUTHOR_CONFIG_CACHE.get()
+            && let Ok(mut guard) = cache.lock()
+        {
+            *guard = None;
+        }
     }
 
     /// Returns the command to invoke git.
@@ -543,6 +636,11 @@ impl Config {
         self.allow_superuser
     }
 
+    /// Returns the configured git-ai author override.
+    pub fn author(&self) -> &AuthorConfig {
+        &self.author
+    }
+
     /// Returns the custom attributes map (from config file + env var override).
     pub fn custom_attributes(&self) -> &HashMap<String, String> {
         &self.custom_attributes
@@ -785,6 +883,36 @@ where
     masked.serialize(serializer)
 }
 
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn author_config_cache_key() -> AuthorConfigCacheKey {
+    let config_path = config_file_path();
+    let config_fingerprint = config_path
+        .as_ref()
+        .and_then(|path| author_config_file_fingerprint(path));
+
+    AuthorConfigCacheKey {
+        config_path,
+        config_fingerprint,
+        #[cfg(any(test, feature = "test-support"))]
+        test_patch: env::var("GIT_AI_TEST_CONFIG_PATCH").ok(),
+    }
+}
+
+fn author_config_file_fingerprint(path: &Path) -> Option<AuthorConfigFileFingerprint> {
+    let data = fs::read(path).ok()?;
+    let mut hasher = DefaultHasher::new();
+    data.hash(&mut hasher);
+    Some(AuthorConfigFileFingerprint {
+        len: data.len() as u64,
+        hash: hasher.finish(),
+    })
+}
+
 fn build_config() -> Config {
     let file_cfg = load_file_config();
     let exclude_prompts_in_repositories = file_cfg
@@ -944,6 +1072,12 @@ fn build_config() -> Config {
         .and_then(|c| c.allow_superuser)
         .unwrap_or(false);
 
+    let author = file_cfg
+        .as_ref()
+        .and_then(|c| c.author.clone())
+        .unwrap_or_default()
+        .normalized();
+
     // Build custom attributes: file config as base, env var overrides
     let custom_attributes = build_custom_attributes(&file_cfg);
 
@@ -1037,6 +1171,7 @@ fn build_config() -> Config {
             api_key,
             quiet,
             allow_superuser,
+            author,
             custom_attributes: custom_attributes.clone(),
             git_ai_hooks: git_ai_hooks.clone(),
             codex_hooks_format,
@@ -1066,6 +1201,7 @@ fn build_config() -> Config {
         api_key,
         quiet,
         allow_superuser,
+        author,
         custom_attributes,
         git_ai_hooks,
         codex_hooks_format,
@@ -1485,6 +1621,9 @@ fn apply_test_config_patch(config: &mut Config) {
         if let Some(custom_attributes) = patch.custom_attributes {
             config.custom_attributes = custom_attributes;
         }
+        if let Some(author) = patch.author {
+            config.author = author.normalized();
+        }
         if let Some(feature_flags_value) = patch.feature_flags
             && let Ok(deserialized) = serde_json::from_value::<
                 crate::feature_flags::DeserializableFeatureFlags,
@@ -1549,12 +1688,51 @@ mod tests {
             api_key: None,
             quiet: false,
             allow_superuser: false,
+            author: AuthorConfig::default(),
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
         }
+    }
+
+    #[test]
+    fn test_author_config_normalizes_empty_fields() {
+        let author = AuthorConfig {
+            name: Some("  Alice  ".to_string()),
+            email: Some("   ".to_string()),
+        }
+        .normalized();
+
+        assert_eq!(author.name.as_deref(), Some("Alice"));
+        assert!(author.email.is_none());
+        assert!(!author.is_empty());
+    }
+
+    #[test]
+    fn test_author_config_empty_when_all_fields_blank() {
+        let author = AuthorConfig {
+            name: Some("".to_string()),
+            email: Some("   ".to_string()),
+        }
+        .normalized();
+
+        assert!(author.is_empty());
+    }
+
+    #[test]
+    fn test_author_config_file_fingerprint_detects_same_length_edits() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        fs::write(&path, br#"{"author":{"name":"Alice"}}"#).unwrap();
+        let first = author_config_file_fingerprint(&path).unwrap();
+
+        fs::write(&path, br#"{"author":{"name":"Carol"}}"#).unwrap();
+        let second = author_config_file_fingerprint(&path).unwrap();
+
+        assert_eq!(first.len, second.len);
+        assert_ne!(first, second);
     }
 
     #[test]
@@ -1752,6 +1930,7 @@ mod tests {
             api_key: None,
             quiet: false,
             allow_superuser: false,
+            author: AuthorConfig::default(),
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
             codex_hooks_format: CodexHooksFormat::ConfigToml,
@@ -1896,6 +2075,7 @@ mod tests {
             api_key: None,
             quiet: false,
             allow_superuser: false,
+            author: AuthorConfig::default(),
             custom_attributes: HashMap::new(),
             git_ai_hooks: HashMap::new(),
             codex_hooks_format: CodexHooksFormat::ConfigToml,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1375,7 +1375,7 @@ fn apply_checkpoint_side_effect(request: CheckpointRequest) -> Result<(), GitAiE
             return Err(e);
         }
     };
-    let author = repo.git_author_identity().formatted_or_unknown();
+    let author = repo.effective_author_identity().formatted_or_unknown();
 
     if request.checkpoint_kind.is_ai()
         && let Some(ref agent_id) = request.agent_id
@@ -1770,7 +1770,7 @@ fn apply_checkout_switch_working_log_side_effect(
                     &old_head,
                     &new_head,
                     clean_snapshot,
-                    Some(repo.git_author_identity().formatted_or_unknown()),
+                    Some(repo.effective_author_identity().formatted_or_unknown()),
                 )?;
             }
             repo.storage.delete_working_log_for_base_commit(&old_head)?;
@@ -2755,7 +2755,7 @@ fn apply_rewrite_side_effect(
     reset_pathspecs: Option<&[String]>,
 ) -> Result<(), GitAiError> {
     let mut repo = find_repository_in_path(worktree)?;
-    let author = repo.git_author_identity().formatted_or_unknown();
+    let author = repo.effective_author_identity().formatted_or_unknown();
     ensure_rewrite_prerequisites(
         coordinator,
         &repo,
@@ -7117,7 +7117,7 @@ impl ActorDaemonCoordinator {
                         let carried_va = crate::authorship::virtual_attribution::VirtualAttributions::from_persisted_working_log(
                             repo.clone(),
                             old_head.clone(),
-                            Some(repo.git_author_identity().formatted_or_unknown()),
+                            Some(repo.effective_author_identity().formatted_or_unknown()),
                         )?;
                         Some((new_head, carried_va, snapshot.clone()))
                     }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -914,7 +914,7 @@ impl<'a> Iterator for References<'a> {
     }
 }
 
-/// The effective git author identity (name + email) for the current repository.
+/// A Git identity (name + email) for the current repository.
 ///
 /// Resolved via `git var GIT_COMMITTER_IDENT` which respects the full git precedence
 /// chain (env vars > config > system defaults), unlike a raw `git config user.name`
@@ -927,6 +927,14 @@ pub struct GitAuthorIdentity {
 }
 
 impl GitAuthorIdentity {
+    /// Apply git-ai's optional author config as a partial override.
+    pub fn with_author_config(&self, author: &config::AuthorConfig) -> Self {
+        GitAuthorIdentity {
+            name: author.name.clone().or_else(|| self.name.clone()),
+            email: author.email.clone().or_else(|| self.email.clone()),
+        }
+    }
+
     /// Format as `"Name <email>"`, `"Name"`, `"<email>"`, or `None`.
     pub fn formatted(&self) -> Option<String> {
         match (&self.name, &self.email) {
@@ -1349,7 +1357,7 @@ impl Repository {
             .map(|cfg| cfg.string(key).map(|cow| cow.to_string()))
     }
 
-    /// Get the effective git user identity for this repository.
+    /// Get the effective raw Git user identity for this repository.
     ///
     /// Uses `git var GIT_COMMITTER_IDENT` which respects the full git identity precedence:
     /// `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` env vars > `user.name`/`user.email` config >
@@ -1358,8 +1366,8 @@ impl Repository {
     /// Falls back to `git config user.name` / `user.email` if `git var` fails.
     /// The result is cached per Repository instance for performance.
     ///
-    /// Use this for "who is the current user" lookups (blame, status, prompts, etc.).
-    /// For commit authorship specifically, use [`Self::git_commit_author_identity`] instead.
+    /// For git-ai authorship metadata, use [`Self::effective_author_identity`] so the
+    /// git-ai author config can override this raw Git identity.
     pub fn git_author_identity(&self) -> &GitAuthorIdentity {
         self.cached_author_identity
             .get_or_init(|| self.resolve_git_var_identity("GIT_COMMITTER_IDENT"))
@@ -1367,6 +1375,15 @@ impl Repository {
 
     pub fn git_author_identity_resolution(&self) -> GitIdentityResolution {
         self.resolve_git_var_identity_resolution("GIT_COMMITTER_IDENT")
+    }
+
+    /// Get the git-ai effective author identity for metadata and display.
+    ///
+    /// This starts from Git's effective committer identity, then overlays any
+    /// configured `author.name` and/or `author.email` from git-ai config.
+    pub fn effective_author_identity(&self) -> GitAuthorIdentity {
+        self.git_author_identity()
+            .with_author_config(&config::Config::fresh_author_cached())
     }
 
     /// Get the effective git commit author identity for this repository.
@@ -3059,6 +3076,58 @@ fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool, u32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn author_config_overlays_full_identity() {
+        let git_identity = GitAuthorIdentity {
+            name: Some("Git User".to_string()),
+            email: Some("git@example.com".to_string()),
+        };
+        let author = config::AuthorConfig {
+            name: Some("Config User".to_string()),
+            email: Some("config@example.com".to_string()),
+        };
+
+        assert_eq!(
+            git_identity
+                .with_author_config(&author)
+                .formatted()
+                .as_deref(),
+            Some("Config User <config@example.com>")
+        );
+    }
+
+    #[test]
+    fn author_config_supports_partial_overrides() {
+        let git_identity = GitAuthorIdentity {
+            name: Some("Git User".to_string()),
+            email: Some("git@example.com".to_string()),
+        };
+
+        let name_only = config::AuthorConfig {
+            name: Some("Config User".to_string()),
+            email: None,
+        };
+        assert_eq!(
+            git_identity
+                .with_author_config(&name_only)
+                .formatted()
+                .as_deref(),
+            Some("Config User <git@example.com>")
+        );
+
+        let email_only = config::AuthorConfig {
+            name: None,
+            email: Some("config@example.com".to_string()),
+        };
+        assert_eq!(
+            git_identity
+                .with_author_config(&email_only)
+                .formatted()
+                .as_deref(),
+            Some("Git User <config@example.com>")
+        );
+    }
 
     #[test]
     fn test_parse_git_version_standard() {

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1037,6 +1037,12 @@ impl TestRepo {
                 serde_json::Value::Object(attrs_map),
             );
         }
+        if let Some(author) = &patch.author {
+            config.insert(
+                "author".to_string(),
+                serde_json::to_value(author).expect("failed to serialize test author config"),
+            );
+        }
         if let Some(feature_flags) = &patch.feature_flags {
             config.insert("feature_flags".to_string(), feature_flags.clone());
         }

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1,6 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+use git_ai::config::AuthorConfig;
 use std::fs;
 
 fn configure_diff_settings(repo: &TestRepo, settings: &[(&str, &str)]) {
@@ -1916,6 +1917,158 @@ fn test_session_record_human_author_includes_email() {
         assert_eq!(
             author, "Test User <test@example.com>",
             "SessionRecord.human_author should be the full git identity"
+        );
+    }
+}
+
+#[test]
+fn test_author_config_cli_set_get_unset() {
+    let repo = TestRepo::new();
+
+    repo.git_ai(&["config", "set", "author.name", "Config User"])
+        .unwrap();
+    repo.git_ai(&["config", "set", "author.email", "config@example.com"])
+        .unwrap();
+
+    let name = repo.git_ai(&["config", "author.name"]).unwrap();
+    assert_eq!(name.trim(), "\"Config User\"");
+
+    let author = repo.git_ai(&["config", "author"]).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(author.trim()).expect("author config should be JSON");
+    assert_eq!(value["name"], "Config User");
+    assert_eq!(value["email"], "config@example.com");
+
+    repo.git_ai(&["config", "unset", "author.name"]).unwrap();
+    let author = repo.git_ai(&["config", "author"]).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(author.trim()).expect("author config should be JSON");
+    assert!(value.get("name").is_none());
+    assert_eq!(value["email"], "config@example.com");
+
+    repo.git_ai(&["config", "unset", "author"]).unwrap();
+    let author = repo.git_ai(&["config", "author"]).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(author.trim()).expect("author config should be JSON");
+    assert_eq!(value.as_object().unwrap().len(), 0);
+}
+
+#[test]
+fn test_author_config_overrides_session_and_known_human_records() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.author = Some(AuthorConfig {
+            name: Some("Config User".to_string()),
+            email: Some("config@example.com".to_string()),
+        });
+    });
+
+    let file_path = repo.path().join("author_config.rs");
+    repo.git_ai(&["checkpoint", "human", "author_config.rs"])
+        .unwrap();
+    fs::write(&file_path, "fn ai() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "author_config.rs"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit with author config")
+        .unwrap();
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let note = repo
+        .read_authorship_note(&sha)
+        .expect("AI commit should have authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    assert!(!log.metadata.sessions.is_empty());
+    for session in log.metadata.sessions.values() {
+        assert_eq!(
+            session.human_author.as_deref(),
+            Some("Config User <config@example.com>")
+        );
+    }
+
+    fs::write(&file_path, "fn ai() {}\nfn human() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "author_config.rs"])
+        .unwrap();
+    repo.stage_all_and_commit("Known human commit with author config")
+        .unwrap();
+
+    let sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let note = repo
+        .read_authorship_note(&sha)
+        .expect("known-human commit should have authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    assert!(!log.metadata.humans.is_empty());
+    for human in log.metadata.humans.values() {
+        assert_eq!(human.author, "Config User <config@example.com>");
+    }
+}
+
+#[test]
+fn test_author_config_partial_overrides_fall_back_to_git_committer_identity() {
+    let mut name_repo = TestRepo::new();
+    name_repo.patch_git_ai_config(|patch| {
+        patch.author = Some(AuthorConfig {
+            name: Some("Config Name".to_string()),
+            email: None,
+        });
+    });
+    let file_path = name_repo.path().join("partial_name.rs");
+    name_repo
+        .git_ai(&["checkpoint", "human", "partial_name.rs"])
+        .unwrap();
+    fs::write(&file_path, "fn ai() {}\n").unwrap();
+    name_repo
+        .git_ai(&["checkpoint", "mock_ai", "partial_name.rs"])
+        .unwrap();
+    name_repo
+        .stage_all_and_commit("AI commit with author name override")
+        .unwrap();
+    let sha = name_repo
+        .git(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let note = name_repo
+        .read_authorship_note(&sha)
+        .expect("AI commit should have note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    for session in log.metadata.sessions.values() {
+        assert_eq!(
+            session.human_author.as_deref(),
+            Some("Config Name <test@example.com>")
+        );
+    }
+
+    let mut email_repo = TestRepo::new();
+    email_repo.patch_git_ai_config(|patch| {
+        patch.author = Some(AuthorConfig {
+            name: None,
+            email: Some("configured-email@example.com".to_string()),
+        });
+    });
+    let file_path = email_repo.path().join("partial_email.rs");
+    email_repo
+        .git_ai(&["checkpoint", "human", "partial_email.rs"])
+        .unwrap();
+    fs::write(&file_path, "fn ai() {}\n").unwrap();
+    email_repo
+        .git_ai(&["checkpoint", "mock_ai", "partial_email.rs"])
+        .unwrap();
+    email_repo
+        .stage_all_and_commit("AI commit with author email override")
+        .unwrap();
+    let sha = email_repo
+        .git(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let note = email_repo
+        .read_authorship_note(&sha)
+        .expect("AI commit should have note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse note");
+    for session in log.metadata.sessions.values() {
+        assert_eq!(
+            session.human_author.as_deref(),
+            Some("Test User <configured-email@example.com>")
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add `author.name` and `author.email` config support, including CLI get/set/unset flows.
- Centralize git-ai effective author identity resolution so config fields partially override the Git committer identity.
- Use the effective author for authorship metadata, status/blame user metadata, daemon rewrite/carryover paths, API identity headers, and `git-ai debug` output.
- Add unit and integration coverage for full and partial author overrides plus debug effective-author formatting.

## Validation
- `task fmt`
- `task build`
- `task test TEST_FILTER=author_config`
- `task test TEST_FILTER=append_git_committer_identity`
- `task lint`
- `task test`