### PR TITLE
Recover Bash attribution from cwd hints

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -2,6 +2,10 @@ use crate::authorship::authorship_log::{LineRange, SessionRecord};
 use crate::authorship::authorship_log_serialization::{
     AuthorshipLog, generate_session_id, generate_trace_id,
 };
+use crate::authorship::bash_repo_hints::{
+    BashAttemptView, BashHintConfidence, BashRepoHint, RecoveryContext, infer_bash_repo_hints,
+    normalize_path_for_matching,
+};
 use crate::authorship::working_log::{AgentId, CheckpointKind};
 use crate::commands::checkpoint_agent::bash_tool::StatEntry;
 use crate::daemon::bash_history_db::{BashCheckpointCall, distance_to_call_window};
@@ -13,7 +17,7 @@ use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded}
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
@@ -143,35 +147,45 @@ fn recover_bash_mtime(
     all_timestamps.sort_unstable();
     all_timestamps.dedup();
 
-    let candidates = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
+    let checkpoint_calls = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
         Ok(db) => match db.lock() {
             Ok(db) => db.candidates_near_timestamps(&all_timestamps, BASH_RECOVERY_WINDOW_NS)?,
             Err(_) => Vec::new(),
         },
         Err(_) => Vec::new(),
     };
-    if candidates.is_empty() {
+    if checkpoint_calls.is_empty() {
         return Ok(());
     }
+    let target_repo_work_dir = PathBuf::from(&repo_work_dir);
 
     let existing_commit_sessions = existing_commit_session_ids(authorship_log);
     for (file_path, unknown_lines) in unknown_by_file {
         let Some(timestamps) = timestamps_by_file.get(&file_path) else {
             continue;
         };
-        let Some(selection) = select_best_bash_candidate(
-            &candidates,
+        let target_file_path = normalize_path_for_matching(&workdir.join(&file_path));
+        let candidates = recovery_candidates_for_file(
+            &checkpoint_calls,
             timestamps,
             &existing_commit_sessions,
             &repo_work_dir,
-        ) else {
-            continue;
-        };
-        let candidate = selection.candidate;
-        let distance_ns = selection.distance_ns;
-        if distance_ns > BASH_RECOVERY_WINDOW_NS {
+            &target_repo_work_dir,
+            &target_file_path,
+        );
+        if candidates.is_empty() {
             continue;
         }
+        if distinct_candidate_sessions(&candidates) > 1 {
+            tracing::debug!(
+                "bash_mtime recovery skipped for {}: multiple strong candidate sessions",
+                file_path
+            );
+            continue;
+        }
+        let Some(candidate) = select_best_recovery_candidate(&candidates) else {
+            continue;
+        };
 
         let trace_id = generate_trace_id();
         let session_id = generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool);
@@ -185,19 +199,22 @@ fn recover_bash_mtime(
             "unknown_lines": unknown_lines,
             "target_repo_work_dir": repo_work_dir.as_str(),
             "file_timestamps_ns": timestamps,
+            "selected_bash_source_id": candidate.source_id,
+            "selected_bash_source_kind": candidate.source_kind,
             "selected_bash_call_id": candidate.id,
             "selected_bash_original_cwd": candidate.original_cwd.as_str(),
             "selected_bash_repo_work_dir": candidate.repo_work_dir.as_deref(),
             "selected_bash_repo_discovery_error": candidate.repo_discovery_error.as_deref(),
             "selected_tool_use_id": candidate.tool_use_id,
             "selected_command": candidate.command,
-            "distance_ns": distance_ns,
+            "selected_evidence": candidate.evidence,
+            "distance_ns": candidate.distance_ns,
             "window_ns": BASH_RECOVERY_WINDOW_NS,
             "start_time_ns": candidate.start_time_ns,
             "end_time_ns": candidate.end_time_ns,
             "start_trace_id": candidate.start_trace_id,
             "end_trace_id": candidate.end_trace_id,
-            "selection_tier": selection.tier.as_str(),
+            "selection_tier": candidate.tier.as_str(),
             "candidate_count": candidates.len(),
         });
         record_recovery_metric(RecoveryMetricInput {
@@ -436,56 +453,177 @@ fn system_time_to_ns(time: SystemTime) -> u128 {
         .as_nanos()
 }
 
-fn select_best_bash_candidate<'a>(
-    candidates: &'a [BashCheckpointCall],
-    timestamps: &[u128],
-    existing_commit_sessions: &HashSet<String>,
-    target_repo_work_dir: &str,
-) -> Option<BashCandidateSelection<'a>> {
-    candidates
-        .iter()
-        .filter_map(|candidate| {
-            let distance = timestamps
-                .iter()
-                .filter_map(|ts| recovery_distance_to_call_window(*ts, candidate))
-                .min()?;
-            Some(BashCandidateSelection {
-                candidate,
-                distance_ns: distance,
-                tier: bash_candidate_tier(
-                    candidate,
-                    existing_commit_sessions,
-                    target_repo_work_dir,
-                ),
-            })
-        })
-        .min_by(|left, right| {
-            left.tier
-                .score()
-                .cmp(&right.tier.score())
-                .then_with(|| left.distance_ns.cmp(&right.distance_ns))
-                .then_with(|| {
-                    right
-                        .candidate
-                        .end_time_ns
-                        .is_some()
-                        .cmp(&left.candidate.end_time_ns.is_some())
-                })
-                .then_with(|| {
-                    right
-                        .candidate
-                        .command
-                        .is_some()
-                        .cmp(&left.candidate.command.is_some())
-                })
-                .then_with(|| right.candidate.id.cmp(&left.candidate.id))
-        })
+#[derive(Debug, Clone)]
+struct BashRecoveryCandidate {
+    source_id: i64,
+    source_kind: &'static str,
+    id: i64,
+    original_cwd: String,
+    repo_work_dir: Option<String>,
+    repo_discovery_error: Option<String>,
+    tool_use_id: String,
+    agent_id: crate::authorship::working_log::AgentId,
+    start_trace_id: Option<String>,
+    end_trace_id: Option<String>,
+    start_time_ns: u128,
+    end_time_ns: Option<u128>,
+    command: Option<String>,
+    distance_ns: u128,
+    evidence: String,
+    tier: BashCandidateTier,
 }
 
-struct BashCandidateSelection<'a> {
-    candidate: &'a BashCheckpointCall,
+fn recovery_candidates_for_file(
+    calls: &[BashCheckpointCall],
+    timestamps: &[u128],
+    existing_commit_sessions: &HashSet<String>,
+    target_repo_work_dir_str: &str,
+    target_repo_work_dir: &Path,
+    target_file_path: &Path,
+) -> Vec<BashRecoveryCandidate> {
+    let mut candidates = Vec::new();
+    for call in calls {
+        let distance_ns = timestamps
+            .iter()
+            .filter_map(|ts| recovery_distance_to_call_window(*ts, call))
+            .min();
+        let Some(distance_ns) = distance_ns else {
+            continue;
+        };
+        candidates.extend(call_to_recovery_candidates(
+            call,
+            distance_ns,
+            existing_commit_sessions,
+            target_repo_work_dir_str,
+            target_repo_work_dir,
+            target_file_path,
+        ));
+    }
+    candidates
+}
+
+fn call_to_recovery_candidates(
+    call: &BashCheckpointCall,
     distance_ns: u128,
-    tier: BashCandidateTier,
+    existing_commit_sessions: &HashSet<String>,
+    target_repo_work_dir_str: &str,
+    target_repo_work_dir: &Path,
+    target_file_path: &Path,
+) -> Vec<BashRecoveryCandidate> {
+    let original_cwd = Path::new(&call.original_cwd);
+    let discovered_repo = call.repo_work_dir.as_deref().map(Path::new);
+    let attempt = BashAttemptView {
+        original_cwd,
+        discovered_repo_work_dir: discovered_repo,
+        command: call.command.as_deref(),
+    };
+    let ctx = RecoveryContext {
+        target_repo_work_dir,
+    };
+    let hints = infer_bash_repo_hints(&attempt, &ctx);
+    let candidates: Vec<_> = hints
+        .into_iter()
+        .filter(|hint| hint_is_strong_file_match(hint, target_file_path))
+        .map(|hint| BashRecoveryCandidate {
+            tier: bash_candidate_tier_for_hint(
+                call,
+                &hint,
+                existing_commit_sessions,
+                target_repo_work_dir_str,
+            ),
+            source_id: call.id,
+            source_kind: "bash_checkpoint_call",
+            id: call.id,
+            original_cwd: call.original_cwd.clone(),
+            repo_work_dir: call.repo_work_dir.clone(),
+            repo_discovery_error: call.repo_discovery_error.clone(),
+            tool_use_id: call.tool_use_id.clone(),
+            agent_id: call.agent_id.clone(),
+            start_trace_id: call.start_trace_id.clone(),
+            end_trace_id: call.end_trace_id.clone(),
+            start_time_ns: call.start_time_ns,
+            end_time_ns: call.end_time_ns,
+            command: call.command.clone(),
+            distance_ns,
+            evidence: hint.evidence,
+        })
+        .collect();
+    if !candidates.is_empty() {
+        return candidates;
+    }
+
+    let tier = bash_candidate_tier(call, existing_commit_sessions, target_repo_work_dir_str);
+    if tier == BashCandidateTier::TimeOnly {
+        return Vec::new();
+    }
+
+    vec![BashRecoveryCandidate {
+        tier,
+        source_id: call.id,
+        source_kind: "bash_checkpoint_call",
+        id: call.id,
+        original_cwd: call.original_cwd.clone(),
+        repo_work_dir: call.repo_work_dir.clone(),
+        repo_discovery_error: call.repo_discovery_error.clone(),
+        tool_use_id: call.tool_use_id.clone(),
+        agent_id: call.agent_id.clone(),
+        start_trace_id: call.start_trace_id.clone(),
+        end_trace_id: call.end_trace_id.clone(),
+        start_time_ns: call.start_time_ns,
+        end_time_ns: call.end_time_ns,
+        command: call.command.clone(),
+        distance_ns,
+        evidence: tier.as_str().to_string(),
+    }]
+}
+
+fn hint_is_strong_file_match(hint: &BashRepoHint, target_file_path: &Path) -> bool {
+    if hint.confidence != BashHintConfidence::Strong {
+        return false;
+    }
+    if hint.target_paths.is_empty() {
+        return true;
+    }
+    let target_file_path = normalize_path_for_matching(target_file_path);
+    hint.target_paths
+        .iter()
+        .any(|path| normalize_path_for_matching(path) == target_file_path)
+}
+
+fn distinct_candidate_sessions(candidates: &[BashRecoveryCandidate]) -> usize {
+    candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.agent_id.tool.as_str(),
+                candidate.agent_id.id.as_str(),
+            )
+        })
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+fn select_best_recovery_candidate(
+    candidates: &[BashRecoveryCandidate],
+) -> Option<&BashRecoveryCandidate> {
+    candidates.iter().min_by(|left, right| {
+        left.tier
+            .score()
+            .cmp(&right.tier.score())
+            .then_with(|| left.distance_ns.cmp(&right.distance_ns))
+            .then_with(|| right.end_time_ns.is_some().cmp(&left.end_time_ns.is_some()))
+            .then_with(|| right.command.is_some().cmp(&left.command.is_some()))
+            .then_with(|| source_kind_rank(left).cmp(&source_kind_rank(right)))
+            .then_with(|| right.source_id.cmp(&left.source_id))
+    })
+}
+
+fn source_kind_rank(candidate: &BashRecoveryCandidate) -> u8 {
+    match candidate.source_kind {
+        "bash_hook_attempt" => 0,
+        "bash_checkpoint_call" => 1,
+        _ => 2,
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -493,6 +631,7 @@ enum BashCandidateTier {
     ExistingCommitSession,
     WorkdirAncestor,
     CwdAncestor,
+    CommandHint,
     TimeOnly,
 }
 
@@ -502,6 +641,7 @@ impl BashCandidateTier {
             Self::ExistingCommitSession => 0,
             Self::WorkdirAncestor => 1,
             Self::CwdAncestor => 2,
+            Self::CommandHint => 2,
             Self::TimeOnly => 3,
         }
     }
@@ -511,8 +651,21 @@ impl BashCandidateTier {
             Self::ExistingCommitSession => "existing_commit_session",
             Self::WorkdirAncestor => "workdir_ancestor",
             Self::CwdAncestor => "cwd_ancestor",
+            Self::CommandHint => "command_hint",
             Self::TimeOnly => "time_only",
         }
+    }
+}
+
+fn bash_candidate_tier_for_hint(
+    candidate: &BashCheckpointCall,
+    _hint: &BashRepoHint,
+    existing_commit_sessions: &HashSet<String>,
+    target_repo_work_dir: &str,
+) -> BashCandidateTier {
+    match bash_candidate_tier(candidate, existing_commit_sessions, target_repo_work_dir) {
+        BashCandidateTier::TimeOnly => BashCandidateTier::CommandHint,
+        tier => tier,
     }
 }
 
