### PR TITLE
[codex] Pin Git core compatibility source

### DIFF
--- a/.github/workflows/git-core-compat.yml
+++ b/.github/workflows/git-core-compat.yml
@@ -7,6 +7,7 @@ env:
   GIT_COMPAT_URL: https://github.com/git/git.git
   GIT_COMPAT_REF: v2.54.0
   GIT_COMPAT_SHA: 94f057755b7941b321fd11fec1b2e3ca5313a4e0
+  GIT_COMPAT_CLEAN_SOURCE: "1"
 
 on:
   pull_request:
@@ -97,9 +98,6 @@ jobs:
           git -C /tmp/git-core-tests clean -ffdx
           git -C /tmp/git-core-tests rev-parse HEAD
           git -C /tmp/git-core-tests describe --tags --always --dirty
-
-      - name: Build git source
-        run: make -C /tmp/git-core-tests -j$(nproc) NO_CURL=YesPlease NO_GETTEXT=YesPlease
 
       - name: Build git-ai
         run: cargo build --release --bin git-ai

--- a/.github/workflows/git-core-compat.yml
+++ b/.github/workflows/git-core-compat.yml
@@ -4,7 +4,9 @@ permissions:
   contents: read
 
 env:
+  GIT_COMPAT_URL: https://github.com/git/git.git
   GIT_COMPAT_REF: v2.54.0
+  GIT_COMPAT_SHA: 94f057755b7941b321fd11fec1b2e3ca5313a4e0
 
 on:
   pull_request:
@@ -62,18 +64,37 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/git-core-tests
-          key: git-source-${{ runner.os }}-${{ env.GIT_COMPAT_REF }}
+          key: git-source-${{ runner.os }}-${{ env.GIT_COMPAT_SHA }}
 
       - name: Clone git source
         run: |
+          set -euo pipefail
           if [ ! -d /tmp/git-core-tests/.git ]; then
-            rm -rf /tmp/git-core-tests
-            git clone --depth 1 --branch "$GIT_COMPAT_REF" https://github.com/git/git.git /tmp/git-core-tests
+            if [ -e /tmp/git-core-tests ]; then
+              echo "::error::/tmp/git-core-tests exists but is not a Git checkout"
+              exit 1
+            fi
+            git clone --depth 1 --branch "$GIT_COMPAT_REF" "$GIT_COMPAT_URL" /tmp/git-core-tests
           else
             echo "Using cached git source"
-            git -C /tmp/git-core-tests fetch --depth 1 origin "$GIT_COMPAT_REF"
-            git -C /tmp/git-core-tests checkout --detach FETCH_HEAD
           fi
+
+          if git -C /tmp/git-core-tests remote get-url origin >/dev/null 2>&1; then
+            git -C /tmp/git-core-tests remote set-url origin "$GIT_COMPAT_URL"
+          else
+            git -C /tmp/git-core-tests remote add origin "$GIT_COMPAT_URL"
+          fi
+          git -C /tmp/git-core-tests fetch --depth 1 origin "$GIT_COMPAT_REF"
+          git -C /tmp/git-core-tests checkout --force --detach FETCH_HEAD
+
+          actual_sha="$(git -C /tmp/git-core-tests rev-parse HEAD)"
+          if [ "$actual_sha" != "$GIT_COMPAT_SHA" ]; then
+            echo "::error::Expected $GIT_COMPAT_REF to resolve to $GIT_COMPAT_SHA, got $actual_sha"
+            exit 1
+          fi
+
+          git -C /tmp/git-core-tests reset --hard "$GIT_COMPAT_SHA"
+          git -C /tmp/git-core-tests clean -ffdx
           git -C /tmp/git-core-tests rev-parse HEAD
           git -C /tmp/git-core-tests describe --tags --always --dirty
 
@@ -88,3 +109,9 @@ jobs:
         env:
           PYTHONUNBUFFERED: "1"
         run: python3 tests/git-compat/run-core-tests.py
+
+      - name: Clean git source before cache save
+        run: |
+          set -euo pipefail
+          git -C /tmp/git-core-tests reset --hard "$GIT_COMPAT_SHA"
+          git -C /tmp/git-core-tests clean -ffdx

