### PR TITLE
test: use explicit known-human fixtures

### DIFF
--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -25,9 +25,17 @@ fn add_self_origin(repo: &TestRepo) {
 fn test_ci_fork_squash_merge() {
     // Setup: create "upstream" repo with initial commit
     let upstream = TestRepo::new();
-    let mut file = upstream.filename("feature.js");
 
-    file.set_contents(lines!["// Original code", "function original() {}"]);
+    let upstream_feature_path = upstream.path().join("feature.js");
+    fs::write(
+        &upstream_feature_path,
+        "// Original code\nfunction original() {}\n",
+    )
+    .unwrap();
+    upstream
+        .git_ai(&["checkpoint", "mock_known_human", "feature.js"])
+        .unwrap();
+    let mut file = upstream.filename("feature.js");
     let base_commit = upstream.stage_all_and_commit("Initial commit").unwrap();
     upstream.git(&["branch", "-M", "main"]).unwrap();
     add_self_origin(&upstream);
@@ -44,8 +52,8 @@ fn test_ci_fork_squash_merge() {
     // Fork contributor adds AI code using git-ai
     let mut fork_file = fork.filename("feature.js");
     fork_file.set_contents(lines![
-        "// Original code",
-        "function original() {}",
+        "// Original code".human(),
+        "function original() {}".human(),
         "// AI added function".ai(),
         "function aiFeature() {".ai(),
         "  return 'from fork';".ai(),

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1224,19 +1224,18 @@ fn test_ci_squash_merge_mixed_content() {
         .commit_sha;
     repo.git(&["branch", "-M", "main"]).unwrap();
 
-    // Feature branch: human comment, AI code, human comment.
+    // Feature branch: known-human comment, AI code, known-human comment.
     repo.git(&["checkout", "-b", "feature"]).unwrap();
-    file.insert_at(
-        2,
-        crate::lines![
-            "// Human comment",
-            "// AI generated function".ai(),
-            "function aiHelper() {".ai(),
-            "  return true;".ai(),
-            "}".ai(),
-            "// Another human comment"
-        ],
-    );
+    file.set_contents(crate::lines![
+        "// Base code".human(),
+        "const base = 1;".human(),
+        "// Human comment".human(),
+        "// AI generated function".ai(),
+        "function aiHelper() {".ai(),
+        "  return true;".ai(),
+        "}".ai(),
+        "// Another human comment".human()
+    ]);
     let head_sha = repo
         .stage_all_and_commit("Add mixed content")
         .unwrap()
@@ -1247,13 +1246,12 @@ fn test_ci_squash_merge_mixed_content() {
     let output = run_ci_local_merge(&repo, &merge_sha, &head_sha, &base_sha);
     assert_ci_rewrite_succeeded(&output);
 
-    // The squashed commit splits attribution by author: the AI block (and the
-    // bare `// Human comment` pulled into the AI hunk boundary) is AI; the
-    // trailing untracked human comment stays human.
+    // The squashed commit splits attribution by author: known-human lines stay
+    // human and the AI block stays AI.
     file.assert_lines_and_blame(crate::lines![
         "// Base code".human(),
         "const base = 1;".human(),
-        "// Human comment".ai(),
+        "// Human comment".human(),
         "// AI generated function".ai(),
         "function aiHelper() {".ai(),
         "  return true;".ai(),

--- a/tests/integration/codex.rs
+++ b/tests/integration/codex.rs
@@ -279,8 +279,11 @@ fn test_codex_commit_inside_bash_inflight_repeated_append_keeps_file_ai() {
         patch.exclude_prompts_in_repositories = Some(vec![]);
     });
 
+    let readme_path = repo.path().join("README.md");
+    fs::write(&readme_path, "Project README\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "README.md"])
+        .expect("initial README known-human checkpoint should succeed");
     let mut readme = repo.filename("README.md");
-    readme.set_contents(crate::lines!["Project README"]);
     repo.stage_all_and_commit("Initial README")
         .expect("initial README commit should succeed");
 

--- a/tests/integration/diff.rs
+++ b/tests/integration/diff.rs
@@ -1988,8 +1988,11 @@ fn test_diff_parsing_is_stable_under_hostile_diff_config() {
 fn test_checkpoint_and_commit_ignore_repo_external_diff_helper() {
     let repo = TestRepo::new();
 
+    let file_path = repo.path().join("tracked.txt");
+    std::fs::write(&file_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "tracked.txt"])
+        .unwrap();
     let mut file = repo.filename("tracked.txt");
-    file.set_contents(crate::lines!["base".human()]);
     repo.stage_all_and_commit("initial").unwrap();
 
     file.set_contents(crate::lines!["base".human(), "added by ai".ai()]);

--- a/tests/integration/github_copilot_integration.rs
+++ b/tests/integration/github_copilot_integration.rs
@@ -97,17 +97,19 @@ fn test_github_copilot_human_checkpoint_scoped_to_files() {
 #[test]
 fn test_github_copilot_human_then_ai_checkpoint() {
     let repo = TestRepo::new();
-    let mut file = repo.filename("test.ts");
 
     // Create initial file
-    file.set_contents(crate::lines!["const x = 1;"]);
+    let file_path = repo.path().join("test.ts");
+    std::fs::write(&file_path, "const x = 1;\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.ts"])
+        .unwrap();
     repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = crate::repos::test_file::TestFile::from_existing_file(file_path.clone(), &repo);
 
     // Human makes a change
     file.insert_at(1, crate::lines!["const y = 2;"]);
 
     // Human checkpoint
-    let file_path = repo.path().join("test.ts");
     let human_hook_input = json!({
         "hook_event_name": "before_edit",
         "workspaceFolder": repo.path().to_str().unwrap(),

--- a/tests/integration/graphite.rs
+++ b/tests/integration/graphite.rs
@@ -612,10 +612,13 @@ fn test_gt_squash_mixed_ai_human_across_commits() {
     gt_init(&repo);
 
     // First commit: all human
-    let mut file = repo.filename("squash_mixed.txt");
-    file.set_contents(crate::lines!["human only line 1", "human only line 2"]);
+    let file_path = repo.path().join("squash_mixed.txt");
+    std::fs::write(&file_path, "human only line 1\nhuman only line 2\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "squash_mixed.txt"])
+        .unwrap();
     repo.git(&["add", "-A"]).unwrap();
     gt(&repo, &["create", "squash-mixed", "-m", "human commit"]).expect("gt create should succeed");
+    let mut file = crate::repos::test_file::TestFile::from_existing_file(file_path, &repo);
 
     // Second commit: add AI lines
     file.set_contents(crate::lines![
@@ -771,10 +774,13 @@ fn test_gt_fold_with_mixed_content() {
     gt_init(&repo);
 
     // Create parent branch with a file containing mixed content
-    let mut file = repo.filename("fold_mixed.txt");
-    file.set_contents(crate::lines!["parent line 1", "parent line 2"]);
+    let file_path = repo.path().join("fold_mixed.txt");
+    std::fs::write(&file_path, "parent line 1\nparent line 2\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "fold_mixed.txt"])
+        .unwrap();
     repo.git(&["add", "-A"]).unwrap();
     gt(&repo, &["create", "fold-mixed-parent", "-m", "parent"]).expect("gt create should succeed");
+    let mut file = crate::repos::test_file::TestFile::from_existing_file(file_path, &repo);
 
     // Create child that modifies the same file
     file.set_contents(crate::lines![

--- a/tests/integration/rebase_attribution_remaining.rs
+++ b/tests/integration/rebase_attribution_remaining.rs
@@ -13,8 +13,12 @@ fn test_pull_rebase_autostash_ff_preserves_uncommitted_ai_attribution() {
     let (local, _upstream) = TestRepo::new_with_remote();
 
     // Initial commit: push to remote so both sides share a base
-    let mut base_file = local.filename("base.txt");
-    base_file.set_contents(crate::lines!["base content".human()]);
+    let base_path = local.path().join("base.txt");
+    std::fs::write(&base_path, "base content\n").unwrap();
+    local
+        .git_ai(&["checkpoint", "mock_known_human", "base.txt"])
+        .unwrap();
+    let mut base_file = crate::repos::test_file::TestFile::from_existing_file(base_path, &local);
     local.stage_all_and_commit("initial").unwrap();
     local.git(&["push", "-u", "origin", "HEAD"]).unwrap();
 

--- a/tests/integration/reset.rs
+++ b/tests/integration/reset.rs
@@ -299,12 +299,12 @@ fn test_reset_mixed_ai_human_changes() {
     let repo = TestRepo::new();
     let mut file = repo.filename("main.rs");
 
-    // Base commit
-    file.set_contents(crate::lines!["fn main() {}"]);
+    // Base commit has known-human wrapper context.
+    file.set_contents(crate::lines!["fn main() {", "}"]);
     let base = repo.stage_all_and_commit("Base").unwrap();
 
     // AI commit
-    file.set_contents(crate::lines!["fn main() {", "    // AI".ai(), "}"]);
+    file.insert_at(1, crate::lines!["    // AI".ai()]);
     repo.stage_all_and_commit("AI changes").unwrap();
 
     // Human commit

--- a/tests/integration/sessions_cutover.rs
+++ b/tests/integration/sessions_cutover.rs
@@ -529,20 +529,25 @@ fn test_old_format_note_roundtrips_without_corruption() {
 #[test]
 fn test_reset_preserves_old_format_notes_in_working_log() {
     let repo = TestRepo::new();
+    let file_path = repo.path().join("test.txt");
 
     // Create initial commit
-    let mut file = repo.filename("test.txt");
-    file.set_contents(crate::lines!["Line 1"]);
+    fs::write(&file_path, "Line 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.txt"])
+        .unwrap();
     repo.stage_all_and_commit("Initial").unwrap();
 
     // Create commit with AI content
-    file.set_contents(crate::lines!["Line 1", "AI line".ai()]);
+    fs::write(&file_path, "Line 1\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "test.txt"]).unwrap();
     let commit = repo.stage_all_and_commit("AI commit").unwrap();
 
     // Replace with old-format note (using "windsurf" as tool name)
     let old_hash = "aabbccddeeff1122";
+    let human_hash = "h_resetoldhuman";
     let old_note = format!(
         r#"test.txt
+  {} 1-1
   {} 2-2
 ---
 {{
@@ -559,9 +564,14 @@ fn test_reset_preserves_old_format_notes_in_working_log() {
       "accepted_lines": 1,
       "overriden_lines": 0
     }}
+  }},
+  "humans": {{
+    "{}": {{
+      "author": "Test User <test@example.com>"
+    }}
   }}
 }}"#,
-        old_hash, commit.commit_sha, old_hash
+        human_hash, old_hash, commit.commit_sha, old_hash, human_hash
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
@@ -587,6 +597,7 @@ fn test_reset_preserves_old_format_notes_in_working_log() {
     );
 
     // Verify AI attribution still works
+    let mut file = repo.filename("test.txt");
     file.assert_committed_lines(crate::lines!["Line 1".human(), "AI line".ai(),]);
 }
 
@@ -644,7 +655,10 @@ fn test_amend_old_prompts_commit_with_new_session_checkpoints() {
     let repo = TestRepo::new();
     let file_path = repo.path().join("example.txt");
 
-    // Step 1: Create initial commit with AI content
+    // Step 1: Create initial commit with known-human context and AI content
+    fs::write(&file_path, "Human line 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.txt"])
+        .unwrap();
     let initial = "Human line 1\nAI old line\n";
     fs::write(&file_path, initial).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
@@ -653,8 +667,10 @@ fn test_amend_old_prompts_commit_with_new_session_checkpoints() {
 
     // Step 2: Replace the note with an old-format note (simulating pre-upgrade git-ai)
     let old_hash = "deadbeef12345678"; // 16-char bare hex (old format)
+    let human_hash = "h_amendoldhuman";
     let old_note = format!(
         r#"example.txt
+  {} 1-1
   {} 2-2
 ---
 {{
@@ -671,9 +687,14 @@ fn test_amend_old_prompts_commit_with_new_session_checkpoints() {
       "accepted_lines": 1,
       "overriden_lines": 0
     }}
+  }},
+  "humans": {{
+    "{}": {{
+      "author": "Test User <test@example.com>"
+    }}
   }}
 }}"#,
-        old_hash, commit.commit_sha, old_hash
+        human_hash, old_hash, commit.commit_sha, old_hash, human_hash
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
@@ -1650,7 +1671,10 @@ fn test_amend_old_prompts_delete_ai_line_then_add_new_session_line() {
     let repo = TestRepo::new();
     let file_path = repo.path().join("prune.txt");
 
-    // Step 1: Create initial commit with AI content
+    // Step 1: Create initial commit with known-human context and AI content
+    fs::write(&file_path, "Human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "prune.txt"])
+        .unwrap();
     let initial = "Human line\nOld AI line\n";
     fs::write(&file_path, initial).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "prune.txt"])
@@ -1659,8 +1683,10 @@ fn test_amend_old_prompts_delete_ai_line_then_add_new_session_line() {
 
     // Step 2: Replace note with old-format
     let old_hash = "prunetest1234567";
+    let human_hash = "h_pruneoldhuman";
     let old_note = format!(
         r#"prune.txt
+  {} 1-1
   {} 2-2
 ---
 {{
@@ -1677,9 +1703,14 @@ fn test_amend_old_prompts_delete_ai_line_then_add_new_session_line() {
       "accepted_lines": 1,
       "overriden_lines": 0
     }}
+  }},
+  "humans": {{
+    "{}": {{
+      "author": "Test User <test@example.com>"
+    }}
   }}
 }}"#,
-        old_hash, commit.commit_sha, old_hash
+        human_hash, old_hash, commit.commit_sha, old_hash, human_hash
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
@@ -1755,7 +1786,10 @@ fn test_amend_old_prompts_keep_old_line_add_new_session_same_file() {
     let repo = TestRepo::new();
     let file_path = repo.path().join("keepold.txt");
 
-    // Step 1: Create initial commit with AI content
+    // Step 1: Create initial commit with known-human context and AI content
+    fs::write(&file_path, "Human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "keepold.txt"])
+        .unwrap();
     let initial = "Human line\nOld AI line\n";
     fs::write(&file_path, initial).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "keepold.txt"])
@@ -1764,8 +1798,10 @@ fn test_amend_old_prompts_keep_old_line_add_new_session_same_file() {
 
     // Step 2: Replace note with old-format
     let old_hash = "keepoldtest12345";
+    let human_hash = "h_keepoldhuman";
     let old_note = format!(
         r#"keepold.txt
+  {} 1-1
   {} 2-2
 ---
 {{
@@ -1782,9 +1818,14 @@ fn test_amend_old_prompts_keep_old_line_add_new_session_same_file() {
       "accepted_lines": 1,
       "overriden_lines": 0
     }}
+  }},
+  "humans": {{
+    "{}": {{
+      "author": "Test User <test@example.com>"
+    }}
   }}
 }}"#,
-        old_hash, commit.commit_sha, old_hash
+        human_hash, old_hash, commit.commit_sha, old_hash, human_hash
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
@@ -1859,7 +1900,10 @@ fn test_multiple_amends_mixed_format_accumulation() {
     let repo = TestRepo::new();
     let file_path = repo.path().join("multi.txt");
 
-    // Step 1: Initial commit
+    // Step 1: Initial commit with known-human context and AI content
+    fs::write(&file_path, "Line 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "multi.txt"])
+        .unwrap();
     let initial = "Line 1\nOld AI line\n";
     fs::write(&file_path, initial).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "multi.txt"])
@@ -1868,8 +1912,10 @@ fn test_multiple_amends_mixed_format_accumulation() {
 
     // Step 2: Replace note with old-format
     let old_hash = "multiamend123456";
+    let human_hash = "h_multiamendhuman";
     let old_note = format!(
         r#"multi.txt
+  {} 1-1
   {} 2-2
 ---
 {{
@@ -1886,9 +1932,14 @@ fn test_multiple_amends_mixed_format_accumulation() {
       "accepted_lines": 1,
       "overriden_lines": 0
     }}
+  }},
+  "humans": {{
+    "{}": {{
+      "author": "Test User <test@example.com>"
+    }}
   }}
 }}"#,
-        old_hash, commit.commit_sha, old_hash
+        human_hash, old_hash, commit.commit_sha, old_hash, human_hash
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
@@ -2071,7 +2122,10 @@ fn test_amend_old_prompts_different_file_gets_session_edits() {
     let file_a = repo.path().join("file_a.txt");
     let file_b = repo.path().join("file_b.txt");
 
-    // Step 1: Initial commit with AI content in file_a
+    // Step 1: Initial commit with known-human context and AI content in file_a
+    fs::write(&file_a, "Human line A\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "file_a.txt"])
+        .unwrap();
     let initial_a = "Human line A\nOld AI line A\n";
     fs::write(&file_a, initial_a).unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "file_a.txt"])
@@ -2080,8 +2134,10 @@ fn test_amend_old_prompts_different_file_gets_session_edits() {
 
     // Step 2: Replace with old-format note for file_a
     let old_hash = "crossfile1234567";
+    let human_hash = "h_crossfilehuman";
     let old_note = format!(
         r#"file_a.txt
+  {} 1-1
   {} 2-2
 ---
 {{
@@ -2098,9 +2154,14 @@ fn test_amend_old_prompts_different_file_gets_session_edits() {
       "accepted_lines": 1,
       "overriden_lines": 0
     }}
+  }},
+  "humans": {{
+    "{}": {{
+      "author": "Test User <test@example.com>"
+    }}
   }}
 }}"#,
-        old_hash, commit.commit_sha, old_hash
+        human_hash, old_hash, commit.commit_sha, old_hash, human_hash
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1121,7 +1121,8 @@ fn test_ai_deletion_with_human_checkpoint_in_same_commit() {
 
     fs::write(&file_path, "Base Line 1\nBase Line 2\nBase Line 3").unwrap();
 
-    repo.git_ai(&["checkpoint"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "data.txt"])
+        .unwrap();
 
     fs::write(
         &file_path,

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -258,8 +258,11 @@ fn test_stash_with_existing_initial_attributions() {
         .expect("commit should succeed");
 
     // Create a file and commit it (this will have some attribution)
+    let example_path = repo.path().join("example.txt");
+    fs::write(&example_path, "existing line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.txt"])
+        .unwrap();
     let mut example = repo.filename("example.txt");
-    example.set_contents(vec!["existing line".human()]);
     let _first_commit = repo
         .stage_all_and_commit("add example")
         .expect("commit should succeed");
@@ -784,8 +787,11 @@ fn test_stash_pop_across_branches() {
         .expect("commit should succeed");
 
     // Create a file with existing human content
+    let example_path = repo.path().join("example.txt");
+    fs::write(&example_path, "line 1\nline 2\nline 3\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.txt"])
+        .unwrap();
     let mut example = repo.filename("example.txt");
-    example.set_contents(vec!["line 1".human(), "line 2".human(), "line 3".human()]);
     repo.stage_all_and_commit("add example file")
         .expect("commit should succeed");
 
@@ -858,8 +864,11 @@ fn test_stash_pop_across_branches_with_conflict() {
         .expect("commit should succeed");
 
     // Create a file with existing content
+    let example_path = repo.path().join("example.txt");
+    fs::write(&example_path, "line 1\nline 2\nline 3\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.txt"])
+        .unwrap();
     let mut example = repo.filename("example.txt");
-    example.set_contents(vec!["line 1".human(), "line 2".human(), "line 3".human()]);
     repo.stage_all_and_commit("add example file")
         .expect("commit should succeed");
 

--- a/tests/integration/subdirs.rs
+++ b/tests/integration/subdirs.rs
@@ -810,12 +810,12 @@ crate::subdir_test_variants! {
 
         let mut file = repo.filename("main.rs");
 
-        // Base commit
-        file.set_contents(crate::lines!["fn main() {}"]);
+        // Base commit has known-human wrapper context.
+        file.set_contents(crate::lines!["fn main() {", "}"]);
         let base = repo.stage_all_and_commit("Base").unwrap();
 
         // AI commit
-        file.set_contents(crate::lines!["fn main() {", "    // AI".ai(), "}"]);
+        file.insert_at(1, crate::lines!["    // AI".ai()]);
         repo.stage_all_and_commit("AI changes").unwrap();
 
         // Human commit

--- a/tests/integration/worktrees.rs
+++ b/tests/integration/worktrees.rs
@@ -222,8 +222,11 @@ crate::worktree_test_wrappers! {
 crate::worktree_test_wrappers! {
     fn stash_pop_preserves_ai_authorship() {
         let repo = TestRepo::new();
+        let file_path = repo.path().join("stash.txt");
+        fs::write(&file_path, "base\n").unwrap();
+        repo.git_ai(&["checkpoint", "mock_known_human", "stash.txt"])
+            .unwrap();
         let mut file = repo.filename("stash.txt");
-        file.set_contents(crate::lines!["base".human()]);
         repo.stage_all_and_commit("base").unwrap();
 
         file.set_contents(crate::lines!["base".human(), "ai stash line".ai()]);
@@ -238,8 +241,11 @@ crate::worktree_test_wrappers! {
 crate::worktree_test_wrappers! {
     fn reset_mixed_reconstructs_working_log() {
         let repo = TestRepo::new();
+        let file_path = repo.path().join("reset.txt");
+        fs::write(&file_path, "base\n").unwrap();
+        repo.git_ai(&["checkpoint", "mock_known_human", "reset.txt"])
+            .unwrap();
         let mut file = repo.filename("reset.txt");
-        file.set_contents(crate::lines!["base".human()]);
         repo.stage_all_and_commit("base").unwrap();
 
         file.set_contents(crate::lines!["base".human(), "ai reset line".ai()]);
@@ -256,8 +262,11 @@ crate::worktree_test_wrappers! {
 crate::worktree_test_wrappers! {
     fn rebase_preserves_ai_authorship() {
         let repo = TestRepo::new();
+        let file_path = repo.path().join("rebase.txt");
+        fs::write(&file_path, "base\n").unwrap();
+        repo.git_ai(&["checkpoint", "mock_known_human", "rebase.txt"])
+            .unwrap();
         let mut file = repo.filename("rebase.txt");
-        file.set_contents(crate::lines!["base".human()]);
         repo.stage_all_and_commit("base").unwrap();
         repo.git(&["checkout", "-b", "integration"]).unwrap();
 
@@ -280,8 +289,11 @@ crate::worktree_test_wrappers! {
 crate::worktree_test_wrappers! {
     fn cherry_pick_preserves_ai_authorship() {
         let repo = TestRepo::new();
+        let file_path = repo.path().join("cherry.txt");
+        fs::write(&file_path, "base\n").unwrap();
+        repo.git_ai(&["checkpoint", "mock_known_human", "cherry.txt"])
+            .unwrap();
         let mut file = repo.filename("cherry.txt");
-        file.set_contents(crate::lines!["base".human()]);
         repo.stage_all_and_commit("base").unwrap();
         repo.git(&["checkout", "-b", "integration"]).unwrap();
 


### PR DESCRIPTION
## Summary
- Convert legacy test fixtures that mean real human edits to use explicit known-human checkpoints.
- Keep old expectations readable by avoiding lines labeled human that are actually legacy/untracked.
- Leave feature-specific bash recovery test changes for the stacked feature PR.

## Verification
- task test TEST_FILTER=ci_squash_merge_mixed_content NO_CAPTURE=true
- task test TEST_FILTER=reset_mixed_ai_human_changes NO_CAPTURE=true
- task test TEST_FILTER=sessions_cutover NO_CAPTURE=true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->