### PR TITLE
fix pull rebase authorship cursor

### DIFF
--- a/docs/pull-rebase-authorship-loss-analysis-2026-06-21.md
+++ b/docs/pull-rebase-authorship-loss-analysis-2026-06-21.md
@@ -1,0 +1,266 @@
+# Pull Rebase Authorship Loss Analysis - 2026-06-21
+
+## Incident
+
+Repository: `/Users/svarlamov/projects/git-ai`
+
+The observed flow was:
+
+1. Local `main` was at `11afd537d`.
+2. A local commit was created:
+   `1e49c4dbf4d11c27c12ad041b5272556ecc03db5`
+   (`update release workflow protections`).
+3. `git push` was rejected because `origin/main` had advanced.
+4. `git pull` fetched remote updates but failed with Git's divergent-branch strategy error.
+5. `git pull --rebase` rebased the local commit onto `origin/main`, producing:
+   `c1c7ae1006127e039d779c9692d760dd43434176`.
+6. The authorship note remained on `1e49c4dbf...`, but no note was created for
+   `c1c7ae100...`.
+
+This was persistent: repeated `git ai show c1c7ae100...` did not recover the note.
+
+## Durable Evidence
+
+The original note existed and was readable:
+
+```text
+git notes --ref=ai list | rg '1e49|c1c7'
+42973ad90d26e51d152d8df9d16ad7d92f76a041 1e49c4dbf4d11c27c12ad041b5272556ecc03db5
+```
+
+`git ai show 1e49c4dbf` showed authorship data for Codex session
+`s_784e3644721859`; `git ai show c1c7ae100...` reported no authorship data.
+
+The rebase mapping is exact:
+
+```text
+git range-diff --no-color --no-abbrev -s --creation-factor=100 \
+  11afd537d..1e49c4dbf 5a3a97f65..c1c7ae100
+
+1:  1e49c4dbf4d11c27c12ad041b5272556ecc03db5 = 1:  c1c7ae1006127e039d779c9692d760dd43434176 update release workflow protections
+```
+
+The commit relationship is non-fast-forward from the old local commit to the
+rebased commit:
+
+```text
+git merge-base 1e49c4dbf c1c7ae100
+11afd537d...
+
+git merge-base --is-ancestor 1e49c4dbf c1c7ae100
+# exit 1
+
+git merge-base --is-ancestor 5a3a97f65 c1c7ae100
+# exit 0
+```
+
+The relevant reflog shape was:
+
+```text
+HEAD:
+11afd537d -> 1e49c4dbf  commit: update release workflow protections
+1e49c4dbf -> 5a3a97f65  pull --rebase (start): checkout 5a3a97f65...
+5a3a97f65 -> c1c7ae100  pull --rebase (pick): update release workflow protections
+c1c7ae100 -> c1c7ae100  pull --rebase (finish): returning to refs/heads/main
+
+refs/heads/main:
+11afd537d -> 1e49c4dbf  commit: update release workflow protections
+1e49c4dbf -> c1c7ae100  pull --rebase (finish): refs/heads/main onto 5a3a97f65...
+
+refs/remotes/origin/main:
+11afd537d -> 5a3a97f65  pull: fast-forward
+```
+
+The notes reflog showed a note write for `1e49c4dbf...`, followed by a notes
+merge from the pull, and then an empty fast-import. There was no later write for
+`c1c7ae100...`. That means the target note was never written, not written and
+then deleted.
+
+The repo's `.git/ai/rewrite_log` had no entries for `1e49c4dbf...`,
+`c1c7ae100...`, `5a3a97f65...`, or `11afd537d...`.
+
+## Ruled Out
+
+- Missing source note: ruled out. The note exists and deserializes through
+  `git ai show 1e49c4dbf`.
+- Missing or ambiguous rebase mapping: ruled out. `range-diff` maps the old and
+  new commits exactly.
+- HTTP/notes-db backend inconsistency: ruled out for this repo. The config uses
+  Git notes, and the notes DB did not contain either commit.
+- Later cleanup deleting the target note: unlikely. The notes reflog does not
+  show a target-note write for `c1c7ae100...`.
+- Daemon totally missing the successful pull: unlikely. The notes merge after
+  the pull proves the successful pull command was processed far enough to run
+  pull side effects.
+- Missing user-facing daemon log line for pull/rebase: not evidence by itself.
+  The current daemon info log for `git write op completed` is not emitted for
+  every tracked write command.
+
+## Root Cause
+
+The failure happened because the successful `pull --rebase` did not supply
+`detect_and_handle_non_ff_rewrites` with a non-fast-forward old/new pair
+`1e49c4dbf... -> c1c7ae100...`.
+
+The concrete mechanism is a cold reflog cursor plus late async offset capture
+for the multi-row `pull --rebase` reflog span:
+
+1. Trace2 command frames are received by the daemon after Git has already
+   written some or all reflog rows.
+2. `capture_reflog_start_offsets_for_worktree` snapshots current reflog byte
+   lengths asynchronously (`src/daemon/ref_cursor.rs:1879`).
+3. The preceding commit can still get an authorship note while leaving the HEAD
+   cursor cold. If the commit's async start offset is captured at EOF after the
+   commit row, `command_start_offset_is_authoritative` returns false
+   (`src/daemon/ref_cursor.rs:1629`). Enrichment can still find the commit row by
+   scanning, but `consume_entry` only marks it consumed and then compacts from
+   the current cursor floor (`src/daemon/ref_cursor.rs:1678`); with no usable
+   floor, older unconsumed reflog rows prevent the cursor from becoming healthy.
+4. On the later `pull --rebase`, a cold cursor can use the captured offset as a
+   hard starting floor (`src/daemon/ref_cursor.rs:190`).
+5. The current cold-start clamp only knows how to recognize `commit` entries
+   (`src/daemon/ref_cursor.rs:288`). It does not know how to clamp back to the
+   beginning of a `pull --rebase` span.
+6. If the daemon starts at or after the first pull-rebase HEAD row, enrichment
+   can miss `HEAD 1e49c4dbf -> 5a3a97f65`.
+7. The daemon may then expose only `HEAD 5a3a97f65 -> c1c7ae100`, which is a
+   fast-forward, or expose no useful branch/HEAD rewrite pair at all. If the
+   branch cursor also seeds after the `refs/heads/main` finish row, it misses the
+   direct branch rewrite `1e49c4dbf -> c1c7ae100`.
+8. `detect_and_handle_non_ff_rewrites` filters to branch changes, falls back to
+   HEAD changes only when branch changes are empty, and skips any collapsed pair
+   where `old_tip` is an ancestor of `new_tip`
+   (`src/daemon.rs:3987`, `src/daemon.rs:4018`, `src/daemon.rs:4098`).
+9. Since rewrite detection never calls
+   `handle_non_fast_forward_rewrite(repo, 1e49c4dbf..., c1c7ae100..., ...)`, the
+   note migration never runs.
+
+This explains why the source note is intact, why the target note is absent, why
+the pull notes merge still happened, and why the failure was persistent.
+
+Confidence: high that the miss is before rewrite-note writing; high that the
+mechanism is cold/late cursor seeding for the pull-rebase span. The exact
+`NormalizedCommand.ref_changes` for the original incident was not persisted, so
+that internal value cannot be directly recovered.
+
+## Relevant Code Paths
+
+- `src/daemon/ref_cursor.rs:190`:
+  command-start reflog offsets initialize or hint the cursor.
+- `src/daemon/ref_cursor.rs:248`:
+  cold-start seed clamping can move a late offset back to a matching own entry.
+- `src/daemon/ref_cursor.rs:288`:
+  cold-start match specs currently exist only for commit/amend.
+- `src/daemon/ref_cursor.rs:1051`:
+  `pull --rebase` HEAD spans are consumed from a start row when one is visible.
+- `src/daemon/ref_cursor.rs:1108`:
+  `find_pull_start_entry` scans from the cursor's reflog start offset.
+- `src/daemon/ref_cursor.rs:1629`:
+  cold command-start offsets are treated as authoritative only when records
+  exist after the offset.
+- `src/daemon/ref_cursor.rs:1678`:
+  consuming a found row marks it consumed and compacts from the existing cursor
+  floor; it does not by itself establish a healthy cursor if older rows block
+  compaction.
+- `src/daemon/ref_cursor.rs:2539`:
+  no-op reflog rows are filtered, so the no-op rebase finish row is not a
+  recoverable transition.
+- `src/daemon.rs:3987`:
+  non-fast-forward rewrite detection starts from enriched `cmd.ref_changes`.
+- `src/daemon.rs:4098`:
+  fast-forward pairs are skipped.
+- `src/authorship/rewrite.rs:60`:
+  once called with the correct old/new pair, rewrite handling derives
+  range-diff mappings and shifts notes.
+- `src/authorship/rewrite.rs:337`:
+  a missing source note would skip a mapping, but the source note in this
+  incident exists.
+
+## Subagent Review
+
+Three read-only code reviews converged on the same boundary:
+
+- Cursor/enrichment review: confirmed the commit note can be written while the
+  reflog cursor remains cold, and that `pull --rebase` has no cold-start clamp
+  for its start/pick/finish span. This is the most likely direct root cause.
+- Rewrite/notes review: found no plausible silent failure once correct
+  `ref_changes` and the source note are present. `handle_non_fast_forward_rewrite`
+  would range-diff, fetch missing source notes, and write target notes or return
+  an error. Side-effect errors would be logged.
+- Test harness review: confirmed `TestRepo::git()` does not literally block
+  after every command. It marks tracked commands with a test-sync session and
+  records expected completions; the actual wait happens at explicit sync/read
+  boundaries. `pull` is tracked, but the harness still runs in a fresh temp repo
+  with cleaner cursor and reflog state than the real incident.
+
+No subagent found a more likely root cause outside ref-change enrichment.
+
+## Why A Simple Passing Test May Not Reproduce
+
+A plain `TestRepo` test can run the same user-level commands and still pass if
+the daemon captures reflog offsets early enough or already has healthy cursors
+for the HEAD and branch reflogs.
+
+The harness also adds test-sync config to tracked commands. In
+`tests/integration/repos/test_repo.rs`, `pull` is a tracked command for test sync
+(`src/daemon/test_sync.rs:16`), and `git()` records expected completion sessions
+for tracked invocations (`tests/integration/repos/test_repo.rs:2695`,
+`tests/integration/repos/test_repo.rs:2756`). The actual wait happens through
+`sync_daemon_force` (`tests/integration/repos/test_repo.rs:2226`), typically
+from read/assertion helpers such as `read_authorship_note`
+(`tests/integration/repos/test_repo.rs:3033`) or commit helpers
+(`tests/integration/repos/test_repo.rs:3123`). That makes normal tests more
+deterministic than the user's shell flow without guaranteeing the same cursor
+state.
+
+This does not make TestRepo invalid. It means a simple normal-flow red test must
+either naturally reproduce the cold/late cursor state or set up the same state
+using normal git-ai operations only. If the simple test cannot reproduce, that
+is useful evidence that the bug depends on a timing/cursor-state precondition
+not automatically present in a fresh harness repo.
+
+## Remaining Questions
+
+- What exact cursor state existed for HEAD and `refs/heads/main` before the
+  successful `pull --rebase` command in the real daemon?
+- Did the failed plain `git pull` leave a cold/late branch cursor or only update
+  the remote-tracking cursor?
+- Did the successful `pull --rebase` produce `cmd.ref_changes` containing only
+  the fast-forward pick row, only the branch finish row, no useful changes, or a
+  different collapsed set?
+
+The durable repo state strongly narrows the failure to enrichment/rewrite
+detection, but those exact in-memory command details were not persisted.
+
+## Remediation Direction
+
+The likely fix is to make pull-rebase/rebase span recovery robust under cold and
+late ingress offsets:
+
+- Add a command-specific cold-start match spec for `pull --rebase`/rebase spans,
+  not just commit entries.
+- Ensure span recovery can clamp to and consume the first non-noop HEAD row
+  (`old local tip -> onto`) when the ingress offset lands inside the span.
+- Ensure branch finish recovery produces or preserves the collapsed
+  `old local tip -> rebased tip` non-fast-forward pair.
+- Add a faithful e2e red test that uses the normal daemon and normal TestRepo
+  flow, keeping any special setup to ordinary git/git-ai operations. If that
+  cannot reproduce the failure, document the remaining timing/state delta rather
+  than forcing it with custom trace2 injection.
+
+## Hardening Implemented
+
+See `docs/pull-rebase-hardening-worklog-2026-06-21.md` for the running log.
+
+The implemented fix keeps the daemon's trace2 ingestion asynchronous and does
+not change production operation ordering. It makes cold-start reflog seed
+clamping span-aware for `pull --rebase` and `rebase`:
+
+- late offsets inside a pull/rebase span are clamped back to the span start;
+- common-ref offsets inside the branch finish row are clamped back to that row;
+- true command-start boundaries are not rewound into older completed spans.
+
+The deterministic proof is the cursor-level red test
+`cold_pull_rebase_late_ingress_offset_still_recovers_start_and_branch_finish`,
+which failed before the fix with only the fast-forward pick row and passes after
+the fix with the full non-fast-forward pair available for rewrite detection.

