### PR TITLE
Fix cherry-pick attribution for local remote refs

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,8 +6,12 @@ use crate::git::cli_parser::{
     ParsedGitInvocation, explicit_rebase_branch_arg, parse_git_cli_args, summarize_rebase_args,
 };
 use crate::git::find_repository_in_path;
-use crate::git::repo_state::{common_dir_for_worktree, worktree_root_for_path};
-use crate::git::repository::{Repository, discover_repository_in_path_no_git_exec, exec_git};
+use crate::git::repo_state::{
+    common_dir_for_worktree, git_dir_for_worktree, worktree_root_for_path,
+};
+use crate::git::repository::{
+    Repository, discover_repository_in_path_no_git_exec, exec_git, exec_git_stdin,
+};
 use crate::git::sync_authorship::{fetch_authorship_notes, fetch_remote_from_args};
 use crate::utils::LockFile;
 use crate::{
@@ -1374,7 +1378,7 @@ fn cherry_pick_destination_commits(cmd: &crate::daemon::domain::NormalizedComman
         .collect()
 }
 
-fn cherry_pick_original_head(cmd: &crate::daemon::domain::NormalizedCommand) -> Option<String> {
+fn first_head_transition_old(cmd: &crate::daemon::domain::NormalizedCommand) -> Option<String> {
     cmd.ref_changes
         .iter()
         .find(|change| {
@@ -1386,6 +1390,310 @@ fn cherry_pick_original_head(cmd: &crate::daemon::domain::NormalizedCommand) -> 
                 && change.old != change.new
         })
         .map(|change| change.old.clone())
+}
+
+fn cherry_pick_original_head(cmd: &crate::daemon::domain::NormalizedCommand) -> Option<String> {
+    first_head_transition_old(cmd)
+}
+
+fn revert_original_head(cmd: &crate::daemon::domain::NormalizedCommand) -> Option<String> {
+    first_head_transition_old(cmd)
+}
+
+fn cherry_pick_source_args_for_side_effect(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> Vec<String> {
+    let parsed = parsed_invocation_for_normalized_command(cmd);
+    if parsed.command.as_deref() != Some("cherry-pick")
+        && cmd.primary_command.as_deref() != Some("cherry-pick")
+    {
+        return Vec::new();
+    }
+
+    cherry_pick_source_args_from_command_args(&parsed.command_args)
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn cherry_pick_command_has_flag(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+    flag: &str,
+) -> bool {
+    let parsed = parsed_invocation_for_normalized_command(cmd);
+    if parsed.command.as_deref() != Some("cherry-pick")
+        && cmd.primary_command.as_deref() != Some("cherry-pick")
+    {
+        return false;
+    }
+
+    parsed.command_args.iter().any(|arg| arg == flag)
+}
+
+fn cherry_pick_source_args_from_command_args(args: &[String]) -> Vec<&str> {
+    let mut sources = Vec::new();
+    let mut idx = 0usize;
+    while idx < args.len() {
+        let arg = args[idx].as_str();
+        if arg == "--" {
+            sources.extend(args[idx + 1..].iter().map(String::as_str));
+            break;
+        }
+        if matches!(arg, "--abort" | "--continue" | "--quit" | "--skip") {
+            return Vec::new();
+        }
+        if matches!(
+            arg,
+            "-m" | "--mainline" | "-X" | "--strategy-option" | "--strategy"
+        ) {
+            idx = idx.saturating_add(2);
+            continue;
+        }
+        if arg.starts_with("--mainline=")
+            || arg.starts_with("--strategy=")
+            || arg.starts_with("--strategy-option=")
+            || arg == "--gpg-sign"
+            || arg.starts_with("--gpg-sign=")
+            || arg.starts_with("-m")
+            || arg.starts_with("-X")
+            || arg.starts_with("-S")
+        {
+            idx += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            idx += 1;
+            continue;
+        }
+        if !arg.is_empty() {
+            sources.push(arg);
+        }
+        idx += 1;
+    }
+    sources
+}
+
+fn cherry_pick_source_is_range(source: &str) -> bool {
+    source.contains("..")
+}
+
+fn cherry_pick_range_has_omitted_side(source: &str) -> bool {
+    if let Some((left, right)) = source.split_once("...") {
+        left.is_empty() || right.is_empty()
+    } else if let Some((left, right)) = source.split_once("..") {
+        left.is_empty() || right.is_empty()
+    } else {
+        false
+    }
+}
+
+fn resolve_cherry_pick_source_args_with_git_in_head_context(
+    repo: &Repository,
+    source_args: &[String],
+    head_context: Option<&str>,
+) -> Result<Vec<String>, GitAiError> {
+    let mut resolved = Vec::new();
+    let mut seen = HashSet::new();
+
+    for source in source_args {
+        let source = head_context
+            .map(|head| rewrite_head_source_arg_for_side_effect(source, head))
+            .unwrap_or_else(|| source.clone());
+        let oids = if cherry_pick_source_is_range(&source) {
+            if cherry_pick_range_has_omitted_side(&source) {
+                Vec::new()
+            } else {
+                resolve_cherry_pick_range_source_with_git(repo, &source)?
+            }
+        } else {
+            resolve_cherry_pick_single_source_with_git(repo, &source)?
+        };
+
+        for oid in oids {
+            if seen.insert(oid.clone()) {
+                resolved.push(oid);
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
+fn rewrite_head_source_arg_for_side_effect(source: &str, head_context: &str) -> String {
+    if head_context.is_empty() || !is_valid_oid(head_context) {
+        return source.to_string();
+    }
+    if let Some((left, right)) = source.split_once("...") {
+        return format!(
+            "{}...{}",
+            rewrite_head_source_term_for_side_effect(left, head_context),
+            rewrite_head_source_term_for_side_effect(right, head_context)
+        );
+    }
+    if let Some((left, right)) = source.split_once("..") {
+        return format!(
+            "{}..{}",
+            rewrite_head_source_term_for_side_effect(left, head_context),
+            rewrite_head_source_term_for_side_effect(right, head_context)
+        );
+    }
+    rewrite_head_source_term_for_side_effect(source, head_context)
+}
+
+fn rewrite_head_source_term_for_side_effect(term: &str, head_context: &str) -> String {
+    if term == "HEAD" || term == "@" {
+        return head_context.to_string();
+    }
+    if let Some(suffix) = term.strip_prefix("HEAD")
+        && (suffix.starts_with('~') || suffix.starts_with('^'))
+    {
+        return format!("{head_context}{suffix}");
+    }
+    if let Some(suffix) = term.strip_prefix('@')
+        && (suffix.starts_with('~') || suffix.starts_with('^'))
+    {
+        return format!("{head_context}{suffix}");
+    }
+    term.to_string()
+}
+
+fn resolve_cherry_pick_single_source_with_git(
+    repo: &Repository,
+    source: &str,
+) -> Result<Vec<String>, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "cat-file".to_string(),
+        "--batch-check=%(objectname) %(objecttype)".to_string(),
+    ]);
+    let stdin_data = format!("{source}^{{commit}}\n");
+    let output = exec_git_stdin(&args, stdin_data.as_bytes())?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            let oid = parts.next()?;
+            (parts.next() == Some("commit") && is_valid_oid(oid)).then(|| oid.to_string())
+        })
+        .collect())
+}
+
+fn resolve_cherry_pick_range_source_with_git(
+    repo: &Repository,
+    source: &str,
+) -> Result<Vec<String>, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "rev-list".to_string(),
+        "--reverse".to_string(),
+        source.to_string(),
+    ]);
+    let output = exec_git(&args)?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| is_valid_oid(line))
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn resolve_explicit_cherry_pick_sources_for_side_effect(
+    repo: &Repository,
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> Result<Vec<String>, GitAiError> {
+    let source_args = cherry_pick_source_args_for_side_effect(cmd);
+    if source_args.is_empty() {
+        return Ok(Vec::new());
+    }
+    let original_head = cherry_pick_original_head(cmd);
+    resolve_cherry_pick_source_args_with_git_in_head_context(
+        repo,
+        &source_args,
+        original_head.as_deref(),
+    )
+}
+
+fn revert_source_args_for_side_effect(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> Vec<String> {
+    let parsed = parsed_invocation_for_normalized_command(cmd);
+    if parsed.command.as_deref() != Some("revert")
+        && cmd.primary_command.as_deref() != Some("revert")
+    {
+        return Vec::new();
+    }
+
+    revert_source_args_from_command_args(&parsed.command_args)
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn revert_source_args_from_command_args(args: &[String]) -> Vec<&str> {
+    let args = if args.first().is_some_and(|arg| arg == "revert") {
+        &args[1..]
+    } else {
+        args
+    };
+    let mut sources = Vec::new();
+    let mut idx = 0usize;
+    while idx < args.len() {
+        let arg = args[idx].as_str();
+        if arg == "--" {
+            sources.extend(args[idx + 1..].iter().map(String::as_str));
+            break;
+        }
+        if matches!(arg, "--abort" | "--continue" | "--quit" | "--skip") {
+            return Vec::new();
+        }
+        if matches!(arg, "-m" | "--mainline") {
+            idx = idx.saturating_add(2);
+            continue;
+        }
+        if arg.starts_with("--mainline=")
+            || arg == "--gpg-sign"
+            || arg.starts_with("--gpg-sign=")
+            || arg.starts_with("-S")
+        {
+            idx += 1;
+            continue;
+        }
+        if matches!(arg, "-n" | "--no-commit" | "--no-edit" | "-e" | "--edit") {
+            idx += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            idx += 1;
+            continue;
+        }
+        if !arg.is_empty() {
+            sources.push(arg);
+        }
+        idx += 1;
+    }
+    sources
+}
+
+fn resolve_explicit_revert_sources_for_side_effect(
+    repo: &Repository,
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> Result<Vec<String>, GitAiError> {
+    let source_args = revert_source_args_for_side_effect(cmd);
+    if source_args.is_empty() {
+        return Ok(Vec::new());
+    }
+    let original_head = revert_original_head(cmd);
+    resolve_cherry_pick_source_args_with_git_in_head_context(
+        repo,
+        &source_args,
+        original_head.as_deref(),
+    )
+}
+
+fn cherry_pick_state_exists_for_worktree(worktree: &Path) -> bool {
+    git_dir_for_worktree(worktree).is_some_and(|git_dir| {
+        git_dir.join("CHERRY_PICK_HEAD").exists() || git_dir.join("sequencer").join("todo").exists()
+    })
 }
 
 fn revert_destination_changes(
@@ -1407,6 +1715,7 @@ fn revert_destination_changes(
 fn apply_revert_complete_rewrite(
     repo: &crate::git::repository::Repository,
     cmd: &crate::daemon::domain::NormalizedCommand,
+    source_oids: &[String],
 ) -> Result<(), GitAiError> {
     let specs: Vec<crate::authorship::rewrite_revert::RevertSpec> = revert_destination_changes(cmd)
         .into_iter()
@@ -1415,7 +1724,7 @@ fn apply_revert_complete_rewrite(
             |(index, change)| crate::authorship::rewrite_revert::RevertSpec {
                 revert_commit: change.new.clone(),
                 parent: Some(change.old.clone()),
-                reverted_commit: cmd.revert_source_oids.get(index).cloned(),
+                reverted_commit: source_oids.get(index).cloned(),
             },
         )
         .collect();
@@ -3816,6 +4125,22 @@ impl ActorDaemonCoordinator {
             .unwrap_or_default())
     }
 
+    fn pending_cherry_pick_sources_for_worktree(
+        &self,
+        worktree: &Path,
+    ) -> Result<Vec<String>, GitAiError> {
+        let map = self
+            .pending_cherry_pick_sources_by_worktree
+            .lock()
+            .map_err(|_| {
+                GitAiError::Generic("pending cherry-pick sources map lock poisoned".to_string())
+            })?;
+        Ok(map
+            .get(&Self::worktree_state_key(worktree))
+            .cloned()
+            .unwrap_or_default())
+    }
+
     fn set_pending_cherry_pick_no_commit_for_worktree(
         &self,
         worktree: &Path,
@@ -4326,7 +4651,29 @@ impl ActorDaemonCoordinator {
                     self.clear_pending_cherry_pick_no_commit_for_worktree(worktree)?;
                 } else if cmd.exit_code != 0 {
                     let new_commits = cherry_pick_destination_commits(cmd);
-                    if !new_commits.is_empty() && !cmd.cherry_pick_source_oids.is_empty() {
+                    let is_continue = cherry_pick_command_has_flag(cmd, "--continue");
+                    let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
+                    let mut source_oids = cmd.cherry_pick_source_oids.clone();
+                    let mut source_oids_from_daemon_pending = false;
+                    if source_oids.is_empty()
+                        && (!new_commits.is_empty()
+                            || cherry_pick_state_exists_for_worktree(worktree))
+                    {
+                        let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+                        source_oids =
+                            resolve_explicit_cherry_pick_sources_for_side_effect(&repo, cmd)?;
+                    }
+                    if source_oids.is_empty() && (is_continue || is_skip) {
+                        source_oids = self.pending_cherry_pick_sources_for_worktree(worktree)?;
+                        source_oids_from_daemon_pending = !source_oids.is_empty();
+                    }
+                    let skipped_sources = usize::from(is_skip && source_oids_from_daemon_pending);
+                    let applied_source_oids = source_oids
+                        .iter()
+                        .skip(skipped_sources)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    if !new_commits.is_empty() && !applied_source_oids.is_empty() {
                         let repo = find_repository_in_path(&worktree.to_string_lossy())?;
                         let original_head = cherry_pick_original_head(cmd).ok_or_else(|| {
                             GitAiError::Generic(format!(
@@ -4337,17 +4684,22 @@ impl ActorDaemonCoordinator {
                         apply_cherry_pick_complete_rewrite(
                             &repo,
                             &original_head,
-                            &cmd.cherry_pick_source_oids,
+                            &applied_source_oids,
                             &new_commits,
                         )?;
                     }
-                    let remaining = cmd
-                        .cherry_pick_source_oids
-                        .iter()
-                        .skip(new_commits.len().min(cmd.cherry_pick_source_oids.len()))
-                        .cloned()
-                        .collect();
-                    self.set_pending_cherry_pick_sources_for_worktree(worktree, remaining)?;
+                    if !source_oids.is_empty() || is_continue || is_skip {
+                        let applied_sources = new_commits
+                            .len()
+                            .min(source_oids.len().saturating_sub(skipped_sources));
+                        let consumed_sources = skipped_sources + applied_sources;
+                        let remaining = source_oids
+                            .iter()
+                            .skip(consumed_sources.min(source_oids.len()))
+                            .cloned()
+                            .collect();
+                        self.set_pending_cherry_pick_sources_for_worktree(worktree, remaining)?;
+                    }
                 }
             }
             // Fix #957: `checkout/switch --merge` exits with code 1 when it produces
@@ -4427,14 +4779,30 @@ impl ActorDaemonCoordinator {
                         if !new_head.is_empty() {
                             let repo = find_repository_in_path(&worktree)?;
                             let mut sources = source_commits.clone();
-                            if sources.is_empty() {
-                                sources = self.take_pending_cherry_pick_sources_for_worktree(
-                                    worktree.as_ref(),
-                                )?;
-                            } else {
+                            let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
+                            let explicit_source_args = cherry_pick_source_args_for_side_effect(cmd);
+                            if !sources.is_empty() {
                                 self.clear_pending_cherry_pick_sources_for_worktree(
                                     worktree.as_ref(),
                                 )?;
+                            } else if !explicit_source_args.is_empty() {
+                                let head_context =
+                                    (!original_head.is_empty()).then_some(original_head.as_str());
+                                sources = resolve_cherry_pick_source_args_with_git_in_head_context(
+                                    &repo,
+                                    &explicit_source_args,
+                                    head_context,
+                                )?;
+                                self.clear_pending_cherry_pick_sources_for_worktree(
+                                    worktree.as_ref(),
+                                )?;
+                            } else {
+                                sources = self.take_pending_cherry_pick_sources_for_worktree(
+                                    worktree.as_ref(),
+                                )?;
+                                if is_skip && !sources.is_empty() {
+                                    sources.remove(0);
+                                }
                             }
                             let destinations = if new_commits.is_empty() {
                                 vec![new_head.clone()]
@@ -4461,10 +4829,16 @@ impl ActorDaemonCoordinator {
                         source_commits,
                         head,
                     } => {
-                        if !head.is_empty() && !source_commits.is_empty() {
+                        let mut sources = source_commits.clone();
+                        if sources.is_empty() {
+                            let repo = find_repository_in_path(&worktree)?;
+                            sources =
+                                resolve_explicit_cherry_pick_sources_for_side_effect(&repo, cmd)?;
+                        }
+                        if !head.is_empty() && !sources.is_empty() {
                             self.set_pending_cherry_pick_no_commit_for_worktree(
                                 worktree.as_ref(),
-                                source_commits.clone(),
+                                sources,
                                 head.clone(),
                             )?;
                         }
@@ -4598,7 +4972,13 @@ impl ActorDaemonCoordinator {
                                 // Reconstruct each destination from the matching HEAD transition
                                 // instead of treating the command as one final CommitCreated event.
                                 let repo = find_repository_in_path(&worktree)?;
-                                apply_revert_complete_rewrite(&repo, cmd)?;
+                                let mut source_oids = cmd.revert_source_oids.clone();
+                                if source_oids.is_empty() {
+                                    source_oids = resolve_explicit_revert_sources_for_side_effect(
+                                        &repo, cmd,
+                                    )?;
+                                }
+                                apply_revert_complete_rewrite(&repo, cmd, &source_oids)?;
                                 handled_revert_commits = true;
                             }
                         } else if !new_head.is_empty() {
@@ -6705,6 +7085,44 @@ mod tests {
         assert!(
             result.is_err(),
             "corrupt destination notes must fail closed instead of being treated as absent"
+        );
+    }
+
+    #[test]
+    fn revert_source_args_do_not_treat_bare_gpg_sign_as_value_option() {
+        assert_eq!(
+            revert_source_args_from_command_args(&["--gpg-sign".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            revert_source_args_from_command_args(&["-S".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            revert_source_args_from_command_args(&["-Smy-key".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+    }
+
+    #[test]
+    fn cherry_pick_source_args_do_not_treat_bare_gpg_sign_as_value_option() {
+        assert_eq!(
+            cherry_pick_source_args_from_command_args(&[
+                "--gpg-sign".to_string(),
+                "HEAD~1".to_string()
+            ]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            cherry_pick_source_args_from_command_args(&["-S".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            cherry_pick_source_args_from_command_args(&[
+                "-Smy-key".to_string(),
+                "HEAD~1".to_string()
+            ]),
+            vec!["HEAD~1"]
         );
     }
 

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -6,7 +6,6 @@ use crate::git::cli_parser::{
 };
 use crate::git::find_repository_in_path;
 use crate::git::repo_state::{common_dir_for_worktree, git_dir_for_worktree, is_valid_git_oid};
-use crate::git::repository::exec_git_stdin;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io::{Read, Seek, SeekFrom};
@@ -436,11 +435,12 @@ impl RefCursor {
             cherry_pick_source_args(&args)
         };
         let explicit_sources = if is_continue || is_skip {
-            Vec::new()
+            Some(Vec::new())
         } else {
             resolve_cherry_pick_source_oids_from_sources(cmd, state, &source_args)?
         };
-        let unresolved_explicit_sources = !source_args.is_empty() && explicit_sources.is_empty();
+        let unresolved_explicit_sources = !source_args.is_empty() && explicit_sources.is_none();
+        let explicit_sources = explicit_sources.unwrap_or_default();
         cmd.cherry_pick_source_oids = if explicit_sources.is_empty() && !unresolved_explicit_sources
         {
             self.pending_cherry_pick_source_oids.clone()
@@ -456,7 +456,11 @@ impl RefCursor {
             return Ok(());
         }
 
-        let source_limit = cmd.cherry_pick_source_oids.len().max(1);
+        let source_limit = if unresolved_explicit_sources {
+            usize::MAX
+        } else {
+            cmd.cherry_pick_source_oids.len().max(1)
+        };
         self.consume_head_span_for_command_limited(
             cmd,
             state,
@@ -518,17 +522,22 @@ impl RefCursor {
             revert_source_args(&args)
         };
         let explicit_sources = if source_args.is_empty() {
-            Vec::new()
+            Some(Vec::new())
         } else {
             resolve_cherry_pick_source_oids_from_sources(cmd, state, &source_args)?
         };
-        cmd.revert_source_oids = explicit_sources;
+        let unresolved_explicit_sources = !source_args.is_empty() && explicit_sources.is_none();
+        cmd.revert_source_oids = explicit_sources.unwrap_or_default();
 
         if is_no_commit {
             return Ok(());
         }
 
-        let source_limit = cmd.revert_source_oids.len().max(1);
+        let source_limit = if unresolved_explicit_sources {
+            usize::MAX
+        } else {
+            cmd.revert_source_oids.len().max(1)
+        };
         self.consume_head_span_for_command_limited(
             cmd,
             state,
@@ -2222,33 +2231,23 @@ fn commit_subject(message: &str) -> Option<String> {
 }
 
 fn resolve_cherry_pick_source_oids_from_sources(
-    cmd: &NormalizedCommand,
+    _cmd: &NormalizedCommand,
     state: &FamilyState,
     sources: &[&str],
-) -> Result<Vec<String>, GitAiError> {
-    let Some(worktree) = cmd.worktree.as_ref() else {
-        return Ok(Vec::new());
-    };
-    let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+) -> Result<Option<Vec<String>>, GitAiError> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
 
-    let has_range = sources
-        .iter()
-        .any(|source| cherry_pick_source_is_range(source));
-    let resolved = if has_range {
-        resolve_cherry_pick_sources_with_rev_list(&repo, sources, &state.refs)?
-    } else {
-        resolve_cherry_pick_sources_with_cat_file(&repo, sources, &state.refs)?
-    };
-
-    for oid in resolved {
+    for source in sources {
+        let Some(oid) = resolve_cherry_pick_source_from_state(source, &state.refs) else {
+            return Ok(None);
+        };
         if seen.insert(oid.clone()) {
             out.push(oid);
         }
     }
 
-    Ok(out)
+    Ok(Some(out))
 }
 
 fn cherry_pick_source_args(args: &[String]) -> Vec<&str> {
@@ -2270,7 +2269,7 @@ fn cherry_pick_source_args(args: &[String]) -> Vec<&str> {
         }
         if matches!(
             arg,
-            "-m" | "--mainline" | "-X" | "--strategy-option" | "--strategy" | "--gpg-sign"
+            "-m" | "--mainline" | "-X" | "--strategy-option" | "--strategy"
         ) {
             idx = idx.saturating_add(2);
             continue;
@@ -2278,6 +2277,7 @@ fn cherry_pick_source_args(args: &[String]) -> Vec<&str> {
         if arg.starts_with("--mainline=")
             || arg.starts_with("--strategy=")
             || arg.starts_with("--strategy-option=")
+            || arg == "--gpg-sign"
             || arg.starts_with("--gpg-sign=")
             || arg.starts_with("-m")
             || arg.starts_with("-X")
@@ -2315,11 +2315,14 @@ fn revert_source_args(args: &[String]) -> Vec<&str> {
         if matches!(arg, "--abort" | "--continue" | "--quit" | "--skip") {
             return Vec::new();
         }
-        if matches!(arg, "-m" | "--mainline" | "-S" | "--gpg-sign") {
+        if matches!(arg, "-m" | "--mainline") {
             idx = idx.saturating_add(2);
             continue;
         }
-        if arg.starts_with("--mainline=") || arg.starts_with("--gpg-sign=") || arg.starts_with("-S")
+        if arg.starts_with("--mainline=")
+            || arg == "--gpg-sign"
+            || arg.starts_with("--gpg-sign=")
+            || arg.starts_with("-S")
         {
             idx += 1;
             continue;
@@ -2344,92 +2347,6 @@ fn cherry_pick_source_is_range(source: &str) -> bool {
     source.contains("..")
 }
 
-fn resolve_cherry_pick_sources_with_rev_list(
-    repo: &crate::git::repository::Repository,
-    sources: &[&str],
-    refs: &HashMap<String, String>,
-) -> Result<Vec<String>, GitAiError> {
-    let concretized: Vec<String> = sources
-        .iter()
-        .filter_map(|source| {
-            if cherry_pick_source_is_range(source) {
-                concretize_revision_range(source, refs)
-            } else {
-                concretize_revision_expr(source, refs)
-            }
-        })
-        .collect();
-    if concretized.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut args = repo.global_args_for_exec();
-    args.extend([
-        "rev-list".to_string(),
-        "--reverse".to_string(),
-        "--stdin".to_string(),
-    ]);
-    let stdin_data = concretized.join("\n") + "\n";
-    let output = exec_git_stdin(&args, stdin_data.as_bytes())?;
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|line| is_valid_git_oid(line))
-        .map(ToOwned::to_owned)
-        .collect())
-}
-
-fn resolve_cherry_pick_sources_with_cat_file(
-    repo: &crate::git::repository::Repository,
-    sources: &[&str],
-    refs: &HashMap<String, String>,
-) -> Result<Vec<String>, GitAiError> {
-    let specs: Vec<String> = sources
-        .iter()
-        .filter_map(|source| concretize_revision_expr(source, refs))
-        .map(|expr| format!("{expr}^{{commit}}"))
-        .collect();
-    if specs.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut args = repo.global_args_for_exec();
-    args.extend([
-        "cat-file".to_string(),
-        "--batch-check=%(objectname) %(objecttype)".to_string(),
-    ]);
-    let stdin_data = specs.join("\n") + "\n";
-    let output = exec_git_stdin(&args, stdin_data.as_bytes())?;
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let mut parts = line.split_whitespace();
-            let oid = parts.next()?;
-            (parts.next() == Some("commit") && is_valid_git_oid(oid)).then(|| oid.to_string())
-        })
-        .collect())
-}
-
-fn concretize_revision_range(source: &str, refs: &HashMap<String, String>) -> Option<String> {
-    let (left, sep, right) = if let Some((left, right)) = source.split_once("...") {
-        (left, "...", right)
-    } else {
-        let (left, right) = source.split_once("..")?;
-        (left, "..", right)
-    };
-    let left = if left.is_empty() {
-        refs.get("HEAD").cloned()
-    } else {
-        concretize_revision_expr(left, refs)
-    }?;
-    let right = if right.is_empty() {
-        refs.get("HEAD").cloned()
-    } else {
-        concretize_revision_expr(right, refs)
-    }?;
-    Some(format!("{left}{sep}{right}"))
-}
-
 fn concretize_revision_expr(expr: &str, refs: &HashMap<String, String>) -> Option<String> {
     if expr.is_empty() {
         return refs.get("HEAD").cloned();
@@ -2452,6 +2369,17 @@ fn concretize_revision_expr(expr: &str, refs: &HashMap<String, String>) -> Optio
         resolve_ref_from_state(base, refs)
     }?;
     Some(format!("{base_oid}{suffix}"))
+}
+
+fn resolve_cherry_pick_source_from_state(
+    source: &str,
+    refs: &HashMap<String, String>,
+) -> Option<String> {
+    if cherry_pick_source_is_range(source) {
+        return None;
+    }
+
+    concretize_revision_expr(source, refs).filter(|oid| valid_non_zero_oid(oid))
 }
 
 fn split_revision_suffix(expr: &str) -> (&str, &str) {
@@ -3499,6 +3427,38 @@ mod tests {
     const E: &str = "5555555555555555555555555555555555555555";
     const F: &str = "6666666666666666666666666666666666666666";
     const G: &str = "7777777777777777777777777777777777777777";
+
+    #[test]
+    fn revert_source_args_do_not_treat_bare_gpg_sign_as_value_option() {
+        assert_eq!(
+            revert_source_args(&["--gpg-sign".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            revert_source_args(&["-S".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            revert_source_args(&["-Smy-key".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+    }
+
+    #[test]
+    fn cherry_pick_source_args_do_not_treat_bare_gpg_sign_as_value_option() {
+        assert_eq!(
+            cherry_pick_source_args(&["--gpg-sign".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            cherry_pick_source_args(&["-S".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+        assert_eq!(
+            cherry_pick_source_args(&["-Smy-key".to_string(), "HEAD~1".to_string()]),
+            vec!["HEAD~1"]
+        );
+    }
 
     fn family_state(family: &FamilyKey) -> FamilyState {
         FamilyState {

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -828,6 +828,294 @@ fn test_cherry_pick_from_remote_without_prefetched_notes() {
     target_file.assert_lines_and_blame(crate::lines!["base".ai(), "AI line".ai(),]);
 }
 
+#[test]
+fn test_cherry_pick_local_remote_tracking_ref_missing_from_daemon_snapshot() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("file.txt");
+    file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("initial").unwrap();
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.insert_at(1, crate::lines!["AI line".ai()]);
+    let source_commit = repo.stage_all_and_commit("AI commit").unwrap();
+
+    repo.read_authorship_note(&source_commit.commit_sha)
+        .expect("source authorship note should already be local");
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    repo.git_og(&[
+        "update-ref",
+        "refs/remotes/origin/feature",
+        &source_commit.commit_sha,
+    ])
+    .unwrap();
+
+    repo.git(&["cherry-pick", "origin/feature"]).unwrap();
+
+    file.assert_lines_and_blame(crate::lines!["base".ai(), "AI line".ai(),]);
+}
+
+#[test]
+fn test_cherry_pick_partial_remote_tracking_ref_resolution_falls_back_to_git() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("file.txt");
+    file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("initial").unwrap();
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.insert_at(1, crate::lines!["AI line 1".ai()]);
+    let first_source_commit = repo.stage_all_and_commit("AI commit 1").unwrap();
+    file.insert_at(2, crate::lines!["AI line 2".ai()]);
+    let second_source_commit = repo.stage_all_and_commit("AI commit 2").unwrap();
+
+    repo.read_authorship_note(&first_source_commit.commit_sha)
+        .expect("first source authorship note should already be local");
+    repo.read_authorship_note(&second_source_commit.commit_sha)
+        .expect("second source authorship note should already be local");
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    repo.git_og(&[
+        "update-ref",
+        "refs/remotes/origin/feature",
+        &second_source_commit.commit_sha,
+    ])
+    .unwrap();
+
+    repo.git(&[
+        "cherry-pick",
+        &first_source_commit.commit_sha,
+        "origin/feature",
+    ])
+    .unwrap();
+
+    file.assert_lines_and_blame(crate::lines![
+        "base".ai(),
+        "AI line 1".ai(),
+        "AI line 2".ai(),
+    ]);
+}
+
+#[test]
+fn test_cherry_pick_failed_continue_keeps_pending_remote_tracking_source() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("file.txt");
+    file.set_contents(crate::lines!["Line 1", "Line 2", "Line 3"]);
+    repo.stage_all_and_commit("initial").unwrap();
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    file.replace_at(1, "AI_REMOTE_VERSION".ai());
+    let source_commit = repo.stage_all_and_commit("AI feature").unwrap();
+    repo.read_authorship_note(&source_commit.commit_sha)
+        .expect("source authorship note should already be local");
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    repo.git_og(&[
+        "update-ref",
+        "refs/remotes/origin/feature",
+        &source_commit.commit_sha,
+    ])
+    .unwrap();
+
+    file.replace_at(1, "MAIN_BRANCH_VERSION".human());
+    repo.stage_all_and_commit("Human change").unwrap();
+
+    let cherry_pick_result = repo.git(&["cherry-pick", "origin/feature"]);
+    assert!(cherry_pick_result.is_err(), "cherry-pick should conflict");
+    repo.sync_daemon();
+
+    let failed_continue = repo.git(&["cherry-pick", "--continue"]);
+    assert!(
+        failed_continue.is_err(),
+        "unresolved cherry-pick should not continue"
+    );
+    repo.sync_daemon();
+
+    fs::write(
+        repo.path().join("file.txt"),
+        "Line 1\nAI_REMOTE_VERSION\nLine 3",
+    )
+    .unwrap();
+    repo.git(&["add", "file.txt"]).unwrap();
+    repo.git(&["cherry-pick", "--continue"]).unwrap();
+
+    file.assert_lines_and_blame(crate::lines![
+        "Line 1".human(),
+        "AI_REMOTE_VERSION".ai(),
+        "Line 3".human(),
+    ]);
+}
+
+#[test]
+fn test_cherry_pick_skip_failed_next_conflict_advances_pending_remote_tracking_source() {
+    let repo = TestRepo::new();
+    let conflict_a_path = repo.path().join("conflict_a.txt");
+    let conflict_b_path = repo.path().join("conflict_b.txt");
+
+    fs::write(&conflict_a_path, "base\nshared\n").unwrap();
+    fs::write(&conflict_b_path, "base\nshared\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_a.txt"])
+        .unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_b.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let mut conflict_a = repo.filename("conflict_a.txt");
+    let mut conflict_b = repo.filename("conflict_b.txt");
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "shared".human(),]);
+    conflict_b.assert_committed_lines(crate::lines!["base".human(), "shared".human(),]);
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&conflict_a_path, "base\nFEATURE_A_HUMAN\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_a.txt"])
+        .unwrap();
+    let skipped_source_commit = repo.stage_all_and_commit("human conflict A").unwrap();
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "FEATURE_A_HUMAN".human(),]);
+
+    fs::write(&conflict_b_path, "base\nAI_REMOTE_VERSION\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "conflict_b.txt"])
+        .unwrap();
+    let applied_source_commit = repo.stage_all_and_commit("AI conflict B").unwrap();
+    conflict_b.assert_committed_lines(crate::lines!["base".human(), "AI_REMOTE_VERSION".ai(),]);
+
+    repo.read_authorship_note(&skipped_source_commit.commit_sha)
+        .expect("skipped source authorship note should already be local");
+    repo.read_authorship_note(&applied_source_commit.commit_sha)
+        .expect("applied source authorship note should already be local");
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    repo.git_og(&[
+        "update-ref",
+        "refs/remotes/origin/feature",
+        &applied_source_commit.commit_sha,
+    ])
+    .unwrap();
+
+    fs::write(&conflict_a_path, "base\nMAIN_A_HUMAN\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_a.txt"])
+        .unwrap();
+    fs::write(&conflict_b_path, "base\nMAIN_B_HUMAN\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_b.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("main conflicts").unwrap();
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "MAIN_A_HUMAN".human(),]);
+    conflict_b.assert_committed_lines(crate::lines!["base".human(), "MAIN_B_HUMAN".human(),]);
+
+    let cherry_pick_result = repo.git(&["cherry-pick", "origin/feature~1", "origin/feature"]);
+    assert!(
+        cherry_pick_result.is_err(),
+        "first cherry-pick should conflict"
+    );
+    repo.sync_daemon();
+
+    let skip_result = repo.git(&["cherry-pick", "--skip"]);
+    assert!(
+        skip_result.is_err(),
+        "skip should advance to the second source and conflict"
+    );
+    repo.sync_daemon();
+
+    fs::write(&conflict_b_path, "base\nAI_REMOTE_VERSION\n").unwrap();
+    repo.git(&["add", "conflict_b.txt"]).unwrap();
+    repo.git(&["cherry-pick", "--continue"]).unwrap();
+
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "MAIN_A_HUMAN".human(),]);
+    conflict_b.assert_committed_lines(crate::lines!["base".human(), "AI_REMOTE_VERSION".ai(),]);
+}
+
+#[test]
+fn test_cherry_pick_skip_failed_next_conflict_does_not_double_skip_refcursor_sources() {
+    let repo = TestRepo::new();
+    let conflict_a_path = repo.path().join("conflict_a.txt");
+    let clean_b_path = repo.path().join("clean_b.txt");
+    let conflict_c_path = repo.path().join("conflict_c.txt");
+
+    fs::write(&conflict_a_path, "base\nshared\n").unwrap();
+    fs::write(&clean_b_path, "base\nshared\n").unwrap();
+    fs::write(&conflict_c_path, "base\nshared\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_a.txt"])
+        .unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "clean_b.txt"])
+        .unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_c.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let mut conflict_a = repo.filename("conflict_a.txt");
+    let mut clean_b = repo.filename("clean_b.txt");
+    let mut conflict_c = repo.filename("conflict_c.txt");
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "shared".human(),]);
+    clean_b.assert_committed_lines(crate::lines!["base".human(), "shared".human(),]);
+    conflict_c.assert_committed_lines(crate::lines!["base".human(), "shared".human(),]);
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&conflict_a_path, "base\nFEATURE_A_HUMAN\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_a.txt"])
+        .unwrap();
+    let skipped_source_commit = repo.stage_all_and_commit("human conflict A").unwrap();
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "FEATURE_A_HUMAN".human(),]);
+
+    fs::write(&clean_b_path, "base\nAI_B_VERSION\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "clean_b.txt"])
+        .unwrap();
+    let applied_during_skip_commit = repo.stage_all_and_commit("AI clean B").unwrap();
+    clean_b.assert_committed_lines(crate::lines!["base".human(), "AI_B_VERSION".ai(),]);
+
+    fs::write(&conflict_c_path, "base\nAI_C_VERSION\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "conflict_c.txt"])
+        .unwrap();
+    let next_conflict_commit = repo.stage_all_and_commit("AI conflict C").unwrap();
+    conflict_c.assert_committed_lines(crate::lines!["base".human(), "AI_C_VERSION".ai(),]);
+
+    repo.read_authorship_note(&skipped_source_commit.commit_sha)
+        .expect("skipped source authorship note should already be local");
+    repo.read_authorship_note(&applied_during_skip_commit.commit_sha)
+        .expect("applied source authorship note should already be local");
+    repo.read_authorship_note(&next_conflict_commit.commit_sha)
+        .expect("next conflict source authorship note should already be local");
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    fs::write(&conflict_a_path, "base\nMAIN_A_HUMAN\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_a.txt"])
+        .unwrap();
+    fs::write(&conflict_c_path, "base\nMAIN_C_HUMAN\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict_c.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("main conflicts").unwrap();
+    conflict_a.assert_committed_lines(crate::lines!["base".human(), "MAIN_A_HUMAN".human(),]);
+    clean_b.assert_committed_lines(crate::lines!["base".human(), "shared".human(),]);
+    conflict_c.assert_committed_lines(crate::lines!["base".human(), "MAIN_C_HUMAN".human(),]);
+
+    let cherry_pick_result = repo.git(&[
+        "cherry-pick",
+        &skipped_source_commit.commit_sha,
+        &applied_during_skip_commit.commit_sha,
+        &next_conflict_commit.commit_sha,
+    ]);
+    assert!(
+        cherry_pick_result.is_err(),
+        "first cherry-pick should conflict"
+    );
+    repo.sync_daemon();
+
+    let skip_result = repo.git(&["cherry-pick", "--skip"]);
+    assert!(
+        skip_result.is_err(),
+        "skip should apply B and then conflict on C"
+    );
+    repo.sync_daemon();
+    clean_b.assert_committed_lines(crate::lines!["base".human(), "AI_B_VERSION".ai(),]);
+
+    fs::write(&conflict_c_path, "base\nAI_C_VERSION\n").unwrap();
+    repo.git(&["add", "conflict_c.txt"]).unwrap();
+    repo.git(&["cherry-pick", "--continue"]).unwrap();
+
+    clean_b.assert_committed_lines(crate::lines!["base".human(), "AI_B_VERSION".ai(),]);
+    conflict_c.assert_committed_lines(crate::lines!["base".human(), "AI_C_VERSION".ai(),]);
+}
+
 fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
     match payload.downcast::<String>() {
         Ok(message) => *message,
@@ -951,4 +1239,6 @@ crate::reuse_tests_in_worktree!(
     test_cherry_pick_from_remote_without_prefetched_notes,
     test_cherry_pick_from_remote_reports_notes_import_failure,
     test_cherry_pick_no_commit_defers_to_final_commit_tree,
+    test_cherry_pick_skip_failed_next_conflict_advances_pending_remote_tracking_source,
+    test_cherry_pick_skip_failed_next_conflict_does_not_double_skip_refcursor_sources,
 );

--- a/tests/integration/internal_spawn_safety.rs
+++ b/tests/integration/internal_spawn_safety.rs
@@ -116,3 +116,26 @@ fn direct_git_command_spawns_are_centralized() {
         );
     }
 }
+
+#[test]
+fn ref_cursor_does_not_spawn_git_on_trace_ingestion_path() {
+    let file = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("daemon")
+        .join("ref_cursor.rs");
+    let content = fs::read_to_string(&file).unwrap();
+    for disallowed in [
+        "Command::new(",
+        "exec_git(",
+        "exec_git_allow_nonzero(",
+        "exec_git_stdin(",
+        "exec_git_stdin_with_profile(",
+    ] {
+        assert!(
+            !content.contains(disallowed),
+            "{} must not contain `{}`; trace2 ingestion must not spawn git",
+            file.display(),
+            disallowed
+        );
+    }
+}

--- a/tests/integration/rewrite_ops_attribution.rs
+++ b/tests/integration/rewrite_ops_attribution.rs
@@ -156,6 +156,40 @@ fn test_revert_older_commit_restores_original_ai_attribution() {
     file.assert_committed_lines(crate::lines!["keep".human(), "restored ai".ai()]);
 }
 
+#[test]
+fn test_revert_revision_expression_restores_original_ai_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("revert_expr.txt");
+
+    fs::write(&file_path, "keep\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "revert_expr.txt"])
+        .unwrap();
+    fs::write(&file_path, "keep\nrestored ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "revert_expr.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("initial mixed attribution")
+        .unwrap();
+
+    let mut file = repo.filename("revert_expr.txt");
+    file.assert_committed_lines(crate::lines!["keep".human(), "restored ai".ai()]);
+
+    fs::write(&file_path, "keep\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "revert_expr.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("delete ai line").unwrap();
+    file.assert_committed_lines(crate::lines!["keep".human()]);
+
+    fs::write(repo.path().join("advance.txt"), "later human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "advance.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("later unrelated commit").unwrap();
+    repo.filename("advance.txt")
+        .assert_committed_lines(crate::lines!["later human".human()]);
+
+    repo.git(&["revert", "HEAD~1"]).unwrap();
+    file.assert_committed_lines(crate::lines!["keep".human(), "restored ai".ai()]);
+}
+
 /// Multi-commit `git revert <del_a> <del_b> <del_c>` (one invocation, several
 /// destinations) exercises the per-destination revert loop. Each reverted
 /// "delete" commit must restore its file's original AI attribution. This pins


### PR DESCRIPTION
## Summary
- add regressions for cherry-picking local remote-tracking refs that exist in Git but are missing from the daemon ref snapshot
- keep `ref_cursor.rs` trace ingestion strictly in-memory, with no Git exec/syscall fallback on that latency-sensitive path
- resolve unresolved explicit cherry-pick and revert source args later in the side-effect pipeline before transferring notes
- treat partial in-memory source resolution as unresolved so the side-effect resolver handles the complete source list
- preserve daemon pending cherry-pick source state across failed `--continue` attempts and advance it correctly across daemon-owned `--skip` source lists
- avoid double-skipping ref-cursor-provided cherry-pick source lists during failed `--skip` flows
- fix cherry-pick and revert source parsing so bare `-S`/`--gpg-sign` do not consume the revision argument

## Root Cause
The source commit and its authorship note can already be fully local. The bug was that trace ingestion resolved cherry-pick source arguments only from the daemon captured in-memory ref snapshot. If a local ref such as `refs/remotes/origin/feature` existed in Git but was missing from that snapshot, `cmd.cherry_pick_source_oids` became empty. The later cherry-pick side-effect code trusted that empty list and skipped note transfer, so attribution was silently lost.

The same state-only resolver is shared by revert source detection. Revert now uses the same side-effect fallback when explicit source args cannot be resolved from the in-memory snapshot. Relative `HEAD`/`@` source expressions are resolved against the command original HEAD so fallback resolution does not accidentally use the post-rewrite HEAD. Bare `-S`/`--gpg-sign` are treated as flags, not value-taking options, so they do not hide the following source revision from either cherry-pick or revert parsers.

For sequenced cherry-picks whose source list only exists in the daemon side-effect pending state, control commands need to update that daemon state too. Failed `--continue` preserves the list; `--skip` consumes exactly one daemon-pending source before any newly created commits are paired. When ref_cursor already supplied `cmd.cherry_pick_source_oids`, that list is already adjusted for `--skip`, so the daemon does not skip it again.

## Latency
This does not add Git subprocesses to the trace2 ingestion/ref-cursor critical path. The only Git-backed source resolution happens in the existing side-effect path, after command normalization/ref-cursor enrichment. `ref_cursor_does_not_spawn_git_on_trace_ingestion_path` guards this by scanning `src/daemon/ref_cursor.rs` for direct spawn/exec helpers.

## Verification
- `task test TEST_FILTER=test_cherry_pick_local_remote_tracking_ref_missing_from_daemon_snapshot`
- `task test TEST_FILTER=test_cherry_pick_partial_remote_tracking_ref_resolution_falls_back_to_git`
- `task test TEST_FILTER=test_cherry_pick_failed_continue_keeps_pending_remote_tracking_source`
- `task test TEST_FILTER=test_cherry_pick_skip_failed_next_conflict_advances_pending_remote_tracking_source`
- `task test TEST_FILTER=test_cherry_pick_skip_failed_next_conflict_does_not_double_skip_refcursor_sources`
- `task test TEST_FILTER=test_revert_revision_expression_restores_original_ai_attribution`
- `task test TEST_FILTER=revert_source_args_do_not_treat_bare_gpg_sign_as_value_option`
- `task test TEST_FILTER=cherry_pick_source_args_do_not_treat_bare_gpg_sign_as_value_option`
- `task test TEST_FILTER=ref_cursor_does_not_spawn_git_on_trace_ingestion_path`
- `task test TEST_FILTER=revert`
- `task test TEST_FILTER=cherry_pick`
- `task fmt`
- `task lint`
- `task test`
