### PR TITLE
Spawn Windows daemon without PowerShell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.4.1"
 winreg = "0.55"
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Console"] }
 
 [features]
 test-support = ["dep:tempfile"]

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -341,6 +341,67 @@ fn daemon_runtime_dir(config: &DaemonConfig) -> Result<PathBuf, String> {
         .ok_or_else(|| "daemon lock path has no parent".to_string())
 }
 
+/// RAII guard that clears the inheritable flag on the process's standard
+/// handles (stdin/stdout/stderr) for its lifetime and restores it on drop.
+///
+/// Windows spawns every child via `CreateProcessW` with `bInheritHandles=TRUE`,
+/// so any inheritable handle in this process leaks into children regardless of
+/// the child's own stdio configuration. When we launch the detached daemon we
+/// must ensure it does not inherit our std handles -- if our stdout/stderr are
+/// pipe write-ends (because a parent captured our output), the daemon would
+/// keep them open for its entire lifetime and the parent's read would hang.
+#[cfg(windows)]
+struct NonInheritableStdHandles {
+    cleared: Vec<windows_sys::Win32::Foundation::HANDLE>,
+}
+
+#[cfg(windows)]
+impl NonInheritableStdHandles {
+    fn new() -> Self {
+        use windows_sys::Win32::Foundation::{
+            GetHandleInformation, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation,
+        };
+        use windows_sys::Win32::System::Console::{
+            GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+        };
+
+        let mut cleared = Vec::new();
+        for std_id in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+            // SAFETY: GetStdHandle/GetHandleInformation/SetHandleInformation are
+            // simple Win32 calls operating on the current process's handle table.
+            unsafe {
+                let handle = GetStdHandle(std_id);
+                if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+                    continue;
+                }
+                let mut flags: u32 = 0;
+                if GetHandleInformation(handle, &mut flags) == 0 {
+                    continue;
+                }
+                if flags & HANDLE_FLAG_INHERIT != 0
+                    && SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0) != 0
+                {
+                    cleared.push(handle);
+                }
+            }
+        }
+        Self { cleared }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for NonInheritableStdHandles {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::{HANDLE_FLAG_INHERIT, SetHandleInformation};
+        for handle in self.cleared.drain(..) {
+            // SAFETY: restoring the inheritable flag on a handle we just cleared.
+            unsafe {
+                SetHandleInformation(handle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+            }
+        }
+    }
+}
+
 #[cfg(any(windows, not(any(test, feature = "test-support"))))]
 fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
     // Use current_git_ai_exe() instead of current_exe() to resolve through
@@ -380,6 +441,20 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
             | CREATE_NEW_PROCESS_GROUP
             | CREATE_BREAKAWAY_FROM_JOB;
         child.creation_flags(preferred_flags);
