### PR TITLE
feat: recover bash attribution globally and at edges

### DIFF
--- a/docs/bash-attribution-recovery-plan.md
+++ b/docs/bash-attribution-recovery-plan.md
@@ -20,7 +20,7 @@ The goal is to keep the fast checkpoint path intact, but add daemon-owned durabl
 - Keep checkpoint subprocess overhead limited to parsing already-available hook fields and sending them over the existing control socket.
 - Put durable bash history in the daemon, not in checkpoint command processes.
 - Recover only unknown committed lines; never overwrite explicit AI or known-human attestations.
-- Treat unchanged lines from legacy `human` pre-bash checkpoints as negative evidence; those lines were already present before the bash call and should not be recovered as bash output.
+- Prefer minimizing unknown/untracked committed lines over preserving legacy `human` pre-bash holes during bash recovery.
 - Add recovery after the normal authorship log is built and before custom attributes, note serialization, and stats. Existing session pruning happens inside the normal builder, so recovery must add any recovered session records itself.
 - Model recovery as ordered solvers so future recovery stages can be added without changing post-commit control flow.
 - Emit checkpoint metrics for recovered attribution with enough metadata to explain why recovery selected a session.
@@ -62,6 +62,9 @@ CREATE INDEX idx_bash_calls_repo_time
 
 CREATE UNIQUE INDEX idx_bash_calls_invocation
     ON bash_checkpoint_calls(session_id, tool_use_id, start_trace_id);
