### PR TITLE
preserve AI authorship for alias-driven pull --rebase

### DIFF
--- a/src/daemon/git_backend.rs
+++ b/src/daemon/git_backend.rs
@@ -18,6 +18,25 @@ pub trait GitBackend: Send + Sync + 'static {
         argv: &[String],
     ) -> Result<Option<String>, GitAiError>;
 
+    /// Resolve the fully alias-expanded invocation: the underlying command
+    /// token plus its command-line arguments after expanding any user aliases
+    /// (e.g. `up` → `pull --rebase`). Git expands aliases before it writes
+    /// reflog messages, so downstream analyzers that reconstruct a command's
+    /// reflog action from its args (notably the pull span matcher) must see the
+    /// expanded flags rather than the literal alias token.
+    ///
+    /// Returns `None` when no alias expansion applies (the command is a builtin
+    /// or unresolvable); callers then fall back to parsing the raw argv, which
+    /// is byte-identical to the pre-alias behavior. The default implementation
+    /// returns `None` so backends without config access keep current behavior.
+    fn resolve_invocation(
+        &self,
+        _worktree: &Path,
+        _argv: &[String],
+    ) -> Result<Option<(String, Vec<String>)>, GitAiError> {
+        Ok(None)
+    }
+
     fn clone_target(&self, argv: &[String], cwd_hint: Option<&Path>) -> Option<PathBuf>;
 
     fn init_target(&self, argv: &[String], cwd_hint: Option<&Path>) -> Option<PathBuf>;
@@ -146,6 +165,46 @@ impl SystemGitBackend {
         let repo = discover_repository_in_path_no_git_exec(worktree)?;
         let key = format!("alias.{}", alias_name);
         repo.config_get_str(&key)
+    }
+
+    /// Iteratively expand user aliases until reaching a builtin command (or an
+    /// unresolvable token / `!`-shell alias / alias cycle), mirroring how git
+    /// itself expands `git <alias> ...` before execution. Returns the resolved
+    /// command token together with its expanded command-line args, or `None`
+    /// when no command can be determined.
+    fn expand_alias_invocation(
+        &self,
+        worktree: &Path,
+        argv: &[String],
+    ) -> Result<Option<(String, Vec<String>)>, GitAiError> {
+        let mut current = parse_git_cli_args(git_invocation_tokens(argv));
+        let mut seen = HashSet::new();
+        loop {
+            let Some(command) = current.command.clone() else {
+                return Ok(None);
+            };
+            if !seen.insert(command.clone()) {
+                return Ok(None);
+            }
+            if is_builtin_primary_command(&command) {
+                return Ok(Some((command, current.command_args)));
+            }
+
+            let alias_value = match self.resolve_alias_cached(worktree, &command)? {
+                Some(value) => value,
+                None => return Ok(Some((command, current.command_args))),
+            };
+
+            let Some(alias_tokens) = parse_alias_tokens(&alias_value) else {
+                return Ok(None);
+            };
+
+            let mut expanded_args = Vec::new();
+            expanded_args.extend(current.global_args.iter().cloned());
+            expanded_args.extend(alias_tokens);
+            expanded_args.extend(current.command_args.iter().cloned());
+            current = parse_git_cli_args(&expanded_args);
+        }
     }
 }
 
