### PR TITLE
[codex] Clarify whoami auth and telemetry status

### DIFF
--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -14,6 +14,16 @@ const RETRY_DELAYS_SECS: [u64; 1] = [60];
 const METRICS_UPLOAD_MIN_REQUEST_INTERVAL: Duration = Duration::from_millis(500);
 static LAST_METRICS_UPLOAD_STARTED_AT: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
 
+/// Returns whether metrics are allowed to upload for the current API context.
+///
+/// Keep this in sync with user-facing status output: the default hosted API
+/// requires either OAuth login or an API key, while custom API URLs are assumed
+/// to be intentionally configured for delivery.
+pub fn metrics_upload_allowed(api_base_url: &str, client: &ApiClient) -> bool {
+    let using_default_api = api_base_url == crate::config::DEFAULT_API_BASE_URL;
+    !using_default_api || client.is_logged_in() || client.has_api_key()
+}
+
 fn wait_for_metrics_upload_rate_limit() -> Result<(), GitAiError> {
     let limiter = LAST_METRICS_UPLOAD_STARTED_AT.get_or_init(|| Mutex::new(None));
     let mut last_started_at = limiter.lock().map_err(|_| {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,5 +6,5 @@ pub mod notes;
 pub mod types;
 
 pub use client::{ApiClient, ApiContext};
-pub use metrics::upload_metrics_with_retry;
+pub use metrics::{metrics_upload_allowed, upload_metrics_with_retry};
 pub use types::*;

--- a/src/commands/flush_metrics_db.rs
+++ b/src/commands/flush_metrics_db.rs
@@ -2,7 +2,7 @@
 //!
 //! Uploads pending metrics database rows to the API.
 
-use crate::api::{ApiClient, ApiContext, upload_metrics_with_retry};
+use crate::api::{ApiClient, ApiContext, metrics_upload_allowed, upload_metrics_with_retry};
 use crate::metrics::db::MetricsDatabase;
 use crate::metrics::{MetricEvent, MetricsBatch};
 
@@ -11,13 +11,11 @@ const MAX_BATCH_SIZE: usize = 1000;
 
 /// Handle the flush-metrics-db command
 pub fn handle_flush_metrics_db(_args: &[String]) {
-    // Check conditions: (!using_default_api) || is_logged_in() || has_api_key()
     let context = ApiContext::new(None);
     let api_base_url = context.base_url.clone();
     let client = ApiClient::new(context);
 
-    let using_default_api = api_base_url == crate::config::DEFAULT_API_BASE_URL;
-    if using_default_api && !client.is_logged_in() && !client.has_api_key() {
+    if !metrics_upload_allowed(&api_base_url, &client) {
         eprintln!("flush-metrics-db: skipping (not logged in and using default API)");
         return;
     }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -41,7 +41,7 @@ pub fn handle_whoami(args: &[String]) {
         )
     );
 
-    if should_exit_failure(&auth, &api_ctx) {
+    if should_exit_failure(&api_ctx) {
         std::process::exit(1);
     }
 }
@@ -90,7 +90,7 @@ fn render_whoami(
         api_key_status(api_ctx.api_key.as_deref())
     )
     .unwrap();
-    writeln!(out, "  Login: {}", login_status(auth)).unwrap();
+    writeln!(out, "  Login: {}", login_status(auth, api_client)).unwrap();
     writeln!(out, "  Credential backend: {}", auth.backend).unwrap();
     if let Some(expires_at) = auth.access_token_expires_at {
         writeln!(
@@ -163,14 +163,15 @@ fn render_whoami(
 }
 
 fn api_access_status(auth: &AuthStatus, api_ctx: &ApiContext, api_client: &ApiClient) -> String {
-    match (
-        api_client.has_api_key(),
-        matches!(auth.state, AuthState::LoggedIn),
-    ) {
+    match (api_client.has_api_key(), api_client.is_logged_in()) {
         (true, true) => "connected via API key and login".to_string(),
         (true, false) => "connected via API key".to_string(),
         (false, true) => "connected via login".to_string(),
         (false, false) => {
+            if matches!(auth.state, AuthState::LoggedIn) {
+                return "not connected (login credentials found, but no usable access token)"
+                    .to_string();
+            }
             if api_ctx.base_url != crate::config::DEFAULT_API_BASE_URL {
                 "no auth credential found (custom API URL configured)".to_string()
             } else {
@@ -180,8 +181,8 @@ fn api_access_status(auth: &AuthStatus, api_ctx: &ApiContext, api_client: &ApiCl
     }
 }
 
-fn should_exit_failure(auth: &AuthStatus, api_ctx: &ApiContext) -> bool {
-    api_ctx.api_key.is_none() && !matches!(auth.state, AuthState::LoggedIn)
+fn should_exit_failure(api_ctx: &ApiContext) -> bool {
+    api_ctx.api_key.is_none() && api_ctx.auth_token.is_none()
 }
 
 fn author_identity_header_status(api_ctx: &ApiContext) -> String {
@@ -201,10 +202,11 @@ fn api_key_status(api_key: Option<&str>) -> String {
         .unwrap_or_else(|| "not configured".to_string())
 }
 
-fn login_status(auth: &AuthStatus) -> String {
+fn login_status(auth: &AuthStatus, api_client: &ApiClient) -> String {
     match &auth.state {
         AuthState::LoggedOut => "not connected".to_string(),
-        AuthState::LoggedIn => "connected".to_string(),
+        AuthState::LoggedIn if api_client.is_logged_in() => "connected".to_string(),
+        AuthState::LoggedIn => "connected (access token unavailable)".to_string(),
         AuthState::RefreshExpired => "not connected (refresh token expired)".to_string(),
         AuthState::Error(err) => format!("error ({})", err),
     }
@@ -374,9 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn should_exit_failure_matches_displayed_auth_state() {
-        let logged_out = auth_status(AuthState::LoggedOut);
-        let logged_in = auth_status(AuthState::LoggedIn);
+    fn should_exit_failure_requires_usable_api_credential() {
         let no_token_no_key = api_context(crate::config::DEFAULT_API_BASE_URL, None, None, None);
         let no_token_with_key = api_context(
             crate::config::DEFAULT_API_BASE_URL,
@@ -384,9 +384,33 @@ mod tests {
             None,
             Some("Alice Example <alice@example.com>"),
         );
+        let with_token_no_key = api_context(
+            crate::config::DEFAULT_API_BASE_URL,
+            None,
+            Some("access-token"),
+            None,
+        );
 
-        assert!(should_exit_failure(&logged_out, &no_token_no_key));
-        assert!(!should_exit_failure(&logged_out, &no_token_with_key));
-        assert!(!should_exit_failure(&logged_in, &no_token_no_key));
+        assert!(should_exit_failure(&no_token_no_key));
+        assert!(!should_exit_failure(&no_token_with_key));
+        assert!(!should_exit_failure(&with_token_no_key));
+    }
+
+    #[test]
+    fn render_whoami_distinguishes_login_credentials_from_usable_token() {
+        let auth = auth_status(AuthState::LoggedIn);
+        let ctx = api_context(crate::config::DEFAULT_API_BASE_URL, None, None, None);
+        let client = ApiClient::new(ctx.clone());
+        let metrics = metrics_status();
+
+        let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), false);
+
+        assert!(output.contains(
+            "API access: not connected (login credentials found, but no usable access token)"
+        ));
+        assert!(output.contains("Login: connected (access token unavailable)"));
+        assert!(
+            output.contains("Metrics delivery: off (default API requires an API key or login)")
+        );
     }
 }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -41,7 +41,7 @@ pub fn handle_whoami(args: &[String]) {
         )
     );
 
-    if should_exit_failure(&api_ctx) {
+    if should_exit_failure(&auth, &api_ctx) {
         std::process::exit(1);
     }
 }
@@ -181,8 +181,8 @@ fn api_access_status(auth: &AuthStatus, api_ctx: &ApiContext, api_client: &ApiCl
     }
 }
 
-fn should_exit_failure(api_ctx: &ApiContext) -> bool {
-    api_ctx.api_key.is_none() && api_ctx.auth_token.is_none()
+fn should_exit_failure(auth: &AuthStatus, api_ctx: &ApiContext) -> bool {
+    api_ctx.api_key.is_none() && !matches!(auth.state, AuthState::LoggedIn)
 }
 
 fn author_identity_header_status(api_ctx: &ApiContext) -> String {
@@ -376,7 +376,9 @@ mod tests {
     }
 
     #[test]
-    fn should_exit_failure_requires_usable_api_credential() {
+    fn should_exit_failure_preserves_stored_login_success() {
+        let logged_out = auth_status(AuthState::LoggedOut);
+        let logged_in = auth_status(AuthState::LoggedIn);
         let no_token_no_key = api_context(crate::config::DEFAULT_API_BASE_URL, None, None, None);
         let no_token_with_key = api_context(
             crate::config::DEFAULT_API_BASE_URL,
@@ -384,16 +386,10 @@ mod tests {
             None,
             Some("Alice Example <alice@example.com>"),
         );
-        let with_token_no_key = api_context(
-            crate::config::DEFAULT_API_BASE_URL,
-            None,
-            Some("access-token"),
-            None,
-        );
 
-        assert!(should_exit_failure(&no_token_no_key));
-        assert!(!should_exit_failure(&no_token_with_key));
-        assert!(!should_exit_failure(&with_token_no_key));
+        assert!(should_exit_failure(&logged_out, &no_token_no_key));
+        assert!(!should_exit_failure(&logged_out, &no_token_with_key));
+        assert!(!should_exit_failure(&logged_in, &no_token_no_key));
     }
 
     #[test]

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -77,7 +77,7 @@ fn render_whoami(
     .unwrap();
     writeln!(
         out,
-        "  Author identity header (X-Author-Identity): {}",
+        "  Identity: {}",
         author_identity_header_status(api_ctx)
     )
     .unwrap();
@@ -110,36 +110,38 @@ fn render_whoami(
     }
     writeln!(out).unwrap();
 
-    writeln!(out, "Login identity").unwrap();
-    writeln!(out, "  User ID: {}", optional_or_unavailable(&auth.user_id)).unwrap();
-    writeln!(out, "  Email: {}", optional_or_unavailable(&auth.email)).unwrap();
-    writeln!(out, "  Name: {}", optional_or_unavailable(&auth.name)).unwrap();
-    writeln!(
-        out,
-        "  Personal org ID: {}",
-        optional_or_unavailable(&auth.personal_org_id)
-    )
-    .unwrap();
-    if auth.orgs.is_empty() {
-        writeln!(out, "  Organizations: <none>").unwrap();
-    } else {
-        writeln!(out, "  Organizations:").unwrap();
-        for org in &auth.orgs {
-            let org_id = org.org_id.as_deref().unwrap_or("<unknown-id>");
-            let org_slug = org.org_slug.as_deref().unwrap_or("<unknown-slug>");
-            let org_name = org.org_name.as_deref().unwrap_or("<unknown-name>");
-            let role = org.role.as_deref().unwrap_or("<unknown-role>");
-            writeln!(
-                out,
-                "    - {} ({}) [{}] role={}",
-                org_slug, org_name, org_id, role
-            )
-            .unwrap();
+    if matches!(auth.state, AuthState::LoggedIn) {
+        writeln!(out, "Login identity").unwrap();
+        writeln!(out, "  User ID: {}", optional_or_unavailable(&auth.user_id)).unwrap();
+        writeln!(out, "  Email: {}", optional_or_unavailable(&auth.email)).unwrap();
+        writeln!(out, "  Name: {}", optional_or_unavailable(&auth.name)).unwrap();
+        writeln!(
+            out,
+            "  Personal org ID: {}",
+            optional_or_unavailable(&auth.personal_org_id)
+        )
+        .unwrap();
+        if auth.orgs.is_empty() {
+            writeln!(out, "  Organizations: <none>").unwrap();
+        } else {
+            writeln!(out, "  Organizations:").unwrap();
+            for org in &auth.orgs {
+                let org_id = org.org_id.as_deref().unwrap_or("<unknown-id>");
+                let org_slug = org.org_slug.as_deref().unwrap_or("<unknown-slug>");
+                let org_name = org.org_name.as_deref().unwrap_or("<unknown-name>");
+                let role = org.role.as_deref().unwrap_or("<unknown-role>");
+                writeln!(
+                    out,
+                    "    - {} ({}) [{}] role={}",
+                    org_slug, org_name, org_id, role
+                )
+                .unwrap();
+            }
         }
+        writeln!(out).unwrap();
     }
-    writeln!(out).unwrap();
 
-    writeln!(out, "Telemetry and metrics").unwrap();
+    writeln!(out, "Telemetry status").unwrap();
     writeln!(
         out,
         "  Metrics delivery: {}",
@@ -335,9 +337,11 @@ mod tests {
         assert!(output.contains("API access: connected via API key"));
         assert!(output.contains("API key: connected (gita...7890)"));
         assert!(output.contains("Login: not connected"));
-        assert!(output.contains(
-            "Author identity header (X-Author-Identity): Alice Example <alice@example.com>"
-        ));
+        assert!(output.contains("Identity: Alice Example <alice@example.com>"));
+        assert!(!output.contains("Author identity header"));
+        assert!(!output.contains("Login identity"));
+        assert!(output.contains("Telemetry status"));
+        assert!(!output.contains("Telemetry and metrics"));
         assert!(output.contains("Metrics delivery: on (API key configured)"));
     }
 
@@ -366,9 +370,13 @@ mod tests {
         let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), true);
 
         assert!(output.contains("API access: connected via login"));
-        assert!(output.contains("Author identity header (X-Author-Identity): not sent"));
+        assert!(output.contains("Identity: not sent"));
+        assert!(!output.contains("Author identity header"));
+        assert!(output.contains("Login identity"));
         assert!(output.contains("Email: user@example.com"));
         assert!(output.contains("- acme (Acme) [org-123] role=owner"));
+        assert!(output.contains("Telemetry status"));
+        assert!(!output.contains("Telemetry and metrics"));
         assert!(output.contains("OSS diagnostic telemetry: off"));
         assert!(output.contains("Events: 12 total, 8 delivered, 4 not delivered"));
         assert!(output.contains("Rows with sync errors: 1"));

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -200,17 +200,20 @@ fn author_identity_header_status(api_ctx: &ApiContext) -> String {
 
 fn api_key_status(api_key: Option<&str>) -> String {
     api_key
-        .map(|key| format!("connected ({})", mask_api_key(key)))
-        .unwrap_or_else(|| "not configured".to_string())
+        .map(|key| format!("configured ({})", mask_api_key(key)))
+        .unwrap_or_else(|| "unset".to_string())
 }
 
 fn login_status(auth: &AuthStatus, api_client: &ApiClient) -> String {
     match &auth.state {
-        AuthState::LoggedOut => "not connected".to_string(),
-        AuthState::LoggedIn if api_client.is_logged_in() => "connected".to_string(),
-        AuthState::LoggedIn => "connected (access token unavailable)".to_string(),
-        AuthState::RefreshExpired => "not connected (refresh token expired)".to_string(),
-        AuthState::Error(err) => format!("error ({})", err),
+        AuthState::LoggedIn => "logged in".to_string(),
+        AuthState::LoggedOut | AuthState::RefreshExpired | AuthState::Error(_) => {
+            if api_client.has_api_key() {
+                "optional (using api key)".to_string()
+            } else {
+                "not logged in".to_string()
+            }
+        }
     }
 }
 
@@ -335,8 +338,8 @@ mod tests {
         let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), false);
 
         assert!(output.contains("API access: connected via API key"));
-        assert!(output.contains("API key: connected (gita...7890)"));
-        assert!(output.contains("Login: not connected"));
+        assert!(output.contains("API key: configured (gita...7890)"));
+        assert!(output.contains("Login: optional (using api key)"));
         assert!(output.contains("Identity: Alice Example <alice@example.com>"));
         assert!(!output.contains("Author identity header"));
         assert!(!output.contains("Login identity"));
@@ -370,6 +373,8 @@ mod tests {
         let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), true);
 
         assert!(output.contains("API access: connected via login"));
+        assert!(output.contains("API key: unset"));
+        assert!(output.contains("Login: logged in"));
         assert!(output.contains("Identity: not sent"));
         assert!(!output.contains("Author identity header"));
         assert!(output.contains("Login identity"));
@@ -381,6 +386,19 @@ mod tests {
         assert!(output.contains("Events: 12 total, 8 delivered, 4 not delivered"));
         assert!(output.contains("Rows with sync errors: 1"));
         assert!(output.contains("Latest sync error: temporary outage"));
+    }
+
+    #[test]
+    fn render_whoami_shows_unset_api_key_and_not_logged_in() {
+        let auth = auth_status(AuthState::LoggedOut);
+        let ctx = api_context(crate::config::DEFAULT_API_BASE_URL, None, None, None);
+        let client = ApiClient::new(ctx.clone());
+        let metrics = metrics_status();
+
+        let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), false);
+
+        assert!(output.contains("API key: unset"));
+        assert!(output.contains("Login: not logged in"));
     }
 
     #[test]
@@ -412,7 +430,7 @@ mod tests {
         assert!(output.contains(
             "API access: not connected (login credentials found, but no usable access token)"
         ));
-        assert!(output.contains("Login: connected (access token unavailable)"));
+        assert!(output.contains("Login: logged in"));
         assert!(
             output.contains("Metrics delivery: off (default API requires an API key or login)")
         );

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -1,6 +1,9 @@
-use crate::api::client::ApiContext;
+use crate::api::{ApiClient, ApiContext, metrics_upload_allowed};
+use crate::auth::state::AuthStatus;
 use crate::auth::{AuthState, collect_auth_status, format_unix_timestamp};
 use crate::config;
+use crate::metrics::db::{MetricsDatabase, MetricsStatus};
+use std::fmt::Write as _;
 
 pub fn handle_whoami(args: &[String]) {
     if args
@@ -17,85 +20,230 @@ pub fn handle_whoami(args: &[String]) {
         std::process::exit(1);
     }
 
-    // Use Config::fresh() to support runtime config updates (daemon mode)
-    let api_base_url = config::Config::fresh().api_base_url().to_string();
+    // Use Config::fresh() to support runtime config updates (daemon mode).
+    let config = config::Config::fresh();
+    let api_base_url = config.api_base_url().to_string();
+    let telemetry_oss_disabled = config.is_telemetry_oss_disabled();
     let auth = collect_auth_status();
     let api_ctx = ApiContext::new(None);
+    let api_client = ApiClient::new(api_ctx.clone());
+    let metrics_status = collect_metrics_status();
 
-    println!("API Base URL: {}", api_base_url);
-    println!("Credential backend: {}", auth.backend);
+    print!(
+        "{}",
+        render_whoami(
+            &api_base_url,
+            &auth,
+            &api_ctx,
+            &api_client,
+            metrics_status.as_ref().map_err(String::as_str),
+            telemetry_oss_disabled,
+        )
+    );
 
-    if let Some(api_key) = &api_ctx.api_key {
-        let masked = mask_api_key(api_key);
-        println!("API key: {}", masked);
+    if !api_client.has_api_key() && !api_client.is_logged_in() {
+        std::process::exit(1);
     }
+}
 
-    match &auth.state {
-        AuthState::LoggedOut => {
-            println!("Auth state: logged out");
-            if api_ctx.api_key.is_none() {
-                std::process::exit(1);
-            }
-        }
-        AuthState::LoggedIn => {
-            println!("Auth state: logged in");
-        }
-        AuthState::RefreshExpired => {
-            println!("Auth state: credentials expired (refresh token expired)");
-            if api_ctx.api_key.is_none() {
-                std::process::exit(1);
-            }
-        }
-        AuthState::Error(err) => {
-            println!("Auth state: error ({})", err);
-            if api_ctx.api_key.is_none() {
-                std::process::exit(1);
-            }
-        }
-    }
+fn collect_metrics_status() -> Result<MetricsStatus, String> {
+    let db = MetricsDatabase::global().map_err(|e| e.to_string())?;
+    let db = db
+        .lock()
+        .map_err(|_| "metrics DB lock poisoned".to_string())?;
+    db.status().map_err(|e| e.to_string())
+}
 
+fn render_whoami(
+    api_base_url: &str,
+    auth: &AuthStatus,
+    api_ctx: &ApiContext,
+    api_client: &ApiClient,
+    metrics_status: Result<&MetricsStatus, &str>,
+    telemetry_oss_disabled: bool,
+) -> String {
+    let mut out = String::new();
+
+    writeln!(out, "git-ai status").unwrap();
+    writeln!(out).unwrap();
+
+    writeln!(out, "API").unwrap();
+    writeln!(out, "  Base URL: {}", api_base_url).unwrap();
+    writeln!(
+        out,
+        "  API access: {}",
+        api_access_status(auth, api_ctx, api_client)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  Author identity header (X-Author-Identity): {}",
+        author_identity_header_status(api_ctx)
+    )
+    .unwrap();
+    writeln!(out).unwrap();
+
+    writeln!(out, "Authentication").unwrap();
+    writeln!(
+        out,
+        "  API key: {}",
+        api_key_status(api_ctx.api_key.as_deref())
+    )
+    .unwrap();
+    writeln!(out, "  Login: {}", login_status(auth)).unwrap();
+    writeln!(out, "  Credential backend: {}", auth.backend).unwrap();
     if let Some(expires_at) = auth.access_token_expires_at {
-        println!(
-            "Access token expires at: {}",
+        writeln!(
+            out,
+            "  Access token expires at: {}",
             format_unix_timestamp(expires_at)
-        );
+        )
+        .unwrap();
     }
     if let Some(expires_at) = auth.refresh_token_expires_at {
-        println!(
-            "Refresh token expires at: {}",
+        writeln!(
+            out,
+            "  Refresh token expires at: {}",
             format_unix_timestamp(expires_at)
-        );
+        )
+        .unwrap();
     }
+    writeln!(out).unwrap();
 
-    println!(
-        "User ID: {}",
-        auth.user_id.unwrap_or_else(|| "<unavailable>".to_string())
-    );
-    println!(
-        "Email: {}",
-        auth.email.unwrap_or_else(|| "<unavailable>".to_string())
-    );
-    println!(
-        "Name: {}",
-        auth.name.unwrap_or_else(|| "<unavailable>".to_string())
-    );
-    println!(
-        "Personal org ID: {}",
-        auth.personal_org_id
-            .unwrap_or_else(|| "<unavailable>".to_string())
-    );
+    writeln!(out, "Login identity").unwrap();
+    writeln!(out, "  User ID: {}", optional_or_unavailable(&auth.user_id)).unwrap();
+    writeln!(out, "  Email: {}", optional_or_unavailable(&auth.email)).unwrap();
+    writeln!(out, "  Name: {}", optional_or_unavailable(&auth.name)).unwrap();
+    writeln!(
+        out,
+        "  Personal org ID: {}",
+        optional_or_unavailable(&auth.personal_org_id)
+    )
+    .unwrap();
     if auth.orgs.is_empty() {
-        println!("Organizations: <none>");
+        writeln!(out, "  Organizations: <none>").unwrap();
     } else {
-        println!("Organizations:");
-        for org in auth.orgs {
-            let org_id = org.org_id.unwrap_or_else(|| "<unknown-id>".to_string());
-            let org_slug = org.org_slug.unwrap_or_else(|| "<unknown-slug>".to_string());
-            let org_name = org.org_name.unwrap_or_else(|| "<unknown-name>".to_string());
-            let role = org.role.unwrap_or_else(|| "<unknown-role>".to_string());
-            println!("  - {} ({}) [{}] role={}", org_slug, org_name, org_id, role);
+        writeln!(out, "  Organizations:").unwrap();
+        for org in &auth.orgs {
+            let org_id = org.org_id.as_deref().unwrap_or("<unknown-id>");
+            let org_slug = org.org_slug.as_deref().unwrap_or("<unknown-slug>");
+            let org_name = org.org_name.as_deref().unwrap_or("<unknown-name>");
+            let role = org.role.as_deref().unwrap_or("<unknown-role>");
+            writeln!(
+                out,
+                "    - {} ({}) [{}] role={}",
+                org_slug, org_name, org_id, role
+            )
+            .unwrap();
         }
     }
+    writeln!(out).unwrap();
+
+    writeln!(out, "Telemetry and metrics").unwrap();
+    writeln!(
+        out,
+        "  Metrics delivery: {}",
+        metrics_delivery_status(api_base_url, api_client)
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  OSS diagnostic telemetry: {}",
+        if telemetry_oss_disabled { "off" } else { "on" }
+    )
+    .unwrap();
+    match metrics_status {
+        Ok(status) => write_metrics_status(&mut out, status),
+        Err(err) => {
+            writeln!(out, "  Local metrics database: unavailable ({})", err).unwrap();
+        }
+    }
+
+    out
+}
+
+fn api_access_status(auth: &AuthStatus, api_ctx: &ApiContext, api_client: &ApiClient) -> String {
+    match (
+        api_client.has_api_key(),
+        matches!(auth.state, AuthState::LoggedIn),
+    ) {
+        (true, true) => "connected via API key and login".to_string(),
+        (true, false) => "connected via API key".to_string(),
+        (false, true) => "connected via login".to_string(),
+        (false, false) => {
+            if api_ctx.base_url != crate::config::DEFAULT_API_BASE_URL {
+                "no auth credential found (custom API URL configured)".to_string()
+            } else {
+                "not connected".to_string()
+            }
+        }
+    }
+}
+
+fn author_identity_header_status(api_ctx: &ApiContext) -> String {
+    if api_ctx.api_key.is_none() {
+        return "not sent (API key not configured)".to_string();
+    }
+
+    api_ctx
+        .author_identity
+        .clone()
+        .unwrap_or_else(|| "unavailable (header will be omitted)".to_string())
+}
+
+fn api_key_status(api_key: Option<&str>) -> String {
+    api_key
+        .map(|key| format!("connected ({})", mask_api_key(key)))
+        .unwrap_or_else(|| "not configured".to_string())
+}
+
+fn login_status(auth: &AuthStatus) -> String {
+    match &auth.state {
+        AuthState::LoggedOut => "not connected".to_string(),
+        AuthState::LoggedIn => "connected".to_string(),
+        AuthState::RefreshExpired => "not connected (refresh token expired)".to_string(),
+        AuthState::Error(err) => format!("error ({})", err),
+    }
+}
+
+fn metrics_delivery_status(api_base_url: &str, api_client: &ApiClient) -> String {
+    if !metrics_upload_allowed(api_base_url, api_client) {
+        return "off (default API requires an API key or login)".to_string();
+    }
+
+    match (api_client.has_api_key(), api_client.is_logged_in()) {
+        (true, true) => "on (API key and login connected)".to_string(),
+        (true, false) => "on (API key configured)".to_string(),
+        (false, true) => "on (login connected)".to_string(),
+        (false, false) => "on (custom API URL configured)".to_string(),
+    }
+}
+
+fn write_metrics_status(out: &mut String, status: &MetricsStatus) {
+    writeln!(out, "  Local metrics database: ok").unwrap();
+    writeln!(
+        out,
+        "  Events: {} total, {} delivered, {} not delivered",
+        status.total, status.delivered, status.not_delivered
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "  Not delivered: {} pending now, {} waiting for retry, {} processing, {} stopped after errors",
+        status.pending_retryable,
+        status.waiting_retry,
+        status.processing,
+        status.stopped_after_errors
+    )
+    .unwrap();
+    writeln!(out, "  Rows with sync errors: {}", status.rows_with_errors).unwrap();
+    if let Some(latest_error) = &status.latest_error {
+        writeln!(out, "  Latest sync error: {}", latest_error).unwrap();
+    }
+}
+
+fn optional_or_unavailable(value: &Option<String>) -> &str {
+    value.as_deref().unwrap_or("<unavailable>")
 }
 
 fn mask_api_key(key: &str) -> String {
@@ -109,9 +257,115 @@ fn mask_api_key(key: &str) -> String {
 }
 
 fn print_help() {
-    eprintln!("git-ai whoami - Show current auth state and identity");
+    eprintln!("git-ai whoami - Show current auth, identity, and telemetry status");
     eprintln!();
     eprintln!("Usage:");
     eprintln!("  git-ai whoami");
     eprintln!("  git-ai whoami --help");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::identity::TokenOrg;
+
+    fn auth_status(state: AuthState) -> AuthStatus {
+        AuthStatus {
+            backend: "test-backend".to_string(),
+            state,
+            access_token_expires_at: None,
+            refresh_token_expires_at: None,
+            user_id: None,
+            email: None,
+            name: None,
+            personal_org_id: None,
+            orgs: Vec::new(),
+        }
+    }
+
+    fn api_context(
+        base_url: &str,
+        api_key: Option<&str>,
+        auth_token: Option<&str>,
+        author_identity: Option<&str>,
+    ) -> ApiContext {
+        ApiContext {
+            base_url: base_url.to_string(),
+            auth_token: auth_token.map(str::to_string),
+            api_key: api_key.map(str::to_string),
+            author_identity: author_identity.map(str::to_string),
+            timeout_secs: Some(30),
+        }
+    }
+
+    fn metrics_status() -> MetricsStatus {
+        MetricsStatus {
+            total: 12,
+            delivered: 8,
+            not_delivered: 4,
+            pending_retryable: 2,
+            waiting_retry: 1,
+            processing: 1,
+            stopped_after_errors: 0,
+            rows_with_errors: 1,
+            latest_error: Some("temporary outage".to_string()),
+        }
+    }
+
+    #[test]
+    fn render_whoami_treats_api_key_only_as_connected() {
+        let auth = auth_status(AuthState::LoggedOut);
+        let ctx = api_context(
+            crate::config::DEFAULT_API_BASE_URL,
+            Some("gitai_test_1234567890"),
+            None,
+            Some("Alice Example <alice@example.com>"),
+        );
+        let client = ApiClient::new(ctx.clone());
+        let metrics = metrics_status();
+
+        let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), false);
+
+        assert!(output.contains("API access: connected via API key"));
+        assert!(output.contains("API key: connected (gita...7890)"));
+        assert!(output.contains("Login: not connected"));
+        assert!(output.contains(
+            "Author identity header (X-Author-Identity): Alice Example <alice@example.com>"
+        ));
+        assert!(output.contains("Metrics delivery: on (API key configured)"));
+    }
+
+    #[test]
+    fn render_whoami_shows_login_identity_and_metrics_summary() {
+        let mut auth = auth_status(AuthState::LoggedIn);
+        auth.user_id = Some("user-123".to_string());
+        auth.email = Some("user@example.com".to_string());
+        auth.name = Some("User Example".to_string());
+        auth.personal_org_id = Some("org-123".to_string());
+        auth.orgs = vec![TokenOrg {
+            org_id: Some("org-123".to_string()),
+            org_slug: Some("acme".to_string()),
+            org_name: Some("Acme".to_string()),
+            role: Some("owner".to_string()),
+        }];
+        let ctx = api_context(
+            crate::config::DEFAULT_API_BASE_URL,
+            None,
+            Some("access-token"),
+            None,
+        );
+        let client = ApiClient::new(ctx.clone());
+        let metrics = metrics_status();
+
+        let output = render_whoami(&ctx.base_url, &auth, &ctx, &client, Ok(&metrics), true);
+
+        assert!(output.contains("API access: connected via login"));
+        assert!(output.contains("Author identity header (X-Author-Identity): not sent"));
+        assert!(output.contains("Email: user@example.com"));
+        assert!(output.contains("- acme (Acme) [org-123] role=owner"));
+        assert!(output.contains("OSS diagnostic telemetry: off"));
+        assert!(output.contains("Events: 12 total, 8 delivered, 4 not delivered"));
+        assert!(output.contains("Rows with sync errors: 1"));
+        assert!(output.contains("Latest sync error: temporary outage"));
+    }
 }

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -41,7 +41,7 @@ pub fn handle_whoami(args: &[String]) {
         )
     );
 
-    if !api_client.has_api_key() && !api_client.is_logged_in() {
+    if should_exit_failure(&auth, &api_ctx) {
         std::process::exit(1);
     }
 }
@@ -178,6 +178,10 @@ fn api_access_status(auth: &AuthStatus, api_ctx: &ApiContext, api_client: &ApiCl
             }
         }
     }
+}
+
+fn should_exit_failure(auth: &AuthStatus, api_ctx: &ApiContext) -> bool {
+    api_ctx.api_key.is_none() && !matches!(auth.state, AuthState::LoggedIn)
 }
 
 fn author_identity_header_status(api_ctx: &ApiContext) -> String {
@@ -367,5 +371,22 @@ mod tests {
         assert!(output.contains("Events: 12 total, 8 delivered, 4 not delivered"));
         assert!(output.contains("Rows with sync errors: 1"));
         assert!(output.contains("Latest sync error: temporary outage"));
+    }
+
+    #[test]
+    fn should_exit_failure_matches_displayed_auth_state() {
+        let logged_out = auth_status(AuthState::LoggedOut);
+        let logged_in = auth_status(AuthState::LoggedIn);
+        let no_token_no_key = api_context(crate::config::DEFAULT_API_BASE_URL, None, None, None);
+        let no_token_with_key = api_context(
+            crate::config::DEFAULT_API_BASE_URL,
+            Some("gitai_test_1234567890"),
+            None,
+            Some("Alice Example <alice@example.com>"),
+        );
+
+        assert!(should_exit_failure(&logged_out, &no_token_no_key));
+        assert!(!should_exit_failure(&logged_out, &no_token_with_key));
+        assert!(!should_exit_failure(&logged_in, &no_token_no_key));
     }
 }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -3,7 +3,7 @@
 //! Runs inside the daemon process using tokio. Accumulates telemetry envelopes
 //! and CAS payloads, then flushes them to their destinations every 3 seconds.
 
-use crate::api::metrics::MetricsUploadResponse;
+use crate::api::metrics::{MetricsUploadResponse, metrics_upload_allowed};
 use crate::api::{ApiClient, ApiContext, CasObject, CasUploadRequest};
 use crate::config::{Config, get_or_create_distinct_id};
 use crate::daemon::control_api::{CasSyncPayload, TelemetryEnvelope};
@@ -430,11 +430,6 @@ fn flush_pending_metrics() {
     if let Err(e) = flush_pending_metrics_from_db(&client, deadline) {
         tracing::warn!(%e, "telemetry: failed to upload pending metrics");
     }
-}
-
-fn metrics_upload_allowed(api_base_url: &str, client: &ApiClient) -> bool {
-    let using_default_api = api_base_url == crate::config::DEFAULT_API_BASE_URL;
-    !using_default_api || client.is_logged_in() || client.has_api_key()
 }
 
 fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -68,6 +68,20 @@ pub struct MetricHistoryRecord {
     pub event: MetricEvent,
 }
 
+/// Point-in-time status summary for local metric delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricsStatus {
+    pub total: usize,
+    pub delivered: usize,
+    pub not_delivered: usize,
+    pub pending_retryable: usize,
+    pub waiting_retry: usize,
+    pub processing: usize,
+    pub stopped_after_errors: usize,
+    pub rows_with_errors: usize,
+    pub latest_error: Option<String>,
+}
+
 /// Database wrapper for metrics storage
 pub struct MetricsDatabase {
     conn: Connection,
@@ -536,6 +550,85 @@ impl MetricsDatabase {
             |row| row.get(0),
         )?;
         Ok(count as usize)
+    }
+
+    /// Summarize local metrics delivery state for user-facing diagnostics.
+    pub fn status(&self) -> Result<MetricsStatus, GitAiError> {
+        let now = current_unix_ts();
+        let (
+            total,
+            delivered,
+            not_delivered,
+            pending_retryable,
+            waiting_retry,
+            processing,
+            stopped_after_errors,
+            rows_with_errors,
+        ): (i64, i64, i64, i64, i64, i64, i64, i64) = self.conn.query_row(
+            r#"
+            SELECT
+                COUNT(*),
+                COALESCE(SUM(CASE WHEN delivered_ts IS NOT NULL THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN delivered_ts IS NULL THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE
+                    WHEN delivered_ts IS NULL
+                     AND processing_started_at IS NULL
+                     AND next_retry_at <= ?1
+                     AND attempts < ?2 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE
+                    WHEN delivered_ts IS NULL
+                     AND processing_started_at IS NULL
+                     AND next_retry_at > ?1
+                     AND attempts < ?2 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE
+                    WHEN delivered_ts IS NULL
+                     AND processing_started_at IS NOT NULL THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE
+                    WHEN delivered_ts IS NULL
+                     AND attempts >= ?2 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE
+                    WHEN last_sync_error IS NOT NULL
+                     AND last_sync_error != '' THEN 1 ELSE 0 END), 0)
+            FROM metrics
+            "#,
+            params![now as i64, MAX_METRIC_UPLOAD_ATTEMPTS as i64],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                ))
+            },
+        )?;
+
+        let latest_error: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT last_sync_error FROM metrics \
+                 WHERE last_sync_error IS NOT NULL AND last_sync_error != '' \
+                 ORDER BY COALESCE(last_sync_at, 0) DESC, id DESC \
+                 LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        Ok(MetricsStatus {
+            total: total as usize,
+            delivered: delivered as usize,
+            not_delivered: not_delivered as usize,
+            pending_retryable: pending_retryable as usize,
+            waiting_retry: waiting_retry as usize,
+            processing: processing as usize,
+            stopped_after_errors: stopped_after_errors as usize,
+            rows_with_errors: rows_with_errors as usize,
+            latest_error,
+        })
     }
 
     fn release_stale_processing_locks(&mut self, now: u64) -> Result<(), GitAiError> {
@@ -1102,6 +1195,72 @@ mod tests {
     }
 
     #[test]
+    fn test_status_counts_delivery_buckets() {
+        let (mut db, _temp_dir) = create_test_db();
+        let now = unix_now();
+
+        db.insert_events_with_delivered_ts(&[event_json(days_ago(5))], Some(now))
+            .unwrap();
+        let ids = db
+            .insert_events(&[
+                event_json(days_ago(4)),
+                event_json(days_ago(3)),
+                event_json(days_ago(2)),
+                event_json(days_ago(1)),
+            ])
+            .unwrap();
+        let pending_id = ids[0];
+        let waiting_id = ids[1];
+        let processing_id = ids[2];
+        let stopped_id = ids[3];
+
+        db.conn
+            .execute(
+                "UPDATE metrics \
+                 SET attempts = 1, last_sync_error = ?1, last_sync_at = ?2, next_retry_at = ?3 \
+                 WHERE id = ?4",
+                params![
+                    "temporary outage",
+                    now.saturating_sub(10) as i64,
+                    now.saturating_add(600) as i64,
+                    waiting_id
+                ],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE metrics SET processing_started_at = ?1 WHERE id = ?2",
+                params![now as i64, processing_id],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE metrics \
+                 SET attempts = ?1, last_sync_error = ?2, last_sync_at = ?3, next_retry_at = ?3 \
+                 WHERE id = ?4",
+                params![
+                    MAX_METRIC_UPLOAD_ATTEMPTS as i64,
+                    "validation failed",
+                    now as i64,
+                    stopped_id
+                ],
+            )
+            .unwrap();
+
+        assert_ne!(pending_id, waiting_id);
+        let status = db.status().unwrap();
+        assert_eq!(status.total, 5);
+        assert_eq!(status.delivered, 1);
+        assert_eq!(status.not_delivered, 4);
+        assert_eq!(status.pending_retryable, 1);
+        assert_eq!(status.waiting_retry, 1);
+        assert_eq!(status.processing, 1);
+        assert_eq!(status.stopped_after_errors, 1);
+        assert_eq!(status.rows_with_errors, 2);
+        assert_eq!(status.latest_error.as_deref(), Some("validation failed"));
+    }
+
+    #[test]
     fn test_mark_records_undeliverable_keeps_history_without_retrying() {
         let (mut db, _temp_dir) = create_test_db();
         let event_ts = days_ago(1);
@@ -1305,6 +1464,17 @@ mod tests {
         // Count empty should return 0
         let count = db.count().unwrap();
         assert_eq!(count, 0);
+
+        let status = db.status().unwrap();
+        assert_eq!(status.total, 0);
+        assert_eq!(status.delivered, 0);
+        assert_eq!(status.not_delivered, 0);
+        assert_eq!(status.pending_retryable, 0);
+        assert_eq!(status.waiting_retry, 0);
+        assert_eq!(status.processing, 0);
+        assert_eq!(status.stopped_after_errors, 0);
+        assert_eq!(status.rows_with_errors, 0);
+        assert_eq!(status.latest_error, None);
     }
 
     #[test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -587,7 +587,8 @@ impl MetricsDatabase {
                     WHEN delivered_ts IS NULL
                      AND attempts >= ?2 THEN 1 ELSE 0 END), 0),
                 COALESCE(SUM(CASE
-                    WHEN last_sync_error IS NOT NULL
+                    WHEN delivered_ts IS NULL
+                     AND last_sync_error IS NOT NULL
                      AND last_sync_error != '' THEN 1 ELSE 0 END), 0)
             FROM metrics
             "#,
@@ -610,7 +611,9 @@ impl MetricsDatabase {
             .conn
             .query_row(
                 "SELECT last_sync_error FROM metrics \
-                 WHERE last_sync_error IS NOT NULL AND last_sync_error != '' \
+                 WHERE delivered_ts IS NULL \
+                   AND last_sync_error IS NOT NULL \
+                   AND last_sync_error != '' \
                  ORDER BY COALESCE(last_sync_at, 0) DESC, id DESC \
                  LIMIT 1",
                 [],
@@ -1199,8 +1202,10 @@ mod tests {
         let (mut db, _temp_dir) = create_test_db();
         let now = unix_now();
 
-        db.insert_events_with_delivered_ts(&[event_json(days_ago(5))], Some(now))
+        let delivered_ids = db
+            .insert_events_with_delivered_ts(&[event_json(days_ago(5))], Some(now))
             .unwrap();
+        let delivered_id = delivered_ids[0];
         let ids = db
             .insert_events(&[
                 event_json(days_ago(4)),
@@ -1214,6 +1219,18 @@ mod tests {
         let processing_id = ids[2];
         let stopped_id = ids[3];
 
+        db.conn
+            .execute(
+                "UPDATE metrics \
+                 SET last_sync_error = ?1, last_sync_at = ?2 \
+                 WHERE id = ?3",
+                params![
+                    "delivered retry recovered",
+                    now.saturating_add(60) as i64,
+                    delivered_id
+                ],
+            )
+            .unwrap();
         db.conn
             .execute(
                 "UPDATE metrics \


### PR DESCRIPTION
## What changed

- Reworked `git-ai whoami` output into clear API, authentication, login identity, and telemetry/metrics sections.
- Shows API key and login as separate auth methods so API-key-only users are reported as connected through the API key, not as a broken logged-out state.
- Prints the exact `X-Author-Identity` value from `ApiContext`, matching what API requests send when an API key is configured.
- Added local metrics DB status counts for delivered, not delivered, pending retryable, waiting for retry, processing, stopped-after-errors, and rows with sync errors.
- Moved the metrics-upload gate into a shared helper used by the daemon, manual metrics flush, and `whoami` status output.

## Validation

- `task fmt`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=commands::whoami`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=metrics::db::tests::test_status_counts_delivery_buckets`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=metrics::db::tests::test_empty_operations`
- `task lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->