@@ -684,7 +837,7 @@ fn path_is_equal_or_child(child: &str, parent: &str) -> bool {
 fn insert_session_record(
     authorship_log: &mut AuthorshipLog,
     session_id: &str,
-    candidate: &BashCheckpointCall,
+    candidate: &BashRecoveryCandidate,
     human_author: &str,
 ) {
     authorship_log
@@ -1055,6 +1208,25 @@ mod tests {
         }
     }
 
+    fn select_best_bash_candidate_for_test(
+        calls: &[BashCheckpointCall],
+        timestamps: &[u128],
+        existing_sessions: &HashSet<String>,
+        target_repo_work_dir: &str,
+    ) -> Option<BashRecoveryCandidate> {
+        let target_repo_path = Path::new(target_repo_work_dir);
+        let target_file_path = target_repo_path.join("file.txt");
+        let candidates = recovery_candidates_for_file(
+            calls,
+            timestamps,
+            existing_sessions,
+            target_repo_work_dir,
+            target_repo_path,
+            &target_file_path,
+        );
+        select_best_recovery_candidate(&candidates).cloned()
+    }
+
     #[test]
     fn unknown_lines_exclude_existing_attestations() {
         let mut log = AuthorshipLog::new();
@@ -1084,10 +1256,10 @@ mod tests {
         ];
 
         let selection =
-            select_best_bash_candidate(&candidates, &[1_050], &existing_sessions, "/repo")
+            select_best_bash_candidate_for_test(&candidates, &[1_050], &existing_sessions, "/repo")
                 .expect("expected candidate");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-existing");
+        assert_eq!(selection.tool_use_id, "tool-existing");
         assert_eq!(selection.tier, BashCandidateTier::ExistingCommitSession);
     }
 
@@ -1103,10 +1275,10 @@ mod tests {
         ];
 
         let selection =
-            select_best_bash_candidate(&candidates, &[1_050], &existing_sessions, "/repo")
+            select_best_bash_candidate_for_test(&candidates, &[1_050], &existing_sessions, "/repo")
                 .expect("expected candidate");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-near");
+        assert_eq!(selection.tool_use_id, "tool-near");
         assert_eq!(selection.distance_ns, 50);
     }
 
