### PR TITLE
Support Claude-format tool names in Copilot CLI hooks

### DIFF
--- a/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
@@ -96,13 +96,13 @@ pub(super) fn parse_cli_hooks(
             stream_source,
         })]),
         ("PreToolUse", ToolClass::FileEdit) => {
-            // `create` PreToolUse: synthesize empty dirty_files for the new path
+            // Full-file creation tools synthesize an empty pre-edit baseline
             // (mirrors the IDE `create_file` behavior).
-            if tool_name == "create" {
+            if is_create_like_cli_tool(tool_name) {
                 if extracted_paths.is_empty() {
-                    return Err(GitAiError::PresetError(
-                        "No path in CopilotCLI create tool_input".to_string(),
-                    ));
+                    return Err(GitAiError::PresetError(format!(
+                        "No path in CopilotCLI {tool_name} tool_input"
+                    )));
                 }
                 let dirty_files: HashMap<PathBuf, String> = extracted_paths
                     .iter()
@@ -167,7 +167,7 @@ fn classify_cli_tool(tool: &str) -> ToolClass {
         // than `str_replace`). We support both the old and new names side by side.
         // For `Edit`/`Write`, `tool_input` is an apply-patch string (`*** Add File: ...` /
         // `*** Update File: ...`); path extraction handles that via collect_apply_patch_paths.
-        "Bash" => ToolClass::Bash,
+        "Bash" | "PowerShell" | "Powershell" => ToolClass::Bash,
         "Edit" | "Write" | "MultiEdit" | "NotebookEdit" => ToolClass::FileEdit,
         // Skip read-only and control tools:
         //   view, read_file, grep, glob, semantic_search — read-only (legacy lowercase).
@@ -177,6 +177,10 @@ fn classify_cli_tool(tool: &str) -> ToolClass {
         //   read_powershell / write_powershell / stop_powershell / list_powershell — same for PS.
         _ => ToolClass::Skip,
     }
+}
+
+fn is_create_like_cli_tool(tool: &str) -> bool {
+    matches!(tool, "create" | "Write")
 }
 
 #[cfg(test)]
@@ -267,6 +271,32 @@ mod tests {
                         .as_ref()
                         .unwrap()
                         .get(&PathBuf::from("/Users/a/project/very_fun.md")),
+                    Some(&String::new())
+                );
+            }
+            other => panic!("Expected PreFileEdit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_write_pre_synthesizes_empty_dirty_files() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-cli",
+            "cwd": "/Users/a/project",
+            "tool_name": "Write",
+            "tool_input": "*** Begin Patch\n*** Add File: very_fun.md\n+# heading\n*** End Patch\n"
+        })
+        .to_string();
+        let events = GithubCopilotPreset
+            .parse(&input, "t_test123456789a")
+            .unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                let path = PathBuf::from("/Users/a/project/very_fun.md");
+                assert_eq!(e.file_paths, vec![path.clone()]);
+                assert_eq!(
+                    e.dirty_files.as_ref().unwrap().get(&path),
                     Some(&String::new())
                 );
             }
@@ -417,6 +447,8 @@ mod tests {
         assert_eq!(classify_cli_tool("bash"), ToolClass::Bash);
         assert_eq!(classify_cli_tool("powershell"), ToolClass::Bash);
         assert_eq!(classify_cli_tool("Bash"), ToolClass::Bash);
+        assert_eq!(classify_cli_tool("PowerShell"), ToolClass::Bash);
+        assert_eq!(classify_cli_tool("Powershell"), ToolClass::Bash);
         // File edit tools (legacy lowercase)
         assert_eq!(classify_cli_tool("create"), ToolClass::FileEdit);
         assert_eq!(classify_cli_tool("str_replace"), ToolClass::FileEdit);
@@ -509,6 +541,27 @@ mod tests {
         match &events[0] {
             ParsedHookEvent::PreBashCall(e) => {
                 assert_eq!(e.tool_use_id, "cli-sess-cli-Bash");
+            }
+            other => panic!("Expected PreBashCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_claude_format_powershell_pre() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-cli",
+            "cwd": "/Users/a/project",
+            "tool_name": "PowerShell",
+            "tool_input": {"command": "Get-ChildItem"}
+        })
+        .to_string();
+        let events = GithubCopilotPreset
+            .parse(&input, "t_test123456789a")
+            .unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.tool_use_id, "cli-sess-cli-PowerShell");
             }
             other => panic!("Expected PreBashCall, got {:?}", other),
         }