--- a/docs/pull-rebase-hardening-worklog-2026-06-21.md
+++ b/docs/pull-rebase-hardening-worklog-2026-06-21.md
@@ -1,0 +1,138 @@
+# Pull Rebase Hardening Worklog - 2026-06-21
+
+## Goal
+
+Prove and harden the `pull --rebase` authorship-loss failure without changing
+production operational semantics:
+
+- keep trace2 as the source of git command events;
+- keep daemon processing asynchronous;
+- do not replace trace2 frames or inject fake git operations in e2e coverage;
+- use TestRepo normal daemon flow where possible;
+- keep deterministic unit coverage for the exact ref-cursor failure shape.
+
+## Current Hypothesis Under Test
+
+The daemon can write the source commit note while the reflog cursor remains
+cold. A later `pull --rebase` command can then receive async reflog-start
+offsets after the rebase start row or branch finish row. Current cold-start
+clamping recognizes commits but not pull-rebase spans, so enrichment can miss the
+non-fast-forward pair `old local commit -> rebased commit`.
+
+## Test Plan
+
+1. Add a red unit test in `src/daemon/ref_cursor.rs` that forces:
+   - cold cursor;
+   - `pull --rebase` HEAD reflog containing start, pick, and no-op finish;
+   - branch reflog containing the direct finish move;
+   - captured offsets after the HEAD start row and at branch EOF.
+2. Add or adjust a plain TestRepo repro that runs:
+   - source AI commit with confirmed note;
+   - rejected push;
+   - failed plain pull;
+   - successful `pull --rebase`;
+   - target note assertion.
+3. Add a cold-repo TestRepo scenario initialized with trace2 disabled, then
+   start the normal daemon and run pull-rebase under delayed/pressured ingest to
+   look for nondeterministic reproduction without custom trace2 frames.
+4. Fix cursor enrichment so pull-rebase spans recover from late cold offsets.
+5. Run focused tests repeatedly enough to validate both deterministic and
+   pressure paths.
+
+## Findings
+
+- Existing `TestRepo::git()` does not literally wait after every command. It
+  records expected daemon sessions for tracked commands; explicit sync/read
+  boundaries wait for those sessions.
+- The deterministic code-level failure shape is independent of note writing:
+  the source note can exist, and migration still fails if `cmd.ref_changes`
+  lacks the non-fast-forward old/new pair.
+- A purely normal TestRepo flow proves the user-visible command sequence and can
+  stress it, but it does not deterministically force the late-offset/cold-cursor
+  timing. The deterministic red proof is therefore at the ref-cursor enrichment
+  boundary; adding a test-only trace timing hook would be more invasive and was
+  not needed for the fix.
+- Added `cold_pull_rebase_late_ingress_offset_still_recovers_start_and_branch_finish`
+  in `src/daemon/ref_cursor.rs`. Before the fix it failed with only
+  `HEAD C -> D`, exactly proving the missing non-fast-forward pair. After the
+  fix it recovers `HEAD B -> C`, `HEAD C -> D`, and
+  `refs/heads/main B -> D`.
+- Added the symmetric
+  `cold_rebase_late_ingress_offset_still_recovers_start_and_branch_finish`
+  coverage for plain `git rebase`.
+- Added true-boundary guard tests for pull-rebase and rebase to prove the new
+  cold span clamp does not rewind a legitimate command-start offset into an
+  older completed span.
+- Added
+  `test_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship` in
+  `tests/integration/cold_trace2_repo.rs`: repo and remote are initialized with
+  trace2 disabled, then the daemon starts and runs the exact rejected push,
+  failed pull, successful pull-rebase flow.
+- Added ignored stress coverage
+  `stress_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship`;
+  one explicit run completed 24 cold pull-rebase attempts across 8 concurrent
+  workers without reproducing the note loss after the fix.
+
+## Fix Direction
+
+- Keep async trace2 ingestion unchanged.
+- Add span-aware cold-start clamping for pull and rebase reflog spans.
+- Avoid moving a true pre-command offset backward into old history by refusing
+  to clamp if a newer matching start row exists after the captured offset.
+- For common refs, clamp only when the captured offset is inside the matching
+  branch reflog row and there is no newer matching row after the offset.
+- If a newer matching start row exists after the captured offset, treat the
+  offset as a real command-start boundary and do not clamp backward.
+
+## Verification Log
+
+- `task test TEST_FILTER=cold_pull_rebase_late_ingress_offset_still_recovers_start_and_branch_finish CARGO_TEST_ARGS="--lib" NO_CAPTURE=true`
+  - failed before the fix with only `HEAD C -> D`;
+  - passed after the fix.
+- `task test TEST_FILTER=cold_start_late_ingress_offset_does_not_skip_commit_on_uninitialized_head_cursor CARGO_TEST_ARGS="--lib"`:
+  passed.
+- `task test TEST_FILTER=commit_reflog_boundary_skips_untraced_duplicate_message CARGO_TEST_ARGS="--lib"`:
+  passed.
+- `task test TEST_FILTER=pull_rebase_span_starts_at_start_entry_when_expected_state_matches_pick CARGO_TEST_ARGS="--lib"`:
+  passed.
+- `task test TEST_FILTER=rebase_span_stops_at_new_rebase_start_before_finish CARGO_TEST_ARGS="--lib"`:
+  passed.
+- `task test TEST_FILTER=test_rejected_push_failed_pull_then_pull_rebase_preserves_committed_ai_authorship NO_CAPTURE=true`:
+  passed.
+- `task test TEST_FILTER=test_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship NO_CAPTURE=true`:
+  passed.
+- `task test TEST_FILTER=stress_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship EXTRA_TEST_BINARY_ARGS="--ignored" NO_CAPTURE=true`:
+  passed.
+- `task test TEST_FILTER=cold_pull_rebase_true_boundary_does_not_replay_older_pull_span CARGO_TEST_ARGS="--lib"`:
+  passed.
+- `task test TEST_FILTER=cold_rebase_true_boundary_does_not_replay_older_rebase_span CARGO_TEST_ARGS="--lib"`:
+  passed.
+- `task test TEST_FILTER=cold_ CARGO_TEST_ARGS="--lib"`:
+  passed 9 cold ref-cursor tests.
+- `task test TEST_FILTER=daemon::ref_cursor::tests CARGO_TEST_ARGS="--lib"`:
+  passed all 40 ref-cursor unit tests.
+- `task test CARGO_TEST_ARGS="--lib"`:
+  passed all 1840 lib tests.
+- `task test TEST_FILTER=cold_trace2_repo`:
+  passed 32 non-ignored cold trace2 integration tests; ignored only the new
+  stress test unless explicitly requested.
+- `task test TEST_FILTER=pull_rebase_ff`:
+  interrupted after several minutes while
+  `test_fast_forward_pull_without_local_changes` was still running; all emitted
+  pull/rebase tests before the interruption had passed. This needs a narrower
+  follow-up if we want a full `pull_rebase_ff` sweep in this branch.
+- `task test TEST_FILTER=test_fast_forward_pull_without_local_changes NO_CAPTURE=true`:
+  passed both generated variants quickly; the broad-filter interruption does
+  not appear to be a deterministic failure in that test.
+- Serial retry via `EXTRA_TEST_BINARY_ARGS="--test-threads 1"` is not supported
+  by the task wrapper because it already supplies `--test-threads 10`.
+- `task build`:
+  passed.
+- `task lint`:
+  passed.
+- `task test`:
+  completed the full test run. The pull/rebase and rebase-heavy integration
+  tests, including `pull_rebase_ff`, passed in this run. The suite failed only
+  in `graphite::test_gt_navigation_preserves_attribution` with:
+  `Failed to execute gt ["checkout", "nav-2"]: No such file or directory (os error 2)`.
+  That failure is outside the ref-cursor/pull-rebase path changed here.

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -99,6 +99,20 @@ struct ReflogAnchor {
     end_offset: u64,
 }
 