@@ -1124,11 +1296,15 @@ mod tests {
             bash_call(2, "closer-session", "tool-closer", "/other", 1_040, None),
         ];
 
-        let selection =
-            select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/tmp/work/repo")
-                .expect("expected candidate");
+        let selection = select_best_bash_candidate_for_test(
+            &candidates,
+            &[1_050],
+            &HashSet::new(),
+            "/tmp/work/repo",
+        )
+        .expect("expected candidate");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-ancestor");
+        assert_eq!(selection.tool_use_id, "tool-ancestor");
         assert_eq!(selection.tier, BashCandidateTier::WorkdirAncestor);
     }
 
@@ -1153,11 +1329,15 @@ mod tests {
             ),
         ];
 
-        let selection =
-            select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/tmp/work/repo")
-                .expect("expected candidate");
+        let selection = select_best_bash_candidate_for_test(
+            &candidates,
+            &[1_050],
+            &HashSet::new(),
+            "/tmp/work/repo",
+        )
+        .expect("expected candidate");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-workdir-ancestor");
+        assert_eq!(selection.tool_use_id, "tool-workdir-ancestor");
         assert_eq!(selection.tier, BashCandidateTier::WorkdirAncestor);
     }
 
@@ -1175,27 +1355,32 @@ mod tests {
             bash_call(2, "closer-session", "tool-closer", "/other", 1_040, None),
         ];
 