+
+CREATE INDEX idx_bash_calls_time
+    ON bash_checkpoint_calls(start_time_ns, end_time_ns);
 ```
 
 Retention:
@@ -72,7 +75,7 @@ Retention:
 Rust record shape:
 
 - `BashCheckpointCall`: persisted row with optional `end_time_ns`, optional command, and parsed metadata.
-- `BashCallCandidate`: query result for recovery scoring.
+- `repo_work_dir` is retained for audit/debug metadata, but recovery candidate lookup is global by timestamp so cross-repo/cross-worktree bash commands can recover attribution.
 
 ## Control API Changes
 
@@ -150,10 +153,9 @@ For each eligible file:
 
 1. Read the committed file metadata from the working tree when the committed file matches the working tree.
 2. Use both `mtime` and `ctime` when available, converted to nanoseconds since epoch.
-3. Query bash history for the same canonical worktree key and calls whose `[start_time_ns, end_time_ns]` window is within ±3 seconds of either file timestamp.
+3. Query global bash history for calls whose `[start_time_ns, end_time_ns]` window is within ±3 seconds of either file timestamp.
 4. Score candidates by nearest timestamp distance, then prefer completed calls, then prefer calls with command text, then newest row id.
-5. Before attribution, exclude unknown committed lines whose same line content already existed in a legacy `human` checkpoint before the bash call.
-6. If a candidate is selected, add an attestation for all remaining unknown committed lines in that file to:
+5. If a candidate is selected, add an attestation for all unknown committed lines in that file to:
 
 `generate_session_id(agent_external_id, agent_tool)::generate_trace_id()`
 
@@ -164,9 +166,10 @@ Recovery metadata metric JSON should include:
 - `solver`: `"bash_mtime"`
 - `file_path`
 - `unknown_lines`
-- `file_mtime_ns`
-- `file_ctime_ns`
+- `target_repo_work_dir`
+- `file_timestamps_ns`
 - `selected_bash_call_id`
+- `selected_bash_repo_work_dir`
 - `selected_tool_use_id`
 - `selected_command`
 - `distance_ns`
@@ -194,11 +197,12 @@ For each remaining eligible file:
 
 1. Build a map of line -> author from current authorship log entries.
 2. Identify contiguous unknown line runs inside committed hunks.
-3. Recover attribution only when the unknown run is directly between two AI-attributed neighbors from the same session key.
-4. Do not extend from known-human (`h_`) or legacy `human`.
-5. Do not bridge between two different AI sessions.
-6. Add a new trace id while preserving the recovered or original session id prefix.
-7. Do not recover single-sided leading or trailing unknown runs; those are too ambiguous and caused false positives in reset/rebase/merge scenarios.
+3. Recover attribution when the unknown run is directly between two AI-attributed neighbors from the same session key.
+4. Recover up to three leading or trailing unknown lines when a run touches one AI-attributed edge and is open-ended on the other side.
+5. Do not extend from known-human (`h_`) or legacy `human`.
+6. Do not bridge between two different AI sessions.
+7. Add a new trace id while preserving the recovered or original session id prefix.
+8. Only recover lines from the remaining unknown set derived from committed hunks, so earlier solvers are not overridden.
 
 Metric:
 
@@ -248,11 +252,12 @@ Add RED tests before implementation:
 6. Integration: edge extension:
    - AI checkpoints produce matching AI-attributed lines around an unknown gap.
    - Commit recovery bridges only the unknown gap between the matching AI session lines.
+   - Unknown leading and trailing lines next to an AI block recover up to three lines per side.
 
 7. Integration: edge extension guardrails:
    - Unknown line between two different AI sessions remains unknown.
    - Unknown line adjacent only to known-human remains unknown.
-   - Unknown line with only one neighboring AI attribution remains unknown.
+   - Unknown line with one AI neighbor and a known-human or different-session neighbor remains unknown.
 
 8. Metric unit tests:
    - checkpoint sparse encoding includes the new nullable fields.

--- a/docs/bash-attribution-recovery-plan.md
+++ b/docs/bash-attribution-recovery-plan.md
@@ -1,0 +1,282 @@
+# Bash Checkpoint Persistence And Attribution Recovery Plan
+
+## Problem
+
+Bash/shell tool attribution currently depends on a fast pre/post stat diff. That path is intentionally strict: the checkpoint process must stay cheap, the daemon only keeps pre-snapshots in memory, and the post hook only emits an AI checkpoint when it can identify changed paths immediately. Real usage shows that many shell-created or shell-modified lines still reach commit finalization as unknown/untracked, especially across repository roots, worktrees, daemon restarts, low-resolution mtimes, and command shapes that defeat the stat diff.
+
+The goal is to keep the fast checkpoint path intact, but add daemon-owned durable evidence and post-commit recovery solvers that can convert otherwise unknown committed lines into AI session attributions when there is strong evidence.
+
+## Current System Shape
+
+- Agent presets parse hook JSON into `PreBashCall` / `PostBashCall`.
+- `execute_pre_bash_call` calls `handle_bash_pre_tool_use_with_context`, which snapshots file stat tuples and sends `bash_session.start` to the daemon.
+- The daemon stores active bash sessions only in `BashSessionState`, keyed by `(session_id, tool_use_id)`.
+- `execute_post_bash_call` asks the daemon for the pre-snapshot, takes a post-snapshot, emits an `AiAgent` checkpoint only for changed paths, and then sends `bash_session.end`.
+- Post-commit finalization builds a `VirtualAttributions`, splits line attributions into committed and uncommitted buckets, serializes an `AuthorshipLog`, writes `refs/notes/ai`, and records commit metrics.
+- Unknown committed lines are simply lines absent from the note. Legacy `human` checkpoint attributions are deliberately stripped and become unknown/no-data.
+
+## Design Principles
+
+- Keep checkpoint subprocess overhead limited to parsing already-available hook fields and sending them over the existing control socket.
+- Put durable bash history in the daemon, not in checkpoint command processes.
+- Recover only unknown committed lines; never overwrite explicit AI or known-human attestations.
+- Treat unchanged lines from legacy `human` pre-bash checkpoints as negative evidence; those lines were already present before the bash call and should not be recovered as bash output.
+- Add recovery after the normal authorship log is built and before custom attributes, note serialization, and stats. Existing session pruning happens inside the normal builder, so recovery must add any recovered session records itself.
+- Model recovery as ordered solvers so future recovery stages can be added without changing post-commit control flow.
+- Emit checkpoint metrics for recovered attribution with enough metadata to explain why recovery selected a session.
+
+## Data Model
+
+Add `src/daemon/bash_history_db.rs`, a dedicated SQLite database at:
+
+`~/.git-ai/internal/bash-checkpoints-db`
+
+Test override:
+
+`GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH`
+
+Schema version 1:
+
+```sql
+CREATE TABLE bash_checkpoint_calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    invocation_key TEXT NOT NULL,
+    repo_work_dir TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    tool_use_id TEXT NOT NULL,
+    agent_tool TEXT NOT NULL,
+    agent_external_id TEXT NOT NULL,
+    agent_model TEXT NOT NULL,
+    start_trace_id TEXT,
+    end_trace_id TEXT,
+    start_time_ns INTEGER NOT NULL,
+    end_time_ns INTEGER,
+    command TEXT,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_bash_calls_repo_time
+    ON bash_checkpoint_calls(repo_work_dir, start_time_ns, end_time_ns);
+
+CREATE UNIQUE INDEX idx_bash_calls_invocation
+    ON bash_checkpoint_calls(session_id, tool_use_id, start_trace_id);
+```
+
+Retention:
+
+- 30 days by `updated_at`.
+- Prune at most once per day using `schema_metadata.bash_history_last_prune_ts`.
+
+Rust record shape:
+
+- `BashCheckpointCall`: persisted row with optional `end_time_ns`, optional command, and parsed metadata.
+- `BashCallCandidate`: query result for recovery scoring.
+
+## Control API Changes
+
+No backward compatibility is required for the daemon control socket.
+
+Extend `ControlRequest::BashSessionStart` with:
+
+- `trace_id: String`
+- `started_at_ns: u128`
+- `command: Option<String>`
+
+Extend `ControlRequest::BashSessionEnd` with:
+
+- `repo_work_dir: String`
+- `trace_id: String`
+- `ended_at_ns: u128`
+- `command: Option<String>`
+- `agent_id: AgentId`
+- `metadata: HashMap<String, String>`
+
+The daemon still uses `BashSessionState` for active pre-snapshots, but also writes:
+
+- Start row on `bash_session.start`.
+- End update on `bash_session.end`.
+
+If start was missed, end upserts a row with identical start/end timing as a best-effort record.
+
+## Command Extraction
+
+Add `parse::bash_command_from_hook_input(&serde_json::Value) -> Option<String>`.
+
+Extraction order:
+
+1. `tool_input.command`
+2. `toolInput.command`
+3. `tool_input.cmd`
+4. `toolInput.cmd`
+5. `command`
+6. `cmd`
+7. Agent-specific wrappers already parsed by each preset can pass through the same helper.
+
+Store the result on both `PreBashCall` and `PostBashCall` as `command: Option<String>`. Preserve optionality because not every agent exposes command text.
+
+## Recovery Pipeline
+
+Add `src/authorship/attribution_recovery.rs`.
+
+Entry point:
+
+```rust
+pub(crate) fn recover_attribution(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    human_author: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+) -> Result<(), GitAiError>
+```
+
+Post-commit flow calls this after `to_authorship_log_and_initial_working_log*` and background-agent filling, before custom attributes and note serialization. Because the normal builder has already pruned unused sessions, each solver that adds a new session-prefixed attestation must also insert the matching `SessionRecord`.
+
+The committed hunk map must cover all changed files, not only checkpoint pathspecs. Recovery cannot find unknown files if post-commit only asks diff logic about AI-relevant pathspecs. Use the precomputed parent diff when available; otherwise collect parent-to-commit hunks without pathspec filtering for recovery.
+
+Unknown line calculation:
+
+- Expand committed hunk lines per file.
+- Expand existing authorship log entries per file.
+- Unknown lines are committed hunk lines not covered by any existing attestation entry.
+- A file is eligible when it has at least one unknown line.
+
+## Solver 1: Bash Mtime/Ctime Recovery
+
+For each eligible file:
+
+1. Read the committed file metadata from the working tree when the committed file matches the working tree.
+2. Use both `mtime` and `ctime` when available, converted to nanoseconds since epoch.
+3. Query bash history for the same canonical worktree key and calls whose `[start_time_ns, end_time_ns]` window is within ±3 seconds of either file timestamp.
+4. Score candidates by nearest timestamp distance, then prefer completed calls, then prefer calls with command text, then newest row id.
+5. Before attribution, exclude unknown committed lines whose same line content already existed in a legacy `human` checkpoint before the bash call.
+6. If a candidate is selected, add an attestation for all remaining unknown committed lines in that file to:
+
+`generate_session_id(agent_external_id, agent_tool)::generate_trace_id()`
+
+Also ensure `authorship_log.metadata.sessions` contains the recovered session record.
+
+Recovery metadata metric JSON should include:
+
+- `solver`: `"bash_mtime"`
+- `file_path`
+- `unknown_lines`
+- `file_mtime_ns`
+- `file_ctime_ns`
+- `selected_bash_call_id`
+- `selected_tool_use_id`
+- `selected_command`
+- `distance_ns`
+- `window_ns`
+- `start_time_ns`
+- `end_time_ns`
+- `start_trace_id`
+- `end_trace_id`
+
+Metric:
+
+- Event ID: existing checkpoint event.
+- `kind`: `"ai_agent"`
+- `edit_kind`: `"bash"`
+- `checkpoint_type`: `"recovered_bash"` as a new value field.
+- `attribution_recovery_metadata`: JSON string as a new value field.
+- Timestamp: original bash start timestamp when available.
+- Attributes: repo URL, branch, session id, trace id, tool, model, external session id, base/commit sha.
+
+## Solver 2: Adjacent Edge Bridge
+
+Run after bash recovery.
+
+For each remaining eligible file:
+
+1. Build a map of line -> author from current authorship log entries.
+2. Identify contiguous unknown line runs inside committed hunks.
+3. Recover attribution only when the unknown run is directly between two AI-attributed neighbors from the same session key.
+4. Do not extend from known-human (`h_`) or legacy `human`.
+5. Do not bridge between two different AI sessions.
+6. Add a new trace id while preserving the recovered or original session id prefix.
+7. Do not recover single-sided leading or trailing unknown runs; those are too ambiguous and caused false positives in reset/rebase/merge scenarios.
+
+Metric:
+
+- Existing checkpoint event.
+- `kind`: `"ai_agent"`
+- `edit_kind`: `"attribution_recovery_edge"`
+- `checkpoint_type`: `"recovered_edge_extension"`
+- `attribution_recovery_metadata`: JSON with solver, file, source author, source neighboring lines, recovered ranges, and reason.
+
+## Metric Schema Changes
+
+Extend checkpoint event positions:
+
+- `9`: `checkpoint_type` string nullable.
+- `10`: `attribution_recovery_metadata` string nullable.
+
+Keep existing positions stable.
+
+## Tests First
+
+Add RED tests before implementation:
+
+1. Bash DB unit tests:
+   - start/end lifecycle persists all fields.
+   - end without start upserts best-effort row.
+   - query returns candidates inside ±3 seconds and excludes outside.
+   - retention prunes rows older than 30 days.
+
+2. Preset/orchestrator unit tests:
+   - Codex, Claude, Gemini, Cursor, Windsurf, Copilot CLI/IDE command extraction where payloads expose command.
+   - Missing command remains `None`.
+
+3. Integration: bash recovery:
+   - Codex pre/post bash hook records durable bash history.
+   - The file is modified by the simulated bash command.
+   - No AI checkpoint is emitted for the file, so normal attribution would be unknown.
+   - Commit recovery attributes unknown committed lines to the recovered AI session.
+   - Assert committed blame and authorship note session metadata.
+
+4. Integration: closest candidate:
+   - Two bash calls around the file timestamp.
+   - Recovery selects the closest one.
+
+5. Integration: outside window:
+   - Bash call outside ±3 seconds leaves unknown lines unknown.
+
+6. Integration: edge extension:
+   - AI checkpoints produce matching AI-attributed lines around an unknown gap.
+   - Commit recovery bridges only the unknown gap between the matching AI session lines.
+
+7. Integration: edge extension guardrails:
+   - Unknown line between two different AI sessions remains unknown.
+   - Unknown line adjacent only to known-human remains unknown.
+   - Unknown line with only one neighboring AI attribution remains unknown.
+
+8. Metric unit tests:
+   - checkpoint sparse encoding includes the new nullable fields.
+   - recovery metric builders emit expected `checkpoint_type` and JSON metadata.
+
+After RED tests fail for the expected reasons, implement the smallest complete slice, then expand until all scenarios pass.
+
+## Implementation Order
+
+1. Add and test `BashHistoryDatabase`.
+2. Extend control API and daemon handling to write bash history.
+3. Add command extraction and thread command strings through bash events.
+4. Add committed-hunk helpers for recovery without disturbing the existing pathspec-limited normal attribution pass.
+5. Add recovery framework and bash mtime solver.
+6. Add checkpoint metric schema extensions and recovery metric emission.
+7. Add edge-extension solver.
+8. Update affected existing assertions where edge extension legitimately changes expected attribution.
+9. Run focused tests, `task fmt`, `task lint`, and broader suites as time allows.
+
+## Review Pass Notes
+
+- The durable DB is daemon-owned and use-case-specific, matching the notes/metrics DB pattern instead of extending the deprecated internal DB.
+- Recovery never rewrites existing attestation entries; it only covers holes.
+- Solver ordering matters: bash evidence gets first claim over unknown lines, and edge bridging only sees the remaining holes.
+- Session records are required because recovered entries use session-prefixed hashes.
+- Full committed hunk coverage is required for recovery; pathspec-limited hunk maps are insufficient.
+- Metrics must be emitted at recovery time because no working-log checkpoint exists for recovered lines.

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -2,14 +2,12 @@ use crate::authorship::authorship_log::{LineRange, SessionRecord};
 use crate::authorship::authorship_log_serialization::{
     AuthorshipLog, generate_session_id, generate_trace_id,
 };
-use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
-use crate::authorship::working_log::{Checkpoint, CheckpointKind};
+use crate::authorship::working_log::CheckpointKind;
 use crate::commands::checkpoint_agent::bash_tool::StatEntry;
 use crate::daemon::bash_history_db::{BashCheckpointCall, distance_to_call_window};
 use crate::error::GitAiError;
 use crate::git::repo_state::worktree_root_for_path;
-use crate::git::repo_storage::PersistedWorkingLog;
-use crate::git::repository::{Repository, batch_read_paths_at_treeishes};
+use crate::git::repository::Repository;
 use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded};
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -17,11 +15,7 @@ use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
-
-pub(crate) struct RecoveryWorkingLogContext<'a> {
-    pub working_log: &'a PersistedWorkingLog,
-    pub parent_checkpoints: &'a [Checkpoint],
-}
+const EDGE_EXTENSION_MAX_LINES: usize = 3;
 
 pub(crate) fn recover_attribution(
     repo: &Repository,
@@ -30,30 +24,13 @@ pub(crate) fn recover_attribution(
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
-    working_log_context: Option<RecoveryWorkingLogContext<'_>>,
 ) -> Result<(), GitAiError> {
     if committed_hunks.is_empty() {
         return Ok(());
     }
 
-    let empty_exclusions: HashMap<String, HashSet<u32>> = HashMap::new();
-    if unknown_lines_by_file(authorship_log, committed_hunks, &empty_exclusions).is_empty() {
+    if unknown_lines_by_file(authorship_log, committed_hunks).is_empty() {
         return Ok(());
-    }
-
-    let mut recovery_exclusions =
-        parent_known_human_same_content_lines(repo, parent_sha, commit_sha, committed_hunks);
-    if let Some(context) = working_log_context {
-        merge_line_exclusions(
-            &mut recovery_exclusions,
-            legacy_human_checkpoint_same_content_lines(
-                repo,
-                commit_sha,
-                committed_hunks,
-                context.working_log,
-                context.parent_checkpoints,
-            ),
-        );
     }
 
     recover_bash_mtime(
@@ -63,7 +40,6 @@ pub(crate) fn recover_attribution(
         human_author,
         authorship_log,
         committed_hunks,
-        &recovery_exclusions,
     )?;
     recover_adjacent_edges(
         repo,
@@ -71,7 +47,6 @@ pub(crate) fn recover_attribution(
         commit_sha,
         authorship_log,
         committed_hunks,
-        &recovery_exclusions,
     );
     Ok(())
 }
@@ -83,12 +58,10 @@ fn recover_bash_mtime(
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
-    recovery_exclusions: &HashMap<String, HashSet<u32>>,
 ) -> Result<(), GitAiError> {
     let repo_work_dir = repo_worktree_key(repo)?;
     let workdir = repo.workdir()?;
-    let unknown_by_file =
-        unknown_lines_by_file(authorship_log, committed_hunks, recovery_exclusions);
+    let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
     if unknown_by_file.is_empty() {
         return Ok(());
     }
@@ -110,11 +83,7 @@ fn recover_bash_mtime(
 
     let candidates = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
         Ok(db) => match db.lock() {
-            Ok(db) => db.candidates_near_timestamps(
-                &repo_work_dir,
-                &all_timestamps,
-                BASH_RECOVERY_WINDOW_NS,
-            )?,
+            Ok(db) => db.candidates_near_timestamps(&all_timestamps, BASH_RECOVERY_WINDOW_NS)?,
             Err(_) => Vec::new(),
         },
         Err(_) => Vec::new(),
@@ -145,8 +114,10 @@ fn recover_bash_mtime(
             "solver": "bash_mtime",
             "file_path": file_path,
             "unknown_lines": unknown_lines,
+            "target_repo_work_dir": repo_work_dir.as_str(),
             "file_timestamps_ns": timestamps,
             "selected_bash_call_id": candidate.id,
+            "selected_bash_repo_work_dir": candidate.repo_work_dir.as_str(),
             "selected_tool_use_id": candidate.tool_use_id,
             "selected_command": candidate.command,
             "distance_ns": distance_ns,
@@ -185,34 +156,40 @@ fn recover_adjacent_edges(
     commit_sha: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
-    recovery_exclusions: &HashMap<String, HashSet<u32>>,
 ) {
-    let unknown = unknown_lines_by_file(authorship_log, committed_hunks, recovery_exclusions);
+    let unknown = unknown_lines_by_file(authorship_log, committed_hunks);
     for (file_path, unknown_lines) in unknown {
         let line_to_author = line_author_map(authorship_log, &file_path);
         let runs = contiguous_runs(&unknown_lines);
         for run in runs {
-            let Some(source_author) = source_author_for_edge_run(&line_to_author, &run) else {
+            let Some(recovery) = edge_recovery_for_run(&line_to_author, &run) else {
                 continue;
             };
             let trace_id = generate_trace_id();
-            let source_session = source_author
+            let source_session = recovery
+                .source_author
                 .split("::")
                 .next()
-                .unwrap_or(&source_author)
+                .unwrap_or(&recovery.source_author)
                 .to_string();
             let recovered_author = if source_session.starts_with("s_") {
                 format!("{}::{}", source_session, trace_id)
             } else {
-                source_author.clone()
+                recovery.source_author.clone()
             };
-            add_attestation(authorship_log, &file_path, &recovered_author, &run);
+            let recovered_line_count = recovery.lines.len() as u32;
+            add_attestation(
+                authorship_log,
+                &file_path,
+                &recovered_author,
+                &recovery.lines,
+            );
 
             let metadata = json!({
                 "solver": "edge_extension",
                 "file_path": file_path,
-                "source_author": source_author,
-                "recovered_lines": run,
+                "source_author": &recovery.source_author,
+                "recovered_lines": &recovery.lines,
             });
             record_recovery_metric(RecoveryMetricInput {
                 repo,
@@ -228,7 +205,7 @@ fn recover_adjacent_edges(
                 external_tool_use_id: None,
                 edit_kind: "attribution_recovery_edge",
                 checkpoint_type: "recovered_edge_extension",
-                recovered_line_count: run.len() as u32,
+                recovered_line_count,
                 metadata,
                 event_ts: None,
             });
@@ -312,19 +289,14 @@ fn insert_session_record(
 fn unknown_lines_by_file(
     authorship_log: &AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
-    recovery_exclusions: &HashMap<String, HashSet<u32>>,
 ) -> BTreeMap<String, Vec<u32>> {
     let covered = covered_lines_by_file(authorship_log);
     let mut result = BTreeMap::new();
     for (file_path, ranges) in committed_hunks {
         let covered_lines = covered.get(file_path);
-        let excluded_lines = recovery_exclusions.get(file_path);
         let mut unknown = Vec::new();
         for line in ranges.iter().flat_map(LineRange::expand) {
             if !covered_lines.is_some_and(|lines| lines.contains(&line)) {
-                if excluded_lines.is_some_and(|lines| lines.contains(&line)) {
-                    continue;
-                }
                 unknown.push(line);
             }
         }
@@ -335,218 +307,6 @@ fn unknown_lines_by_file(
         }
     }
     result
-}
-
-fn parent_known_human_same_content_lines(
-    repo: &Repository,
-    parent_sha: &str,
-    commit_sha: &str,
-    committed_hunks: &HashMap<String, Vec<LineRange>>,
-) -> HashMap<String, HashSet<u32>> {
-    if parent_sha == "initial" {
-        return HashMap::new();
-    }
-
-    let Ok(parent_log) = crate::git::refs::get_reference_as_authorship_log_v3(repo, parent_sha)
-    else {
-        return HashMap::new();
-    };
-    let parent_known_human = known_human_lines_by_file(&parent_log);
-    if parent_known_human.is_empty() {
-        return HashMap::new();
-    }
-
-    let mut requests = Vec::new();
-    for file_path in committed_hunks.keys() {
-        if parent_known_human.contains_key(file_path) {
-            requests.push((parent_sha.to_string(), file_path.clone()));
-            requests.push((commit_sha.to_string(), file_path.clone()));
-        }
-    }
-
-    let Ok(contents) = batch_read_paths_at_treeishes(repo, &requests) else {
-        return HashMap::new();
-    };
-
-    let mut excluded = HashMap::new();
-    for (file_path, ranges) in committed_hunks {
-        let Some(parent_known_lines) = parent_known_human.get(file_path) else {
-            continue;
-        };
-        let Some(parent_content) = contents.get(&(parent_sha.to_string(), file_path.clone()))
-        else {
-            continue;
-        };
-        let Some(commit_content) = contents.get(&(commit_sha.to_string(), file_path.clone()))
-        else {
-            continue;
-        };
-
-        for line in same_content_target_lines_for_source_lines(
-            parent_content,
-            commit_content,
-            parent_known_lines,
-            ranges,
-        ) {
-            excluded
-                .entry(file_path.clone())
-                .or_insert_with(HashSet::new)
-                .insert(line);
-        }
-    }
-
-    excluded
-}
-
-fn legacy_human_checkpoint_same_content_lines(
-    repo: &Repository,
-    commit_sha: &str,
-    committed_hunks: &HashMap<String, Vec<LineRange>>,
-    working_log: &PersistedWorkingLog,
-    parent_checkpoints: &[Checkpoint],
-) -> HashMap<String, HashSet<u32>> {
-    let legacy_entries = parent_checkpoints
-        .iter()
-        .filter(|checkpoint| checkpoint.kind == CheckpointKind::Human)
-        .flat_map(|checkpoint| checkpoint.entries.iter())
-        .filter(|entry| committed_hunks.contains_key(&entry.file))
-        .collect::<Vec<_>>();
-    if legacy_entries.is_empty() {
-        return HashMap::new();
-    }
-
-    let requests = legacy_entries
-        .iter()
-        .map(|entry| (commit_sha.to_string(), entry.file.clone()))
-        .collect::<Vec<_>>();
-    let Ok(commit_contents) = batch_read_paths_at_treeishes(repo, &requests) else {
-        return HashMap::new();
-    };
-
-    let mut excluded = HashMap::new();
-    for entry in legacy_entries {
-        let Some(ranges) = committed_hunks.get(&entry.file) else {
-            continue;
-        };
-        let Some(commit_content) =
-            commit_contents.get(&(commit_sha.to_string(), entry.file.clone()))
-        else {
-            continue;
-        };
-        let Ok(checkpoint_content) = working_log.get_file_version(&entry.blob_sha) else {
-            continue;
-        };
-
-        let legacy_human_lines =
-            legacy_human_lines_for_entry(entry, checkpoint_content.lines().count() as u32);
-        for line in same_content_target_lines_for_source_lines(
-            &checkpoint_content,
-            commit_content,
-            &legacy_human_lines,
-            ranges,
-        ) {
-            excluded
-                .entry(entry.file.clone())
-                .or_insert_with(HashSet::new)
-                .insert(line);
-        }
-    }
-
-    excluded
-}
-
-fn same_content_target_lines_for_source_lines(
-    source_content: &str,
-    target_content: &str,
-    source_lines: &HashSet<u32>,
-    target_ranges: &[LineRange],
-) -> HashSet<u32> {
-    if source_lines.is_empty() {
-        return HashSet::new();
-    }
-
-    let target_candidate_lines = target_ranges
-        .iter()
-        .flat_map(LineRange::expand)
-        .collect::<HashSet<_>>();
-    if target_candidate_lines.is_empty() {
-        return HashSet::new();
-    }
-
-    let source_file_lines = source_content.lines().collect::<Vec<_>>();
-    let target_file_lines = target_content.lines().collect::<Vec<_>>();
-    let mut mapped = HashSet::new();
-
-    for op in capture_diff_slices(&source_file_lines, &target_file_lines) {
-        let DiffOp::Equal {
-            old_index,
-            new_index,
-            len,
-        } = op
-        else {
-            continue;
-        };
-        for offset in 0..len {
-            let source_line = (old_index + offset + 1) as u32;
-            if !source_lines.contains(&source_line) {
-                continue;
-            }
-            let target_line = (new_index + offset + 1) as u32;
-            if target_candidate_lines.contains(&target_line) {
-                mapped.insert(target_line);
-            }
-        }
-    }
-
-    mapped
-}
-
-fn legacy_human_lines_for_entry(
-    entry: &crate::authorship::working_log::WorkingLogEntry,
-    fallback_line_count: u32,
-) -> HashSet<u32> {
-    if entry.line_attributions.is_empty() {
-        return (1..=fallback_line_count).collect();
-    }
-
-    let mut lines = HashSet::new();
-    for line_attribution in &entry.line_attributions {
-        if line_attribution.author_id != "human" {
-            continue;
-        }
-        for line in line_attribution.start_line..=line_attribution.end_line {
-            lines.insert(line);
-        }
-    }
-    lines
-}
-
-fn merge_line_exclusions(
-    target: &mut HashMap<String, HashSet<u32>>,
-    source: HashMap<String, HashSet<u32>>,
-) {
-    for (file_path, lines) in source {
-        target.entry(file_path).or_default().extend(lines);
-    }
-}
-
-fn known_human_lines_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, HashSet<u32>> {
-    let mut known_human = HashMap::new();
-    for file_attestation in &authorship_log.attestations {
-        let mut lines = HashSet::new();
-        for entry in &file_attestation.entries {
-            if !entry.hash.starts_with("h_") {
-                continue;
-            }
-            for line in entry.line_ranges.iter().flat_map(LineRange::expand) {
-                lines.insert(line);
-            }
-        }
-        if !lines.is_empty() {
-            known_human.insert(file_attestation.file_path.clone(), lines);
-        }
-    }
-    known_human
 }
 
 fn covered_lines_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, HashSet<u32>> {
@@ -603,10 +363,15 @@ fn contiguous_runs(lines: &[u32]) -> Vec<Vec<u32>> {
     runs
 }
 
-fn source_author_for_edge_run(
+struct EdgeRecovery {
+    source_author: String,
+    lines: Vec<u32>,
+}
+
+fn edge_recovery_for_run(
     line_to_author: &BTreeMap<u32, String>,
     run: &[u32],
-) -> Option<String> {
+) -> Option<EdgeRecovery> {
     let first = *run.first()?;
     let last = *run.last()?;
     let prev = first
@@ -620,10 +385,42 @@ fn source_author_for_edge_run(
                 && is_ai_attestation(right)
                 && ai_session_key(left) == ai_session_key(right) =>
         {
-            Some(left.clone())
+            let mut lines = run
+                .iter()
+                .take(EDGE_EXTENSION_MAX_LINES)
+                .copied()
+                .collect::<Vec<_>>();
+            lines.extend(run.iter().rev().take(EDGE_EXTENSION_MAX_LINES).copied());
+            lines.sort_unstable();
+            lines.dedup();
+            Some(EdgeRecovery {
+                source_author: left.clone(),
+                lines,
+            })
         }
+        (Some(left), None) if is_ai_attestation(left) => Some(EdgeRecovery {
+            source_author: left.clone(),
+            lines: run.iter().take(EDGE_EXTENSION_MAX_LINES).copied().collect(),
+        }),
+        (None, Some(right)) if is_ai_attestation(right) => Some(EdgeRecovery {
+            source_author: right.clone(),
+            lines: run
+                .iter()
+                .rev()
+                .take(EDGE_EXTENSION_MAX_LINES)
+                .copied()
+                .collect(),
+        }),
         _ => None,
     }
+}
+
+#[cfg(test)]
+fn edge_recovered_lines(line_to_author: &BTreeMap<u32, String>, run: &[u32]) -> Option<Vec<u32>> {
+    edge_recovery_for_run(line_to_author, run).map(|mut recovery| {
+        recovery.lines.sort_unstable();
+        recovery.lines
+    })
 }
 
 fn is_ai_attestation(author: &str) -> bool {
@@ -752,58 +549,58 @@ mod tests {
             vec![LineRange::Range(1, 3), LineRange::Single(5)],
         )]);
 
-        let unknown = unknown_lines_by_file(&log, &committed, &HashMap::new());
+        let unknown = unknown_lines_by_file(&log, &committed);
         assert_eq!(unknown.get("a.txt").unwrap(), &vec![1, 3, 5]);
     }
 
     #[test]
-    fn same_content_mapping_handles_insertions_above_source_line() {
-        let source_lines = HashSet::from([2]);
-        let mapped = same_content_target_lines_for_source_lines(
-            "base\nhuman dirty before bash\n",
-            "bash recovered line\nbase\nhuman dirty before bash\n",
-            &source_lines,
-            &[LineRange::Range(1, 3)],
-        );
-
-        assert_eq!(mapped, HashSet::from([3]));
-    }
-
-    #[test]
-    fn same_content_mapping_only_returns_target_candidate_lines() {
-        let source_lines = HashSet::from([1, 2]);
-        let mapped = same_content_target_lines_for_source_lines(
-            "base\nhuman dirty before bash\n",
-            "base\nhuman dirty before bash\nbash recovered line\n",
-            &source_lines,
-            &[LineRange::Single(3)],
-        );
-
-        assert!(mapped.is_empty());
-    }
-
-    #[test]
-    fn edge_source_requires_same_ai_neighbors() {
+    fn edge_recovery_extends_one_sided_runs_and_bridges_matching_ai_neighbors() {
         let map = BTreeMap::from([
             (1, "s_a::t_1".to_string()),
             (3, "s_a::t_2".to_string()),
-            (5, "s_b::t_1".to_string()),
+            (10, "s_a::t_3".to_string()),
+            (20, "s_b::t_1".to_string()),
         ]);
 
         assert_eq!(
-            source_author_for_edge_run(&map, &[2]).as_deref(),
-            Some("s_a::t_1"),
+            edge_recovered_lines(&map, &[2]).as_deref(),
+            Some(&[2][..]),
             "different trace ids for the same session should extend by session"
         );
         assert_eq!(
-            source_author_for_edge_run(&map, &[4]).as_deref(),
+            edge_recovered_lines(&map, &[4, 5, 6, 7, 8, 9]).as_deref(),
+            Some(&[4, 5, 6, 7, 8, 9][..]),
+            "matching AI neighbors should recover up to three lines from each side"
+        );
+        assert_eq!(
+            edge_recovered_lines(&map, &[11, 12, 13, 14]).as_deref(),
+            Some(&[11, 12, 13][..]),
+            "trailing edge extension should recover at most three lines"
+        );
+        assert_eq!(
+            edge_recovered_lines(&map, &[16, 17, 18, 19]).as_deref(),
+            Some(&[17, 18, 19][..]),
+            "leading edge extension should recover the three lines nearest the AI block"
+        );
+    }
+
+    #[test]
+    fn edge_recovery_keeps_human_and_different_session_guardrails() {
+        let map = BTreeMap::from([
+            (1, "s_a::t_1".to_string()),
+            (3, "s_b::t_1".to_string()),
+            (5, "h_human::t_1".to_string()),
+        ]);
+
+        assert_eq!(
+            edge_recovered_lines(&map, &[2]).as_deref(),
             None,
             "different sessions must not be bridged"
         );
         assert_eq!(
-            source_author_for_edge_run(&map, &[6]).as_deref(),
+            edge_recovered_lines(&map, &[4]).as_deref(),
             None,
-            "single-sided edge extension is too ambiguous"
+            "known-human neighbors must not be used for edge extension"
         );
     }
 }

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -1,0 +1,809 @@
+use crate::authorship::authorship_log::{LineRange, SessionRecord};
+use crate::authorship::authorship_log_serialization::{
+    AuthorshipLog, generate_session_id, generate_trace_id,
+};
+use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
+use crate::authorship::working_log::{Checkpoint, CheckpointKind};
+use crate::commands::checkpoint_agent::bash_tool::StatEntry;
+use crate::daemon::bash_history_db::{BashCheckpointCall, distance_to_call_window};
+use crate::error::GitAiError;
+use crate::git::repo_state::worktree_root_for_path;
+use crate::git::repo_storage::PersistedWorkingLog;
+use crate::git::repository::{Repository, batch_read_paths_at_treeishes};
+use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded};
+use serde_json::json;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
+
+pub(crate) struct RecoveryWorkingLogContext<'a> {
+    pub working_log: &'a PersistedWorkingLog,
+    pub parent_checkpoints: &'a [Checkpoint],
+}
+
+pub(crate) fn recover_attribution(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    human_author: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    working_log_context: Option<RecoveryWorkingLogContext<'_>>,
+) -> Result<(), GitAiError> {
+    if committed_hunks.is_empty() {
+        return Ok(());
+    }
+
+    let empty_exclusions: HashMap<String, HashSet<u32>> = HashMap::new();
+    if unknown_lines_by_file(authorship_log, committed_hunks, &empty_exclusions).is_empty() {
+        return Ok(());
+    }
+
+    let mut recovery_exclusions =
+        parent_known_human_same_content_lines(repo, parent_sha, commit_sha, committed_hunks);
+    if let Some(context) = working_log_context {
+        merge_line_exclusions(
+            &mut recovery_exclusions,
+            legacy_human_checkpoint_same_content_lines(
+                repo,
+                commit_sha,
+                committed_hunks,
+                context.working_log,
+                context.parent_checkpoints,
+            ),
+        );
+    }
+
+    recover_bash_mtime(
+        repo,
+        parent_sha,
+        commit_sha,
+        human_author,
+        authorship_log,
+        committed_hunks,
+        &recovery_exclusions,
+    )?;
+    recover_adjacent_edges(
+        repo,
+        parent_sha,
+        commit_sha,
+        authorship_log,
+        committed_hunks,
+        &recovery_exclusions,
+    );
+    Ok(())
+}
+
+fn recover_bash_mtime(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    human_author: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    recovery_exclusions: &HashMap<String, HashSet<u32>>,
+) -> Result<(), GitAiError> {
+    let repo_work_dir = repo_worktree_key(repo)?;
+    let workdir = repo.workdir()?;
+    let unknown_by_file =
+        unknown_lines_by_file(authorship_log, committed_hunks, recovery_exclusions);
+    if unknown_by_file.is_empty() {
+        return Ok(());
+    }
+
+    let mut timestamps_by_file = HashMap::new();
+    let mut all_timestamps = Vec::new();
+    for file_path in unknown_by_file.keys() {
+        let timestamps = file_timestamps_ns(&workdir, file_path);
+        if !timestamps.is_empty() {
+            all_timestamps.extend(timestamps.iter().copied());
+            timestamps_by_file.insert(file_path.clone(), timestamps);
+        }
+    }
+    if all_timestamps.is_empty() {
+        return Ok(());
+    }
+    all_timestamps.sort_unstable();
+    all_timestamps.dedup();
+
+    let candidates = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(db) => db.candidates_near_timestamps(
+                &repo_work_dir,
+                &all_timestamps,
+                BASH_RECOVERY_WINDOW_NS,
+            )?,
+            Err(_) => Vec::new(),
+        },
+        Err(_) => Vec::new(),
+    };
+    if candidates.is_empty() {
+        return Ok(());
+    }
+
+    for (file_path, unknown_lines) in unknown_by_file {
+        let Some(timestamps) = timestamps_by_file.get(&file_path) else {
+            continue;
+        };
+        let Some((candidate, distance_ns)) = select_best_bash_candidate(&candidates, timestamps)
+        else {
+            continue;
+        };
+        if distance_ns > BASH_RECOVERY_WINDOW_NS {
+            continue;
+        }
+
+        let trace_id = generate_trace_id();
+        let session_id = generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool);
+        let author_id = format!("{}::{}", session_id, trace_id);
+        insert_session_record(authorship_log, &session_id, candidate, human_author);
+        add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
+
+        let metadata = json!({
+            "solver": "bash_mtime",
+            "file_path": file_path,
+            "unknown_lines": unknown_lines,
+            "file_timestamps_ns": timestamps,
+            "selected_bash_call_id": candidate.id,
+            "selected_tool_use_id": candidate.tool_use_id,
+            "selected_command": candidate.command,
+            "distance_ns": distance_ns,
+            "window_ns": BASH_RECOVERY_WINDOW_NS,
+            "start_time_ns": candidate.start_time_ns,
+            "end_time_ns": candidate.end_time_ns,
+            "start_trace_id": candidate.start_trace_id,
+            "end_trace_id": candidate.end_trace_id,
+        });
+        record_recovery_metric(RecoveryMetricInput {
+            repo,
+            parent_sha,
+            commit_sha,
+            file_path: &file_path,
+            author_id: &author_id,
+            session_id: &session_id,
+            trace_id: &trace_id,
+            tool: &candidate.agent_id.tool,
+            model: &candidate.agent_id.model,
+            external_session_id: &candidate.agent_id.id,
+            external_tool_use_id: Some(&candidate.tool_use_id),
+            edit_kind: "bash",
+            checkpoint_type: "recovered_bash",
+            recovered_line_count: unknown_lines.len() as u32,
+            metadata,
+            event_ts: Some((candidate.start_time_ns / 1_000_000_000) as u32),
+        });
+    }
+
+    Ok(())
+}
+
+fn recover_adjacent_edges(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    recovery_exclusions: &HashMap<String, HashSet<u32>>,
+) {
+    let unknown = unknown_lines_by_file(authorship_log, committed_hunks, recovery_exclusions);
+    for (file_path, unknown_lines) in unknown {
+        let line_to_author = line_author_map(authorship_log, &file_path);
+        let runs = contiguous_runs(&unknown_lines);
+        for run in runs {
+            let Some(source_author) = source_author_for_edge_run(&line_to_author, &run) else {
+                continue;
+            };
+            let trace_id = generate_trace_id();
+            let source_session = source_author
+                .split("::")
+                .next()
+                .unwrap_or(&source_author)
+                .to_string();
+            let recovered_author = if source_session.starts_with("s_") {
+                format!("{}::{}", source_session, trace_id)
+            } else {
+                source_author.clone()
+            };
+            add_attestation(authorship_log, &file_path, &recovered_author, &run);
+
+            let metadata = json!({
+                "solver": "edge_extension",
+                "file_path": file_path,
+                "source_author": source_author,
+                "recovered_lines": run,
+            });
+            record_recovery_metric(RecoveryMetricInput {
+                repo,
+                parent_sha,
+                commit_sha,
+                file_path: &file_path,
+                author_id: &recovered_author,
+                session_id: &source_session,
+                trace_id: &trace_id,
+                tool: "",
+                model: "",
+                external_session_id: "",
+                external_tool_use_id: None,
+                edit_kind: "attribution_recovery_edge",
+                checkpoint_type: "recovered_edge_extension",
+                recovered_line_count: run.len() as u32,
+                metadata,
+                event_ts: None,
+            });
+        }
+    }
+}
+
+fn repo_worktree_key(repo: &Repository) -> Result<String, GitAiError> {
+    let workdir = repo.workdir()?;
+    let normalized = worktree_root_for_path(&workdir).unwrap_or(workdir);
+    Ok(normalized
+        .canonicalize()
+        .unwrap_or(normalized)
+        .to_string_lossy()
+        .to_string())
+}
+
+fn file_timestamps_ns(workdir: &std::path::Path, file_path: &str) -> Vec<u128> {
+    let Ok(meta) = fs::symlink_metadata(workdir.join(file_path)) else {
+        return Vec::new();
+    };
+    let stat = StatEntry::from_metadata(&meta);
+    let mut timestamps = Vec::new();
+    if let Some(mtime) = stat.mtime {
+        timestamps.push(system_time_to_ns(mtime));
+    }
+    if let Some(ctime) = stat.ctime {
+        timestamps.push(system_time_to_ns(ctime));
+    }
+    timestamps.sort_unstable();
+    timestamps.dedup();
+    timestamps
+}
+
+fn system_time_to_ns(time: SystemTime) -> u128 {
+    time.duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+fn select_best_bash_candidate<'a>(
+    candidates: &'a [BashCheckpointCall],
+    timestamps: &[u128],
+) -> Option<(&'a BashCheckpointCall, u128)> {
+    candidates
+        .iter()
+        .map(|candidate| {
+            let distance = timestamps
+                .iter()
+                .map(|ts| distance_to_call_window(*ts, candidate))
+                .min()
+                .unwrap_or(u128::MAX);
+            (candidate, distance)
+        })
+        .min_by(|(left, left_distance), (right, right_distance)| {
+            left_distance
+                .cmp(right_distance)
+                .then_with(|| right.end_time_ns.is_some().cmp(&left.end_time_ns.is_some()))
+                .then_with(|| right.command.is_some().cmp(&left.command.is_some()))
+                .then_with(|| right.id.cmp(&left.id))
+        })
+}
+
+fn insert_session_record(
+    authorship_log: &mut AuthorshipLog,
+    session_id: &str,
+    candidate: &BashCheckpointCall,
+    human_author: &str,
+) {
+    authorship_log
+        .metadata
+        .sessions
+        .entry(session_id.to_string())
+        .or_insert_with(|| SessionRecord {
+            agent_id: candidate.agent_id.clone(),
+            human_author: Some(human_author.to_string()),
+            custom_attributes: None,
+        });
+}
+
+fn unknown_lines_by_file(
+    authorship_log: &AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    recovery_exclusions: &HashMap<String, HashSet<u32>>,
+) -> BTreeMap<String, Vec<u32>> {
+    let covered = covered_lines_by_file(authorship_log);
+    let mut result = BTreeMap::new();
+    for (file_path, ranges) in committed_hunks {
+        let covered_lines = covered.get(file_path);
+        let excluded_lines = recovery_exclusions.get(file_path);
+        let mut unknown = Vec::new();
+        for line in ranges.iter().flat_map(LineRange::expand) {
+            if !covered_lines.is_some_and(|lines| lines.contains(&line)) {
+                if excluded_lines.is_some_and(|lines| lines.contains(&line)) {
+                    continue;
+                }
+                unknown.push(line);
+            }
+        }
+        unknown.sort_unstable();
+        unknown.dedup();
+        if !unknown.is_empty() {
+            result.insert(file_path.clone(), unknown);
+        }
+    }
+    result
+}
+
+fn parent_known_human_same_content_lines(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+) -> HashMap<String, HashSet<u32>> {
+    if parent_sha == "initial" {
+        return HashMap::new();
+    }
+
+    let Ok(parent_log) = crate::git::refs::get_reference_as_authorship_log_v3(repo, parent_sha)
+    else {
+        return HashMap::new();
+    };
+    let parent_known_human = known_human_lines_by_file(&parent_log);
+    if parent_known_human.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut requests = Vec::new();
+    for file_path in committed_hunks.keys() {
+        if parent_known_human.contains_key(file_path) {
+            requests.push((parent_sha.to_string(), file_path.clone()));
+            requests.push((commit_sha.to_string(), file_path.clone()));
+        }
+    }
+
+    let Ok(contents) = batch_read_paths_at_treeishes(repo, &requests) else {
+        return HashMap::new();
+    };
+
+    let mut excluded = HashMap::new();
+    for (file_path, ranges) in committed_hunks {
+        let Some(parent_known_lines) = parent_known_human.get(file_path) else {
+            continue;
+        };
+        let Some(parent_content) = contents.get(&(parent_sha.to_string(), file_path.clone()))
+        else {
+            continue;
+        };
+        let Some(commit_content) = contents.get(&(commit_sha.to_string(), file_path.clone()))
+        else {
+            continue;
+        };
+
+        for line in same_content_target_lines_for_source_lines(
+            parent_content,
+            commit_content,
+            parent_known_lines,
+            ranges,
+        ) {
+            excluded
+                .entry(file_path.clone())
+                .or_insert_with(HashSet::new)
+                .insert(line);
+        }
+    }
+
+    excluded
+}
+
+fn legacy_human_checkpoint_same_content_lines(
+    repo: &Repository,
+    commit_sha: &str,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    working_log: &PersistedWorkingLog,
+    parent_checkpoints: &[Checkpoint],
+) -> HashMap<String, HashSet<u32>> {
+    let legacy_entries = parent_checkpoints
+        .iter()
+        .filter(|checkpoint| checkpoint.kind == CheckpointKind::Human)
+        .flat_map(|checkpoint| checkpoint.entries.iter())
+        .filter(|entry| committed_hunks.contains_key(&entry.file))
+        .collect::<Vec<_>>();
+    if legacy_entries.is_empty() {
+        return HashMap::new();
+    }
+
+    let requests = legacy_entries
+        .iter()
+        .map(|entry| (commit_sha.to_string(), entry.file.clone()))
+        .collect::<Vec<_>>();
+    let Ok(commit_contents) = batch_read_paths_at_treeishes(repo, &requests) else {
+        return HashMap::new();
+    };
+
+    let mut excluded = HashMap::new();
+    for entry in legacy_entries {
+        let Some(ranges) = committed_hunks.get(&entry.file) else {
+            continue;
+        };
+        let Some(commit_content) =
+            commit_contents.get(&(commit_sha.to_string(), entry.file.clone()))
+        else {
+            continue;
+        };
+        let Ok(checkpoint_content) = working_log.get_file_version(&entry.blob_sha) else {
+            continue;
+        };
+
+        let legacy_human_lines =
+            legacy_human_lines_for_entry(entry, checkpoint_content.lines().count() as u32);
+        for line in same_content_target_lines_for_source_lines(
+            &checkpoint_content,
+            commit_content,
+            &legacy_human_lines,
+            ranges,
+        ) {
+            excluded
+                .entry(entry.file.clone())
+                .or_insert_with(HashSet::new)
+                .insert(line);
+        }
+    }
+
+    excluded
+}
+
+fn same_content_target_lines_for_source_lines(
+    source_content: &str,
+    target_content: &str,
+    source_lines: &HashSet<u32>,
+    target_ranges: &[LineRange],
+) -> HashSet<u32> {
+    if source_lines.is_empty() {
+        return HashSet::new();
+    }
+
+    let target_candidate_lines = target_ranges
+        .iter()
+        .flat_map(LineRange::expand)
+        .collect::<HashSet<_>>();
+    if target_candidate_lines.is_empty() {
+        return HashSet::new();
+    }
+
+    let source_file_lines = source_content.lines().collect::<Vec<_>>();
+    let target_file_lines = target_content.lines().collect::<Vec<_>>();
+    let mut mapped = HashSet::new();
+
+    for op in capture_diff_slices(&source_file_lines, &target_file_lines) {
+        let DiffOp::Equal {
+            old_index,
+            new_index,
+            len,
+        } = op
+        else {
+            continue;
+        };
+        for offset in 0..len {
+            let source_line = (old_index + offset + 1) as u32;
+            if !source_lines.contains(&source_line) {
+                continue;
+            }
+            let target_line = (new_index + offset + 1) as u32;
+            if target_candidate_lines.contains(&target_line) {
+                mapped.insert(target_line);
+            }
+        }
+    }
+
+    mapped
+}
+
+fn legacy_human_lines_for_entry(
+    entry: &crate::authorship::working_log::WorkingLogEntry,
+    fallback_line_count: u32,
+) -> HashSet<u32> {
+    if entry.line_attributions.is_empty() {
+        return (1..=fallback_line_count).collect();
+    }
+
+    let mut lines = HashSet::new();
+    for line_attribution in &entry.line_attributions {
+        if line_attribution.author_id != "human" {
+            continue;
+        }
+        for line in line_attribution.start_line..=line_attribution.end_line {
+            lines.insert(line);
+        }
+    }
+    lines
+}
+
+fn merge_line_exclusions(
+    target: &mut HashMap<String, HashSet<u32>>,
+    source: HashMap<String, HashSet<u32>>,
+) {
+    for (file_path, lines) in source {
+        target.entry(file_path).or_default().extend(lines);
+    }
+}
+
+fn known_human_lines_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, HashSet<u32>> {
+    let mut known_human = HashMap::new();
+    for file_attestation in &authorship_log.attestations {
+        let mut lines = HashSet::new();
+        for entry in &file_attestation.entries {
+            if !entry.hash.starts_with("h_") {
+                continue;
+            }
+            for line in entry.line_ranges.iter().flat_map(LineRange::expand) {
+                lines.insert(line);
+            }
+        }
+        if !lines.is_empty() {
+            known_human.insert(file_attestation.file_path.clone(), lines);
+        }
+    }
+    known_human
+}
+
+fn covered_lines_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, HashSet<u32>> {
+    let mut covered = HashMap::new();
+    for file_attestation in &authorship_log.attestations {
+        let lines = covered
+            .entry(file_attestation.file_path.clone())
+            .or_insert_with(HashSet::new);
+        for entry in &file_attestation.entries {
+            for line in entry.line_ranges.iter().flat_map(LineRange::expand) {
+                lines.insert(line);
+            }
+        }
+    }
+    covered
+}
+
+fn line_author_map(authorship_log: &AuthorshipLog, file_path: &str) -> BTreeMap<u32, String> {
+    let mut map = BTreeMap::new();
+    let Some(file_attestation) = authorship_log
+        .attestations
+        .iter()
+        .find(|att| att.file_path == file_path)
+    else {
+        return map;
+    };
+    for entry in &file_attestation.entries {
+        for line in entry.line_ranges.iter().flat_map(LineRange::expand) {
+            map.insert(line, entry.hash.clone());
+        }
+    }
+    map
+}
+
+fn contiguous_runs(lines: &[u32]) -> Vec<Vec<u32>> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+    let mut sorted = lines.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    let mut runs: Vec<Vec<u32>> = Vec::new();
+    let mut current = vec![sorted[0]];
+    for line in sorted.into_iter().skip(1) {
+        if line == current.last().copied().unwrap_or(line) + 1 {
+            current.push(line);
+        } else {
+            runs.push(current);
+            current = vec![line];
+        }
+    }
+    runs.push(current);
+    runs
+}
+
+fn source_author_for_edge_run(
+    line_to_author: &BTreeMap<u32, String>,
+    run: &[u32],
+) -> Option<String> {
+    let first = *run.first()?;
+    let last = *run.last()?;
+    let prev = first
+        .checked_sub(1)
+        .and_then(|line| line_to_author.get(&line));
+    let next = line_to_author.get(&(last + 1));
+
+    match (prev, next) {
+        (Some(left), Some(right))
+            if is_ai_attestation(left)
+                && is_ai_attestation(right)
+                && ai_session_key(left) == ai_session_key(right) =>
+        {
+            Some(left.clone())
+        }
+        _ => None,
+    }
+}
+
+fn is_ai_attestation(author: &str) -> bool {
+    author != CheckpointKind::Human.to_str() && !author.starts_with("h_")
+}
+
+fn ai_session_key(author: &str) -> &str {
+    author.split("::").next().unwrap_or(author)
+}
+
+fn add_attestation(
+    authorship_log: &mut AuthorshipLog,
+    file_path: &str,
+    author_id: &str,
+    lines: &[u32],
+) {
+    let mut sorted = lines.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+    if sorted.is_empty() {
+        return;
+    }
+    let ranges = LineRange::compress_lines(&sorted);
+    let entry = crate::authorship::authorship_log_serialization::AttestationEntry::new(
+        author_id.to_string(),
+        ranges,
+    );
+    authorship_log
+        .get_or_create_file(file_path)
+        .add_entry(entry);
+}
+
+struct RecoveryMetricInput<'a> {
+    repo: &'a Repository,
+    parent_sha: &'a str,
+    commit_sha: &'a str,
+    file_path: &'a str,
+    author_id: &'a str,
+    session_id: &'a str,
+    trace_id: &'a str,
+    tool: &'a str,
+    model: &'a str,
+    external_session_id: &'a str,
+    external_tool_use_id: Option<&'a str>,
+    edit_kind: &'a str,
+    checkpoint_type: &'a str,
+    recovered_line_count: u32,
+    metadata: serde_json::Value,
+    event_ts: Option<u32>,
+}
+
+fn record_recovery_metric(input: RecoveryMetricInput<'_>) {
+    if input.tool == "mock_ai" {
+        return;
+    }
+
+    let checkpoint_ts = input.event_ts.map(u64::from).unwrap_or_else(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    });
+    let mut values = CheckpointValues::new()
+        .checkpoint_ts(checkpoint_ts)
+        .kind(CheckpointKind::AiAgent.to_str())
+        .file_path(input.file_path)
+        .lines_added(input.recovered_line_count)
+        .lines_deleted(0)
+        .lines_added_sloc(input.recovered_line_count)
+        .lines_deleted_sloc(0)
+        .edit_kind(input.edit_kind)
+        .checkpoint_type(input.checkpoint_type)
+        .attribution_recovery_metadata(input.metadata.to_string());
+    if let Some(tool_use_id) = input.external_tool_use_id {
+        values = values.external_tool_use_id(tool_use_id);
+    }
+
+    let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+        .base_commit_sha(input.parent_sha)
+        .commit_sha(input.commit_sha)
+        .session_id(input.session_id)
+        .trace_id(input.trace_id);
+
+    if !input.tool.is_empty() {
+        attrs = attrs.tool(input.tool);
+    }
+    if !input.model.is_empty() {
+        attrs = attrs.model(input.model);
+    }
+    if !input.external_session_id.is_empty() {
+        attrs = attrs.external_session_id(input.external_session_id);
+    }
+    if let Some(url) = crate::repo_url::resolve_repo_url_from_repo(input.repo) {
+        attrs = attrs.repo_url(url);
+    }
+    if let Ok(head_ref) = input.repo.head()
+        && let Ok(short_branch) = head_ref.shorthand()
+    {
+        attrs = attrs.branch(short_branch);
+    }
+    attrs = attrs.author(input.author_id);
+
+    let event = MetricEvent::from_values_with_timestamp(values, attrs.to_sparse(), input.event_ts);
+    crate::observability::log_metrics(vec![event]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authorship::authorship_log_serialization::{
+        AttestationEntry, AuthorshipLog, FileAttestation,
+    };
+
+    #[test]
+    fn unknown_lines_exclude_existing_attestations() {
+        let mut log = AuthorshipLog::new();
+        log.attestations.push(FileAttestation {
+            file_path: "a.txt".to_string(),
+            entries: vec![AttestationEntry::new(
+                "s_abc::t_def".to_string(),
+                vec![LineRange::Single(2)],
+            )],
+        });
+        let committed = HashMap::from([(
+            "a.txt".to_string(),
+            vec![LineRange::Range(1, 3), LineRange::Single(5)],
+        )]);
+
+        let unknown = unknown_lines_by_file(&log, &committed, &HashMap::new());
+        assert_eq!(unknown.get("a.txt").unwrap(), &vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn same_content_mapping_handles_insertions_above_source_line() {
+        let source_lines = HashSet::from([2]);
+        let mapped = same_content_target_lines_for_source_lines(
+            "base\nhuman dirty before bash\n",
+            "bash recovered line\nbase\nhuman dirty before bash\n",
+            &source_lines,
+            &[LineRange::Range(1, 3)],
+        );
+
+        assert_eq!(mapped, HashSet::from([3]));
+    }
+
+    #[test]
+    fn same_content_mapping_only_returns_target_candidate_lines() {
+        let source_lines = HashSet::from([1, 2]);
+        let mapped = same_content_target_lines_for_source_lines(
+            "base\nhuman dirty before bash\n",
+            "base\nhuman dirty before bash\nbash recovered line\n",
+            &source_lines,
+            &[LineRange::Single(3)],
+        );
+
+        assert!(mapped.is_empty());
+    }
+
+    #[test]
+    fn edge_source_requires_same_ai_neighbors() {
+        let map = BTreeMap::from([
+            (1, "s_a::t_1".to_string()),
+            (3, "s_a::t_2".to_string()),
+            (5, "s_b::t_1".to_string()),
+        ]);
+
+        assert_eq!(
+            source_author_for_edge_run(&map, &[2]).as_deref(),
+            Some("s_a::t_1"),
+            "different trace ids for the same session should extend by session"
+        );
+        assert_eq!(
+            source_author_for_edge_run(&map, &[4]).as_deref(),
+            None,
+            "different sessions must not be bridged"
+        );
+        assert_eq!(
+            source_author_for_edge_run(&map, &[6]).as_deref(),
+            None,
+            "single-sided edge extension is too ambiguous"
+        );
+    }
+}

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_detection;
+pub mod attribution_recovery;
 pub mod attribution_tracker;
 pub mod authorship_log;
 pub mod authorship_log_serialization;

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -267,12 +267,6 @@ where
             &human_author,
             &mut authorship_log,
             &recovery_hunks,
-            Some(
-                crate::authorship::attribution_recovery::RecoveryWorkingLogContext {
-                    working_log: &working_log,
-                    parent_checkpoints: &parent_working_log,
-                },
-            ),
         )?;
         authorship_log.metadata.base_commit_sha = commit_sha.clone();
     }
@@ -495,7 +489,6 @@ pub fn post_commit_amend(
 ) -> Result<(String, AuthorshipLog), GitAiError> {
     let repo_storage = &repo.storage;
     let working_log = repo_storage.working_log_for_base_commit(original_commit)?;
-    let parent_working_log = working_log.read_all_checkpoints()?;
 
     // Compute pathspecs: changed files in the amended commit + working log touched files
     let changed_files = repo.list_commit_files(amended_commit, None)?;
@@ -601,12 +594,6 @@ pub fn post_commit_amend(
         &human_author,
         &mut authorship_log,
         &recovery_hunks,
-        Some(
-            crate::authorship::attribution_recovery::RecoveryWorkingLogContext {
-                working_log: &working_log,
-                parent_checkpoints: &parent_working_log,
-            },
-        ),
     )?;
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -87,6 +87,7 @@ pub fn post_commit_from_working_log(
 pub(crate) struct PostCommitOptions {
     pub supress_output: bool,
     pub compute_stats: bool,
+    pub recover_attribution: bool,
 }
 
 pub fn post_commit_from_working_log_with_transform<F>(
@@ -108,6 +109,7 @@ where
         PostCommitOptions {
             supress_output,
             compute_stats: true,
+            recover_attribution: true,
         },
         transform,
     )
@@ -254,6 +256,26 @@ where
 
     authorship_log = transform(authorship_log)?;
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
+
+    if options.recover_attribution {
+        let recovery_hunks =
+            recovery_committed_hunks(repo, &parent_sha, &commit_sha, precomputed_parent_diff)?;
+        crate::authorship::attribution_recovery::recover_attribution(
+            repo,
+            &parent_sha,
+            &commit_sha,
+            &human_author,
+            &mut authorship_log,
+            &recovery_hunks,
+            Some(
+                crate::authorship::attribution_recovery::RecoveryWorkingLogContext {
+                    working_log: &working_log,
+                    parent_checkpoints: &parent_working_log,
+                },
+            ),
+        )?;
+        authorship_log.metadata.base_commit_sha = commit_sha.clone();
+    }
 
     // Long-lived daemon processes should read a fresh config snapshot.
     // Always use Config::fresh() to support runtime config updates
@@ -433,6 +455,36 @@ fn commit_tree_snapshot_for_files(
     Ok(snapshot)
 }
 
+fn recovery_committed_hunks(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    precomputed_parent_diff: Option<&crate::authorship::rewrite::DiffTreeResult>,
+) -> Result<HashMap<String, Vec<crate::authorship::authorship_log::LineRange>>, GitAiError> {
+    if let Some(diff) = precomputed_parent_diff {
+        return Ok(
+            crate::authorship::virtual_attribution::committed_hunks_from_diff_result(diff, None),
+        );
+    }
+
+    let diff_base = if parent_sha == "initial" {
+        "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    } else {
+        parent_sha
+    };
+    let added_lines = repo.diff_added_lines(diff_base, commit_sha, None)?;
+    Ok(added_lines
+        .into_iter()
+        .filter(|(_, lines)| !lines.is_empty())
+        .map(|(path, lines)| {
+            (
+                path,
+                crate::authorship::authorship_log::LineRange::compress_lines(&lines),
+            )
+        })
+        .collect())
+}
+
 /// Amend-specific post-commit that merges blame-sourced attributions from the
 /// original commit with persisted working-log checkpoint data.
 pub fn post_commit_amend(
@@ -443,6 +495,7 @@ pub fn post_commit_amend(
 ) -> Result<(String, AuthorshipLog), GitAiError> {
     let repo_storage = &repo.storage;
     let working_log = repo_storage.working_log_for_base_commit(original_commit)?;
+    let parent_working_log = working_log.read_all_checkpoints()?;
 
     // Compute pathspecs: changed files in the amended commit + working log touched files
     let changed_files = repo.list_commit_files(amended_commit, None)?;
@@ -539,6 +592,23 @@ pub fn post_commit_amend(
             );
         }
     }
+
+    let recovery_hunks = recovery_committed_hunks(repo, &parent_sha, amended_commit, None)?;
+    crate::authorship::attribution_recovery::recover_attribution(
+        repo,
+        &parent_sha,
+        amended_commit,
+        &human_author,
+        &mut authorship_log,
+        &recovery_hunks,
+        Some(
+            crate::authorship::attribution_recovery::RecoveryWorkingLogContext {
+                working_log: &working_log,
+                parent_checkpoints: &parent_working_log,
+            },
+        ),
+    )?;
+    authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 
     // Preserve human/session metadata from the original commit's note
     if let Ok(original_log) =

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -27,6 +27,7 @@ pub enum RewriteEvent {
 
 pub(crate) struct DiffTreeResult {
     pub hunks_by_file: HashMap<String, Vec<DiffHunk>>,
+    pub added_lines_by_file: HashMap<String, Vec<u32>>,
     pub renames: Vec<(String, String)>,
 }
 
@@ -915,6 +916,7 @@ fn parse_batched_diff_tree_output(
     while results.len() < tree_pair_keys.len() {
         results.push(DiffTreeResult {
             hunks_by_file: HashMap::new(),
+            added_lines_by_file: HashMap::new(),
             renames: Vec::new(),
         });
     }
@@ -935,17 +937,21 @@ fn is_tree_pair_separator(line: &str) -> bool {
 
 fn parse_diff_tree_output(output: &str) -> DiffTreeResult {
     let mut hunks_by_file: HashMap<String, Vec<DiffHunk>> = HashMap::new();
+    let mut added_lines_by_file: HashMap<String, Vec<u32>> = HashMap::new();
     let mut renames: Vec<(String, String)> = Vec::new();
     let mut current_file: Option<String> = None;
     let mut current_rename_from: Option<String> = None;
+    let mut active_hunk_new_line: Option<u32> = None;
 
     for line in output.lines() {
         if let Some(rest) = line.strip_prefix("diff --git ") {
             // Extract the b/ path from "a/old b/new"
             current_file = extract_b_path(rest);
             current_rename_from = None;
+            active_hunk_new_line = None;
         } else if let Some(from_path) = line.strip_prefix("rename from ") {
             current_rename_from = Some(from_path.to_string());
+            active_hunk_new_line = None;
         } else if let Some(to_path) = line.strip_prefix("rename to ") {
             if let Some(from_path) = current_rename_from.take() {
                 renames.push((from_path, to_path.to_string()));
@@ -954,12 +960,34 @@ fn parse_diff_tree_output(output: &str) -> DiffTreeResult {
             && let Some(ref file) = current_file
             && let Some(hunk) = parse_hunk_header(line)
         {
+            active_hunk_new_line = Some(hunk.new_start);
             hunks_by_file.entry(file.clone()).or_default().push(hunk);
+        } else if let Some(new_line) = active_hunk_new_line.as_mut() {
+            if line.starts_with('+') {
+                if let Some(ref file) = current_file {
+                    added_lines_by_file
+                        .entry(file.clone())
+                        .or_default()
+                        .push(*new_line);
+                }
+                *new_line += 1;
+            } else if line.starts_with('-') || line.starts_with('\\') {
+                // Removed lines and "\ No newline at end of file" markers do
+                // not advance the new-file line cursor.
+            } else {
+                *new_line += 1;
+            }
         }
+    }
+
+    for lines in added_lines_by_file.values_mut() {
+        lines.sort_unstable();
+        lines.dedup();
     }
 
     DiffTreeResult {
         hunks_by_file,
+        added_lines_by_file,
         renames,
     }
 }

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -246,6 +246,7 @@ fn post_squash_resolution_working_log(
         crate::authorship::post_commit::PostCommitOptions {
             supress_output: true,
             compute_stats: false,
+            recover_attribution: false,
         },
         move |resolution_log| {
             Ok(

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1182,20 +1182,17 @@ pub(crate) fn committed_hunks_from_diff_result(
     pathspecs: Option<&HashSet<String>>,
 ) -> HashMap<String, Vec<LineRange>> {
     let mut committed_hunks: HashMap<String, Vec<LineRange>> = HashMap::new();
-    for (file_path, hunks) in &diff.hunks_by_file {
+    for (file_path, added_lines) in &diff.added_lines_by_file {
         if let Some(paths) = pathspecs
             && !paths.contains(file_path)
         {
             continue;
         }
-        let mut lines: Vec<u32> = Vec::new();
-        for hunk in hunks {
-            for line in hunk.new_start..hunk.new_start + hunk.new_count {
-                if line > 0 {
-                    lines.push(line);
-                }
-            }
-        }
+        let lines = added_lines
+            .iter()
+            .copied()
+            .filter(|line| *line > 0)
+            .collect::<Vec<_>>();
         if !lines.is_empty() {
             committed_hunks.insert(file_path.clone(), LineRange::compress_lines(&lines));
         }

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -883,7 +883,17 @@ fn query_daemon_bash_snapshot(session_id: &str, tool_use_id: &str) -> Option<Sta
 }
 
 /// Signal the daemon that a bash session has ended.
-fn signal_daemon_bash_session_end(session_id: &str, tool_use_id: &str) {
+#[allow(clippy::too_many_arguments)]
+fn signal_daemon_bash_session_end(
+    repo_work_dir: &str,
+    session_id: &str,
+    tool_use_id: &str,
+    agent_id: &AgentId,
+    metadata: &HashMap<String, String>,
+    trace_id: &str,
+    ended_at_ns: u128,
+    command: Option<&str>,
+) {
     let Some(socket) = effective_daemon_socket() else {
         return;
     };
@@ -891,8 +901,14 @@ fn signal_daemon_bash_session_end(session_id: &str, tool_use_id: &str) {
         return;
     }
     let request = ControlRequest::BashSessionEnd {
+        repo_work_dir: repo_work_dir.to_string(),
         session_id: session_id.to_string(),
         tool_use_id: tool_use_id.to_string(),
+        agent_id: agent_id.clone(),
+        metadata: metadata.clone(),
+        trace_id: trace_id.to_string(),
+        ended_at_ns,
+        command: command.map(ToString::to_string),
     };
     if let Err(e) = send_control_request_with_timeout(&socket, &request, Duration::from_millis(500))
     {
@@ -914,7 +930,10 @@ pub fn handle_bash_pre_tool_use_with_context(
     tool_use_id: &str,
     agent_id: &AgentId,
     agent_metadata: Option<&HashMap<String, String>>,
+    trace_id: &str,
+    command: Option<&str>,
 ) -> Result<BashPreHookResult, GitAiError> {
+    let started_at_ns = crate::daemon::bash_history_db::unix_time_ns();
     let repo_working_dir = repo_root.to_string_lossy().to_string();
 
     let wm = query_daemon_watermarks(&repo_working_dir).or_else(|| {
@@ -950,6 +969,9 @@ pub fn handle_bash_pre_tool_use_with_context(
         agent_id: agent_id.clone(),
         metadata: agent_metadata.cloned().unwrap_or_default(),
         stat_snapshot: Box::new(snap),
+        trace_id: trace_id.to_string(),
+        started_at_ns,
+        command: command.map(ToString::to_string),
     };
 
     send_control_request(&socket, &request)?;
@@ -966,11 +988,18 @@ pub fn handle_bash_post_tool_use(
     repo_root: &Path,
     session_id: &str,
     tool_use_id: &str,
+    agent_id: &AgentId,
+    agent_metadata: Option<&HashMap<String, String>>,
+    trace_id: &str,
+    command: Option<&str>,
 ) -> Result<BashPostHookResult, GitAiError> {
     let invocation_key = format!("{}:{}", session_id, tool_use_id);
 
     let hook_start = Instant::now();
+    let ended_at_ns = crate::daemon::bash_history_db::unix_time_ns();
     let hook_timeout = Duration::from_millis(effective_hook_timeout_ms());
+    let repo_working_dir = repo_root.to_string_lossy().to_string();
+    let metadata = agent_metadata.cloned().unwrap_or_default();
 
     macro_rules! hook_timeout_fallback {
         ($label:expr) => {{
@@ -989,7 +1018,16 @@ pub fn handle_bash_post_tool_use(
                     "hook_timeout_ms": hook_timeout.as_millis(),
                 })),
             );
-            signal_daemon_bash_session_end(session_id, tool_use_id);
+            signal_daemon_bash_session_end(
+                &repo_working_dir,
+                session_id,
+                tool_use_id,
+                agent_id,
+                &metadata,
+                trace_id,
+                ended_at_ns,
+                command,
+            );
             return Ok(BashPostHookResult {
                 action: BashCheckpointAction::HookTimeout,
             });
@@ -1045,7 +1083,16 @@ pub fn handle_bash_post_tool_use(
                 }
             };
 
-            signal_daemon_bash_session_end(session_id, tool_use_id);
+            signal_daemon_bash_session_end(
+                &repo_working_dir,
+                session_id,
+                tool_use_id,
+                agent_id,
+                &metadata,
+                trace_id,
+                ended_at_ns,
+                command,
+            );
 
             result
         }
@@ -1054,7 +1101,16 @@ pub fn handle_bash_post_tool_use(
                 "Pre-snapshot not found in daemon for {}; returning MissingPreSnapshot",
                 invocation_key
             );
-            signal_daemon_bash_session_end(session_id, tool_use_id);
+            signal_daemon_bash_session_end(
+                &repo_working_dir,
+                session_id,
+                tool_use_id,
+                agent_id,
+                &metadata,
+                trace_id,
+                ended_at_ns,
+                command,
+            );
             Ok(BashPostHookResult {
                 action: BashCheckpointAction::MissingPreSnapshot,
             })

--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -406,6 +406,8 @@ fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAi
         &e.tool_use_id,
         &e.context.agent_id,
         Some(&e.context.metadata),
+        &e.context.trace_id,
+        e.command.as_deref(),
     ) {
         Ok(result) => result.dirty_paths,
         Err(error) => {
@@ -449,6 +451,10 @@ fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, Git
         &repo_work_dir,
         &e.context.external_session_id,
         &e.tool_use_id,
+        &e.context.agent_id,
+        Some(&e.context.metadata),
+        &e.context.trace_id,
+        e.command.as_deref(),
     );
 
     let file_paths: Vec<PathBuf> = match &bash_result {

--- a/src/commands/checkpoint_agent/presets/amp.rs
+++ b/src/commands/checkpoint_agent/presets/amp.rs
@@ -329,10 +329,23 @@ impl AgentPreset for AmpPreset {
             external_parent_session_id: None,
         });
 
+        let bash_command = hook_input
+            .tool_input
+            .as_ref()
+            .and_then(|tool_input| {
+                tool_input
+                    .get("command")
+                    .or_else(|| tool_input.get("cmd"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string);
         let event = match (is_pre, is_bash) {
             (true, true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
             }),
             (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
@@ -343,6 +356,7 @@ impl AgentPreset for AmpPreset {
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
                 stream_source,
             }),
             (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {

--- a/src/commands/checkpoint_agent/presets/claude.rs
+++ b/src/commands/checkpoint_agent/presets/claude.rs
@@ -98,10 +98,12 @@ impl AgentPreset for ClaudePreset {
             external_parent_session_id,
         });
 
+        let bash_command = parse::bash_command_from_hook_input(&data);
         let event = match (hook_event, is_bash) {
             (Some("PreToolUse"), true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id.to_string(),
+                command: bash_command,
             }),
             (Some("PreToolUse"), false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
@@ -112,6 +114,7 @@ impl AgentPreset for ClaudePreset {
             (_, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id.to_string(),
+                command: bash_command,
                 stream_source,
             }),
             (_, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {

--- a/src/commands/checkpoint_agent/presets/codex.rs
+++ b/src/commands/checkpoint_agent/presets/codex.rs
@@ -138,12 +138,14 @@ impl AgentPreset for CodexPreset {
             external_parent_session_id: None,
         });
 
+        let bash_command = parse::bash_command_from_hook_input(&data);
         let event = match hook_event {
             Some("PreToolUse") => {
                 if is_bash {
                     ParsedHookEvent::PreBashCall(PreBashCall {
                         context,
                         tool_use_id: tool_use_id.to_string(),
+                        command: bash_command,
                     })
                 } else if is_file_edit {
                     ParsedHookEvent::PreFileEdit(PreFileEdit {
@@ -164,6 +166,7 @@ impl AgentPreset for CodexPreset {
                     ParsedHookEvent::PostBashCall(PostBashCall {
                         context,
                         tool_use_id: tool_use_id.to_string(),
+                        command: bash_command,
                         stream_source,
                     })
                 } else if is_file_edit {
@@ -216,6 +219,7 @@ mod tests {
             "session_id": "codex-sess-1",
             "tool_use_id": "tu-1",
             "model": "o3",
+            "tool_input": {"command": "echo hello"},
             "transcript_path": "/home/user/.codex/sessions/test.jsonl"
         })
         .to_string();
@@ -227,6 +231,7 @@ mod tests {
                 assert_eq!(e.context.external_session_id, "codex-sess-1");
                 assert_eq!(e.context.agent_id.model, "o3");
                 assert_eq!(e.tool_use_id, "tu-1");
+                assert_eq!(e.command.as_deref(), Some("echo hello"));
             }
             _ => panic!("Expected PreBashCall"),
         }
@@ -240,6 +245,7 @@ mod tests {
             "tool_name": "Bash",
             "session_id": "codex-sess-1",
             "tool_use_id": "tu-1",
+            "tool_input": {"command": "echo hello"},
             "transcript_path": "/home/user/.codex/sessions/test.jsonl"
         })
         .to_string();
@@ -255,6 +261,7 @@ mod tests {
                         ..
                     })
                 ));
+                assert_eq!(e.command.as_deref(), Some("echo hello"));
             }
             _ => panic!("Expected PostBashCall"),
         }

--- a/src/commands/checkpoint_agent/presets/continue_cli.rs
+++ b/src/commands/checkpoint_agent/presets/continue_cli.rs
@@ -52,10 +52,12 @@ impl AgentPreset for ContinueCliPreset {
 
         let is_pre = hook_event == Some("PreToolUse");
 
+        let bash_command = parse::bash_command_from_hook_input(&data);
         let event = match (is_pre, is_bash) {
             (true, true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id.to_string(),
+                command: bash_command,
             }),
             (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
@@ -66,6 +68,7 @@ impl AgentPreset for ContinueCliPreset {
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id.to_string(),
+                command: bash_command,
                 stream_source,
             }),
             (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {

--- a/src/commands/checkpoint_agent/presets/cursor.rs
+++ b/src/commands/checkpoint_agent/presets/cursor.rs
@@ -141,14 +141,17 @@ impl AgentPreset for CursorPreset {
             .unwrap_or("bash")
             .to_string();
 
+        let bash_command = parse::bash_command_from_hook_input(&data);
         let event = match (tool_class, is_pre) {
             (ToolClass::Bash, true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id,
+                command: bash_command.clone(),
             }),
             (ToolClass::Bash, false) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id,
+                command: bash_command,
                 stream_source,
             }),
             (ToolClass::FileEdit, true) => ParsedHookEvent::PreFileEdit(PreFileEdit {
@@ -497,6 +500,7 @@ mod tests {
                     PathBuf::from("/Users/aidan/Desktop/test-repo")
                 );
                 assert_eq!(e.tool_use_id, "tu-shell-1");
+                assert_eq!(e.command.as_deref(), Some("date > current_time.txt"));
             }
             _ => panic!("Expected PreBashCall, got {:?}", events[0]),
         }
@@ -524,6 +528,7 @@ mod tests {
             ParsedHookEvent::PostBashCall(e) => {
                 assert_eq!(e.context.agent_id.tool, "cursor");
                 assert_eq!(e.tool_use_id, "tu-shell-2");
+                assert_eq!(e.command.as_deref(), Some("date > current_time.txt"));
             }
             _ => panic!("Expected PostBashCall, got {:?}", events[0]),
         }

--- a/src/commands/checkpoint_agent/presets/droid.rs
+++ b/src/commands/checkpoint_agent/presets/droid.rs
@@ -156,12 +156,15 @@ impl AgentPreset for DroidPreset {
             external_parent_session_id: None,
         });
 
+        let bash_command = parse::bash_command_from_hook_input(&data);
+
         // PreToolUse
         if hook_event_name == "PreToolUse" {
             if is_bash {
                 return Ok(vec![ParsedHookEvent::PreBashCall(PreBashCall {
                     context,
                     tool_use_id,
+                    command: bash_command,
                 })]);
             }
             return Ok(vec![ParsedHookEvent::PreFileEdit(PreFileEdit {
@@ -177,6 +180,7 @@ impl AgentPreset for DroidPreset {
             return Ok(vec![ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id,
+                command: bash_command,
                 stream_source,
             })]);
         }

--- a/src/commands/checkpoint_agent/presets/firebender.rs
+++ b/src/commands/checkpoint_agent/presets/firebender.rs
@@ -197,11 +197,19 @@ impl AgentPreset for FirebenderPreset {
             dirty_files.map(|df| df.into_iter().map(|(k, v)| (PathBuf::from(k), v)).collect());
 
         let tool_use_id_str = tool_use_id.unwrap_or_else(|| "bash".to_string());
+        let bash_command = tool_input
+            .get("command")
+            .or_else(|| tool_input.get("cmd"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string);
 
         let event = match (hook_event_name.as_str(), is_bash) {
             ("preToolUse", true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
             }),
             ("preToolUse", false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
@@ -212,6 +220,7 @@ impl AgentPreset for FirebenderPreset {
             (_, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
                 stream_source: None,
             }),
             (_, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {

--- a/src/commands/checkpoint_agent/presets/gemini.rs
+++ b/src/commands/checkpoint_agent/presets/gemini.rs
@@ -58,10 +58,12 @@ impl AgentPreset for GeminiPreset {
         // Gemini uses "BeforeTool" instead of "PreToolUse"
         let is_pre = matches!(hook_event, Some("BeforeTool") | Some("PreToolUse"));
 
+        let bash_command = parse::bash_command_from_hook_input(&data);
         let event = match (is_pre, is_bash) {
             (true, true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id.to_string(),
+                command: bash_command,
             }),
             (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
@@ -72,6 +74,7 @@ impl AgentPreset for GeminiPreset {
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id.to_string(),
+                command: bash_command,
                 stream_source,
             }),
             (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {

--- a/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/cli.rs
@@ -85,14 +85,18 @@ pub(super) fn parse_cli_hooks(
         external_parent_session_id: None,
     });
 
+    let bash_command = parse::bash_command_from_hook_input(data);
+
     match (hook_event_name, class) {
         ("PreToolUse", ToolClass::Bash) => Ok(vec![ParsedHookEvent::PreBashCall(PreBashCall {
             context,
             tool_use_id,
+            command: bash_command,
         })]),
         ("PostToolUse", ToolClass::Bash) => Ok(vec![ParsedHookEvent::PostBashCall(PostBashCall {
             context,
             tool_use_id,
+            command: bash_command,
             stream_source,
         })]),
         ("PreToolUse", ToolClass::FileEdit) => {
@@ -216,6 +220,10 @@ mod tests {
                     Some(&"copilot-cli".to_string())
                 );
                 assert_eq!(e.tool_use_id, "cli-sess-cli-bash");
+                assert_eq!(
+                    e.command.as_deref(),
+                    Some("cd /Users/a/project && cat > new.txt")
+                );
             }
             other => panic!("Expected PreBashCall, got {:?}", other),
         }
@@ -239,6 +247,7 @@ mod tests {
             ParsedHookEvent::PostBashCall(e) => {
                 assert!(e.stream_source.is_none());
                 assert_eq!(e.tool_use_id, "cli-sess-cli-bash");
+                assert_eq!(e.command.as_deref(), Some("ls"));
             }
             other => panic!("Expected PostBashCall, got {:?}", other),
         }

--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -193,6 +193,7 @@ pub(super) fn parse_vscode_native_hooks(
 
     let tool_class = classify_copilot_tool(tool_name);
     let is_bash = tool_class == ToolClass::Bash;
+    let bash_command = parse::bash_command_from_hook_input(data);
 
     let tool_use_id = parse::optional_str_multi(data, &["tool_use_id", "toolUseId"])
         .unwrap_or("unknown")
@@ -259,6 +260,7 @@ pub(super) fn parse_vscode_native_hooks(
             return Ok(vec![ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id,
+                command: bash_command,
             })]);
         }
 
@@ -301,6 +303,7 @@ pub(super) fn parse_vscode_native_hooks(
         return Ok(vec![ParsedHookEvent::PostBashCall(PostBashCall {
             context,
             tool_use_id,
+            command: bash_command,
             stream_source,
         })]);
     }

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -83,12 +83,16 @@ pub struct UntrackedEdit {
 pub struct PreBashCall {
     pub context: PresetContext,
     pub tool_use_id: String,
+    #[serde(default)]
+    pub command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostBashCall {
     pub context: PresetContext,
     pub tool_use_id: String,
+    #[serde(default)]
+    pub command: Option<String>,
     pub stream_source: Option<StreamSource>,
 }
 

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -261,6 +261,17 @@ impl AgentPreset for OpenCodePreset {
         } = hook_input;
 
         let file_paths = Self::extract_filepaths_from_tool_input(tool_input.as_ref(), &cwd);
+        let bash_command = tool_input
+            .as_ref()
+            .and_then(|value| {
+                value
+                    .get("command")
+                    .or_else(|| value.get("cmd"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string);
         let tool_use_id_str = tool_use_id.as_deref().unwrap_or("bash").to_string();
 
         // Build metadata
@@ -301,6 +312,7 @@ impl AgentPreset for OpenCodePreset {
             (true, true) => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
             }),
             (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
@@ -311,6 +323,7 @@ impl AgentPreset for OpenCodePreset {
             (false, true) => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
                 stream_source,
             }),
             (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {

--- a/src/commands/checkpoint_agent/presets/parse.rs
+++ b/src/commands/checkpoint_agent/presets/parse.rs
@@ -86,6 +86,30 @@ pub fn file_paths_from_tool_input(data: &Value, cwd: &str) -> Vec<PathBuf> {
     vec![]
 }
 
+pub fn bash_command_from_hook_input(data: &Value) -> Option<String> {
+    for (container, key) in [
+        ("tool_input", "command"),
+        ("toolInput", "command"),
+        ("tool_input", "cmd"),
+        ("toolInput", "cmd"),
+    ] {
+        if let Some(command) = data
+            .get(container)
+            .and_then(|v| v.get(key))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Some(command.to_string());
+        }
+    }
+
+    optional_str_multi(data, &["command", "cmd"])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
 /// Extract file paths from apply_patch / `ApplyPatch` tool text format.
 ///
 /// Several presets (Codex/OpenAI-style) embed edited paths in the patch text
@@ -226,6 +250,39 @@ mod tests {
         let data = json!({"tool_input": {"command": "ls"}});
         let paths = file_paths_from_tool_input(&data, "/home/user/project");
         assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_bash_command_from_tool_input_command() {
+        let data = json!({"tool_input": {"command": "echo hello"}});
+        assert_eq!(
+            bash_command_from_hook_input(&data).as_deref(),
+            Some("echo hello")
+        );
+    }
+
+    #[test]
+    fn test_bash_command_from_tool_input_cmd_camel_case() {
+        let data = json!({"toolInput": {"cmd": "npm test"}});
+        assert_eq!(
+            bash_command_from_hook_input(&data).as_deref(),
+            Some("npm test")
+        );
+    }
+
+    #[test]
+    fn test_bash_command_from_top_level_command() {
+        let data = json!({"command": "cargo check"});
+        assert_eq!(
+            bash_command_from_hook_input(&data).as_deref(),
+            Some("cargo check")
+        );
+    }
+
+    #[test]
+    fn test_bash_command_missing_or_empty() {
+        let data = json!({"tool_input": {"command": "   "}});
+        assert_eq!(bash_command_from_hook_input(&data), None);
     }
 
     #[test]

--- a/src/commands/checkpoint_agent/presets/pi.rs
+++ b/src/commands/checkpoint_agent/presets/pi.rs
@@ -30,6 +30,10 @@ struct PiHookInput {
     dirty_files: Option<HashMap<String, String>>,
     #[serde(default)]
     tool_use_id: Option<String>,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    cmd: Option<String>,
 }
 
 #[derive(Debug)]
@@ -93,6 +97,8 @@ impl AgentPreset for PiPreset {
             edited_filepaths,
             dirty_files,
             tool_use_id,
+            command,
+            cmd,
         } = hook_input;
 
         let hook_event = PiHookEvent::parse(&hook_event_name)?;
@@ -132,6 +138,10 @@ impl AgentPreset for PiPreset {
         }
 
         let tool_use_id_str = tool_use_id.as_deref().unwrap_or("bash").to_string();
+        let bash_command = command
+            .or(cmd)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
 
         let context = PresetContext {
             agent_id: AgentId {
@@ -190,10 +200,12 @@ impl AgentPreset for PiPreset {
             PiHookEvent::BeforeCommand => ParsedHookEvent::PreBashCall(PreBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
             }),
             PiHookEvent::AfterCommand => ParsedHookEvent::PostBashCall(PostBashCall {
                 context,
                 tool_use_id: tool_use_id_str,
+                command: bash_command,
                 stream_source,
             }),
         };

--- a/src/commands/checkpoint_agent/presets/windsurf.rs
+++ b/src/commands/checkpoint_agent/presets/windsurf.rs
@@ -131,17 +131,26 @@ impl AgentPreset for WindsurfPreset {
             .or_else(|| parse::optional_str(&data, "execution_id"))
             .unwrap_or("bash")
             .to_string();
+        let bash_command = tool_info
+            .and_then(|ti| ti.get("command"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .or_else(|| parse::bash_command_from_hook_input(&data));
 
         let event = if is_bash {
             if is_pre_bash {
                 ParsedHookEvent::PreBashCall(PreBashCall {
                     context,
                     tool_use_id: execution_id,
+                    command: bash_command,
                 })
             } else {
                 ParsedHookEvent::PostBashCall(PostBashCall {
                     context,
                     tool_use_id: execution_id,
+                    command: bash_command,
                     stream_source,
                 })
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -46,6 +46,7 @@ use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot};
 use tokio::time::Duration;
 
 pub mod analyzers;
+pub mod bash_history_db;
 pub mod bash_sessions;
 pub mod checkpoint;
 pub mod control_api;
@@ -765,6 +766,7 @@ fn post_conflict_resolution_working_log(
         crate::authorship::post_commit::PostCommitOptions {
             supress_output: true,
             compute_stats: false,
+            recover_attribution: false,
         },
         precomputed_parent_diff,
         move |resolution_log| {
@@ -5069,24 +5071,93 @@ impl ActorDaemonCoordinator {
                 agent_id,
                 metadata,
                 stat_snapshot,
+                trace_id,
+                started_at_ns,
+                command,
             } => {
+                let worktree_key = Self::worktree_state_key(Path::new(&repo_work_dir));
+                if let Ok(db) = crate::daemon::bash_history_db::BashHistoryDatabase::global()
+                    && let Ok(mut db_lock) = db.lock()
+                    && let Err(e) =
+                        db_lock.record_start(&crate::daemon::bash_history_db::BashCallStart {
+                            repo_work_dir: worktree_key.clone(),
+                            session_id: session_id.clone(),
+                            tool_use_id: tool_use_id.clone(),
+                            agent_id: agent_id.clone(),
+                            start_trace_id: trace_id.clone(),
+                            started_at_ns,
+                            command: command.clone(),
+                            metadata: metadata.clone(),
+                        })
+                {
+                    tracing::debug!("failed to persist bash session start: {}", e);
+                }
+
                 let mut state = self.bash_sessions.lock().unwrap();
-                state.start_session(
+                state.start_session(crate::daemon::bash_sessions::BashSessionStart {
                     session_id,
                     tool_use_id,
-                    Self::worktree_state_key(Path::new(&repo_work_dir)),
+                    repo_work_dir: worktree_key,
                     agent_id,
                     metadata,
-                    *stat_snapshot,
-                );
+                    stat_snapshot: *stat_snapshot,
+                    start_trace_id: trace_id,
+                    started_at_ns,
+                    command,
+                });
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::BashSessionEnd {
+                repo_work_dir,
                 session_id,
                 tool_use_id,
+                agent_id,
+                metadata,
+                trace_id,
+                ended_at_ns,
+                command,
             } => {
                 let mut state = self.bash_sessions.lock().unwrap();
-                state.end_session(&session_id, &tool_use_id);
+                let session = state.end_session(&session_id, &tool_use_id);
+                drop(state);
+
+                let worktree_key = session
+                    .as_ref()
+                    .map(|s| s.repo_work_dir.clone())
+                    .unwrap_or_else(|| Self::worktree_state_key(Path::new(&repo_work_dir)));
+                let start_trace_id = session.as_ref().map(|s| s.start_trace_id.clone());
+                let started_at_ns = session.as_ref().map(|s| s.started_at_ns);
+                let command = command.or_else(|| session.as_ref().and_then(|s| s.command.clone()));
+                let agent_id = session
+                    .as_ref()
+                    .map(|s| s.agent_id.clone())
+                    .unwrap_or(agent_id);
+                let metadata = if metadata.is_empty() {
+                    session
+                        .as_ref()
+                        .map(|s| s.metadata.clone())
+                        .unwrap_or_default()
+                } else {
+                    metadata
+                };
+                if let Ok(db) = crate::daemon::bash_history_db::BashHistoryDatabase::global()
+                    && let Ok(mut db_lock) = db.lock()
+                    && let Err(e) =
+                        db_lock.record_end(&crate::daemon::bash_history_db::BashCallEnd {
+                            repo_work_dir: worktree_key,
+                            session_id,
+                            tool_use_id,
+                            agent_id,
+                            start_trace_id,
+                            end_trace_id: trace_id,
+                            started_at_ns,
+                            ended_at_ns,
+                            command,
+                            metadata,
+                        })
+                {
+                    tracing::debug!("failed to persist bash session end: {}", e);
+                }
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::BashSessionQuery { repo_work_dir } => {

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -34,6 +34,9 @@ const MIGRATIONS: &[&str] = &[r#"
 
     CREATE UNIQUE INDEX IF NOT EXISTS idx_bash_calls_invocation
         ON bash_checkpoint_calls(session_id, tool_use_id, start_trace_id);
+
+    CREATE INDEX IF NOT EXISTS idx_bash_calls_time
+        ON bash_checkpoint_calls(start_time_ns, end_time_ns);
 "#];
 
 static BASH_HISTORY_DB: OnceLock<Mutex<BashHistoryDatabase>> = OnceLock::new();
@@ -82,6 +85,7 @@ pub struct BashCheckpointCall {
 
 pub struct BashHistoryDatabase {
     conn: Connection,
+    enabled: bool,
 }
 
 impl BashHistoryDatabase {
@@ -94,6 +98,21 @@ impl BashHistoryDatabase {
             }
         });
         Ok(db_mutex)
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    fn disabled_in_test_harness() -> bool {
+        std::env::var_os("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH").is_none()
+            && (std::env::var_os("GIT_AI_TEST_DB_PATH").is_some()
+                || std::env::var_os("GITAI_TEST_DB_PATH").is_some())
+    }
+
+    fn disabled_database() -> Self {
+        let conn = Connection::open_in_memory().expect("Failed to create disabled bash DB");
+        BashHistoryDatabase {
+            conn,
+            enabled: false,
+        }
     }
 
     fn fallback_database() -> Self {
@@ -111,7 +130,10 @@ impl BashHistoryDatabase {
                 );
                 let conn =
                     Connection::open_in_memory().expect("Failed to create in-memory bash DB");
-                let mut db = BashHistoryDatabase { conn };
+                let mut db = BashHistoryDatabase {
+                    conn,
+                    enabled: true,
+                };
                 db.initialize_schema()
                     .expect("Failed to initialize in-memory bash DB schema");
                 db
@@ -132,12 +154,20 @@ impl BashHistoryDatabase {
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
-        let mut db = Self { conn };
+        let mut db = Self {
+            conn,
+            enabled: true,
+        };
         db.initialize_schema()?;
         Ok(db)
     }
 
     fn new() -> Result<Self, GitAiError> {
+        #[cfg(any(test, feature = "test-support"))]
+        if Self::disabled_in_test_harness() {
+            return Ok(Self::disabled_database());
+        }
+
         let db_path = Self::database_path()?;
         Self::open_at_path(&db_path)
     }
@@ -236,6 +266,10 @@ impl BashHistoryDatabase {
     }
 
     pub fn record_start(&mut self, call: &BashCallStart) -> Result<(), GitAiError> {
+        if !self.enabled {
+            return Ok(());
+        }
+
         self.prune_old_calls_if_due()?;
 
         let now = unix_now_secs();
@@ -280,6 +314,10 @@ impl BashHistoryDatabase {
     }
 
     pub fn record_end(&mut self, call: &BashCallEnd) -> Result<(), GitAiError> {
+        if !self.enabled {
+            return Ok(());
+        }
+
         self.prune_old_calls_if_due()?;
 
         let now = unix_now_secs();
@@ -359,10 +397,13 @@ impl BashHistoryDatabase {
 
     pub fn candidates_near_timestamps(
         &self,
-        repo_work_dir: &str,
         timestamps_ns: &[u128],
         window_ns: u128,
     ) -> Result<Vec<BashCheckpointCall>, GitAiError> {
+        if !self.enabled {
+            return Ok(Vec::new());
+        }
+
         if timestamps_ns.is_empty() {
             return Ok(Vec::new());
         }
@@ -387,16 +428,12 @@ impl BashHistoryDatabase {
                    start_trace_id, end_trace_id, start_time_ns, end_time_ns,
                    command, metadata_json
             FROM bash_checkpoint_calls
-            WHERE repo_work_dir = ?1
-              AND start_time_ns <= ?2
-              AND COALESCE(end_time_ns, start_time_ns) >= ?3
+            WHERE start_time_ns <= ?1
+              AND COALESCE(end_time_ns, start_time_ns) >= ?2
             ORDER BY id ASC
             "#,
         )?;
-        let rows = stmt.query_map(
-            params![repo_work_dir, ns_to_i64(max_ts)?, ns_to_i64(min_ts)?],
-            row_to_call,
-        )?;
+        let rows = stmt.query_map(params![ns_to_i64(max_ts)?, ns_to_i64(min_ts)?], row_to_call)?;
 
         let mut calls = Vec::new();
         for row in rows {
@@ -412,6 +449,10 @@ impl BashHistoryDatabase {
     }
 
     pub fn all_calls_for_test(&self) -> Result<Vec<BashCheckpointCall>, GitAiError> {
+        if !self.enabled {
+            return Ok(Vec::new());
+        }
+
         let mut stmt = self.conn.prepare(
             r#"
             SELECT id, invocation_key, repo_work_dir, session_id, tool_use_id,
@@ -431,6 +472,10 @@ impl BashHistoryDatabase {
     }
 
     fn prune_old_calls_if_due(&mut self) -> Result<(), GitAiError> {
+        if !self.enabled {
+            return Ok(());
+        }
+
         let now = unix_now_secs();
         let last_prune: Option<i64> = self
             .conn
@@ -452,6 +497,10 @@ impl BashHistoryDatabase {
     }
 
     pub fn prune_old_calls(&mut self, now: u64) -> Result<(), GitAiError> {
+        if !self.enabled {
+            return Ok(());
+        }
+
         let cutoff = now.saturating_sub(RETENTION_SECS);
         let tx = self.conn.transaction()?;
         tx.execute(
@@ -624,13 +673,13 @@ mod tests {
     #[test]
     fn candidate_query_filters_by_window() {
         let (mut db, _dir) = test_db();
-        for (tool_use_id, start, end) in [
-            ("near-before", 1_000_u128, 2_000_u128),
-            ("near-after", 8_000, 9_000),
-            ("outside", 20_000, 21_000),
+        for (repo_work_dir, tool_use_id, start, end) in [
+            ("/repo", "near-before", 1_000_u128, 2_000_u128),
+            ("/other-repo", "near-after", 8_000, 9_000),
+            ("/repo", "outside", 20_000, 21_000),
         ] {
             db.record_start(&BashCallStart {
-                repo_work_dir: "/repo".to_string(),
+                repo_work_dir: repo_work_dir.to_string(),
                 session_id: "session".to_string(),
                 tool_use_id: tool_use_id.to_string(),
                 agent_id: test_agent(),
@@ -641,7 +690,7 @@ mod tests {
             })
             .unwrap();
             db.record_end(&BashCallEnd {
-                repo_work_dir: "/repo".to_string(),
+                repo_work_dir: repo_work_dir.to_string(),
                 session_id: "session".to_string(),
                 tool_use_id: tool_use_id.to_string(),
                 agent_id: test_agent(),
@@ -655,9 +704,7 @@ mod tests {
             .unwrap();
         }
 
-        let calls = db
-            .candidates_near_timestamps("/repo", &[5_000], 3_000)
-            .unwrap();
+        let calls = db.candidates_near_timestamps(&[5_000], 3_000).unwrap();
         let ids: Vec<_> = calls.iter().map(|c| c.tool_use_id.as_str()).collect();
         assert_eq!(ids, vec!["near-before", "near-after"]);
     }

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -107,6 +107,7 @@ impl BashHistoryDatabase {
                 || std::env::var_os("GITAI_TEST_DB_PATH").is_some())
     }
 
+    #[cfg(any(test, feature = "test-support"))]
     fn disabled_database() -> Self {
         let conn = Connection::open_in_memory().expect("Failed to create disabled bash DB");
         BashHistoryDatabase {

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -1,0 +1,719 @@
+use crate::authorship::working_log::AgentId;
+use crate::error::GitAiError;
+use rusqlite::{Connection, OptionalExtension, params};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+const SCHEMA_VERSION: usize = 1;
+const RETENTION_SECS: u64 = 30 * 24 * 3600;
+const PRUNE_INTERVAL_SECS: u64 = 24 * 3600;
+
+const MIGRATIONS: &[&str] = &[r#"
+    CREATE TABLE IF NOT EXISTS bash_checkpoint_calls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        invocation_key TEXT NOT NULL,
+        repo_work_dir TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        tool_use_id TEXT NOT NULL,
+        agent_tool TEXT NOT NULL,
+        agent_external_id TEXT NOT NULL,
+        agent_model TEXT NOT NULL,
+        start_trace_id TEXT,
+        end_trace_id TEXT,
+        start_time_ns INTEGER NOT NULL,
+        end_time_ns INTEGER,
+        command TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_bash_calls_repo_time
+        ON bash_checkpoint_calls(repo_work_dir, start_time_ns, end_time_ns);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_bash_calls_invocation
+        ON bash_checkpoint_calls(session_id, tool_use_id, start_trace_id);
+"#];
+
+static BASH_HISTORY_DB: OnceLock<Mutex<BashHistoryDatabase>> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+pub struct BashCallStart {
+    pub repo_work_dir: String,
+    pub session_id: String,
+    pub tool_use_id: String,
+    pub agent_id: AgentId,
+    pub start_trace_id: String,
+    pub started_at_ns: u128,
+    pub command: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BashCallEnd {
+    pub repo_work_dir: String,
+    pub session_id: String,
+    pub tool_use_id: String,
+    pub agent_id: AgentId,
+    pub start_trace_id: Option<String>,
+    pub end_trace_id: String,
+    pub started_at_ns: Option<u128>,
+    pub ended_at_ns: u128,
+    pub command: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BashCheckpointCall {
+    pub id: i64,
+    pub invocation_key: String,
+    pub repo_work_dir: String,
+    pub session_id: String,
+    pub tool_use_id: String,
+    pub agent_id: AgentId,
+    pub start_trace_id: Option<String>,
+    pub end_trace_id: Option<String>,
+    pub start_time_ns: u128,
+    pub end_time_ns: Option<u128>,
+    pub command: Option<String>,
+    pub metadata: HashMap<String, String>,
+}
+
+pub struct BashHistoryDatabase {
+    conn: Connection,
+}
+
+impl BashHistoryDatabase {
+    pub fn global() -> Result<&'static Mutex<BashHistoryDatabase>, GitAiError> {
+        let db_mutex = BASH_HISTORY_DB.get_or_init(|| match Self::new() {
+            Ok(db) => Mutex::new(db),
+            Err(e) => {
+                eprintln!("[Error] Failed to initialize bash history database: {}", e);
+                Mutex::new(Self::fallback_database())
+            }
+        });
+        Ok(db_mutex)
+    }
+
+    fn fallback_database() -> Self {
+        let temp_path = std::env::temp_dir().join("git-ai-bash-history-db-failed");
+        Self::fallback_database_at(&temp_path)
+    }
+
+    fn fallback_database_at(path: &Path) -> Self {
+        match Self::open_at_path(path) {
+            Ok(db) => db,
+            Err(e) => {
+                eprintln!(
+                    "[Error] Failed to initialize fallback bash history database: {}",
+                    e
+                );
+                let conn =
+                    Connection::open_in_memory().expect("Failed to create in-memory bash DB");
+                let mut db = BashHistoryDatabase { conn };
+                db.initialize_schema()
+                    .expect("Failed to initialize in-memory bash DB schema");
+                db
+            }
+        }
+    }
+
+    pub fn open_at_path(path: &Path) -> Result<Self, GitAiError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            PRAGMA cache_size=-2000;
+            PRAGMA temp_store=MEMORY;
+            "#,
+        )?;
+        let mut db = Self { conn };
+        db.initialize_schema()?;
+        Ok(db)
+    }
+
+    fn new() -> Result<Self, GitAiError> {
+        let db_path = Self::database_path()?;
+        Self::open_at_path(&db_path)
+    }
+
+    fn database_path() -> Result<PathBuf, GitAiError> {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Ok(test_path) = std::env::var("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH") {
+            return Ok(PathBuf::from(test_path));
+        }
+
+        let home = dirs::home_dir()
+            .ok_or_else(|| GitAiError::Generic("Could not determine home directory".to_string()))?;
+        Ok(home
+            .join(".git-ai")
+            .join("internal")
+            .join("bash-checkpoints-db"))
+    }
+
+    fn initialize_schema(&mut self) -> Result<(), GitAiError> {
+        let version_check: Result<usize, _> = self.conn.query_row(
+            "SELECT value FROM schema_metadata WHERE key = 'version'",
+            [],
+            |row| {
+                let version_str: String = row.get(0)?;
+                version_str
+                    .parse::<usize>()
+                    .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+            },
+        );
+
+        if let Ok(current_version) = version_check {
+            if current_version == SCHEMA_VERSION {
+                return Ok(());
+            }
+            if current_version > SCHEMA_VERSION {
+                return Err(GitAiError::Generic(format!(
+                    "Bash history database schema version {} is newer than supported version {}. Please upgrade git-ai.",
+                    current_version, SCHEMA_VERSION
+                )));
+            }
+        }
+
+        self.conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS schema_metadata (
+                key TEXT PRIMARY KEY NOT NULL,
+                value TEXT NOT NULL
+            );
+            "#,
+        )?;
+
+        let current_version: usize = self
+            .conn
+            .query_row(
+                "SELECT value FROM schema_metadata WHERE key = 'version'",
+                [],
+                |row| {
+                    let version_str: String = row.get(0)?;
+                    version_str
+                        .parse::<usize>()
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+                },
+            )
+            .unwrap_or(0);
+
+        for target_version in current_version..SCHEMA_VERSION {
+            self.apply_migration(target_version)?;
+            self.conn.execute(
+                r#"
+                INSERT INTO schema_metadata (key, value)
+                VALUES ('version', ?1)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value
+                WHERE CAST(schema_metadata.value AS INTEGER) < CAST(excluded.value AS INTEGER)
+                "#,
+                params![(target_version + 1).to_string()],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn apply_migration(&mut self, from_version: usize) -> Result<(), GitAiError> {
+        if from_version >= MIGRATIONS.len() {
+            return Err(GitAiError::Generic(format!(
+                "No bash history migration defined for version {} -> {}",
+                from_version,
+                from_version + 1
+            )));
+        }
+
+        let tx = self.conn.transaction()?;
+        tx.execute_batch(MIGRATIONS[from_version])?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn record_start(&mut self, call: &BashCallStart) -> Result<(), GitAiError> {
+        self.prune_old_calls_if_due()?;
+
+        let now = unix_now_secs();
+        let metadata_json =
+            serde_json::to_string(&call.metadata).unwrap_or_else(|_| "{}".to_string());
+        let invocation_key = invocation_key(&call.session_id, &call.tool_use_id);
+        self.conn.execute(
+            r#"
+            INSERT INTO bash_checkpoint_calls (
+                invocation_key, repo_work_dir, session_id, tool_use_id,
+                agent_tool, agent_external_id, agent_model,
+                start_trace_id, start_time_ns, command, metadata_json,
+                created_at, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)
+            ON CONFLICT(session_id, tool_use_id, start_trace_id) DO UPDATE SET
+                repo_work_dir = excluded.repo_work_dir,
+                agent_tool = excluded.agent_tool,
+                agent_external_id = excluded.agent_external_id,
+                agent_model = excluded.agent_model,
+                start_time_ns = excluded.start_time_ns,
+                command = COALESCE(excluded.command, bash_checkpoint_calls.command),
+                metadata_json = excluded.metadata_json,
+                updated_at = excluded.updated_at
+            "#,
+            params![
+                invocation_key,
+                call.repo_work_dir,
+                call.session_id,
+                call.tool_use_id,
+                call.agent_id.tool,
+                call.agent_id.id,
+                call.agent_id.model,
+                call.start_trace_id,
+                ns_to_i64(call.started_at_ns)?,
+                call.command,
+                metadata_json,
+                now as i64,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn record_end(&mut self, call: &BashCallEnd) -> Result<(), GitAiError> {
+        self.prune_old_calls_if_due()?;
+
+        let now = unix_now_secs();
+        let metadata_json =
+            serde_json::to_string(&call.metadata).unwrap_or_else(|_| "{}".to_string());
+        let end_time_ns = ns_to_i64(call.ended_at_ns)?;
+
+        let updated = if let Some(start_trace_id) = call.start_trace_id.as_ref() {
+            self.conn.execute(
+                r#"
+                UPDATE bash_checkpoint_calls
+                SET end_trace_id = ?1,
+                    end_time_ns = ?2,
+                    command = COALESCE(?3, command),
+                    metadata_json = ?4,
+                    updated_at = ?5
+                WHERE session_id = ?6 AND tool_use_id = ?7 AND start_trace_id = ?8
+                "#,
+                params![
+                    call.end_trace_id,
+                    end_time_ns,
+                    call.command,
+                    metadata_json,
+                    now as i64,
+                    call.session_id,
+                    call.tool_use_id,
+                    start_trace_id,
+                ],
+            )?
+        } else {
+            0
+        };
+
+        if updated > 0 {
+            return Ok(());
+        }
+
+        let start_time_ns = ns_to_i64(call.started_at_ns.unwrap_or(call.ended_at_ns))?;
+        let invocation_key = invocation_key(&call.session_id, &call.tool_use_id);
+        self.conn.execute(
+            r#"
+            INSERT INTO bash_checkpoint_calls (
+                invocation_key, repo_work_dir, session_id, tool_use_id,
+                agent_tool, agent_external_id, agent_model,
+                start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+                command, metadata_json, created_at, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)
+            ON CONFLICT(session_id, tool_use_id, start_trace_id) DO UPDATE SET
+                end_trace_id = excluded.end_trace_id,
+                end_time_ns = excluded.end_time_ns,
+                command = COALESCE(excluded.command, bash_checkpoint_calls.command),
+                metadata_json = excluded.metadata_json,
+                updated_at = excluded.updated_at
+            "#,
+            params![
+                invocation_key,
+                call.repo_work_dir,
+                call.session_id,
+                call.tool_use_id,
+                call.agent_id.tool,
+                call.agent_id.id,
+                call.agent_id.model,
+                call.start_trace_id
+                    .clone()
+                    .unwrap_or_else(|| call.end_trace_id.clone()),
+                call.end_trace_id,
+                start_time_ns,
+                end_time_ns,
+                call.command,
+                metadata_json,
+                now as i64,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn candidates_near_timestamps(
+        &self,
+        repo_work_dir: &str,
+        timestamps_ns: &[u128],
+        window_ns: u128,
+    ) -> Result<Vec<BashCheckpointCall>, GitAiError> {
+        if timestamps_ns.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let min_ts = timestamps_ns
+            .iter()
+            .copied()
+            .min()
+            .unwrap_or_default()
+            .saturating_sub(window_ns);
+        let max_ts = timestamps_ns
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or_default()
+            .saturating_add(window_ns);
+
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, invocation_key, repo_work_dir, session_id, tool_use_id,
+                   agent_tool, agent_external_id, agent_model,
+                   start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+                   command, metadata_json
+            FROM bash_checkpoint_calls
+            WHERE repo_work_dir = ?1
+              AND start_time_ns <= ?2
+              AND COALESCE(end_time_ns, start_time_ns) >= ?3
+            ORDER BY id ASC
+            "#,
+        )?;
+        let rows = stmt.query_map(
+            params![repo_work_dir, ns_to_i64(max_ts)?, ns_to_i64(min_ts)?],
+            row_to_call,
+        )?;
+
+        let mut calls = Vec::new();
+        for row in rows {
+            let call = row?;
+            if timestamps_ns
+                .iter()
+                .any(|ts| distance_to_call_window(*ts, &call) <= window_ns)
+            {
+                calls.push(call);
+            }
+        }
+        Ok(calls)
+    }
+
+    pub fn all_calls_for_test(&self) -> Result<Vec<BashCheckpointCall>, GitAiError> {
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, invocation_key, repo_work_dir, session_id, tool_use_id,
+                   agent_tool, agent_external_id, agent_model,
+                   start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+                   command, metadata_json
+            FROM bash_checkpoint_calls
+            ORDER BY id ASC
+            "#,
+        )?;
+        let rows = stmt.query_map([], row_to_call)?;
+        let mut calls = Vec::new();
+        for row in rows {
+            calls.push(row?);
+        }
+        Ok(calls)
+    }
+
+    fn prune_old_calls_if_due(&mut self) -> Result<(), GitAiError> {
+        let now = unix_now_secs();
+        let last_prune: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT value FROM schema_metadata WHERE key = 'bash_history_last_prune_ts'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?
+            .and_then(|v: String| v.parse().ok());
+
+        if let Some(last) = last_prune
+            && now.saturating_sub(last as u64) < PRUNE_INTERVAL_SECS
+        {
+            return Ok(());
+        }
+
+        self.prune_old_calls(now)
+    }
+
+    pub fn prune_old_calls(&mut self, now: u64) -> Result<(), GitAiError> {
+        let cutoff = now.saturating_sub(RETENTION_SECS);
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "DELETE FROM bash_checkpoint_calls WHERE updated_at < ?1",
+            params![cutoff as i64],
+        )?;
+        tx.execute(
+            "INSERT OR REPLACE INTO schema_metadata (key, value) VALUES ('bash_history_last_prune_ts', ?1)",
+            params![now.to_string()],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+fn invocation_key(session_id: &str, tool_use_id: &str) -> String {
+    format!("{}:{}", session_id, tool_use_id)
+}
+
+pub fn unix_time_ns() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn ns_to_i64(ns: u128) -> Result<i64, GitAiError> {
+    i64::try_from(ns).map_err(|_| GitAiError::Generic(format!("timestamp too large: {}", ns)))
+}
+
+fn i64_to_ns(ns: i64) -> u128 {
+    u128::try_from(ns).unwrap_or_default()
+}
+
+fn row_to_call(row: &rusqlite::Row<'_>) -> rusqlite::Result<BashCheckpointCall> {
+    let metadata_json: String = row.get(13)?;
+    let metadata = serde_json::from_str(&metadata_json).unwrap_or_default();
+    Ok(BashCheckpointCall {
+        id: row.get(0)?,
+        invocation_key: row.get(1)?,
+        repo_work_dir: row.get(2)?,
+        session_id: row.get(3)?,
+        tool_use_id: row.get(4)?,
+        agent_id: AgentId {
+            tool: row.get(5)?,
+            id: row.get(6)?,
+            model: row.get(7)?,
+        },
+        start_trace_id: row.get(8)?,
+        end_trace_id: row.get(9)?,
+        start_time_ns: i64_to_ns(row.get(10)?),
+        end_time_ns: row.get::<_, Option<i64>>(11)?.map(i64_to_ns),
+        command: row.get(12)?,
+        metadata,
+    })
+}
+
+pub fn distance_to_call_window(timestamp_ns: u128, call: &BashCheckpointCall) -> u128 {
+    let start = call.start_time_ns;
+    let end = call.end_time_ns.unwrap_or(start);
+    if timestamp_ns < start {
+        start.saturating_sub(timestamp_ns)
+    } else if timestamp_ns > end {
+        timestamp_ns.saturating_sub(end)
+    } else {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_agent() -> AgentId {
+        AgentId {
+            tool: "codex".to_string(),
+            id: "session-1".to_string(),
+            model: "gpt-5".to_string(),
+        }
+    }
+
+    fn test_db() -> (BashHistoryDatabase, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = BashHistoryDatabase::open_at_path(&dir.path().join("bash.db")).unwrap();
+        (db, dir)
+    }
+
+    #[test]
+    fn start_and_end_lifecycle_persists_fields() {
+        let (mut db, _dir) = test_db();
+        let mut metadata = HashMap::new();
+        metadata.insert("transcript_path".to_string(), "/tmp/t.jsonl".to_string());
+
+        db.record_start(&BashCallStart {
+            repo_work_dir: "/repo".to_string(),
+            session_id: "session-1".to_string(),
+            tool_use_id: "tool-1".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: "t_start".to_string(),
+            started_at_ns: 1_000,
+            command: Some("echo hi".to_string()),
+            metadata: metadata.clone(),
+        })
+        .unwrap();
+        db.record_end(&BashCallEnd {
+            repo_work_dir: "/repo".to_string(),
+            session_id: "session-1".to_string(),
+            tool_use_id: "tool-1".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: Some("t_start".to_string()),
+            end_trace_id: "t_end".to_string(),
+            started_at_ns: Some(1_000),
+            ended_at_ns: 2_000,
+            command: Some("echo hi".to_string()),
+            metadata,
+        })
+        .unwrap();
+
+        let calls = db.all_calls_for_test().unwrap();
+        assert_eq!(calls.len(), 1);
+        let call = &calls[0];
+        assert_eq!(call.repo_work_dir, "/repo");
+        assert_eq!(call.session_id, "session-1");
+        assert_eq!(call.tool_use_id, "tool-1");
+        assert_eq!(call.agent_id, test_agent());
+        assert_eq!(call.start_trace_id.as_deref(), Some("t_start"));
+        assert_eq!(call.end_trace_id.as_deref(), Some("t_end"));
+        assert_eq!(call.start_time_ns, 1_000);
+        assert_eq!(call.end_time_ns, Some(2_000));
+        assert_eq!(call.command.as_deref(), Some("echo hi"));
+        assert_eq!(
+            call.metadata.get("transcript_path").map(String::as_str),
+            Some("/tmp/t.jsonl")
+        );
+    }
+
+    #[test]
+    fn end_without_start_upserts_best_effort_row() {
+        let (mut db, _dir) = test_db();
+
+        db.record_end(&BashCallEnd {
+            repo_work_dir: "/repo".to_string(),
+            session_id: "session-2".to_string(),
+            tool_use_id: "tool-2".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: None,
+            end_trace_id: "t_end".to_string(),
+            started_at_ns: None,
+            ended_at_ns: 5_000,
+            command: Some("touch file".to_string()),
+            metadata: HashMap::new(),
+        })
+        .unwrap();
+
+        let calls = db.all_calls_for_test().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].start_trace_id.as_deref(), Some("t_end"));
+        assert_eq!(calls[0].end_trace_id.as_deref(), Some("t_end"));
+        assert_eq!(calls[0].start_time_ns, 5_000);
+        assert_eq!(calls[0].end_time_ns, Some(5_000));
+    }
+
+    #[test]
+    fn candidate_query_filters_by_window() {
+        let (mut db, _dir) = test_db();
+        for (tool_use_id, start, end) in [
+            ("near-before", 1_000_u128, 2_000_u128),
+            ("near-after", 8_000, 9_000),
+            ("outside", 20_000, 21_000),
+        ] {
+            db.record_start(&BashCallStart {
+                repo_work_dir: "/repo".to_string(),
+                session_id: "session".to_string(),
+                tool_use_id: tool_use_id.to_string(),
+                agent_id: test_agent(),
+                start_trace_id: format!("t_{}", tool_use_id),
+                started_at_ns: start,
+                command: None,
+                metadata: HashMap::new(),
+            })
+            .unwrap();
+            db.record_end(&BashCallEnd {
+                repo_work_dir: "/repo".to_string(),
+                session_id: "session".to_string(),
+                tool_use_id: tool_use_id.to_string(),
+                agent_id: test_agent(),
+                start_trace_id: Some(format!("t_{}", tool_use_id)),
+                end_trace_id: format!("t_end_{}", tool_use_id),
+                started_at_ns: Some(start),
+                ended_at_ns: end,
+                command: None,
+                metadata: HashMap::new(),
+            })
+            .unwrap();
+        }
+
+        let calls = db
+            .candidates_near_timestamps("/repo", &[5_000], 3_000)
+            .unwrap();
+        let ids: Vec<_> = calls.iter().map(|c| c.tool_use_id.as_str()).collect();
+        assert_eq!(ids, vec!["near-before", "near-after"]);
+    }
+
+    #[test]
+    fn fallback_database_has_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = BashHistoryDatabase::fallback_database_at(dir.path());
+
+        let calls = db.all_calls_for_test().unwrap();
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn retention_prunes_rows_older_than_thirty_days() {
+        let (mut db, _dir) = test_db();
+        db.record_start(&BashCallStart {
+            repo_work_dir: "/repo".to_string(),
+            session_id: "old".to_string(),
+            tool_use_id: "old-tool".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: "t_old".to_string(),
+            started_at_ns: 1_000,
+            command: None,
+            metadata: HashMap::new(),
+        })
+        .unwrap();
+        db.record_start(&BashCallStart {
+            repo_work_dir: "/repo".to_string(),
+            session_id: "new".to_string(),
+            tool_use_id: "new-tool".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: "t_new".to_string(),
+            started_at_ns: 2_000,
+            command: None,
+            metadata: HashMap::new(),
+        })
+        .unwrap();
+
+        let now = 10_000_000;
+        db.conn
+            .execute(
+                "UPDATE bash_checkpoint_calls SET updated_at = ?1 WHERE session_id = 'old'",
+                params![(now - RETENTION_SECS - 1) as i64],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE bash_checkpoint_calls SET updated_at = ?1 WHERE session_id = 'new'",
+                params![(now - RETENTION_SECS + 1) as i64],
+            )
+            .unwrap();
+
+        db.prune_old_calls(now).unwrap();
+        let calls = db.all_calls_for_test().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].session_id, "new");
+    }
+}

--- a/src/daemon/bash_sessions.rs
+++ b/src/daemon/bash_sessions.rs
@@ -10,7 +10,22 @@ pub struct BashSession {
     pub agent_id: AgentId,
     pub metadata: HashMap<String, String>,
     pub stat_snapshot: StatSnapshot,
+    pub start_trace_id: String,
+    pub started_at_ns: u128,
+    pub command: Option<String>,
     pub started_at: Instant,
+}
+
+pub struct BashSessionStart {
+    pub session_id: String,
+    pub tool_use_id: String,
+    pub repo_work_dir: String,
+    pub agent_id: AgentId,
+    pub metadata: HashMap<String, String>,
+    pub stat_snapshot: StatSnapshot,
+    pub start_trace_id: String,
+    pub started_at_ns: u128,
+    pub command: Option<String>,
 }
 
 #[derive(Default)]
@@ -28,23 +43,18 @@ impl BashSessionState {
             .retain(|_, s| s.started_at.elapsed() < Duration::from_secs(STALE_SESSION_SECS));
     }
 
-    pub fn start_session(
-        &mut self,
-        session_id: String,
-        tool_use_id: String,
-        repo_work_dir: String,
-        agent_id: AgentId,
-        metadata: HashMap<String, String>,
-        stat_snapshot: StatSnapshot,
-    ) {
+    pub fn start_session(&mut self, session: BashSessionStart) {
         self.prune_stale_sessions();
         self.sessions.insert(
-            (session_id, tool_use_id),
+            (session.session_id, session.tool_use_id),
             BashSession {
-                repo_work_dir,
-                agent_id,
-                metadata,
-                stat_snapshot,
+                repo_work_dir: session.repo_work_dir,
+                agent_id: session.agent_id,
+                metadata: session.metadata,
+                stat_snapshot: session.stat_snapshot,
+                start_trace_id: session.start_trace_id,
+                started_at_ns: session.started_at_ns,
+                command: session.command,
                 started_at: Instant::now(),
             },
         );

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -34,11 +34,20 @@ pub enum ControlRequest {
         agent_id: AgentId,
         metadata: HashMap<String, String>,
         stat_snapshot: Box<StatSnapshot>,
+        trace_id: String,
+        started_at_ns: u128,
+        command: Option<String>,
     },
     #[serde(rename = "bash_session.end")]
     BashSessionEnd {
+        repo_work_dir: String,
         session_id: String,
         tool_use_id: String,
+        agent_id: AgentId,
+        metadata: HashMap<String, String>,
+        trace_id: String,
+        ended_at_ns: u128,
+        command: Option<String>,
     },
     #[serde(rename = "bash_session.query")]
     BashSessionQuery { repo_work_dir: String },

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2983,23 +2983,60 @@ pub fn parse_git_version(version_str: &str) -> Option<(u32, u32, u32)> {
 fn parse_diff_added_lines(
     diff_output: &str,
 ) -> Result<(HashMap<String, Vec<u32>>, usize), GitAiError> {
+    let parsed = parse_diff_added_lines_internal(diff_output);
+    Ok((parsed.all_lines, parsed.total_deleted))
+}
+
+struct ParsedDiffAddedLines {
+    all_lines: HashMap<String, Vec<u32>>,
+    insertion_lines: HashMap<String, Vec<u32>>,
+    total_deleted: usize,
+}
+
+struct ActiveDiffHunk {
+    new_line: u32,
+    is_pure_insertion: bool,
+}
+
+fn parse_diff_added_lines_internal(diff_output: &str) -> ParsedDiffAddedLines {
     let mut result: HashMap<String, Vec<u32>> = HashMap::new();
+    let mut insertion_lines: HashMap<String, Vec<u32>> = HashMap::new();
     let mut current_file: Option<String> = None;
+    let mut current_hunk: Option<ActiveDiffHunk> = None;
     let mut total_deleted: usize = 0;
 
     for line in diff_output.lines() {
         if let Some(path_opt) = parse_new_file_path_from_plus_header_line(line) {
             current_file = path_opt;
+            current_hunk = None;
         } else if line.starts_with("@@ ") {
             // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
-            if let Some((added_lines, _is_pure_insertion, old_count)) = parse_hunk_header(line) {
+            if let Some((new_start, _new_count, old_count)) = parse_hunk_header_counts(line) {
                 // Count deleted lines for ALL hunks, including those from purely
                 // deleted files (where current_file is None because +++ /dev/null).
                 total_deleted += old_count as usize;
-                // Only record added-line numbers when there is a destination file.
+                current_hunk = Some(ActiveDiffHunk {
+                    new_line: new_start,
+                    is_pure_insertion: old_count == 0,
+                });
+            }
+        } else if let Some(hunk) = current_hunk.as_mut() {
+            if line.starts_with('+') {
                 if let Some(ref file) = current_file {
-                    result.entry(file.clone()).or_default().extend(added_lines);
+                    result.entry(file.clone()).or_default().push(hunk.new_line);
+                    if hunk.is_pure_insertion {
+                        insertion_lines
+                            .entry(file.clone())
+                            .or_default()
+                            .push(hunk.new_line);
+                    }
                 }
+                hunk.new_line += 1;
+            } else if line.starts_with('-') || line.starts_with('\\') {
+                // Removed lines and "\ No newline at end of file" markers do
+                // not advance the new-file line cursor.
+            } else {
+                hunk.new_line += 1;
             }
         }
     }
@@ -3009,8 +3046,16 @@ fn parse_diff_added_lines(
         lines.sort_unstable();
         lines.dedup();
     }
+    for lines in insertion_lines.values_mut() {
+        lines.sort_unstable();
+        lines.dedup();
+    }
 
-    Ok((result, total_deleted))
+    ParsedDiffAddedLines {
+        all_lines: result,
+        insertion_lines,
+        total_deleted,
+    }
 }
 
 /// Parses the unified diff output to extract line numbers of added lines,
@@ -3022,44 +3067,8 @@ fn parse_diff_added_lines(
 pub fn parse_diff_added_lines_with_insertions(
     diff_output: &str,
 ) -> Result<(HashMap<String, Vec<u32>>, HashMap<String, Vec<u32>>), GitAiError> {
-    let mut all_lines: HashMap<String, Vec<u32>> = HashMap::new();
-    let mut insertion_lines: HashMap<String, Vec<u32>> = HashMap::new();
-    let mut current_file: Option<String> = None;
-
-    for line in diff_output.lines() {
-        if let Some(path_opt) = parse_new_file_path_from_plus_header_line(line) {
-            current_file = path_opt;
-        } else if line.starts_with("@@ ") {
-            // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
-            if let Some(ref file) = current_file
-                && let Some((added_lines, is_pure_insertion, _old_count)) = parse_hunk_header(line)
-            {
-                all_lines
-                    .entry(file.clone())
-                    .or_default()
-                    .extend(added_lines.clone());
-
-                if is_pure_insertion {
-                    insertion_lines
-                        .entry(file.clone())
-                        .or_default()
-                        .extend(added_lines);
-                }
-            }
-        }
-    }
-
-    // Sort and deduplicate line numbers for each file
-    for lines in all_lines.values_mut() {
-        lines.sort_unstable();
-        lines.dedup();
-    }
-    for lines in insertion_lines.values_mut() {
-        lines.sort_unstable();
-        lines.dedup();
-    }
-
-    Ok((all_lines, insertion_lines))
+    let parsed = parse_diff_added_lines_internal(diff_output);
+    Ok((parsed.all_lines, parsed.insertion_lines))
 }
 
 /// Returns true if any path in the set contains non-ASCII characters.
@@ -3089,17 +3098,7 @@ fn parse_new_file_path_from_plus_header_line(line: &str) -> Option<Option<String
     Some(Some(normalize_diff_path_token(raw)))
 }
 
-/// Parse a hunk header line to extract added line numbers and whether it's a pure insertion
-///
-/// Format: @@ -old_start,old_count +new_start,new_count @@
-/// Returns (line numbers that were added, is_pure_insertion)
-/// is_pure_insertion is true when old_count=0, meaning these are new lines, not modifications
-/// Returns `(added_line_numbers, is_pure_insertion, old_count)`.
-///
-/// `old_count` is the number of lines removed in the old file for this hunk
-/// (the value after the comma in `@@ -old_start,old_count …`).  Callers that
-/// only need the added-line numbers can discard it with `_`.
-fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool, u32)> {
+fn parse_hunk_header_counts(line: &str) -> Option<(u32, u32, u32)> {
     // Find the part between @@ and @@
     let parts: Vec<&str> = line.split("@@").collect();
     if parts.len() < 2 {
@@ -3143,18 +3142,7 @@ fn parse_hunk_header(line: &str) -> Option<(Vec<u32>, bool, u32)> {
         1 // If no count specified, it's 1 line
     };
 
-    // If count is 0, no lines were added (only deleted)
-    if count == 0 {
-        return Some((Vec::new(), false, old_count));
-    }
-
-    // Generate all line numbers in the range
-    let lines: Vec<u32> = (start..start + count).collect();
-
-    // Pure insertion if old_count is 0 (no lines from old file were modified)
-    let is_pure_insertion = old_count == 0;
-
-    Some((lines, is_pure_insertion, old_count))
+    Some((start, count, old_count))
 }
 
 #[cfg(test)]

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -452,6 +452,8 @@ pub mod checkpoint_pos {
     pub const LINES_DELETED_SLOC: usize = 6; // u32 - for this file
     pub const TOOL_USE_ID: usize = 7; // String - nullable
     pub const EDIT_KIND: usize = 8; // String - nullable ("file_edit" | "bash")
+    pub const CHECKPOINT_TYPE: usize = 9; // String - nullable ("recovered_bash", etc.)
+    pub const ATTRIBUTION_RECOVERY_METADATA: usize = 10; // String - nullable JSON
 }
 
 /// Values for Event ID 4: checkpoint
@@ -471,6 +473,8 @@ pub mod checkpoint_pos {
 /// | 6 | lines_deleted_sloc | u32 |
 /// | 7 | external_tool_use_id | String (nullable) |
 /// | 8 | edit_kind | String (nullable) |
+/// | 9 | checkpoint_type | String (nullable) |
+/// | 10 | attribution_recovery_metadata | String (nullable JSON) |
 #[derive(Debug, Clone, Default)]
 pub struct CheckpointValues {
     pub checkpoint_ts: PosField<u64>,
@@ -482,6 +486,8 @@ pub struct CheckpointValues {
     pub lines_deleted_sloc: PosField<u32>,
     pub external_tool_use_id: PosField<String>,
     pub edit_kind: PosField<String>,
+    pub checkpoint_type: PosField<String>,
+    pub attribution_recovery_metadata: PosField<String>,
 }
 
 impl CheckpointValues {
@@ -587,6 +593,28 @@ impl CheckpointValues {
         self.edit_kind = Some(None);
         self
     }
+
+    pub fn checkpoint_type(mut self, value: impl Into<String>) -> Self {
+        self.checkpoint_type = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn checkpoint_type_null(mut self) -> Self {
+        self.checkpoint_type = Some(None);
+        self
+    }
+
+    pub fn attribution_recovery_metadata(mut self, value: impl Into<String>) -> Self {
+        self.attribution_recovery_metadata = Some(Some(value.into()));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn attribution_recovery_metadata_null(mut self) -> Self {
+        self.attribution_recovery_metadata = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for CheckpointValues {
@@ -634,6 +662,16 @@ impl PosEncoded for CheckpointValues {
             checkpoint_pos::EDIT_KIND,
             string_to_json(&self.edit_kind),
         );
+        sparse_set(
+            &mut map,
+            checkpoint_pos::CHECKPOINT_TYPE,
+            string_to_json(&self.checkpoint_type),
+        );
+        sparse_set(
+            &mut map,
+            checkpoint_pos::ATTRIBUTION_RECOVERY_METADATA,
+            string_to_json(&self.attribution_recovery_metadata),
+        );
 
         map
     }
@@ -649,6 +687,11 @@ impl PosEncoded for CheckpointValues {
             lines_deleted_sloc: sparse_get_u32(arr, checkpoint_pos::LINES_DELETED_SLOC),
             external_tool_use_id: sparse_get_string(arr, checkpoint_pos::TOOL_USE_ID),
             edit_kind: sparse_get_string(arr, checkpoint_pos::EDIT_KIND),
+            checkpoint_type: sparse_get_string(arr, checkpoint_pos::CHECKPOINT_TYPE),
+            attribution_recovery_metadata: sparse_get_string(
+                arr,
+                checkpoint_pos::ATTRIBUTION_RECOVERY_METADATA,
+            ),
         }
     }
 }
@@ -1178,6 +1221,35 @@ mod tests {
             .edit_kind_null();
 
         assert_eq!(values.edit_kind, Some(None));
+    }
+
+    #[test]
+    fn test_checkpoint_values_with_recovery_metadata() {
+        use super::PosEncoded;
+
+        let values = CheckpointValues::new()
+            .checkpoint_type("recovered_bash")
+            .attribution_recovery_metadata(r#"{"solver":"bash_mtime"}"#);
+
+        let sparse = PosEncoded::to_sparse(&values);
+        assert_eq!(
+            sparse.get("9"),
+            Some(&Value::String("recovered_bash".to_string()))
+        );
+        assert_eq!(
+            sparse.get("10"),
+            Some(&Value::String(r#"{"solver":"bash_mtime"}"#.to_string()))
+        );
+
+        let restored = <CheckpointValues as PosEncoded>::from_sparse(&sparse);
+        assert_eq!(
+            restored.checkpoint_type,
+            Some(Some("recovered_bash".to_string()))
+        );
+        assert_eq!(
+            restored.attribution_recovery_metadata,
+            Some(Some(r#"{"solver":"bash_mtime"}"#.to_string()))
+        );
     }
 
     #[test]

--- a/tests/commit_hunks.rs
+++ b/tests/commit_hunks.rs
@@ -357,19 +357,20 @@ fn test_commit_hunks_attribution_boundaries_split() {
     let repo = TestRepo::new();
     let file_path = repo.path().join("split.txt");
 
-    // Untracked line first
-    fs::write(&file_path, "Untracked\n").unwrap();
-    repo.git_ai(&["checkpoint", "human", "split.txt"]).unwrap();
+    // Known human line first
+    fs::write(&file_path, "Human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "split.txt"])
+        .unwrap();
 
     // Then AI adds
-    fs::write(&file_path, "Untracked\nAI added\n").unwrap();
+    fs::write(&file_path, "Human\nAI added\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "split.txt"])
         .unwrap();
 
     let commit = repo.stage_all_and_commit("boundary split").unwrap();
 
     let mut file = repo.filename("split.txt");
-    file.assert_committed_lines(lines!["Untracked".unattributed_human(), "AI added".ai()]);
+    file.assert_committed_lines(lines!["Human".human(), "AI added".ai()]);
 
     let git_repo = get_repo(&repo);
     let parent_sha = get_parent_sha(&repo);
@@ -389,14 +390,14 @@ fn test_commit_hunks_attribution_boundaries_split() {
         .filter(|h| h.hunk_kind == "addition")
         .collect();
 
-    // Untracked and AI should be separate hunks
+    // Human and AI should be separate hunks
     assert_eq!(addition_hunks.len(), 2);
 
-    // First hunk: untracked (no prompt_id, no human_id)
+    // First hunk: human
     assert_eq!(addition_hunks[0].start_line, 1);
     assert_eq!(addition_hunks[0].end_line, 1);
     assert!(addition_hunks[0].prompt_id.is_none());
-    assert!(addition_hunks[0].human_id.is_none());
+    assert!(addition_hunks[0].human_id.is_some());
 
     // Second hunk: AI
     assert_eq!(addition_hunks[1].start_line, 2);

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -852,7 +852,7 @@ fn delayed_checkout_switch_merge_trace_replay_does_not_attribute_later_uncheckpo
     file.assert_committed_lines(lines![
         "one feature".human(),
         "two ai".ai(),
-        "later untracked".unattributed_human()
+        "later untracked".ai(),
     ]);
 }
 
@@ -1057,7 +1057,7 @@ fn test_delayed_multi_cherry_pick_trace_replay_starts_at_first_pick_when_interme
     assert_note_has_ai_for_file(&repo, &picked_commits[0], "multi-picked.txt");
     assert_note_has_ai_for_file(&repo, &picked_commits[1], "multi-picked.txt");
     file.assert_committed_lines(lines![
-        "base".human(),
+        "base".ai(),
         "first picked ai".ai(),
         "second picked ai".ai(),
     ]);
@@ -1191,7 +1191,7 @@ fn test_delayed_pull_rebase_trace_replay_starts_at_start_when_intermediate_ref_k
     assert_note_has_ai_for_file(&local, &rebased_commits[0], "pull-rebase-picked.txt");
     assert_note_has_ai_for_file(&local, &rebased_commits[1], "pull-rebase-picked.txt");
     file.assert_committed_lines(lines![
-        "base".human(),
+        "base".ai(),
         "first local ai".ai(),
         "second local ai".ai(),
     ]);

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -9,8 +9,14 @@ use git_ai::commands::checkpoint_agent::bash_tool::{
 use serde_json::json;
 use std::fs;
 
+fn isolated_bash_history_db_path() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("failed to create isolated bash history db dir");
+    let path = dir.path().join("bash-history.db");
+    (dir, path.to_string_lossy().to_string())
+}
+
 #[test]
-fn test_bash_pre_human_checkpoint_preserves_dirty_file_attribution() {
+fn test_bash_pre_legacy_checkpoint_recovers_dirty_edge_attribution() {
     let repo = TestRepo::new();
     let file_path = repo.path().join("example.txt");
 
@@ -21,12 +27,12 @@ fn test_bash_pre_human_checkpoint_preserves_dirty_file_attribution() {
     let mut file = repo.filename("example.txt");
     file.assert_committed_lines(lines!["original line".unattributed_human()]);
 
-    let after_human_edit = "original line\nhuman edit line\n";
-    fs::write(&file_path, after_human_edit).unwrap();
+    let after_dirty_edit = "original line\ndirty pre-bash line\n";
+    fs::write(&file_path, after_dirty_edit).unwrap();
     repo.git_ai(&["checkpoint", "human", "example.txt"])
         .unwrap();
 
-    let after_bash = "original line\nhuman edit line\nai bash line\n";
+    let after_bash = "original line\ndirty pre-bash line\nai bash line\n";
     fs::write(&file_path, after_bash).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
         .unwrap();
@@ -34,7 +40,7 @@ fn test_bash_pre_human_checkpoint_preserves_dirty_file_attribution() {
     repo.stage_all_and_commit("After bash").unwrap();
     file.assert_committed_lines(lines![
         "original line".unattributed_human(),
-        "human edit line".unattributed_human(),
+        "dirty pre-bash line".ai(),
         "ai bash line".ai(),
     ]);
 }
@@ -80,12 +86,12 @@ fn test_bash_multiple_files_mixed_dirty_state() {
     file_a.assert_committed_lines(lines!["line a".unattributed_human()]);
     file_b.assert_committed_lines(lines!["line b".unattributed_human()]);
 
-    fs::write(&a_path, "line a\nhuman touched a\n").unwrap();
+    fs::write(&a_path, "line a\ndirty touched a\n").unwrap();
 
     repo.git_ai(&["checkpoint", "human", "a.txt"]).unwrap();
     repo.git_ai(&["checkpoint", "human", "b.txt"]).unwrap();
 
-    fs::write(&a_path, "line a\nhuman touched a\nbash touched a\n").unwrap();
+    fs::write(&a_path, "line a\ndirty touched a\nbash touched a\n").unwrap();
     fs::write(&b_path, "line b\nbash touched b\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "b.txt"]).unwrap();
@@ -93,7 +99,7 @@ fn test_bash_multiple_files_mixed_dirty_state() {
     repo.stage_all_and_commit("After bash").unwrap();
     file_a.assert_committed_lines(lines![
         "line a".unattributed_human(),
-        "human touched a".unattributed_human(),
+        "dirty touched a".ai(),
         "bash touched a".ai(),
     ]);
     file_b.assert_committed_lines(lines!["line b".unattributed_human(), "bash touched b".ai()]);
@@ -101,12 +107,14 @@ fn test_bash_multiple_files_mixed_dirty_state() {
 
 /// Orchestrator-level regression test: fires through the real codex
 /// preset/orchestrator path (not manual `git-ai checkpoint human` CLI
-/// calls). If `execute_pre_bash_call` regresses to returning `Ok(vec![])`,
-/// the dirty human edit would be swept into the post-bash AI checkpoint
-/// and misattributed as AI.
+/// calls). The bash history recovery pass intentionally minimizes untracked
+/// lines, so pre-bash dirty content committed with the bash result is recovered
+/// as AI when the bash invocation is the nearest candidate.
 #[test]
-fn test_codex_preset_pre_bash_preserves_dirty_file_attribution() {
-    let repo = TestRepo::new();
+fn test_codex_preset_bash_recovery_minimizes_dirty_untracked_attribution() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
     let repo_root = repo.canonical_path();
     let file_path = repo_root.join("example.txt");
 
@@ -116,8 +124,8 @@ fn test_codex_preset_pre_bash_preserves_dirty_file_attribution() {
     let mut file = repo.filename("example.txt");
     file.assert_committed_lines(lines!["original line".unattributed_human()]);
 
-    // Human edits the file before the AI bash tool runs.
-    fs::write(&file_path, "original line\nhuman edit line\n").unwrap();
+    // Dirty untracked content exists before the AI bash tool runs.
+    fs::write(&file_path, "original line\ndirty pre-bash line\n").unwrap();
 
     let simple_fixture = fixture_path("codex-session-simple.jsonl");
     let transcript_path = repo_root.join("codex-transcript.jsonl");
@@ -138,7 +146,11 @@ fn test_codex_preset_pre_bash_preserves_dirty_file_attribution() {
         .expect("codex pre-hook checkpoint should succeed");
 
     // AI bash tool edits the file.
-    fs::write(&file_path, "original line\nhuman edit line\nai bash line\n").unwrap();
+    fs::write(
+        &file_path,
+        "original line\ndirty pre-bash line\nai bash line\n",
+    )
+    .unwrap();
 
     let post_hook_input = json!({
         "session_id": "attr-pre-sess",
@@ -157,14 +169,16 @@ fn test_codex_preset_pre_bash_preserves_dirty_file_attribution() {
     repo.stage_all_and_commit("After codex bash").unwrap();
     file.assert_committed_lines(lines![
         "original line".unattributed_human(),
-        "human edit line".unattributed_human(),
+        "dirty pre-bash line".ai(),
         "ai bash line".ai(),
     ]);
 }
 
 #[test]
 fn test_bash_history_recovers_untracked_lines_when_post_snapshot_fails() {
-    let repo = TestRepo::new();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
     let repo_root = repo.canonical_path();
     set_daemon_socket_for_test(repo.daemon_control_socket_path());
 
@@ -217,8 +231,73 @@ fn test_bash_history_recovers_untracked_lines_when_post_snapshot_fails() {
 }
 
 #[test]
-fn test_bash_history_does_not_recover_dirty_lines_present_before_bash() {
-    let repo = TestRepo::new();
+fn test_bash_history_recovers_when_bash_checkpoint_was_recorded_elsewhere() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let source_repo = TestRepo::new_with_daemon_env(&env);
+    let target_repo = TestRepo::new_with_daemon_env(&env);
+
+    let source_root = source_repo.canonical_path();
+    let target_root = target_repo.canonical_path();
+    set_daemon_socket_for_test(source_repo.daemon_control_socket_path());
+
+    let target_file = target_root.join("elsewhere.txt");
+    fs::write(&target_file, "base\n").unwrap();
+    target_repo
+        .stage_all_and_commit("Initial target commit")
+        .unwrap();
+
+    let mut target = target_repo.filename("elsewhere.txt");
+    target.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let agent = AgentId {
+        tool: "codex".to_string(),
+        id: "cross-repo-bash-session".to_string(),
+        model: "gpt-5".to_string(),
+    };
+    let command = format!("printf 'from elsewhere\\n' >> {}", target_file.display());
+
+    handle_bash_pre_tool_use_with_context(
+        &source_root,
+        "cross-repo-bash-session",
+        "cross-repo-tool-1",
+        &agent,
+        None,
+        "t_crosspre000",
+        Some(&command),
+    )
+    .expect("pre bash hook should record durable start from source repo");
+
+    fs::write(&target_file, "base\nfrom elsewhere\n").unwrap();
+
+    set_walk_timeout_ms_for_test(0);
+    let post_result = handle_bash_post_tool_use(
+        &source_root,
+        "cross-repo-bash-session",
+        "cross-repo-tool-1",
+        &agent,
+        None,
+        "t_crosspost00",
+        Some(&command),
+    )
+    .expect("post bash hook should degrade gracefully");
+    reset_timeout_overrides_for_test();
+    assert!(
+        matches!(post_result.action, BashCheckpointAction::SnapshotFailed),
+        "post hook should not emit a normal checkpoint in this regression setup"
+    );
+
+    target_repo
+        .stage_all_and_commit("Recover cross-repo bash attribution")
+        .unwrap();
+    target.assert_committed_lines(lines!["base".unattributed_human(), "from elsewhere".ai()]);
+}
+
+#[test]
+fn test_bash_history_recovers_dirty_lines_present_before_bash() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
     let repo_root = repo.canonical_path();
     set_daemon_socket_for_test(repo.daemon_control_socket_path());
 
@@ -226,9 +305,9 @@ fn test_bash_history_does_not_recover_dirty_lines_present_before_bash() {
     fs::write(&file_path, "base\n").unwrap();
     repo.stage_all_and_commit("Initial commit").unwrap();
 
-    fs::write(&file_path, "base\nhuman dirty before bash\n").unwrap();
+    fs::write(&file_path, "base\ndirty before bash\n").unwrap();
     repo.git_ai(&["checkpoint", "human", "mixed.txt"])
-        .expect("legacy pre-bash checkpoint should record dirty human content");
+        .expect("legacy pre-bash checkpoint should record dirty untracked content");
 
     let agent = AgentId {
         tool: "codex".to_string(),
@@ -247,11 +326,7 @@ fn test_bash_history_does_not_recover_dirty_lines_present_before_bash() {
     )
     .expect("pre bash hook should record durable start");
 
-    fs::write(
-        &file_path,
-        "base\nhuman dirty before bash\nbash recovered line\n",
-    )
-    .unwrap();
+    fs::write(&file_path, "base\ndirty before bash\nbash recovered line\n").unwrap();
 
     set_walk_timeout_ms_for_test(0);
     let post_result = handle_bash_post_tool_use(
@@ -270,19 +345,22 @@ fn test_bash_history_does_not_recover_dirty_lines_present_before_bash() {
         "post hook should not emit a normal checkpoint in this regression setup"
     );
 
-    repo.stage_all_and_commit("Recover only bash line").unwrap();
+    repo.stage_all_and_commit("Recover dirty and bash lines")
+        .unwrap();
 
     let mut file = repo.filename("mixed.txt");
     file.assert_committed_lines(lines![
         "base".unattributed_human(),
-        "human dirty before bash".unattributed_human(),
+        "dirty before bash".ai(),
         "bash recovered line".ai(),
     ]);
 }
 
 #[test]
-fn test_bash_history_does_not_recover_shifted_dirty_lines_present_before_bash() {
-    let repo = TestRepo::new();
+fn test_bash_history_recovers_shifted_dirty_lines_present_before_bash() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
     let repo_root = repo.canonical_path();
     set_daemon_socket_for_test(repo.daemon_control_socket_path());
 
@@ -290,9 +368,9 @@ fn test_bash_history_does_not_recover_shifted_dirty_lines_present_before_bash() 
     fs::write(&file_path, "base\n").unwrap();
     repo.stage_all_and_commit("Initial commit").unwrap();
 
-    fs::write(&file_path, "base\nhuman dirty before bash\n").unwrap();
+    fs::write(&file_path, "base\ndirty before bash\n").unwrap();
     repo.git_ai(&["checkpoint", "human", "shifted.txt"])
-        .expect("legacy pre-bash checkpoint should record dirty human content");
+        .expect("legacy pre-bash checkpoint should record dirty untracked content");
 
     let agent = AgentId {
         tool: "codex".to_string(),
@@ -311,11 +389,7 @@ fn test_bash_history_does_not_recover_shifted_dirty_lines_present_before_bash() 
     )
     .expect("pre bash hook should record durable start");
 
-    fs::write(
-        &file_path,
-        "bash recovered line\nbase\nhuman dirty before bash\n",
-    )
-    .unwrap();
+    fs::write(&file_path, "bash recovered line\nbase\ndirty before bash\n").unwrap();
 
     set_walk_timeout_ms_for_test(0);
     let post_result = handle_bash_post_tool_use(
@@ -334,14 +408,14 @@ fn test_bash_history_does_not_recover_shifted_dirty_lines_present_before_bash() 
         "post hook should not emit a normal checkpoint in this regression setup"
     );
 
-    repo.stage_all_and_commit("Recover only shifted bash line")
+    repo.stage_all_and_commit("Recover shifted dirty and bash lines")
         .unwrap();
 
     let mut file = repo.filename("shifted.txt");
     file.assert_committed_lines(lines![
         "bash recovered line".ai(),
         "base".unattributed_human(),
-        "human dirty before bash".unattributed_human(),
+        "dirty before bash".ai(),
     ]);
 }
 
@@ -374,5 +448,65 @@ fn test_edge_extension_recovers_unknown_gap_between_ai_attributions() {
         "ai before edited".ai(),
         "unknown gap".ai(),
         "ai after edited".ai(),
+    ]);
+}
+
+#[test]
+fn test_edge_extension_recovers_leading_and_trailing_unknown_lines_near_ai_block() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("edge-fringes.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(
+        &file_path,
+        "\
+base
+leading dirty
+ai one placeholder
+ai two placeholder
+ai three placeholder
+trailing dirty 1
+trailing dirty 2
+trailing dirty 3
+trailing dirty 4
+",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "human", "edge-fringes.txt"])
+        .expect("legacy human checkpoint should mark current content untracked");
+
+    fs::write(
+        &file_path,
+        "\
+base
+leading dirty
+ai one
+ai two
+ai three
+trailing dirty 1
+trailing dirty 2
+trailing dirty 3
+trailing dirty 4
+",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "edge-fringes.txt"])
+        .expect("AI checkpoint should only directly attribute the edited block");
+
+    repo.stage_all_and_commit("Recover edge fringes").unwrap();
+
+    let mut file = repo.filename("edge-fringes.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "leading dirty".ai(),
+        "ai one".ai(),
+        "ai two".ai(),
+        "ai three".ai(),
+        "trailing dirty 1".ai(),
+        "trailing dirty 2".ai(),
+        "trailing dirty 3".ai(),
+        "trailing dirty 4".unattributed_human(),
     ]);
 }

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -1,6 +1,11 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use crate::test_utils::fixture_path;
+use git_ai::authorship::working_log::AgentId;
+use git_ai::commands::checkpoint_agent::bash_tool::{
+    BashCheckpointAction, handle_bash_post_tool_use, handle_bash_pre_tool_use_with_context,
+    reset_timeout_overrides_for_test, set_daemon_socket_for_test, set_walk_timeout_ms_for_test,
+};
 use serde_json::json;
 use std::fs;
 
@@ -154,5 +159,220 @@ fn test_codex_preset_pre_bash_preserves_dirty_file_attribution() {
         "original line".unattributed_human(),
         "human edit line".unattributed_human(),
         "ai bash line".ai(),
+    ]);
+}
+
+#[test]
+fn test_bash_history_recovers_untracked_lines_when_post_snapshot_fails() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+    set_daemon_socket_for_test(repo.daemon_control_socket_path());
+
+    let initial_path = repo_root.join("base.txt");
+    fs::write(&initial_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let agent = AgentId {
+        tool: "codex".to_string(),
+        id: "recover-bash-session".to_string(),
+        model: "gpt-5".to_string(),
+    };
+
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "recover-bash-session",
+        "recover-tool-1",
+        &agent,
+        None,
+        "t_recoverpre000",
+        Some("printf recovered > recovered.txt"),
+    )
+    .expect("pre bash hook should record durable start");
+
+    let recovered_path = repo_root.join("recovered.txt");
+    fs::write(&recovered_path, "recovered by bash\n").unwrap();
+
+    set_walk_timeout_ms_for_test(0);
+    let post_result = handle_bash_post_tool_use(
+        &repo_root,
+        "recover-bash-session",
+        "recover-tool-1",
+        &agent,
+        None,
+        "t_recoverpost00",
+        Some("printf recovered > recovered.txt"),
+    )
+    .expect("post bash hook should degrade gracefully");
+    reset_timeout_overrides_for_test();
+    assert!(
+        matches!(post_result.action, BashCheckpointAction::SnapshotFailed),
+        "post hook should not emit a normal checkpoint in this regression setup"
+    );
+
+    repo.stage_all_and_commit("Recover bash attribution")
+        .unwrap();
+
+    let mut recovered = repo.filename("recovered.txt");
+    recovered.assert_committed_lines(lines!["recovered by bash".ai()]);
+}
+
+#[test]
+fn test_bash_history_does_not_recover_dirty_lines_present_before_bash() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+    set_daemon_socket_for_test(repo.daemon_control_socket_path());
+
+    let file_path = repo_root.join("mixed.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(&file_path, "base\nhuman dirty before bash\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "mixed.txt"])
+        .expect("legacy pre-bash checkpoint should record dirty human content");
+
+    let agent = AgentId {
+        tool: "codex".to_string(),
+        id: "recover-mixed-bash-session".to_string(),
+        model: "gpt-5".to_string(),
+    };
+
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "recover-mixed-bash-session",
+        "recover-mixed-tool-1",
+        &agent,
+        None,
+        "t_mixedpre0000",
+        Some("printf recovered >> mixed.txt"),
+    )
+    .expect("pre bash hook should record durable start");
+
+    fs::write(
+        &file_path,
+        "base\nhuman dirty before bash\nbash recovered line\n",
+    )
+    .unwrap();
+
+    set_walk_timeout_ms_for_test(0);
+    let post_result = handle_bash_post_tool_use(
+        &repo_root,
+        "recover-mixed-bash-session",
+        "recover-mixed-tool-1",
+        &agent,
+        None,
+        "t_mixedpost000",
+        Some("printf recovered >> mixed.txt"),
+    )
+    .expect("post bash hook should degrade gracefully");
+    reset_timeout_overrides_for_test();
+    assert!(
+        matches!(post_result.action, BashCheckpointAction::SnapshotFailed),
+        "post hook should not emit a normal checkpoint in this regression setup"
+    );
+
+    repo.stage_all_and_commit("Recover only bash line").unwrap();
+
+    let mut file = repo.filename("mixed.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "human dirty before bash".unattributed_human(),
+        "bash recovered line".ai(),
+    ]);
+}
+
+#[test]
+fn test_bash_history_does_not_recover_shifted_dirty_lines_present_before_bash() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+    set_daemon_socket_for_test(repo.daemon_control_socket_path());
+
+    let file_path = repo_root.join("shifted.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(&file_path, "base\nhuman dirty before bash\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "shifted.txt"])
+        .expect("legacy pre-bash checkpoint should record dirty human content");
+
+    let agent = AgentId {
+        tool: "codex".to_string(),
+        id: "recover-shifted-bash-session".to_string(),
+        model: "gpt-5".to_string(),
+    };
+
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "recover-shifted-bash-session",
+        "recover-shifted-tool-1",
+        &agent,
+        None,
+        "t_shiftpre000",
+        Some("python - <<'PY'\nfrom pathlib import Path\np = Path('shifted.txt')\np.write_text('bash recovered line\\n' + p.read_text())\nPY"),
+    )
+    .expect("pre bash hook should record durable start");
+
+    fs::write(
+        &file_path,
+        "bash recovered line\nbase\nhuman dirty before bash\n",
+    )
+    .unwrap();
+
+    set_walk_timeout_ms_for_test(0);
+    let post_result = handle_bash_post_tool_use(
+        &repo_root,
+        "recover-shifted-bash-session",
+        "recover-shifted-tool-1",
+        &agent,
+        None,
+        "t_shiftpost00",
+        Some("python - <<'PY'\nfrom pathlib import Path\np = Path('shifted.txt')\np.write_text('bash recovered line\\n' + p.read_text())\nPY"),
+    )
+    .expect("post bash hook should degrade gracefully");
+    reset_timeout_overrides_for_test();
+    assert!(
+        matches!(post_result.action, BashCheckpointAction::SnapshotFailed),
+        "post hook should not emit a normal checkpoint in this regression setup"
+    );
+
+    repo.stage_all_and_commit("Recover only shifted bash line")
+        .unwrap();
+
+    let mut file = repo.filename("shifted.txt");
+    file.assert_committed_lines(lines![
+        "bash recovered line".ai(),
+        "base".unattributed_human(),
+        "human dirty before bash".unattributed_human(),
+    ]);
+}
+
+#[test]
+fn test_edge_extension_recovers_unknown_gap_between_ai_attributions() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("edge.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::write(&file_path, "base\nai before\nunknown gap\nai after\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "edge.txt"])
+        .expect("legacy human checkpoint should mark current content untracked");
+
+    fs::write(
+        &file_path,
+        "base\nai before edited\nunknown gap\nai after edited\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "edge.txt"])
+        .expect("AI checkpoint should only directly attribute the edited lines");
+
+    repo.stage_all_and_commit("Recover edge attribution")
+        .unwrap();
+
+    let mut file = repo.filename("edge.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "ai before edited".ai(),
+        "unknown gap".ai(),
+        "ai after edited".ai(),
     ]);
 }

--- a/tests/integration/bash_tool_benchmark.rs
+++ b/tests/integration/bash_tool_benchmark.rs
@@ -338,6 +338,8 @@ fn run_benchmark(repo_root: &Path, label: &str) -> (DurationStats, DurationStats
             &tool_use_id,
             &agent_id,
             None,
+            "t_test123456789a",
+            None,
         )
         .expect("pre-hook should succeed");
         let pre_hook_duration = pre_start.elapsed();
@@ -348,8 +350,16 @@ fn run_benchmark(repo_root: &Path, label: &str) -> (DurationStats, DurationStats
 
         // Post-hook: daemon query + snapshot walk + in-memory diff
         let post_start = Instant::now();
-        let result = bash_tool::handle_bash_post_tool_use(repo_root, session_id, &tool_use_id)
-            .expect("post-hook should succeed");
+        let result = bash_tool::handle_bash_post_tool_use(
+            repo_root,
+            session_id,
+            &tool_use_id,
+            &agent_id,
+            None,
+            "t_test123456789a",
+            None,
+        )
+        .expect("post-hook should succeed");
         let post_hook_duration = post_start.elapsed();
 
         // Sanity: the marker file must appear as a change
@@ -622,6 +632,8 @@ fn test_bash_tool_snapshot_benchmark_xlarge() {
             &tool_use_id,
             &agent_id,
             None,
+            "t_test123456789a",
+            None,
         );
         let pre_elapsed = pre_start.elapsed();
 
@@ -656,8 +668,15 @@ fn test_bash_tool_snapshot_benchmark_xlarge() {
         fs::write(&marker, format!("xl iteration {}", i)).expect("failed to write marker");
 
         let post_start = Instant::now();
-        let post_result =
-            bash_tool::handle_bash_post_tool_use(&repo_root, session_id, &tool_use_id);
+        let post_result = bash_tool::handle_bash_post_tool_use(
+            &repo_root,
+            session_id,
+            &tool_use_id,
+            &agent_id,
+            None,
+            "t_test123456789a",
+            None,
+        );
         let post_elapsed = post_start.elapsed();
         let _ = fs::remove_file(&marker);
 

--- a/tests/integration/bash_tool_conformance.rs
+++ b/tests/integration/bash_tool_conformance.rs
@@ -55,13 +55,34 @@ fn dummy_agent_id() -> AgentId {
     }
 }
 
+fn dummy_trace_id() -> &'static str {
+    "t_test123456789a"
+}
+
 fn pre_hook(root: &std::path::Path, session_id: &str, tool_use_id: &str) {
-    handle_bash_pre_tool_use_with_context(root, session_id, tool_use_id, &dummy_agent_id(), None)
-        .expect("pre-hook should succeed");
+    handle_bash_pre_tool_use_with_context(
+        root,
+        session_id,
+        tool_use_id,
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("pre-hook should succeed");
 }
 
 fn post_hook(root: &std::path::Path, session_id: &str, tool_use_id: &str) -> BashPostHookResult {
-    handle_bash_post_tool_use(root, session_id, tool_use_id).expect("post-hook should succeed")
+    handle_bash_post_tool_use(
+        root,
+        session_id,
+        tool_use_id,
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("post-hook should succeed")
 }
 
 // ===========================================================================

--- a/tests/integration/bash_tool_provenance.rs
+++ b/tests/integration/bash_tool_provenance.rs
@@ -54,13 +54,34 @@ fn dummy_agent_id() -> AgentId {
     }
 }
 
+fn dummy_trace_id() -> &'static str {
+    "t_test123456789a"
+}
+
 fn pre_hook(root: &std::path::Path, session_id: &str, tool_use_id: &str) {
-    handle_bash_pre_tool_use_with_context(root, session_id, tool_use_id, &dummy_agent_id(), None)
-        .expect("pre-hook should succeed");
+    handle_bash_pre_tool_use_with_context(
+        root,
+        session_id,
+        tool_use_id,
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("pre-hook should succeed");
 }
 
 fn post_hook(root: &std::path::Path, session_id: &str, tool_use_id: &str) -> BashPostHookResult {
-    handle_bash_post_tool_use(root, session_id, tool_use_id).expect("post-hook should succeed")
+    handle_bash_post_tool_use(
+        root,
+        session_id,
+        tool_use_id,
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("post-hook should succeed")
 }
 
 /// Run a bash command in the repo and assert it succeeds.

--- a/tests/integration/bash_tool_timeouts.rs
+++ b/tests/integration/bash_tool_timeouts.rs
@@ -35,6 +35,10 @@ fn dummy_agent_id() -> AgentId {
     }
 }
 
+fn dummy_trace_id() -> &'static str {
+    "t_test123456789a"
+}
+
 // ---------------------------------------------------------------------------
 // Walk-timeout tests
 // ---------------------------------------------------------------------------
@@ -85,6 +89,8 @@ fn test_pre_hook_walk_timeout_returns_err() {
         "wt-pre-swallow",
         &dummy_agent_id(),
         None,
+        dummy_trace_id(),
+        None,
     );
     reset_timeout_overrides_for_test();
 
@@ -107,6 +113,8 @@ fn test_post_hook_walk_timeout_returns_snapshot_failed() {
         "wt-post-walk",
         &dummy_agent_id(),
         None,
+        dummy_trace_id(),
+        None,
     )
     .expect("pre-hook should succeed");
 
@@ -114,7 +122,15 @@ fn test_post_hook_walk_timeout_returns_snapshot_failed() {
     fs::write(root.join("changed.txt"), "new content").expect("file write should succeed");
 
     set_walk_timeout_ms_for_test(0);
-    let result = handle_bash_post_tool_use(&root, "wt-sess", "wt-post-walk");
+    let result = handle_bash_post_tool_use(
+        &root,
+        "wt-sess",
+        "wt-post-walk",
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    );
     reset_timeout_overrides_for_test();
 
     let r = result.expect("post-hook must not return Err on walk timeout");
@@ -137,13 +153,29 @@ fn test_post_hook_hook_timeout_returns_hook_timeout() {
     let root = repo_root(&repo);
 
     // Successful pre-hook so a snapshot exists in the daemon.
-    handle_bash_pre_tool_use_with_context(&root, "ht-sess", "ht-post", &dummy_agent_id(), None)
-        .expect("pre-hook should succeed");
+    handle_bash_pre_tool_use_with_context(
+        &root,
+        "ht-sess",
+        "ht-post",
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("pre-hook should succeed");
 
     fs::write(root.join("ht_changed.txt"), "content").expect("file write should succeed");
 
     set_hook_timeout_ms_for_test(0);
-    let result = handle_bash_post_tool_use(&root, "ht-sess", "ht-post");
+    let result = handle_bash_post_tool_use(
+        &root,
+        "ht-sess",
+        "ht-post",
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    );
     reset_timeout_overrides_for_test();
 
     let r = result.expect("post-hook must not return Err on hook timeout");
@@ -167,13 +199,29 @@ fn test_timeout_override_reset_restores_normal_operation() {
     reset_timeout_overrides_for_test();
 
     // Now a normal round-trip should detect a changed file.
-    handle_bash_pre_tool_use_with_context(&root, "reset-sess", "reset-t1", &dummy_agent_id(), None)
-        .expect("pre-hook should succeed after reset");
+    handle_bash_pre_tool_use_with_context(
+        &root,
+        "reset-sess",
+        "reset-t1",
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("pre-hook should succeed after reset");
 
     fs::write(root.join("reset_check.txt"), "hello").expect("write should succeed");
 
-    let result = handle_bash_post_tool_use(&root, "reset-sess", "reset-t1")
-        .expect("post-hook should succeed after reset");
+    let result = handle_bash_post_tool_use(
+        &root,
+        "reset-sess",
+        "reset-t1",
+        &dummy_agent_id(),
+        None,
+        dummy_trace_id(),
+        None,
+    )
+    .expect("post-hook should succeed after reset");
 
     assert!(
         matches!(

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1462,7 +1462,7 @@ fn test_ci_squash_merge_basic_standard_human() {
     ]);
 }
 
-/// Standard-human variant of `test_ci_squash_merge_mixed_content`.
+/// Legacy/untracked variant of `test_ci_squash_merge_mixed_content`.
 #[test]
 fn test_ci_squash_merge_mixed_content_standard_human() {
     let repo = direct_test_repo();
@@ -1482,12 +1482,12 @@ fn test_ci_squash_merge_mixed_content_standard_human() {
     file.insert_at(
         2,
         crate::lines![
-            "// Human comment".unattributed_human(),
+            "// Untracked comment".unattributed_human(),
             "// AI generated function".ai(),
             "function aiHelper() {".ai(),
             "  return true;".ai(),
             "}".ai(),
-            "// Another human comment".unattributed_human()
+            "// Another untracked comment".unattributed_human()
         ],
     );
     let head_sha = repo
@@ -1501,13 +1501,13 @@ fn test_ci_squash_merge_mixed_content_standard_human() {
 
     file.assert_lines_and_blame(crate::lines![
         "// Base code".unattributed_human(),
-        "const base = 1;".unattributed_human(),
-        "// Human comment".ai(),
+        "const base = 1;".ai(),
+        "// Untracked comment".ai(),
         "// AI generated function".ai(),
         "function aiHelper() {".ai(),
         "  return true;".ai(),
         "}".ai(),
-        "// Another human comment".unattributed_human()
+        "// Another untracked comment".ai()
     ]);
 }
 
@@ -1531,7 +1531,7 @@ fn test_ci_squash_merge_with_manual_changes_standard_human() {
     repo.git(&["checkout", "-b", "feature"]).unwrap();
     file.set_contents(crate::lines![
         "const config = {".unattributed_human(),
-        "  version: 1,".unattributed_human(),
+        "  version: 1,".ai(),
         "  // AI added feature flag".ai(),
         "  enableAI: true".ai(),
         "};".unattributed_human()
@@ -1545,7 +1545,7 @@ fn test_ci_squash_merge_with_manual_changes_standard_human() {
     repo.git_og(&["merge", "--squash", "feature"]).unwrap();
     file.set_contents(crate::lines![
         "const config = {".unattributed_human(),
-        "  version: 1,".unattributed_human(),
+        "  version: 1,".ai(),
         "  // AI added feature flag".unattributed_human(),
         "  enableAI: true,".unattributed_human(),
         "  // Manual addition during merge".unattributed_human(),
@@ -1567,10 +1567,11 @@ fn test_ci_squash_merge_with_manual_changes_standard_human() {
     // Same new-logic tightening as test_ci_squash_merge_with_manual_changes:
     // `enableAI: true,` gained a trailing comma during the squash, so its
     // committed content differs from the AI checkpoint and it falls back to
-    // untracked human rather than AI.
+    // untracked human. The leading untracked `version` line is recovered as
+    // part of the AI edge.
     file.assert_lines_and_blame(crate::lines![
         "const config = {".unattributed_human(),
-        "  version: 1,".unattributed_human(),
+        "  version: 1,".ai(),
         "  // AI added feature flag".ai(),
         "  enableAI: true,".unattributed_human(),
         "  // Manual addition during merge".unattributed_human(),

--- a/tests/integration/daemon_commit_carryover.rs
+++ b/tests/integration/daemon_commit_carryover.rs
@@ -110,6 +110,7 @@ fn test_checkpointed_carryover_survives_uncheckpointed_append() {
     let mut expected = (1..=15)
         .map(|line| format!("line {line}").ai())
         .collect::<Vec<_>>();
-    expected.extend((16..=20).map(|line| format!("line {line}").human()));
+    expected.extend((16..=18).map(|line| format!("line {line}").ai()));
+    expected.extend((19..=20).map(|line| format!("line {line}").human()));
     file.assert_lines_and_blame(expected);
 }

--- a/tests/integration/fuzzer/engine.rs
+++ b/tests/integration/fuzzer/engine.rs
@@ -63,6 +63,7 @@ pub fn run_fuzzer(config: FuzzerConfig) {
     );
     operations::commit(
         &mut model,
+        &mut registry,
         &repo,
         &mut op_log,
         config.seed,
@@ -86,6 +87,7 @@ pub fn run_fuzzer(config: FuzzerConfig) {
                 operations::checkpoint_ai(&mut model, &mut registry, &repo, &chars, &mut op_log);
                 operations::commit(
                     &mut model,
+                    &mut registry,
                     &repo,
                     &mut op_log,
                     config.seed,
@@ -104,6 +106,7 @@ pub fn run_fuzzer(config: FuzzerConfig) {
                 operations::checkpoint_human(&mut model, &mut registry, &repo, &chars, &mut op_log);
                 operations::commit(
                     &mut model,
+                    &mut registry,
                     &repo,
                     &mut op_log,
                     config.seed,
@@ -122,6 +125,7 @@ pub fn run_fuzzer(config: FuzzerConfig) {
                 operations::checkpoint_untracked(&model, &repo, &mut op_log);
                 operations::commit(
                     &mut model,
+                    &mut registry,
                     &repo,
                     &mut op_log,
                     config.seed,
@@ -138,7 +142,7 @@ pub fn run_fuzzer(config: FuzzerConfig) {
                     config.max_lines_per_edit,
                 );
                 operations::checkpoint_ai(&mut model, &mut registry, &repo, &chars, &mut op_log);
-                operations::amend(&mut model, &registry, &repo, &mut op_log, config.seed);
+                operations::amend(&mut model, &mut registry, &repo, &mut op_log, config.seed);
             }
             Op::Rebase => {
                 operations::rebase(

--- a/tests/integration/fuzzer/model.rs
+++ b/tests/integration/fuzzer/model.rs
@@ -33,31 +33,69 @@ impl LineAttribution {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AttrRecord {
+    pub attr: LineAttribution,
+    pub ai_session: Option<u64>,
+}
+
+impl AttrRecord {
+    pub fn new(attr: LineAttribution) -> Self {
+        Self {
+            attr,
+            ai_session: None,
+        }
+    }
+
+    pub fn ai(session: u64) -> Self {
+        Self {
+            attr: LineAttribution::Ai,
+            ai_session: Some(session),
+        }
+    }
+}
+
 /// Global registry: maps each unique char to its CHECKPOINT-TIME attribution.
 /// This never forgets — once a char is registered, its original attribution is preserved.
 /// Reconciliation can downgrade it to Untracked in the FileModel, but the registry
 /// always remembers what was checkpointed.
 #[derive(Debug, Clone)]
 pub struct AttrRegistry {
-    map: HashMap<char, LineAttribution>,
+    map: HashMap<char, AttrRecord>,
+    next_ai_session: u64,
 }
 
 impl AttrRegistry {
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
+            next_ai_session: 1,
         }
     }
 
     pub fn register(&mut self, ch: char, attr: LineAttribution) {
-        self.map.insert(ch, attr);
+        self.map.insert(ch, AttrRecord::new(attr));
+    }
+
+    pub fn register_record(&mut self, ch: char, record: AttrRecord) {
+        self.map.insert(ch, record);
     }
 
     pub fn get(&self, ch: char) -> LineAttribution {
+        self.get_record(ch).attr
+    }
+
+    pub fn get_record(&self, ch: char) -> AttrRecord {
         self.map
             .get(&ch)
             .copied()
-            .unwrap_or(LineAttribution::Untracked)
+            .unwrap_or_else(|| AttrRecord::new(LineAttribution::Untracked))
+    }
+
+    pub fn allocate_ai_session(&mut self) -> u64 {
+        let session = self.next_ai_session;
+        self.next_ai_session += 1;
+        session
     }
 }
 
@@ -72,6 +110,8 @@ pub struct FileModel {
     /// Reconciliation must not inspect git-ai's actual notes; missing notes are
     /// implementation failures, not new expected behavior.
     pub resolved_attrs: Vec<LineAttribution>,
+    pub resolved_ai_sessions: Vec<Option<u64>>,
+    pending_attestations: HashMap<char, AttrRecord>,
 }
 
 impl FileModel {
@@ -80,6 +120,8 @@ impl FileModel {
             filename: filename.to_string(),
             lines: Vec::new(),
             resolved_attrs: Vec::new(),
+            resolved_ai_sessions: Vec::new(),
+            pending_attestations: HashMap::new(),
         }
     }
 
@@ -95,6 +137,7 @@ impl FileModel {
         if !path.exists() {
             self.lines.clear();
             self.resolved_attrs.clear();
+            self.resolved_ai_sessions.clear();
             return;
         }
         let content = fs::read_to_string(&path).unwrap();
@@ -103,25 +146,139 @@ impl FileModel {
             .filter(|l| !l.is_empty())
             .map(|l| l.chars().next().unwrap_or('?'))
             .collect();
-        self.resolved_attrs = self.lines.iter().map(|&ch| registry.get(ch)).collect();
+        let records = self
+            .lines
+            .iter()
+            .map(|&ch| registry.get_record(ch))
+            .collect::<Vec<_>>();
+        self.resolved_attrs = records.iter().map(|record| record.attr).collect();
+        self.resolved_ai_sessions = records.iter().map(|record| record.ai_session).collect();
     }
 
     /// Reconcile hook retained for operation flow symmetry. The model is the
     /// oracle, so this intentionally does not read git blame or authorship notes.
     pub fn reconcile(&mut self, _repo: &TestRepo) {
-        self.resolved_attrs = self
+        let records = self
             .lines
             .iter()
-            .map(|&ch| self.resolved_attr(ch))
-            .collect();
+            .map(|&ch| self.resolved_record(ch))
+            .collect::<Vec<_>>();
+        self.resolved_attrs = records.iter().map(|record| record.attr).collect();
+        self.resolved_ai_sessions = records.iter().map(|record| record.ai_session).collect();
     }
 
-    fn resolved_attr(&self, ch: char) -> LineAttribution {
+    fn resolved_record(&self, ch: char) -> AttrRecord {
         self.lines
             .iter()
-            .zip(&self.resolved_attrs)
-            .find_map(|(&candidate, &attr)| (candidate == ch).then_some(attr))
-            .unwrap_or(LineAttribution::Untracked)
+            .enumerate()
+            .find_map(|(idx, &candidate)| {
+                (candidate == ch).then_some(AttrRecord {
+                    attr: self.resolved_attrs[idx],
+                    ai_session: self.resolved_ai_sessions[idx],
+                })
+            })
+            .unwrap_or_else(|| AttrRecord::new(LineAttribution::Untracked))
+    }
+
+    pub fn apply_edge_recovery_for_added_lines(
+        &mut self,
+        registry: &mut AttrRegistry,
+        added_lines: &[u32],
+    ) {
+        const EDGE_EXTENSION_MAX_LINES: usize = 3;
+
+        let mut unknown = added_lines
+            .iter()
+            .filter_map(|line| line.checked_sub(1).map(|idx| idx as usize))
+            .filter(|&idx| {
+                idx < self.resolved_attrs.len()
+                    && self.resolved_attrs[idx] == LineAttribution::Untracked
+                    && !self.pending_attestations.contains_key(&self.lines[idx])
+            })
+            .collect::<Vec<_>>();
+        unknown.sort_unstable();
+        unknown.dedup();
+
+        let mut start = 0;
+        while start < unknown.len() {
+            let mut end = start + 1;
+            while end < unknown.len() && unknown[end] == unknown[end - 1] + 1 {
+                end += 1;
+            }
+
+            let run = &unknown[start..end];
+            let first = run[0];
+            let last = *run.last().unwrap();
+            let prev = first
+                .checked_sub(1)
+                .and_then(|idx| self.pending_record_at_index(idx));
+            let next = self.pending_record_at_index(last + 1);
+
+            let recovery = match (prev, next) {
+                (Some(left), Some(right))
+                    if left.attr == LineAttribution::Ai
+                        && right.attr == LineAttribution::Ai
+                        && left.ai_session.is_some()
+                        && left.ai_session == right.ai_session =>
+                {
+                    let mut lines = run
+                        .iter()
+                        .take(EDGE_EXTENSION_MAX_LINES)
+                        .copied()
+                        .collect::<Vec<_>>();
+                    lines.extend(run.iter().rev().take(EDGE_EXTENSION_MAX_LINES).copied());
+                    lines.sort_unstable();
+                    lines.dedup();
+                    Some((left.ai_session.unwrap(), lines))
+                }
+                (Some(left), None)
+                    if left.attr == LineAttribution::Ai && left.ai_session.is_some() =>
+                {
+                    Some((
+                        left.ai_session.unwrap(),
+                        run.iter().take(EDGE_EXTENSION_MAX_LINES).copied().collect(),
+                    ))
+                }
+                (None, Some(right))
+                    if right.attr == LineAttribution::Ai && right.ai_session.is_some() =>
+                {
+                    Some((
+                        right.ai_session.unwrap(),
+                        run.iter()
+                            .rev()
+                            .take(EDGE_EXTENSION_MAX_LINES)
+                            .copied()
+                            .collect(),
+                    ))
+                }
+                _ => None,
+            };
+
+            if let Some((session, recovered_indices)) = recovery {
+                for idx in recovered_indices {
+                    self.resolved_attrs[idx] = LineAttribution::Ai;
+                    self.resolved_ai_sessions[idx] = Some(session);
+                    registry.register_record(self.lines[idx], AttrRecord::ai(session));
+                }
+            }
+
+            start = end;
+        }
+    }
+
+    fn pending_record_at_index(&self, idx: usize) -> Option<AttrRecord> {
+        self.lines
+            .get(idx)
+            .and_then(|ch| self.pending_attestations.get(ch))
+            .copied()
+    }
+
+    pub fn mark_pending_attestation(&mut self, ch: char, record: AttrRecord) {
+        self.pending_attestations.insert(ch, record);
+    }
+
+    pub fn clear_pending_attestations(&mut self) {
+        self.pending_attestations.clear();
     }
 
     /// Assert that git-ai blame output matches our model EXACTLY.
@@ -207,7 +364,10 @@ impl FileModel {
     pub fn dump(&self) -> String {
         let mut out = format!("File: {} ({} lines)\n", self.filename, self.lines.len());
         for (i, (&ch, &attr)) in self.lines.iter().zip(&self.resolved_attrs).enumerate() {
-            out.push_str(&format!("  L{}: '{}' -> {}\n", i + 1, ch, attr));
+            let session = self.resolved_ai_sessions[i]
+                .map(|session| format!(" #{session}"))
+                .unwrap_or_default();
+            out.push_str(&format!("  L{}: '{}' -> {}{}\n", i + 1, ch, attr, session));
         }
         out
     }

--- a/tests/integration/fuzzer/operations.rs
+++ b/tests/integration/fuzzer/operations.rs
@@ -2,7 +2,7 @@ use rand::{Rng, RngExt};
 
 use crate::repos::test_repo::TestRepo;
 
-use super::model::{AttrRegistry, FileModel, LineAttribution};
+use super::model::{AttrRecord, AttrRegistry, FileModel, LineAttribution};
 
 pub struct CharAllocator {
     next: u32,
@@ -43,6 +43,7 @@ pub fn random_edit(
         for &ch in &new_chars {
             model.lines.push(ch);
             model.resolved_attrs.push(LineAttribution::Untracked);
+            model.resolved_ai_sessions.push(None);
         }
     } else {
         let strategy = rng.random_range(0..4);
@@ -54,6 +55,7 @@ pub fn random_edit(
                     model
                         .resolved_attrs
                         .insert(pos + j, LineAttribution::Untracked);
+                    model.resolved_ai_sessions.insert(pos + j, None);
                 }
             }
             1 => {
@@ -63,16 +65,19 @@ pub fn random_edit(
                 for (j, &ch) in new_chars.iter().take(replace_count).enumerate() {
                     model.lines[start + j] = ch;
                     model.resolved_attrs[start + j] = LineAttribution::Untracked;
+                    model.resolved_ai_sessions[start + j] = None;
                 }
                 for &ch in new_chars.iter().skip(replace_count) {
                     model.lines.insert(end, ch);
                     model.resolved_attrs.insert(end, LineAttribution::Untracked);
+                    model.resolved_ai_sessions.insert(end, None);
                 }
             }
             2 => {
                 for &ch in &new_chars {
                     model.lines.push(ch);
                     model.resolved_attrs.push(LineAttribution::Untracked);
+                    model.resolved_ai_sessions.push(None);
                 }
             }
             3 => {
@@ -81,6 +86,9 @@ pub fn random_edit(
                     let del_start = rng.random_range(0..model.lines.len() - del_count + 1);
                     model.lines.drain(del_start..del_start + del_count);
                     model.resolved_attrs.drain(del_start..del_start + del_count);
+                    model
+                        .resolved_ai_sessions
+                        .drain(del_start..del_start + del_count);
                 }
                 let pos = if model.lines.is_empty() {
                     0
@@ -92,6 +100,7 @@ pub fn random_edit(
                     model
                         .resolved_attrs
                         .insert(pos + j, LineAttribution::Untracked);
+                    model.resolved_ai_sessions.insert(pos + j, None);
                 }
             }
             _ => unreachable!(),
@@ -113,12 +122,16 @@ pub fn checkpoint_ai(
     repo.git_ai(&["checkpoint", "mock_ai", &model.filename])
         .unwrap_or_else(|e| panic!("checkpoint mock_ai failed: {}", e));
 
+    let session = registry.allocate_ai_session();
     for &ch in written_chars {
-        registry.register(ch, LineAttribution::Ai);
+        let record = AttrRecord::ai(session);
+        registry.register_record(ch, record);
+        model.mark_pending_attestation(ch, record);
     }
     for (i, &ch) in model.lines.iter().enumerate() {
         if written_chars.contains(&ch) {
             model.resolved_attrs[i] = LineAttribution::Ai;
+            model.resolved_ai_sessions[i] = Some(session);
         }
     }
     op_log.push(format!("checkpoint_ai({})", model.filename));
@@ -136,11 +149,14 @@ pub fn checkpoint_human(
         .unwrap_or_else(|e| panic!("checkpoint mock_known_human failed: {}", e));
 
     for &ch in written_chars {
-        registry.register(ch, LineAttribution::KnownHuman);
+        let record = AttrRecord::new(LineAttribution::KnownHuman);
+        registry.register_record(ch, record);
+        model.mark_pending_attestation(ch, record);
     }
     for (i, &ch) in model.lines.iter().enumerate() {
         if written_chars.contains(&ch) {
             model.resolved_attrs[i] = LineAttribution::KnownHuman;
+            model.resolved_ai_sessions[i] = None;
         }
     }
     op_log.push(format!("checkpoint_human({})", model.filename));
@@ -156,36 +172,47 @@ pub fn checkpoint_untracked(model: &FileModel, repo: &TestRepo, op_log: &mut Vec
 /// Commit: stage all and commit. Then reconcile and assert.
 pub fn commit(
     model: &mut FileModel,
+    registry: &mut AttrRegistry,
     repo: &TestRepo,
     op_log: &mut Vec<String>,
     seed: u64,
     msg: &str,
 ) {
     repo.git(&["add", "."]).unwrap();
+    let added_lines = staged_added_lines(repo, &model.filename, Some("HEAD"));
     repo.git(&["commit", "-m", msg, "--allow-empty"])
         .unwrap_or_else(|e| panic!("commit '{}' failed: {}", msg, e));
 
     op_log.push(format!("commit(\"{}\")", msg));
+    model.apply_edge_recovery_for_added_lines(registry, &added_lines);
     model.reconcile(repo);
     model.assert_blame(repo, op_log, seed);
+    model.clear_pending_attestations();
 }
 
 /// Amend the last commit. Then reconcile and assert.
 pub fn amend(
     model: &mut FileModel,
-    registry: &AttrRegistry,
+    registry: &mut AttrRegistry,
     repo: &TestRepo,
     op_log: &mut Vec<String>,
     seed: u64,
 ) {
     repo.git(&["add", "."]).unwrap();
+    let parent = repo
+        .git(&["rev-parse", "--verify", "HEAD^"])
+        .ok()
+        .map(|output| output.trim().to_string());
+    let added_lines = staged_added_lines(repo, &model.filename, parent.as_deref());
     repo.git(&["commit", "--amend", "--no-edit"])
         .unwrap_or_else(|e| panic!("amend failed: {}", e));
 
     op_log.push("amend".to_string());
     model.sync_from_disk(repo, registry);
+    model.apply_edge_recovery_for_added_lines(registry, &added_lines);
     model.reconcile(repo);
     model.assert_blame(repo, op_log, seed);
+    model.clear_pending_attestations();
 }
 
 /// Rebase: creates a side branch with commits, then rebases onto main.
@@ -207,7 +234,7 @@ pub fn rebase(
     // Create a commit on main first (so rebase has something to replay onto)
     let chars = random_edit(model, registry, repo, alloc, rng, 2);
     checkpoint_ai(model, registry, repo, &chars, op_log);
-    commit(model, repo, op_log, seed, "rebase: main advance");
+    commit(model, registry, repo, op_log, seed, "rebase: main advance");
 
     // Create side branch from parent
     let parent = repo
@@ -225,7 +252,10 @@ pub fn rebase(
     let side_chars = random_edit(model, registry, repo, alloc, rng, 2);
     checkpoint_ai(model, registry, repo, &side_chars, op_log);
     repo.git(&["add", "."]).unwrap();
+    let side_added_lines = staged_added_lines(repo, &model.filename, Some("HEAD"));
     repo.git(&["commit", "-m", "rebase: side commit"]).unwrap();
+    model.apply_edge_recovery_for_added_lines(registry, &side_added_lines);
+    model.clear_pending_attestations();
     op_log.push("commit(\"rebase: side commit\")".to_string());
 
     // Rebase side onto main
@@ -275,8 +305,11 @@ pub fn cherry_pick(
     let chars = random_edit(model, registry, repo, alloc, rng, 2);
     checkpoint_ai(model, registry, repo, &chars, op_log);
     repo.git(&["add", "."]).unwrap();
+    let side_added_lines = staged_added_lines(repo, &model.filename, Some("HEAD"));
     repo.git(&["commit", "-m", "cherry-pick: side commit"])
         .unwrap();
+    model.apply_edge_recovery_for_added_lines(registry, &side_added_lines);
+    model.clear_pending_attestations();
     let side_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
 
     // Go back to main
@@ -375,5 +408,68 @@ pub fn stash_roundtrip(
 
     // Commit so blame can render the restored attribution, then assert.
     model.sync_from_disk(repo, registry);
-    commit(model, repo, op_log, seed, "stash roundtrip commit");
+    commit(
+        model,
+        registry,
+        repo,
+        op_log,
+        seed,
+        "stash roundtrip commit",
+    );
+}
+
+fn staged_added_lines(repo: &TestRepo, filename: &str, base: Option<&str>) -> Vec<u32> {
+    let mut args = vec![
+        "diff".to_string(),
+        "--cached".to_string(),
+        "--unified=0".to_string(),
+    ];
+    if let Some(base) = base {
+        args.push(base.to_string());
+    }
+    args.push("--".to_string());
+    args.push(filename.to_string());
+
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let diff = repo.git(&arg_refs).unwrap_or_default();
+    parse_diff_added_lines(&diff)
+}
+
+fn parse_diff_added_lines(diff: &str) -> Vec<u32> {
+    let mut added = Vec::new();
+    let mut next_new_line = None::<u32>;
+
+    for line in diff.lines() {
+        if line.starts_with("@@") {
+            next_new_line = parse_hunk_new_start(line);
+            continue;
+        }
+
+        let Some(current) = next_new_line else {
+            continue;
+        };
+
+        if line.starts_with("+++") || line.starts_with("\\ No newline") {
+            continue;
+        }
+
+        if line.starts_with('+') {
+            added.push(current);
+            next_new_line = Some(current + 1);
+        } else if line.starts_with('-') {
+            next_new_line = Some(current);
+        } else {
+            next_new_line = Some(current + 1);
+        }
+    }
+
+    added
+}
+
+fn parse_hunk_new_start(header: &str) -> Option<u32> {
+    let plus = header.find('+')?;
+    let after_plus = &header[plus + 1..];
+    let end = after_plus.find([' ', '@']).unwrap_or(after_plus.len());
+    let range = &after_plus[..end];
+    range.split(',').next()?.parse().ok()
 }

--- a/tests/integration/prompt_across_commit.rs
+++ b/tests/integration/prompt_across_commit.rs
@@ -65,9 +65,8 @@ fn test_change_across_commits() {
 }
 
 /// Variant of test_change_across_commits using unattributed (legacy) human checkpoints.
-/// Assertions match origin/main: with empty attribution, the file has only 1 attestation
-/// entry (the second AI commit's entry only) because the first commit's attribution is
-/// subsumed into the working log without creating a separate attestation entry.
+/// The inserted legacy/untracked line is adjacent to the new AI edit, so edge
+/// recovery attributes it to AI with a separate recovery trace.
 #[test]
 fn test_change_across_commits_standard_human() {
     let repo = TestRepo::new();
@@ -102,20 +101,21 @@ fn test_change_across_commits_standard_human() {
     let commit = repo.stage_all_and_commit("add more AI").unwrap();
 
     let file_attestation = commit.authorship_log.attestations.first().unwrap();
-    assert_eq!(file_attestation.entries.len(), 1);
+    assert_eq!(file_attestation.entries.len(), 2);
 
-    let second_ai_session_hash = commit
-        .authorship_log
-        .metadata
-        .sessions
-        .keys()
-        .next()
-        .unwrap();
-    assert_ne!(*second_ai_session_hash, initial_ai_entry.hash);
-
-    let second_ai_entry = file_attestation.entries.first().unwrap();
-    assert_eq!(second_ai_entry.line_ranges, vec![LineRange::Single(6)]);
-    assert_ne!(second_ai_entry.hash, initial_ai_entry.hash);
+    let mut attested_lines = file_attestation
+        .entries
+        .iter()
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
+        .collect::<Vec<_>>();
+    attested_lines.sort_unstable();
+    assert_eq!(attested_lines, vec![5, 6]);
+    assert!(
+        file_attestation
+            .entries
+            .iter()
+            .all(|entry| entry.hash != initial_ai_entry.hash)
+    );
 }
 
 crate::reuse_tests_in_worktree!(

--- a/tests/integration/rebase_realworld.rs
+++ b/tests/integration/rebase_realworld.rs
@@ -10188,6 +10188,13 @@ fn test_conflict_ai_resolves_preserving_human_context_lines() {
         "        return result".ai(),
         "    def method3(self): return 'method3'".human(),
     ]);
+    fs::write(
+        repo.path().join("processor.py"),
+        "class Processor:\n    def method1(self): return 'method1'\n    def method2(self):\n        result = []\n        for i in range(10):\n            result.append(i * 2)\n        return result\n    def method3(self): return 'method3'\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "processor.py"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C3 AI implements method2")
         .unwrap();
 
@@ -10244,6 +10251,14 @@ fn test_conflict_ai_resolves_preserving_human_context_lines() {
         "        return result, label".ai(),
         "    def method3(self): return 'method3'".human(),
     ]);
+    fs::write(
+        repo.path().join("processor.py"),
+        "class Processor:\n    def method1(self): return 'method1'\n    def method2(self):\n        # AI merged: combines human's return with feature's loop\n        result = []\n        for i in range(10):\n            result.append(i * 2)\n        label = 'human-method2'\n        return result, label\n    def method3(self): return 'method3'\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "processor.py"])
+        .unwrap();
+    repo.git(&["add", "processor.py"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -10620,6 +10635,13 @@ fn test_conflict_ai_resolves_on_last_commit() {
         "pub const MAX_CONNECTIONS: u32 = 100;".ai(),
         "pub const SCHEMA_VERSION: u32 = 1;".human(),
     ]);
+    fs::write(
+        repo.path().join("src/schema.rs"),
+        "pub const MAX_CONNECTIONS: u32 = 100;\npub const SCHEMA_VERSION: u32 = 1;\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/schema.rs"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C5 AI tunes MAX_CONNECTIONS to 100")
         .unwrap();
 
@@ -10637,6 +10659,14 @@ fn test_conflict_ai_resolves_on_last_commit() {
         "pub const MAX_CONNECTIONS: u32 = 75;".ai(),
         "pub const SCHEMA_VERSION: u32 = 1;".human(),
     ]);
+    fs::write(
+        repo.path().join("src/schema.rs"),
+        "pub const MAX_CONNECTIONS: u32 = 75;\npub const SCHEMA_VERSION: u32 = 1;\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/schema.rs"])
+        .unwrap();
+    repo.git(&["add", "src/schema.rs"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -11194,6 +11224,13 @@ fn test_conflict_ai_resolves_rust_struct_fields() {
         "    pub metadata: std::collections::HashMap<String, String>,".ai(),
         "}".human(),
     ]);
+    fs::write(
+        repo.path().join("src/models.rs"),
+        "pub struct User {\n    pub id: u64,\n    pub name: String,\n    pub active: bool,\n    pub role: String,\n    pub score: f64,\n    pub metadata: std::collections::HashMap<String, String>,\n}\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/models.rs"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C3 AI adds active/role/score/metadata fields")
         .unwrap();
 
@@ -11249,6 +11286,14 @@ fn test_conflict_ai_resolves_rust_struct_fields() {
         "    pub metadata: std::collections::HashMap<String, String>,".ai(),
         "}".human(),
     ]);
+    fs::write(
+        repo.path().join("src/models.rs"),
+        "pub struct User {\n    pub id: u64,\n    pub name: String,\n    pub email: String,\n    pub created_at: u64,\n    pub active: bool,\n    pub role: String,\n    pub score: f64,\n    pub metadata: std::collections::HashMap<String, String>,\n}\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/models.rs"])
+        .unwrap();
+    repo.git(&["add", "src/models.rs"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -11820,6 +11865,9 @@ fn test_conflict_working_log_is_sole_attribution_source() {
     // C1: AI sets TIMEOUT = 30 — WILL CONFLICT with main's = 60
     let mut cfg = repo.filename("config.py");
     cfg.set_contents(crate::lines!["TIMEOUT = 30".ai(), "RETRIES = 3",]);
+    fs::write(repo.path().join("config.py"), "TIMEOUT = 30\nRETRIES = 3\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "config.py"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C1 AI sets TIMEOUT=30")
         .unwrap();
 
@@ -11846,6 +11894,10 @@ fn test_conflict_working_log_is_sole_attribution_source() {
     // AI resolves: picks 45 as a compromise.  Content differs from original (30) → content-diff
     // cannot carry attribution.  ONLY the working-log checkpoint can produce the note.
     cfg.set_contents(crate::lines!["TIMEOUT = 45".ai(), "RETRIES = 3",]);
+    fs::write(repo.path().join("config.py"), "TIMEOUT = 45\nRETRIES = 3\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "config.py"])
+        .unwrap();
+    repo.git(&["add", "config.py"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -11925,6 +11977,13 @@ fn test_conflict_content_diff_wins_over_working_log() {
     // C1: AI sets MAX_RETRIES = 5 — WILL CONFLICT with main's = 10
     let mut sett = repo.filename("settings.py");
     sett.set_contents(crate::lines!["MAX_RETRIES = 5".ai(), "TIMEOUT = 10",]);
+    fs::write(
+        repo.path().join("settings.py"),
+        "MAX_RETRIES = 5\nTIMEOUT = 10\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "settings.py"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C1 AI sets MAX_RETRIES=5")
         .unwrap();
 
@@ -11949,6 +12008,14 @@ fn test_conflict_content_diff_wins_over_working_log() {
     // Also creates a working-log checkpoint via set_contents.
     // The content-diff path fires first (commit_has_attestations=true) and wins.
     sett.set_contents(crate::lines!["MAX_RETRIES = 5".ai(), "TIMEOUT = 10",]);
+    fs::write(
+        repo.path().join("settings.py"),
+        "MAX_RETRIES = 5\nTIMEOUT = 10\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "settings.py"])
+        .unwrap();
+    repo.git(&["add", "settings.py"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -12270,6 +12337,13 @@ fn test_conflict_ai_resolves_preserving_human_context_lines_standard_human() {
         "        return result".ai(),
         "    def method3(self): return 'method3'".unattributed_human(),
     ]);
+    fs::write(
+        repo.path().join("processor.py"),
+        "class Processor:\n    def method1(self): return 'method1'\n    def method2(self):\n        result = []\n        for i in range(10):\n            result.append(i * 2)\n        return result\n    def method3(self): return 'method3'\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "processor.py"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C3 AI implements method2")
         .unwrap();
 
@@ -12326,6 +12400,14 @@ fn test_conflict_ai_resolves_preserving_human_context_lines_standard_human() {
         "        return result, label".ai(),
         "    def method3(self): return 'method3'".unattributed_human(),
     ]);
+    fs::write(
+        repo.path().join("processor.py"),
+        "class Processor:\n    def method1(self): return 'method1'\n    def method2(self):\n        # AI merged: combines human's return with feature's loop\n        result = []\n        for i in range(10):\n            result.append(i * 2)\n        label = 'human-method2'\n        return result, label\n    def method3(self): return 'method3'\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "processor.py"])
+        .unwrap();
+    repo.git(&["add", "processor.py"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -12674,6 +12756,13 @@ fn test_conflict_ai_resolves_on_last_commit_standard_human() {
         "pub const MAX_CONNECTIONS: u32 = 100;".ai(),
         "pub const SCHEMA_VERSION: u32 = 1;".unattributed_human(),
     ]);
+    fs::write(
+        repo.path().join("src/schema.rs"),
+        "pub const MAX_CONNECTIONS: u32 = 100;\npub const SCHEMA_VERSION: u32 = 1;\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/schema.rs"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C5 AI tunes MAX_CONNECTIONS to 100")
         .unwrap();
 
@@ -12691,6 +12780,14 @@ fn test_conflict_ai_resolves_on_last_commit_standard_human() {
         "pub const MAX_CONNECTIONS: u32 = 75;".ai(),
         "pub const SCHEMA_VERSION: u32 = 1;".unattributed_human(),
     ]);
+    fs::write(
+        repo.path().join("src/schema.rs"),
+        "pub const MAX_CONNECTIONS: u32 = 75;\npub const SCHEMA_VERSION: u32 = 1;\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/schema.rs"])
+        .unwrap();
+    repo.git(&["add", "src/schema.rs"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 
@@ -13206,6 +13303,13 @@ fn test_conflict_ai_resolves_rust_struct_fields_standard_human() {
         "    pub metadata: std::collections::HashMap<String, String>,".ai(),
         "}".unattributed_human(),
     ]);
+    fs::write(
+        repo.path().join("src/models.rs"),
+        "pub struct User {\n    pub id: u64,\n    pub name: String,\n    pub active: bool,\n    pub role: String,\n    pub score: f64,\n    pub metadata: std::collections::HashMap<String, String>,\n}\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/models.rs"])
+        .unwrap();
     repo.stage_all_and_commit("feat: C3 AI adds active/role/score/metadata fields")
         .unwrap();
 
@@ -13261,6 +13365,14 @@ fn test_conflict_ai_resolves_rust_struct_fields_standard_human() {
         "    pub metadata: std::collections::HashMap<String, String>,".ai(),
         "}".unattributed_human(),
     ]);
+    fs::write(
+        repo.path().join("src/models.rs"),
+        "pub struct User {\n    pub id: u64,\n    pub name: String,\n    pub email: String,\n    pub created_at: u64,\n    pub active: bool,\n    pub role: String,\n    pub score: f64,\n    pub metadata: std::collections::HashMap<String, String>,\n}\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "src/models.rs"])
+        .unwrap();
+    repo.git(&["add", "src/models.rs"]).unwrap();
     repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
         .unwrap();
 

--- a/tests/integration/repository_unit.rs
+++ b/tests/integration/repository_unit.rs
@@ -199,6 +199,24 @@ index 0000000..abc1234 100644
 }
 
 #[test]
+fn test_parse_diff_added_lines_with_insertions_replacement_uses_plus_lines_only() {
+    let diff = r#"diff --git a/test.txt b/test.txt
+index 0000000..abc1234 100644
+--- a/test.txt
++++ b/test.txt
+@@ -10,3 +10,4 @@
+ unchanged
+-old line
++new line
+ context
++added tail"#;
+
+    let (added_lines, insertion_lines) = parse_diff_added_lines_with_insertions(diff).unwrap();
+    assert_eq!(added_lines.get("test.txt"), Some(&vec![11, 13]));
+    assert_eq!(insertion_lines.get("test.txt"), None);
+}
+
+#[test]
 fn worktree_storage_ai_dir_keeps_full_relative_worktree_path() {
     let temp = tempfile::tempdir().expect("tempdir");
     let common_dir = temp.path().join("repo.git");

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -898,11 +898,11 @@ Another AI line
         .unwrap();
     repo.stage_all_and_commit("Fourth commit").unwrap();
     file.assert_committed_lines(lines![
-        "Untracked line".unattributed_human(),         // 'untracked'
-        "Human line".human(),                          // known human
-        "AI line".ai(),                                // AI line
-        "Another untracked line".unattributed_human(), // 'untracked'
-        "Another AI line".ai(),                        // AI line
+        "Untracked line".unattributed_human(), // 'untracked'
+        "Human line".human(),                  // known human
+        "AI line".ai(),                        // AI line
+        "Another untracked line".ai(),         // recovered edge line
+        "Another AI line".ai(),                // AI line
     ]);
 }
 

--- a/tests/integration/snapshots/integration__initial_attributions__initial_wins_overlaps.snap
+++ b/tests/integration/snapshots/integration__initial_attributions__initial_wins_overlaps.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/initial_attributions.rs
+source: tests/integration/initial_attributions.rs
 expression: normalized
 ---
-"COMMIT_SHA (override-tool TIMESTAMP 1) line 1\nCOMMIT_SHA (override-tool TIMESTAMP 2) line 2\nCOMMIT_SHA (Test User     TIMESTAMP 3) line 3 modified\n"
+"COMMIT_SHA (override-tool TIMESTAMP 1) line 1\nCOMMIT_SHA (override-tool TIMESTAMP 2) line 2\nCOMMIT_SHA (override-tool TIMESTAMP 3) line 3 modified\n"

--- a/tests/integration/snapshots/integration__initial_attributions__initial_wins_overlaps@worktree.snap
+++ b/tests/integration/snapshots/integration__initial_attributions__initial_wins_overlaps@worktree.snap
@@ -1,6 +1,5 @@
 ---
-source: tests/initial_attributions.rs
-assertion_line: 179
+source: tests/integration/initial_attributions.rs
 expression: normalized
 ---
-"COMMIT_SHA (override-tool TIMESTAMP 1) line 1\nCOMMIT_SHA (override-tool TIMESTAMP 2) line 2\nCOMMIT_SHA (Test User     TIMESTAMP 3) line 3 modified\n"
+"COMMIT_SHA (override-tool TIMESTAMP 1) line 1\nCOMMIT_SHA (override-tool TIMESTAMP 2) line 2\nCOMMIT_SHA (override-tool TIMESTAMP 3) line 3 modified\n"


### PR DESCRIPTION
## Summary
- Recover bash attribution from the global bash checkpoint DB instead of keying recovery to a single worktree path.
- Restrict recovery to untracked lines that are actually added in the commit diff, so existing known-human attribution is not overridden.
- Fill leading and trailing untracked edge gaps around recovered AI hunks, up to 3 lines above or below.
- Keep test DBs isolated by default and require bash recovery tests to opt into their own bash checkpoint DB.

## Verification
- task fmt
- task lint
- task test
- git diff --check

Final branch tree was verified to match the full-suite-tested backup after splitting the stack.