### PR TITLE
Add enterprise configuration client support

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -503,8 +503,18 @@ if ($env:INSTALL_NONCE -and $env:API_BASE) {
 Write-Host 'Setting up IDE/agent hooks...'
 try {
     & $finalExe install-hooks | Out-Host
-    Write-Success 'Successfully set up IDE/agent hooks'
+    if ($LASTEXITCODE -ne 0) {
+        if ($env:API_KEY) {
+            Write-ErrorAndExit 'Failed to set up enterprise git-ai configuration. Please retry the installer.'
+        }
+        Write-Warning "Warning: Failed to set up IDE/agent hooks. Please try running 'git-ai install-hooks' manually."
+    } else {
+        Write-Success 'Successfully set up IDE/agent hooks'
+    }
 } catch {
+    if ($env:API_KEY) {
+        Write-ErrorAndExit 'Failed to set up enterprise git-ai configuration. Please retry the installer.'
+    }
     Write-Warning "Warning: Failed to set up IDE/agent hooks. Please try running 'git-ai install-hooks' manually."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -323,6 +323,9 @@ fi
 
 echo "Setting up IDE/agent hooks..."
 if ! ${INSTALL_DIR}/git-ai install-hooks; then
+    if [ -n "${API_KEY:-}" ]; then
+        error "Failed to set up enterprise git-ai configuration. Please retry the installer."
+    fi
     warn "Warning: Failed to set up IDE/agent hooks. Please try running 'git-ai install-hooks' manually."
 else
     success "Successfully set up IDE/agent hooks"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -196,6 +196,7 @@ impl ApiContext {
                 "User-Agent",
                 &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
             )
+            .set("X-Git-AI-Version", env!("CARGO_PKG_VERSION"))
             .set("X-Distinct-ID", &config::get_or_create_distinct_id());
         (agent, request)
     }
@@ -211,6 +212,7 @@ impl ApiContext {
                 "User-Agent",
                 &format!("git-ai/{}", env!("CARGO_PKG_VERSION")),
             )
+            .set("X-Git-AI-Version", env!("CARGO_PKG_VERSION"))
             .set("X-Distinct-ID", &config::get_or_create_distinct_id());
         (agent, request)
     }