+enum ColdSeedMatchSpec {
+    SingleEntry {
+        expected: ExpectedTransition,
+        prefixes: Vec<String>,
+    },
+    PullSpan {
+        action: String,
+        expected: ExpectedTransition,
+    },
+    RebaseSpan {
+        expected: ExpectedTransition,
+    },
+}
+
 impl RefCursor {
     pub fn new(family: FamilyKey) -> Self {
         Self {
@@ -257,55 +271,120 @@ impl RefCursor {
         let Some(path) = self.reflog_path_for_key(key) else {
             return Ok(offset);
         };
-        let Some((expected, prefixes)) = self.cold_seed_match_spec(cmd) else {
+        let Some(spec) = self.cold_seed_match_spec(cmd) else {
             // No command-specific matcher (e.g. update-ref --stdin / stash that
             // match by transition only): keep the offset as the boundary to
             // preserve existing first-observed-boundary semantics.
             return Ok(offset);
         };
+        match spec {
+            ColdSeedMatchSpec::SingleEntry { expected, prefixes } => {
+                let prefix_refs = prefixes.iter().map(String::as_str).collect::<Vec<_>>();
+                let reference = if let Some(reference) = key.strip_prefix("common:") {
+                    reference.to_string()
+                } else {
+                    "HEAD".to_string()
+                };
+                let entries = read_reflog_entries(key.to_string(), &path, &reference, None)?;
+                let earliest_own = entries
+                    .into_iter()
+                    .filter(|entry| {
+                        entry.start_offset < offset
+                            && expected.matches(entry)
+                            && message_matches(&entry.message, &prefix_refs)
+                    })
+                    .map(|entry| entry.start_offset)
+                    .min();
+                Ok(earliest_own.unwrap_or(offset))
+            }
+            ColdSeedMatchSpec::PullSpan { action, expected } => {
+                self.clamp_seed_to_pull_span_entry(key, &path, offset, &action, expected)
+            }
+            ColdSeedMatchSpec::RebaseSpan { expected } => {
+                self.clamp_seed_to_rebase_span_entry(key, &path, offset, expected)
+            }
+        }
+    }
+
+    fn clamp_seed_to_pull_span_entry(
+        &self,
+        key: &str,
+        path: &Path,
+        offset: u64,
+        action: &str,
+        expected: ExpectedTransition,
+    ) -> Result<u64, GitAiError> {
         let reference = if let Some(reference) = key.strip_prefix("common:") {
             reference.to_string()
         } else {
             "HEAD".to_string()
         };
-        let entries = read_reflog_entries(key.to_string(), &path, &reference, None)?;
-        let earliest_own = entries
-            .into_iter()
-            .filter(|entry| {
-                entry.start_offset < offset
-                    && expected.matches(entry)
-                    && message_matches(&entry.message, &prefixes)
-            })
-            .map(|entry| entry.start_offset)
-            .min();
-        Ok(earliest_own.unwrap_or(offset))
+        let entries = read_reflog_entries_including_noops(key.to_string(), path, &reference, None)?;
+        let prefixes = pull_reflog_message_prefixes(action);
+        let prefix_refs = prefixes.iter().map(String::as_str).collect::<Vec<_>>();
+
+        if key.starts_with("common:") {
+            return Ok(
+                clamp_seed_to_entry_containing_offset(&entries, offset, &prefix_refs)
+                    .unwrap_or(offset),
+            );
+        }
+
+        Ok(pull_span_start_containing_offset(&entries, offset, action, expected).unwrap_or(offset))
+    }
+
+    fn clamp_seed_to_rebase_span_entry(
+        &self,
+        key: &str,
+        path: &Path,
+        offset: u64,
+        expected: ExpectedTransition,
+    ) -> Result<u64, GitAiError> {
+        let reference = if let Some(reference) = key.strip_prefix("common:") {
+            reference.to_string()
+        } else {
+            "HEAD".to_string()
+        };
+        let entries = read_reflog_entries_including_noops(key.to_string(), path, &reference, None)?;
+        if key.starts_with("common:") {
+            return Ok(
+                clamp_seed_to_entry_containing_offset(&entries, offset, &["rebase"])
+                    .unwrap_or(offset),
+            );
+        }
+
+        Ok(rebase_span_start_containing_offset(&entries, offset, expected).unwrap_or(offset))
     }
 
     /// The expected transition + reflog message prefixes used to recognize a
     /// command's OWN entry during cold-start seed clamping. Returns None for
     /// commands matched by transition alone (no message discriminator), where
     /// clamping must not change the seed (update-ref --stdin, stash, etc.).
-    fn cold_seed_match_spec(
-        &self,
-        cmd: &NormalizedCommand,
-    ) -> Option<(ExpectedTransition, Vec<&'static str>)> {
-        // Only commit/amend entries carry a message specific enough to identify
-        // the command's own entry unambiguously (both on HEAD and on the branch
-        // ref it moves). These are exactly the attribution-critical cases the
-        // concurrent-burst / rebase-patch-stack flake hits.
+    fn cold_seed_match_spec(&self, cmd: &NormalizedCommand) -> Option<ColdSeedMatchSpec> {
+        // Only commands with enough reflog structure to distinguish their own
+        // rows should clamp a cold asynchronous seed backward. Single-entry
+        // commits use their subject-specific reflog message; rebase/pull use
+        // their start/pick/finish span shape.
         let args = command_args(cmd);
         match cmd.primary_command.as_deref()? {
             "commit" => {
                 let amend = args.iter().any(|arg| arg == "--amend");
-                let prefixes: Vec<&'static str> = if amend {
-                    vec!["commit (amend):"]
+                let prefixes: Vec<String> = if amend {
+                    vec!["commit (amend):".to_string()]
                 } else {
-                    vec!["commit", "commit (initial):"]
+                    vec!["commit".to_string(), "commit (initial):".to_string()]
                 };
                 let expected = ExpectedTransition::default()
                     .with_reflog_messages(commit_reflog_messages(&args, amend));
-                Some((expected, prefixes))
+                Some(ColdSeedMatchSpec::SingleEntry { expected, prefixes })
             }
+            "pull" => Some(ColdSeedMatchSpec::PullSpan {
+                action: pull_reflog_action(cmd),
+                expected: ExpectedTransition::default(),
+            }),
+            "rebase" => Some(ColdSeedMatchSpec::RebaseSpan {
+                expected: ExpectedTransition::default(),
+            }),
             _ => None,
         }
     }
@@ -2462,6 +2541,78 @@ fn pull_reflog_action_starts_new_command(message: &str, action: &str) -> bool {
     )
 }
 
+fn clamp_seed_to_entry_containing_offset(
+    entries: &[CursorEntry],
+    offset: u64,
+    message_prefixes: &[&str],
+) -> Option<u64> {
+    // A matching row after the offset means the offset is a real command-start
+    // boundary before the current command's reflog write. Do not rewind into
+    // older history in that case.
+    if entries.iter().any(|entry| {
+        entry.start_offset >= offset && message_matches(&entry.message, message_prefixes)
+    }) {
+        return None;
+    }
+
+    // If the asynchronous offset landed at EOF or in the middle of the command's
+    // own branch-finish row, seed from the row start so the parser never begins
+    // inside a reflog record.
+    entries
+        .iter()
+        .rev()
+        .find(|entry| {
+            entry.start_offset < offset
+                && offset <= entry.end_offset
+                && message_matches(&entry.message, message_prefixes)
+        })
+        .map(|entry| entry.start_offset)
+}
+
+fn pull_span_start_containing_offset(
+    entries: &[CursorEntry],
+    offset: u64,
+    action: &str,
+    expected: ExpectedTransition,
+) -> Option<u64> {
+    // If a rebase/pull start row exists after the offset, the offset is a true
+    // boundary before the current span. Keep it as-is.
+    if entries.iter().any(|entry| {
+        entry.start_offset >= offset && pull_reflog_action_is(&entry.message, action, "start")
+    }) {
+        return None;
+    }
+
+    entries
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(idx, entry)| {
+            entry.start_offset < offset
+                && pull_reflog_action_is(&entry.message, action, "start")
+                && expected.matches_span_boundary(entry)
+                && pull_span_covers_offset(entries, *idx, offset, action)
+        })
+        .map(|(_, entry)| entry.start_offset)
+}
+
+fn pull_span_covers_offset(
+    entries: &[CursorEntry],
+    start_idx: usize,
+    offset: u64,
+    action: &str,
+) -> bool {
+    for entry in entries.iter().skip(start_idx + 1) {
+        if entry.start_offset >= offset {
+            return true;
+        }
+        if pull_reflog_action_starts_new_command(&entry.message, action) {
+            return offset <= entry.end_offset;
+        }
+    }
+    true
+}
+
 fn rebase_reflog_action(message: &str) -> Option<&str> {
     let rest = message.strip_prefix("rebase")?;
     let open = rest.find('(')?;
@@ -2472,6 +2623,51 @@ fn rebase_reflog_action(message: &str) -> Option<&str> {
 
 fn rebase_reflog_action_is(message: &str, expected: &str) -> bool {
     rebase_reflog_action(message).is_some_and(|action| action == expected)
+}
+
+fn rebase_reflog_action_starts_new_command(message: &str) -> bool {
+    matches!(
+        rebase_reflog_action(message),
+        Some("start" | "continue" | "skip" | "abort" | "quit" | "finish")
+    )
+}
+
+fn rebase_span_start_containing_offset(
+    entries: &[CursorEntry],
+    offset: u64,
+    expected: ExpectedTransition,
+) -> Option<u64> {
+    // If a rebase start row exists after the offset, the offset is a true
+    // boundary before the current span. Keep it as-is.
+    if entries.iter().any(|entry| {
+        entry.start_offset >= offset && rebase_reflog_action_is(&entry.message, "start")
+    }) {
+        return None;
+    }
+
+    entries
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(idx, entry)| {
+            entry.start_offset < offset
+                && rebase_reflog_action_is(&entry.message, "start")
+                && expected.matches_span_boundary(entry)
+                && rebase_span_covers_offset(entries, *idx, offset)
+        })
+        .map(|(_, entry)| entry.start_offset)
+}
+
+fn rebase_span_covers_offset(entries: &[CursorEntry], start_idx: usize, offset: u64) -> bool {
+    for entry in entries.iter().skip(start_idx + 1) {
+        if entry.start_offset >= offset {
+            return true;
+        }
+        if rebase_reflog_action_starts_new_command(&entry.message) {
+            return offset <= entry.end_offset;
+        }
+    }
+    true
 }
 
 fn rebase_start_checkout_target_from_args(args: &[String]) -> Option<String> {
@@ -4491,6 +4687,156 @@ mod tests {
     }
 
     #[test]
+    fn cold_rebase_late_ingress_offset_still_recovers_start_and_branch_finish() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
+
+        let start_line = format!(
+            "{B} {C} Test User <test@example.com> 0 +0000\trebase (start): checkout main\n"
+        );
+        let pick_line =
+            format!("{C} {D} Test User <test@example.com> 0 +0000\trebase (pick): Local commit\n");
+        let finish_line = format!(
+            "{D} {D} Test User <test@example.com> 0 +0000\trebase (finish): returning to refs/heads/topic\n"
+        );
+        fs::write(
+            git_dir.join("logs/HEAD"),
+            format!("{start_line}{pick_line}{finish_line}"),
+        )
+        .unwrap();
+        let late_head_offset = start_line.len() as u64;
+
+        let branch_line = format!(
+            "{B} {D} Test User <test@example.com> 0 +0000\trebase (finish): refs/heads/topic onto main\n"
+        );
+        fs::write(git_dir.join("logs/refs/heads/topic"), &branch_line).unwrap();
+        let late_branch_offset = branch_line.len() as u64;
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let mut state = family_state(&family);
+        state.refs.insert("HEAD".to_string(), C.to_string());
+        state
+            .refs
+            .insert("refs/heads/topic".to_string(), C.to_string());
+        let mut cursor = RefCursor::new(family.clone());
+        let mut cmd = command_with_worktree(&family, Some(worktree), &["rebase", "main"]);
+        cmd.reflog_start_offsets
+            .insert(head_key(&git_dir), late_head_offset);
+        cmd.reflog_start_offsets
+            .insert(common_key("refs/heads/topic"), late_branch_offset);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert_eq!(
+            cmd.ref_changes,
+            vec![
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: B.to_string(),
+                    new: C.to_string(),
+                },
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: C.to_string(),
+                    new: D.to_string(),
+                },
+                RefChange {
+                    reference: "refs/heads/topic".to_string(),
+                    old: B.to_string(),
+                    new: D.to_string(),
+                },
+            ],
+            "cold late rebase enrichment must preserve the non-fast-forward local-tip to rebased-tip pair"
+        );
+    }
+
+    #[test]
+    fn cold_rebase_true_boundary_does_not_replay_older_rebase_span() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
+
+        let old_start = format!(
+            "{A} {B} Test User <test@example.com> 0 +0000\trebase (start): checkout main\n"
+        );
+        let old_pick =
+            format!("{B} {C} Test User <test@example.com> 0 +0000\trebase (pick): Old commit\n");
+        let old_finish = format!(
+            "{C} {C} Test User <test@example.com> 0 +0000\trebase (finish): returning to refs/heads/topic\n"
+        );
+        let current_start = format!(
+            "{D} {E} Test User <test@example.com> 0 +0000\trebase (start): checkout main\n"
+        );
+        let current_pick = format!(
+            "{E} {F} Test User <test@example.com> 0 +0000\trebase (pick): Current commit\n"
+        );
+        let current_finish = format!(
+            "{F} {F} Test User <test@example.com> 0 +0000\trebase (finish): returning to refs/heads/topic\n"
+        );
+        let true_head_boundary = (old_start.len() + old_pick.len() + old_finish.len()) as u64;
+        fs::write(
+            git_dir.join("logs/HEAD"),
+            format!(
+                "{old_start}{old_pick}{old_finish}{current_start}{current_pick}{current_finish}"
+            ),
+        )
+        .unwrap();
+
+        let old_branch = format!(
+            "{A} {C} Test User <test@example.com> 0 +0000\trebase (finish): refs/heads/topic onto main\n"
+        );
+        let current_branch = format!(
+            "{D} {F} Test User <test@example.com> 0 +0000\trebase (finish): refs/heads/topic onto main\n"
+        );
+        let true_branch_boundary = old_branch.len() as u64;
+        fs::write(
+            git_dir.join("logs/refs/heads/topic"),
+            format!("{old_branch}{current_branch}"),
+        )
+        .unwrap();
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let mut state = family_state(&family);
+        state.refs.insert("HEAD".to_string(), D.to_string());
+        state
+            .refs
+            .insert("refs/heads/topic".to_string(), D.to_string());
+        let mut cursor = RefCursor::new(family.clone());
+        let mut cmd = command_with_worktree(&family, Some(worktree), &["rebase", "main"]);
+        cmd.reflog_start_offsets
+            .insert(head_key(&git_dir), true_head_boundary);
+        cmd.reflog_start_offsets
+            .insert(common_key("refs/heads/topic"), true_branch_boundary);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert_eq!(
+            cmd.ref_changes,
+            vec![
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: D.to_string(),
+                    new: E.to_string(),
+                },
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: E.to_string(),
+                    new: F.to_string(),
+                },
+                RefChange {
+                    reference: "refs/heads/topic".to_string(),
+                    old: D.to_string(),
+                    new: F.to_string(),
+                },
+            ],
+            "true command-start boundary must not rewind into an older rebase span"
+        );
+    }
+
+    #[test]
     fn rebase_span_stops_before_later_rebase_after_checkout() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