-        let selection =
-            select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/tmp/work/repo")
-                .expect("expected candidate");
+        let selection = select_best_bash_candidate_for_test(
+            &candidates,
+            &[1_050],
+            &HashSet::new(),
+            "/tmp/work/repo",
+        )
+        .expect("expected candidate");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-cwd-ancestor");
+        assert_eq!(selection.tool_use_id, "tool-cwd-ancestor");
         assert_eq!(selection.tier, BashCandidateTier::CwdAncestor);
     }
 
     #[test]
-    fn bash_candidate_ranking_falls_back_to_closest_time() {
+    fn bash_candidate_ranking_excludes_time_only_candidates() {
         let candidates = vec![
             bash_call(1, "far-session", "tool-far", "/other-a", 900, None),
             bash_call(2, "near-session", "tool-near", "/other-b", 1_040, None),
         ];
 
-        let selection = select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/repo")
-            .expect("expected candidate");
+        let selection =
+            select_best_bash_candidate_for_test(&candidates, &[1_050], &HashSet::new(), "/repo");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-near");
-        assert_eq!(selection.tier, BashCandidateTier::TimeOnly);
-        assert_eq!(selection.distance_ns, 10);
+        assert!(
+            selection.is_none(),
+            "unrelated time-only bash candidates must not recover attribution"
+        );
     }
 
     #[test]
@@ -1291,7 +1476,7 @@ mod tests {
         ];
 
         let selection =
-            select_best_bash_candidate(&candidates, &[1_500], &existing_sessions, "/repo");
+            select_best_bash_candidate_for_test(&candidates, &[1_500], &existing_sessions, "/repo");
 
         assert!(
             selection.is_none(),
@@ -1310,11 +1495,15 @@ mod tests {
             Some(3_000_000_000),
         )];
 
-        let selection =
-            select_best_bash_candidate(&candidates, &[2_000_000_000], &HashSet::new(), "/repo")
-                .expect("expected coarse timestamp to match");
+        let selection = select_best_bash_candidate_for_test(
+            &candidates,
+            &[2_000_000_000],
+            &HashSet::new(),
+            "/repo",
+        )
+        .expect("expected coarse timestamp to match");
 
-        assert_eq!(selection.candidate.tool_use_id, "tool-coarse");
+        assert_eq!(selection.tool_use_id, "tool-coarse");
         assert_eq!(selection.distance_ns, 500_000_000);
     }
 

