### PR TITLE
Rank bash attribution recovery candidates

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
+const BASH_RECOVERY_COARSE_TIMESTAMP_NS: u128 = 1_000_000_000;
 const EDGE_EXTENSION_MAX_LINES: usize = 3;
 
 pub(crate) fn recover_attribution(
@@ -360,8 +361,19 @@ fn recovery_distance_to_call_window(timestamp_ns: u128, call: &BashCheckpointCal
         .end_time_ns
         .unwrap_or_else(|| start.saturating_add(BASH_RECOVERY_WINDOW_NS));
 
-    if timestamp_ns < start || timestamp_ns > end {
+    if timestamp_ns > end {
         return None;
+    }
+
+    if timestamp_ns < start {
+        let start_skew_ns = start.saturating_sub(timestamp_ns);
+        // Low-resolution filesystems can truncate mtimes to whole seconds.
+        // Only grant start-side grace to timestamps that look truncated.
+        if start_skew_ns >= BASH_RECOVERY_COARSE_TIMESTAMP_NS
+            || timestamp_ns % BASH_RECOVERY_COARSE_TIMESTAMP_NS != 0
+        {
+            return None;
+        }
     }
 
     Some(distance_to_call_window(timestamp_ns, call))
@@ -802,6 +814,29 @@ mod tests {
             selection.is_none(),
             "nearby candidates outside their matching bash time range must not recover attribution"
         );
+    }
+
+    #[test]
+    fn bash_candidate_ranking_allows_coarse_timestamp_rounded_before_start() {
+        let candidates = vec![bash_call(
+            1,
+            "coarse-session",
+            "tool-coarse",
+            "/repo",
+            2_500_000_000,
+            Some(3_000_000_000),
+        )];
+
+        let selection = select_best_bash_candidate(
+            &candidates,
+            &[2_000_000_000],
+            &HashSet::new(),
+            "/repo",
+        )
+        .expect("expected coarse timestamp to match");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-coarse");
+        assert_eq!(selection.distance_ns, 500_000_000);
     }
 
     #[test]

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -12,6 +12,7 @@ use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded}
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
@@ -92,14 +93,21 @@ fn recover_bash_mtime(
         return Ok(());
     }
 
+    let existing_commit_sessions = existing_commit_session_ids(authorship_log);
     for (file_path, unknown_lines) in unknown_by_file {
         let Some(timestamps) = timestamps_by_file.get(&file_path) else {
             continue;
         };
-        let Some((candidate, distance_ns)) = select_best_bash_candidate(&candidates, timestamps)
-        else {
+        let Some(selection) = select_best_bash_candidate(
+            &candidates,
+            timestamps,
+            &existing_commit_sessions,
+            &repo_work_dir,
+        ) else {
             continue;
         };
+        let candidate = selection.candidate;
+        let distance_ns = selection.distance_ns;
         if distance_ns > BASH_RECOVERY_WINDOW_NS {
             continue;
         }
@@ -126,6 +134,8 @@ fn recover_bash_mtime(
             "end_time_ns": candidate.end_time_ns,
             "start_trace_id": candidate.start_trace_id,
             "end_trace_id": candidate.end_trace_id,
+            "selection_tier": selection.tier.as_str(),
+            "candidate_count": candidates.len(),
         });
         record_recovery_metric(RecoveryMetricInput {
             repo,
@@ -249,24 +259,135 @@ fn system_time_to_ns(time: SystemTime) -> u128 {
 fn select_best_bash_candidate<'a>(
     candidates: &'a [BashCheckpointCall],
     timestamps: &[u128],
-) -> Option<(&'a BashCheckpointCall, u128)> {
+    existing_commit_sessions: &HashSet<String>,
+    target_repo_work_dir: &str,
+) -> Option<BashCandidateSelection<'a>> {
     candidates
         .iter()
-        .map(|candidate| {
+        .filter_map(|candidate| {
             let distance = timestamps
                 .iter()
-                .map(|ts| distance_to_call_window(*ts, candidate))
-                .min()
-                .unwrap_or(u128::MAX);
-            (candidate, distance)
+                .filter_map(|ts| recovery_distance_to_call_window(*ts, candidate))
+                .min()?;
+            Some(BashCandidateSelection {
+                candidate,
+                distance_ns: distance,
+                tier: bash_candidate_tier(
+                    candidate,
+                    existing_commit_sessions,
+                    target_repo_work_dir,
+                ),
+            })
         })
-        .min_by(|(left, left_distance), (right, right_distance)| {
-            left_distance
-                .cmp(right_distance)
-                .then_with(|| right.end_time_ns.is_some().cmp(&left.end_time_ns.is_some()))
-                .then_with(|| right.command.is_some().cmp(&left.command.is_some()))
-                .then_with(|| right.id.cmp(&left.id))
+        .min_by(|left, right| {
+            left.tier
+                .score()
+                .cmp(&right.tier.score())
+                .then_with(|| left.distance_ns.cmp(&right.distance_ns))
+                .then_with(|| {
+                    right
+                        .candidate
+                        .end_time_ns
+                        .is_some()
+                        .cmp(&left.candidate.end_time_ns.is_some())
+                })
+                .then_with(|| {
+                    right
+                        .candidate
+                        .command
+                        .is_some()
+                        .cmp(&left.candidate.command.is_some())
+                })
+                .then_with(|| right.candidate.id.cmp(&left.candidate.id))
         })
+}
+
+struct BashCandidateSelection<'a> {
+    candidate: &'a BashCheckpointCall,
+    distance_ns: u128,
+    tier: BashCandidateTier,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BashCandidateTier {
+    ExistingCommitSession,
+    WorkdirAncestor,
+    TimeOnly,
+}
+
+impl BashCandidateTier {
+    fn score(self) -> u8 {
+        match self {
+            Self::ExistingCommitSession => 0,
+            Self::WorkdirAncestor => 1,
+            Self::TimeOnly => 2,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ExistingCommitSession => "existing_commit_session",
+            Self::WorkdirAncestor => "workdir_ancestor",
+            Self::TimeOnly => "time_only",
+        }
+    }
+}
+
+fn bash_candidate_tier(
+    candidate: &BashCheckpointCall,
+    existing_commit_sessions: &HashSet<String>,
+    target_repo_work_dir: &str,
+) -> BashCandidateTier {
+    let session_id = bash_candidate_session_id(candidate);
+    if existing_commit_sessions.contains(&session_id) {
+        return BashCandidateTier::ExistingCommitSession;
+    }
+
+    if path_is_equal_or_child(target_repo_work_dir, &candidate.repo_work_dir) {
+        return BashCandidateTier::WorkdirAncestor;
+    }
+
+    BashCandidateTier::TimeOnly
+}
+
+fn bash_candidate_session_id(candidate: &BashCheckpointCall) -> String {
+    generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool)
+}
+
+fn recovery_distance_to_call_window(timestamp_ns: u128, call: &BashCheckpointCall) -> Option<u128> {
+    let start = call.start_time_ns;
+    let end = call
+        .end_time_ns
+        .unwrap_or_else(|| start.saturating_add(BASH_RECOVERY_WINDOW_NS));
+
+    if timestamp_ns < start || timestamp_ns > end {
+        return None;
+    }
+
+    Some(distance_to_call_window(timestamp_ns, call))
+}
+
+fn existing_commit_session_ids(authorship_log: &AuthorshipLog) -> HashSet<String> {
+    let mut sessions = HashSet::new();
+    for file_attestation in &authorship_log.attestations {
+        for entry in &file_attestation.entries {
+            let session = ai_session_key(&entry.hash);
+            if session.starts_with("s_") {
+                sessions.insert(session.to_string());
+            }
+        }
+    }
+    sessions
+}
+
+fn path_is_equal_or_child(child: &str, parent: &str) -> bool {
+    if child.is_empty() || parent.is_empty() {
+        return false;
+    }
+
+    let child = Path::new(child);
+    let parent = Path::new(parent);
+    child == parent || child.starts_with(parent)
 }
 
 fn insert_session_record(
@@ -533,6 +654,39 @@ mod tests {
     use crate::authorship::authorship_log_serialization::{
         AttestationEntry, AuthorshipLog, FileAttestation,
     };
+    use crate::authorship::working_log::AgentId;
+
+    fn test_agent(external_session_id: &str) -> AgentId {
+        AgentId {
+            tool: "codex".to_string(),
+            id: external_session_id.to_string(),
+            model: "gpt-5".to_string(),
+        }
+    }
+
+    fn bash_call(
+        id: i64,
+        external_session_id: &str,
+        tool_use_id: &str,
+        repo_work_dir: &str,
+        start_time_ns: u128,
+        end_time_ns: Option<u128>,
+    ) -> BashCheckpointCall {
+        BashCheckpointCall {
+            id,
+            invocation_key: format!("{}:{}", external_session_id, tool_use_id),
+            repo_work_dir: repo_work_dir.to_string(),
+            session_id: external_session_id.to_string(),
+            tool_use_id: tool_use_id.to_string(),
+            agent_id: test_agent(external_session_id),
+            start_trace_id: Some(format!("t_start_{}", id)),
+            end_trace_id: end_time_ns.map(|_| format!("t_end_{}", id)),
+            start_time_ns,
+            end_time_ns,
+            command: Some("true".to_string()),
+            metadata: HashMap::new(),
+        }
+    }
 
     #[test]
     fn unknown_lines_exclude_existing_attestations() {
@@ -551,6 +705,103 @@ mod tests {
 
         let unknown = unknown_lines_by_file(&log, &committed);
         assert_eq!(unknown.get("a.txt").unwrap(), &vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_prefers_session_already_in_commit() {
+        let existing_session = generate_session_id("existing-session", "codex");
+        let existing_sessions = HashSet::from([existing_session]);
+        let candidates = vec![
+            bash_call(1, "closer-session", "tool-closer", "/repo", 1_040, None),
+            bash_call(2, "existing-session", "tool-existing", "/other", 900, None),
+        ];
+
+        let selection =
+            select_best_bash_candidate(&candidates, &[1_050], &existing_sessions, "/repo")
+                .expect("expected candidate");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-existing");
+        assert_eq!(selection.tier, BashCandidateTier::ExistingCommitSession);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_uses_time_within_existing_commit_sessions() {
+        let existing_sessions = HashSet::from([
+            generate_session_id("existing-far", "codex"),
+            generate_session_id("existing-near", "codex"),
+        ]);
+        let candidates = vec![
+            bash_call(1, "existing-far", "tool-far", "/other", 900, None),
+            bash_call(2, "existing-near", "tool-near", "/other", 1_000, None),
+        ];
+
+        let selection =
+            select_best_bash_candidate(&candidates, &[1_050], &existing_sessions, "/repo")
+                .expect("expected candidate");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-near");
+        assert_eq!(selection.distance_ns, 50);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_prefers_workdir_ancestor_when_no_session_matches() {
+        let candidates = vec![
+            bash_call(
+                1,
+                "ancestor-session",
+                "tool-ancestor",
+                "/tmp/work",
+                900,
+                None,
+            ),
+            bash_call(2, "closer-session", "tool-closer", "/other", 1_040, None),
+        ];
+
+        let selection =
+            select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/tmp/work/repo")
+                .expect("expected candidate");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-ancestor");
+        assert_eq!(selection.tier, BashCandidateTier::WorkdirAncestor);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_falls_back_to_closest_time() {
+        let candidates = vec![
+            bash_call(1, "far-session", "tool-far", "/other-a", 900, None),
+            bash_call(2, "near-session", "tool-near", "/other-b", 1_040, None),
+        ];
+
+        let selection = select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/repo")
+            .expect("expected candidate");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-near");
+        assert_eq!(selection.tier, BashCandidateTier::TimeOnly);
+        assert_eq!(selection.distance_ns, 10);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_requires_matching_time_range() {
+        let existing_sessions = HashSet::from([generate_session_id("existing-session", "codex")]);
+        let candidates = vec![
+            bash_call(
+                1,
+                "existing-session",
+                "tool-completed",
+                "/repo",
+                1_000,
+                Some(1_100),
+            ),
+            bash_call(2, "open-session", "tool-open", "/repo", 2_000, None),
+        ];
+
+        let selection =
+            select_best_bash_candidate(&candidates, &[1_500], &existing_sessions, "/repo");
+
+        assert!(
+            selection.is_none(),
+            "nearby candidates outside their matching bash time range must not recover attribution"
+        );
     }
 
     #[test]

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -370,7 +370,7 @@ fn recovery_distance_to_call_window(timestamp_ns: u128, call: &BashCheckpointCal
         // Low-resolution filesystems can truncate mtimes to whole seconds.
         // Only grant start-side grace to timestamps that look truncated.
         if start_skew_ns >= BASH_RECOVERY_COARSE_TIMESTAMP_NS
-            || timestamp_ns % BASH_RECOVERY_COARSE_TIMESTAMP_NS != 0
+            || !timestamp_ns.is_multiple_of(BASH_RECOVERY_COARSE_TIMESTAMP_NS)
         {
             return None;
         }
@@ -827,13 +827,9 @@ mod tests {
             Some(3_000_000_000),
         )];
 
-        let selection = select_best_bash_candidate(
-            &candidates,
-            &[2_000_000_000],
-            &HashSet::new(),
-            "/repo",
-        )
-        .expect("expected coarse timestamp to match");
+        let selection =
+            select_best_bash_candidate(&candidates, &[2_000_000_000], &HashSet::new(), "/repo")
+                .expect("expected coarse timestamp to match");
 
         assert_eq!(selection.candidate.tool_use_id, "tool-coarse");
         assert_eq!(selection.distance_ns, 500_000_000);

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -175,6 +175,108 @@ fn test_codex_preset_bash_recovery_minimizes_dirty_untracked_attribution() {
 }
 
 #[test]
+fn test_bash_recovery_does_not_attribute_manual_edit_after_unrelated_bash() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    let repo_root = repo.canonical_path();
+    set_daemon_socket_for_test(repo.daemon_control_socket_path());
+
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+
+    let agent = AgentId {
+        tool: "codex".to_string(),
+        id: "manual-after-bash-session".to_string(),
+        model: "gpt-5".to_string(),
+    };
+
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "manual-after-bash-session",
+        "manual-after-bash-tool-1",
+        &agent,
+        None,
+        "t_manualpre000",
+        Some("true"),
+    )
+    .expect("pre bash hook should record durable start");
+
+    let post_result = handle_bash_post_tool_use(
+        &repo_root,
+        "manual-after-bash-session",
+        "manual-after-bash-tool-1",
+        &agent,
+        None,
+        "t_manualpost00",
+        Some("true"),
+    )
+    .expect("post bash hook should record durable end");
+    assert!(
+        matches!(post_result.action, BashCheckpointAction::NoChanges),
+        "bash call should not emit a normal checkpoint"
+    );
+
+    fs::write(repo_root.join("manual-after.txt"), "manual after bash\n").unwrap();
+    repo.stage_all_and_commit("Manual edit after bash").unwrap();
+
+    let mut file = repo.filename("manual-after.txt");
+    file.assert_committed_lines(lines!["manual after bash".unattributed_human()]);
+}
+
+#[test]
+fn test_bash_recovery_does_not_attribute_manual_edit_before_unrelated_bash() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    let repo_root = repo.canonical_path();
+    set_daemon_socket_for_test(repo.daemon_control_socket_path());
+
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+
+    fs::write(repo_root.join("manual-before.txt"), "manual before bash\n").unwrap();
+
+    let agent = AgentId {
+        tool: "codex".to_string(),
+        id: "manual-before-bash-session".to_string(),
+        model: "gpt-5".to_string(),
+    };
+
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "manual-before-bash-session",
+        "manual-before-bash-tool-1",
+        &agent,
+        None,
+        "t_manualbefpre",
+        Some("true"),
+    )
+    .expect("pre bash hook should record durable start");
+
+    let post_result = handle_bash_post_tool_use(
+        &repo_root,
+        "manual-before-bash-session",
+        "manual-before-bash-tool-1",
+        &agent,
+        None,
+        "t_manualbefpst",
+        Some("true"),
+    )
+    .expect("post bash hook should record durable end");
+    assert!(
+        matches!(post_result.action, BashCheckpointAction::NoChanges),
+        "bash call should not emit a normal checkpoint"
+    );
+
+    repo.stage_all_and_commit("Manual edit before bash")
+        .unwrap();
+
+    let mut file = repo.filename("manual-before.txt");
+    file.assert_committed_lines(lines!["manual before bash".unattributed_human()]);
+}
+
+#[test]
 fn test_bash_history_recovers_untracked_lines_when_post_snapshot_fails() {
     let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
     let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];


### PR DESCRIPTION
## Summary

Follow-up to #1625.

This PR makes bash mtime attribution recovery more precise when multiple bash sessions are plausible candidates for the same committed file.

Ranking now applies these rules before falling back to raw timestamp distance:

1. Prefer a bash session whose generated GitAI session ID already appears in the commit authorship log.
2. If no candidate session already appears in the commit, prefer a candidate whose recorded bash workdir is a parent of the repo workdir being recovered.
3. If neither signal applies, pick the closest candidate by file mtime/ctime distance within the recovery window.

It also requires the file timestamp to fall inside the matched bash call interval. For unclosed calls, the interval is bounded to `start_time_ns + BASH_RECOVERY_WINDOW_NS`. This protects manual edits immediately before or after an unrelated bash call from being recovered as AI just because they landed inside the old symmetric +/-3 second query window.

## Expected behavior

- If the commit already contains AI-attributed lines from one session, recovered bash holes prefer that same session over a closer unrelated session.
- If no existing commit session matches, a candidate whose bash workdir is an ancestor of the target repo workdir wins over an unrelated closer candidate.
- If there is no session or workdir signal, recovery keeps the existing closest-by-time fallback.
- Manual edits before or after an unrelated no-op bash call stay unattributed/human.
- PR #1625's main recovery cases still pass: post-snapshot failure, cross-repo/workdir bash recovery, dirty-before-bash recovery, shifted dirty-line recovery, and edge extension.

## Implementation notes

- Adds a ranked `BashCandidateSelection` in `src/authorship/attribution_recovery.rs`.
- Adds `selection_tier` and `candidate_count` to the recovery metadata JSON for observability.
- Adds unit tests for each ranking tier and the time-range guard.
- Adds integration guardrails for manual edits before/after unrelated bash calls.

## Verification

Ran:

```bash
cargo test attribution_recovery --lib -- --nocapture
cargo test --test integration bash_attribution -- --nocapture
cargo fmt --check
git diff --check
```

Results:

- `cargo test attribution_recovery --lib -- --nocapture`: 8 passed.
- `cargo test --test integration bash_attribution -- --nocapture`: 12 passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

## How to test manually

1. Create an AI-authored line in a commit from session A, then create an unattributed bash-recoverable line while session B has a closer timestamp. Expected: recovery chooses session A.
2. Run a bash checkpoint from a parent directory of the target repo and a closer unrelated checkpoint elsewhere. Expected: recovery chooses the parent-workdir checkpoint.
3. Run a no-op bash checkpoint, then manually create a file after the bash call and commit it. Expected: the manual line remains unattributed/human.
4. Manually create a file before a no-op bash checkpoint and commit it. Expected: the manual line remains unattributed/human.