### PR TITLE
Fix Cursor hook stdin decoding for CJK content

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -391,11 +391,18 @@ fn handle_checkpoint(args: &[String]) {
                     hook_input = Some(strip_utf8_bom(args[i + 1].clone()));
                     if hook_input.as_ref().unwrap() == "stdin" {
                         let mut stdin = std::io::stdin();
-                        let mut buffer = String::new();
-                        if let Err(e) = stdin.read_to_string(&mut buffer) {
+                        let mut buffer = Vec::new();
+                        if let Err(e) = stdin.read_to_end(&mut buffer) {
                             eprintln!("Failed to read stdin for hook input: {}", e);
                             std::process::exit(0);
                         }
+                        let buffer = match decode_hook_input_bytes(buffer) {
+                            Ok(buffer) => buffer,
+                            Err(e) => {
+                                eprintln!("Failed to decode stdin for hook input: {}", e);
+                                std::process::exit(0);
+                            }
+                        };
                         if buffer.trim().is_empty() {
                             eprintln!("No hook input provided (via --hook-input or stdin).");
                             std::process::exit(0);
@@ -572,6 +579,65 @@ fn strip_utf8_bom(input: String) -> String {
     } else {
         input
     }
+}
+
+fn decode_hook_input_bytes(bytes: Vec<u8>) -> Result<String, String> {
+    if bytes.starts_with(&[0xFF, 0xFE]) {
+        return decode_utf16_hook_input(&bytes[2..], Utf16Endian::Little);
+    }
+    if bytes.starts_with(&[0xFE, 0xFF]) {
+        return decode_utf16_hook_input(&bytes[2..], Utf16Endian::Big);
+    }
+
+    match likely_utf16_endian(&bytes) {
+        Some(endian) => decode_utf16_hook_input(&bytes, endian),
+        None => String::from_utf8(bytes).map_err(|e| e.to_string()),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Utf16Endian {
+    Little,
+    Big,
+}
+
+fn likely_utf16_endian(bytes: &[u8]) -> Option<Utf16Endian> {
+    let sample_len = bytes.len().min(512);
+    if sample_len < 8 {
+        return None;
+    }
+
+    let sample = &bytes[..sample_len];
+    let even_nuls = sample.iter().step_by(2).filter(|&&b| b == 0).count();
+    let odd_nuls = sample
+        .iter()
+        .skip(1)
+        .step_by(2)
+        .filter(|&&b| b == 0)
+        .count();
+    let min_nuls = sample_len / 8;
+
+    if odd_nuls > min_nuls && odd_nuls > even_nuls.saturating_mul(4) {
+        Some(Utf16Endian::Little)
+    } else if even_nuls > min_nuls && even_nuls > odd_nuls.saturating_mul(4) {
+        Some(Utf16Endian::Big)
+    } else {
+        None
+    }
+}
+
+fn decode_utf16_hook_input(bytes: &[u8], endian: Utf16Endian) -> Result<String, String> {
+    let chunks = bytes.chunks_exact(2);
+    if !chunks.remainder().is_empty() {
+        return Err("UTF-16 hook input has an odd byte length".to_string());
+    }
+
+    let code_units = chunks.map(|chunk| match endian {
+        Utf16Endian::Little => u16::from_le_bytes([chunk[0], chunk[1]]),
+        Utf16Endian::Big => u16::from_be_bytes([chunk[0], chunk[1]]),
+    });
+
+    String::from_utf16(&code_units.collect::<Vec<u16>>()).map_err(|e| e.to_string())
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/tests/integration/cursor.rs
+++ b/tests/integration/cursor.rs
@@ -245,6 +245,61 @@ fn test_cursor_checkpoint_stdin_with_utf8_bom() {
     );
 }
 
+fn utf16le_bytes(input: &str) -> Vec<u8> {
+    input
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect()
+}
+
+#[test]
+fn test_cursor_checkpoint_stdin_with_utf16le_odd_cjk_content() {
+    use std::fs;
+
+    let repo = TestRepo::new();
+
+    let src_dir = repo.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    let file_path = repo.path().join("src/文案文.js");
+    fs::write(&file_path, "const a = \"base\";\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("src/文案文.js");
+    file.assert_committed_lines(crate::lines!["const a = \"base\";".unattributed_human(),]);
+
+    let edited_content = "const a = \"文案文\"; // 3 chars\n";
+    fs::write(&file_path, edited_content).unwrap();
+
+    let hook_input = serde_json::json!({
+        "conversation_id": TEST_CONVERSATION_ID,
+        "workspace_roots": [repo.canonical_path().to_string_lossy().to_string()],
+        "hook_event_name": "postToolUse",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": file_path.to_string_lossy().to_string(),
+            "content": edited_content,
+        },
+        "model": "model-name-from-hook-test"
+    })
+    .to_string();
+
+    let output = repo
+        .git_ai_with_stdin(
+            &["checkpoint", "cursor", "--hook-input", "stdin"],
+            &utf16le_bytes(&hook_input),
+        )
+        .expect("checkpoint should parse UTF-16LE stdin payload with odd CJK content");
+
+    assert!(
+        !output.contains("Invalid JSON in hook_input"),
+        "Should not fail JSON parsing for odd CJK content in UTF-16LE stdin. Output: {output}"
+    );
+
+    repo.stage_all_and_commit("Add cursor CJK edit").unwrap();
+
+    file.assert_lines_and_blame(crate::lines!["const a = \"文案文\"; // 3 chars".ai(),]);
+}
+
 #[test]
 fn test_cursor_e2e_with_attribution() {
     use std::fs;


### PR DESCRIPTION
## Summary
- Read `--hook-input stdin` as bytes before decoding
- Support UTF-8 plus UTF-16LE/UTF-16BE hook payloads, including BOM and NUL-pattern detection
- Add a Cursor regression with odd-count CJK content encoded as UTF-16LE stdin

Fixes #1317.

## Validation
Run from the repo root on this branch:

```bash
task fmt
task lint
task test TEST_FILTER=test_cursor_checkpoint_stdin_with_utf16le_odd_cjk_content
```

Expected outcomes:
- `task fmt` exits cleanly with no rustfmt diffs.
- `task lint` exits cleanly with no clippy/lint failures.
- The targeted Cursor test passes.
- The test sends a UTF-16LE JSON hook payload through `--hook-input stdin`, the checkpoint command does not emit `Invalid JSON in hook_input`, and the committed CJK line is verified as AI-authored.

Broader regression sweep:

```bash
task test TEST_FILTER=cursor
```

Expected outcome: Cursor preset and integration tests pass, including UTF-8 BOM and UTF-16 stdin decoding paths.

Additional whitespace check:

```bash
git diff --check origin/main..siddhant/1317-cursor-windows-cjk-hook-json
```

Expected outcome: no output and exit code `0`.

## Docs
No docs change needed. This is an input decoding bug fix for existing Cursor hook behavior and is covered by regression tests.

## Notes
Draft PR for focused review and CI validation.