--- a/src/authorship/bash_repo_hints.rs
+++ b/src/authorship/bash_repo_hints.rs
@@ -1,0 +1,654 @@
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(dead_code)]
+pub(crate) enum BashHintConfidence {
+    Weak,
+    Medium,
+    Strong,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BashRepoHint {
+    pub repo_work_dir: PathBuf,
+    pub target_paths: Vec<PathBuf>,
+    pub confidence: BashHintConfidence,
+    pub evidence: String,
+}
+
+pub(crate) struct BashAttemptView<'a> {
+    pub original_cwd: &'a Path,
+    pub discovered_repo_work_dir: Option<&'a Path>,
+    pub command: Option<&'a str>,
+}
+
+pub(crate) struct RecoveryContext<'a> {
+    pub target_repo_work_dir: &'a Path,
+}
+
+pub(crate) trait BashRepoHintStrategy {
+    fn name(&self) -> &'static str;
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint>;
+}
+
+pub(crate) fn infer_bash_repo_hints(
+    attempt: &BashAttemptView<'_>,
+    ctx: &RecoveryContext<'_>,
+) -> Vec<BashRepoHint> {
+    let strategies: [&dyn BashRepoHintStrategy; 6] = [
+        &OriginalCwdRepoStrategy,
+        &AbsolutePathStrategy,
+        &LeadingCdStrategy,
+        &RedirectionPathStrategy,
+        &GitCStrategy,
+        &ToolCwdFlagStrategy,
+    ];
+
+    let mut hints = Vec::new();
+    for strategy in strategies {
+        hints.extend(strategy.infer(attempt, ctx));
+    }
+    dedup_hints(hints)
+}
+
+pub(crate) fn normalize_path_for_matching(path: &Path) -> PathBuf {
+    let lexical = normalize_components(path);
+    let path = lexical.as_path();
+
+    if let Ok(canonical) = path.canonicalize() {
+        return normalize_components(&canonical);
+    }
+
+    let mut existing = path;
+    let mut missing = Vec::<OsString>::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name() else {
+            break;
+        };
+        missing.push(name.to_os_string());
+        let Some(parent) = existing.parent() else {
+            break;
+        };
+        if parent == existing {
+            break;
+        }
+        existing = parent;
+    }
+
+    let mut rebuilt = existing
+        .canonicalize()
+        .unwrap_or_else(|_| existing.to_path_buf());
+    for part in missing.into_iter().rev() {
+        rebuilt.push(part);
+    }
+    normalize_components(&rebuilt)
+}
+
+pub(crate) fn path_is_within(path: &Path, root: &Path) -> bool {
+    let path = normalize_path_for_matching(path);
+    let root = normalize_path_for_matching(root);
+    path == root || path.starts_with(root)
+}
+
+fn dedup_hints(hints: Vec<BashRepoHint>) -> Vec<BashRepoHint> {
+    let mut deduped = Vec::<BashRepoHint>::new();
+    for hint in hints {
+        if !deduped.iter().any(|existing| {
+            existing.repo_work_dir == hint.repo_work_dir
+                && existing.target_paths == hint.target_paths
+                && existing.confidence == hint.confidence
+                && existing.evidence == hint.evidence
+        }) {
+            deduped.push(hint);
+        }
+    }
+    deduped
+}
+
+fn normalize_components(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+fn repo_hint(
+    target_repo: &Path,
+    target_paths: Vec<PathBuf>,
+    confidence: BashHintConfidence,
+    evidence: impl Into<String>,
+) -> BashRepoHint {
+    BashRepoHint {
+        repo_work_dir: normalize_path_for_matching(target_repo),
+        target_paths: target_paths
+            .into_iter()
+            .map(|path| normalize_path_for_matching(&path))
+            .collect(),
+        confidence,
+        evidence: evidence.into(),
+    }
+}
+
+fn hint_for_candidate_path(
+    path: &Path,
+    target_repo: &Path,
+    evidence: impl Into<String>,
+) -> Option<BashRepoHint> {
+    if !path_is_within(path, target_repo) {
+        return None;
+    }
+    Some(repo_hint(
+        target_repo,
+        vec![path.to_path_buf()],
+        BashHintConfidence::Strong,
+        evidence,
+    ))
+}
+
+fn resolve_path(base: &Path, path: &str) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn command_tokens(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.chars().peekable();
+    let mut quote: Option<char> = None;
+
+    while let Some(ch) = chars.next() {
+        if let Some(active_quote) = quote {
+            if ch == active_quote {
+                quote = None;
+            } else if ch == '\\' && active_quote == '"' {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            ch if ch.is_whitespace() => {
+                push_token(&mut tokens, &mut current);
+            }
+            ';' | '(' | ')' | '{' | '}' => {
+                push_token(&mut tokens, &mut current);
+                tokens.push(ch.to_string());
+            }
+            '&' | '|' => {
+                push_token(&mut tokens, &mut current);
+                if chars.peek() == Some(&ch) {
+                    chars.next();
+                    tokens.push(format!("{ch}{ch}"));
+                } else {
+                    tokens.push(ch.to_string());
+                }
+            }
+            '>' | '<' => {
+                push_token(&mut tokens, &mut current);
+                let mut op = ch.to_string();
+                while chars.peek() == Some(&ch) {
+                    chars.next();
+                    op.push(ch);
+                }
+                tokens.push(op);
+            }
+            _ => current.push(ch),
+        }
+    }
+    push_token(&mut tokens, &mut current);
+    tokens
+}
+
+fn push_token(tokens: &mut Vec<String>, current: &mut String) {
+    if !current.is_empty() {
+        tokens.push(std::mem::take(current));
+    }
+}
+
+fn redirection_target_tokens(tokens: &[String]) -> Vec<&str> {
+    let mut paths = Vec::new();
+    for index in 0..tokens.len() {
+        let token = tokens[index].as_str();
+        let next = tokens.get(index + 1).map(String::as_str);
+        if matches!(token, ">" | ">>" | "<" | "<<" | "<<<")
+            && let Some(path) = next
+            && !is_control_token(path)
+        {
+            paths.push(path);
+        }
+        if token.ends_with('>')
+            && token.len() > 1
+            && token.chars().all(|ch| ch.is_ascii_digit() || ch == '>')
+            && let Some(path) = next
+            && !is_control_token(path)
+        {
+            paths.push(path);
+        }
+        if token == "tee" {
+            let mut cursor = index + 1;
+            while let Some(candidate) = tokens.get(cursor).map(String::as_str) {
+                if candidate.starts_with('-') {
+                    cursor += 1;
+                    continue;
+                }
+                if !is_control_token(candidate) {
+                    paths.push(candidate);
+                }
+                break;
+            }
+        }
+    }
+    paths
+}
+
+fn is_control_token(token: &str) -> bool {
+    matches!(token, ";" | "&&" | "||" | "|" | "(" | ")" | "{" | "}")
+}
+
+fn leading_effective_cwd(tokens: &[String], original_cwd: &Path) -> Option<PathBuf> {
+    let mut index = 0;
+    while matches!(tokens.get(index).map(String::as_str), Some("(" | "{")) {
+        index += 1;
+    }
+
+    match tokens.get(index).map(String::as_str) {
+        Some("cd") => {
+            let dir = tokens.get(index + 1)?;
+            if is_control_token(dir) {
+                return None;
+            }
+            Some(resolve_path(original_cwd, dir))
+        }
+        Some("pushd") => {
+            let dir = tokens.get(index + 1)?;
+            if is_control_token(dir) {
+                return None;
+            }
+            Some(resolve_path(original_cwd, dir))
+        }
+        _ => None,
+    }
+}
+
+struct OriginalCwdRepoStrategy;
+
+impl BashRepoHintStrategy for OriginalCwdRepoStrategy {
+    fn name(&self) -> &'static str {
+        "original_cwd_repo"
+    }
+
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint> {
+        let mut hints = Vec::new();
+        if let Some(discovered_repo) = attempt.discovered_repo_work_dir
+            && normalize_path_for_matching(discovered_repo)
+                == normalize_path_for_matching(ctx.target_repo_work_dir)
+        {
+            hints.push(repo_hint(
+                ctx.target_repo_work_dir,
+                Vec::new(),
+                BashHintConfidence::Strong,
+                self.name(),
+            ));
+        } else if path_is_within(attempt.original_cwd, ctx.target_repo_work_dir) {
+            hints.push(repo_hint(
+                ctx.target_repo_work_dir,
+                Vec::new(),
+                BashHintConfidence::Strong,
+                self.name(),
+            ));
+        }
+        hints
+    }
+}
+
+struct AbsolutePathStrategy;
+
+impl BashRepoHintStrategy for AbsolutePathStrategy {
+    fn name(&self) -> &'static str {
+        "absolute_path"
+    }
+
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint> {
+        let Some(command) = attempt.command else {
+            return Vec::new();
+        };
+        command_tokens(command)
+            .into_iter()
+            .filter(|token| Path::new(token).is_absolute())
+            .filter_map(|token| {
+                hint_for_candidate_path(Path::new(&token), ctx.target_repo_work_dir, self.name())
+            })
+            .collect()
+    }
+}
+
+struct LeadingCdStrategy;
+
+impl BashRepoHintStrategy for LeadingCdStrategy {
+    fn name(&self) -> &'static str {
+        "leading_cd"
+    }
+
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint> {
+        let Some(command) = attempt.command else {
+            return Vec::new();
+        };
+        let tokens = command_tokens(command);
+        let Some(effective_cwd) = leading_effective_cwd(&tokens, attempt.original_cwd) else {
+            return Vec::new();
+        };
+        if !path_is_within(&effective_cwd, ctx.target_repo_work_dir) {
+            return Vec::new();
+        }
+
+        let redirection_targets = redirection_target_tokens(&tokens);
+        if redirection_targets.is_empty() {
+            return vec![repo_hint(
+                ctx.target_repo_work_dir,
+                Vec::new(),
+                BashHintConfidence::Strong,
+                self.name(),
+            )];
+        }
+        redirection_targets
+            .into_iter()
+            .filter_map(|target| {
+                let resolved = resolve_path(&effective_cwd, target);
+                hint_for_candidate_path(&resolved, ctx.target_repo_work_dir, self.name())
+            })
+            .collect()
+    }
+}
+
+struct RedirectionPathStrategy;
+
+impl BashRepoHintStrategy for RedirectionPathStrategy {
+    fn name(&self) -> &'static str {
+        "redirection_path"
+    }
+
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint> {
+        let Some(command) = attempt.command else {
+            return Vec::new();
+        };
+        let tokens = command_tokens(command);
+        redirection_target_tokens(&tokens)
+            .into_iter()
+            .filter_map(|target| {
+                let resolved = resolve_path(attempt.original_cwd, target);
+                hint_for_candidate_path(&resolved, ctx.target_repo_work_dir, self.name())
+            })
+            .collect()
+    }
+}
+
+struct GitCStrategy;
+
+impl BashRepoHintStrategy for GitCStrategy {
+    fn name(&self) -> &'static str {
+        "git_c"
+    }
+
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint> {
+        let Some(command) = attempt.command else {
+            return Vec::new();
+        };
+        let tokens = command_tokens(command);
+        let mut hints = Vec::new();
+        for index in 0..tokens.len() {
+            if tokens[index] == "git"
+                && tokens.get(index + 1).map(String::as_str) == Some("-C")
+                && let Some(dir) = tokens.get(index + 2)
+            {
+                let resolved = resolve_path(attempt.original_cwd, dir);
+                if path_is_within(&resolved, ctx.target_repo_work_dir) {
+                    hints.push(repo_hint(
+                        ctx.target_repo_work_dir,
+                        Vec::new(),
+                        BashHintConfidence::Strong,
+                        self.name(),
+                    ));
+                }
+            }
+        }
+        hints
+    }
+}
+
+struct ToolCwdFlagStrategy;
+
+impl BashRepoHintStrategy for ToolCwdFlagStrategy {
+    fn name(&self) -> &'static str {
+        "tool_cwd_flag"
+    }
+
+    fn infer(&self, attempt: &BashAttemptView<'_>, ctx: &RecoveryContext<'_>) -> Vec<BashRepoHint> {
+        let Some(command) = attempt.command else {
+            return Vec::new();
+        };
+        let tokens = command_tokens(command);
+        let mut hints = Vec::new();
+        for index in 0..tokens.len() {
+            let flag_dir = match tokens[index].as_str() {
+                "make" if tokens.get(index + 1).map(String::as_str) == Some("-C") => {
+                    tokens.get(index + 2)
+                }
+                "npm" if tokens.get(index + 1).map(String::as_str) == Some("--prefix") => {
+                    tokens.get(index + 2)
+                }
+                "yarn" if tokens.get(index + 1).map(String::as_str) == Some("--cwd") => {
+                    tokens.get(index + 2)
+                }
+                "pnpm" if tokens.get(index + 1).map(String::as_str) == Some("-C") => {
+                    tokens.get(index + 2)
+                }
+                _ => None,
+            };
+            if let Some(dir) = flag_dir {
+                let resolved = resolve_path(attempt.original_cwd, dir);
+                if path_is_within(&resolved, ctx.target_repo_work_dir) {
+                    hints.push(repo_hint(
+                        ctx.target_repo_work_dir,
+                        Vec::new(),
+                        BashHintConfidence::Strong,
+                        self.name(),
+                    ));
+                }
+            }
+        }
+        hints
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(repo: &Path) -> RecoveryContext<'_> {
+        RecoveryContext {
+            target_repo_work_dir: repo,
+        }
+    }
+
+    fn attempt<'a>(cwd: &'a Path, command: &'a str) -> BashAttemptView<'a> {
+        BashAttemptView {
+            original_cwd: cwd,
+            discovered_repo_work_dir: None,
+            command: Some(command),
+        }
+    }
+
+    #[test]
+    fn absolute_path_inside_repo_is_strong_file_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("workspace/project");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+        let command = format!("printf x >> {}", repo.join("src/a.rs").display());
+
+        let hints = infer_bash_repo_hints(&attempt(tmp.path(), &command), &ctx(&repo));
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong
+                && hint.target_paths == vec![normalize_path_for_matching(&repo.join("src/a.rs"))]
+        }));
+    }
+
+    #[test]
+    fn absolute_path_with_parent_component_normalizes_inside_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("workspace/project");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+        let command = format!("printf x >> {}", repo.join("src/toto/../a.rs").display());
+
+        let hints = infer_bash_repo_hints(&attempt(tmp.path(), &command), &ctx(&repo));
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong
+                && hint.target_paths == vec![normalize_path_for_matching(&repo.join("src/a.rs"))]
+        }));
+    }
+
+    #[test]
+    fn leading_cd_resolves_relative_redirection_into_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+
+        let hints = infer_bash_repo_hints(
+            &attempt(&workspace, "cd project && printf x >> src/a.rs"),
+            &ctx(&repo),
+        );
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong
+                && hint.target_paths == vec![normalize_path_for_matching(&repo.join("src/a.rs"))]
+        }));
+    }
+
+    #[test]
+    fn subshell_cd_resolves_relative_redirection_into_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+
+        let hints = infer_bash_repo_hints(
+            &attempt(&workspace, "(cd project && printf x >> src/a.rs)"),
+            &ctx(&repo),
+        );
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong
+                && hint.target_paths == vec![normalize_path_for_matching(&repo.join("src/a.rs"))]
+        }));
+    }
+
+    #[test]
+    fn relative_redirection_from_parent_resolves_into_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+
+        let hints = infer_bash_repo_hints(
+            &attempt(&workspace, "printf x >> project/src/a.rs"),
+            &ctx(&repo),
+        );
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong
+                && hint.target_paths == vec![normalize_path_for_matching(&repo.join("src/a.rs"))]
+        }));
+    }
+
+    #[test]
+    fn git_c_produces_repo_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let hints = infer_bash_repo_hints(
+            &attempt(&workspace, "git -C project apply /tmp/change.patch"),
+            &ctx(&repo),
+        );
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong && hint.target_paths.is_empty()
+        }));
+    }
+
+    #[test]
+    fn tool_cwd_flag_produces_repo_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let hints = infer_bash_repo_hints(&attempt(&workspace, "make -C project"), &ctx(&repo));
+
+        assert!(hints.iter().any(|hint| {
+            hint.confidence == BashHintConfidence::Strong && hint.target_paths.is_empty()
+        }));
+    }
+
+    #[test]
+    fn parent_relative_path_outside_repo_is_not_file_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(repo.join("src")).unwrap();
+
+        let hints = infer_bash_repo_hints(
+            &attempt(&workspace, "cd project && printf x >> ../outside.txt"),
+            &ctx(&repo),
+        );
+
+        assert!(!hints.iter().any(|hint| {
+            hint.target_paths
+                .contains(&normalize_path_for_matching(&workspace.join("outside.txt")))
+        }));
+    }
+
+    #[test]
+    fn weak_unparseable_command_produces_no_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        let repo = workspace.join("project");
+        std::fs::create_dir_all(&repo).unwrap();
+
+        let hints = infer_bash_repo_hints(
+            &attempt(&workspace, "REPO=project; cd \"$REPO\" && ./gen.sh"),
+            &ctx(&repo),
+        );
+
+        assert!(hints.is_empty());
+    }
+}

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -4,6 +4,7 @@ pub mod attribution_tracker;
 pub mod authorship_log;
 pub mod authorship_log_serialization;
 pub mod background_agent;