@@ -4804,6 +5150,158 @@ mod tests {
                     new: D.to_string(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn cold_pull_rebase_late_ingress_offset_still_recovers_start_and_branch_finish() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
+
+        let start_line = format!(
+            "{B} {C} Test User <test@example.com> 0 +0000\tpull --rebase (start): checkout {C}\n"
+        );
+        let pick_line = format!(
+            "{C} {D} Test User <test@example.com> 0 +0000\tpull --rebase (pick): Local commit\n"
+        );
+        let finish_line = format!(
+            "{D} {D} Test User <test@example.com> 0 +0000\tpull --rebase (finish): returning to refs/heads/main\n"
+        );
+        fs::write(
+            git_dir.join("logs/HEAD"),
+            format!("{start_line}{pick_line}{finish_line}"),
+        )
+        .unwrap();
+        let late_head_offset = start_line.len() as u64;
+
+        let branch_line = format!(
+            "{B} {D} Test User <test@example.com> 0 +0000\tpull --rebase (finish): refs/heads/main onto {C}\n"
+        );
+        fs::write(git_dir.join("logs/refs/heads/main"), &branch_line).unwrap();
+        let late_branch_offset = branch_line.len() as u64;
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let mut state = family_state(&family);
+        state.refs.insert("HEAD".to_string(), C.to_string());
+        state
+            .refs
+            .insert("refs/heads/main".to_string(), C.to_string());
+        let mut cursor = RefCursor::new(family.clone());
+        let mut cmd = command_with_worktree(&family, Some(worktree), &["pull", "--rebase"]);
+        cmd.reflog_start_offsets
+            .insert(head_key(&git_dir), late_head_offset);
+        cmd.reflog_start_offsets
+            .insert(common_key("refs/heads/main"), late_branch_offset);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert_eq!(
+            cmd.ref_changes,
+            vec![
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: B.to_string(),
+                    new: C.to_string(),
+                },
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: C.to_string(),
+                    new: D.to_string(),
+                },
+                RefChange {
+                    reference: "refs/heads/main".to_string(),
+                    old: B.to_string(),
+                    new: D.to_string(),
+                },
+            ],
+            "cold late pull-rebase enrichment must preserve the non-fast-forward local-tip to rebased-tip pair"
+        );
+    }
+
+    #[test]
+    fn cold_pull_rebase_true_boundary_does_not_replay_older_pull_span() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
+
+        let old_start = format!(
+            "{A} {B} Test User <test@example.com> 0 +0000\tpull --rebase (start): checkout main\n"
+        );
+        let old_pick = format!(
+            "{B} {C} Test User <test@example.com> 0 +0000\tpull --rebase (pick): Old commit\n"
+        );
+        let old_finish = format!(
+            "{C} {C} Test User <test@example.com> 0 +0000\tpull --rebase (finish): returning to refs/heads/main\n"
+        );
+        let current_start = format!(
+            "{D} {E} Test User <test@example.com> 0 +0000\tpull --rebase (start): checkout main\n"
+        );
+        let current_pick = format!(
+            "{E} {F} Test User <test@example.com> 0 +0000\tpull --rebase (pick): Current commit\n"
+        );
+        let current_finish = format!(
+            "{F} {F} Test User <test@example.com> 0 +0000\tpull --rebase (finish): returning to refs/heads/main\n"
+        );
+        let true_head_boundary = (old_start.len() + old_pick.len() + old_finish.len()) as u64;
+        fs::write(
+            git_dir.join("logs/HEAD"),
+            format!(
+                "{old_start}{old_pick}{old_finish}{current_start}{current_pick}{current_finish}"
+            ),
+        )
+        .unwrap();
+
+        let old_branch = format!(
+            "{A} {C} Test User <test@example.com> 0 +0000\tpull --rebase (finish): refs/heads/main onto main\n"
+        );
+        let current_branch = format!(
+            "{D} {F} Test User <test@example.com> 0 +0000\tpull --rebase (finish): refs/heads/main onto main\n"
+        );
+        let true_branch_boundary = old_branch.len() as u64;
+        fs::write(
+            git_dir.join("logs/refs/heads/main"),
+            format!("{old_branch}{current_branch}"),
+        )
+        .unwrap();
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let mut state = family_state(&family);
+        state.refs.insert("HEAD".to_string(), D.to_string());
+        state
+            .refs
+            .insert("refs/heads/main".to_string(), D.to_string());
+        let mut cursor = RefCursor::new(family.clone());
+        let mut cmd = command_with_worktree(&family, Some(worktree), &["pull", "--rebase"]);
+        cmd.reflog_start_offsets
+            .insert(head_key(&git_dir), true_head_boundary);
+        cmd.reflog_start_offsets
+            .insert(common_key("refs/heads/main"), true_branch_boundary);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert_eq!(
+            cmd.ref_changes,
+            vec![
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: D.to_string(),
+                    new: E.to_string(),
+                },
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: E.to_string(),
+                    new: F.to_string(),
+                },
+                RefChange {
+                    reference: "refs/heads/main".to_string(),
+                    old: D.to_string(),
+                    new: F.to_string(),
+                },
+            ],
+            "true command-start boundary must not rewind into an older pull-rebase span"
         );
     }
 

