### PR TITLE
Preserve attribution across git restore --source

### DIFF
--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -18,6 +18,7 @@ pub mod range_authorship;
 pub mod rewrite;
 pub mod rewrite_cherry_pick;
 pub mod rewrite_reset;
+pub mod rewrite_restore;
 pub mod rewrite_revert;
 pub mod rewrite_stash;
 pub mod secrets;

--- a/src/authorship/rewrite_reset.rs
+++ b/src/authorship/rewrite_reset.rs
@@ -147,7 +147,7 @@ pub fn reconstruct_working_log_after_backward_reset(
     Ok(())
 }
 
-fn extract_attributions_from_log_shifted(
+pub(crate) fn extract_attributions_from_log_shifted(
     log: &AuthorshipLog,
     hunks_by_file: Option<&HashMap<String, Vec<DiffHunk>>>,
     file_attributions: &mut HashMap<String, Vec<LineAttribution>>,

--- a/src/authorship/rewrite_restore.rs
+++ b/src/authorship/rewrite_restore.rs
@@ -28,6 +28,12 @@ use crate::git::repository::{Repository, batch_read_paths_at_treeishes};
 
 /// Trailing-`*` prefix glob matcher mirroring `rewrite_stash::path_matches_any`,
 /// so partial restores scoped to a directory/glob attribute only those paths.
+///
+/// `path` is repo-root-relative (authorship-log space); `pathspecs` come from the
+/// command's raw argv. As with the stash handler, a pathspec given relative to a
+/// subdirectory CWD (e.g. `feature.ts` from `src/`) is not CWD-normalized and so
+/// may not match the root-relative log path. This shares the trace2 raw-argv
+/// limitation of `rewrite_stash` and is acceptable for the common root-CWD case.
 fn path_matches_any(path: &str, pathspecs: &[String]) -> bool {
     pathspecs.iter().any(|spec| {
         if let Some(prefix) = spec.strip_suffix('*') {

--- a/src/authorship/rewrite_restore.rs
+++ b/src/authorship/rewrite_restore.rs
@@ -119,39 +119,30 @@ pub fn reconstruct_working_log_after_restore(
         return Ok(());
     }
 
-    // Merge into any existing INITIAL: preserve entries for files we are NOT
-    // restoring, and add/overwrite entries for the restored files. We only touch
-    // the INITIAL file -- never checkpoints.jsonl (see rewrite_reset.rs note).
-    // `write_initial_attributions_with_contents` re-persists each file's blob, so
-    // we must supply content for every retained file, including preserved ones
-    // (reconstructed from their stored INITIAL blob snapshot).
-    let existing = working_log.read_initial_attributions();
-    for (path, attrs) in &existing.files {
-        if file_attributions.contains_key(path) {
-            continue; // restored file: source attribution wins
-        }
-        if let Some(content) = working_log.stored_initial_file_content_from(&existing, path) {
-            file_attributions.insert(path.clone(), attrs.clone());
-            contents.insert(path.clone(), content);
-        }
+    // Merge directly into the existing INITIAL: set entries (and persist blobs)
+    // for the restored files, while leaving every other file's entry and stored
+    // blob snapshot untouched. This avoids round-tripping unrelated files through
+    // content reconstruction, so a restore can never drop another file's INITIAL
+    // attribution. We only touch the INITIAL file -- never checkpoints.jsonl (see
+    // rewrite_reset.rs note).
+    let mut initial = working_log.read_initial_attributions();
+    for (path, attrs) in file_attributions {
+        let content = contents.remove(&path).unwrap_or_default();
+        let blob_sha = working_log.persist_file_version(&content)?;
+        initial.files.insert(path.clone(), attrs);
+        initial.file_blobs.insert(path, blob_sha);
     }
-    for (k, v) in existing.prompts {
-        prompts.entry(k).or_insert(v);
+    for (k, v) in prompts {
+        initial.prompts.entry(k).or_insert(v);
     }
-    for (k, v) in existing.humans {
-        humans.entry(k).or_insert(v);
+    for (k, v) in humans {
+        initial.humans.entry(k).or_insert(v);
     }
-    for (k, v) in existing.sessions {
-        sessions.entry(k).or_insert(v);
+    for (k, v) in sessions {
+        initial.sessions.entry(k).or_insert(v);
     }
 
-    working_log.write_initial_attributions_with_contents(
-        file_attributions,
-        prompts,
-        humans,
-        contents,
-        sessions,
-    )?;
+    working_log.write_initial(initial)?;
     Ok(())
 }
 

--- a/src/authorship/rewrite_restore.rs
+++ b/src/authorship/rewrite_restore.rs
@@ -1,0 +1,183 @@
+//! Working-log reconstruction after `git restore --source <commit> -- <files>`.
+//!
+//! `git restore --source <C> -- <files>` rewrites the worktree/index for the
+//! listed files using commit `C`'s versions, but fires no checkpoint and leaves
+//! HEAD untouched. Without help, the next `git commit` finds an empty working
+//! log for its base and attributes every restored line as untracked -- even
+//! though the restored bytes are byte-identical to content that `C` already
+//! attributes (AI or human) in its authorship note.
+//!
+//! This mirrors `rewrite_reset::reconstruct_working_log_after_backward_reset`,
+//! but is simpler: the restored bytes equal `C`'s bytes 1:1 per file, so the
+//! per-file line attributions map directly with NO line shifting. We read `C`'s
+//! note, extract the attributions for the restored files, and write them as an
+//! INITIAL working log keyed to the current HEAD (the base the next commit
+//! uses). The existing post-commit `VirtualAttributions` machinery then
+//! reconciles that INITIAL baseline against the committed content -- exactly as
+//! it already does for reset and stash.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::authorship::attribution_tracker::LineAttribution;
+use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord};
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::rewrite_reset::extract_attributions_from_log_shifted;
+use crate::error::GitAiError;
+use crate::git::notes_api;
+use crate::git::repository::{Repository, batch_read_paths_at_treeishes};
+
+/// Trailing-`*` prefix glob matcher mirroring `rewrite_stash::path_matches_any`,
+/// so partial restores scoped to a directory/glob attribute only those paths.
+fn path_matches_any(path: &str, pathspecs: &[String]) -> bool {
+    pathspecs.iter().any(|spec| {
+        if let Some(prefix) = spec.strip_suffix('*') {
+            return path.starts_with(prefix);
+        }
+        let normalized = spec.trim_end_matches('/');
+        path == spec || path == normalized || {
+            let prefix = format!("{}/", normalized);
+            path.starts_with(&prefix)
+        }
+    })
+}
+
+/// Seed an INITIAL working log at `head` from `source_oid`'s authorship note for
+/// the restored `pathspecs`, so the next commit preserves their attribution.
+pub fn reconstruct_working_log_after_restore(
+    repo: &Repository,
+    source_oid: &str,
+    head: &str,
+    pathspecs: &[String],
+) -> Result<(), GitAiError> {
+    if pathspecs.is_empty() {
+        return Ok(());
+    }
+
+    // Read the source commit's authorship note. No note => nothing to carry.
+    let notes = notes_api::read_notes_batch(repo, &[source_oid.to_string()])?;
+    let Some(raw_note) = notes.get(source_oid) else {
+        return Ok(());
+    };
+    let Ok(log) = AuthorshipLog::deserialize_from_string(raw_note) else {
+        return Ok(());
+    };
+
+    // Extract per-file attributions with NO shifting (hunks = None => 1:1).
+    let mut file_attributions: HashMap<String, Vec<LineAttribution>> = HashMap::new();
+    let mut prompts: HashMap<String, PromptRecord> = HashMap::new();
+    let mut sessions: BTreeMap<String, SessionRecord> = BTreeMap::new();
+    let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
+    extract_attributions_from_log_shifted(
+        &log,
+        None,
+        &mut file_attributions,
+        &mut prompts,
+        &mut sessions,
+        &mut humans,
+    );
+
+    // Restrict to the files actually restored.
+    file_attributions.retain(|path, _| path_matches_any(path, pathspecs));
+    if file_attributions.is_empty() {
+        return Ok(());
+    }
+
+    // Files that already carry a live checkpoint in the current working log are
+    // owned by that checkpoint -- the customer's no-checkpoint scenario does not
+    // apply to them, and the post-commit reconciliation already handles them.
+    // Drop them so the restore baseline never clobbers richer checkpoint data.
+    let working_log = repo.storage.working_log_for_base_commit(head)?;
+    let checkpointed_files: HashSet<String> = working_log
+        .read_all_checkpoints()
+        .unwrap_or_default()
+        .iter()
+        .flat_map(|cp| cp.entries.iter().map(|e| e.file.clone()))
+        .collect();
+    file_attributions.retain(|path, _| !checkpointed_files.contains(path));
+    if file_attributions.is_empty() {
+        return Ok(());
+    }
+
+    // Snapshot the restored content from the source commit (the restored bytes
+    // equal source_oid's version for each file). Skip files absent/empty there.
+    let blob_requests: Vec<(String, String)> = file_attributions
+        .keys()
+        .map(|file| (source_oid.to_string(), file.clone()))
+        .collect();
+    let tree_contents = batch_read_paths_at_treeishes(repo, &blob_requests)?;
+
+    let mut contents: HashMap<String, String> = HashMap::new();
+    for file in file_attributions.keys() {
+        if let Some(content) = tree_contents.get(&(source_oid.to_string(), file.clone()))
+            && !content.is_empty()
+        {
+            contents.insert(file.clone(), content.clone());
+        }
+    }
+    file_attributions.retain(|path, _| contents.contains_key(path));
+    if file_attributions.is_empty() {
+        return Ok(());
+    }
+
+    // Merge into any existing INITIAL: preserve entries for files we are NOT
+    // restoring, and add/overwrite entries for the restored files. We only touch
+    // the INITIAL file -- never checkpoints.jsonl (see rewrite_reset.rs note).
+    // `write_initial_attributions_with_contents` re-persists each file's blob, so
+    // we must supply content for every retained file, including preserved ones
+    // (reconstructed from their stored INITIAL blob snapshot).
+    let existing = working_log.read_initial_attributions();
+    for (path, attrs) in &existing.files {
+        if file_attributions.contains_key(path) {
+            continue; // restored file: source attribution wins
+        }
+        if let Some(content) = working_log.stored_initial_file_content_from(&existing, path) {
+            file_attributions.insert(path.clone(), attrs.clone());
+            contents.insert(path.clone(), content);
+        }
+    }
+    for (k, v) in existing.prompts {
+        prompts.entry(k).or_insert(v);
+    }
+    for (k, v) in existing.humans {
+        humans.entry(k).or_insert(v);
+    }
+    for (k, v) in existing.sessions {
+        sessions.entry(k).or_insert(v);
+    }
+
+    working_log.write_initial_attributions_with_contents(
+        file_attributions,
+        prompts,
+        humans,
+        contents,
+        sessions,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_matches_any;
+
+    #[test]
+    fn matches_exact_path() {
+        let specs = vec!["src/a.ts".to_string()];
+        assert!(path_matches_any("src/a.ts", &specs));
+        assert!(!path_matches_any("src/b.ts", &specs));
+    }
+
+    #[test]
+    fn matches_directory_pathspec() {
+        let specs = vec!["src/".to_string()];
+        assert!(path_matches_any("src/a.ts", &specs));
+        assert!(path_matches_any("src/nested/b.ts", &specs));
+        assert!(!path_matches_any("other/c.ts", &specs));
+    }
+
+    #[test]
+    fn matches_trailing_glob() {
+        let specs = vec!["src/foo*".to_string()];
+        assert!(path_matches_any("src/foobar.ts", &specs));
+        assert!(!path_matches_any("src/bar.ts", &specs));
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4476,6 +4476,25 @@ impl ActorDaemonCoordinator {
                             onto.clone(),
                         )?;
                     }
+                    crate::daemon::domain::SemanticEvent::RestorePaths {
+                        source_oid,
+                        pathspecs,
+                        head,
+                    } => {
+                        if let (Some(src), Some(head_sha)) = (&source_oid, &head)
+                            && !src.is_empty()
+                            && !head_sha.is_empty()
+                            && !pathspecs.is_empty()
+                        {
+                            let repo = find_repository_in_path(&worktree)?;
+                            crate::authorship::rewrite_restore::reconstruct_working_log_after_restore(
+                                &repo,
+                                src,
+                                head_sha,
+                                pathspecs.as_slice(),
+                            )?;
+                        }
+                    }
                     crate::daemon::domain::SemanticEvent::StashOperation { kind, head } => {
                         let repo = find_repository_in_path(&worktree)?;
                         match kind {
@@ -6790,6 +6809,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes,
             confidence: crate::daemon::domain::Confidence::High,
         }

--- a/src/daemon/analyzers/generic.rs
+++ b/src/daemon/analyzers/generic.rs
@@ -117,6 +117,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }

--- a/src/daemon/analyzers/history.rs
+++ b/src/daemon/analyzers/history.rs
@@ -417,6 +417,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: vec![RefChange {
                 reference: "HEAD".to_string(),
                 old: "a".to_string(),

--- a/src/daemon/analyzers/mod.rs
+++ b/src/daemon/analyzers/mod.rs
@@ -55,7 +55,7 @@ impl AnalyzerRegistry {
         }
 
         let workspace: Arc<dyn CommandAnalyzer> = Arc::new(workspace::WorkspaceAnalyzer);
-        for command in ["stash", "checkout", "switch"] {
+        for command in ["stash", "checkout", "switch", "restore"] {
             registry.register_command(command, workspace.clone());
         }
 

--- a/src/daemon/analyzers/transport.rs
+++ b/src/daemon/analyzers/transport.rs
@@ -143,6 +143,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }

--- a/src/daemon/analyzers/workspace.rs
+++ b/src/daemon/analyzers/workspace.rs
@@ -45,6 +45,20 @@ impl CommandAnalyzer for WorkspaceAnalyzer {
                     });
                 }
             }
+            "restore" => {
+                // Only `git restore --source <commit> -- <files>` moves attributed
+                // content across a commit boundary. A no-source restore pulls from
+                // the index/HEAD and is not attribution-bearing, so it falls through
+                // to OpaqueCommand. `restore_source_oid` is resolved by the ref cursor.
+                let summary = crate::git::cli_parser::summarize_restore_args(&command_args(cmd));
+                if cmd.restore_source_oid.is_some() && !summary.pathspecs.is_empty() {
+                    events.push(SemanticEvent::RestorePaths {
+                        source_oid: cmd.restore_source_oid.clone(),
+                        pathspecs: summary.pathspecs,
+                        head: current_head_for_workspace_command(cmd, state.refs),
+                    });
+                }
+            }
             _ => unreachable!("registry should not route '{}' to WorkspaceAnalyzer", name),
         }
 
@@ -137,6 +151,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }
@@ -159,5 +174,104 @@ mod tests {
                 ..
             } if head == "abc123"
         )));
+    }
+
+    #[test]
+    fn restore_with_source_emits_restore_paths() {
+        let analyzer = WorkspaceAnalyzer;
+        let mut refs = std::collections::HashMap::new();
+        refs.insert("HEAD".to_string(), "head_oid".to_string());
+        let mut cmd = command(
+            "restore",
+            &[
+                "git",
+                "restore",
+                "--source",
+                "src_ref",
+                "--staged",
+                "--worktree",
+                "--",
+                "f.ts",
+            ],
+        );
+        // The ref cursor resolves --source to a full OID before analysis.
+        cmd.restore_source_oid = Some("resolved_src_oid".to_string());
+        let result = analyzer
+            .analyze(&cmd, AnalysisView { refs: &refs })
+            .unwrap();
+        assert!(result.events.iter().any(|event| matches!(
+            event,
+            SemanticEvent::RestorePaths { source_oid: Some(src), pathspecs, head: Some(head) }
+                if src == "resolved_src_oid" && pathspecs == &["f.ts".to_string()] && head == "head_oid"
+        )));
+    }
+
+    #[test]
+    fn restore_without_source_is_opaque() {
+        let analyzer = WorkspaceAnalyzer;
+        let mut refs = std::collections::HashMap::new();
+        refs.insert("HEAD".to_string(), "head_oid".to_string());
+        // No --source => ref cursor leaves restore_source_oid None.
+        let cmd = command("restore", &["git", "restore", "--", "f.ts"]);
+        let result = analyzer
+            .analyze(&cmd, AnalysisView { refs: &refs })
+            .unwrap();
+        assert!(
+            !result
+                .events
+                .iter()
+                .any(|event| matches!(event, SemanticEvent::RestorePaths { .. })),
+            "no-source restore must not emit RestorePaths"
+        );
+        assert!(
+            result
+                .events
+                .iter()
+                .any(|event| matches!(event, SemanticEvent::OpaqueCommand)),
+            "no-source restore should fall through to OpaqueCommand"
+        );
+    }
+
+    #[test]
+    fn restore_staged_and_worktree_flags_parse_pathspecs_identically() {
+        let analyzer = WorkspaceAnalyzer;
+        let mut refs = std::collections::HashMap::new();
+        refs.insert("HEAD".to_string(), "head_oid".to_string());
+        for flags in [
+            vec!["git", "restore", "--source", "s", "--staged", "--", "f.ts"],
+            vec![
+                "git",
+                "restore",
+                "--source",
+                "s",
+                "--worktree",
+                "--",
+                "f.ts",
+            ],
+            vec![
+                "git",
+                "restore",
+                "--source",
+                "s",
+                "--staged",
+                "--worktree",
+                "--",
+                "f.ts",
+            ],
+        ] {
+            let mut cmd = command("restore", &flags);
+            cmd.restore_source_oid = Some("resolved".to_string());
+            let result = analyzer
+                .analyze(&cmd, AnalysisView { refs: &refs })
+                .unwrap();
+            assert!(
+                result.events.iter().any(|event| matches!(
+                    event,
+                    SemanticEvent::RestorePaths { pathspecs, .. }
+                        if pathspecs == &["f.ts".to_string()]
+                )),
+                "flags {flags:?} should yield pathspec f.ts"
+            );
+        }
     }
 }

--- a/src/daemon/coordinator.rs
+++ b/src/daemon/coordinator.rs
@@ -169,6 +169,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }
@@ -192,6 +193,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }

--- a/src/daemon/domain.rs
+++ b/src/daemon/domain.rs
@@ -56,6 +56,11 @@ pub struct NormalizedCommand {
     pub stash_target_oid: Option<String>,
     pub cherry_pick_source_oids: Vec<String>,
     pub revert_source_oids: Vec<String>,
+    /// Resolved full commit OID of `git restore --source <X>`, when present.
+    /// `restore` does not move HEAD, so this is resolved against the live
+    /// worktree at analysis time. `None` for restores without `--source`.
+    #[serde(default)]
+    pub restore_source_oid: Option<String>,
     pub ref_changes: Vec<RefChange>,
     pub confidence: Confidence,
 }
@@ -176,7 +181,15 @@ pub enum SemanticEvent {
     NotesUpdated,
     ReplaceUpdated,
     CheckoutPaths,
-    RestorePaths,
+    RestorePaths {
+        /// Resolved full OID of `--source`; `None` => no-op (no cross-commit move).
+        source_oid: Option<String>,
+        /// Files being restored (pathspecs after `--`).
+        pathspecs: Vec<String>,
+        /// Current HEAD OID (restore does not move HEAD); the base the next
+        /// commit will use.
+        head: Option<String>,
+    },
     CleanedWorkspace,
     StashOperation {
         kind: StashOpKind,

--- a/src/daemon/domain.rs
+++ b/src/daemon/domain.rs
@@ -59,7 +59,6 @@ pub struct NormalizedCommand {
     /// Resolved full commit OID of `git restore --source <X>`, when present.
     /// `restore` does not move HEAD, so this is resolved against the live
     /// worktree at analysis time. `None` for restores without `--source`.
-    #[serde(default)]
     pub restore_source_oid: Option<String>,
     pub ref_changes: Vec<RefChange>,
     pub confidence: Confidence,

--- a/src/daemon/family_actor.rs
+++ b/src/daemon/family_actor.rs
@@ -191,6 +191,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }

--- a/src/daemon/global_actor.rs
+++ b/src/daemon/global_actor.rs
@@ -82,6 +82,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }

--- a/src/daemon/reducer.rs
+++ b/src/daemon/reducer.rs
@@ -288,6 +288,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: vec![RefChange {
                 reference: "refs/heads/main".to_string(),
                 old: "".to_string(),

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -2,7 +2,7 @@ use crate::daemon::analyzers::{command_args, normalized_args};
 use crate::daemon::domain::{Confidence, FamilyKey, FamilyState, NormalizedCommand, RefChange};
 use crate::error::GitAiError;
 use crate::git::cli_parser::{
-    explicit_rebase_branch_arg, parse_git_cli_args, summarize_rebase_args,
+    explicit_rebase_branch_arg, parse_git_cli_args, summarize_rebase_args, summarize_restore_args,
 };
 use crate::git::find_repository_in_path;
 use crate::git::repo_state::{common_dir_for_worktree, git_dir_for_worktree, is_valid_git_oid};
@@ -191,6 +191,7 @@ impl RefCursor {
             "pull" => self.consume_pull_transition(cmd, state),
             "branch" => self.enrich_branch(cmd, state),
             "stash" => self.enrich_stash(cmd, state),
+            "restore" => self.enrich_restore(cmd, state),
             "update-ref" => self.enrich_update_ref(cmd, state),
             _ => Ok(()),
         }?;
@@ -842,6 +843,30 @@ impl RefCursor {
             }
         }
 
+        Ok(())
+    }
+
+    /// `git restore` never moves refs, so there is no reflog transition to
+    /// consume. We only resolve the `--source <rev>` argument to a full commit
+    /// OID (against the sequenced ref snapshot) so the workspace analyzer can
+    /// emit a `RestorePaths` event that carries the source commit. Resolving
+    /// against the live worktree is safe because restore leaves HEAD untouched.
+    fn enrich_restore(
+        &mut self,
+        cmd: &mut NormalizedCommand,
+        state: &FamilyState,
+    ) -> Result<(), GitAiError> {
+        let summary = summarize_restore_args(&command_args(cmd));
+        let Some(source) = summary.source else {
+            return Ok(());
+        };
+        let Some(worktree) = cmd.worktree.clone() else {
+            return Ok(());
+        };
+        let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+        let resolved =
+            resolve_cherry_pick_sources_with_cat_file(&repo, &[source.as_str()], &state.refs)?;
+        cmd.restore_source_oid = resolved.into_iter().next();
         Ok(())
     }
 
@@ -3378,6 +3403,7 @@ fn command_uses_ref_cursor(primary: &str) -> bool {
             | "pull"
             | "branch"
             | "stash"
+            | "restore"
             | "update-ref"
     )
 }