+
+        // CreateProcessW (which std::process::Command wraps) is always called
+        // with bInheritHandles=TRUE, so the long-lived daemon would inherit
+        // every inheritable handle our process holds -- including the write-ends
+        // of the stdout/stderr pipes when our caller captured output (e.g. a
+        // parent that ran `git-ai bg start` via Command::output(), or the test
+        // harness). The daemon outlives us and never closes those handles, so
+        // the caller's read-end never sees EOF and its read blocks forever.
+        // PowerShell's Start-Process avoided this by launching with
+        // bInheritHandles=FALSE; replicate that guarantee by temporarily
+        // clearing the inheritable flag on our std handles across the spawn.
+        // The child uses null stdio, so it needs none of them.
+        let _no_inherit = NonInheritableStdHandles::new();
+
         match child.spawn() {
             Ok(_) => Ok(()),
             Err(preferred_err) => {

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -5,7 +5,9 @@ use crate::daemon::{
 };
 use crate::utils::LockFile;
 #[cfg(windows)]
-use crate::utils::{CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
+use crate::utils::{
+    CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS,
+};
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -13,8 +15,6 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
-#[cfg(windows)]
-use std::{ffi::OsStr, path::Path};
 
 pub fn handle_daemon(args: &[String]) {
     if args.is_empty() || is_help(args[0].as_str()) {
@@ -341,11 +341,6 @@ fn daemon_runtime_dir(config: &DaemonConfig) -> Result<PathBuf, String> {
         .ok_or_else(|| "daemon lock path has no parent".to_string())
 }
 
-#[cfg(windows)]
-fn powershell_single_quote_literal(value: &OsStr) -> String {
-    format!("'{}'", value.to_string_lossy().replace('\'', "''"))
-}
-
 #[cfg(any(windows, not(any(test, feature = "test-support"))))]
 fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
     // Use current_git_ai_exe() instead of current_exe() to resolve through
@@ -357,19 +352,20 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
 
     #[cfg(windows)]
     {
-        let script = format!(
-            "Start-Process -FilePath {} -ArgumentList @('bg','run') -WorkingDirectory {} -WindowStyle Hidden",
-            powershell_single_quote_literal(exe.as_os_str()),
-            powershell_single_quote_literal(Path::new(&runtime_dir).as_os_str())
-        );
-        let mut child = Command::new("powershell.exe");
+        // Spawn the daemon directly via the Windows process API (CreateProcessW,
+        // which std::process::Command wraps) instead of shelling out to
+        // PowerShell's Start-Process. PowerShell is blocked in some locked-down
+        // corporate environments (issue #1366), and it was only ever used here
+        // as a detachment launcher. The creation flags below provide the same
+        // detachment: DETACHED_PROCESS gives the daemon no inherited console,
+        // CREATE_NO_WINDOW suppresses any console window, CREATE_NEW_PROCESS_GROUP
+        // isolates it from parent signals, and CREATE_BREAKAWAY_FROM_JOB lets it
+        // outlive the short-lived git command that triggered the spawn.
+        let mut child = Command::new(&exe);
         child
-            .arg("-NoProfile")
-            .arg("-NonInteractive")
-            .arg("-WindowStyle")
-            .arg("Hidden")
-            .arg("-Command")
-            .arg(script)
+            .arg("bg")
+            .arg("run")
+            .current_dir(&runtime_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
@@ -379,8 +375,10 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
         }
         child.env_remove("GIT_AI");
 
-        let preferred_flags =
-            CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP | CREATE_BREAKAWAY_FROM_JOB;
+        let preferred_flags = CREATE_NO_WINDOW
+            | DETACHED_PROCESS
+            | CREATE_NEW_PROCESS_GROUP
+            | CREATE_BREAKAWAY_FROM_JOB;
         child.creation_flags(preferred_flags);
         match child.spawn() {
             Ok(_) => Ok(()),
@@ -389,7 +387,8 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
                     "detached daemon spawn with CREATE_BREAKAWAY_FROM_JOB failed, retrying without it: {}",
                     preferred_err
                 );
-                child.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
+                child
+                    .creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
                 child.spawn().map(|_| ()).map_err(|fallback_err| {
                     format!(
                         "failed to spawn detached daemon with flags {:#x}: {}; retry without CREATE_BREAKAWAY_FROM_JOB also failed: {}",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5857,10 +5857,17 @@ fn spawn_self_restart() -> Result<(), String> {
 
     #[cfg(windows)]
     {
+        use crate::utils::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, DETACHED_PROCESS};
         use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-        const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
-        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
+        // Match the detachment flags used by the wrapper's daemon spawn
+        // (commands::daemon::spawn_daemon_run_detached): DETACHED_PROCESS gives
+        // the child no inherited console, CREATE_NO_WINDOW suppresses any
+        // console window, and CREATE_NEW_PROCESS_GROUP isolates it from parent
+        // signals. No NonInheritableStdHandles guard is needed here: the daemon
+        // is configured with null stdio, so it holds no pipe handles a spawned
+        // child could inherit (the guard only matters when a parent captured our
+        // stdout/stderr via a pipe).
+        cmd.creation_flags(CREATE_NO_WINDOW | DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
     }
 
     cmd.spawn()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -346,6 +346,9 @@ pub const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
 /// Windows-specific flag to allow a child process to break away from the current job object
 #[cfg(windows)]
 pub const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x01000000;
+/// Windows-specific flag to detach the child from the parent's console
+#[cfg(windows)]
+pub const DETACHED_PROCESS: u32 = 0x00000008;
 /// Unescape a git-quoted path that may contain octal escape sequences.
 ///
 /// Git quotes filenames containing non-ASCII characters (and some special characters)
@@ -1190,6 +1193,12 @@ mod tests {
     #[test]
     fn test_create_breakaway_from_job_constant() {
         assert_eq!(CREATE_BREAKAWAY_FROM_JOB, 0x01000000);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_detached_process_constant() {
+        assert_eq!(DETACHED_PROCESS, 0x00000008);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

The Windows daemon was started by shelling out to `powershell.exe` running `Start-Process`, which fails in locked-down corporate environments where PowerShell is blocked (#1366). PowerShell was only ever used here as a detachment launcher.

This spawns `git-ai bg run` directly via `std::process::Command` (which wraps the native `CreateProcessW` Win32 API) and adds the `DETACHED_PROCESS` creation flag. `DETACHED_PROCESS` gives the daemon no inherited console (the same detachment `Start-Process` provided) with no external shell. It also unifies the Windows spawn path with the direct spawn already used on macOS/Linux.

`DETACHED_PROCESS` (0x8) combines safely with the existing flags: per the [Win32 docs](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags) it only conflicts with `CREATE_NEW_CONSOLE` (unused here); `CREATE_NO_WINDOW` is simply ignored alongside it.

**Scope:** Only daemon startup. `upgrade.rs` also uses PowerShell but for a different reason (a logged installer that must outlive the binary to release file locks during self-update), so it is intentionally left unchanged.

Fixes #1366.

### Handle inheritance (fixed in this PR)

The first direct-spawn commit hung the Windows CI test job until the 6h timeout. Root cause: `CreateProcessW` (which `std::process::Command` wraps) always runs with `bInheritHandles=TRUE`, so the long-lived daemon inherited every inheritable handle the launching process held. When a parent captured our output via `Command::output()` (as the async daemon tests do by running `bg start`), the daemon inherited the stdout/stderr pipe write-ends and never closed them, so the parent's read never saw EOF and blocked forever. `Start-Process` avoided this because it launched with `bInheritHandles=FALSE`.

The second commit on this branch fixes it with an RAII guard (`NonInheritableStdHandles`) that clears the `HANDLE_FLAG_INHERIT` flag on our std handles across the spawn and restores it on drop, giving the same `bInheritHandles=FALSE` guarantee. The detached daemon uses null stdio, so it needs none of those handles. This promotes `windows-sys` (already a dev-dependency) to a Windows runtime dependency for `GetStdHandle` and `Get`/`SetHandleInformation`.

### Self-restart consistency

A third commit aligns the daemon's own self-restart spawn (`spawn_self_restart` in `src/daemon.rs`) with the wrapper's spawn: it reuses the shared `crate::utils` flag constants instead of a duplicated local copy and adds `DETACHED_PROCESS`. This is a consistency change, not a hang fix. The self-restart parent is the daemon itself, which runs with null stdio, so it holds no pipe handles a child could inherit and the `NonInheritableStdHandles` guard is unnecessary on that path (documented inline).

## Docs & flags

No documentation or feature-flag changes are required:

- This is a purely internal implementation swap (PowerShell launcher to direct `CreateProcessW`). Behavior is identical from the user's perspective: the daemon just starts without requiring PowerShell.
- No new user-facing flag is introduced, and no existing `define_feature_flags!` entry changes. The new `DETACHED_PROCESS` constant is an internal Win32 flag value, not a config/feature flag.
- No existing doc described the PowerShell-based spawn (the PowerShell references in `README.md` are about the installer, which is unchanged), and `git-ai bg` help text never mentioned PowerShell, so it remains accurate.

## Build & test (Windows)

```powershell
# From the repo root
cargo build --bin git-ai

# Targeted regression test for detached daemon spawn
cargo test --test daemon_mode daemon_start_spawns_detached_run_process

# Broader daemon suite
cargo test --test daemon_mode

# Lint & format
cargo clippy --bin git-ai
cargo fmt --check
```

### Manual end-to-end test in a PowerShell-blocked shell

A bare `cargo build` only produces `target\debug\git-ai.exe`; it does not put `git-ai` on `PATH`. Install the fresh build first (`task dev`, or run `scripts/dev.ps1` directly if the `task` runner isn't installed), then simulate a locked-down environment in the same shell:

```powershell
# 1. Build + install the branch build (run from repo root).
#    If you have the `task` runner: `task dev`. Otherwise run the dev script directly:
powershell -NonInteractive -NoProfile -ExecutionPolicy Bypass -File scripts/dev.ps1

# 2. Hard-stop the running daemon so the next call spawns a fresh one with the new code
~\.git-ai\bin\git-ai.exe bg shutdown --hard

# 3. Confirm no daemon is running
Get-Process git-ai -ErrorAction SilentlyContinue

# 4. Simulate the locked-down env: block PowerShell for THIS shell only
$blocked = Join-Path $env:TEMP 'no-powershell'
New-Item -ItemType Directory -Force -Path $blocked | Out-Null
$env:Path = ($env:Path -split ';' | Where-Object { $_ -notmatch 'PowerShell|System32\\WindowsPowerShell' }) -join ';'
$env:Path = "$blocked;$env:Path"

# 5. Confirm PowerShell is unreachable in this shell
Get-Command powershell.exe -ErrorAction SilentlyContinue   # should print nothing
Get-Command pwsh.exe       -ErrorAction SilentlyContinue   # should print nothing

# 6. Trigger daemon auto-spawn (stay in THIS shell; opening a new terminal resets PATH)
git-ai status

# 7. Verify the daemon came up without PowerShell
git-ai bg status
Get-Process git-ai -ErrorAction SilentlyContinue
```

**Expected:** steps 6-7 succeed even with PowerShell blocked. `Get-Process` shows a `git-ai.exe` background process and no `powershell.exe`. On `main` the daemon fails to spawn because it relied on `powershell.exe Start-Process`. (`task dev` in step 1 must run before PowerShell is blocked, since `scripts/dev.ps1` itself runs in PowerShell. If `git-ai` doesn't resolve in step 6, use the full path `~\.git-ai\bin\git-ai.exe status`.)

## Verification done in this PR

- Cross-compiled type-check + clippy for `x86_64-pc-windows-gnu` (clean), including the handle-inheritance fix.
- Native Ubuntu: `cargo fmt`, `cargo clippy`, and the full `daemon_mode` suite pass, including `daemon_start_spawns_detached_run_process`.
- CI: Ubuntu and macOS jobs green. The handle-inheritance fix resolves the earlier Windows test-job hang.
- Manual Windows test with PowerShell disabled: committing routes through the daemon and authorship is recorded, confirming the daemon spawns and runs without PowerShell ([comment](https://github.com/git-ai-project/git-ai/pull/1587#issuecomment-4765069518)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

