### PR TITLE
fix(status): wire --diff-only flag into git-ai status

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -339,6 +339,9 @@ fn print_help() {
     eprintln!("    --json                 Output in JSON format");
     eprintln!("  status             Show uncommitted AI authorship status (debug)");
     eprintln!("    --json                 Output in JSON format");
+    eprintln!(
+        "    --diff-only            Report only current-diff stats, omitting the per-checkpoint breakdown"
+    );
     eprintln!("  show <rev|range>   Display authorship logs for a revision or range");
     eprintln!("  show-prompt <id>   Display a prompt record by its ID");
     eprintln!("    --commit <rev>        Look in a specific commit only");

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -25,27 +25,34 @@ struct CheckpointInfo {
 #[derive(Serialize)]
 struct StatusOutput {
     stats: CommitStats,
-    checkpoints: Vec<CheckpointInfo>,
+    /// Per-checkpoint session breakdown. Omitted entirely when `--diff-only`
+    /// is requested, so consumers that only care about the current diff scope
+    /// get just the diff-scoped `stats`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checkpoints: Option<Vec<CheckpointInfo>>,
 }
 
 pub fn handle_status(args: &[String]) {
     let mut json_output = false;
+    let mut diff_only = false;
 
     let mut i = 0;
     while i < args.len() {
-        if args[i].as_str() == "--json" {
-            json_output = true;
+        match args[i].as_str() {
+            "--json" => json_output = true,
+            "--diff-only" => diff_only = true,
+            _ => {}
         }
         i += 1;
     }
 
-    if let Err(e) = run_status(json_output) {
+    if let Err(e) = run_status(json_output, diff_only) {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     }
 }
 
-fn run_status(json: bool) -> Result<(), GitAiError> {
+fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     let repo = find_repository(&[])?;
     let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&ignore_patterns);
@@ -66,7 +73,7 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
         if json {
             let output = StatusOutput {
                 stats: CommitStats::default(),
-                checkpoints: vec![],
+                checkpoints: if diff_only { None } else { Some(vec![]) },
             };
             let json_str = serde_json::to_string(&output)?;
             println!("{}", json_str);
@@ -87,28 +94,31 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
         return Ok(());
     }
 
+    // The per-checkpoint breakdown is only needed for the default (non-diff-only)
+    // output, so skip building it entirely when `--diff-only` is requested.
     let mut checkpoint_infos = Vec::new();
+    if !diff_only {
+        for checkpoint in checkpoints.iter().rev() {
+            let (additions, deletions) = (
+                checkpoint.line_stats.additions,
+                checkpoint.line_stats.deletions,
+            );
 
-    for checkpoint in checkpoints.iter().rev() {
-        let (additions, deletions) = (
-            checkpoint.line_stats.additions,
-            checkpoint.line_stats.deletions,
-        );
+            let tool_model = checkpoint
+                .agent_id
+                .as_ref()
+                .map(|a| format!("{} {}", capitalize(&a.tool), &a.model))
+                .unwrap_or_else(|| default_user_name.clone());
 
-        let tool_model = checkpoint
-            .agent_id
-            .as_ref()
-            .map(|a| format!("{} {}", capitalize(&a.tool), &a.model))
-            .unwrap_or_else(|| default_user_name.clone());
-
-        let is_human = checkpoint.kind == CheckpointKind::Human;
-        checkpoint_infos.push(CheckpointInfo {
-            time_ago: format_time_ago(checkpoint.timestamp),
-            additions,
-            deletions,
-            tool_model,
-            is_human,
-        });
+            let is_human = checkpoint.kind == CheckpointKind::Human;
+            checkpoint_infos.push(CheckpointInfo {
+                time_ago: format_time_ago(checkpoint.timestamp),
+                additions,
+                deletions,
+                tool_model,
+                is_human,
+            });
+        }
     }
 
     let working_va = VirtualAttributions::from_just_working_log(
@@ -157,7 +167,11 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
     if json {
         let output = StatusOutput {
             stats,
-            checkpoints: checkpoint_infos,
+            checkpoints: if diff_only {
+                None
+            } else {
+                Some(checkpoint_infos)
+            },
         };
         let json_str = serde_json::to_string(&output)?;
         println!("{}", json_str);
@@ -165,6 +179,10 @@ fn run_status(json: bool) -> Result<(), GitAiError> {
     }
 
     write_stats_to_terminal(&stats, true);
+
+    if diff_only {
+        return Ok(());
+    }
 
     println!();
     for cp in &checkpoint_infos {

--- a/tests/integration/status_unit.rs
+++ b/tests/integration/status_unit.rs
@@ -24,6 +24,21 @@ fn status_json(repo: &TestRepo) -> StatusOutput {
     serde_json::from_str(&json).expect("valid status json")
 }
 
+/// Mirror of `StatusOutput` where `checkpoints` is optional, so tests can
+/// distinguish "field present" (default mode) from "field omitted" (--diff-only).
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct DiffOnlyStatusOutput {
+    stats: CommitStats,
+    checkpoints: Option<Vec<serde_json::Value>>,
+}
+
+fn status_json_with_args(repo: &TestRepo, args: &[&str]) -> DiffOnlyStatusOutput {
+    let raw = repo.git_ai(args).expect("git-ai status should succeed");
+    let json = extract_json_object(&raw);
+    serde_json::from_str(&json).expect("valid status json")
+}
+
 fn write_file(repo: &TestRepo, path: &str, contents: &str) {
     let abs_path = repo.path().join(path);
     if let Some(parent) = abs_path.parent() {
@@ -243,6 +258,64 @@ fn test_ai_accepted_respects_ignore_patterns() {
     );
 }
 
+/// `--diff-only` must keep the same diff-scoped `stats` as a plain `--json`
+/// run, while omitting the per-checkpoint breakdown.
+#[test]
+fn test_diff_only_omits_checkpoints_but_keeps_stats() {
+    let repo = TestRepo::new();
+
+    write_file(&repo, "a.txt", "L1\nL2\nL3\n");
+    repo.stage_all_and_commit("initial").unwrap();
+
+    write_file(&repo, "a.txt", "L1\nL2\nL3\nL4\nL5\n");
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+
+    // Default mode includes the checkpoints array.
+    let default = status_json_with_args(&repo, &["status", "--json"]);
+    assert!(
+        default.checkpoints.is_some(),
+        "default --json should include the checkpoints array"
+    );
+    assert!(
+        !default.checkpoints.as_ref().unwrap().is_empty(),
+        "default --json should list the recorded checkpoint"
+    );
+
+    // --diff-only omits the checkpoints field entirely.
+    let diff_only = status_json_with_args(&repo, &["status", "--json", "--diff-only"]);
+    assert!(
+        diff_only.checkpoints.is_none(),
+        "--diff-only should omit the checkpoints field"
+    );
+
+    // Diff-scoped stats are identical between the two modes.
+    assert_eq!(
+        diff_only.stats.git_diff_added_lines, default.stats.git_diff_added_lines,
+        "--diff-only must not change the diff-scoped stats"
+    );
+    assert_eq!(
+        diff_only.stats.git_diff_added_lines, 2,
+        "a.txt adds 2 lines (L4, L5)"
+    );
+}
+
+/// `--diff-only` also omits checkpoints in the no-changes empty state.
+#[test]
+fn test_diff_only_no_changes_omits_checkpoints() {
+    let repo = TestRepo::new();
+
+    write_file(&repo, "a.txt", "L1\nL2\n");
+    repo.stage_all_and_commit("initial").unwrap();
+
+    let diff_only = status_json_with_args(&repo, &["status", "--json", "--diff-only"]);
+    assert!(
+        diff_only.checkpoints.is_none(),
+        "--diff-only should omit checkpoints even with no changes"
+    );
+    assert_eq!(diff_only.stats.git_diff_added_lines, 0);
+    assert_eq!(diff_only.stats.git_diff_deleted_lines, 0);
+}
+
 crate::reuse_tests_in_worktree!(
     test_working_dir_diff_stats_single_file_checkpoint,
     test_working_dir_diff_stats_exclusion_by_checkpoint,
@@ -251,4 +324,6 @@ crate::reuse_tests_in_worktree!(
     test_working_dir_diff_stats_with_rename,
     test_working_dir_diff_stats_respects_ignore_patterns,
     test_ai_accepted_respects_ignore_patterns,
+    test_diff_only_omits_checkpoints_but_keeps_stats,
+    test_diff_only_no_changes_omits_checkpoints,
 );


### PR DESCRIPTION
## What

`git-ai status` parsed `--json` but silently ignored `--diff-only`. Running

```bash
git-ai status --json --diff-only
```

produced output **identical** to `git-ai status --json` — the flag was accepted as an argument but never wired into the execution path.

Fixes #859.

## Why it matters

Integrations and hooks pass `--diff-only` to evaluate **only the current diff scope** (the AI/human ratio of uncommitted changes) without the per-checkpoint session history. Because the flag was ignored, those consumers always received the full payload, including the `checkpoints` breakdown, and could not tell the two modes apart.

## The fix

- Parse `--diff-only` in `handle_status` and thread a `diff_only: bool` into `run_status`.
- When `diff_only` is set:
  - skip building the per-checkpoint breakdown entirely (no wasted work), and
  - omit the `checkpoints` field from JSON output (`StatusOutput.checkpoints` is now `Option<...>` with `skip_serializing_if`), leaving only the diff-scoped `stats`.
  - in human/terminal mode, print the stats and stop before the checkpoint table.
- Document the flag in `git-ai help`.

The diff-scoped `stats` are unchanged between the two modes; `--diff-only` only controls whether the session breakdown is included.

## Example

Default (`--json`) — includes session breakdown:

```json
{
  "stats": { "git_diff_added_lines": 2, "ai_accepted": 2, ... },
  "checkpoints": [ { "time_ago": "5 secs ago", "additions": 2, "tool_model": "Cursor ...", "is_human": false } ]
}
```

With `--json --diff-only` — only the diff-scoped stats:

```json
{
  "stats": { "git_diff_added_lines": 2, "ai_accepted": 2, ... }
}
```

## Validation

```bash
task fmt
task lint                         # clippy -D warnings: clean
task build
task test TEST_FILTER=status_unit # 18 passed
```

New integration tests in `tests/integration/status_unit.rs`:

- `test_diff_only_omits_checkpoints_but_keeps_stats` — asserts `--diff-only` omits the `checkpoints` field while the diff-scoped `stats` stay identical to a plain `--json` run.
- `test_diff_only_no_changes_omits_checkpoints` — asserts the omission also holds in the empty/no-changes state.

Both run under the standard suite plus the auto-generated `_in_worktree` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->