### PR TITLE
Rank bash attribution recovery candidates

### DIFF
--- a/docs/bash-attribution-scenarios.md
+++ b/docs/bash-attribution-scenarios.md
@@ -1,0 +1,77 @@
+# Bash Attribution Recovery Scenarios
+
+## Manual Installed-Build Matrix
+
+| Scenario | Expected result |
+| --- | --- |
+| Bash hook from worktree A writes a new file in sibling worktree B, then commit in B | New file lines are attributed to the agent session |
+| Same cross-worktree bash write, then a later human-created file is committed in B | Bash-created file is attributed to the agent; later human file remains human/untracked |
+| Same file: bash writes an unknown line, then a human appends after the bash post hook and before commit | Do not attribute the later human line to AI; with mtime-only recovery this may conservatively leave both lines human/untracked |
+| Multiple overlapping agent sessions with nearby timestamps | Attribute to the best matching session; prefer evidence tied to the same directory/session when available |
+| Rebase/cherry-pick/rewrite paths | Do not run mtime recovery during rewrite-note regeneration unless explicitly proven safe |
+
+## PR #1625 Installed-Build Results
+
+Tested from local branch `pr-1625` after installing with `task dev`.
+
+| Scenario | Observed result | Status |
+| --- | --- | --- |
+| Cross-worktree bash write | `generated.txt` was blamed to `codex` | Working |
+| Later human-created separate file after bash post-hook | `generated.txt` was blamed to `codex`, but `manual.txt` was also blamed to `codex` | Not working: over-attribution |
+| Same-file human append after bash post-hook | Both the bash-created line and later human-appended line were blamed to `codex` | Not working: over-attribution |
+| Two nearby Codex sessions writing separate files | Authorship note mapped `a.txt` to session A and `b.txt` to session B | Working |
+
+### PR #1625 Takeaway
+
+PR #1625 fixes Sasha's core cross-worktree miss, but it reproduces the main risk Sasha called out: a file modified after the bash post-hook and before commit can be swept into the bash session if its mtime lands in the recovery window.
+
+The later-human separate-file case is the clearest blocker because no same-file ambiguity is involved: the file was created after the bash session, yet it was still attributed to Codex.
+
+## Notes
+
+- The core regression from Sasha is the first scenario: normal bash checkpoint scanning only looks in the originating repo directory, so sibling worktree writes can be missed.
+- The main safety risk is over-attribution when file mtimes are updated after a bash session by later human edits.
+- The same-file mixed edit case needs content/snapshot-based evidence to recover the AI subset safely.
+
+## PR #1644 Ranking Rules
+
+PR #1644 keeps the PR #1625 mtime recovery window, but changes which bash candidate is selected when several sessions are close enough to explain the same file timestamp.
+
+The intended ranking order is:
+
+1. Prefer a bash session ID that is already represented elsewhere in the commit.
+2. If more than one commit session matches, choose the closest matching bash call by time.
+3. If no candidate session is already represented in the commit, prefer a candidate whose recorded workdir contains the file being recovered.
+4. If neither of the stronger signals applies, choose the closest matching bash call by time within the 3-second recovery window.
+
+Tie-breakers after those signals keep the previous behavior: prefer completed bash calls, then calls with a captured command, then the newest database row.
+
+### PR #1644 Expected Results
+
+| Scenario | Expected result | Coverage |
+| --- | --- | --- |
+| Commit already contains attributed lines from session A, and an unknown file timestamp is closer to unrelated session B | Unknown lines are attributed to session A if session A is still inside the recovery window | `bash_candidate_ranking_prefers_session_already_in_commit_then_time` |
+| Commit already contains attributed lines from sessions A and B | Unknown lines are attributed to the closer of A or B | `bash_candidate_ranking_prefers_session_already_in_commit_then_time` |
+| No candidate session is already present in the commit, and one candidate workdir contains the target file | Unknown lines are attributed to the containing-workdir candidate, even if another candidate is slightly closer by time | `bash_candidate_ranking_prefers_parent_workdir_when_no_session_matches_commit` |
+| No candidate session is in the commit and no candidate workdir contains the target file | Unknown lines are attributed to the closest candidate by time within the 3-second window | `bash_candidate_ranking_falls_back_to_closest_time` |
+| Candidate workdir or target path includes a platform-level symlink, such as macOS `/var` to `/private/var` | Workdir containment is compared after canonicalizing the file path or its existing parent directory | `bash_candidate_ranking_prefers_parent_workdir_when_no_session_matches_commit` |
+
+### PR #1644 Local Verification
+
+Run these before merging changes to the ranking logic:
+
+```bash
+task fmt
+task lint
+task test TEST_FILTER=bash_candidate_ranking NO_CAPTURE=true
+task test TEST_FILTER=bash_attribution NO_CAPTURE=true
+task dev
+```
+
+The focused ranking test verifies the candidate ordering directly. The broader `bash_attribution` filter verifies the mtime recovery path through the integration test harness. `task dev` verifies the debug build can be installed locally for manual end-to-end testing.
+
+### Remaining Known Gaps
+
+- CWD-not-a-repo recording is intentionally out of scope for PR #1644.
+- Same-file human edits after a bash post-hook can still require content-based evidence to split AI and human lines safely.
+- The 3-second mtime window is unchanged; PR #1644 reduces cross-session misattribution inside that window, but does not replace mtime matching with content matching.