--- a/src/api/enterprise_config.rs
+++ b/src/api/enterprise_config.rs
@@ -1,0 +1,36 @@
+use crate::api::client::ApiClient;
+use crate::enterprise_config::{
+    EnterpriseConfigFetchResponse, EnterpriseConfigFetchResult, FETCH_ENDPOINT_PATH,
+    validate_enterprise_config,
+};
+
+impl ApiClient {
+    pub fn fetch_enterprise_config(&self) -> Result<EnterpriseConfigFetchResult, String> {
+        let response = self
+            .context()
+            .get(FETCH_ENDPOINT_PATH)
+            .map_err(|e| e.to_string())?;
+        let status_code = response.status_code;
+        let body = response
+            .as_str()
+            .map_err(|e| format!("failed to read enterprise config response: {e}"))?;
+
+        if status_code != 200 {
+            return Err(format!(
+                "enterprise config fetch failed with status {status_code}: {body}"
+            ));
+        }
+
+        let parsed: EnterpriseConfigFetchResponse = serde_json::from_str(body)
+            .map_err(|e| format!("invalid enterprise config response: {e}"))?;
+        if !parsed.enabled {
+            return Ok(EnterpriseConfigFetchResult::Disabled);
+        }
+
+        let config = parsed
+            .config
+            .ok_or_else(|| "enabled enterprise config response missing config".to_string())
+            .and_then(validate_enterprise_config)?;
+        Ok(EnterpriseConfigFetchResult::Enabled(Box::new(config)))
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,7 @@
 pub mod bundle;
 pub mod cas;
 pub mod client;
+pub mod enterprise_config;
 pub mod logs;
 pub mod metrics;
 pub mod notes;

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -259,36 +259,19 @@ fn show_all_config() -> Result<(), String> {
         Value::String(runtime_config.git_cmd().to_string()),
     );
 
-    // Arrays
-    if let Some(ref repos) = file_config.exclude_prompts_in_repositories {
-        effective_config.insert(
-            "exclude_prompts_in_repositories".to_string(),
-            serde_json::to_value(repos).unwrap(),
-        );
-    } else {
-        effective_config.insert(
-            "exclude_prompts_in_repositories".to_string(),
-            Value::Array(vec![]),
-        );
-    }
-
-    if let Some(ref repos) = file_config.allow_repositories {
-        effective_config.insert(
-            "allow_repositories".to_string(),
-            serde_json::to_value(repos).unwrap(),
-        );
-    } else {
-        effective_config.insert("allow_repositories".to_string(), Value::Array(vec![]));
-    }
-
-    if let Some(ref repos) = file_config.exclude_repositories {
-        effective_config.insert(
-            "exclude_repositories".to_string(),
-            serde_json::to_value(repos).unwrap(),
-        );
-    } else {
-        effective_config.insert("exclude_repositories".to_string(), Value::Array(vec![]));
-    }
+    // Arrays with runtime values, including enterprise overrides.
+    effective_config.insert(
+        "exclude_prompts_in_repositories".to_string(),
+        serde_json::to_value(runtime_config.exclude_prompts_in_repositories()).unwrap(),
+    );
+    effective_config.insert(
+        "allow_repositories".to_string(),
+        serde_json::to_value(runtime_config.allow_repositories()).unwrap(),
+    );
+    effective_config.insert(
+        "exclude_repositories".to_string(),
+        serde_json::to_value(runtime_config.exclude_repositories()).unwrap(),
+    );
 
     // Booleans with runtime values
     effective_config.insert(
@@ -305,10 +288,10 @@ fn show_all_config() -> Result<(), String> {
     );
 
     // Optional strings
-    if let Some(ref dsn) = file_config.telemetry_enterprise_dsn {
+    if let Some(dsn) = runtime_config.telemetry_enterprise_dsn() {
         effective_config.insert(
             "telemetry_enterprise_dsn".to_string(),
-            Value::String(dsn.clone()),
+            Value::String(dsn.to_string()),
         );
     }
 
@@ -322,19 +305,16 @@ fn show_all_config() -> Result<(), String> {
         Value::String(runtime_config.prompt_storage().to_string()),
     );
 
-    // include_prompts_in_repositories
-    if let Some(ref repos) = file_config.include_prompts_in_repositories {
-        effective_config.insert(
-            "include_prompts_in_repositories".to_string(),
-            serde_json::to_value(repos).unwrap_or(Value::Array(vec![])),
-        );
-    }
+    effective_config.insert(
+        "include_prompts_in_repositories".to_string(),
+        serde_json::to_value(runtime_config.include_prompts_in_repositories())
+            .unwrap_or(Value::Array(vec![])),
+    );
 
-    // default_prompt_storage
-    if let Some(ref storage) = file_config.default_prompt_storage {
+    if let Some(storage) = runtime_config.default_prompt_storage() {
         effective_config.insert(
             "default_prompt_storage".to_string(),
-            Value::String(storage.clone()),
+            Value::String(storage.to_string()),
         );
     }
 
@@ -429,30 +409,18 @@ fn get_config_value(key: &str) -> Result<(), String> {
         let value = match key_path[0].as_str() {
             "git_path" => Value::String(runtime_config.git_cmd().to_string()),
             "exclude_prompts_in_repositories" => {
-                if let Some(ref repos) = file_config.exclude_prompts_in_repositories {
-                    serde_json::to_value(repos).unwrap()
-                } else {
-                    Value::Array(vec![])
-                }
+                serde_json::to_value(runtime_config.exclude_prompts_in_repositories()).unwrap()
             }
             "allow_repositories" => {
-                if let Some(ref repos) = file_config.allow_repositories {
-                    serde_json::to_value(repos).unwrap()
-                } else {
-                    Value::Array(vec![])
-                }
+                serde_json::to_value(runtime_config.allow_repositories()).unwrap()
             }
             "exclude_repositories" => {
-                if let Some(ref repos) = file_config.exclude_repositories {
-                    serde_json::to_value(repos).unwrap()
-                } else {
-                    Value::Array(vec![])
-                }
+                serde_json::to_value(runtime_config.exclude_repositories()).unwrap()
             }
             "telemetry_oss_disabled" => Value::Bool(runtime_config.is_telemetry_oss_disabled()),
             "telemetry_enterprise_dsn" => {
-                if let Some(ref dsn) = file_config.telemetry_enterprise_dsn {
-                    Value::String(dsn.clone())
+                if let Some(dsn) = runtime_config.telemetry_enterprise_dsn() {
+                    Value::String(dsn.to_string())
                 } else {
                     Value::Null
                 }
@@ -475,15 +443,11 @@ fn get_config_value(key: &str) -> Result<(), String> {
             }
             "prompt_storage" => Value::String(runtime_config.prompt_storage().to_string()),
             "include_prompts_in_repositories" => {
-                if let Some(ref repos) = file_config.include_prompts_in_repositories {
-                    serde_json::to_value(repos).unwrap()
-                } else {
-                    Value::Array(vec![])
-                }
+                serde_json::to_value(runtime_config.include_prompts_in_repositories()).unwrap()
             }
             "default_prompt_storage" => {
-                if let Some(ref storage) = file_config.default_prompt_storage {
-                    Value::String(storage.clone())
+                if let Some(storage) = runtime_config.default_prompt_storage() {
+                    Value::String(storage.to_string())
                 } else {
                     Value::Null
                 }

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1304,6 +1304,33 @@ mod tests {
 
     #[test]
     #[serial]
+    fn enterprise_bootstrap_preserves_fetch_error_when_cache_is_invalid() {
+        let temp = tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", temp.path().to_str().unwrap());
+        #[cfg(windows)]
+        let _userprofile = EnvVarGuard::set("USERPROFILE", temp.path().to_str().unwrap());
+        let _api_key_env = EnvVarGuard::remove("GIT_AI_API_KEY");
+        let _api_base_env = EnvVarGuard::remove("GIT_AI_API_BASE_URL");
+
+        let server = mockito::Server::new();
+        crate::config::save_file_config(&crate::config::FileConfig {
+            api_base_url: Some(server.url()),
+            api_key: Some("sk-enterprise-key".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        let cache_path = crate::enterprise_config::enterprise_config_cache_path().unwrap();
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(cache_path, b"not-json").unwrap();
+
+        let err = bootstrap_enterprise_config(false).unwrap_err().to_string();
+        assert!(err.contains("enterprise config bootstrap failed"));
+        assert!(err.contains("enterprise config fetch failed"));
+        assert!(!err.contains("invalid enterprise cache"));
+    }
+
+    #[test]
+    #[serial]
     fn enterprise_bootstrap_uses_valid_cache_on_fetch_failure() {
         let temp = tempdir().unwrap();
         let _home = EnvVarGuard::set("HOME", temp.path().to_str().unwrap());

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1249,11 +1249,20 @@ mod tests {
         let _userprofile = EnvVarGuard::set("USERPROFILE", temp.path().to_str().unwrap());
         let _api_key_env = EnvVarGuard::remove("GIT_AI_API_KEY");
         let _api_base_env = EnvVarGuard::remove("GIT_AI_API_BASE_URL");
+        let _git_committer_name = EnvVarGuard::set("GIT_COMMITTER_NAME", "Enterprise User");
+        let _git_committer_email =
+            EnvVarGuard::set("GIT_COMMITTER_EMAIL", "enterprise@example.com");
 
         let mut server = mockito::Server::new();
         let mock = server
             .mock("GET", "/worker/config/enterprise")
             .match_header("x-api-key", "sk-enterprise-key")
+            .match_header("x-git-ai-version", env!("CARGO_PKG_VERSION"))
+            .match_header("x-distinct-id", mockito::Matcher::Regex(".+".to_string()))
+            .match_header(
+                "x-author-identity",
+                "Enterprise User <enterprise@example.com>",
+            )
             .with_status(200)
             .with_body(r#"{"enabled":true,"config":{"prompt_storage":"local"}}"#)
             .create();

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
 const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
@@ -301,9 +302,33 @@ fn ensure_daemon(dry_run: bool) {
     }
 }
 
+fn bootstrap_enterprise_config(dry_run: bool) -> Result<(), GitAiError> {
+    if dry_run {
+        return Ok(());
+    }
+
+    match crate::enterprise_config::bootstrap_enterprise_config(
+        "install-hooks",
+        Duration::from_secs(5),
+    ) {
+        Ok(outcome) => {
+            tracing::info!(?outcome, "enterprise config bootstrap completed");
+            Ok(())
+        }
+        Err(e) => Err(GitAiError::Generic(e)),
+    }
+}
+
 /// Main entry point for install-hooks command
 pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
     let options = parse_install_options(args);
+
+    // Get absolute path to the current binary and persist API_BASE/API_KEY
+    // before touching daemon state. Enterprise bootstrap and trace2 setup must
+    // see the newly installed API configuration.
+    let binary_path = get_current_binary_path()?;
+    persist_install_config(&binary_path, options.dry_run)?;
+    bootstrap_enterprise_config(options.dry_run)?;
 
     // Daemon trace2 config must be in place before any install work starts.
     // Non-fatal: the global git config may be read-only (e.g. Nix store symlink).
@@ -318,9 +343,6 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
         let _ = crate::daemon::telemetry_handle::init_daemon_telemetry_handle();
     }
 
-    // Get absolute path to the current binary
-    let binary_path = get_current_binary_path()?;
-    persist_install_config(&binary_path, options.dry_run)?;
     let params = HookInstallerParams { binary_path };
 
     // Run async operations and convert result.
@@ -1184,6 +1206,122 @@ mod tests {
             Some("https://enterprise.example")
         );
         assert_eq!(config.api_key.as_deref(), Some("sk-enterprise-key-12345"));
+    }
+
+    #[test]
+    #[serial]
+    fn enterprise_bootstrap_succeeds_when_server_disables_config() {
+        let temp = tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", temp.path().to_str().unwrap());
+        #[cfg(windows)]
+        let _userprofile = EnvVarGuard::set("USERPROFILE", temp.path().to_str().unwrap());
+        let _api_key_env = EnvVarGuard::remove("GIT_AI_API_KEY");
+        let _api_base_env = EnvVarGuard::remove("GIT_AI_API_BASE_URL");
+
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/worker/config/enterprise")
+            .match_header("x-api-key", "sk-enterprise-key")
+            .with_status(200)
+            .with_body(r#"{"enabled":false}"#)
+            .create();
+
+        crate::config::save_file_config(&crate::config::FileConfig {
+            api_base_url: Some(server.url()),
+            api_key: Some("sk-enterprise-key".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        bootstrap_enterprise_config(false).expect("bootstrap should succeed");
+        assert!(
+            crate::enterprise_config::effective_cached_config(Some("sk-enterprise-key")).is_none()
+        );
+        mock.assert();
+    }
+
+    #[test]
+    #[serial]
+    fn enterprise_bootstrap_fetches_and_caches_config() {
+        let temp = tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", temp.path().to_str().unwrap());
+        #[cfg(windows)]
+        let _userprofile = EnvVarGuard::set("USERPROFILE", temp.path().to_str().unwrap());
+        let _api_key_env = EnvVarGuard::remove("GIT_AI_API_KEY");
+        let _api_base_env = EnvVarGuard::remove("GIT_AI_API_BASE_URL");
+
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("GET", "/worker/config/enterprise")
+            .match_header("x-api-key", "sk-enterprise-key")
+            .with_status(200)
+            .with_body(r#"{"enabled":true,"config":{"prompt_storage":"local"}}"#)
+            .create();
+
+        crate::config::save_file_config(&crate::config::FileConfig {
+            api_base_url: Some(server.url()),
+            api_key: Some("sk-enterprise-key".to_string()),
+            prompt_storage: Some("default".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        bootstrap_enterprise_config(false).expect("bootstrap should succeed");
+        assert_eq!(crate::config::Config::fresh().prompt_storage(), "local");
+        mock.assert();
+    }
+
+    #[test]
+    #[serial]
+    fn enterprise_bootstrap_errors_without_cache_on_fetch_failure() {
+        let temp = tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", temp.path().to_str().unwrap());
+        #[cfg(windows)]
+        let _userprofile = EnvVarGuard::set("USERPROFILE", temp.path().to_str().unwrap());
+        let _api_key_env = EnvVarGuard::remove("GIT_AI_API_KEY");
+        let _api_base_env = EnvVarGuard::remove("GIT_AI_API_BASE_URL");
+
+        let server = mockito::Server::new();
+        crate::config::save_file_config(&crate::config::FileConfig {
+            api_base_url: Some(server.url()),
+            api_key: Some("sk-enterprise-key".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let err = bootstrap_enterprise_config(false).unwrap_err().to_string();
+        assert!(err.contains("enterprise config bootstrap failed"));
+    }
+
+    #[test]
+    #[serial]
+    fn enterprise_bootstrap_uses_valid_cache_on_fetch_failure() {
+        let temp = tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", temp.path().to_str().unwrap());
+        #[cfg(windows)]
+        let _userprofile = EnvVarGuard::set("USERPROFILE", temp.path().to_str().unwrap());
+        let _api_key_env = EnvVarGuard::remove("GIT_AI_API_KEY");
+        let _api_base_env = EnvVarGuard::remove("GIT_AI_API_BASE_URL");
+
+        let server = mockito::Server::new();
+        crate::config::save_file_config(&crate::config::FileConfig {
+            api_base_url: Some(server.url()),
+            api_key: Some("sk-enterprise-key".to_string()),
+            prompt_storage: Some("default".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        crate::enterprise_config::save_cache_for_api_key(
+            "sk-enterprise-key",
+            &crate::enterprise_config::EnterpriseConfig {
+                prompt_storage: Some("local".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        bootstrap_enterprise_config(false).expect("bootstrap should use cache");
+        assert_eq!(crate::config::Config::fresh().prompt_storage(), "local");
     }
 
     #[cfg(windows)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -534,6 +534,38 @@ impl Config {
         &self.prompt_storage
     }
 
+    pub fn exclude_prompts_in_repositories(&self) -> Vec<String> {
+        self.exclude_prompts_in_repositories
+            .iter()
+            .map(|pattern| pattern.as_str().to_string())
+            .collect()
+    }
+
+    pub fn include_prompts_in_repositories(&self) -> Vec<String> {
+        self.include_prompts_in_repositories
+            .iter()
+            .map(|pattern| pattern.as_str().to_string())
+            .collect()
+    }
+
+    pub fn allow_repositories(&self) -> Vec<String> {
+        self.allow_repositories
+            .iter()
+            .map(|pattern| pattern.as_str().to_string())
+            .collect()
+    }
+
+    pub fn exclude_repositories(&self) -> Vec<String> {
+        self.exclude_repositories
+            .iter()
+            .map(|pattern| pattern.as_str().to_string())
+            .collect()
+    }
+
+    pub fn default_prompt_storage(&self) -> Option<&str> {
+        self.default_prompt_storage.as_deref()
+    }
+
     /// Returns the effective prompt storage mode for a given repository.
     ///
     /// The resolution order is:
@@ -915,9 +947,29 @@ fn author_config_file_fingerprint(path: &Path) -> Option<AuthorConfigFileFingerp
 
 fn build_config() -> Config {
     let file_cfg = load_file_config();
-    let exclude_prompts_in_repositories = file_cfg
-        .as_ref()
+
+    // Get API key from env var or config file (env var takes precedence). This
+    // is intentionally resolved before enterprise overrides because the
+    // enterprise cache is scoped to the configured API key.
+    let api_key = env::var("GIT_AI_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.api_key.clone())
+                .filter(|s| !s.is_empty())
+        });
+    let enterprise_cfg = crate::enterprise_config::effective_cached_config(api_key.as_deref());
+    let enterprise_cfg = enterprise_cfg.as_ref();
+
+    let exclude_prompts_in_repositories = enterprise_cfg
         .and_then(|c| c.exclude_prompts_in_repositories.clone())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.exclude_prompts_in_repositories.clone())
+        })
         .unwrap_or_default()
         .into_iter()
         .filter_map(|pattern_str| {
@@ -931,10 +983,14 @@ fn build_config() -> Config {
                 .ok()
         })
         .collect();
-    let include_prompts_in_repositories = file_cfg
-        .as_ref()
+    let include_prompts_in_repositories = enterprise_cfg
         .and_then(|c| c.include_prompts_in_repositories.clone())
-        .unwrap_or(vec![])
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.include_prompts_in_repositories.clone())
+        })
+        .unwrap_or_default()
         .into_iter()
         .filter_map(|pattern_str| {
             Pattern::new(&pattern_str)
@@ -947,9 +1003,9 @@ fn build_config() -> Config {
                 .ok()
         })
         .collect();
-    let allow_repositories = file_cfg
-        .as_ref()
+    let allow_repositories = enterprise_cfg
         .and_then(|c| c.allow_repositories.clone())
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.allow_repositories.clone()))
         .unwrap_or_default()
         .into_iter()
         .filter_map(|pattern_str| {
@@ -963,9 +1019,13 @@ fn build_config() -> Config {
                 .ok()
         })
         .collect();
-    let exclude_repositories = file_cfg
-        .as_ref()
+    let exclude_repositories = enterprise_cfg
         .and_then(|c| c.exclude_repositories.clone())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.exclude_repositories.clone())
+        })
         .unwrap_or_default()
         .into_iter()
         .filter_map(|pattern_str| {
@@ -979,31 +1039,35 @@ fn build_config() -> Config {
                 .ok()
         })
         .collect();
-    let telemetry_oss_disabled = file_cfg
-        .as_ref()
+    let telemetry_oss_disabled = enterprise_cfg
         .and_then(|c| c.telemetry_oss.clone())
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.telemetry_oss.clone()))
         .filter(|s| s == "off")
         .is_some();
-    let telemetry_enterprise_dsn = file_cfg
-        .as_ref()
+    let telemetry_enterprise_dsn = enterprise_cfg
         .and_then(|c| c.telemetry_enterprise_dsn.clone())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.telemetry_enterprise_dsn.clone())
+        })
         .filter(|s| !s.is_empty());
 
     // Default to disabled (true) unless this is an OSS build
     // OSS builds set OSS_BUILD env var at compile time to "1", which enables auto-updates by default
     let auto_update_flags_default_disabled = option_env!("OSS_BUILD") != Some("1");
 
-    let disable_version_checks = file_cfg
-        .as_ref()
+    let disable_version_checks = enterprise_cfg
         .and_then(|c| c.disable_version_checks)
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.disable_version_checks))
         .unwrap_or(auto_update_flags_default_disabled);
-    let disable_auto_updates = file_cfg
-        .as_ref()
+    let disable_auto_updates = enterprise_cfg
         .and_then(|c| c.disable_auto_updates)
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.disable_auto_updates))
         .unwrap_or(auto_update_flags_default_disabled);
-    let update_channel = file_cfg
-        .as_ref()
+    let update_channel = enterprise_cfg
         .and_then(|c| c.update_channel.as_deref())
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.update_channel.as_deref()))
         .and_then(UpdateChannel::from_str)
         .unwrap_or_default();
 
@@ -1021,9 +1085,9 @@ fn build_config() -> Config {
 
     // Get prompt_storage setting (defaults to "default")
     // Valid values: "default", "notes", "local"
-    let prompt_storage = file_cfg
-        .as_ref()
+    let prompt_storage = enterprise_cfg
         .and_then(|c| c.prompt_storage.clone())
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.prompt_storage.clone()))
         .unwrap_or_else(|| "default".to_string());
     let prompt_storage = match prompt_storage.as_str() {
         "default" | "notes" | "local" => prompt_storage,
@@ -1038,9 +1102,13 @@ fn build_config() -> Config {
 
     // Get default_prompt_storage setting (fallback for repos not in include list)
     // Valid values: "default", "notes", "local", or None (defaults to "local")
-    let default_prompt_storage = file_cfg
-        .as_ref()
+    let default_prompt_storage = enterprise_cfg
         .and_then(|c| c.default_prompt_storage.clone())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.default_prompt_storage.clone())
+        })
         .and_then(|s| {
             if matches!(s.as_str(), "default" | "notes" | "local") {
                 Some(s)
@@ -1051,17 +1119,6 @@ fn build_config() -> Config {
                 );
                 None
             }
-        });
-
-    // Get API key from env var or config file (env var takes precedence)
-    let api_key = env::var("GIT_AI_API_KEY")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .or_else(|| {
-            file_cfg
-                .as_ref()
-                .and_then(|c| c.api_key.clone())
-                .filter(|s| !s.is_empty())
         });
 
     // Get quiet setting (defaults to false)
@@ -1120,8 +1177,11 @@ fn build_config() -> Config {
         })
         .unwrap_or_default();
 
-    // Resolve notes_backend config: env vars override file config, which overrides defaults.
+    // Resolve notes_backend config: env vars override enterprise config, which
+    // overrides file config and defaults.
     let file_backend = file_cfg.as_ref().and_then(|c| c.notes_backend.clone());
+    let enterprise_backend = enterprise_cfg.and_then(|c| c.notes_backend.clone());
+    let base_backend = enterprise_backend.or(file_backend).unwrap_or_default();
     let kind_from_env = env::var("GIT_AI_NOTES_BACKEND_KIND")
         .ok()
         .and_then(|s| match s.as_str() {
@@ -1132,17 +1192,15 @@ fn build_config() -> Config {
     let url_from_env = env::var("GIT_AI_NOTES_BACKEND_URL").ok();
 
     let notes_backend = NotesBackendConfig {
-        kind: kind_from_env
-            .or_else(|| file_backend.as_ref().map(|b| b.kind))
-            .unwrap_or(NotesBackendKind::GitNotes),
-        backend_url: url_from_env
-            .or_else(|| file_backend.as_ref().and_then(|b| b.backend_url.clone())),
+        kind: kind_from_env.unwrap_or(base_backend.kind),
+        backend_url: url_from_env.or(base_backend.backend_url),
     };
 
-    // Transcript streaming lookback: env > file > default (7 days). 0 means unlimited (None).
+    // Transcript streaming lookback: env > enterprise > file > default (7 days). 0 means unlimited (None).
     let transcript_streaming_lookback_days = env::var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS")
         .ok()
         .and_then(|v| v.parse::<u32>().ok())
+        .or_else(|| enterprise_cfg.and_then(|c| c.transcript_streaming_lookback_days))
         .or_else(|| {
             file_cfg
                 .as_ref()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2515,6 +2515,7 @@ pub struct ActorDaemonCoordinator {
     telemetry_worker: Option<crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle>,
     stream_worker: Option<crate::daemon::stream_worker::StreamWorkerHandle>,
     transcript_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
+    enterprise_config_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
     streams_db: Option<Arc<crate::streams::db::StreamsDatabase>>,
     next_trace_ingest_seq: AtomicUsize,
     queued_trace_payloads: AtomicUsize,
@@ -2606,6 +2607,7 @@ impl ActorDaemonCoordinator {
             telemetry_worker: None,
             stream_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
+            enterprise_config_shutdown_notify: std::sync::OnceLock::new(),
             streams_db: None,
             next_trace_ingest_seq: AtomicUsize::new(0),
             queued_trace_payloads: AtomicUsize::new(0),
@@ -2812,6 +2814,9 @@ impl ActorDaemonCoordinator {
         self.shutdown_notify.notify_waiters();
         if let Some(transcript_shutdown) = self.transcript_shutdown_notify.get() {
             transcript_shutdown.notify_one();
+        }
+        if let Some(enterprise_config_shutdown) = self.enterprise_config_shutdown_notify.get() {
+            enterprise_config_shutdown.notify_one();
         }
         // Hold the condvar mutex so notify_all cannot race with the
         // check-then-wait sequence in daemon_update_check_loop.
@@ -7163,7 +7168,6 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     remove_stale_daemon_files(&config);
     let _lock = DaemonLock::acquire(&config.lock_path)?;
     let _active_guard = DaemonProcessActiveGuard::enter();
-    write_pid_metadata(&config)?;
 
     // Initialize tracing subscriber before log file redirect so the fmt layer
     // captures stderr (fd 2). After dup2, writes go to the daemon log file.
@@ -7200,10 +7204,26 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
         "daemon started"
     );
 
+    match crate::enterprise_config::bootstrap_enterprise_config(
+        "daemon startup",
+        std::time::Duration::from_secs(5),
+    ) {
+        Ok(outcome) => tracing::info!(?outcome, "enterprise config bootstrap completed"),
+        Err(e) => return Err(GitAiError::Generic(e)),
+    }
+
+    write_pid_metadata(&config)?;
+
     remove_socket_if_exists(&config.trace_socket_path)?;
     remove_socket_if_exists(&config.control_socket_path)?;
 
     let mut coordinator_inner = ActorDaemonCoordinator::new();
+
+    let enterprise_config_shutdown = Arc::new(tokio::sync::Notify::new());
+    crate::enterprise_config::spawn_enterprise_config_worker(enterprise_config_shutdown.clone());
+    let _ = coordinator_inner
+        .enterprise_config_shutdown_notify
+        .set(enterprise_config_shutdown);
 
     // Spawn the telemetry worker inside the daemon's tokio runtime.
     let telemetry_handle = crate::daemon::telemetry_worker::spawn_telemetry_worker();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7204,14 +7204,6 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
         "daemon started"
     );
 
-    match crate::enterprise_config::bootstrap_enterprise_config(
-        "daemon startup",
-        std::time::Duration::from_secs(5),
-    ) {
-        Ok(outcome) => tracing::info!(?outcome, "enterprise config bootstrap completed"),
-        Err(e) => return Err(GitAiError::Generic(e)),
-    }
-
     write_pid_metadata(&config)?;
 
     remove_socket_if_exists(&config.trace_socket_path)?;
@@ -7220,7 +7212,7 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     let mut coordinator_inner = ActorDaemonCoordinator::new();
 
     let enterprise_config_shutdown = Arc::new(tokio::sync::Notify::new());
-    crate::enterprise_config::spawn_enterprise_config_worker(enterprise_config_shutdown.clone());
+    let enterprise_config_shutdown_for_worker = enterprise_config_shutdown.clone();
     let _ = coordinator_inner
         .enterprise_config_shutdown_notify
         .set(enterprise_config_shutdown);
@@ -7317,6 +7309,8 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     let health_thread = std::thread::spawn(move || {
         daemon_socket_health_check_loop(health_coord, health_control, health_trace);
     });
+
+    crate::enterprise_config::spawn_enterprise_config_worker(enterprise_config_shutdown_for_worker);
 
     coordinator.wait_for_shutdown().await;
 

--- a/src/enterprise_config.rs
+++ b/src/enterprise_config.rs
@@ -11,7 +11,7 @@ const CACHE_FILE_NAME: &str = "config.enterprise.json";
 const FETCH_ENDPOINT: &str = "/worker/config/enterprise";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct EnterpriseConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_prompts_in_repositories: Option<Vec<String>>,
@@ -198,9 +198,27 @@ pub fn enterprise_config_options() -> &'static [EnterpriseConfigOption] {
 }
 
 pub fn validate_enterprise_config_json(input: &str) -> Result<EnterpriseConfig, String> {
-    let config: EnterpriseConfig =
+    let value: serde_json::Value =
         serde_json::from_str(input).map_err(|e| format!("invalid enterprise config: {e}"))?;
+    reject_unknown_enterprise_config_keys(&value)?;
+    let config: EnterpriseConfig =
+        serde_json::from_value(value).map_err(|e| format!("invalid enterprise config: {e}"))?;
     validate_enterprise_config(config)
+}
+
+fn reject_unknown_enterprise_config_keys(value: &serde_json::Value) -> Result<(), String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "enterprise config must be an object".to_string())?;
+    for key in obj.keys() {
+        if !enterprise_config_options()
+            .iter()
+            .any(|option| option.key == key)
+        {
+            return Err(format!("unknown enterprise config field: {key}"));
+        }
+    }
+    Ok(())
 }
 
 pub fn validate_enterprise_config(config: EnterpriseConfig) -> Result<EnterpriseConfig, String> {
@@ -388,16 +406,21 @@ pub fn bootstrap_enterprise_config(
         .and_then(|result| apply_fetch_result(&api_key, result))
     {
         Ok(outcome) => Ok(outcome),
-        Err(error) => {
-            if load_cache_for_api_key(&api_key)?.is_some() {
+        Err(error) => match load_cache_for_api_key(&api_key) {
+            Ok(Some(_)) => {
                 tracing::warn!(%reason, %error, "enterprise config fetch failed; using cached config");
                 Ok(EnterpriseConfigBootstrapOutcome::CachedAfterError(error))
-            } else {
+            }
+            Ok(None) => Err(format!(
+                "enterprise config bootstrap failed during {reason}: {error}"
+            )),
+            Err(cache_error) => {
+                tracing::debug!(%cache_error, "failed to load enterprise config cache after fetch failure");
                 Err(format!(
                     "enterprise config bootstrap failed during {reason}: {error}"
                 ))
             }
-        }
+        },
     }
 }
 
@@ -493,7 +516,17 @@ mod tests {
     #[test]
     fn validates_unknown_keys() {
         let err = validate_enterprise_config_json(r#"{"api_key":"secret"}"#).unwrap_err();
-        assert!(err.contains("unknown field") || err.contains("invalid enterprise config"));
+        assert!(err.contains("unknown enterprise config field"));
+    }
+
+    #[test]
+    fn response_deserialization_ignores_unknown_keys() {
+        let response: EnterpriseConfigFetchResponse = serde_json::from_str(
+            r#"{"enabled":true,"config":{"prompt_storage":"local","future_setting":true}}"#,
+        )
+        .unwrap();
+        let config = response.config.unwrap();
+        assert_eq!(config.prompt_storage.as_deref(), Some("local"));
     }
 
     #[test]

--- a/src/enterprise_config.rs
+++ b/src/enterprise_config.rs
@@ -1,0 +1,514 @@
+use crate::config::{NotesBackendConfig, NotesBackendKind};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+use std::time::Duration;
+
+const CACHE_VERSION: u32 = 1;
+const CACHE_FILE_NAME: &str = "config.enterprise.json";
+const FETCH_ENDPOINT: &str = "/worker/config/enterprise";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct EnterpriseConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_prompts_in_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_prompts_in_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exclude_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry_oss: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry_enterprise_dsn: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disable_version_checks: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disable_auto_updates: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update_channel: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_storage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_prompt_storage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes_backend: Option<NotesBackendConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript_streaming_lookback_days: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct EnterpriseConfigOption {
+    pub key: &'static str,
+    pub value_type: &'static str,
+    pub enterprise_compatible: bool,
+    pub label: &'static str,
+    pub description: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<&'static [&'static str]>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EnterpriseConfigCache {
+    version: u32,
+    api_key_sha256: String,
+    config: EnterpriseConfig,
+}
+
+#[derive(Debug, Clone)]
+pub enum EnterpriseConfigFetchResult {
+    Enabled(Box<EnterpriseConfig>),
+    Disabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnterpriseConfigFetchResponse {
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<EnterpriseConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub enum EnterpriseConfigBootstrapOutcome {
+    Disabled,
+    Fetched,
+    CachedAfterError(String),
+    NoApiKey,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryCache {
+    api_key_sha256: String,
+    config: EnterpriseConfig,
+}
+
+static ENTERPRISE_CONFIG_MEMORY: OnceLock<RwLock<Option<MemoryCache>>> = OnceLock::new();
+
+pub fn enterprise_config_options() -> &'static [EnterpriseConfigOption] {
+    &[
+        EnterpriseConfigOption {
+            key: "exclude_prompts_in_repositories",
+            value_type: "string_array",
+            enterprise_compatible: true,
+            label: "Exclude prompts in repositories",
+            description: "Repository patterns where prompts are stored locally only.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "include_prompts_in_repositories",
+            value_type: "string_array",
+            enterprise_compatible: true,
+            label: "Include prompts in repositories",
+            description: "Repository patterns where the primary prompt storage policy applies.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "allow_repositories",
+            value_type: "string_array",
+            enterprise_compatible: true,
+            label: "Allow repositories",
+            description: "Repository patterns where git-ai is allowed to run.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "exclude_repositories",
+            value_type: "string_array",
+            enterprise_compatible: true,
+            label: "Exclude repositories",
+            description: "Repository patterns where git-ai is disabled.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "telemetry_oss",
+            value_type: "enum",
+            enterprise_compatible: true,
+            label: "OSS telemetry",
+            description: "Controls OSS telemetry collection.",
+            enum_values: Some(&["on", "off"]),
+        },
+        EnterpriseConfigOption {
+            key: "telemetry_enterprise_dsn",
+            value_type: "string",
+            enterprise_compatible: true,
+            label: "Enterprise telemetry DSN",
+            description: "Sentry DSN for enterprise telemetry.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "disable_version_checks",
+            value_type: "boolean",
+            enterprise_compatible: true,
+            label: "Disable version checks",
+            description: "Disable CLI version check requests.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "disable_auto_updates",
+            value_type: "boolean",
+            enterprise_compatible: true,
+            label: "Disable auto updates",
+            description: "Disable daemon-triggered automatic updates.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "update_channel",
+            value_type: "enum",
+            enterprise_compatible: true,
+            label: "Update channel",
+            description: "Release channel used for update checks.",
+            enum_values: Some(&["latest", "next", "enterprise-latest", "enterprise-next"]),
+        },
+        EnterpriseConfigOption {
+            key: "prompt_storage",
+            value_type: "enum",
+            enterprise_compatible: true,
+            label: "Prompt storage",
+            description: "Primary prompt storage mode.",
+            enum_values: Some(&["default", "notes", "local"]),
+        },
+        EnterpriseConfigOption {
+            key: "default_prompt_storage",
+            value_type: "enum",
+            enterprise_compatible: true,
+            label: "Default prompt storage",
+            description: "Fallback prompt storage mode for repositories outside the include list.",
+            enum_values: Some(&["default", "notes", "local"]),
+        },
+        EnterpriseConfigOption {
+            key: "notes_backend",
+            value_type: "object",
+            enterprise_compatible: true,
+            label: "Notes backend",
+            description: "Backend used for authorship notes.",
+            enum_values: None,
+        },
+        EnterpriseConfigOption {
+            key: "transcript_streaming_lookback_days",
+            value_type: "number",
+            enterprise_compatible: true,
+            label: "Transcript streaming lookback days",
+            description: "Number of days transcript streaming should scan; 0 means unlimited.",
+            enum_values: None,
+        },
+    ]
+}
+
+pub fn validate_enterprise_config_json(input: &str) -> Result<EnterpriseConfig, String> {
+    let config: EnterpriseConfig =
+        serde_json::from_str(input).map_err(|e| format!("invalid enterprise config: {e}"))?;
+    validate_enterprise_config(config)
+}
+
+pub fn validate_enterprise_config(config: EnterpriseConfig) -> Result<EnterpriseConfig, String> {
+    validate_string_list(
+        "exclude_prompts_in_repositories",
+        &config.exclude_prompts_in_repositories,
+    )?;
+    validate_string_list(
+        "include_prompts_in_repositories",
+        &config.include_prompts_in_repositories,
+    )?;
+    validate_string_list("allow_repositories", &config.allow_repositories)?;
+    validate_string_list("exclude_repositories", &config.exclude_repositories)?;
+
+    if let Some(value) = config.telemetry_oss.as_deref()
+        && !matches!(value, "on" | "off")
+    {
+        return Err("telemetry_oss must be 'on' or 'off'".to_string());
+    }
+    if let Some(value) = config.update_channel.as_deref()
+        && !matches!(
+            value,
+            "latest" | "next" | "enterprise-latest" | "enterprise-next"
+        )
+    {
+        return Err("update_channel is invalid".to_string());
+    }
+    if let Some(value) = config.prompt_storage.as_deref() {
+        validate_prompt_storage("prompt_storage", value)?;
+    }
+    if let Some(value) = config.default_prompt_storage.as_deref() {
+        validate_prompt_storage("default_prompt_storage", value)?;
+    }
+    if let Some(notes_backend) = &config.notes_backend
+        && notes_backend.kind == NotesBackendKind::Http
+        && notes_backend
+            .backend_url
+            .as_ref()
+            .is_none_or(|value| value.trim().is_empty())
+    {
+        return Err("notes_backend.backend_url is required when kind is http".to_string());
+    }
+
+    Ok(config)
+}
+
+fn validate_string_list(key: &str, values: &Option<Vec<String>>) -> Result<(), String> {
+    if let Some(values) = values {
+        for value in values {
+            if value.trim().is_empty() {
+                return Err(format!("{key} cannot contain blank values"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_prompt_storage(key: &str, value: &str) -> Result<(), String> {
+    if matches!(value, "default" | "notes" | "local") {
+        Ok(())
+    } else {
+        Err(format!("{key} must be 'default', 'notes', or 'local'"))
+    }
+}
+
+pub fn enterprise_config_cache_path() -> Option<PathBuf> {
+    crate::config::internal_dir_path().map(|dir| dir.join(CACHE_FILE_NAME))
+}
+
+pub fn effective_cached_config(api_key: Option<&str>) -> Option<EnterpriseConfig> {
+    let api_key = api_key?;
+    let fingerprint = api_key_fingerprint(api_key);
+
+    if let Ok(guard) = memory_cache().read()
+        && let Some(cache) = guard.as_ref()
+        && cache.api_key_sha256 == fingerprint
+    {
+        return Some(cache.config.clone());
+    }
+
+    match load_cache_for_api_key(api_key) {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::debug!(error = %e, "failed to load enterprise config cache");
+            None
+        }
+    }
+}
+
+pub fn load_cache_for_api_key(api_key: &str) -> Result<Option<EnterpriseConfig>, String> {
+    let Some(path) = enterprise_config_cache_path() else {
+        clear_memory_cache();
+        return Ok(None);
+    };
+
+    let data = match fs::read(&path) {
+        Ok(data) => data,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            clear_memory_cache();
+            return Ok(None);
+        }
+        Err(e) => return Err(format!("failed to read enterprise config cache: {e}")),
+    };
+
+    let cache: EnterpriseConfigCache =
+        serde_json::from_slice(&data).map_err(|e| format!("invalid enterprise cache: {e}"))?;
+    let fingerprint = api_key_fingerprint(api_key);
+    if cache.version != CACHE_VERSION || cache.api_key_sha256 != fingerprint {
+        let _ = fs::remove_file(&path);
+        clear_memory_cache();
+        return Ok(None);
+    }
+
+    let config = validate_enterprise_config(cache.config)?;
+    set_memory_cache(fingerprint, config.clone());
+    Ok(Some(config))
+}
+
+pub fn save_cache_for_api_key(api_key: &str, config: &EnterpriseConfig) -> Result<(), String> {
+    let path = enterprise_config_cache_path()
+        .ok_or_else(|| "could not determine enterprise config cache path".to_string())?;
+    let fingerprint = api_key_fingerprint(api_key);
+    let config = validate_enterprise_config(config.clone())?;
+    let cache = EnterpriseConfigCache {
+        version: CACHE_VERSION,
+        api_key_sha256: fingerprint.clone(),
+        config: config.clone(),
+    };
+    atomic_write_json(&path, &cache)?;
+    set_memory_cache(fingerprint, config);
+    Ok(())
+}
+
+pub fn clear_cache() -> Result<(), String> {
+    clear_memory_cache();
+    if let Some(path) = enterprise_config_cache_path() {
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("failed to remove enterprise config cache: {e}")),
+        }
+    }
+    Ok(())
+}
+
+fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("failed to create cache dir: {e}"))?;
+    }
+    let json = serde_json::to_vec_pretty(value)
+        .map_err(|e| format!("failed to serialize enterprise cache: {e}"))?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, json).map_err(|e| format!("failed to write enterprise cache: {e}"))?;
+    fs::rename(&tmp_path, path).map_err(|e| format!("failed to replace enterprise cache: {e}"))?;
+    Ok(())
+}
+
+pub fn apply_fetch_result(
+    api_key: &str,
+    result: EnterpriseConfigFetchResult,
+) -> Result<EnterpriseConfigBootstrapOutcome, String> {
+    match result {
+        EnterpriseConfigFetchResult::Enabled(config) => {
+            save_cache_for_api_key(api_key, &config)?;
+            Ok(EnterpriseConfigBootstrapOutcome::Fetched)
+        }
+        EnterpriseConfigFetchResult::Disabled => {
+            clear_cache()?;
+            Ok(EnterpriseConfigBootstrapOutcome::Disabled)
+        }
+    }
+}
+
+pub fn bootstrap_enterprise_config(
+    reason: &str,
+    timeout: Duration,
+) -> Result<EnterpriseConfigBootstrapOutcome, String> {
+    let config = crate::config::Config::fresh();
+    let Some(api_key) = config.api_key().map(str::to_string) else {
+        clear_cache()?;
+        return Ok(EnterpriseConfigBootstrapOutcome::NoApiKey);
+    };
+
+    match fetch_enterprise_config_once(timeout)
+        .and_then(|result| apply_fetch_result(&api_key, result))
+    {
+        Ok(outcome) => Ok(outcome),
+        Err(error) => {
+            if load_cache_for_api_key(&api_key)?.is_some() {
+                tracing::warn!(%reason, %error, "enterprise config fetch failed; using cached config");
+                Ok(EnterpriseConfigBootstrapOutcome::CachedAfterError(error))
+            } else {
+                Err(format!(
+                    "enterprise config bootstrap failed during {reason}: {error}"
+                ))
+            }
+        }
+    }
+}
+
+pub fn fetch_enterprise_config_once(
+    timeout: Duration,
+) -> Result<EnterpriseConfigFetchResult, String> {
+    let cfg = crate::config::Config::fresh();
+    if cfg.api_key().is_none() {
+        return Err("api key is not configured".to_string());
+    }
+
+    let context = crate::api::client::ApiContext::new(None).with_timeout(timeout.as_secs().max(1));
+    let client = crate::api::client::ApiClient::new(context);
+    client.fetch_enterprise_config()
+}
+
+fn fetch_enterprise_config_with_retries(
+    timeout: Duration,
+    retries: usize,
+) -> Result<EnterpriseConfigFetchResult, String> {
+    let mut last_error = None;
+    for attempt in 0..=retries {
+        match fetch_enterprise_config_once(timeout) {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                last_error = Some(e);
+                if attempt < retries {
+                    std::thread::sleep(Duration::from_secs(1 << attempt.min(3)));
+                }
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "enterprise config fetch failed".to_string()))
+}
+
+pub fn spawn_enterprise_config_worker(shutdown: std::sync::Arc<tokio::sync::Notify>) {
+    tokio::spawn(async move {
+        loop {
+            let result = tokio::task::spawn_blocking(|| {
+                let cfg = crate::config::Config::fresh();
+                let Some(api_key) = cfg.api_key().map(str::to_string) else {
+                    clear_cache()?;
+                    return Ok(());
+                };
+                fetch_enterprise_config_with_retries(Duration::from_secs(30), 3)
+                    .and_then(|result| apply_fetch_result(&api_key, result).map(|_| ()))
+            })
+            .await;
+
+            if let Err(e) = result.unwrap_or_else(|e| Err(format!("worker panicked: {e}"))) {
+                tracing::warn!(error = %e, "enterprise config refresh failed");
+            }
+
+            tokio::select! {
+                _ = shutdown.notified() => break,
+                _ = tokio::time::sleep(Duration::from_secs(30 * 60)) => {}
+            }
+        }
+    });
+}
+
+fn api_key_fingerprint(api_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(api_key.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn memory_cache() -> &'static RwLock<Option<MemoryCache>> {
+    ENTERPRISE_CONFIG_MEMORY.get_or_init(|| RwLock::new(None))
+}
+
+fn set_memory_cache(api_key_sha256: String, config: EnterpriseConfig) {
+    if let Ok(mut guard) = memory_cache().write() {
+        *guard = Some(MemoryCache {
+            api_key_sha256,
+            config,
+        });
+    }
+}
+
+fn clear_memory_cache() {
+    if let Ok(mut guard) = memory_cache().write() {
+        *guard = None;
+    }
+}
+
+pub(crate) const FETCH_ENDPOINT_PATH: &str = FETCH_ENDPOINT;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_unknown_keys() {
+        let err = validate_enterprise_config_json(r#"{"api_key":"secret"}"#).unwrap_err();
+        assert!(err.contains("unknown field") || err.contains("invalid enterprise config"));
+    }
+
+    #[test]
+    fn rejects_invalid_prompt_storage() {
+        let err = validate_enterprise_config_json(r#"{"prompt_storage":"remote"}"#).unwrap_err();
+        assert!(err.contains("prompt_storage"));
+    }
+
+    #[test]
+    fn accepts_policy_config() {
+        let cfg = validate_enterprise_config_json(
+            r#"{"prompt_storage":"local","disable_auto_updates":true}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.prompt_storage.as_deref(), Some("local"));
+        assert_eq!(cfg.disable_auto_updates, Some(true));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod config;
 pub mod daemon;
 pub mod diagnostic_sentinels;
 pub mod diagnostics;
+pub mod enterprise_config;
 pub mod error;
 pub mod feature_flags;
 pub mod git;

--- a/tests/config_fresh_test.rs
+++ b/tests/config_fresh_test.rs
@@ -2,7 +2,11 @@ use git_ai::api::client::ApiContext;
 use git_ai::auth::client::OAuthClient;
 /// Tests for config refresh behavior (Config::fresh() vs Config::get())
 /// These tests verify that Config::fresh() reads from disk while Config::get() uses cached values.
-use git_ai::config::{Config, load_file_config_public, save_file_config};
+use git_ai::config::{
+    Config, FileConfig, NotesBackendConfig, NotesBackendKind, load_file_config_public,
+    save_file_config,
+};
+use git_ai::enterprise_config::{EnterpriseConfig, EnterpriseConfigFetchResult};
 use serial_test::serial;
 use std::env;
 use tempfile::TempDir;
@@ -74,6 +78,41 @@ impl Drop for HomeEnvGuard {
                     Some(v) => env::set_var("HOMEPATH", v),
                     None => env::remove_var("HOMEPATH"),
                 }
+            }
+        }
+    }
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn remove(key: &'static str) -> Self {
+        let previous = env::var_os(key);
+        unsafe {
+            env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = env::var_os(key);
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(previous) = self.previous.as_ref() {
+                env::set_var(self.key, previous);
+            } else {
+                env::remove_var(self.key);
             }
         }
     }
@@ -229,6 +268,126 @@ fn test_config_fresh_respects_env_vars() {
             env::remove_var("GIT_AI_API_BASE_URL");
         }
     }
+}
+
+#[test]
+#[serial]
+fn test_enterprise_config_overrides_user_config_for_compatible_fields() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _home_guard = HomeEnvGuard::set(temp_dir.path());
+    let _api_key_guard = EnvVarGuard::remove("GIT_AI_API_KEY");
+
+    save_file_config(&FileConfig {
+        api_key: Some("enterprise-key".to_string()),
+        prompt_storage: Some("default".to_string()),
+        disable_auto_updates: Some(false),
+        ..Default::default()
+    })
+    .expect("save config");
+
+    git_ai::enterprise_config::save_cache_for_api_key(
+        "enterprise-key",
+        &EnterpriseConfig {
+            prompt_storage: Some("local".to_string()),
+            disable_auto_updates: Some(true),
+            ..Default::default()
+        },
+    )
+    .expect("save enterprise cache");
+
+    let config = Config::fresh();
+    assert_eq!(config.prompt_storage(), "local");
+    assert!(config.auto_updates_disabled());
+    assert_eq!(config.api_key(), Some("enterprise-key"));
+}
+
+#[test]
+#[serial]
+fn test_enterprise_config_cache_is_scoped_to_api_key() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _home_guard = HomeEnvGuard::set(temp_dir.path());
+    let _api_key_guard = EnvVarGuard::remove("GIT_AI_API_KEY");
+
+    save_file_config(&FileConfig {
+        api_key: Some("new-key".to_string()),
+        prompt_storage: Some("notes".to_string()),
+        ..Default::default()
+    })
+    .expect("save config");
+
+    git_ai::enterprise_config::save_cache_for_api_key(
+        "old-key",
+        &EnterpriseConfig {
+            prompt_storage: Some("local".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("save enterprise cache");
+
+    let config = Config::fresh();
+    assert_eq!(config.prompt_storage(), "notes");
+    assert!(
+        git_ai::enterprise_config::effective_cached_config(Some("new-key")).is_none(),
+        "mismatched cache should not be used"
+    );
+}
+
+#[test]
+#[serial]
+fn test_env_vars_override_enterprise_config() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _home_guard = HomeEnvGuard::set(temp_dir.path());
+    let _backend_kind_guard = EnvVarGuard::set("GIT_AI_NOTES_BACKEND_KIND", "git_notes");
+    let _backend_url_guard = EnvVarGuard::remove("GIT_AI_NOTES_BACKEND_URL");
+
+    save_file_config(&FileConfig {
+        api_key: Some("enterprise-key".to_string()),
+        notes_backend: Some(NotesBackendConfig {
+            kind: NotesBackendKind::GitNotes,
+            backend_url: None,
+        }),
+        ..Default::default()
+    })
+    .expect("save config");
+
+    git_ai::enterprise_config::save_cache_for_api_key(
+        "enterprise-key",
+        &EnterpriseConfig {
+            notes_backend: Some(NotesBackendConfig {
+                kind: NotesBackendKind::Http,
+                backend_url: Some("https://enterprise.example.com".to_string()),
+            }),
+            ..Default::default()
+        },
+    )
+    .expect("save enterprise cache");
+
+    let config = Config::fresh();
+    assert_eq!(config.notes_backend_kind(), NotesBackendKind::GitNotes);
+}
+
+#[test]
+#[serial]
+fn test_disabled_enterprise_response_clears_cache() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let _home_guard = HomeEnvGuard::set(temp_dir.path());
+
+    git_ai::enterprise_config::save_cache_for_api_key(
+        "enterprise-key",
+        &EnterpriseConfig {
+            prompt_storage: Some("local".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("save enterprise cache");
+
+    git_ai::enterprise_config::apply_fetch_result(
+        "enterprise-key",
+        EnterpriseConfigFetchResult::Disabled,
+    )
+    .expect("apply disabled");
+
+    assert!(git_ai::enterprise_config::effective_cached_config(Some("enterprise-key")).is_none());
 }
 /// Test that ApiContext picks up config changes via Config::fresh()
 #[test]


### PR DESCRIPTION
## Summary
- add enterprise configuration metadata, validation, fetch response parsing, and API-key scoped cache storage
- apply enterprise overrides separately from user config for compatible policy fields
- bootstrap enterprise config during install-hooks and daemon startup, then refresh in a daemon worker
- fail enterprise API-key installs when the first config fetch cannot complete without a valid cache

## Tests
- task fmt
- task lint
- cargo test --test config_fresh_test
- cargo test commands::install_hooks::tests --lib
- cargo test commands::config::tests --lib
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->