--- a/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
@@ -158,11 +158,20 @@ fn resolve_copilot_cli_session_path(session_id: &str) -> Option<PathBuf> {
 
 fn classify_cli_tool(tool: &str) -> ToolClass {
     match tool {
+        // Legacy lowercase tool names (older Copilot CLI builds).
         "bash" | "powershell" => ToolClass::Bash,
         "create" | "str_replace" | "edit" | "str_replace_editor" | "apply_patch"
         | "git_apply_patch" => ToolClass::FileEdit,
+        // Claude-format tool names. Copilot CLI >= 1.0.62 emits Claude-style PascalCase
+        // tool names in its hook payloads (e.g. `Bash` rather than `bash`, `Edit` rather
+        // than `str_replace`). We support both the old and new names side by side.
+        // For `Edit`/`Write`, `tool_input` is an apply-patch string (`*** Add File: ...` /
+        // `*** Update File: ...`); path extraction handles that via collect_apply_patch_paths.
+        "Bash" => ToolClass::Bash,
+        "Edit" | "Write" | "MultiEdit" | "NotebookEdit" => ToolClass::FileEdit,
         // Skip read-only and control tools:
-        //   view, read_file, grep, glob, semantic_search — read-only.
+        //   view, read_file, grep, glob, semantic_search — read-only (legacy lowercase).
+        //   Read, Grep, Glob, LS, Task, TodoWrite, WebFetch, WebSearch — read-only/control (Claude-format).
         //   report_intent, task_complete, ask_user, update_todo — metadata/control.
         //   read_bash / write_bash / stop_bash / list_bash — control ops on async shell.
         //   read_powershell / write_powershell / stop_powershell / list_powershell — same for PS.
@@ -404,21 +413,31 @@ mod tests {
 
     #[test]
     fn classify_cli_tool_matrix() {
-        // Bash tools
+        // Bash tools (legacy lowercase + Claude-format)
         assert_eq!(classify_cli_tool("bash"), ToolClass::Bash);
         assert_eq!(classify_cli_tool("powershell"), ToolClass::Bash);
-        // File edit tools
+        assert_eq!(classify_cli_tool("Bash"), ToolClass::Bash);
+        // File edit tools (legacy lowercase)
         assert_eq!(classify_cli_tool("create"), ToolClass::FileEdit);
         assert_eq!(classify_cli_tool("str_replace"), ToolClass::FileEdit);
         assert_eq!(classify_cli_tool("edit"), ToolClass::FileEdit);
         assert_eq!(classify_cli_tool("str_replace_editor"), ToolClass::FileEdit);
         assert_eq!(classify_cli_tool("apply_patch"), ToolClass::FileEdit);
         assert_eq!(classify_cli_tool("git_apply_patch"), ToolClass::FileEdit);
-        // Skip: read-only tools
+        // File edit tools (Claude-format, Copilot CLI >= 1.0.62)
+        assert_eq!(classify_cli_tool("Edit"), ToolClass::FileEdit);
+        assert_eq!(classify_cli_tool("Write"), ToolClass::FileEdit);
+        assert_eq!(classify_cli_tool("MultiEdit"), ToolClass::FileEdit);
+        assert_eq!(classify_cli_tool("NotebookEdit"), ToolClass::FileEdit);
+        // Skip: read-only tools (legacy lowercase)
         assert_eq!(classify_cli_tool("view"), ToolClass::Skip);
         assert_eq!(classify_cli_tool("read_file"), ToolClass::Skip);
         assert_eq!(classify_cli_tool("grep"), ToolClass::Skip);
         assert_eq!(classify_cli_tool("glob"), ToolClass::Skip);
+        // Skip: read-only tools (Claude-format)
+        assert_eq!(classify_cli_tool("Read"), ToolClass::Skip);
+        assert_eq!(classify_cli_tool("Grep"), ToolClass::Skip);
+        assert_eq!(classify_cli_tool("Glob"), ToolClass::Skip);
         // Skip: control/metadata tools
         assert_eq!(classify_cli_tool("report_intent"), ToolClass::Skip);
         assert_eq!(classify_cli_tool("read_bash"), ToolClass::Skip);
@@ -426,5 +445,86 @@ mod tests {
         assert_eq!(classify_cli_tool("stop_bash"), ToolClass::Skip);
         assert_eq!(classify_cli_tool("list_bash"), ToolClass::Skip);
         assert_eq!(classify_cli_tool("nonsense"), ToolClass::Skip);
+    }
+
+    // Claude-format payloads captured from a live Copilot CLI 1.0.64 session. `Edit`
+    // creates/updates files via an apply-patch STRING tool_input; `Read` is read-only.
+    #[test]
+    fn cli_claude_format_edit_pre_post() {
+        let pre = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "a5f5793e",
+            "cwd": "/Users/a/project",
+            "tool_name": "Edit",
+            "tool_input": "*** Begin Patch\n*** Add File: hello.txt\n+hi\n+bye\n*** End Patch\n"
+        })
+        .to_string();
+        let pre_events = GithubCopilotPreset.parse(&pre, "t_test123456789a").unwrap();
+        match &pre_events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/Users/a/project/hello.txt")]
+                );
+            }
+            other => panic!("Expected PreFileEdit, got {:?}", other),
+        }
+
+        let post = json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "a5f5793e",
+            "cwd": "/Users/a/project",
+            "tool_name": "Edit",
+            "tool_input": "*** Begin Patch\n*** Add File: hello.txt\n+hi\n+bye\n*** End Patch\n",
+            "tool_result": {"result_type": "success", "text_result_for_llm": "Added 1 file(s): hello.txt"}
+        })
+        .to_string();
+        let post_events = GithubCopilotPreset
+            .parse(&post, "t_test123456789a")
+            .unwrap();
+        match &post_events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/Users/a/project/hello.txt")]
+                );
+            }
+            other => panic!("Expected PostFileEdit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_claude_format_bash_pre() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-cli",
+            "cwd": "/Users/a/project",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"}
+        })
+        .to_string();
+        let events = GithubCopilotPreset
+            .parse(&input, "t_test123456789a")
+            .unwrap();
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.tool_use_id, "cli-sess-cli-Bash");
+            }
+            other => panic!("Expected PreBashCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_skips_claude_format_read() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-cli",
+            "cwd": "/Users/a/project",
+            "tool_name": "Read",
+            "tool_input": {"path": "/Users/a/project/hello.txt"}
+        })
+        .to_string();
+        let result = GithubCopilotPreset.parse(&input, "t_test123456789a");
+        assert!(result.is_err());
     }
 }