--- a/docs/bash-attribution-scenarios.md
+++ b/docs/bash-attribution-scenarios.md
@@ -70,6 +70,18 @@ task dev
 
 The focused ranking test verifies the candidate ordering directly. The broader `bash_attribution` filter verifies the mtime recovery path through the integration test harness. `task dev` verifies the debug build can be installed locally for manual end-to-end testing.
 
+### PR #1644 Installed-Build Ranking Results
+
+Tested from local branch `siddhant/bash-attribution-rerank` after installing with `task dev`. Each scenario used temporary repos, real `git-ai checkpoint codex --hook-input ...` calls, real `git commit`, and `git notes --ref=ai show HEAD` to map the recovered file's session hash back to the external Codex session ID.
+
+| Scenario | Observed result | Status |
+| --- | --- | --- |
+| Commit already contained a normal Codex-attributed edit from `rank-session-a`; the unknown file was written during a closer unrelated `rank-session-b` bash call from another repo | The unknown file was attributed to `rank-session-a` | Working |
+| No session was already present in the commit; an older candidate from a parent workdir competed with a closer non-parent candidate | The unknown file was attributed to `rank-parent-session` | Working |
+| No session was already present in the commit and no candidate workdir contained the target file | The unknown file was attributed to the closest candidate, `rank-close-session` | Working |
+
+These manual runs exercise the installed debug build rather than only the unit-level ranking helper.
+
 ### Remaining Known Gaps
 
 - CWD-not-a-repo recording is intentionally out of scope for PR #1644.

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -342,13 +342,24 @@ fn session_ids_in_commit(authorship_log: &AuthorshipLog) -> HashSet<String> {
 
 fn candidate_workdir_contains_path(candidate: &BashCheckpointCall, target_path: &Path) -> bool {
     let candidate_workdir = PathBuf::from(&candidate.repo_work_dir);
-    let candidate_workdir = candidate_workdir
-        .canonicalize()
-        .unwrap_or(candidate_workdir);
-    let target_path = target_path
-        .canonicalize()
-        .unwrap_or_else(|_| target_path.to_path_buf());
+    let candidate_workdir = canonicalize_path_or_parent(&candidate_workdir);
+    let target_path = canonicalize_path_or_parent(target_path);
     target_path.starts_with(candidate_workdir)
+}
+
+fn canonicalize_path_or_parent(path: &Path) -> PathBuf {
+    if let Ok(canonical_path) = path.canonicalize() {
+        return canonical_path;
+    }
+
+    if let Some(parent) = path.parent()
+        && let Some(file_name) = path.file_name()
+        && let Ok(canonical_parent) = parent.canonicalize()
+    {
+        return canonical_parent.join(file_name);
+    }
+
+    path.to_path_buf()
 }
 
 fn insert_session_record(
@@ -746,7 +757,9 @@ mod tests {
     #[test]
     fn bash_candidate_ranking_prefers_parent_workdir_when_no_session_matches_commit() {
         let temp = tempfile::tempdir().unwrap();
-        let target = temp.path().join("repo").join("target.txt");
+        let repo_dir = temp.path().join("repo");
+        fs::create_dir_all(&repo_dir).unwrap();
+        let target = repo_dir.join("target.txt");
         let parent = test_candidate(
             1,
             "parent",

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -12,6 +12,7 @@ use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded}
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
@@ -91,18 +92,22 @@ fn recover_bash_mtime(
     if candidates.is_empty() {
         return Ok(());
     }
+    let commit_session_ids = session_ids_in_commit(authorship_log);
 
     for (file_path, unknown_lines) in unknown_by_file {
         let Some(timestamps) = timestamps_by_file.get(&file_path) else {
             continue;
         };
-        let Some((candidate, distance_ns)) = select_best_bash_candidate(&candidates, timestamps)
+        let target_path = workdir.join(&file_path);
+        let Some(selection) =
+            select_best_bash_candidate(&candidates, timestamps, &commit_session_ids, &target_path)
         else {
             continue;
         };
-        if distance_ns > BASH_RECOVERY_WINDOW_NS {
+        if selection.distance_ns > BASH_RECOVERY_WINDOW_NS {
             continue;
         }
+        let candidate = selection.candidate;
 
         let trace_id = generate_trace_id();
         let session_id = generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool);
@@ -120,7 +125,9 @@ fn recover_bash_mtime(
             "selected_bash_repo_work_dir": candidate.repo_work_dir.as_str(),
             "selected_tool_use_id": candidate.tool_use_id,
             "selected_command": candidate.command,
-            "distance_ns": distance_ns,
+            "distance_ns": selection.distance_ns,
+            "ranking_session_already_in_commit": selection.session_already_in_commit,
+            "ranking_repo_workdir_is_parent": selection.repo_workdir_is_parent,
             "window_ns": BASH_RECOVERY_WINDOW_NS,
             "start_time_ns": candidate.start_time_ns,
             "end_time_ns": candidate.end_time_ns,
@@ -246,27 +253,102 @@ fn system_time_to_ns(time: SystemTime) -> u128 {
         .as_nanos()
 }
 
+#[derive(Debug, Clone, Copy)]
+struct BashCandidateSelection<'a> {
+    candidate: &'a BashCheckpointCall,
+    distance_ns: u128,
+    session_already_in_commit: bool,
+    repo_workdir_is_parent: bool,
+}
+
 fn select_best_bash_candidate<'a>(
     candidates: &'a [BashCheckpointCall],
     timestamps: &[u128],
-) -> Option<(&'a BashCheckpointCall, u128)> {
+    commit_session_ids: &HashSet<String>,
+    target_path: &Path,
+) -> Option<BashCandidateSelection<'a>> {
     candidates
         .iter()
-        .map(|candidate| {
+        .filter_map(|candidate| {
             let distance = timestamps
                 .iter()
                 .map(|ts| distance_to_call_window(*ts, candidate))
                 .min()
                 .unwrap_or(u128::MAX);
-            (candidate, distance)
+            (distance <= BASH_RECOVERY_WINDOW_NS).then(|| {
+                let session_id =
+                    generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool);
+                BashCandidateSelection {
+                    candidate,
+                    distance_ns: distance,
+                    session_already_in_commit: commit_session_ids.contains(&session_id),
+                    repo_workdir_is_parent: candidate_workdir_contains_path(candidate, target_path),
+                }
+            })
         })
-        .min_by(|(left, left_distance), (right, right_distance)| {
-            left_distance
-                .cmp(right_distance)
-                .then_with(|| right.end_time_ns.is_some().cmp(&left.end_time_ns.is_some()))
-                .then_with(|| right.command.is_some().cmp(&left.command.is_some()))
-                .then_with(|| right.id.cmp(&left.id))
+        .min_by(compare_bash_candidate_selection)
+}
+
+fn compare_bash_candidate_selection(
+    left: &BashCandidateSelection<'_>,
+    right: &BashCandidateSelection<'_>,
+) -> std::cmp::Ordering {
+    left.session_already_in_commit
+        .cmp(&right.session_already_in_commit)
+        .reverse()
+        .then_with(|| {
+            if left.session_already_in_commit && right.session_already_in_commit {
+                std::cmp::Ordering::Equal
+            } else {
+                left.repo_workdir_is_parent
+                    .cmp(&right.repo_workdir_is_parent)
+                    .reverse()
+            }
         })
+        .then_with(|| left.distance_ns.cmp(&right.distance_ns))
+        .then_with(|| {
+            right
+                .candidate
+                .end_time_ns
+                .is_some()
+                .cmp(&left.candidate.end_time_ns.is_some())
+        })
+        .then_with(|| {
+            right
+                .candidate
+                .command
+                .is_some()
+                .cmp(&left.candidate.command.is_some())
+        })
+        .then_with(|| right.candidate.id.cmp(&left.candidate.id))
+}
+
+fn session_ids_in_commit(authorship_log: &AuthorshipLog) -> HashSet<String> {
+    authorship_log
+        .attestations
+        .iter()
+        .flat_map(|file| file.entries.iter())
+        .filter(|entry| entry.hash.starts_with("s_"))
+        .map(|entry| {
+            entry
+                .hash
+                .split("::")
+                .next()
+                .unwrap_or(&entry.hash)
+                .to_string()
+        })
+        .collect()
+}
+
+fn candidate_workdir_contains_path(candidate: &BashCheckpointCall, target_path: &Path) -> bool {
+    let candidate_workdir = PathBuf::from(&candidate.repo_work_dir);
+    let candidate_workdir = candidate_workdir
+        .canonicalize()
+        .unwrap_or(candidate_workdir);
+    let target_path = target_path
+        .canonicalize()
+        .unwrap_or_else(|_| target_path.to_path_buf());
+    target_path.starts_with(candidate_workdir)
 }
 
 fn insert_session_record(
@@ -533,6 +615,34 @@ mod tests {
     use crate::authorship::authorship_log_serialization::{
         AttestationEntry, AuthorshipLog, FileAttestation,
     };
+    use crate::authorship::working_log::AgentId;
+
+    fn test_candidate(
+        id: i64,
+        external_session_id: &str,
+        repo_work_dir: &str,
+        start_time_ns: u128,
+        end_time_ns: u128,
+    ) -> BashCheckpointCall {
+        BashCheckpointCall {
+            id,
+            invocation_key: format!("{external_session_id}/tool"),
+            repo_work_dir: repo_work_dir.to_string(),
+            session_id: external_session_id.to_string(),
+            tool_use_id: "tool".to_string(),
+            agent_id: AgentId {
+                tool: "codex".to_string(),
+                id: external_session_id.to_string(),
+                model: "gpt-5".to_string(),
+            },
+            start_trace_id: Some(format!("t_start_{id}")),
+            end_trace_id: Some(format!("t_end_{id}")),
+            start_time_ns,
+            end_time_ns: Some(end_time_ns),
+            command: Some("cat > target.txt".to_string()),
+            metadata: HashMap::new(),
+        }
+    }
 
     #[test]
     fn unknown_lines_exclude_existing_attestations() {
@@ -602,5 +712,74 @@ mod tests {
             None,
             "known-human neighbors must not be used for edge extension"
         );
+    }
+
+    #[test]
+    fn bash_candidate_ranking_prefers_session_already_in_commit_then_time() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target.txt");
+        let in_commit_far =
+            test_candidate(1, "in-commit-far", "/outside", 1_000_000_000, 1_100_000_000);
+        let in_commit_near = test_candidate(
+            2,
+            "in-commit-near",
+            "/outside",
+            2_000_000_000,
+            2_100_000_000,
+        );
+        let unrelated_closest =
+            test_candidate(3, "unrelated", "/outside", 2_400_000_000, 2_500_000_000);
+        let candidates = vec![in_commit_far, in_commit_near, unrelated_closest];
+        let commit_sessions = HashSet::from([
+            generate_session_id("in-commit-far", "codex"),
+            generate_session_id("in-commit-near", "codex"),
+        ]);
+
+        let selected =
+            select_best_bash_candidate(&candidates, &[2_550_000_000], &commit_sessions, &target)
+                .unwrap();
+
+        assert_eq!(selected.candidate.agent_id.id, "in-commit-near");
+        assert!(selected.session_already_in_commit);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_prefers_parent_workdir_when_no_session_matches_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("repo").join("target.txt");
+        let parent = test_candidate(
+            1,
+            "parent",
+            temp.path().to_str().unwrap(),
+            1_000_000_000,
+            1_100_000_000,
+        );
+        let closer_non_parent =
+            test_candidate(2, "closer", "/outside", 2_000_000_000, 2_100_000_000);
+        let candidates = vec![parent, closer_non_parent];
+
+        let selected =
+            select_best_bash_candidate(&candidates, &[2_150_000_000], &HashSet::new(), &target)
+                .unwrap();
+
+        assert_eq!(selected.candidate.agent_id.id, "parent");
+        assert!(selected.repo_workdir_is_parent);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_falls_back_to_closest_time() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target.txt");
+        let older = test_candidate(1, "older", "/outside-a", 1_000_000_000, 1_100_000_000);
+        let closer = test_candidate(2, "closer", "/outside-b", 2_000_000_000, 2_100_000_000);
+        let candidates = vec![older, closer];
+
+        let selected =
+            select_best_bash_candidate(&candidates, &[2_200_000_000], &HashSet::new(), &target)
+                .unwrap();
+
+        assert_eq!(selected.candidate.agent_id.id, "closer");
+        assert!(!selected.session_already_in_commit);
+        assert!(!selected.repo_workdir_is_parent);
     }
 }


### PR DESCRIPTION
## Superseded

Closed in favor of #1645.

#1645 covers the same session/workdir/time ranking goal and additionally adds the bash-call interval guard plus integration coverage for manual edits before/after unrelated bash calls.

The installed-build scenario validation from this PR remains useful context, but the implementation should converge on #1645 rather than keeping two overlapping ranking PRs open.