### PR TITLE
Handle persisted checkpoints with missing line attributions

### DIFF
--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1,5 +1,6 @@
 use crate::authorship::attribution_tracker::{
-    Attribution, LineAttribution, line_attributions_to_attributions,
+    Attribution, LineAttribution, attributions_to_line_attributions,
+    line_attributions_to_attributions,
 };
 use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord, SessionRecord};
 use crate::authorship::hunk_shift::{DiffHunk, apply_hunk_shifts_to_line_attributions};
@@ -900,23 +901,11 @@ impl VirtualAttributions {
                 let file_content = working_log.get_file_version(&entry.blob_sha)?;
                 file_contents.insert(entry.file.clone(), file_content.clone());
 
-                if entry.line_attributions.is_empty() {
-                    let has_ai_char_attribution = entry.attributions.iter().any(|attr| {
-                        attr.author_id != CheckpointKind::Human.to_str()
-                            && !attr.author_id.starts_with("h_")
-                    });
-                    if !has_ai_char_attribution || checkpoint.line_stats.additions == 0 {
-                        attributions.remove(&entry.file);
-                        continue;
-                    }
-                    return Err(GitAiError::Generic(format!(
-                        "checkpoint entry for {} missing persisted line attributions",
-                        entry.file
-                    )));
-                }
-                let line_attrs = entry.line_attributions.clone();
-                let char_attrs = line_attributions_to_attributions(&line_attrs, &file_content, 0);
-
+                let line_attrs = if entry.line_attributions.is_empty() {
+                    attributions_to_line_attributions(&entry.attributions, &file_content)
+                } else {
+                    entry.line_attributions.clone()
+                };
                 if line_attrs.is_empty() {
                     // The entry had attribution data but no AI lines remain after
                     // filtering (e.g. human rewrote the entire file).  Clear any
@@ -925,6 +914,7 @@ impl VirtualAttributions {
                     continue;
                 }
 
+                let char_attrs = line_attributions_to_attributions(&line_attrs, &file_content, 0);
                 attributions.insert(entry.file.clone(), (char_attrs, line_attrs));
             }
         }

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1,6 +1,8 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::attribution_tracker::Attribution;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+use git_ai::authorship::working_log::{CheckpointKind, WorkingLogEntry};
 use git_ai::config::AuthorConfig;
 use std::fs;
 
@@ -1783,6 +1785,70 @@ fn test_ai_generated_file_then_human_full_rewrite() {
     file.assert_lines_and_blame(crate::lines![
         "console.log('hello world');".human(),
         "console.log('goodbye');".human(),
+    ]);
+}
+
+/// Regression test: one stale checkpoint entry with character attribution but no
+/// line attribution must not abort note generation for the whole commit.
+#[test]
+fn test_stale_zero_width_checkpoint_entry_does_not_abort_persisted_working_log() {
+    let repo = TestRepo::new();
+    let feature_path = repo.path().join("feature.rs");
+
+    fs::write(&feature_path, "fn main() {}\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "feature.rs"])
+        .unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut file = repo.filename("feature.rs");
+    file.assert_committed_lines(crate::lines!["fn main() {}".human(),]);
+
+    fs::write(
+        &feature_path,
+        "fn main() {}\nfn generated_by_ai() -> bool { true }\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.rs"])
+        .unwrap();
+
+    let working_log = repo.current_working_logs();
+    let mut checkpoints = working_log
+        .read_all_checkpoints()
+        .expect("checkpoints should be readable");
+    let ai_checkpoint = checkpoints
+        .iter_mut()
+        .find(|checkpoint| checkpoint.kind == CheckpointKind::AiAgent)
+        .expect("AI checkpoint should exist");
+    let feature_entry = ai_checkpoint
+        .entries
+        .iter()
+        .find(|entry| entry.file == "feature.rs")
+        .expect("feature checkpoint entry should exist")
+        .clone();
+    let ai_author_id = feature_entry
+        .line_attributions
+        .iter()
+        .find(|attr| {
+            attr.author_id != CheckpointKind::Human.to_str() && !attr.author_id.starts_with("h_")
+        })
+        .expect("feature entry should have an AI line attribution")
+        .author_id
+        .clone();
+
+    ai_checkpoint.entries.push(WorkingLogEntry::new(
+        "stale.rs".to_string(),
+        feature_entry.blob_sha,
+        vec![Attribution::new(0, 0, ai_author_id, 0)],
+        Vec::new(),
+    ));
+    working_log
+        .write_all_checkpoints(&checkpoints)
+        .expect("modified checkpoints should be writable");
+
+    repo.stage_all_and_commit("AI feature").unwrap();
+
+    file.assert_lines_and_blame(crate::lines![
+        "fn main() {}".human(),
+        "fn generated_by_ai() -> bool { true }".ai(),
     ]);
 }
 


### PR DESCRIPTION
## Summary
- fall back from missing persisted `line_attributions` to character attribution conversion
- skip stale entries when no line attribution can be recovered instead of aborting the whole authorship note generation
- add a regression test for a stale zero-width AI attribution entry in a persisted working log

## Root cause
`VirtualAttributions::from_persisted_working_log` treated checkpoint entries with character attributions but empty `line_attributions` as fatal when the checkpoint had AI additions. A stale/no-op entry could therefore fail post-commit authorship generation for the entire commit, even when other files in the commit had valid AI attribution data. Other reconstruction paths already convert character attributions back to line attributions and skip empty results; this makes the persisted path behave consistently.

## Verification
- `cargo test --test integration test_stale_zero_width_checkpoint_entry_does_not_abort_persisted_working_log -- --nocapture`
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

Note: I ran cargo/rustc through the installed stable toolchain path locally because the rustup shim on this machine hangs without an explicit default toolchain in the test harness environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->