--- a/tests/integration/cold_trace2_repo.rs
+++ b/tests/integration/cold_trace2_repo.rs
@@ -46,6 +46,18 @@ fn raw_commit_file(repo: &TestRepo, path: &str, content: &str, message: &str) ->
     raw_commit_all(repo, message)
 }
 
+fn raw_clone(source: &TestRepo, target_path: &std::path::Path) -> TestRepo {
+    raw_git(
+        source,
+        &[
+            "clone",
+            source.path().to_str().expect("source path should be utf-8"),
+            target_path.to_str().expect("target path should be utf-8"),
+        ],
+    );
+    TestRepo::new_at_path_with_daemon_scope(target_path, DaemonTestScope::NoDaemon)
+}
+
 fn traced_ai_commit_file(repo: &TestRepo, path: &str, content: &str, message: &str) -> String {
     write_file(repo, path, content);
     repo.git_ai(&["checkpoint", "mock_ai", path])
@@ -77,6 +89,20 @@ fn run_traced_git_without_sync(repo: &TestRepo, args: &[&str]) -> String {
     );
     repo.git(args)
         .unwrap_or_else(|error| panic!("traced git {:?} failed: {}", args, error))
+}
+
+fn assert_ai_authorship_note(repo: &TestRepo, commit_sha: &str) {
+    let note = repo
+        .read_authorship_note(commit_sha)
+        .unwrap_or_else(|| panic!("commit {commit_sha} should have an authorship note"));
+    let log = AuthorshipLog::deserialize_from_string(&note)
+        .unwrap_or_else(|error| panic!("failed to parse authorship note: {}", error));
+    assert!(
+        log.attestations
+            .iter()
+            .any(|attestation| !attestation.entries.is_empty()),
+        "commit {commit_sha} should contain AI authorship entries"
+    );
 }
 
 fn assert_no_ai_authorship_for_commit(repo: &TestRepo, commit_sha: &str) {
@@ -136,6 +162,84 @@ fn test_cold_repo_first_traced_commit_is_processed() {
     assert_no_ai_authorship_for_commit(&repo, &raw_first);
     assert_no_ai_authorship_for_commit(&repo, &raw_second);
     assert_no_ai_authorship_for_commit(&repo, &head);
+}
+
+fn run_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship() {
+    let upstream = TestRepo::new_bare_with_daemon_scope(DaemonTestScope::NoDaemon);
+    raw_git(&upstream, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    let mut repo = cold_repo();
+    raw_git(&repo, &["branch", "-M", "main"]);
+    raw_git(
+        &repo,
+        &["remote", "add", "origin", upstream.path().to_str().unwrap()],
+    );
+    raw_commit_file(&repo, "README.md", "# Test Repo\n", "raw initial");
+    raw_git(&repo, &["push", "-u", "origin", "HEAD:main"]);
+
+    start_cold_daemon(&mut repo);
+    let local_ai_commit = traced_ai_commit_file(
+        &repo,
+        "ai_feature.txt",
+        "AI generated feature line 1\nAI generated feature line 2\n",
+        "add AI feature",
+    );
+    assert_ai_authorship_note(&repo, &local_ai_commit);
+
+    let contributor_parent = tempfile::tempdir().expect("contributor temp dir");
+    let contributor_path = contributor_parent.path().join("contributor");
+    let contributor = raw_clone(&upstream, &contributor_path);
+    raw_git(&contributor, &["checkout", "main"]);
+    raw_commit_file(
+        &contributor,
+        "upstream_change.txt",
+        "upstream content\n",
+        "upstream divergent commit",
+    );
+    raw_git(&contributor, &["push", "origin", "HEAD:main"]);
+
+    assert!(
+        repo.git(&["push"]).is_err(),
+        "push should be rejected because origin has diverged"
+    );
+    assert!(
+        repo.git(&["pull"]).is_err(),
+        "plain pull should fail before an explicit reconciliation strategy"
+    );
+    repo.git(&["pull", "--rebase"])
+        .expect("pull --rebase should succeed");
+    repo.sync_daemon_force();
+
+    let rebased = raw_head(&repo);
+    assert_ne!(rebased, local_ai_commit);
+    assert_ai_authorship_note(&repo, &rebased);
+}
+
+#[test]
+fn test_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship() {
+    run_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship();
+}
+
+#[test]
+#[ignore = "stress test for nondeterministic cold pull-rebase reflog timing"]
+fn stress_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship() {
+    std::thread::scope(|scope| {
+        let handles = (0..8)
+            .map(|_| {
+                scope.spawn(|| {
+                    for _ in 0..3 {
+                        run_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship();
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle
+                .join()
+                .expect("cold pull-rebase stress worker panicked");
+        }
+    });
 }
 
 #[test]

--- a/tests/integration/cross_repo_cwd_attribution.rs
+++ b/tests/integration/cross_repo_cwd_attribution.rs
@@ -937,6 +937,11 @@ fn test_nested_subrepo_mixed_edits_mock_ai() {
         )
         .expect("mixed checkpoint (parent + nested subrepo) should succeed");
 
+    // The mixed checkpoint fans out to both repo families; drain both before
+    // committing so this test does not race delegated checkpoint processing.
+    parent.sync_daemon();
+    subrepo.sync_daemon();
+
     // Verify parent repo has attestation
     let parent_commit = parent.stage_all_and_commit("AI edits in parent").unwrap();
     assert!(
@@ -994,6 +999,11 @@ fn test_nested_multiple_subrepos_mock_ai() {
             ],
         )
         .expect("checkpoint across multiple nested subrepos should succeed");
+
+    // The checkpoint spans two nested repo families; drain both before either
+    // commit so each repo sees its delegated checkpoint.
+    sub1.sync_daemon();
+    sub2.sync_daemon();
 
     let commit_s1 = sub1.stage_all_and_commit("AI in sub1").unwrap();
     assert!(

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -1,7 +1,7 @@
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 
 use crate::repos::test_file::ExpectedLineExt;
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use serde_json::json;
 use std::collections::BTreeSet;
 
@@ -322,6 +322,98 @@ fn test_pull_rebase_preserves_committed_ai_authorship() {
 
     // Verify AI authorship is preserved on the rebased commit
     let mut ai_file = local.filename("ai_feature.txt");
+    ai_file.assert_lines_and_blame(vec![
+        "AI generated feature line 1".ai(),
+        "AI generated feature line 2".ai(),
+    ]);
+}
+
+#[test]
+fn test_rejected_push_failed_pull_then_pull_rebase_preserves_committed_ai_authorship() {
+    let (local, upstream) = TestRepo::new_with_remote();
+
+    let mut readme = local.filename("README.md");
+    readme.set_contents(vec!["# Test Repo".to_string()]);
+    local
+        .stage_all_and_commit("initial commit")
+        .expect("initial commit should succeed");
+    local
+        .git(&["push", "-u", "origin", "HEAD"])
+        .expect("push initial commit should succeed");
+
+    let mut ai_file = local.filename("ai_feature.txt");
+    ai_file.set_contents(vec![
+        "AI generated feature line 1".ai(),
+        "AI generated feature line 2".ai(),
+    ]);
+    let local_ai_commit = local
+        .stage_all_and_commit("add AI feature")
+        .expect("AI feature commit should succeed");
+
+    assert!(
+        local
+            .read_authorship_note(&local_ai_commit.commit_sha)
+            .is_some(),
+        "precondition: original local AI commit should have authorship note"
+    );
+
+    let branch = local.current_branch();
+    let contributor_parent = tempfile::tempdir().expect("contributor temp dir");
+    let contributor_path = contributor_parent.path().join("contributor");
+    local
+        .git_og(&[
+            "clone",
+            upstream
+                .path()
+                .to_str()
+                .expect("upstream path should be utf-8"),
+            contributor_path
+                .to_str()
+                .expect("contributor path should be utf-8"),
+        ])
+        .expect("clone contributor should succeed");
+    let contributor =
+        TestRepo::new_at_path_with_daemon_scope(&contributor_path, DaemonTestScope::NoDaemon);
+    std::fs::write(
+        contributor.path().join("upstream_change.txt"),
+        "upstream content\n",
+    )
+    .expect("write upstream change");
+    contributor.git_og(&["add", "."]).unwrap();
+    contributor
+        .git_og(&["commit", "-m", "upstream divergent commit"])
+        .expect("upstream commit should succeed");
+    contributor
+        .git_og(&["push", "origin", &format!("HEAD:{}", branch)])
+        .expect("push upstream divergence should succeed");
+
+    assert!(
+        local.git(&["push"]).is_err(),
+        "push should be rejected because origin has diverged"
+    );
+    assert!(
+        local.git(&["pull"]).is_err(),
+        "plain pull should fail before an explicit reconciliation strategy"
+    );
+
+    local
+        .git(&["pull", "--rebase"])
+        .expect("pull --rebase should succeed");
+
+    let rebased_head = local
+        .git(&["rev-parse", "HEAD"])
+        .expect("rev-parse should succeed")
+        .trim()
+        .to_string();
+    assert_ne!(
+        rebased_head, local_ai_commit.commit_sha,
+        "HEAD should have a new SHA after rebase"
+    );
+    assert!(
+        local.read_authorship_note(&rebased_head).is_some(),
+        "rebased local AI commit should have authorship note"
+    );
+
     ai_file.assert_lines_and_blame(vec![
         "AI generated feature line 1".ai(),
         "AI generated feature line 2".ai(),


### PR DESCRIPTION
Fixes #1599 

## Summary
- harden cold/late reflog cursor recovery for pull --rebase spans
- add faithful e2e coverage for rejected push, failed pull, then pull --rebase preserving AI authorship
- add cold trace2 repo coverage and analysis docs for the root cause and hardening pass

## Root Cause
A cold or late reflog cursor could seed inside the pull --rebase operation span and miss the pre-fetch HEAD transition. The daemon then saw only replay movement and failed to migrate authorship notes from the original local commit to its rebased replacement.

## Validation
- task fmt
- task lint
- task test, run 3x successfully

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->