+pub mod bash_repo_hints;
 pub mod conflict_resolution;
 pub mod diff_ai_accepted;
 pub mod git_ai_hooks;

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -18,6 +18,25 @@ fn isolated_bash_history_db_path() -> (tempfile::TempDir, String) {
     (dir, path.to_string_lossy().to_string())
 }
 
+fn codex_bash_hook_input(
+    cwd: &std::path::Path,
+    event: &str,
+    session_id: &str,
+    tool_use_id: &str,
+    command: &str,
+) -> String {
+    json!({
+        "cwd": cwd.to_string_lossy().to_string(),
+        "session_id": session_id,
+        "hook_event_name": event,
+        "tool_name": "Bash",
+        "tool_use_id": tool_use_id,
+        "tool_input": { "command": command },
+        "model": "gpt-5"
+    })
+    .to_string()
+}
+
 #[test]
 fn test_bash_pre_legacy_checkpoint_recovers_dirty_edge_attribution() {
     let repo = TestRepo::new();
@@ -45,6 +64,161 @@ fn test_bash_pre_legacy_checkpoint_recovers_dirty_edge_attribution() {
         "original line".unattributed_human(),
         "dirty pre-bash line".ai(),
         "ai bash line".ai(),
+    ]);
+}
+
+#[test]
+fn test_bash_history_recovers_parent_cwd_leading_cd_attempt() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    let repo_root = repo.canonical_path();
+    let parent_cwd = repo_root.parent().unwrap().to_path_buf();
+    let repo_name = repo_root.file_name().unwrap().to_string_lossy().to_string();
+
+    fs::write(repo_root.join("README.md"), "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::create_dir_all(repo_root.join("src")).unwrap();
+    let command = format!("cd {} && printf x >> src/a.rs", repo_name);
+    let pre_hook_input = codex_bash_hook_input(
+        &parent_cwd,
+        "PreToolUse",
+        "session-parent-cwd",
+        "tool-parent-cwd",
+        &command,
+    );
+    repo.git_ai_from_working_dir(
+        &parent_cwd,
+        &["checkpoint", "codex", "--hook-input", &pre_hook_input],
+    )
+    .expect("parent-cwd pre hook exits successfully after recording attempt");
+
+    fs::write(repo_root.join("src/a.rs"), "x\n").unwrap();
+
+    let post_hook_input = codex_bash_hook_input(
+        &parent_cwd,
+        "PostToolUse",
+        "session-parent-cwd",
+        "tool-parent-cwd",
+        &command,
+    );
+    repo.git_ai_from_working_dir(
+        &parent_cwd,
+        &["checkpoint", "codex", "--hook-input", &post_hook_input],
+    )
+    .expect("parent-cwd post hook exits successfully after recording attempt");
+
+    let commit = repo
+        .stage_all_and_commit("Recover parent-cwd bash attribution")
+        .unwrap();
+
+    let mut file = repo.filename("src/a.rs");
+    file.assert_committed_lines(lines!["x".ai()]);
+
+    assert!(
+        commit
+            .authorship_log
+            .metadata
+            .sessions
+            .values()
+            .any(|record| {
+                record.agent_id.tool == "codex" && record.agent_id.id == "session-parent-cwd"
+            })
+    );
+
+    let db = BashHistoryDatabase::open_at_path(std::path::Path::new(&bash_db_path)).unwrap();
+    let calls = db.all_calls_for_test().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].original_cwd, parent_cwd.to_string_lossy());
+    assert_eq!(calls[0].repo_work_dir, None);
+    assert!(calls[0].repo_discovery_error.is_some());
+    assert_eq!(calls[0].command.as_deref(), Some(command.as_str()));
+}
+
+#[test]
+fn test_bash_history_skips_ambiguous_distinct_sessions_for_same_window() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    let repo_root = repo.canonical_path();
+    set_daemon_socket_for_test(repo.daemon_control_socket_path());
+
+    fs::write(repo_root.join("base.txt"), "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let codex = AgentId {
+        tool: "codex".to_string(),
+        id: "session-ambiguous-codex".to_string(),
+        model: "gpt-5".to_string(),
+    };
+    let claude = AgentId {
+        tool: "claude".to_string(),
+        id: "session-ambiguous-claude".to_string(),
+        model: "unknown".to_string(),
+    };
+
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "session-ambiguous-codex",
+        "tool-ambiguous-codex",
+        &codex,
+        None,
+        "t_ambiguous_codex_pre",
+        Some("printf codex >> ambiguous.txt"),
+    )
+    .expect("codex pre hook should record durable start");
+    handle_bash_pre_tool_use_with_context(
+        &repo_root,
+        "session-ambiguous-claude",
+        "tool-ambiguous-claude",
+        &claude,
+        None,
+        "t_ambiguous_claude_pre",
+        Some("printf claude >> ambiguous.txt"),
+    )
+    .expect("claude pre hook should record durable start");
+
+    fs::write(repo_root.join("ambiguous.txt"), "from codex\nfrom claude\n").unwrap();
+
+    set_walk_timeout_ms_for_test(0);
+    let codex_post = handle_bash_post_tool_use(
+        &repo_root,
+        "session-ambiguous-codex",
+        "tool-ambiguous-codex",
+        &codex,
+        None,
+        "t_ambiguous_codex_post",
+        Some("printf codex >> ambiguous.txt"),
+    )
+    .expect("codex post hook should degrade gracefully");
+    let claude_post = handle_bash_post_tool_use(
+        &repo_root,
+        "session-ambiguous-claude",
+        "tool-ambiguous-claude",
+        &claude,
+        None,
+        "t_ambiguous_claude_post",
+        Some("printf claude >> ambiguous.txt"),
+    )
+    .expect("claude post hook should degrade gracefully");
+    reset_timeout_overrides_for_test();
+    assert!(matches!(
+        codex_post.action,
+        BashCheckpointAction::SnapshotFailed
+    ));
+    assert!(matches!(
+        claude_post.action,
+        BashCheckpointAction::SnapshotFailed
+    ));
+
+    repo.stage_all_and_commit("Skip ambiguous bash attribution")
+        .unwrap();
+
+    let mut file = repo.filename("ambiguous.txt");
+    file.assert_committed_lines(lines![
+        "from codex".unattributed_human(),
+        "from claude".unattributed_human(),
     ]);
 }
 