--- a/tests/integration/github_copilot_tools.rs
+++ b/tests/integration/github_copilot_tools.rs
@@ -288,6 +288,13 @@ fn test_copilot_cli_claude_format_edit_update_attribution() {
     .unwrap();
     repo.git(&["add", "jokes.csv"]).unwrap();
     repo.git(&["commit", "-m", "Initial jokes"]).unwrap();
+    repo.sync_daemon();
+
+    let mut file = repo.filename("jokes.csv");
+    file.assert_committed_lines(crate::lines![
+        "id,setup,punchline".unattributed_human(),
+        "1,Why do programmers prefer dark mode?,Because light attracts bugs.".unattributed_human(),
+    ]);
 
     let session_id = "a5f5793e-0cae-4cfd-9414-b35bce1c127f";
     // apply-patch string referencing the file via its repo-relative path.
@@ -361,6 +368,10 @@ fn test_copilot_cli_claude_format_edit_create_attribution() {
     std::fs::write(&existing, "# Hello\n").unwrap();
     repo.git(&["add", "readme.md"]).unwrap();
     repo.git(&["commit", "-m", "Initial"]).unwrap();
+    repo.sync_daemon();
+
+    let mut existing_file = repo.filename("readme.md");
+    existing_file.assert_committed_lines(crate::lines!["# Hello".unattributed_human()]);
 
     let session_id = "a5f5793e-0cae-4cfd-9414-b35bce1c127f";
     let new_file = repo.path().join("hello.txt");
@@ -413,6 +424,73 @@ fn test_copilot_cli_claude_format_edit_create_attribution() {
 
     let mut file = repo.filename("hello.txt");
     file.assert_lines_and_blame(crate::lines!["hi".ai(), "bye".ai()]);
+}
+
+/// Test Copilot CLI Claude-format `Write` treats the pre-edit state as empty,
+/// matching legacy `create` semantics even if the path already exists on disk.
+#[test]
+fn test_copilot_cli_claude_format_write_overwrite_attribution() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("story.txt");
+    std::fs::write(&file_path, "old draft\n").unwrap();
+    repo.git(&["add", "story.txt"]).unwrap();
+    repo.git(&["commit", "-m", "Initial draft"]).unwrap();
+    repo.sync_daemon();
+
+    let mut file = repo.filename("story.txt");
+    file.assert_committed_lines(crate::lines!["old draft".unattributed_human()]);
+
+    let session_id = "a5f5793e-0cae-4cfd-9414-b35bce1c127f";
+    let patch =
+        "*** Begin Patch\n*** Add File: story.txt\n+new draft\n+second line\n*** End Patch\n";
+
+    let pre_hook_input = json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": session_id,
+        "timestamp": "2026-06-22T20:10:33.166Z",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "Write",
+        "tool_input": patch,
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &pre_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    std::fs::write(&file_path, "new draft\nsecond line\n").unwrap();
+
+    let post_hook_input = json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "timestamp": "2026-06-22T20:10:33.212Z",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "Write",
+        "tool_input": patch,
+        "tool_result": {
+            "result_type": "success",
+            "text_result_for_llm": "Wrote 1 file(s): story.txt"
+        }
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &post_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    repo.sync_daemon();
+    repo.git(&["add", "story.txt"]).unwrap();
+    repo.git(&["commit", "-m", "Overwrite file via Claude-format Write"])
+        .unwrap();
+    repo.sync_daemon();
+
+    let mut file = repo.filename("story.txt");
+    file.assert_lines_and_blame(crate::lines!["new draft".ai(), "second line".ai()]);
 }
 
 /// Test Copilot CLI `view` tool is properly skipped (read-only, no checkpoint needed)

--- a/tests/integration/github_copilot_tools.rs
+++ b/tests/integration/github_copilot_tools.rs
@@ -272,6 +272,149 @@ fn test_copilot_cli_create_tool_attribution() {
     file.assert_lines_and_blame(crate::lines!["print('hello world')".ai()]);
 }
 
+/// Test Copilot CLI Claude-format `Edit` tool updating an existing file.
+/// Copilot CLI >= 1.0.62 emits Claude-style PascalCase tool names (`Edit` instead of
+/// `edit`/`str_replace`) and the edit `tool_input` is an apply-patch STRING rather than
+/// an object with a `path` field. Both must still attribute to AI.
+#[test]
+fn test_copilot_cli_claude_format_edit_update_attribution() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("jokes.csv");
+    std::fs::write(
+        &file_path,
+        "id,setup,punchline\n1,Why do programmers prefer dark mode?,Because light attracts bugs.\n",
+    )
+    .unwrap();
+    repo.git(&["add", "jokes.csv"]).unwrap();
+    repo.git(&["commit", "-m", "Initial jokes"]).unwrap();
+
+    let session_id = "a5f5793e-0cae-4cfd-9414-b35bce1c127f";
+    // apply-patch string referencing the file via its repo-relative path.
+    let patch = "*** Begin Patch\n*** Update File: jokes.csv\n@@\n 1,Why do programmers prefer dark mode?,Because light attracts bugs.\n+2,Why did the developer go broke?,Because he used up all his cache.\n*** End Patch\n";
+
+    let pre_hook_input = json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": session_id,
+        "timestamp": "2026-06-22T20:10:33.166Z",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "Edit",
+        "tool_input": patch,
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &pre_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    // AI writes the edit to disk before PostToolUse.
+    std::fs::write(
+        &file_path,
+        "id,setup,punchline\n1,Why do programmers prefer dark mode?,Because light attracts bugs.\n2,Why did the developer go broke?,Because he used up all his cache.\n",
+    )
+    .unwrap();
+
+    let post_hook_input = json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "timestamp": "2026-06-22T20:10:33.212Z",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "Edit",
+        "tool_input": patch,
+        "tool_result": {
+            "result_type": "success",
+            "text_result_for_llm": "Updated 1 file(s): jokes.csv"
+        }
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &post_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    repo.sync_daemon();
+    repo.git(&["add", "jokes.csv"]).unwrap();
+    repo.git(&["commit", "-m", "Add joke via Claude-format Edit"])
+        .unwrap();
+    repo.sync_daemon();
+
+    let mut file = repo.filename("jokes.csv");
+    file.assert_lines_and_blame(crate::lines![
+        "id,setup,punchline".human(),
+        "1,Why do programmers prefer dark mode?,Because light attracts bugs.".human(),
+        "2,Why did the developer go broke?,Because he used up all his cache.".ai(),
+    ]);
+}
+
+/// Test Copilot CLI Claude-format `Edit` tool creating a NEW file via an
+/// `*** Add File:` apply-patch string (the shape captured from a live 1.0.64 session).
+#[test]
+fn test_copilot_cli_claude_format_edit_create_attribution() {
+    let repo = TestRepo::new();
+
+    // Initial commit so HEAD exists.
+    let existing = repo.path().join("readme.md");
+    std::fs::write(&existing, "# Hello\n").unwrap();
+    repo.git(&["add", "readme.md"]).unwrap();
+    repo.git(&["commit", "-m", "Initial"]).unwrap();
+
+    let session_id = "a5f5793e-0cae-4cfd-9414-b35bce1c127f";
+    let new_file = repo.path().join("hello.txt");
+    let patch = "*** Begin Patch\n*** Add File: hello.txt\n+hi\n+bye\n*** End Patch\n";
+
+    let pre_hook_input = json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": session_id,
+        "timestamp": "2026-06-22T20:10:33.166Z",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "Edit",
+        "tool_input": patch,
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &pre_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    // Copilot CLI writes the new file.
+    std::fs::write(&new_file, "hi\nbye\n").unwrap();
+
+    let post_hook_input = json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": session_id,
+        "timestamp": "2026-06-22T20:10:33.212Z",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "Edit",
+        "tool_input": patch,
+        "tool_result": {
+            "result_type": "success",
+            "text_result_for_llm": "Added 1 file(s): hello.txt"
+        }
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &post_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    repo.sync_daemon();
+    repo.git(&["add", "hello.txt"]).unwrap();
+    repo.git(&["commit", "-m", "Add file via Claude-format Edit"])
+        .unwrap();
+    repo.sync_daemon();
+
+    let mut file = repo.filename("hello.txt");
+    file.assert_lines_and_blame(crate::lines!["hi".ai(), "bye".ai()]);
+}
+
 /// Test Copilot CLI `view` tool is properly skipped (read-only, no checkpoint needed)
 #[test]
 fn test_copilot_cli_view_tool_skipped() {


### PR DESCRIPTION
## Summary

GitHub Copilot CLI stopped attributing AI edits in Git AI after a recent update (reproduced on `1.0.64-2`). This restores attribution by teaching the Copilot CLI preset to recognize Copilot's newer Claude-format hook tool names while keeping support for the legacy names.

## What Changed In Copilot CLI

Around `v1.0.62`, Copilot CLI switched hook payloads to Claude-format PascalCase tool names. For example, hook payloads now use names like `Bash`, `Edit`, `Write`, and `Read` instead of only the older lowercase names such as `bash`, `edit`, `str_replace`, `create`, and `view`.

The edit payload shape also changed for the captured `Edit` case: `tool_input` can be an apply-patch string, for example:

```json
{"hook_event_name":"PreToolUse","tool_name":"Edit",
 "tool_input":"*** Begin Patch\n*** Add File: hello.txt\n+hi\n+bye\n*** End Patch\n", ...}
```

## What Broke

`classify_cli_tool` in `presets/github_copilot/cli.rs` only matched the legacy lowercase names. Modern Copilot CLI tools fell through to `ToolClass::Skip`, so pre/post checkpoints were not taken and edits were not attributed.

Feeding the captured payload to the installed binary produced:

```text
github-copilot preset error: Skipping CopilotCLI hook for non-edit tool 'Edit'.
```

## Fix

This PR extends the Copilot CLI preset without dropping legacy support:

- Shell tools now include legacy `bash` / `powershell` and Claude-format `Bash` / `PowerShell` / `Powershell`.
- File edit tools now include legacy `create`, `str_replace`, `edit`, `str_replace_editor`, `apply_patch`, `git_apply_patch` and Claude-format `Edit`, `Write`, `MultiEdit`, `NotebookEdit`.
- Apply-patch string payloads continue to flow through the existing path extraction logic, which parses `*** Add File:`, `*** Update File:`, `*** Delete File:`, and `*** Move to:` lines.
- `Write` now gets the same synthetic empty pre-edit baseline as legacy `create`, so full-file writes/overwrites attribute the resulting content to Copilot instead of only attributing the diff from whatever happened to be on disk before `PreToolUse`.

## Testing

Added unit coverage in `cli.rs` for:

- Legacy and Claude-format tool classification.
- Claude-format `Edit` pre/post file edit parsing.
- Claude-format `Write` pre-edit empty-baseline behavior.
- Claude-format `Bash` and `PowerShell` pre-bash parsing.
- Claude-format `Read` skip behavior.

Added integration coverage in `github_copilot_tools.rs` for:

- Claude-format `Edit` updating an existing file with line-level AI attribution.
- Claude-format `Edit` creating a new file with line-level AI attribution.
- Claude-format `Write` overwriting an existing file while attributing all resulting lines to AI.

Useful verification commands for this PR:

```bash
task fmt
task lint
task test TEST_FILTER=github_copilot
```

CI also runs the full format/lint/doc/test matrix for the PR branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->