### PR TITLE
test(show-prompt): lock in --commit scoping behavior

### DIFF
--- a/tests/integration/show_prompt.rs
+++ b/tests/integration/show_prompt.rs
@@ -1,5 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use git_ai::git::refs::notes_add;
+use serde_json::Value;
 
 // Local helper mirroring the CLI arg vector used by main
 fn args(list: &[&str]) -> Vec<String> {
@@ -169,6 +171,107 @@ fn show_prompt_with_offset_skips_occurrences() {
     );
 }
 
+/// Regression test for #861: `show-prompt --commit <rev>` must scope its output
+/// to the note attached to that specific commit.
+///
+/// The same prompt ID can appear in several commits of a single agent session.
+/// Each commit's authorship note carries its own per-commit prompt record (stats
+/// such as `total_additions`). `--commit` must read the note of the requested
+/// commit, so two different commits yield two different records — rather than the
+/// original bug where output was identical regardless of `--commit`.
+#[test]
+fn show_prompt_commit_flag_scopes_to_requested_commit() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("test.txt");
+
+    file.set_contents(crate::lines!["Human line", "AI line".ai()]);
+    let first_commit = repo.stage_all_and_commit("First commit").unwrap();
+
+    file.insert_at(2, crate::lines!["AI line 2".ai()]);
+    let second_commit = repo.stage_all_and_commit("Second commit").unwrap();
+
+    // Attach a note to each commit for the SAME prompt ID, but with distinct
+    // per-commit stats so we can prove the output is scoped to the right note.
+    let prompt_id = "16e1bbcfe4838018";
+    let note = |sha: &str, additions: u32| {
+        format!(
+            r#"test.txt
+  {prompt_id} 2-2
+---
+{{
+  "schema_version": "authorship/3.0.0",
+  "git_ai_version": "1.2.0",
+  "base_commit_sha": "{sha}",
+  "prompts": {{
+    "{prompt_id}": {{
+      "agent_id": {{"tool": "claude", "id": "shared_session", "model": "opus"}},
+      "human_author": null,
+      "total_additions": {additions},
+      "total_deletions": 0,
+      "accepted_lines": {additions},
+      "overriden_lines": 0
+    }}
+  }}
+}}"#
+        )
+    };
+
+    let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("find repository");
+    notes_add(
+        &git_ai_repo,
+        &first_commit.commit_sha,
+        &note(&first_commit.commit_sha, 5),
+    )
+    .expect("attach note to first commit");
+    notes_add(
+        &git_ai_repo,
+        &second_commit.commit_sha,
+        &note(&second_commit.commit_sha, 99),
+    )
+    .expect("attach note to second commit");
+
+    let show = |rev: &str| -> Value {
+        let out = repo
+            .git_ai(&["show-prompt", prompt_id, "--commit", rev])
+            .expect("show-prompt --commit should succeed");
+        serde_json::from_str(out.trim()).expect("valid show-prompt json")
+    };
+
+    let first = show(&first_commit.commit_sha);
+    let second = show(&second_commit.commit_sha);
+
+    // The reported commit must match the requested commit.
+    assert_eq!(
+        first["commit"].as_str(),
+        Some(first_commit.commit_sha.as_str()),
+        "--commit <first> must report the first commit"
+    );
+    assert_eq!(
+        second["commit"].as_str(),
+        Some(second_commit.commit_sha.as_str()),
+        "--commit <second> must report the second commit"
+    );
+
+    // The per-commit prompt record must come from the requested commit's note.
+    assert_eq!(
+        first["prompt"]["total_additions"].as_u64(),
+        Some(5),
+        "first commit note records total_additions=5"
+    );
+    assert_eq!(
+        second["prompt"]["total_additions"].as_u64(),
+        Some(99),
+        "second commit note records total_additions=99"
+    );
+
+    // And the two scoped outputs must genuinely differ (the core of #861).
+    assert_ne!(
+        first["prompt"], second["prompt"],
+        "--commit must scope output to the requested commit, not return identical records"
+    );
+}
+
 crate::reuse_tests_in_worktree!(
     parse_args_requires_prompt_id,
     parse_args_parses_basic_id,
@@ -182,4 +285,5 @@ crate::reuse_tests_in_worktree!(
     parse_args_rejects_unknown_flag,
     show_prompt_returns_latest_prompt_by_default,
     show_prompt_with_offset_skips_occurrences,
+    show_prompt_commit_flag_scopes_to_requested_commit,
 );


### PR DESCRIPTION
## TL;DR

Issue #861 — `git-ai show-prompt <id> --commit <rev>` returning the same output regardless of `--commit` — **is already resolved on `main`**. This PR adds a regression test that proves the correct behavior and guards against re-introduction. No production code change is required.

Closes #861.

## Background: what the bug was

When #861 was filed, a `PromptRecord` embedded the **full message transcript** of an agent session. In a multi-commit session the same prompt ID appears in several commits, all carrying the *same* transcript. `--commit` resolved the right commit's note, but since every note held the identical transcript, the output looked the same no matter which commit you passed:

```bash
git-ai show-prompt 16e1bbcfe4838018                 # 1133 lines
git-ai show-prompt 16e1bbcfe4838018 --commit HEAD    # 1133 lines (identical)
git-ai show-prompt 16e1bbcfe4838018 --commit HEAD~   # 1133 lines (identical)
```

## Why it's already fixed

The CAS-removal refactor (`8aa516d5b`, "refactor: remove CAS infrastructure and uploads") dropped the message transcript from `PromptRecord` entirely. A record now carries only **per-commit** data — `total_additions`, `accepted_lines`, etc. — and `find_prompt_in_commit` (`src/authorship/prompt_utils.rs`) reads the note of the *requested* commit. So two commits now legitimately differ in their scoped output.

## Verification

I reproduced the exact scenario on current `main`: the same prompt ID attached to two commits with distinct per-commit stats.

```
--commit <first>  -> { "commit": "<first>",  "prompt": { "total_additions": 5  } }
--commit <second> -> { "commit": "<second>", "prompt": { "total_additions": 99 } }
```

Both the `commit` field and the `prompt` body differ — confirming `--commit` scopes correctly.

## What this PR adds

`show_prompt_commit_flag_scopes_to_requested_commit` in `tests/integration/show_prompt.rs`:

- creates two commits, then attaches an authorship note to **each** for the same prompt ID but with different per-commit stats (`total_additions` 5 vs 99),
- runs `show-prompt --commit <rev>` for each commit, and
- asserts the reported `commit` matches the requested commit, the stats come from that commit's note, and the two scoped records are **not** identical (the heart of #861).

## Validation

```bash
cargo fmt --check                       # clean
task lint                               # clippy -D warnings: clean
task test TEST_FILTER=show_prompt       # 28 passed
```

Runs under the standard suite plus the auto-generated `_in_worktree` variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->