@@ -3539,6 +3565,7 @@ mod tests {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes: Vec::new(),
             confidence: Confidence::Low,
         }

--- a/src/daemon/test_sync.rs
+++ b/src/daemon/test_sync.rs
@@ -16,7 +16,9 @@ pub fn tracks_primary_command_for_test_sync(
     match primary_command {
         "branch" => !invoked_args.iter().any(|arg| arg == "--show-current"),
         "checkout" | "cherry-pick" | "clone" | "commit" | "fetch" | "init" | "merge" | "pull"
-        | "push" | "rebase" | "reset" | "revert" | "switch" | "tag" | "update-ref" => true,
+        | "push" | "rebase" | "reset" | "restore" | "revert" | "switch" | "tag" | "update-ref" => {
+            true
+        }
         // `git worktree list` is classified as readonly by the daemon's fast-path
         // and is discarded before reaching the completion log — exclude it from
         // tracking to avoid test sync timeouts (mirrors the stash list exclusion).

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -699,6 +699,7 @@ impl<B: GitBackend> TraceNormalizer<B> {
             stash_target_oid: None,
             cherry_pick_source_oids: Vec::new(),
             revert_source_oids: Vec::new(),
+            restore_source_oid: None,
             ref_changes,
             confidence,
         };

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -196,6 +196,14 @@ pub fn summarize_restore_args(command_args: &[String]) -> RestoreArgsSummary {
         }
 
         if arg.starts_with('-') {
+            // Flags that take a space-separated value (`--conflict <style>`,
+            // `--pathspec-from-file <file>`); skip the value so it is not
+            // mistaken for a pathspec. The `=` forms are self-contained.
+            let takes_value = matches!(arg, "--conflict" | "--pathspec-from-file");
+            if takes_value && !arg.contains('=') {
+                i += 2;
+                continue;
+            }
             // Other restore flags (--staged, --worktree, --ours, --theirs, ...)
             // are value-less; skip the flag itself.
             i += 1;
@@ -845,6 +853,37 @@ mod tests {
         let s = restore(&["restore", "-sHEAD~1", "--", "f.ts"]);
         assert_eq!(s.source.as_deref(), Some("HEAD~1"));
         assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+    }
+
+    #[test]
+    fn restore_args_value_taking_flags_do_not_become_pathspecs() {
+        // `--conflict <style>` and `--pathspec-from-file <file>` take a
+        // space-separated value that must not be collected as a pathspec.
+        let s = restore(&[
+            "restore",
+            "--source",
+            "abc",
+            "--conflict",
+            "merge",
+            "--",
+            "f.ts",
+        ]);
+        assert_eq!(s.source.as_deref(), Some("abc"));
+        assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+
+        let s = restore(&[
+            "restore",
+            "--source",
+            "abc",
+            "--pathspec-from-file",
+            "paths.txt",
+        ]);
+        assert_eq!(s.source.as_deref(), Some("abc"));
+        assert!(
+            s.pathspecs.is_empty(),
+            "the pathspec-from-file argument must not be treated as a pathspec, got {:?}",
+            s.pathspecs
+        );
     }
 
     #[test]

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -141,6 +141,69 @@ pub fn is_flag_with_value(flag: &str) -> bool {
     )
 }
 
+/// Parsed shape of a `git restore` invocation, limited to the parts that matter
+/// for attribution: the `--source` revision (if any) and the restored pathspecs.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RestoreArgsSummary {
+    /// The `--source <rev>` / `--source=<rev>` / `-s <rev>` value, if present.
+    pub source: Option<String>,
+    /// The files being restored. Tokens after `--`, or trailing positionals when
+    /// no `--` separator is given.
+    pub pathspecs: Vec<String>,
+}
+
+/// Parse `git restore` arguments (the args AFTER the `restore` subcommand).
+/// Consumes `--source`'s value so it is never mistaken for a pathspec, and
+/// collects pathspecs from after `--` (or trailing positionals if absent).
+pub fn summarize_restore_args(command_args: &[String]) -> RestoreArgsSummary {
+    let args = if command_args.first().is_some_and(|arg| arg == "restore") {
+        &command_args[1..]
+    } else {
+        command_args
+    };
+
+    let mut source: Option<String> = None;
+    let mut positionals: Vec<String> = Vec::new();
+    let mut i = 0usize;
+    while i < args.len() {
+        let arg = args[i].as_str();
+
+        if arg == "--" {
+            positionals.extend(args[i + 1..].iter().cloned());
+            break;
+        }
+
+        if let Some(rev) = arg.strip_prefix("--source=") {
+            source = Some(rev.to_string());
+            i += 1;
+            continue;
+        }
+        if arg == "--source" || arg == "-s" {
+            if let Some(next) = args.get(i + 1) {
+                source = Some(next.clone());
+                i += 2;
+                continue;
+            }
+            break;
+        }
+
+        if arg.starts_with('-') {
+            // Other restore flags (--staged, --worktree, --ours, --theirs, ...)
+            // are value-less; skip the flag itself.
+            i += 1;
+            continue;
+        }
+
+        positionals.push(arg.to_string());
+        i += 1;
+    }
+
+    RestoreArgsSummary {
+        source,
+        pathspecs: positionals,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RebaseArgsSummary {
     pub is_control_mode: bool,
@@ -733,6 +796,55 @@ fn derive_directory_from_url(url: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn restore(args: &[&str]) -> RestoreArgsSummary {
+        summarize_restore_args(&args.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn restore_args_separated_source_and_pathspecs() {
+        let s = restore(&[
+            "restore",
+            "--source",
+            "abc",
+            "--staged",
+            "--worktree",
+            "--",
+            "f.ts",
+        ]);
+        assert_eq!(s.source.as_deref(), Some("abc"));
+        assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+    }
+
+    #[test]
+    fn restore_args_equals_source_form() {
+        let s = restore(&["restore", "--source=abc", "--", "a.ts", "b.ts"]);
+        assert_eq!(s.source.as_deref(), Some("abc"));
+        assert_eq!(s.pathspecs, vec!["a.ts".to_string(), "b.ts".to_string()]);
+    }
+
+    #[test]
+    fn restore_args_short_source_flag_consumes_value() {
+        // `-s abc` must consume `abc` as the source, not treat it as a pathspec.
+        let s = restore(&["restore", "-s", "abc", "--", "f.ts"]);
+        assert_eq!(s.source.as_deref(), Some("abc"));
+        assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+    }
+
+    #[test]
+    fn restore_args_no_source() {
+        let s = restore(&["restore", "--", "f.ts"]);
+        assert_eq!(s.source, None);
+        assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+    }
+
+    #[test]
+    fn restore_args_pathspecs_without_separator() {
+        // No `--`: trailing positionals are pathspecs; --source value is consumed.
+        let s = restore(&["restore", "--source", "abc", "f.ts"]);
+        assert_eq!(s.source.as_deref(), Some("abc"));
+        assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+    }
 
     #[test]
     fn test_pos_command_basic() {

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -155,6 +155,10 @@ pub struct RestoreArgsSummary {
 /// Parse `git restore` arguments (the args AFTER the `restore` subcommand).
 /// Consumes `--source`'s value so it is never mistaken for a pathspec, and
 /// collects pathspecs from after `--` (or trailing positionals if absent).
+///
+/// Note: pathspecs supplied via `--pathspec-from-file` live in a file and never
+/// appear in argv, so `pathspecs` is empty for that form and attribution carry
+/// is skipped — the same limitation the stash handler has.
 pub fn summarize_restore_args(command_args: &[String]) -> RestoreArgsSummary {
     let args = if command_args.first().is_some_and(|arg| arg == "restore") {
         &command_args[1..]

--- a/src/git/cli_parser.rs
+++ b/src/git/cli_parser.rs
@@ -186,6 +186,14 @@ pub fn summarize_restore_args(command_args: &[String]) -> RestoreArgsSummary {
             }
             break;
         }
+        // Combined short form: `-sHEAD~1` (value concatenated, no space).
+        if let Some(rev) = arg.strip_prefix("-s")
+            && !rev.is_empty()
+        {
+            source = Some(rev.to_string());
+            i += 1;
+            continue;
+        }
 
         if arg.starts_with('-') {
             // Other restore flags (--staged, --worktree, --ours, --theirs, ...)
@@ -828,6 +836,14 @@ mod tests {
         // `-s abc` must consume `abc` as the source, not treat it as a pathspec.
         let s = restore(&["restore", "-s", "abc", "--", "f.ts"]);
         assert_eq!(s.source.as_deref(), Some("abc"));
+        assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
+    }
+
+    #[test]
+    fn restore_args_combined_short_source_flag() {
+        // Combined `-sabc` form (value concatenated without a space).
+        let s = restore(&["restore", "-sHEAD~1", "--", "f.ts"]);
+        assert_eq!(s.source.as_deref(), Some("HEAD~1"));
         assert_eq!(s.pathspecs, vec!["f.ts".to_string()]);
     }
 

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -86,6 +86,7 @@ pub fn may_mutate_repo_state_command(command: &str) -> bool {
             | "rebase"
             | "remote"
             | "reset"
+            | "restore"
             | "revert"
             | "stash"
             | "switch"
@@ -120,6 +121,7 @@ pub fn participates_in_family_sequencer_command(command: &str) -> bool {
             | "rebase"
             | "remote"
             | "reset"
+            | "restore"
             | "revert"
             | "stash"
             | "switch"
@@ -577,6 +579,7 @@ mod tests {
             "rebase",
             "remote",
             "reset",
+            "restore",
             "revert",
             "stash",
             "switch",
@@ -611,12 +614,39 @@ mod tests {
             );
         }
 
-        for cmd in ["commit", "rebase", "reset", "stash", "update-ref"] {
+        for cmd in [
+            "commit",
+            "rebase",
+            "reset",
+            "restore",
+            "stash",
+            "update-ref",
+        ] {
             assert!(
                 participates_in_family_sequencer_command(cmd),
                 "{cmd} should be sequenced inside its repo family"
             );
         }
+    }
+
+    #[test]
+    fn restore_with_source_is_mutating_and_sequenced_but_not_read_only() {
+        let args = ["--source", "abc123", "--", "file.ts"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert!(
+            !is_definitely_read_only_git_invocation("restore", &args),
+            "git restore --source should never be read-only"
+        );
+        assert!(
+            git_invocation_may_mutate_repo_state("restore", &args),
+            "git restore --source should be treated as mutating"
+        );
+        assert!(
+            git_invocation_participates_in_family_sequencer("restore", &args),
+            "git restore --source should be sequenced inside its repo family"
+        );
     }
 
     #[test]

--- a/tests/integration/git_restore_source_attribution.rs
+++ b/tests/integration/git_restore_source_attribution.rs
@@ -1,0 +1,267 @@
+//! Attribution preservation across `git restore --source <commit>`.
+//!
+//! Reproduces a real-world stacked-PR workflow where all AI editing happens on a
+//! single "squash" branch (with proper checkpoints), and the work is then split
+//! into a stack of focused commits on fresh branches by pulling file content out
+//! of the squash commit via `git restore --source <squash> -- <files>` followed
+//! by a plain `git commit` -- with NO checkpoint between the restore and the
+//! commit.
+//!
+//! Because `git restore` writes the worktree/index without firing a checkpoint,
+//! the restored content arrives "invisibly" and the resulting commits are
+//! attributed as 100% untracked even though the byte-identical content was AI
+//! authored on the squash commit (which carries a correct AI authorship note).
+//!
+//! All data here is synthetic.
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+/// AI-authored content carried into a new commit via `git restore --source`
+/// should remain AI-attributed, not collapse to untracked.
+#[test]
+fn test_restore_source_preserves_ai_attribution() {
+    let repo = TestRepo::new();
+
+    // Base commit on the default branch -- this stands in for `origin/master`,
+    // the base the stacked PR branches are created from.
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let main_branch = repo.current_branch();
+
+    // --- Phase A: all AI work happens on a single "squash" branch ---
+    repo.git(&["switch", "-c", "squash", &main_branch]).unwrap();
+    let feature_path = repo.path().join("feature.ts");
+    fs::write(
+        &feature_path,
+        "export const feature = () => \"written by AI\";\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.ts"])
+        .unwrap();
+    repo.stage_all_and_commit("Migrate feature (squash, AI authored)")
+        .unwrap();
+
+    // Sanity check: the squash commit is AI-attributed.
+    let mut squash_file = repo.filename("feature.ts");
+    squash_file.assert_committed_lines(crate::lines![
+        "export const feature = () => \"written by AI\";".ai(),
+    ]);
+
+    let squash_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // --- Phase B: split into a fresh stack branch off the base via restore ---
+    // New branch from the base (NOT from the squash branch), then pull the file
+    // content out of the squash commit and commit it. No checkpoint fires.
+    repo.git(&["switch", "-c", "stack", &main_branch]).unwrap();
+    repo.git(&[
+        "restore",
+        "--source",
+        &squash_commit,
+        "--staged",
+        "--worktree",
+        "--",
+        "feature.ts",
+    ])
+    .unwrap();
+    repo.stage_all_and_commit("Add feature (stack)").unwrap();
+
+    // The restored content is byte-identical to the AI-authored squash commit and
+    // must remain AI-attributed.
+    let mut stack_file = repo.filename("feature.ts");
+    stack_file.assert_committed_lines(crate::lines![
+        "export const feature = () => \"written by AI\";".ai(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.ai_additions, 1,
+        "restored AI content should count as 1 AI addition, got stats: {stats:?}"
+    );
+    assert_eq!(
+        stats.unknown_additions, 0,
+        "restored AI content must not be untracked, got stats: {stats:?}"
+    );
+}
+
+/// Human-authored content restored via `--source` should stay human, never be
+/// misattributed to AI.
+#[test]
+fn test_restore_source_preserves_human_attribution() {
+    let repo = TestRepo::new();
+
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let main_branch = repo.current_branch();
+
+    repo.git(&["switch", "-c", "squash", &main_branch]).unwrap();
+    let human_path = repo.path().join("human.ts");
+    fs::write(
+        &human_path,
+        "export const human = () => \"typed by hand\";\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "human.ts"])
+        .unwrap();
+    repo.stage_all_and_commit("Add human file (squash)")
+        .unwrap();
+
+    let mut squash_file = repo.filename("human.ts");
+    squash_file.assert_committed_lines(crate::lines![
+        "export const human = () => \"typed by hand\";".human(),
+    ]);
+    let squash_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    repo.git(&["switch", "-c", "stack", &main_branch]).unwrap();
+    repo.git(&[
+        "restore",
+        "--source",
+        &squash_commit,
+        "--staged",
+        "--worktree",
+        "--",
+        "human.ts",
+    ])
+    .unwrap();
+    repo.stage_all_and_commit("Add human file (stack)").unwrap();
+
+    let mut stack_file = repo.filename("human.ts");
+    stack_file.assert_committed_lines(crate::lines![
+        "export const human = () => \"typed by hand\";".human(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.ai_additions, 0,
+        "human-source restore must not produce AI attribution, got stats: {stats:?}"
+    );
+}
+
+/// A partial restore (subset of the source's files) attributes only the
+/// restored files; unrestored files do not leak in.
+#[test]
+fn test_restore_source_partial_subset_only_attributes_restored_files() {
+    let repo = TestRepo::new();
+
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let main_branch = repo.current_branch();
+
+    repo.git(&["switch", "-c", "squash", &main_branch]).unwrap();
+    let a_path = repo.path().join("a.ts");
+    let b_path = repo.path().join("b.ts");
+    fs::write(&a_path, "export const a = () => \"ai a\";\n").unwrap();
+    fs::write(&b_path, "export const b = () => \"ai b\";\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.ts"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "b.ts"]).unwrap();
+    repo.stage_all_and_commit("Add a and b (squash)").unwrap();
+    let squash_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // Restore only a.ts onto a fresh branch.
+    repo.git(&["switch", "-c", "stack", &main_branch]).unwrap();
+    repo.git(&[
+        "restore",
+        "--source",
+        &squash_commit,
+        "--staged",
+        "--worktree",
+        "--",
+        "a.ts",
+    ])
+    .unwrap();
+    repo.stage_all_and_commit("Add a (stack)").unwrap();
+
+    let mut a_file = repo.filename("a.ts");
+    a_file.assert_committed_lines(crate::lines!["export const a = () => \"ai a\";".ai()]);
+
+    // b.ts was never restored onto this branch, so it must not exist here.
+    assert!(
+        !repo.path().join("b.ts").exists(),
+        "b.ts should not be present on the stack branch"
+    );
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.ai_additions, 1,
+        "only the restored file should be AI-attributed, got stats: {stats:?}"
+    );
+}
+
+/// `--source` accepts a relative revision (e.g. HEAD~1); it must resolve and
+/// attribute correctly.
+#[test]
+fn test_restore_source_relative_ref_resolves() {
+    let repo = TestRepo::new();
+
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let main_branch = repo.current_branch();
+
+    // Squash branch: AI file committed, then a follow-up commit on top, so that
+    // from this branch HEAD~1 points at the AI commit.
+    repo.git(&["switch", "-c", "squash", &main_branch]).unwrap();
+    let feature_path = repo.path().join("feature.ts");
+    fs::write(&feature_path, "export const feature = () => \"ai\";\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.ts"])
+        .unwrap();
+    repo.stage_all_and_commit("Add AI feature").unwrap();
+
+    let other_path = repo.path().join("other.txt");
+    fs::write(&other_path, "unrelated\n").unwrap();
+    repo.stage_all_and_commit("Unrelated commit").unwrap();
+
+    // Fresh branch off the base (without feature.ts), restore it from the
+    // squash branch's HEAD~1 (a relative ref that must resolve), then commit.
+    repo.git(&["switch", "-c", "stack", &main_branch]).unwrap();
+    repo.git(&[
+        "restore",
+        "--source",
+        "squash~1",
+        "--staged",
+        "--worktree",
+        "--",
+        "feature.ts",
+    ])
+    .unwrap();
+    repo.stage_all_and_commit("Add feature from squash~1")
+        .unwrap();
+
+    let mut feature_file = repo.filename("feature.ts");
+    feature_file.assert_committed_lines(crate::lines!["export const feature = () => \"ai\";".ai()]);
+}
+
+/// A plain `git restore <file>` (no `--source`) restores from the index and is
+/// not an attribution-bearing cross-commit move; it must not corrupt existing
+/// attribution or fabricate AI attribution.
+#[test]
+fn test_restore_without_source_is_noop_for_attribution() {
+    let repo = TestRepo::new();
+
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // AI file, checkpointed and committed.
+    let feature_path = repo.path().join("feature.ts");
+    fs::write(&feature_path, "export const feature = () => \"ai\";\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.ts"])
+        .unwrap();
+    repo.stage_all_and_commit("Add AI feature").unwrap();
+
+    // Make an uncommitted local edit, then discard it with a no-source restore.
+    fs::write(
+        &feature_path,
+        "export const feature = () => \"local edit\";\n",
+    )
+    .unwrap();
+    repo.git(&["restore", "--", "feature.ts"]).unwrap();
+
+    // The committed attribution is unchanged and no spurious commit was created.
+    let mut feature_file = repo.filename("feature.ts");
+    feature_file.assert_committed_lines(crate::lines!["export const feature = () => \"ai\";".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -65,6 +65,7 @@ mod gemini;
 mod git_alias_resolution;
 mod git_cli_arg_parsing;
 mod git_repository_comprehensive;
+mod git_restore_source_attribution;
 mod github_copilot;
 mod github_copilot_create_file;
 mod github_copilot_integration;


### PR DESCRIPTION
## Summary

`git restore --source <commit> -- <files>` rewrites worktree/index content without firing a checkpoint, and was not recognized anywhere in the attribution pipeline. As a result, a subsequent `git commit` attributed the restored lines as untracked even though the source commit's authorship note already attributed them (AI or human).

This change recognizes `git restore` end-to-end:

- Classifies `git restore` as a mutating, family-sequenced command (`command_classification.rs`).
- Resolves the `--source` revision to a full commit OID in the ref cursor (`ref_cursor.rs`), reusing the existing cat-file resolution.
- Parses restore args (`cli_parser.rs::summarize_restore_args`) and emits a `RestorePaths` semantic event from the workspace analyzer for source-bearing restores only.
- Adds `rewrite_restore.rs`, which reads the source commit's authorship note, extracts per-file attributions (no line shifting — restored bytes equal the source 1:1), and seeds an INITIAL working log keyed to HEAD. The existing post-commit reconciliation then preserves the attribution.

A plain `git restore <file>` (no `--source`) restores from the index/HEAD and is not a cross-commit move, so it is treated as a no-op for attribution.

## Tests

- Integration (`git_restore_source_attribution.rs`): AI-source preserved, human-source stays human, partial file subset, `--source` relative ref, and no-source no-op.
- Unit: restore arg parsing, workspace analyzer emission, command classification, and pathspec matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->