--- a/.github/workflows/git-core-compat.yml
+++ b/.github/workflows/git-core-compat.yml
@@ -3,6 +3,9 @@ name: Git Core Compatibility
 permissions:
   contents: read
 
+env:
+  GIT_COMPAT_REF: v2.54.0
+
 on:
   pull_request:
     paths:
@@ -55,33 +58,27 @@ jobs:
           restore-keys: |
             ubuntu-cargo-
 
-      - name: Get week for git source cache key
-        id: date
-        run: echo "week=$(date +'%Y-%U')" >> $GITHUB_OUTPUT
-
       - name: Cache git source
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/git-core-tests
-          key: git-source-${{ runner.os }}-${{ steps.date.outputs.week }}
-          restore-keys: |
-            git-source-${{ runner.os }}-
+          key: git-source-${{ runner.os }}-${{ env.GIT_COMPAT_REF }}
 
       - name: Clone git source
         run: |
-          if [ ! -d /tmp/git-core-tests ]; then
-            git clone --depth 1 https://github.com/git/git.git /tmp/git-core-tests
+          if [ ! -d /tmp/git-core-tests/.git ]; then
+            rm -rf /tmp/git-core-tests
+            git clone --depth 1 --branch "$GIT_COMPAT_REF" https://github.com/git/git.git /tmp/git-core-tests
           else
             echo "Using cached git source"
+            git -C /tmp/git-core-tests fetch --depth 1 origin "$GIT_COMPAT_REF"
+            git -C /tmp/git-core-tests checkout --detach FETCH_HEAD
           fi
+          git -C /tmp/git-core-tests rev-parse HEAD
+          git -C /tmp/git-core-tests describe --tags --always --dirty
 
       - name: Build git source
-        run: |
-          if [ ! -f /tmp/git-core-tests/GIT-BUILD-OPTIONS ]; then
-            make -C /tmp/git-core-tests -j$(nproc) NO_CURL=YesPlease NO_GETTEXT=YesPlease
-          else
-            echo "Using cached git build"
-          fi
+        run: make -C /tmp/git-core-tests -j$(nproc) NO_CURL=YesPlease NO_GETTEXT=YesPlease
 
       - name: Build git-ai
         run: cargo build --release --bin git-ai

--- a/.github/workflows/git-core-compat.yml
+++ b/.github/workflows/git-core-compat.yml
@@ -70,6 +70,14 @@ jobs:
       - name: Clone git source
         run: |
           set -euo pipefail
+          if [ -L /tmp/git-core-tests ]; then
+            echo "::error::/tmp/git-core-tests is a symlink"
+            exit 1
+          fi
+          if [ -L /tmp/git-core-tests/.git ]; then
+            echo "::error::/tmp/git-core-tests/.git is a symlink"
+            exit 1
+          fi
           if [ ! -d /tmp/git-core-tests/.git ]; then
             if [ -e /tmp/git-core-tests ]; then
               echo "::error::/tmp/git-core-tests exists but is not a Git checkout"
@@ -111,5 +119,9 @@ jobs:
       - name: Clean git source before cache save
         run: |
           set -euo pipefail
+          if [ -L /tmp/git-core-tests ] || [ -L /tmp/git-core-tests/.git ] || [ ! -d /tmp/git-core-tests/.git ]; then
+            echo "::error::/tmp/git-core-tests is not a normal Git checkout"
+            exit 1
+          fi
           git -C /tmp/git-core-tests reset --hard "$GIT_COMPAT_SHA"
           git -C /tmp/git-core-tests clean -ffdx

