### PR TITLE
[codex] Exclude ignored files from telemetry stats

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -671,10 +671,12 @@ fn estimate_stats_cost(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<StatsCostEstimate, GitAiError> {
-    let (mut added_lines_by_file, total_deleted_lines) =
-        repo.diff_added_lines_with_deleted_count(parent_sha, commit_sha)?;
+    let (mut added_lines_by_file, mut deleted_lines_by_file) =
+        repo.diff_added_lines_with_deleted_counts(parent_sha, commit_sha)?;
     let ignore_matcher = build_ignore_matcher(ignore_patterns);
     added_lines_by_file
+        .retain(|file_path, _| !should_ignore_file_with_matcher(file_path, &ignore_matcher));
+    deleted_lines_by_file
         .retain(|file_path, _| !should_ignore_file_with_matcher(file_path, &ignore_matcher));
 
     let files_with_additions = added_lines_by_file
@@ -697,7 +699,7 @@ fn estimate_stats_cost(
         files_with_additions,
         added_lines,
         hunk_ranges,
-        deleted_lines: total_deleted_lines,
+        deleted_lines: deleted_lines_by_file.values().sum(),
     })
 }
 
@@ -735,7 +737,7 @@ fn record_commit_metrics(
     checkpoints: &[Checkpoint],
     hunks_json: Option<&str>,
 ) {
-    use crate::metrics::{CommittedValues, EventAttributes, record};
+    use crate::metrics::{EventAttributes, record};
 
     // Never emit telemetry for mock_ai (test preset).  If every tool in the
     // breakdown is mock_ai the entire committed event is test data.
@@ -747,6 +749,66 @@ fn record_commit_metrics(
     if only_mock_ai {
         return;
     }
+
+    let (commit_subject, commit_body) = match repo.find_commit(commit_sha.to_string()) {
+        Ok(commit) => (
+            Some(commit.summary().unwrap_or_default().to_string()),
+            Some(commit.body().unwrap_or_default().to_string()),
+        ),
+        Err(_) => (None, None),
+    };
+
+    let values = build_committed_metric_values(
+        stats,
+        checkpoints,
+        commit_subject.as_deref(),
+        commit_body.as_deref(),
+        authorship_note,
+        hunks_json,
+    );
+
+    // Build attributes - start with version and extract session_id from first AI checkpoint
+    // session_id links this commit to the AI agent conversation that produced it
+    // Note: session_id removed from committed events - commits can contain code from multiple AI sessions
+    let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"));
+
+    attrs = attrs
+        .author(human_author)
+        .commit_sha(commit_sha)
+        .base_commit_sha(parent_sha);
+
+    // Get repo URL from default remote
+    if let Ok(Some(remote_name)) = repo.get_default_remote()
+        && let Ok(remotes) = repo.remotes_with_urls()
+        && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
+        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
+    {
+        attrs = attrs.repo_url(normalized);
+    }
+
+    // Get current branch
+    if let Ok(head_ref) = repo.head()
+        && let Ok(short_branch) = head_ref.shorthand()
+    {
+        attrs = attrs.branch(short_branch);
+    }
+
+    // Attach custom attributes using Config::fresh() to support runtime config updates
+    attrs = attrs.custom_attributes_map(Config::fresh().custom_attributes());
+
+    // Record the metric
+    record(values, attrs);
+}
+
+fn build_committed_metric_values(
+    stats: &crate::authorship::stats::CommitStats,
+    checkpoints: &[Checkpoint],
+    commit_subject: Option<&str>,
+    commit_body: Option<&str>,
+    authorship_note: &str,
+    hunks_json: Option<&str>,
+) -> crate::metrics::CommittedValues {
+    use crate::metrics::CommittedValues;
 
     // Subtract mock_ai contributions from the aggregates so the "all" entry
     // only reflects real tools.
@@ -791,63 +853,128 @@ fn record_commit_metrics(
     };
 
     // Add commit subject and body
-    let values = if let Ok(commit) = repo.find_commit(commit_sha.to_string()) {
-        let subject = commit.summary().unwrap_or_default();
-        let values = values.commit_subject(subject);
-        let body = commit.body().unwrap_or_default();
-        if body.is_empty() {
-            values.commit_body_null()
-        } else {
-            values.commit_body(body)
-        }
+    let values = if let Some(subject) = commit_subject {
+        values.commit_subject(subject)
     } else {
-        values.commit_subject_null().commit_body_null()
+        values.commit_subject_null()
+    };
+    let values = if let Some(body) = commit_body.filter(|body| !body.is_empty()) {
+        values.commit_body(body)
+    } else {
+        values.commit_body_null()
     };
 
     let values = values.authorship_note(authorship_note);
 
-    let values = if let Some(hunks) = hunks_json {
+    if let Some(hunks) = hunks_json {
         values.hunks(hunks)
     } else {
         values.hunks_null()
-    };
-
-    // Build attributes - start with version and extract session_id from first AI checkpoint
-    // session_id links this commit to the AI agent conversation that produced it
-    // Note: session_id removed from committed events - commits can contain code from multiple AI sessions
-    let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"));
-
-    attrs = attrs
-        .author(human_author)
-        .commit_sha(commit_sha)
-        .base_commit_sha(parent_sha);
-
-    // Get repo URL from default remote
-    if let Ok(Some(remote_name)) = repo.get_default_remote()
-        && let Ok(remotes) = repo.remotes_with_urls()
-        && let Some((_, url)) = remotes.into_iter().find(|(n, _)| n == &remote_name)
-        && let Ok(normalized) = crate::repo_url::normalize_repo_url(&url)
-    {
-        attrs = attrs.repo_url(normalized);
     }
-
-    // Get current branch
-    if let Ok(head_ref) = repo.head()
-        && let Ok(short_branch) = head_ref.shorthand()
-    {
-        attrs = attrs.branch(short_branch);
-    }
-
-    // Attach custom attributes using Config::fresh() to support runtime config updates
-    attrs = attrs.custom_attributes_map(Config::fresh().custom_attributes());
-
-    // Record the metric
-    record(values, attrs);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_committed_metric_values_use_filtered_stats_and_hunks_payload() {
+        use crate::authorship::stats::{CommitStats, ToolModelHeadlineStats};
+        use crate::metrics::PosEncoded;
+        use crate::metrics::events::committed_pos;
+        use serde_json::json;
+        use std::collections::BTreeMap;
+
+        let mut tool_model_breakdown = BTreeMap::new();
+        tool_model_breakdown.insert(
+            "claude::sonnet".to_string(),
+            ToolModelHeadlineStats {
+                ai_additions: 2,
+                ai_accepted: 1,
+            },
+        );
+        tool_model_breakdown.insert(
+            "mock_ai::unknown".to_string(),
+            ToolModelHeadlineStats {
+                ai_additions: 10,
+                ai_accepted: 10,
+            },
+        );
+
+        let stats = CommitStats {
+            human_additions: 1,
+            unknown_additions: 1,
+            ai_additions: 12,
+            ai_accepted: 11,
+            git_diff_deleted_lines: 0,
+            git_diff_added_lines: 3,
+            tool_model_breakdown,
+        };
+
+        let mut checkpoint = Checkpoint::new(
+            CheckpointKind::AiAgent,
+            String::new(),
+            "agent@example.com".to_string(),
+            Vec::new(),
+        );
+        checkpoint.timestamp = 1_704_067_200;
+
+        let hunks_json = r#"[{"file_path":"src/lib.rs","hunk_kind":"addition"}]"#;
+        let values = build_committed_metric_values(
+            &stats,
+            &[checkpoint],
+            Some("Update source"),
+            Some(""),
+            "authorship-note",
+            Some(hunks_json),
+        );
+        let sparse = values.to_sparse();
+
+        assert_eq!(
+            sparse.get(&committed_pos::HUMAN_ADDITIONS.to_string()),
+            Some(&json!(1))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::GIT_DIFF_ADDED_LINES.to_string()),
+            Some(&json!(3))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::GIT_DIFF_DELETED_LINES.to_string()),
+            Some(&json!(0))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::TOOL_MODEL_PAIRS.to_string()),
+            Some(&json!(["all", "claude::sonnet"]))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::AI_ADDITIONS.to_string()),
+            Some(&json!([2, 2]))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::AI_ACCEPTED.to_string()),
+            Some(&json!([1, 1]))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::HUNKS.to_string()),
+            Some(&json!(hunks_json))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::FIRST_CHECKPOINT_TS.to_string()),
+            Some(&json!(1_704_067_200_u64))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::COMMIT_SUBJECT.to_string()),
+            Some(&json!("Update source"))
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::COMMIT_BODY.to_string()),
+            Some(&serde_json::Value::Null)
+        );
+        assert_eq!(
+            sparse.get(&committed_pos::AUTHORSHIP_NOTE.to_string()),
+            Some(&json!("authorship-note"))
+        );
+    }
 
     #[test]
     fn test_count_line_ranges_handles_scattered_and_contiguous_lines() {

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -31,6 +31,10 @@ thread_local! {
 }
 static INTERNAL_GIT_HOOKS_DISABLED_DEPTH_GLOBAL: AtomicUsize = AtomicUsize::new(0);
 
+pub type DiffAddedLinesByFile = HashMap<String, Vec<u32>>;
+pub type DiffDeletedLineCountsByFile = HashMap<String, usize>;
+pub type DiffAddedAndDeletedLineCounts = (DiffAddedLinesByFile, DiffDeletedLineCountsByFile);
+
 pub struct InternalGitHooksGuard;
 
 impl Drop for InternalGitHooksGuard {
@@ -1826,6 +1830,19 @@ impl Repository {
         from_ref: &str,
         to_ref: &str,
     ) -> Result<(HashMap<String, Vec<u32>>, usize), GitAiError> {
+        let (added_lines, deleted_lines_by_file) =
+            self.diff_added_lines_with_deleted_counts(from_ref, to_ref)?;
+        let deleted_count = deleted_lines_by_file.values().sum();
+        Ok((added_lines, deleted_count))
+    }
+
+    /// Like `diff_added_lines` but also returns deleted-line counts keyed by
+    /// the destination-oriented file path used by the stats hunk parser.
+    pub fn diff_added_lines_with_deleted_counts(
+        &self,
+        from_ref: &str,
+        to_ref: &str,
+    ) -> Result<DiffAddedAndDeletedLineCounts, GitAiError> {
         let mut args = self.global_args_for_exec();
         args.push("diff".to_string());
         args.push("-U0".to_string());
@@ -1837,7 +1854,7 @@ impl Repository {
         let output = exec_git_with_profile(&args, InternalGitProfile::PatchParse)?;
         let diff_output = String::from_utf8_lossy(&output.stdout);
 
-        parse_diff_added_lines(&diff_output)
+        parse_diff_added_lines_and_deleted_counts(&diff_output)
     }
 
     /// Get list of changed files between two refs using `git diff --name-only`
@@ -2980,26 +2997,39 @@ pub fn parse_git_version(version_str: &str) -> Option<(u32, u32, u32)> {
 /// Also returns the total number of deleted lines across all hunks so that
 /// callers can estimate the cost of a deletion-heavy commit without a second
 /// git invocation.
-fn parse_diff_added_lines(
+fn parse_diff_added_lines(diff_output: &str) -> Result<(DiffAddedLinesByFile, usize), GitAiError> {
+    let (added_lines, deleted_lines_by_file) =
+        parse_diff_added_lines_and_deleted_counts(diff_output)?;
+    let total_deleted = deleted_lines_by_file.values().sum();
+    Ok((added_lines, total_deleted))
+}
+
+fn parse_diff_added_lines_and_deleted_counts(
     diff_output: &str,
-) -> Result<(HashMap<String, Vec<u32>>, usize), GitAiError> {
-    let mut result: HashMap<String, Vec<u32>> = HashMap::new();
+) -> Result<DiffAddedAndDeletedLineCounts, GitAiError> {
+    let mut result: DiffAddedLinesByFile = HashMap::new();
+    let mut deleted_lines_by_file: DiffDeletedLineCountsByFile = HashMap::new();
+    let mut current_old_file: Option<String> = None;
     let mut current_file: Option<String> = None;
-    let mut total_deleted: usize = 0;
 
     for line in diff_output.lines() {
-        if let Some(path_opt) = parse_new_file_path_from_plus_header_line(line) {
-            current_file = path_opt;
-        } else if line.starts_with("@@ ") {
+        if line.starts_with("diff --git ") {
+            current_old_file = None;
+            current_file = None;
+        } else if let Some(path_opt) = parse_old_file_path_from_minus_header_line(line) {
+            current_old_file = path_opt;
+        } else if let Some(path_opt) = parse_new_file_path_from_plus_header_line(line) {
+            current_file = path_opt.or_else(|| current_old_file.clone());
+        } else if line.starts_with("@@ ")
+            && let Some((added_lines, _is_pure_insertion, old_count)) = parse_hunk_header(line)
+            && let Some(ref file) = current_file
+        {
             // Parse hunk header: @@ -old_start,old_count +new_start,new_count @@
-            if let Some((added_lines, _is_pure_insertion, old_count)) = parse_hunk_header(line) {
-                // Count deleted lines for ALL hunks, including those from purely
-                // deleted files (where current_file is None because +++ /dev/null).
-                total_deleted += old_count as usize;
-                // Only record added-line numbers when there is a destination file.
-                if let Some(ref file) = current_file {
-                    result.entry(file.clone()).or_default().extend(added_lines);
-                }
+            if old_count > 0 {
+                *deleted_lines_by_file.entry(file.clone()).or_default() += old_count as usize;
+            }
+            if !added_lines.is_empty() {
+                result.entry(file.clone()).or_default().extend(added_lines);
             }
         }
     }
@@ -3010,7 +3040,7 @@ fn parse_diff_added_lines(
         lines.dedup();
     }
 
-    Ok((result, total_deleted))
+    Ok((result, deleted_lines_by_file))
 }
 
 /// Parses the unified diff output to extract line numbers of added lines,
@@ -3082,7 +3112,15 @@ fn normalize_diff_path_token(path: &str) -> String {
 }
 
 fn parse_new_file_path_from_plus_header_line(line: &str) -> Option<Option<String>> {
-    let raw = line.strip_prefix("+++ ")?;
+    parse_file_path_from_header_line(line, "+++ ")
+}
+
+fn parse_old_file_path_from_minus_header_line(line: &str) -> Option<Option<String>> {
+    parse_file_path_from_header_line(line, "--- ")
+}
+
+fn parse_file_path_from_header_line(line: &str, prefix: &str) -> Option<Option<String>> {
+    let raw = line.strip_prefix(prefix)?;
     if raw.trim_end() == "/dev/null" {
         return Some(None);
     }

--- a/tests/commit_hunks.rs
+++ b/tests/commit_hunks.rs
@@ -575,3 +575,93 @@ fn test_commit_hunks_interleaved_attributions() {
     assert_eq!(addition_hunks[1].end_line, 3);
     assert!(addition_hunks[1].prompt_id.is_some());
 }
+
+#[test]
+fn test_commit_hunks_post_commit_path_respects_all_ignore_sources() {
+    let repo = TestRepo::new();
+
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::create_dir_all(repo.path().join("generated")).unwrap();
+    fs::create_dir_all(repo.path().join("docs")).unwrap();
+
+    fs::write(
+        repo.path().join(".gitattributes"),
+        "generated/** linguist-generated=true\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join(".git-ai-ignore"), "docs/**\n").unwrap();
+    fs::write(
+        repo.path().join("src/app.ts"),
+        "export const visible = 1;\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("setup ignore metadata").unwrap();
+
+    fs::write(
+        repo.path().join("src/app.ts"),
+        "export const visible = 1;\nexport const counted = 2;\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("Cargo.lock"),
+        "lockfile-entry\n".repeat(10),
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("generated/schema.ts"),
+        "export const generated = true;\n".repeat(10),
+    )
+    .unwrap();
+    fs::write(repo.path().join("docs/api.md"), "docs\n".repeat(10)).unwrap();
+
+    repo.git_ai(&[
+        "checkpoint",
+        "mock_ai",
+        "src/app.ts",
+        "Cargo.lock",
+        "generated/schema.ts",
+        "docs/api.md",
+    ])
+    .unwrap();
+    let commit = repo
+        .stage_all_and_commit("change visible and ignored files")
+        .unwrap();
+
+    let git_repo = get_repo(&repo);
+    let parent_sha = get_parent_sha(&repo);
+    let diff_hunks =
+        get_diff_with_line_numbers(&git_repo, &parent_sha, &commit.commit_sha).unwrap();
+
+    let raw_paths: Vec<&str> = diff_hunks
+        .iter()
+        .map(|hunk| hunk.file_path.as_str())
+        .collect();
+    assert!(raw_paths.contains(&"src/app.ts"));
+    assert!(raw_paths.contains(&"Cargo.lock"));
+    assert!(raw_paths.contains(&"generated/schema.ts"));
+    assert!(raw_paths.contains(&"docs/api.md"));
+
+    let artifacts = build_diff_artifacts_from_hunks(
+        &git_repo,
+        diff_hunks,
+        &commit.commit_sha,
+        Some(&commit.authorship_log),
+    )
+    .unwrap();
+
+    let mut artifact_paths: Vec<&str> = artifacts
+        .json_hunks
+        .iter()
+        .map(|hunk| hunk.file_path.as_str())
+        .collect();
+    artifact_paths.sort_unstable();
+    artifact_paths.dedup();
+
+    assert_eq!(artifact_paths, vec!["src/app.ts"]);
+
+    let hunks_json = serde_json::to_string(&artifacts.json_hunks).unwrap();
+    assert!(hunks_json.contains("src/app.ts"));
+    assert!(!hunks_json.contains("Cargo.lock"));
+    assert!(!hunks_json.contains("generated/schema.ts"));
+    assert!(!hunks_json.contains("docs/api.md"));
+}

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -701,6 +701,62 @@ fn test_post_commit_large_ignored_files_do_not_trigger_skip_warning() {
 }
 
 #[test]
+fn test_post_commit_large_ignored_deletions_do_not_trigger_skip_warning() {
+    let repo = TestRepo::new();
+
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::create_dir_all(repo.path().join("generated")).unwrap();
+    fs::create_dir_all(repo.path().join("docs")).unwrap();
+
+    fs::write(
+        repo.path().join(".gitattributes"),
+        "generated/** linguist-generated=true\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join(".git-ai-ignore"), "docs/**\n").unwrap();
+    fs::write(repo.path().join("src/lib.rs"), "pub fn existing() {}\n").unwrap();
+    fs::write(
+        repo.path().join("Cargo.lock"),
+        "lockfile-entry\n".repeat(2500),
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("generated/schema.ts"),
+        "export const generated = true;\n".repeat(2500),
+    )
+    .unwrap();
+    fs::write(repo.path().join("docs/api.md"), "docs\n".repeat(2500)).unwrap();
+    repo.stage_all_and_commit("Initial ignored artifacts")
+        .unwrap();
+
+    fs::remove_file(repo.path().join("Cargo.lock")).unwrap();
+    fs::remove_dir_all(repo.path().join("generated")).unwrap();
+    fs::remove_dir_all(repo.path().join("docs")).unwrap();
+    fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub fn existing() {}\npub fn counted() {}\n",
+    )
+    .unwrap();
+
+    let commit = repo
+        .stage_all_and_commit("Delete ignored artifacts and update source")
+        .expect("commit should succeed");
+
+    assert!(
+        !commit
+            .stdout
+            .contains("Skipped git-ai stats for large commit"),
+        "large ignored deletions should not trigger post-commit skip warning: {}",
+        commit.stdout
+    );
+
+    let stats = stats_from_args(&repo, &["stats", "HEAD", "--json"]);
+    assert_eq!(stats.git_diff_added_lines, 1);
+    assert_eq!(stats.git_diff_deleted_lines, 0);
+    assert_eq!(stats.unknown_additions, 1);
+}
+
+#[test]
 fn test_stats_ignores_renamed_files() {
     // Test that stats correctly ignores pure renames (no content changes)
     // Reproduces issue #923
@@ -783,5 +839,6 @@ crate::reuse_tests_in_worktree!(
     test_stats_ignore_flag_is_additive_to_defaults,
     test_stats_range_uses_default_ignores,
     test_post_commit_large_ignored_files_do_not_trigger_skip_warning,
+    test_post_commit_large_ignored_deletions_do_not_trigger_skip_warning,
     test_stats_ignores_renamed_files,
 );


### PR DESCRIPTION
## Summary

- Track deleted-line counts per file in the git diff parser so post-commit stats-cost estimation can filter ignored deletions before summing.
- Keep committed metric scalar values sourced from ignore-filtered commit stats and add sparse-position coverage for the committed event payload.
- Add post-commit hunk coverage showing metric-facing hunk JSON excludes default ignored files, `.git-ai-ignore` matches, and linguist-generated files.

## Why

Commit stats and telemetry can otherwise overcount large ignored/generated changes, especially deletion-heavy commits where ignored files previously contributed to the expensive stats preflight estimate.

## Validation

- `task fmt`
- `task lint`
- `task build`
- `git diff --check`
- `task test TEST_FILTER=test_committed_metric_values_use_filtered_stats_and_hunks_payload`
- `task test TEST_FILTER=test_commit_hunks_post_commit_path_respects_all_ignore_sources`
- `task test TEST_FILTER=test_post_commit_large_ignored_deletions_do_not_trigger_skip_warning`
- `task test TEST_FILTER=test_parse_diff_added_lines_with_insertions`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->