### PR DESCRIPTION
## Primary changes

- Persist Bash hook attempts before repo discovery succeeds, including out-of-repo cwd failures, command text, session/tool identity, timestamps, and metadata.
- Add a Bash repo hint strategy layer for high-confidence command evidence such as absolute paths, leading `cd`, subshell/group `cd`, redirection targets, `git -C`, and common cwd flags.
- Fold unresolved Bash attempts into post-commit attribution recovery while failing closed for ambiguous distinct-session candidates.
- Add focused unit and integration coverage for parent-cwd recovery, ambiguous same-window candidates, strategy parsing, attempt persistence, and recovery ranking.

## Reviewer walkthrough

- `src/daemon/bash_history_db.rs`: new `bash_hook_attempts` schema, persistence lifecycle, query helpers, and unit tests.
- `src/commands/checkpoint_agent/orchestrator.rs` and `src/commands/checkpoint_agent/bash_tool.rs`: record Bash hook attempt start/end around repo discovery.
- `src/authorship/bash_repo_hints.rs`: strategy-based command/path hint inference and path normalization helpers.
- `src/authorship/attribution_recovery.rs`: combine repo-scoped Bash calls and unresolved attempts into conservative recovery candidates.
- `tests/integration/bash_attribution.rs`: parent-cwd recovery and ambiguity regression coverage.

## Correctness and invariants

- Existing repo-root and repo-subdirectory Bash recovery remains supported through the original repo-scoped checkpoint call path.
- Out-of-repo attempts only recover attribution when the command yields strong repo/file evidence or an existing trusted repo/session context applies.
- Multiple distinct plausible sessions for the same file/window leave unknown lines unattributed rather than assigning ownership to one candidate.
- Path matching uses normalized paths and path-boundary checks instead of string-prefix matching.

## Testing and QA
