### PR TITLE
Record non-repo Bash hook attempts

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -126,7 +126,7 @@ fn recover_bash_mtime(
             "target_repo_work_dir": repo_work_dir.as_str(),
             "file_timestamps_ns": timestamps,
             "selected_bash_call_id": candidate.id,
-            "selected_bash_repo_work_dir": candidate.repo_work_dir.as_str(),
+            "selected_bash_repo_work_dir": candidate.repo_work_dir.as_deref(),
             "selected_tool_use_id": candidate.tool_use_id,
             "selected_command": candidate.command,
             "distance_ns": distance_ns,
@@ -344,7 +344,9 @@ fn bash_candidate_tier(
         return BashCandidateTier::ExistingCommitSession;
     }
 
-    if path_is_equal_or_child(target_repo_work_dir, &candidate.repo_work_dir) {
+    if let Some(repo_work_dir) = candidate.repo_work_dir.as_deref()
+        && path_is_equal_or_child(target_repo_work_dir, repo_work_dir)
+    {
         return BashCandidateTier::WorkdirAncestor;
     }
 
@@ -687,7 +689,9 @@ mod tests {
         BashCheckpointCall {
             id,
             invocation_key: format!("{}:{}", external_session_id, tool_use_id),
-            repo_work_dir: repo_work_dir.to_string(),
+            original_cwd: repo_work_dir.to_string(),
+            repo_work_dir: Some(repo_work_dir.to_string()),
+            repo_discovery_error: None,
             session_id: external_session_id.to_string(),
             tool_use_id: tool_use_id.to_string(),
             agent_id: test_agent(external_session_id),

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -126,7 +126,9 @@ fn recover_bash_mtime(
             "target_repo_work_dir": repo_work_dir.as_str(),
             "file_timestamps_ns": timestamps,
             "selected_bash_call_id": candidate.id,
+            "selected_bash_original_cwd": candidate.original_cwd.as_str(),
             "selected_bash_repo_work_dir": candidate.repo_work_dir.as_deref(),
+            "selected_bash_repo_discovery_error": candidate.repo_discovery_error.as_deref(),
             "selected_tool_use_id": candidate.tool_use_id,
             "selected_command": candidate.command,
             "distance_ns": distance_ns,
@@ -313,6 +315,7 @@ struct BashCandidateSelection<'a> {
 enum BashCandidateTier {
     ExistingCommitSession,
     WorkdirAncestor,
+    CwdAncestor,
     TimeOnly,
 }
 
@@ -321,7 +324,8 @@ impl BashCandidateTier {
         match self {
             Self::ExistingCommitSession => 0,
             Self::WorkdirAncestor => 1,
-            Self::TimeOnly => 2,
+            Self::CwdAncestor => 2,
+            Self::TimeOnly => 3,
         }
     }
 
@@ -329,6 +333,7 @@ impl BashCandidateTier {
         match self {
             Self::ExistingCommitSession => "existing_commit_session",
             Self::WorkdirAncestor => "workdir_ancestor",
+            Self::CwdAncestor => "cwd_ancestor",
             Self::TimeOnly => "time_only",
         }
     }
@@ -348,6 +353,10 @@ fn bash_candidate_tier(
         && path_is_equal_or_child(target_repo_work_dir, repo_work_dir)
     {
         return BashCandidateTier::WorkdirAncestor;
+    }
+
+    if path_is_equal_or_child(target_repo_work_dir, &candidate.original_cwd) {
+        return BashCandidateTier::CwdAncestor;
     }
 
     BashCandidateTier::TimeOnly
@@ -704,6 +713,32 @@ mod tests {
         }
     }
 
+    fn unresolved_bash_attempt(
+        id: i64,
+        external_session_id: &str,
+        tool_use_id: &str,
+        original_cwd: &str,
+        start_time_ns: u128,
+        end_time_ns: Option<u128>,
+    ) -> BashCheckpointCall {
+        BashCheckpointCall {
+            id,
+            invocation_key: format!("{}:{}", external_session_id, tool_use_id),
+            original_cwd: original_cwd.to_string(),
+            repo_work_dir: None,
+            repo_discovery_error: Some("No git repository found".to_string()),
+            session_id: external_session_id.to_string(),
+            tool_use_id: tool_use_id.to_string(),
+            agent_id: test_agent(external_session_id),
+            start_trace_id: Some(format!("t_start_{}", id)),
+            end_trace_id: end_time_ns.map(|_| format!("t_end_{}", id)),
+            start_time_ns,
+            end_time_ns,
+            command: Some("cd repo && true".to_string()),
+            metadata: HashMap::new(),
+        }
+    }
+
     #[test]
     fn unknown_lines_exclude_existing_attestations() {
         let mut log = AuthorshipLog::new();
@@ -779,6 +814,57 @@ mod tests {
 
         assert_eq!(selection.candidate.tool_use_id, "tool-ancestor");
         assert_eq!(selection.tier, BashCandidateTier::WorkdirAncestor);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_prefers_workdir_ancestor_over_cwd_ancestor() {
+        let candidates = vec![
+            bash_call(
+                1,
+                "workdir-ancestor-session",
+                "tool-workdir-ancestor",
+                "/tmp/work",
+                900,
+                None,
+            ),
+            unresolved_bash_attempt(
+                2,
+                "cwd-ancestor-session",
+                "tool-cwd-ancestor",
+                "/tmp/work",
+                1_040,
+                None,
+            ),
+        ];
+
+        let selection =
+            select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/tmp/work/repo")
+                .expect("expected candidate");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-workdir-ancestor");
+        assert_eq!(selection.tier, BashCandidateTier::WorkdirAncestor);
+    }
+
+    #[test]
+    fn bash_candidate_ranking_prefers_cwd_ancestor_over_time_only() {
+        let candidates = vec![
+            unresolved_bash_attempt(
+                1,
+                "cwd-ancestor-session",
+                "tool-cwd-ancestor",
+                "/tmp/work",
+                900,
+                None,
+            ),
+            bash_call(2, "closer-session", "tool-closer", "/other", 1_040, None),
+        ];
+
+        let selection =
+            select_best_bash_candidate(&candidates, &[1_050], &HashSet::new(), "/tmp/work/repo")
+                .expect("expected candidate");
+
+        assert_eq!(selection.candidate.tool_use_id, "tool-cwd-ancestor");
+        assert_eq!(selection.tier, BashCandidateTier::CwdAncestor);
     }
 
     #[test]

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -882,17 +882,38 @@ fn query_daemon_bash_snapshot(session_id: &str, tool_use_id: &str) -> Option<Sta
     snapshot_response.stat_snapshot
 }
 
-/// Signal the daemon that a bash session has ended.
-#[allow(clippy::too_many_arguments)]
-fn signal_daemon_bash_session_end(
-    repo_work_dir: &str,
-    session_id: &str,
-    tool_use_id: &str,
-    agent_id: &AgentId,
-    metadata: &HashMap<String, String>,
-    trace_id: &str,
-    ended_at_ns: u128,
-    command: Option<&str>,
+#[derive(Debug, Clone, Copy)]
+pub enum BashHookAttemptPhase {
+    Start,
+    End,
+}
+
+pub struct BashHookAttemptSignal<'a> {
+    pub original_cwd: &'a Path,
+    pub discovered_repo_work_dir: Option<&'a Path>,
+    pub repo_discovery_error: Option<&'a str>,
+    pub session_id: &'a str,
+    pub tool_use_id: &'a str,
+    pub agent_id: &'a AgentId,
+    pub metadata: &'a HashMap<String, String>,
+    pub trace_id: &'a str,
+    pub timestamp_ns: u128,
+    pub command: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BashToolHookContext<'a> {
+    pub session_id: &'a str,
+    pub tool_use_id: &'a str,
+    pub agent_id: &'a AgentId,
+    pub agent_metadata: Option<&'a HashMap<String, String>>,
+    pub trace_id: &'a str,
+    pub command: Option<&'a str>,
+}
+
+pub fn signal_daemon_bash_hook_attempt(
+    phase: BashHookAttemptPhase,
+    signal: BashHookAttemptSignal<'_>,
 ) {
     let Some(socket) = effective_daemon_socket() else {
         return;
@@ -900,15 +921,80 @@ fn signal_daemon_bash_session_end(
     if !socket.exists() {
         return;
     }
+    let original_cwd = signal.original_cwd.to_string_lossy().to_string();
+    let discovered_repo_work_dir = signal
+        .discovered_repo_work_dir
+        .map(|path| path.to_string_lossy().to_string());
+    let repo_discovery_error = signal.repo_discovery_error.map(ToString::to_string);
+    let session_id = signal.session_id.to_string();
+    let tool_use_id = signal.tool_use_id.to_string();
+    let agent_id = signal.agent_id.clone();
+    let metadata = signal.metadata.clone();
+    let trace_id = signal.trace_id.to_string();
+    let command = signal.command.map(ToString::to_string);
+
+    let request = match phase {
+        BashHookAttemptPhase::Start => ControlRequest::BashHookAttemptStart {
+            original_cwd,
+            discovered_repo_work_dir,
+            repo_discovery_error,
+            session_id,
+            tool_use_id,
+            agent_id,
+            metadata,
+            trace_id,
+            started_at_ns: signal.timestamp_ns,
+            command,
+        },
+        BashHookAttemptPhase::End => ControlRequest::BashHookAttemptEnd {
+            original_cwd,
+            discovered_repo_work_dir,
+            repo_discovery_error,
+            session_id,
+            tool_use_id,
+            agent_id,
+            metadata,
+            trace_id,
+            ended_at_ns: signal.timestamp_ns,
+            command,
+        },
+    };
+    if let Err(e) = send_control_request_with_timeout(&socket, &request, Duration::from_millis(500))
+    {
+        tracing::debug!("Failed to signal bash hook attempt {:?}: {}", phase, e);
+    }
+}
+
+struct BashSessionEndSignal<'a> {
+    repo_work_dir: &'a str,
+    original_cwd: &'a Path,
+    session_id: &'a str,
+    tool_use_id: &'a str,
+    agent_id: &'a AgentId,
+    metadata: &'a HashMap<String, String>,
+    trace_id: &'a str,
+    ended_at_ns: u128,
+    command: Option<&'a str>,
+}
+
+/// Signal the daemon that a bash session has ended.
+fn signal_daemon_bash_session_end(signal: BashSessionEndSignal<'_>) {
+    let Some(socket) = effective_daemon_socket() else {
+        return;
+    };
+    if !socket.exists() {
+        return;
+    }
     let request = ControlRequest::BashSessionEnd {
-        repo_work_dir: repo_work_dir.to_string(),
-        session_id: session_id.to_string(),
-        tool_use_id: tool_use_id.to_string(),
-        agent_id: agent_id.clone(),
-        metadata: metadata.clone(),
-        trace_id: trace_id.to_string(),
-        ended_at_ns,
-        command: command.map(ToString::to_string),
+        repo_work_dir: signal.repo_work_dir.to_string(),
+        original_cwd: Some(signal.original_cwd.to_string_lossy().to_string()),
+        session_id: signal.session_id.to_string(),
+        tool_use_id: signal.tool_use_id.to_string(),
+        agent_id: signal.agent_id.clone(),
+        metadata: signal.metadata.clone(),
+        trace_id: signal.trace_id.to_string(),
+        ended_at_ns: signal.ended_at_ns,
+        command: signal.command.map(ToString::to_string),
     };
     if let Err(e) = send_control_request_with_timeout(&socket, &request, Duration::from_millis(500))
     {
@@ -933,6 +1019,26 @@ pub fn handle_bash_pre_tool_use_with_context(
     trace_id: &str,
     command: Option<&str>,
 ) -> Result<BashPreHookResult, GitAiError> {
+    handle_bash_pre_tool_use_with_context_and_cwd(
+        repo_root,
+        repo_root,
+        BashToolHookContext {
+            session_id,
+            tool_use_id,
+            agent_id,
+            agent_metadata,
+            trace_id,
+            command,
+        },
+    )
+}
+
+/// Handle the pre-tool-use hook with a separately tracked original cwd.
+pub fn handle_bash_pre_tool_use_with_context_and_cwd(
+    repo_root: &Path,
+    original_cwd: &Path,
+    context: BashToolHookContext<'_>,
+) -> Result<BashPreHookResult, GitAiError> {
     let started_at_ns = crate::daemon::bash_history_db::unix_time_ns();
     let repo_working_dir = repo_root.to_string_lossy().to_string();
 
@@ -942,7 +1048,12 @@ pub fn handle_bash_pre_tool_use_with_context(
             worktree: Some(ts),
         })
     });
-    let snap = snapshot(repo_root, session_id, tool_use_id, wm.as_ref())?;
+    let snap = snapshot(
+        repo_root,
+        context.session_id,
+        context.tool_use_id,
+        wm.as_ref(),
+    )?;
 
     // When watermarks are unavailable (no daemon + no .git/index), the snapshot
     // contains every non-ignored file in the repo. Using that as dirty_paths
@@ -964,14 +1075,15 @@ pub fn handle_bash_pre_tool_use_with_context(
 
     let request = ControlRequest::BashSessionStart {
         repo_work_dir: repo_working_dir,
-        session_id: session_id.to_string(),
-        tool_use_id: tool_use_id.to_string(),
-        agent_id: agent_id.clone(),
-        metadata: agent_metadata.cloned().unwrap_or_default(),
+        original_cwd: Some(original_cwd.to_string_lossy().to_string()),
+        session_id: context.session_id.to_string(),
+        tool_use_id: context.tool_use_id.to_string(),
+        agent_id: context.agent_id.clone(),
+        metadata: context.agent_metadata.cloned().unwrap_or_default(),
         stat_snapshot: Box::new(snap),
-        trace_id: trace_id.to_string(),
+        trace_id: context.trace_id.to_string(),
         started_at_ns,
-        command: command.map(ToString::to_string),
+        command: context.command.map(ToString::to_string),
     };
 
     send_control_request(&socket, &request)?;
@@ -993,13 +1105,33 @@ pub fn handle_bash_post_tool_use(
     trace_id: &str,
     command: Option<&str>,
 ) -> Result<BashPostHookResult, GitAiError> {
-    let invocation_key = format!("{}:{}", session_id, tool_use_id);
+    handle_bash_post_tool_use_with_cwd(
+        repo_root,
+        repo_root,
+        BashToolHookContext {
+            session_id,
+            tool_use_id,
+            agent_id,
+            agent_metadata,
+            trace_id,
+            command,
+        },
+    )
+}
+
+/// Handle the post-tool-use hook with a separately tracked original cwd.
+pub fn handle_bash_post_tool_use_with_cwd(
+    repo_root: &Path,
+    original_cwd: &Path,
+    context: BashToolHookContext<'_>,
+) -> Result<BashPostHookResult, GitAiError> {
+    let invocation_key = format!("{}:{}", context.session_id, context.tool_use_id);
 
     let hook_start = Instant::now();
     let ended_at_ns = crate::daemon::bash_history_db::unix_time_ns();
     let hook_timeout = Duration::from_millis(effective_hook_timeout_ms());
     let repo_working_dir = repo_root.to_string_lossy().to_string();
-    let metadata = agent_metadata.cloned().unwrap_or_default();
+    let metadata = context.agent_metadata.cloned().unwrap_or_default();
 
     macro_rules! hook_timeout_fallback {
         ($label:expr) => {{
@@ -1018,23 +1150,24 @@ pub fn handle_bash_post_tool_use(
                     "hook_timeout_ms": hook_timeout.as_millis(),
                 })),
             );
-            signal_daemon_bash_session_end(
-                &repo_working_dir,
-                session_id,
-                tool_use_id,
-                agent_id,
-                &metadata,
-                trace_id,
+            signal_daemon_bash_session_end(BashSessionEndSignal {
+                repo_work_dir: &repo_working_dir,
+                original_cwd,
+                session_id: context.session_id,
+                tool_use_id: context.tool_use_id,
+                agent_id: context.agent_id,
+                metadata: &metadata,
+                trace_id: context.trace_id,
                 ended_at_ns,
-                command,
-            );
+                command: context.command,
+            });
             return Ok(BashPostHookResult {
                 action: BashCheckpointAction::HookTimeout,
             });
         }};
     }
 
-    let pre_snapshot = query_daemon_bash_snapshot(session_id, tool_use_id);
+    let pre_snapshot = query_daemon_bash_snapshot(context.session_id, context.tool_use_id);
 
     match pre_snapshot {
         Some(pre) => {
@@ -1051,7 +1184,12 @@ pub fn handle_bash_post_tool_use(
                 } else {
                     None
                 };
-            let result = match snapshot(repo_root, session_id, tool_use_id, post_wm.as_ref()) {
+            let result = match snapshot(
+                repo_root,
+                context.session_id,
+                context.tool_use_id,
+                post_wm.as_ref(),
+            ) {
                 Ok(post) => {
                     let diff_result = diff(&pre, &post);
 
@@ -1083,16 +1221,17 @@ pub fn handle_bash_post_tool_use(
                 }
             };
 
-            signal_daemon_bash_session_end(
-                &repo_working_dir,
-                session_id,
-                tool_use_id,
-                agent_id,
-                &metadata,
-                trace_id,
+            signal_daemon_bash_session_end(BashSessionEndSignal {
+                repo_work_dir: &repo_working_dir,
+                original_cwd,
+                session_id: context.session_id,
+                tool_use_id: context.tool_use_id,
+                agent_id: context.agent_id,
+                metadata: &metadata,
+                trace_id: context.trace_id,
                 ended_at_ns,
-                command,
-            );
+                command: context.command,
+            });
 
             result
         }
@@ -1101,16 +1240,17 @@ pub fn handle_bash_post_tool_use(
                 "Pre-snapshot not found in daemon for {}; returning MissingPreSnapshot",
                 invocation_key
             );
-            signal_daemon_bash_session_end(
-                &repo_working_dir,
-                session_id,
-                tool_use_id,
-                agent_id,
-                &metadata,
-                trace_id,
+            signal_daemon_bash_session_end(BashSessionEndSignal {
+                repo_work_dir: &repo_working_dir,
+                original_cwd,
+                session_id: context.session_id,
+                tool_use_id: context.tool_use_id,
+                agent_id: context.agent_id,
+                metadata: &metadata,
+                trace_id: context.trace_id,
                 ended_at_ns,
-                command,
-            );
+                command: context.command,
+            });
             Ok(BashPostHookResult {
                 action: BashCheckpointAction::MissingPreSnapshot,
             })

--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -395,19 +395,47 @@ fn execute_untracked_edit(e: UntrackedEdit) -> Result<Vec<CheckpointRequest>, Gi
 }
 
 fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAiError> {
-    use crate::commands::checkpoint_agent::bash_tool;
+    use crate::commands::checkpoint_agent::bash_tool::{
+        self, BashHookAttemptPhase, BashHookAttemptSignal,
+    };
 
-    let repo = discover_repository_in_path_no_git_exec(e.context.cwd.as_path())?;
-    let repo_work_dir = repo.workdir()?;
+    let started_at_ns = crate::daemon::bash_history_db::unix_time_ns();
+    let repo_work_dir = match discover_repository_in_path_no_git_exec(e.context.cwd.as_path())
+        .and_then(|repo| repo.workdir())
+    {
+        Ok(repo_work_dir) => repo_work_dir,
+        Err(error) => {
+            let error_message = error.to_string();
+            bash_tool::signal_daemon_bash_hook_attempt(
+                BashHookAttemptPhase::Start,
+                BashHookAttemptSignal {
+                    original_cwd: e.context.cwd.as_path(),
+                    discovered_repo_work_dir: None,
+                    repo_discovery_error: Some(&error_message),
+                    session_id: &e.context.external_session_id,
+                    tool_use_id: &e.tool_use_id,
+                    agent_id: &e.context.agent_id,
+                    metadata: &e.context.metadata,
+                    trace_id: &e.context.trace_id,
+                    timestamp_ns: started_at_ns,
+                    command: e.command.as_deref(),
+                },
+            );
+            return Ok(vec![]);
+        }
+    };
 
-    let dirty_paths = match bash_tool::handle_bash_pre_tool_use_with_context(
+    let dirty_paths = match bash_tool::handle_bash_pre_tool_use_with_context_and_cwd(
         &repo_work_dir,
-        &e.context.external_session_id,
-        &e.tool_use_id,
-        &e.context.agent_id,
-        Some(&e.context.metadata),
-        &e.context.trace_id,
-        e.command.as_deref(),
+        e.context.cwd.as_path(),
+        bash_tool::BashToolHookContext {
+            session_id: &e.context.external_session_id,
+            tool_use_id: &e.tool_use_id,
+            agent_id: &e.context.agent_id,
+            agent_metadata: Some(&e.context.metadata),
+            trace_id: &e.context.trace_id,
+            command: e.command.as_deref(),
+        },
     ) {
         Ok(result) => result.dirty_paths,
         Err(error) => {
@@ -442,19 +470,47 @@ fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAi
 }
 
 fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, GitAiError> {
-    use crate::commands::checkpoint_agent::bash_tool;
+    use crate::commands::checkpoint_agent::bash_tool::{
+        self, BashHookAttemptPhase, BashHookAttemptSignal,
+    };
 
-    let repo = discover_repository_in_path_no_git_exec(e.context.cwd.as_path())?;
-    let repo_work_dir = repo.workdir()?;
+    let ended_at_ns = crate::daemon::bash_history_db::unix_time_ns();
+    let repo_work_dir = match discover_repository_in_path_no_git_exec(e.context.cwd.as_path())
+        .and_then(|repo| repo.workdir())
+    {
+        Ok(repo_work_dir) => repo_work_dir,
+        Err(error) => {
+            let error_message = error.to_string();
+            bash_tool::signal_daemon_bash_hook_attempt(
+                BashHookAttemptPhase::End,
+                BashHookAttemptSignal {
+                    original_cwd: e.context.cwd.as_path(),
+                    discovered_repo_work_dir: None,
+                    repo_discovery_error: Some(&error_message),
+                    session_id: &e.context.external_session_id,
+                    tool_use_id: &e.tool_use_id,
+                    agent_id: &e.context.agent_id,
+                    metadata: &e.context.metadata,
+                    trace_id: &e.context.trace_id,
+                    timestamp_ns: ended_at_ns,
+                    command: e.command.as_deref(),
+                },
+            );
+            return Ok(vec![]);
+        }
+    };
 
-    let bash_result = bash_tool::handle_bash_post_tool_use(
+    let bash_result = bash_tool::handle_bash_post_tool_use_with_cwd(
         &repo_work_dir,
-        &e.context.external_session_id,
-        &e.tool_use_id,
-        &e.context.agent_id,
-        Some(&e.context.metadata),
-        &e.context.trace_id,
-        e.command.as_deref(),
+        e.context.cwd.as_path(),
+        bash_tool::BashToolHookContext {
+            session_id: &e.context.external_session_id,
+            tool_use_id: &e.tool_use_id,
+            agent_id: &e.context.agent_id,
+            agent_metadata: Some(&e.context.metadata),
+            trace_id: &e.context.trace_id,
+            command: e.command.as_deref(),
+        },
     );
 
     let file_paths: Vec<PathBuf> = match &bash_result {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4658,28 +4658,26 @@ impl ActorDaemonCoordinator {
                         kind,
                         old_head,
                         new_head,
-                    } => {
-                        if !old_head.is_empty() && !new_head.is_empty() && old_head != new_head {
-                            let repo = find_repository_in_path(&worktree)?;
-                            match kind {
-                                crate::daemon::domain::ResetKind::Hard => {
-                                    repo.storage.delete_working_log_for_base_commit(old_head)?;
-                                }
-                                _ => {
-                                    if is_ancestor_commit(&repo, new_head, old_head) {
-                                        crate::authorship::rewrite_reset::reconstruct_working_log_after_backward_reset(
-                                            &repo, old_head, new_head,
-                                        )?;
-                                    } else if !is_ancestor_commit(&repo, old_head, new_head) {
-                                        crate::authorship::rewrite::handle_rewrite_event(
-                                            &repo,
-                                            crate::authorship::rewrite::RewriteEvent::NonFastForward {
-                                                old_tip: old_head.to_string(),
-                                                new_tip: new_head.to_string(),
-                                                onto: None,
-                                            },
-                                        )?;
-                                    }
+                    } if !old_head.is_empty() && !new_head.is_empty() && old_head != new_head => {
+                        let repo = find_repository_in_path(&worktree)?;
+                        match kind {
+                            crate::daemon::domain::ResetKind::Hard => {
+                                repo.storage.delete_working_log_for_base_commit(old_head)?;
+                            }
+                            _ => {
+                                if is_ancestor_commit(&repo, new_head, old_head) {
+                                    crate::authorship::rewrite_reset::reconstruct_working_log_after_backward_reset(
+                                        &repo, old_head, new_head,
+                                    )?;
+                                } else if !is_ancestor_commit(&repo, old_head, new_head) {
+                                    crate::authorship::rewrite::handle_rewrite_event(
+                                        &repo,
+                                        crate::authorship::rewrite::RewriteEvent::NonFastForward {
+                                            old_tip: old_head.to_string(),
+                                            new_tip: new_head.to_string(),
+                                            onto: None,
+                                        },
+                                    )?;
                                 }
                             }
                         }
@@ -5066,6 +5064,7 @@ impl ActorDaemonCoordinator {
             }
             ControlRequest::BashSessionStart {
                 repo_work_dir,
+                original_cwd,
                 session_id,
                 tool_use_id,
                 agent_id,
@@ -5076,11 +5075,14 @@ impl ActorDaemonCoordinator {
                 command,
             } => {
                 let worktree_key = Self::worktree_state_key(Path::new(&repo_work_dir));
+                let original_cwd = original_cwd.unwrap_or_else(|| repo_work_dir.clone());
                 if let Ok(db) = crate::daemon::bash_history_db::BashHistoryDatabase::global()
                     && let Ok(mut db_lock) = db.lock()
                     && let Err(e) =
                         db_lock.record_start(&crate::daemon::bash_history_db::BashCallStart {
-                            repo_work_dir: worktree_key.clone(),
+                            original_cwd: Self::worktree_state_key(Path::new(&original_cwd)),
+                            repo_work_dir: Some(worktree_key.clone()),
+                            repo_discovery_error: None,
                             session_id: session_id.clone(),
                             tool_use_id: tool_use_id.clone(),
                             agent_id: agent_id.clone(),
@@ -5109,6 +5111,7 @@ impl ActorDaemonCoordinator {
             }
             ControlRequest::BashSessionEnd {
                 repo_work_dir,
+                original_cwd,
                 session_id,
                 tool_use_id,
                 agent_id,
@@ -5125,6 +5128,9 @@ impl ActorDaemonCoordinator {
                     .as_ref()
                     .map(|s| s.repo_work_dir.clone())
                     .unwrap_or_else(|| Self::worktree_state_key(Path::new(&repo_work_dir)));
+                let original_cwd = original_cwd
+                    .map(|cwd| Self::worktree_state_key(Path::new(&cwd)))
+                    .unwrap_or_else(|| worktree_key.clone());
                 let start_trace_id = session.as_ref().map(|s| s.start_trace_id.clone());
                 let started_at_ns = session.as_ref().map(|s| s.started_at_ns);
                 let command = command.or_else(|| session.as_ref().and_then(|s| s.command.clone()));
@@ -5144,7 +5150,9 @@ impl ActorDaemonCoordinator {
                     && let Ok(mut db_lock) = db.lock()
                     && let Err(e) =
                         db_lock.record_end(&crate::daemon::bash_history_db::BashCallEnd {
-                            repo_work_dir: worktree_key,
+                            original_cwd,
+                            repo_work_dir: Some(worktree_key),
+                            repo_discovery_error: None,
                             session_id,
                             tool_use_id,
                             agent_id,
@@ -5157,6 +5165,80 @@ impl ActorDaemonCoordinator {
                         })
                 {
                     tracing::debug!("failed to persist bash session end: {}", e);
+                }
+                Ok(ControlResponse::ok(None, None))
+            }
+            ControlRequest::BashHookAttemptStart {
+                original_cwd,
+                discovered_repo_work_dir,
+                repo_discovery_error,
+                session_id,
+                tool_use_id,
+                agent_id,
+                metadata,
+                trace_id,
+                started_at_ns,
+                command,
+            } => {
+                let discovered_repo_work_dir = discovered_repo_work_dir
+                    .as_deref()
+                    .map(Path::new)
+                    .map(Self::worktree_state_key);
+                if let Ok(db) = crate::daemon::bash_history_db::BashHistoryDatabase::global()
+                    && let Ok(mut db_lock) = db.lock()
+                    && let Err(e) =
+                        db_lock.record_start(&crate::daemon::bash_history_db::BashCallStart {
+                            original_cwd: Self::worktree_state_key(Path::new(&original_cwd)),
+                            repo_work_dir: discovered_repo_work_dir,
+                            repo_discovery_error,
+                            session_id,
+                            tool_use_id,
+                            agent_id,
+                            start_trace_id: trace_id,
+                            started_at_ns,
+                            command,
+                            metadata,
+                        })
+                {
+                    tracing::debug!("failed to persist bash hook attempt start: {}", e);
+                }
+                Ok(ControlResponse::ok(None, None))
+            }
+            ControlRequest::BashHookAttemptEnd {
+                original_cwd,
+                discovered_repo_work_dir,
+                repo_discovery_error,
+                session_id,
+                tool_use_id,
+                agent_id,
+                metadata,
+                trace_id,
+                ended_at_ns,
+                command,
+            } => {
+                let discovered_repo_work_dir = discovered_repo_work_dir
+                    .as_deref()
+                    .map(Path::new)
+                    .map(Self::worktree_state_key);
+                if let Ok(db) = crate::daemon::bash_history_db::BashHistoryDatabase::global()
+                    && let Ok(mut db_lock) = db.lock()
+                    && let Err(e) =
+                        db_lock.record_end(&crate::daemon::bash_history_db::BashCallEnd {
+                            original_cwd: Self::worktree_state_key(Path::new(&original_cwd)),
+                            repo_work_dir: discovered_repo_work_dir,
+                            repo_discovery_error,
+                            session_id,
+                            tool_use_id,
+                            agent_id,
+                            start_trace_id: None,
+                            end_trace_id: trace_id,
+                            started_at_ns: None,
+                            ended_at_ns,
+                            command,
+                            metadata,
+                        })
+                {
+                    tracing::debug!("failed to persist bash hook attempt end: {}", e);
                 }
                 Ok(ControlResponse::ok(None, None))
             }

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -5,11 +5,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-const SCHEMA_VERSION: usize = 1;
+const SCHEMA_VERSION: usize = 2;
 const RETENTION_SECS: u64 = 30 * 24 * 3600;
 const PRUNE_INTERVAL_SECS: u64 = 24 * 3600;
 
-const MIGRATIONS: &[&str] = &[r#"
+const MIGRATIONS: &[&str] = &[
+    r#"
     CREATE TABLE IF NOT EXISTS bash_checkpoint_calls (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         invocation_key TEXT NOT NULL,
@@ -37,13 +38,64 @@ const MIGRATIONS: &[&str] = &[r#"
 
     CREATE INDEX IF NOT EXISTS idx_bash_calls_time
         ON bash_checkpoint_calls(start_time_ns, end_time_ns);
-"#];
+"#,
+    r#"
+    ALTER TABLE bash_checkpoint_calls RENAME TO bash_checkpoint_calls_v1;
+
+    CREATE TABLE IF NOT EXISTS bash_checkpoint_calls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        invocation_key TEXT NOT NULL,
+        original_cwd TEXT NOT NULL,
+        repo_work_dir TEXT,
+        repo_discovery_error TEXT,
+        session_id TEXT NOT NULL,
+        tool_use_id TEXT NOT NULL,
+        agent_tool TEXT NOT NULL,
+        agent_external_id TEXT NOT NULL,
+        agent_model TEXT NOT NULL,
+        start_trace_id TEXT,
+        end_trace_id TEXT,
+        start_time_ns INTEGER NOT NULL,
+        end_time_ns INTEGER,
+        command TEXT,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+    );
+
+    INSERT INTO bash_checkpoint_calls (
+        id, invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+        session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
+        start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+        command, metadata_json, created_at, updated_at
+    )
+    SELECT
+        id, invocation_key, repo_work_dir, repo_work_dir, NULL,
+        session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
+        start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+        command, metadata_json, created_at, updated_at
+    FROM bash_checkpoint_calls_v1;
+
+    DROP TABLE bash_checkpoint_calls_v1;
+
+    CREATE INDEX IF NOT EXISTS idx_bash_calls_repo_time
+        ON bash_checkpoint_calls(repo_work_dir, start_time_ns, end_time_ns);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_bash_calls_invocation
+        ON bash_checkpoint_calls(session_id, tool_use_id, start_trace_id);
+
+    CREATE INDEX IF NOT EXISTS idx_bash_calls_time
+        ON bash_checkpoint_calls(start_time_ns, end_time_ns);
+"#,
+];
 
 static BASH_HISTORY_DB: OnceLock<Mutex<BashHistoryDatabase>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct BashCallStart {
-    pub repo_work_dir: String,
+    pub original_cwd: String,
+    pub repo_work_dir: Option<String>,
+    pub repo_discovery_error: Option<String>,
     pub session_id: String,
     pub tool_use_id: String,
     pub agent_id: AgentId,
@@ -55,7 +107,9 @@ pub struct BashCallStart {
 
 #[derive(Debug, Clone)]
 pub struct BashCallEnd {
-    pub repo_work_dir: String,
+    pub original_cwd: String,
+    pub repo_work_dir: Option<String>,
+    pub repo_discovery_error: Option<String>,
     pub session_id: String,
     pub tool_use_id: String,
     pub agent_id: AgentId,
@@ -71,7 +125,9 @@ pub struct BashCallEnd {
 pub struct BashCheckpointCall {
     pub id: i64,
     pub invocation_key: String,
-    pub repo_work_dir: String,
+    pub original_cwd: String,
+    pub repo_work_dir: Option<String>,
+    pub repo_discovery_error: Option<String>,
     pub session_id: String,
     pub tool_use_id: String,
     pub agent_id: AgentId,
@@ -280,14 +336,17 @@ impl BashHistoryDatabase {
         self.conn.execute(
             r#"
             INSERT INTO bash_checkpoint_calls (
-                invocation_key, repo_work_dir, session_id, tool_use_id,
+                invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+                session_id, tool_use_id,
                 agent_tool, agent_external_id, agent_model,
                 start_trace_id, start_time_ns, command, metadata_json,
                 created_at, updated_at
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)
             ON CONFLICT(session_id, tool_use_id, start_trace_id) DO UPDATE SET
+                original_cwd = excluded.original_cwd,
                 repo_work_dir = excluded.repo_work_dir,
+                repo_discovery_error = excluded.repo_discovery_error,
                 agent_tool = excluded.agent_tool,
                 agent_external_id = excluded.agent_external_id,
                 agent_model = excluded.agent_model,
@@ -298,7 +357,9 @@ impl BashHistoryDatabase {
             "#,
             params![
                 invocation_key,
+                call.original_cwd,
                 call.repo_work_dir,
+                call.repo_discovery_error,
                 call.session_id,
                 call.tool_use_id,
                 call.agent_id.tool,
@@ -330,14 +391,20 @@ impl BashHistoryDatabase {
             self.conn.execute(
                 r#"
                 UPDATE bash_checkpoint_calls
-                SET end_trace_id = ?1,
-                    end_time_ns = ?2,
-                    command = COALESCE(?3, command),
-                    metadata_json = ?4,
-                    updated_at = ?5
-                WHERE session_id = ?6 AND tool_use_id = ?7 AND start_trace_id = ?8
+                SET original_cwd = ?1,
+                    repo_work_dir = COALESCE(?2, repo_work_dir),
+                    repo_discovery_error = COALESCE(?3, repo_discovery_error),
+                    end_trace_id = ?4,
+                    end_time_ns = ?5,
+                    command = COALESCE(?6, command),
+                    metadata_json = ?7,
+                    updated_at = ?8
+                WHERE session_id = ?9 AND tool_use_id = ?10 AND start_trace_id = ?11
                 "#,
                 params![
+                    call.original_cwd,
+                    call.repo_work_dir,
+                    call.repo_discovery_error,
                     call.end_trace_id,
                     end_time_ns,
                     call.command,
@@ -349,7 +416,40 @@ impl BashHistoryDatabase {
                 ],
             )?
         } else {
-            0
+            self.conn.execute(
+                r#"
+                UPDATE bash_checkpoint_calls
+                SET original_cwd = ?1,
+                    repo_work_dir = COALESCE(?2, repo_work_dir),
+                    repo_discovery_error = COALESCE(?3, repo_discovery_error),
+                    end_trace_id = ?4,
+                    end_time_ns = ?5,
+                    command = COALESCE(?6, command),
+                    metadata_json = ?7,
+                    updated_at = ?8
+                WHERE id = (
+                    SELECT id
+                    FROM bash_checkpoint_calls
+                    WHERE session_id = ?9
+                      AND tool_use_id = ?10
+                      AND end_time_ns IS NULL
+                    ORDER BY id DESC
+                    LIMIT 1
+                )
+                "#,
+                params![
+                    call.original_cwd,
+                    call.repo_work_dir,
+                    call.repo_discovery_error,
+                    call.end_trace_id,
+                    end_time_ns,
+                    call.command,
+                    metadata_json,
+                    now as i64,
+                    call.session_id,
+                    call.tool_use_id,
+                ],
+            )?
         };
 
         if updated > 0 {
@@ -361,13 +461,17 @@ impl BashHistoryDatabase {
         self.conn.execute(
             r#"
             INSERT INTO bash_checkpoint_calls (
-                invocation_key, repo_work_dir, session_id, tool_use_id,
+                invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+                session_id, tool_use_id,
                 agent_tool, agent_external_id, agent_model,
                 start_trace_id, end_trace_id, start_time_ns, end_time_ns,
                 command, metadata_json, created_at, updated_at
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?16)
             ON CONFLICT(session_id, tool_use_id, start_trace_id) DO UPDATE SET
+                original_cwd = excluded.original_cwd,
+                repo_work_dir = COALESCE(excluded.repo_work_dir, bash_checkpoint_calls.repo_work_dir),
+                repo_discovery_error = COALESCE(excluded.repo_discovery_error, bash_checkpoint_calls.repo_discovery_error),
                 end_trace_id = excluded.end_trace_id,
                 end_time_ns = excluded.end_time_ns,
                 command = COALESCE(excluded.command, bash_checkpoint_calls.command),
@@ -376,7 +480,9 @@ impl BashHistoryDatabase {
             "#,
             params![
                 invocation_key,
+                call.original_cwd,
                 call.repo_work_dir,
+                call.repo_discovery_error,
                 call.session_id,
                 call.tool_use_id,
                 call.agent_id.tool,
@@ -424,12 +530,13 @@ impl BashHistoryDatabase {
 
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT id, invocation_key, repo_work_dir, session_id, tool_use_id,
-                   agent_tool, agent_external_id, agent_model,
+            SELECT id, invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+                   session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
                    start_trace_id, end_trace_id, start_time_ns, end_time_ns,
                    command, metadata_json
             FROM bash_checkpoint_calls
-            WHERE start_time_ns <= ?1
+            WHERE repo_work_dir IS NOT NULL
+              AND start_time_ns <= ?1
               AND COALESCE(end_time_ns, start_time_ns) >= ?2
             ORDER BY id ASC
             "#,
@@ -456,8 +563,8 @@ impl BashHistoryDatabase {
 
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT id, invocation_key, repo_work_dir, session_id, tool_use_id,
-                   agent_tool, agent_external_id, agent_model,
+            SELECT id, invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+                   session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
                    start_trace_id, end_trace_id, start_time_ns, end_time_ns,
                    command, metadata_json
             FROM bash_checkpoint_calls
@@ -544,24 +651,26 @@ fn i64_to_ns(ns: i64) -> u128 {
 }
 
 fn row_to_call(row: &rusqlite::Row<'_>) -> rusqlite::Result<BashCheckpointCall> {
-    let metadata_json: String = row.get(13)?;
+    let metadata_json: String = row.get(15)?;
     let metadata = serde_json::from_str(&metadata_json).unwrap_or_default();
     Ok(BashCheckpointCall {
         id: row.get(0)?,
         invocation_key: row.get(1)?,
-        repo_work_dir: row.get(2)?,
-        session_id: row.get(3)?,
-        tool_use_id: row.get(4)?,
+        original_cwd: row.get(2)?,
+        repo_work_dir: row.get(3)?,
+        repo_discovery_error: row.get(4)?,
+        session_id: row.get(5)?,
+        tool_use_id: row.get(6)?,
         agent_id: AgentId {
-            tool: row.get(5)?,
-            id: row.get(6)?,
-            model: row.get(7)?,
+            tool: row.get(7)?,
+            id: row.get(8)?,
+            model: row.get(9)?,
         },
-        start_trace_id: row.get(8)?,
-        end_trace_id: row.get(9)?,
-        start_time_ns: i64_to_ns(row.get(10)?),
-        end_time_ns: row.get::<_, Option<i64>>(11)?.map(i64_to_ns),
-        command: row.get(12)?,
+        start_trace_id: row.get(10)?,
+        end_trace_id: row.get(11)?,
+        start_time_ns: i64_to_ns(row.get(12)?),
+        end_time_ns: row.get::<_, Option<i64>>(13)?.map(i64_to_ns),
+        command: row.get(14)?,
         metadata,
     })
 }
@@ -603,7 +712,9 @@ mod tests {
         metadata.insert("transcript_path".to_string(), "/tmp/t.jsonl".to_string());
 
         db.record_start(&BashCallStart {
-            repo_work_dir: "/repo".to_string(),
+            original_cwd: "/repo/subdir".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
             session_id: "session-1".to_string(),
             tool_use_id: "tool-1".to_string(),
             agent_id: test_agent(),
@@ -614,7 +725,9 @@ mod tests {
         })
         .unwrap();
         db.record_end(&BashCallEnd {
-            repo_work_dir: "/repo".to_string(),
+            original_cwd: "/repo/subdir".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
             session_id: "session-1".to_string(),
             tool_use_id: "tool-1".to_string(),
             agent_id: test_agent(),
@@ -630,7 +743,9 @@ mod tests {
         let calls = db.all_calls_for_test().unwrap();
         assert_eq!(calls.len(), 1);
         let call = &calls[0];
-        assert_eq!(call.repo_work_dir, "/repo");
+        assert_eq!(call.original_cwd, "/repo/subdir");
+        assert_eq!(call.repo_work_dir.as_deref(), Some("/repo"));
+        assert_eq!(call.repo_discovery_error, None);
         assert_eq!(call.session_id, "session-1");
         assert_eq!(call.tool_use_id, "tool-1");
         assert_eq!(call.agent_id, test_agent());
@@ -650,7 +765,9 @@ mod tests {
         let (mut db, _dir) = test_db();
 
         db.record_end(&BashCallEnd {
-            repo_work_dir: "/repo".to_string(),
+            original_cwd: "/repo".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
             session_id: "session-2".to_string(),
             tool_use_id: "tool-2".to_string(),
             agent_id: test_agent(),
@@ -665,10 +782,58 @@ mod tests {
 
         let calls = db.all_calls_for_test().unwrap();
         assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].original_cwd, "/repo");
+        assert_eq!(calls[0].repo_work_dir.as_deref(), Some("/repo"));
         assert_eq!(calls[0].start_trace_id.as_deref(), Some("t_end"));
         assert_eq!(calls[0].end_trace_id.as_deref(), Some("t_end"));
         assert_eq!(calls[0].start_time_ns, 5_000);
         assert_eq!(calls[0].end_time_ns, Some(5_000));
+    }
+
+    #[test]
+    fn unresolved_cwd_call_persists_without_becoming_candidate() {
+        let (mut db, _dir) = test_db();
+
+        db.record_start(&BashCallStart {
+            original_cwd: "/workspace".to_string(),
+            repo_work_dir: None,
+            repo_discovery_error: Some("No git repository found".to_string()),
+            session_id: "session-3".to_string(),
+            tool_use_id: "tool-3".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: "t_start".to_string(),
+            started_at_ns: 1_000,
+            command: Some("cd project && printf x >> src/a.rs".to_string()),
+            metadata: HashMap::new(),
+        })
+        .unwrap();
+        db.record_end(&BashCallEnd {
+            original_cwd: "/workspace".to_string(),
+            repo_work_dir: None,
+            repo_discovery_error: Some("No git repository found".to_string()),
+            session_id: "session-3".to_string(),
+            tool_use_id: "tool-3".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: Some("t_start".to_string()),
+            end_trace_id: "t_end".to_string(),
+            started_at_ns: Some(1_000),
+            ended_at_ns: 2_000,
+            command: Some("cd project && printf x >> src/a.rs".to_string()),
+            metadata: HashMap::new(),
+        })
+        .unwrap();
+
+        let calls = db.all_calls_for_test().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].original_cwd, "/workspace");
+        assert_eq!(calls[0].repo_work_dir, None);
+        assert_eq!(
+            calls[0].repo_discovery_error.as_deref(),
+            Some("No git repository found")
+        );
+
+        let candidates = db.candidates_near_timestamps(&[1_500], 1_000).unwrap();
+        assert!(candidates.is_empty());
     }
 
     #[test]
@@ -680,7 +845,9 @@ mod tests {
             ("/repo", "outside", 20_000, 21_000),
         ] {
             db.record_start(&BashCallStart {
-                repo_work_dir: repo_work_dir.to_string(),
+                original_cwd: repo_work_dir.to_string(),
+                repo_work_dir: Some(repo_work_dir.to_string()),
+                repo_discovery_error: None,
                 session_id: "session".to_string(),
                 tool_use_id: tool_use_id.to_string(),
                 agent_id: test_agent(),
@@ -691,7 +858,9 @@ mod tests {
             })
             .unwrap();
             db.record_end(&BashCallEnd {
-                repo_work_dir: repo_work_dir.to_string(),
+                original_cwd: repo_work_dir.to_string(),
+                repo_work_dir: Some(repo_work_dir.to_string()),
+                repo_discovery_error: None,
                 session_id: "session".to_string(),
                 tool_use_id: tool_use_id.to_string(),
                 agent_id: test_agent(),
@@ -723,7 +892,9 @@ mod tests {
     fn retention_prunes_rows_older_than_thirty_days() {
         let (mut db, _dir) = test_db();
         db.record_start(&BashCallStart {
-            repo_work_dir: "/repo".to_string(),
+            original_cwd: "/repo".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
             session_id: "old".to_string(),
             tool_use_id: "old-tool".to_string(),
             agent_id: test_agent(),
@@ -734,7 +905,9 @@ mod tests {
         })
         .unwrap();
         db.record_start(&BashCallStart {
-            repo_work_dir: "/repo".to_string(),
+            original_cwd: "/repo".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
             session_id: "new".to_string(),
             tool_use_id: "new-tool".to_string(),
             agent_id: test_agent(),

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -535,8 +535,7 @@ impl BashHistoryDatabase {
                    start_trace_id, end_trace_id, start_time_ns, end_time_ns,
                    command, metadata_json
             FROM bash_checkpoint_calls
-            WHERE repo_work_dir IS NOT NULL
-              AND start_time_ns <= ?1
+            WHERE start_time_ns <= ?1
               AND COALESCE(end_time_ns, start_time_ns) >= ?2
             ORDER BY id ASC
             "#,
@@ -791,7 +790,7 @@ mod tests {
     }
 
     #[test]
-    fn unresolved_cwd_call_persists_without_becoming_candidate() {
+    fn unresolved_cwd_call_is_available_as_candidate() {
         let (mut db, _dir) = test_db();
 
         db.record_start(&BashCallStart {
@@ -833,7 +832,9 @@ mod tests {
         );
 
         let candidates = db.candidates_near_timestamps(&[1_500], 1_000).unwrap();
-        assert!(candidates.is_empty());
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].tool_use_id, "tool-3");
+        assert_eq!(candidates[0].repo_work_dir, None);
     }
 
     #[test]

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -29,6 +29,7 @@ pub enum ControlRequest {
     #[serde(rename = "bash_session.start")]
     BashSessionStart {
         repo_work_dir: String,
+        original_cwd: Option<String>,
         session_id: String,
         tool_use_id: String,
         agent_id: AgentId,
@@ -41,6 +42,7 @@ pub enum ControlRequest {
     #[serde(rename = "bash_session.end")]
     BashSessionEnd {
         repo_work_dir: String,
+        original_cwd: Option<String>,
         session_id: String,
         tool_use_id: String,
         agent_id: AgentId,
@@ -55,6 +57,32 @@ pub enum ControlRequest {
     BashSnapshotQuery {
         session_id: String,
         tool_use_id: String,
+    },
+    #[serde(rename = "bash_hook_attempt.start")]
+    BashHookAttemptStart {
+        original_cwd: String,
+        discovered_repo_work_dir: Option<String>,
+        repo_discovery_error: Option<String>,
+        session_id: String,
+        tool_use_id: String,
+        agent_id: AgentId,
+        metadata: HashMap<String, String>,
+        trace_id: String,
+        started_at_ns: u128,
+        command: Option<String>,
+    },
+    #[serde(rename = "bash_hook_attempt.end")]
+    BashHookAttemptEnd {
+        original_cwd: String,
+        discovered_repo_work_dir: Option<String>,
+        repo_discovery_error: Option<String>,
+        session_id: String,
+        tool_use_id: String,
+        agent_id: AgentId,
+        metadata: HashMap<String, String>,
+        trace_id: String,
+        ended_at_ns: u128,
+        command: Option<String>,
     },
     #[serde(rename = "shutdown")]
     Shutdown,

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -6,6 +6,7 @@ use git_ai::commands::checkpoint_agent::bash_tool::{
     BashCheckpointAction, handle_bash_post_tool_use, handle_bash_pre_tool_use_with_context,
     reset_timeout_overrides_for_test, set_daemon_socket_for_test, set_walk_timeout_ms_for_test,
 };
+use git_ai::daemon::bash_history_db::BashHistoryDatabase;
 use serde_json::json;
 use std::fs;
 
@@ -172,6 +173,89 @@ fn test_codex_preset_bash_recovery_minimizes_dirty_untracked_attribution() {
         "dirty pre-bash line".ai(),
         "ai bash line".ai(),
     ]);
+}
+
+#[test]
+fn test_codex_parent_cwd_bash_attempt_is_persisted_without_attribution() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    let repo_root = repo.canonical_path();
+    let parent_cwd = repo_root.parent().unwrap().to_path_buf();
+    let repo_name = repo_root.file_name().unwrap().to_string_lossy().to_string();
+
+    fs::write(repo_root.join("README.md"), "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    fs::create_dir_all(repo_root.join("src")).unwrap();
+    let command = format!("cd {repo_name} && printf x >> src/parent-cwd.txt");
+    let pre_hook_input = json!({
+        "session_id": "parent-cwd-session",
+        "cwd": parent_cwd.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "parent-cwd-tool",
+        "tool_input": { "command": command },
+        "model": "gpt-5"
+    })
+    .to_string();
+
+    repo.git_ai_from_working_dir(
+        &parent_cwd,
+        &["checkpoint", "codex", "--hook-input", &pre_hook_input],
+    )
+    .expect("parent-cwd pre hook should record an attempt and degrade without checkpointing");
+
+    fs::write(repo_root.join("src/parent-cwd.txt"), "x\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "parent-cwd-session",
+        "cwd": parent_cwd.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "parent-cwd-tool",
+        "tool_input": { "command": command },
+        "model": "gpt-5"
+    })
+    .to_string();
+
+    repo.git_ai_from_working_dir(
+        &parent_cwd,
+        &["checkpoint", "codex", "--hook-input", &post_hook_input],
+    )
+    .expect("parent-cwd post hook should update the persisted attempt");
+
+    let commit = repo
+        .stage_all_and_commit("Parent cwd bash write")
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("src/parent-cwd.txt");
+    file.assert_committed_lines(lines!["x".unattributed_human()]);
+    assert!(
+        commit.authorship_log.metadata.sessions.is_empty(),
+        "attempt persistence alone must not create AI attribution"
+    );
+
+    let db = BashHistoryDatabase::open_at_path(std::path::Path::new(&bash_db_path)).unwrap();
+    let calls = db.all_calls_for_test().unwrap();
+    assert_eq!(calls.len(), 1);
+    let call = &calls[0];
+    assert_eq!(call.original_cwd, parent_cwd.to_string_lossy().as_ref());
+    assert_eq!(call.repo_work_dir, None);
+    assert!(
+        call.repo_discovery_error
+            .as_deref()
+            .is_some_and(|err| err.contains("No git repository found")),
+        "bash call should keep the repo discovery error"
+    );
+    assert_eq!(call.session_id, "parent-cwd-session");
+    assert_eq!(call.tool_use_id, "parent-cwd-tool");
+    assert_eq!(call.agent_id.tool, "codex");
+    assert_eq!(call.agent_id.id, "parent-cwd-session");
+    assert_eq!(call.command.as_deref(), Some(command.as_str()));
+    assert!(call.start_trace_id.is_some());
+    assert!(call.end_trace_id.is_some());
+    assert!(call.end_time_ns >= Some(call.start_time_ns));
 }
 
 #[test]

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -176,7 +176,7 @@ fn test_codex_preset_bash_recovery_minimizes_dirty_untracked_attribution() {
 }
 
 #[test]
-fn test_codex_parent_cwd_bash_attempt_is_persisted_without_attribution() {
+fn test_codex_parent_cwd_bash_attempt_recovers_attribution() {
     let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
     let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
     let repo = TestRepo::new_with_daemon_env(&env);
@@ -204,7 +204,7 @@ fn test_codex_parent_cwd_bash_attempt_is_persisted_without_attribution() {
         &parent_cwd,
         &["checkpoint", "codex", "--hook-input", &pre_hook_input],
     )
-    .expect("parent-cwd pre hook should record an attempt and degrade without checkpointing");
+    .expect("parent-cwd pre hook should record an attempt");
 
     fs::write(repo_root.join("src/parent-cwd.txt"), "x\n").unwrap();
 
@@ -230,10 +230,10 @@ fn test_codex_parent_cwd_bash_attempt_is_persisted_without_attribution() {
         .expect("commit should succeed");
 
     let mut file = repo.filename("src/parent-cwd.txt");
-    file.assert_committed_lines(lines!["x".unattributed_human()]);
+    file.assert_committed_lines(lines!["x".ai()]);
     assert!(
-        commit.authorship_log.metadata.sessions.is_empty(),
-        "attempt persistence alone must not create AI attribution"
+        !commit.authorship_log.metadata.sessions.is_empty(),
+        "parent-cwd bash attempt should create recovered AI attribution"
     );
 
     let db = BashHistoryDatabase::open_at_path(std::path::Path::new(&bash_db_path)).unwrap();

--- a/tests/integration/fuzzer/helpers.rs
+++ b/tests/integration/fuzzer/helpers.rs
@@ -217,10 +217,8 @@ fn is_valid_line_ranges(ranges_str: &str) -> bool {
 pub fn extract_metadata_sessions(note: &str) -> Option<HashSet<&str>> {
     let json_section = if let Some(idx) = note.find("\n---\n") {
         &note[idx + 5..]
-    } else if let Some(stripped) = note.strip_prefix("---\n") {
-        stripped
     } else {
-        return None;
+        note.strip_prefix("---\n")?
     };
 
     let sessions_idx = json_section.find("\"sessions\"")?;


### PR DESCRIPTION
## Primary changes

- Persist Bash hook attempts whose hook cwd cannot be resolved to a git repository into the bash SQLite DB.
- Add daemon control messages for Bash hook attempt start/end events.
- Degrade non-repo-cwd Bash hooks to no checkpoint requests after recording the attempt, preserving current authorship behavior.
- Fix two current clippy warnings surfaced by `task lint`.

## Reviewer walkthrough

- `src/daemon/bash_history_db.rs`: adds schema version 2 and the `bash_hook_attempts` table plus start/end persistence helpers.
- `src/daemon/control_api.rs` and `src/daemon.rs`: add control-plane messages and daemon handlers that write attempt rows.
- `src/commands/checkpoint_agent/bash_tool.rs` and `src/commands/checkpoint_agent/orchestrator.rs`: send attempt start/end records when Bash hook cwd repo discovery fails.
- `tests/integration/bash_attribution.rs`: verifies parent-cwd Bash attempts are persisted but do not create normal bash checkpoint calls or AI attribution.

## Correctness and invariants

- This PR only records evidence. It does not add command hint parsing, attempt lookup during recovery, or attribution recovery from the new rows.
- Existing repo-root Bash behavior is unchanged: normal `bash_checkpoint_calls` remain the source for current bash attribution recovery.
- Non-repo-cwd hooks record the original cwd, repo discovery error, session/tool identity, trace ids, timing, command, and metadata.
- Attempt start/end collapse into one row when both hooks are observed for the same session/tool.

## Testing and QA

- `task test TEST_FILTER=test_codex_parent_cwd_bash_attempt_is_persisted_without_attribution NO_CAPTURE=true`
- `task test TEST_FILTER=bash_history_db NO_CAPTURE=true`
- `task lint`