@@ -282,34 +341,17 @@ impl GitBackend for SystemGitBackend {
         worktree: &Path,
         argv: &[String],
     ) -> Result<Option<String>, GitAiError> {
-        let mut current = parse_git_cli_args(git_invocation_tokens(argv));
-        let mut seen = HashSet::new();
-        loop {
-            let Some(command) = current.command.clone() else {
-                return Ok(None);
-            };
-            if !seen.insert(command.clone()) {
-                return Ok(None);
-            }
-            if is_builtin_primary_command(&command) {
-                return Ok(Some(command));
-            }
+        Ok(self
+            .expand_alias_invocation(worktree, argv)?
+            .map(|(command, _args)| command))
+    }
 
-            let alias_value = match self.resolve_alias_cached(worktree, &command)? {
-                Some(value) => value,
-                None => return Ok(Some(command)),
-            };
-
-            let Some(alias_tokens) = parse_alias_tokens(&alias_value) else {
-                return Ok(None);
-            };
-
-            let mut expanded_args = Vec::new();
-            expanded_args.extend(current.global_args.iter().cloned());
-            expanded_args.extend(alias_tokens);
-            expanded_args.extend(current.command_args.iter().cloned());
-            current = parse_git_cli_args(&expanded_args);
-        }
+    fn resolve_invocation(
+        &self,
+        worktree: &Path,
+        argv: &[String],
+    ) -> Result<Option<(String, Vec<String>)>, GitAiError> {
+        self.expand_alias_invocation(worktree, argv)
     }
 
     fn clone_target(&self, argv: &[String], cwd_hint: Option<&Path>) -> Option<PathBuf> {

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -603,9 +603,17 @@ impl<B: GitBackend> TraceNormalizer<B> {
         // reflog. Surface the alias-expanded command+args when the invoked token
         // was itself an alias, so downstream analyzers (notably the pull span
         // matcher, which reconstructs a command's reflog action from its args)
-        // see the same flags git did. Non-alias invocations expand to the same
-        // command token and are left untouched, preserving existing behavior.
-        if let Some(worktree) = pending.worktree.as_deref()
+        // see the same flags git did.
+        //
+        // Fast path: only consult the backend when the resolved command differs
+        // from the literal invoked token — that mismatch is exactly the alias
+        // signature (git ignores an alias that shadows a builtin, so a plain
+        // `pull`/`status`/etc. always has primary == invoked and is skipped
+        // here). This keeps every common, non-aliased command off the
+        // alias-cache path entirely, so trace-ingestion finalize pays nothing
+        // extra for it.
+        if primary_command.as_deref() != invoked_command.as_deref()
+            && let Some(worktree) = pending.worktree.as_deref()
             && let Some((expanded_command, expanded_args)) = self
                 .backend
                 .resolve_invocation(worktree, &pending.raw_argv)?

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -595,8 +595,25 @@ impl<B: GitBackend> TraceNormalizer<B> {
             pending.worktree.as_deref(),
             pending.family_key.as_ref(),
         )?;
-        let (invoked_command, invoked_args) =
+        let (mut invoked_command, mut invoked_args) =
             canonical_invocation(&pending.raw_argv, primary_command.as_deref());
+        // Git expands user aliases (e.g. `up` → `pull --rebase`) before it runs
+        // the command and before it writes reflog messages, so the literal argv
+        // token and its trailing args do not reflect the flags that shaped the
+        // reflog. Surface the alias-expanded command+args when the invoked token
+        // was itself an alias, so downstream analyzers (notably the pull span
+        // matcher, which reconstructs a command's reflog action from its args)
+        // see the same flags git did. Non-alias invocations expand to the same
+        // command token and are left untouched, preserving existing behavior.
+        if let Some(worktree) = pending.worktree.as_deref()
+            && let Some((expanded_command, expanded_args)) = self
+                .backend
+                .resolve_invocation(worktree, &pending.raw_argv)?
+            && Some(expanded_command.as_str()) != invoked_command.as_deref()
+        {
+            invoked_command = Some(expanded_command);
+            invoked_args = expanded_args;
+        }
         if primary_command.is_none() {
             primary_command = invoked_command.clone();
         }
@@ -1021,20 +1038,44 @@ mod tests {
             worktree: &Path,
             argv: &[String],
         ) -> Result<Option<String>, GitAiError> {
+            Ok(self
+                .resolve_invocation(worktree, argv)?
+                .map(|(command, _args)| command))
+        }
+
+        fn resolve_invocation(
+            &self,
+            worktree: &Path,
+            argv: &[String],
+        ) -> Result<Option<(String, Vec<String>)>, GitAiError> {
             let raw = argv_primary_command(argv);
             let Some(command) = raw else {
                 return Ok(None);
             };
             let worktree_key = normalize_path_key(worktree);
-            let resolved = self
+            // Stored alias targets may carry flags (e.g. "pull --rebase"); split
+            // them into a command token plus leading args, then append the
+            // invocation's own trailing args, mirroring real alias expansion.
+            let expansion = self
                 .alias_by_worktree_command
                 .lock()
                 .unwrap()
                 .get(&worktree_key)
                 .and_then(|commands| commands.get(&command))
-                .cloned()
-                .unwrap_or(command);
-            Ok(Some(resolved))
+                .cloned();
+            let trailing = args_after_command(argv, &command);
+            match expansion {
+                Some(target) => {
+                    let mut tokens = target.split_whitespace().map(str::to_string);
+                    let Some(resolved_command) = tokens.next() else {
+                        return Ok(Some((command, trailing)));
+                    };
+                    let mut args = tokens.collect::<Vec<_>>();
+                    args.extend(trailing);
+                    Ok(Some((resolved_command, args)))
+                }
+                None => Ok(Some((command, trailing))),
+            }
         }
 
         fn clone_target(&self, _argv: &[String], _cwd_hint: Option<&Path>) -> Option<PathBuf> {
@@ -1372,6 +1413,107 @@ mod tests {
         assert!(normalizer.ingest_payload(&exit).unwrap().is_none());
         let cmd = normalizer.ingest_payload(&atexit).unwrap().unwrap();
         assert_eq!(cmd.primary_command.as_deref(), Some("commit"));
+    }
+
+    #[test]
+    fn alias_pull_rebase_expands_invoked_args_with_flags() {
+        // `git up origin main` where `up = pull --rebase` must surface the
+        // alias-expanded flags so downstream reflog-action matching sees
+        // `pull --rebase ...` (matching git's reflog label) rather than the
+        // literal alias token `up`.
+        let backend = Arc::new(MockBackend::default());
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        backend.set_alias(
+            worktree.to_str().expect("utf8 worktree"),
+            "up",
+            "pull --rebase",
+        );
+        let mut normalizer = TraceNormalizer::new(backend);
+
+        let start = serde_json::json!({
+            "event":"start",
+            "sid":"alias-pull",
+            "ts":1,
+            "argv":["git","up","origin","main"],
+            "worktree":worktree
+        });
+        // git emits a child cmd_name of `pull` for the expanded alias, exactly
+        // as observed in real trace2 output, so the primary command is already
+        // resolved without consulting the backend.
+        let child = serde_json::json!({
+            "event":"cmd_name",
+            "sid":"alias-pull/child",
+            "ts":1,
+            "name":"pull",
+            "hierarchy":"_run_git_alias_/pull"
+        });
+        let exit = serde_json::json!({
+            "event":"exit",
+            "sid":"alias-pull",
+            "ts":2,
+            "code":0
+        });
+        let atexit = atexit_payload("alias-pull", 3);
+
+        assert!(normalizer.ingest_payload(&start).unwrap().is_none());
+        assert!(normalizer.ingest_payload(&child).unwrap().is_none());
+        assert!(normalizer.ingest_payload(&exit).unwrap().is_none());
+        let cmd = normalizer.ingest_payload(&atexit).unwrap().unwrap();
+
+        assert_eq!(cmd.primary_command.as_deref(), Some("pull"));
+        assert_eq!(cmd.invoked_command.as_deref(), Some("pull"));
+        assert_eq!(
+            cmd.invoked_args,
+            vec![
+                "--rebase".to_string(),
+                "origin".to_string(),
+                "main".to_string()
+            ],
+            "alias-expanded invocation must carry the --rebase flag and trailing args"
+        );
+    }
+
+    #[test]
+    fn non_alias_pull_invocation_is_unchanged() {
+        // A plain (non-alias) invocation must expand to the identical command
+        // token, leaving invoked_args byte-identical to the pre-alias behavior.
+        let backend = Arc::new(MockBackend::default());
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        let mut normalizer = TraceNormalizer::new(backend);
+
+        let start = serde_json::json!({
+            "event":"start",
+            "sid":"plain-pull",
+            "ts":1,
+            "argv":["git","pull","--rebase","origin","main"],
+            "worktree":worktree
+        });
+        let exit = serde_json::json!({
+            "event":"exit",
+            "sid":"plain-pull",
+            "ts":2,
+            "code":0
+        });
+        let atexit = atexit_payload("plain-pull", 3);
+
+        assert!(normalizer.ingest_payload(&start).unwrap().is_none());
+        assert!(normalizer.ingest_payload(&exit).unwrap().is_none());
+        let cmd = normalizer.ingest_payload(&atexit).unwrap().unwrap();
+
+        assert_eq!(cmd.primary_command.as_deref(), Some("pull"));
+        assert_eq!(cmd.invoked_command.as_deref(), Some("pull"));
+        assert_eq!(
+            cmd.invoked_args,
+            vec![
+                "--rebase".to_string(),
+                "origin".to_string(),
+                "main".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -668,6 +668,50 @@ fn test_pull_rebase_via_git_config_preserves_committed_ai_authorship() {
     ]);
 }
 
+#[test]
+fn test_pull_rebase_via_alias_preserves_committed_ai_authorship() {
+    // Regression: `git up` where `up = pull --rebase`. Git expands the alias
+    // before writing the reflog (label `pull --rebase ... (start)`), but the
+    // daemon previously reconstructed the pull action from the literal alias
+    // token `up`, so the span matcher never matched and the rebased AI commit's
+    // authorship note was dropped. The invocation must expand to `pull
+    // --rebase` so attribution migrates with the rebase.
+    let setup = setup_divergent_pull_test();
+    let local = setup.local;
+
+    // Define an alias that expands to `pull --rebase`.
+    local
+        .git(&["config", "alias.up", "pull --rebase"])
+        .expect("set alias.up should succeed");
+
+    // Drive the rebase entirely through the alias (no explicit --rebase flag).
+    local.git(&["up"]).expect("aliased pull should succeed");
+
+    // Verify upstream changes arrived and the commit SHA changed (real rebase).
+    assert!(
+        local.read_file("upstream_change.txt").is_some(),
+        "Should have upstream_change.txt after aliased pull --rebase"
+    );
+
+    let new_head = local
+        .git(&["rev-parse", "HEAD"])
+        .expect("rev-parse should succeed")
+        .trim()
+        .to_string();
+
+    assert_ne!(
+        new_head, setup.local_ai_commit_sha,
+        "HEAD should have a new SHA after rebase"
+    );
+
+    // Verify AI authorship survived the alias-driven rebase.
+    let mut ai_file = local.filename("ai_feature.txt");
+    ai_file.assert_lines_and_blame(vec![
+        "AI generated feature line 1".ai(),
+        "AI generated feature line 2".ai(),
+    ]);
+}
+
 // =============================================================================
 // Pull --rebase --autostash with uncommitted changes
 // =============================================================================


### PR DESCRIPTION
## Summary
Stacked on #1589. Fixes a pre-existing gap surfaced while reviewing that PR: alias-driven `pull --rebase` (e.g. `git up` where `up = pull --rebase`) loses AI authorship on the rebased commit.

## Root cause
Git expands user aliases before running the command and before writing reflog messages, so an aliased pull writes a reflog label like `pull --rebase … (start)`. The daemon reconstructed the pull reflog action from the **literal alias token** (`up`) and its **unexpanded** trailing args, so the pull span matcher never matched git's label and the rebased local commit's authorship note was silently dropped.

`SystemGitBackend::resolve_primary_command` already fully expanded aliases internally but returned only the command name, throwing away the expanded args (`primary_command="pull"` while `invoked_args=["origin","main"]`, missing `--rebase`).

## Fix
- Factor the alias-expansion loop into `expand_alias_invocation` and expose it via a new `GitBackend::resolve_invocation`, which returns the resolved command **plus its alias-expanded args**.
- The trace normalizer now surfaces the expanded invocation in `invoked_command`/`invoked_args` when the invoked token was an alias, so downstream reflog-action matching sees the same flags git did.
- Non-alias invocations expand to the identical command token and are left untouched (byte-identical to prior behavior). The trait default returns `None`, so backends without config access are unchanged.

## Tests
- **unit** (`trace_normalizer`): aliased `up origin main` expands `invoked_args` to `--rebase origin main`; plain pull is unchanged.
- **integration** (`pull_rebase_ff`): alias-driven `git up` preserves committed AI authorship across a real divergent rebase. Confirmed this **fails without the fix** (rebased lines lose AI attribution) and passes with it.

## Validation
- `task fmt`, `task lint` clean
- targeted suites green: `pull_rebase`, `trace_normalizer`, `daemon_`, `alias`

## Scope note
The config-driven (`pull.rebase=true`) and `--autostash` cases were also investigated during review and are **already correct** (git's reflog label is `pull (start)` / embeds the full command line respectively, both of which the existing derivation matches). Existing tests cover those; this PR only adds the missing alias path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->