--- a/tests/git-compat/run-core-tests.py
+++ b/tests/git-compat/run-core-tests.py
@@ -31,6 +31,16 @@ DEFAULT_GIT_SHA = os.environ.get("GIT_COMPAT_SHA", "94f057755b7941b321fd11fec1b2
 DEFAULT_CLONE_DIR = Path("/tmp/git-core-tests")
 
 
+def env_flag(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+DEFAULT_CLEAN_GIT_SOURCE = env_flag("GIT_COMPAT_CLEAN_SOURCE", env_flag("GITHUB_ACTIONS", False))
+
+
 def read_tests_list(path: Path) -> List[str]:
     tests: List[str] = []
     for line in path.read_text(encoding="utf-8").splitlines():
@@ -131,9 +141,17 @@ def ensure_origin(clone_dir: Path, clone_url: str, env: dict) -> None:
         )
 
 
-def checkout_git_ref(clone_dir: Path, git_ref: str, expected_sha: str, env: dict) -> None:
+def checkout_git_ref(clone_dir: Path, git_ref: str, expected_sha: str, clean_source: bool, env: dict) -> bool:
     if not git_ref:
-        return
+        return clean_source
+    previous_sha = subprocess.run(
+        ["git", "-C", str(clone_dir), "rev-parse", "HEAD"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    previous_head = previous_sha.stdout.strip() if previous_sha.returncode == 0 else None
     subprocess.run(
         ["git", "-C", str(clone_dir), "fetch", "--depth", "1", "origin", git_ref],
         check=True,
@@ -156,14 +174,23 @@ def checkout_git_ref(clone_dir: Path, git_ref: str, expected_sha: str, env: dict
         check=True,
         env=env,
     )
-    subprocess.run(
-        ["git", "-C", str(clone_dir), "clean", "-ffdx"],
-        check=True,
-        env=env,
-    )
+    if clean_source:
+        subprocess.run(
+            ["git", "-C", str(clone_dir), "clean", "-ffdx"],
+            check=True,
+            env=env,
+        )
+    return clean_source or previous_head != actual_sha
 
 
-def ensure_git_clone(clone_dir: Path, clone_url: str, git_ref: str, expected_sha: str, env: dict) -> None:
+def ensure_git_clone(
+    clone_dir: Path,
+    clone_url: str,
+    git_ref: str,
+    expected_sha: str,
+    clean_source: bool,
+    env: dict,
+) -> bool:
     if clone_dir.exists() or clone_dir.is_symlink():
         if clone_dir.is_symlink():
             raise ValueError(f"Refusing to use symlinked Git source path: {clone_dir}")
@@ -177,7 +204,7 @@ def ensure_git_clone(clone_dir: Path, clone_url: str, git_ref: str, expected_sha
         cmd.extend([clone_url, str(clone_dir)])
         subprocess.run(cmd, check=True, env=env)
     ensure_origin(clone_dir, clone_url, env)
-    checkout_git_ref(clone_dir, git_ref, expected_sha, env)
+    return checkout_git_ref(clone_dir, git_ref, expected_sha, clean_source, env)
 
 
 def git_checkout_summary(clone_dir: Path, env: dict) -> Tuple[str, str]:
@@ -194,7 +221,10 @@ def git_checkout_summary(clone_dir: Path, env: dict) -> Tuple[str, str]:
     return head, description
 
 
-def ensure_git_build(clone_dir: Path, jobs: int, env: dict) -> None:
+def ensure_git_build(clone_dir: Path, jobs: int, force: bool, env: dict) -> None:
+    build_options = clone_dir / "GIT-BUILD-OPTIONS"
+    if build_options.exists() and not force:
+        return
     subprocess.run(
         [
             "make",
@@ -384,6 +414,11 @@ def main() -> int:
     parser.add_argument("--git-url", default=DEFAULT_GIT_URL)
     parser.add_argument("--git-ref", default=DEFAULT_GIT_REF)
     parser.add_argument("--git-sha", default=DEFAULT_GIT_SHA)
+    parser.add_argument(
+        "--clean-git-source",
+        action=argparse.BooleanOptionalAction,
+        default=DEFAULT_CLEAN_GIT_SOURCE,
+    )
     parser.add_argument("--clone-dir", type=Path, default=DEFAULT_CLONE_DIR)
     parser.add_argument("--jobs", type=int, default=4)
     parser.add_argument("--git-ai-bin", type=Path, default=REPO_ROOT / "target" / "release" / "git-ai")
@@ -406,9 +441,16 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="git-ai-compat-home-") as isolated_home:
         env = make_isolated_env(isolated_home)
 
-        ensure_git_clone(args.clone_dir, args.git_url, args.git_ref, args.git_sha, env)
+        force_git_build = ensure_git_clone(
+            args.clone_dir,
+            args.git_url,
+            args.git_ref,
+            args.git_sha,
+            args.clean_git_source,
+            env,
+        )
         git_head, git_description = git_checkout_summary(args.clone_dir, env)
-        ensure_git_build(args.clone_dir, args.jobs, env)
+        ensure_git_build(args.clone_dir, args.jobs, force_git_build, env)
         git_tests_dir = args.clone_dir / "t"
 
         if not git_tests_dir.exists():

--- a/tests/git-compat/run-core-tests.py
+++ b/tests/git-compat/run-core-tests.py
@@ -25,8 +25,9 @@ from typing import Dict, List, Set, Tuple
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_TESTS_FILE = REPO_ROOT / "tests" / "git-compat" / "core-tests.txt"
 DEFAULT_WHITELIST = REPO_ROOT / "tests" / "git-compat" / "whitelist.csv"
-DEFAULT_GIT_URL = "https://github.com/git/git.git"
+DEFAULT_GIT_URL = os.environ.get("GIT_COMPAT_URL", "https://github.com/git/git.git")
 DEFAULT_GIT_REF = os.environ.get("GIT_COMPAT_REF", "v2.54.0")
+DEFAULT_GIT_SHA = os.environ.get("GIT_COMPAT_SHA", "94f057755b7941b321fd11fec1b2e3ca5313a4e0")
 DEFAULT_CLONE_DIR = Path("/tmp/git-core-tests")
 
 
@@ -109,23 +110,65 @@ def make_isolated_env(isolated_home: str) -> dict:
     return env
 
 
-def ensure_git_clone(clone_dir: Path, clone_url: str, git_ref: str, env: dict) -> None:
-    if clone_dir.exists():
+def ensure_origin(clone_dir: Path, clone_url: str, env: dict) -> None:
+    remote = subprocess.run(
+        ["git", "-C", str(clone_dir), "remote", "get-url", "origin"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if remote.returncode == 0:
+        subprocess.run(
+            ["git", "-C", str(clone_dir), "remote", "set-url", "origin", clone_url],
+            check=True,
+            env=env,
+        )
+    else:
+        subprocess.run(
+            ["git", "-C", str(clone_dir), "remote", "add", "origin", clone_url],
+            check=True,
+            env=env,
+        )
+
+
+def checkout_git_ref(clone_dir: Path, git_ref: str, expected_sha: str, env: dict) -> None:
+    if not git_ref:
+        return
+    subprocess.run(
+        ["git", "-C", str(clone_dir), "fetch", "--depth", "1", "origin", git_ref],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone_dir), "checkout", "--force", "--detach", "FETCH_HEAD"],
+        check=True,
+        env=env,
+    )
+    actual_sha = subprocess.check_output(
+        ["git", "-C", str(clone_dir), "rev-parse", "HEAD"],
+        env=env,
+        text=True,
+    ).strip()
+    if expected_sha and actual_sha != expected_sha:
+        raise RuntimeError(f"Expected {git_ref} to resolve to {expected_sha}, got {actual_sha}")
+    subprocess.run(
+        ["git", "-C", str(clone_dir), "reset", "--hard", expected_sha or "HEAD"],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone_dir), "clean", "-ffdx"],
+        check=True,
+        env=env,
+    )
+
+
+def ensure_git_clone(clone_dir: Path, clone_url: str, git_ref: str, expected_sha: str, env: dict) -> None:
+    if clone_dir.exists() or clone_dir.is_symlink():
+        if clone_dir.is_symlink():
+            raise ValueError(f"Refusing to use symlinked Git source path: {clone_dir}")
         if not (clone_dir / ".git").is_dir():
-            shutil.rmtree(clone_dir)
-        else:
-            if git_ref:
-                subprocess.run(
-                    ["git", "-C", str(clone_dir), "fetch", "--depth", "1", "origin", git_ref],
-                    check=True,
-                    env=env,
-                )
-                subprocess.run(
-                    ["git", "-C", str(clone_dir), "checkout", "--detach", "FETCH_HEAD"],
-                    check=True,
-                    env=env,
-                )
-            return
+            raise FileExistsError(f"{clone_dir} exists but is not a Git checkout")
     if not clone_dir.exists():
         clone_dir.parent.mkdir(parents=True, exist_ok=True)
         cmd = ["git", "clone", "--depth", "1"]
@@ -133,6 +176,8 @@ def ensure_git_clone(clone_dir: Path, clone_url: str, git_ref: str, env: dict) -
             cmd.extend(["--branch", git_ref])
         cmd.extend([clone_url, str(clone_dir)])
         subprocess.run(cmd, check=True, env=env)
+    ensure_origin(clone_dir, clone_url, env)
+    checkout_git_ref(clone_dir, git_ref, expected_sha, env)
 
 
 def git_checkout_summary(clone_dir: Path, env: dict) -> Tuple[str, str]:
@@ -338,6 +383,7 @@ def main() -> int:
     parser.add_argument("--whitelist", type=Path, default=DEFAULT_WHITELIST)
     parser.add_argument("--git-url", default=DEFAULT_GIT_URL)
     parser.add_argument("--git-ref", default=DEFAULT_GIT_REF)
+    parser.add_argument("--git-sha", default=DEFAULT_GIT_SHA)
     parser.add_argument("--clone-dir", type=Path, default=DEFAULT_CLONE_DIR)
     parser.add_argument("--jobs", type=int, default=4)
     parser.add_argument("--git-ai-bin", type=Path, default=REPO_ROOT / "target" / "release" / "git-ai")
@@ -360,7 +406,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="git-ai-compat-home-") as isolated_home:
         env = make_isolated_env(isolated_home)
 
-        ensure_git_clone(args.clone_dir, args.git_url, args.git_ref, env)
+        ensure_git_clone(args.clone_dir, args.git_url, args.git_ref, args.git_sha, env)
         git_head, git_description = git_checkout_summary(args.clone_dir, env)
         ensure_git_build(args.clone_dir, args.jobs, env)
         git_tests_dir = args.clone_dir / "t"

--- a/tests/git-compat/run-core-tests.py
+++ b/tests/git-compat/run-core-tests.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_TESTS_FILE = REPO_ROOT / "tests" / "git-compat" / "core-tests.txt"
 DEFAULT_WHITELIST = REPO_ROOT / "tests" / "git-compat" / "whitelist.csv"
 DEFAULT_GIT_URL = "https://github.com/git/git.git"
+DEFAULT_GIT_REF = os.environ.get("GIT_COMPAT_REF", "v2.54.0")
 DEFAULT_CLONE_DIR = Path("/tmp/git-core-tests")
 
 
@@ -80,8 +82,6 @@ def make_isolated_env(isolated_home: str) -> dict:
     env["PATH"] = os.pathsep.join(sanitized)
 
     # Find the real git binary (PATH already sanitised above).
-    import shutil
-
     real_git = shutil.which("git", path=env["PATH"]) or "/usr/bin/git"
 
     # Write git-ai config.
@@ -109,21 +109,47 @@ def make_isolated_env(isolated_home: str) -> dict:
     return env
 
 
-def ensure_git_clone(clone_dir: Path, clone_url: str, env: dict) -> None:
+def ensure_git_clone(clone_dir: Path, clone_url: str, git_ref: str, env: dict) -> None:
     if clone_dir.exists():
-        return
-    clone_dir.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        ["git", "clone", "--depth", "1", clone_url, str(clone_dir)],
-        check=True,
+        if not (clone_dir / ".git").is_dir():
+            shutil.rmtree(clone_dir)
+        else:
+            if git_ref:
+                subprocess.run(
+                    ["git", "-C", str(clone_dir), "fetch", "--depth", "1", "origin", git_ref],
+                    check=True,
+                    env=env,
+                )
+                subprocess.run(
+                    ["git", "-C", str(clone_dir), "checkout", "--detach", "FETCH_HEAD"],
+                    check=True,
+                    env=env,
+                )
+            return
+    if not clone_dir.exists():
+        clone_dir.parent.mkdir(parents=True, exist_ok=True)
+        cmd = ["git", "clone", "--depth", "1"]
+        if git_ref:
+            cmd.extend(["--branch", git_ref])
+        cmd.extend([clone_url, str(clone_dir)])
+        subprocess.run(cmd, check=True, env=env)
+
+
+def git_checkout_summary(clone_dir: Path, env: dict) -> Tuple[str, str]:
+    head = subprocess.check_output(
+        ["git", "-C", str(clone_dir), "rev-parse", "HEAD"],
         env=env,
-    )
+        text=True,
+    ).strip()
+    description = subprocess.check_output(
+        ["git", "-C", str(clone_dir), "describe", "--tags", "--always", "--dirty"],
+        env=env,
+        text=True,
+    ).strip()
+    return head, description
 
 
 def ensure_git_build(clone_dir: Path, jobs: int, env: dict) -> None:
-    build_options = clone_dir / "GIT-BUILD-OPTIONS"
-    if build_options.exists():
-        return
     subprocess.run(
         [
             "make",
@@ -311,6 +337,7 @@ def main() -> int:
     parser.add_argument("--tests-file", type=Path, default=DEFAULT_TESTS_FILE)
     parser.add_argument("--whitelist", type=Path, default=DEFAULT_WHITELIST)
     parser.add_argument("--git-url", default=DEFAULT_GIT_URL)
+    parser.add_argument("--git-ref", default=DEFAULT_GIT_REF)
     parser.add_argument("--clone-dir", type=Path, default=DEFAULT_CLONE_DIR)
     parser.add_argument("--jobs", type=int, default=4)
     parser.add_argument("--git-ai-bin", type=Path, default=REPO_ROOT / "target" / "release" / "git-ai")
@@ -333,7 +360,8 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="git-ai-compat-home-") as isolated_home:
         env = make_isolated_env(isolated_home)
 
-        ensure_git_clone(args.clone_dir, args.git_url, env)
+        ensure_git_clone(args.clone_dir, args.git_url, args.git_ref, env)
+        git_head, git_description = git_checkout_summary(args.clone_dir, env)
         ensure_git_build(args.clone_dir, args.jobs, env)
         git_tests_dir = args.clone_dir / "t"
 
@@ -362,6 +390,7 @@ def main() -> int:
 
             cmd_preview = " ".join(shlex.quote(t) for t in tests)
             print(f"[+] Running core Git tests with: prove -j{args.jobs} {cmd_preview}")
+            print(f"[+] Git source ref={args.git_ref} description={git_description} head={git_head}")
             print(f"[+] GIT_TEST_INSTALLED={wrapper_dir}")
             print(f"[+] HOME={isolated_home} (isolated)")
 

--- a/tests/git-compat/run-core-tests.py
+++ b/tests/git-compat/run-core-tests.py
@@ -194,7 +194,10 @@ def ensure_git_clone(
     if clone_dir.exists() or clone_dir.is_symlink():
         if clone_dir.is_symlink():
             raise ValueError(f"Refusing to use symlinked Git source path: {clone_dir}")
-        if not (clone_dir / ".git").is_dir():
+        git_dir = clone_dir / ".git"
+        if git_dir.is_symlink():
+            raise ValueError(f"Refusing to use Git source checkout with symlinked .git directory: {clone_dir}")
+        if not git_dir.is_dir():
             raise FileExistsError(f"{clone_dir} exists but is not a Git checkout")
     if not clone_dir.exists():
         clone_dir.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Pin the upstream Git source used by the Git Core Compatibility workflow to `v2.54.0` instead of cloning the moving `git/git` default branch.

## Root cause

The compatibility job runs upstream Git tests through `git-ai`, but `git-ai` proxies to the runner's installed Git. On June 17, a fresh clone of upstream `git/git` picked up `2.55.0-rc0` tests for `--max-count-oldest`, while the Ubuntu runner still had Git `2.54.0`, so `t4202-log.sh` started failing with `fatal: unrecognized argument`.

## Changes

- Add `GIT_COMPAT_REF=v2.54.0` to the workflow.
- Key the Git source cache by the pinned ref instead of a weekly moving key.
- Make the workflow checkout and print the exact Git source SHA/tag.
- Add `--git-ref` support and checkout logging to `tests/git-compat/run-core-tests.py` so manual runs use the same pinned default.

## Validation

- `python3 -m py_compile tests/git-compat/run-core-tests.py`
- `python3 tests/git-compat/run-core-tests.py --help`
- `git diff --check`
- `task fmt`
- `task lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->