### PR TITLE
Capture commit-time recovery mtimes

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -19,6 +19,8 @@ const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
 const BASH_RECOVERY_COARSE_TIMESTAMP_NS: u128 = 1_000_000_000;
 const EDGE_EXTENSION_MAX_LINES: usize = 3;
 
+pub(crate) type FileTimestampsByPath = HashMap<String, Vec<u128>>;
+
 pub(crate) fn recover_attribution(
     repo: &Repository,
     parent_sha: &str,
@@ -26,6 +28,7 @@ pub(crate) fn recover_attribution(
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
+    file_timestamps: Option<&FileTimestampsByPath>,
 ) -> Result<(), GitAiError> {
     if committed_hunks.is_empty() {
         return Ok(());
@@ -42,6 +45,7 @@ pub(crate) fn recover_attribution(
         human_author,
         authorship_log,
         committed_hunks,
+        file_timestamps,
     )?;
     recover_adjacent_edges(
         repo,
@@ -60,6 +64,7 @@ fn recover_bash_mtime(
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
+    captured_file_timestamps: Option<&FileTimestampsByPath>,
 ) -> Result<(), GitAiError> {
     let repo_work_dir = repo_worktree_key(repo)?;
     let workdir = repo.workdir()?;
@@ -71,7 +76,11 @@ fn recover_bash_mtime(
     let mut timestamps_by_file = HashMap::new();
     let mut all_timestamps = Vec::new();
     for file_path in unknown_by_file.keys() {
-        let timestamps = file_timestamps_ns(&workdir, file_path);
+        let timestamps = captured_file_timestamps
+            .and_then(|timestamps| timestamps.get(file_path))
+            .filter(|timestamps| !timestamps.is_empty())
+            .cloned()
+            .unwrap_or_else(|| file_timestamps_ns(&workdir, file_path));
         if !timestamps.is_empty() {
             all_timestamps.extend(timestamps.iter().copied());
             timestamps_by_file.insert(file_path.clone(), timestamps);
@@ -237,7 +246,11 @@ fn repo_worktree_key(repo: &Repository) -> Result<String, GitAiError> {
 }
 
 fn file_timestamps_ns(workdir: &std::path::Path, file_path: &str) -> Vec<u128> {
-    let Ok(meta) = fs::symlink_metadata(workdir.join(file_path)) else {
+    file_timestamps_for_path(&workdir.join(file_path))
+}
+
+pub(crate) fn file_timestamps_for_path(path: &Path) -> Vec<u128> {
+    let Ok(meta) = fs::symlink_metadata(path) else {
         return Vec::new();
     };
     let stat = StatEntry::from_metadata(&meta);

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -1,7 +1,9 @@
+use crate::authorship::attribution_recovery::FileTimestampsByPath;
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
+use crate::authorship::rewrite::DiffTreeResult;
 use crate::authorship::stats::{stats_for_commit_stats_from_hunks, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry};
@@ -83,11 +85,43 @@ pub fn post_commit_from_working_log(
     )
 }
 
+pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
+    repo: &Repository,
+    base_commit: Option<String>,
+    commit_sha: String,
+    human_author: String,
+    supress_output: bool,
+    recovery_file_timestamps: Option<&FileTimestampsByPath>,
+) -> Result<(String, AuthorshipLog), GitAiError> {
+    post_commit_from_working_log_with_transform_context(
+        repo,
+        base_commit,
+        commit_sha,
+        human_author,
+        PostCommitOptions {
+            supress_output,
+            compute_stats: true,
+            recover_attribution: true,
+        },
+        PostCommitContext {
+            precomputed_parent_diff: None,
+            recovery_file_timestamps,
+        },
+        Ok,
+    )
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PostCommitOptions {
     pub supress_output: bool,
     pub compute_stats: bool,
     pub recover_attribution: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+struct PostCommitContext<'a> {
+    precomputed_parent_diff: Option<&'a DiffTreeResult>,
+    recovery_file_timestamps: Option<&'a FileTimestampsByPath>,
 }
 
 pub fn post_commit_from_working_log_with_transform<F>(
@@ -149,7 +183,33 @@ pub(crate) fn post_commit_from_working_log_with_transform_options_and_diff<F>(
     commit_sha: String,
     human_author: String,
     options: PostCommitOptions,
-    precomputed_parent_diff: Option<&crate::authorship::rewrite::DiffTreeResult>,
+    precomputed_parent_diff: Option<&DiffTreeResult>,
+    transform: F,
+) -> Result<(String, AuthorshipLog), GitAiError>
+where
+    F: FnOnce(AuthorshipLog) -> Result<AuthorshipLog, GitAiError>,
+{
+    post_commit_from_working_log_with_transform_context(
+        repo,
+        base_commit,
+        commit_sha,
+        human_author,
+        options,
+        PostCommitContext {
+            precomputed_parent_diff,
+            recovery_file_timestamps: None,
+        },
+        transform,
+    )
+}
+
+fn post_commit_from_working_log_with_transform_context<F>(
+    repo: &Repository,
+    base_commit: Option<String>,
+    commit_sha: String,
+    human_author: String,
+    options: PostCommitOptions,
+    context: PostCommitContext<'_>,
     transform: F,
 ) -> Result<(String, AuthorshipLog), GitAiError>
 where
@@ -199,7 +259,7 @@ where
             &commit_sha,
             Some(&pathspecs),
             Some(&observed_snapshot),
-            precomputed_parent_diff,
+            context.precomputed_parent_diff,
         )?;
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
@@ -216,7 +276,7 @@ where
         // otherwise fall back to a per-commit `git diff`.
         let committed_hunks: Option<
             HashMap<String, Vec<crate::authorship::authorship_log::LineRange>>,
-        > = if let Some(diff) = precomputed_parent_diff {
+        > = if let Some(diff) = context.precomputed_parent_diff {
             Some(
                 crate::authorship::virtual_attribution::committed_hunks_from_diff_result(
                     diff, None,
@@ -258,8 +318,12 @@ where
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 
     if options.recover_attribution {
-        let recovery_hunks =
-            recovery_committed_hunks(repo, &parent_sha, &commit_sha, precomputed_parent_diff)?;
+        let recovery_hunks = recovery_committed_hunks(
+            repo,
+            &parent_sha,
+            &commit_sha,
+            context.precomputed_parent_diff,
+        )?;
         crate::authorship::attribution_recovery::recover_attribution(
             repo,
             &parent_sha,
@@ -267,6 +331,7 @@ where
             &human_author,
             &mut authorship_log,
             &recovery_hunks,
+            context.recovery_file_timestamps,
         )?;
         authorship_log.metadata.base_commit_sha = commit_sha.clone();
     }
@@ -487,6 +552,22 @@ pub fn post_commit_amend(
     amended_commit: &str,
     human_author: String,
 ) -> Result<(String, AuthorshipLog), GitAiError> {
+    post_commit_amend_with_recovery_timestamps(
+        repo,
+        original_commit,
+        amended_commit,
+        human_author,
+        None,
+    )
+}
+
+pub(crate) fn post_commit_amend_with_recovery_timestamps(
+    repo: &Repository,
+    original_commit: &str,
+    amended_commit: &str,
+    human_author: String,
+    recovery_file_timestamps: Option<&FileTimestampsByPath>,
+) -> Result<(String, AuthorshipLog), GitAiError> {
     let repo_storage = &repo.storage;
     let working_log = repo_storage.working_log_for_base_commit(original_commit)?;
 
@@ -594,6 +675,7 @@ pub fn post_commit_amend(
         &human_author,
         &mut authorship_log,
         &recovery_hunks,
+        recovery_file_timestamps,
     )?;
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -950,6 +950,25 @@ fn compute_watermarks_from_stat(
     watermarks
 }
 
+fn capture_commit_file_timestamps(
+    worktree: &Path,
+    commit_sha: &str,
+) -> Result<crate::authorship::attribution_recovery::FileTimestampsByPath, GitAiError> {
+    let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+    let workdir = repo.workdir()?;
+    let files = repo.list_commit_files(commit_sha, None)?;
+    let mut timestamps_by_path = HashMap::new();
+    for file_path in files {
+        let timestamps = crate::authorship::attribution_recovery::file_timestamps_for_path(
+            &workdir.join(&file_path),
+        );
+        if !timestamps.is_empty() {
+            timestamps_by_path.insert(file_path, timestamps);
+        }
+    }
+    Ok(timestamps_by_path)
+}
+
 fn parsed_invocation_for_side_effect(
     command: Option<&str>,
     args: &[String],
@@ -1923,6 +1942,12 @@ struct PendingRootSlot {
     order: FamilySequencerOrder,
 }
 
+type CommitFileTimestampSnapshotHandle =
+    tokio::task::JoinHandle<Option<crate::authorship::attribution_recovery::FileTimestampsByPath>>;
+type CommitFileTimestampSnapshotHandles = HashMap<String, CommitFileTimestampSnapshotHandle>;
+
+const COMMIT_FILE_TIMESTAMP_SNAPSHOT_WAIT: Duration = Duration::from_millis(500);
+
 #[derive(Debug, Clone)]
 struct PendingSquashMerge {
     source_head: String,
@@ -1987,6 +2012,8 @@ pub struct ActorDaemonCoordinator {
     pending_ai_edits_by_family: Mutex<HashMap<String, HashMap<String, u128>>>,
     family_sequencers_by_family: Mutex<HashMap<String, FamilySequencerState>>,
     pending_root_slots_by_root: Mutex<HashMap<String, PendingRootSlot>>,
+    commit_file_timestamp_snapshots_by_root:
+        Mutex<HashMap<String, CommitFileTimestampSnapshotHandles>>,
     recent_replay_prerequisites_by_family:
         Mutex<HashMap<String, VecDeque<RecentReplayPrerequisite>>>,
     side_effect_errors_by_family: Mutex<HashMap<String, BTreeMap<u64, String>>>,
@@ -2071,6 +2098,7 @@ impl ActorDaemonCoordinator {
             pending_ai_edits_by_family: Mutex::new(HashMap::new()),
             family_sequencers_by_family: Mutex::new(HashMap::new()),
             pending_root_slots_by_root: Mutex::new(HashMap::new()),
+            commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
             side_effect_errors_by_family: Mutex::new(HashMap::new()),
             side_effect_exec_locks: Mutex::new(HashMap::new()),
@@ -3417,11 +3445,15 @@ impl ActorDaemonCoordinator {
                     // does not kill the daemon process.
                     let side_effect_result = {
                         let future = async {
+                            let root_sid = command.root_sid.clone();
+                            let mut commit_file_timestamp_snapshots =
+                                self.take_cached_commit_file_timestamp_snapshots(&root_sid)?;
                             let applied = self.coordinator.route_command(*command).await?;
                             let side_effect = self
                                 .maybe_apply_side_effects_for_applied_command(
                                     Some(family),
                                     &applied,
+                                    &mut commit_file_timestamp_snapshots,
                                 )
                                 .await;
                             Ok::<_, GitAiError>((applied, side_effect))
@@ -4123,10 +4155,112 @@ impl ActorDaemonCoordinator {
         Ok(())
     }
 
+    fn start_commit_file_timestamp_snapshots_for_command(
+        command: &crate::daemon::domain::NormalizedCommand,
+    ) -> CommitFileTimestampSnapshotHandles {
+        let Some(worktree) = command.worktree.clone() else {
+            return HashMap::new();
+        };
+        if command.exit_code != 0
+            || !matches!(
+                command.primary_command.as_deref(),
+                Some("commit" | "merge" | "am")
+            )
+        {
+            return HashMap::new();
+        }
+
+        let (_, new_head) = Self::resolve_heads_for_command(command);
+        if new_head.is_empty() || !is_valid_oid(&new_head) || is_zero_oid(&new_head) {
+            return HashMap::new();
+        }
+
+        let mut handles = HashMap::new();
+        let task_commit_sha = new_head.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            match capture_commit_file_timestamps(&worktree, &task_commit_sha) {
+                Ok(timestamps) => Some(timestamps),
+                Err(error) => {
+                    tracing::debug!(
+                        %error,
+                        commit_sha = %task_commit_sha,
+                        "failed to capture commit-time file timestamps"
+                    );
+                    None
+                }
+            }
+        });
+        handles.insert(new_head, handle);
+
+        handles
+    }
+
+    fn cache_commit_file_timestamp_snapshots_for_command(
+        &self,
+        command: &crate::daemon::domain::NormalizedCommand,
+    ) -> Result<(), GitAiError> {
+        let handles = Self::start_commit_file_timestamp_snapshots_for_command(command);
+        if handles.is_empty() {
+            return Ok(());
+        }
+        let mut cache = self
+            .commit_file_timestamp_snapshots_by_root
+            .lock()
+            .map_err(|_| {
+                GitAiError::Generic(
+                    "commit file timestamp snapshot cache lock poisoned".to_string(),
+                )
+            })?;
+        cache.insert(command.root_sid.clone(), handles);
+        Ok(())
+    }
+
+    fn take_cached_commit_file_timestamp_snapshots(
+        &self,
+        root_sid: &str,
+    ) -> Result<CommitFileTimestampSnapshotHandles, GitAiError> {
+        let mut cache = self
+            .commit_file_timestamp_snapshots_by_root
+            .lock()
+            .map_err(|_| {
+                GitAiError::Generic(
+                    "commit file timestamp snapshot cache lock poisoned".to_string(),
+                )
+            })?;
+        Ok(cache.remove(root_sid).unwrap_or_default())
+    }
+
+    async fn take_commit_file_timestamps(
+        handles: &mut CommitFileTimestampSnapshotHandles,
+        commit_sha: &str,
+    ) -> Option<crate::authorship::attribution_recovery::FileTimestampsByPath> {
+        let handle = handles.remove(commit_sha)?;
+        match tokio::time::timeout(COMMIT_FILE_TIMESTAMP_SNAPSHOT_WAIT, handle).await {
+            Ok(Ok(Some(timestamps))) if !timestamps.is_empty() => Some(timestamps),
+            Ok(Ok(_)) => None,
+            Ok(Err(error)) => {
+                tracing::debug!(
+                    %error,
+                    %commit_sha,
+                    "commit-time file timestamp task failed"
+                );
+                None
+            }
+            Err(_) => {
+                tracing::debug!(
+                    %commit_sha,
+                    "commit-time file timestamp task timed out"
+                );
+                None
+            }
+        }
+    }
+
     async fn maybe_apply_side_effects_for_applied_command(
         &self,
         family: Option<&str>,
         applied: &crate::daemon::domain::AppliedCommand,
+        commit_file_timestamp_snapshots: &mut CommitFileTimestampSnapshotHandles,
     ) -> Result<(), GitAiError> {
         // Test-only: allow inducing a panic in the side-effect pipeline to verify
         // that the daemon's catch_unwind recovery keeps the process alive.
@@ -4607,13 +4741,19 @@ impl ActorDaemonCoordinator {
                             let repo = find_repository_in_path(&worktree)?;
                             let author = repo.effective_author_identity().formatted_or_unknown();
                             let base_opt = base.clone().filter(|b| !b.is_empty() && b != "initial");
+                            let recovery_file_timestamps = Self::take_commit_file_timestamps(
+                                commit_file_timestamp_snapshots,
+                                new_head,
+                            )
+                            .await;
 
-                            crate::authorship::post_commit::post_commit_from_working_log(
+                            crate::authorship::post_commit::post_commit_from_working_log_with_recovery_timestamps(
                                 &repo,
                                 base_opt.clone(),
                                 new_head.clone(),
                                 author,
                                 true,
+                                recovery_file_timestamps.as_ref(),
                             )?;
 
                             if cmd.primary_command.as_deref() == Some("commit")
@@ -4649,8 +4789,17 @@ impl ActorDaemonCoordinator {
                         {
                             let repo = find_repository_in_path(&worktree)?;
                             let author = repo.effective_author_identity().formatted_or_unknown();
-                            crate::authorship::post_commit::post_commit_amend(
-                                &repo, old_head, new_head, author,
+                            let recovery_file_timestamps = Self::take_commit_file_timestamps(
+                                commit_file_timestamp_snapshots,
+                                new_head,
+                            )
+                            .await;
+                            crate::authorship::post_commit::post_commit_amend_with_recovery_timestamps(
+                                &repo,
+                                old_head,
+                                new_head,
+                                author,
+                                recovery_file_timestamps.as_ref(),
                             )?;
                         }
                     }
@@ -4855,6 +5004,7 @@ impl ActorDaemonCoordinator {
             )
             .await?
         {
+            self.cache_commit_file_timestamp_snapshots_for_command(&command)?;
             family_to_drain_after_clear = Some(family);
             TracePayloadApplyOutcome::QueuedFamily
         } else if let Some(family) = command.family_key.as_ref().map(|family| family.0.clone())
@@ -4863,6 +5013,7 @@ impl ActorDaemonCoordinator {
                 &command.raw_argv,
             )
         {
+            self.cache_commit_file_timestamp_snapshots_for_command(&command)?;
             self.append_ready_command_entry(&family, command).await?;
             family_to_drain_after_clear = Some(family);
             TracePayloadApplyOutcome::QueuedFamily
@@ -4890,8 +5041,14 @@ impl ActorDaemonCoordinator {
             TracePayloadApplyOutcome::Applied(applied) => {
                 if let Some(family) = applied.command.family_key.as_ref().map(|key| key.0.clone()) {
                     self.begin_family_effect(&family)?;
+                    let mut commit_file_timestamp_snapshots =
+                        Self::start_commit_file_timestamp_snapshots_for_command(&applied.command);
                     let result = self
-                        .maybe_apply_side_effects_for_applied_command(Some(&family), &applied)
+                        .maybe_apply_side_effects_for_applied_command(
+                            Some(&family),
+                            &applied,
+                            &mut commit_file_timestamp_snapshots,
+                        )
                         .await;
                     let _ = self.end_family_effect(&family);
                     if let Err(error) = &result {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4161,12 +4161,7 @@ impl ActorDaemonCoordinator {
         let Some(worktree) = command.worktree.clone() else {
             return HashMap::new();
         };
-        if command.exit_code != 0
-            || !matches!(
-                command.primary_command.as_deref(),
-                Some("commit" | "merge" | "am")
-            )
-        {
+        if command.exit_code != 0 || command.primary_command.as_deref() != Some("commit") {
             return HashMap::new();
         }
 

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -9,6 +9,8 @@ use git_ai::commands::checkpoint_agent::bash_tool::{
 use git_ai::daemon::bash_history_db::BashHistoryDatabase;
 use serde_json::json;
 use std::fs;
+use std::thread;
+use std::time::Duration;
 
 fn isolated_bash_history_db_path() -> (tempfile::TempDir, String) {
     let dir = tempfile::tempdir().expect("failed to create isolated bash history db dir");
@@ -173,6 +175,80 @@ fn test_codex_preset_bash_recovery_minimizes_dirty_untracked_attribution() {
         "dirty pre-bash line".ai(),
         "ai bash line".ai(),
     ]);
+}
+
+#[test]
+fn test_bash_recovery_uses_commit_time_file_timestamps_when_processing_is_delayed() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+        (
+            "GIT_AI_TEST_DELAY_SIDE_EFFECT_MS_FOR_COMMAND",
+            "remote=6500",
+        ),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("delayed.txt");
+
+    fs::write(&file_path, "dirty pre-bash line\n").unwrap();
+
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-transcript.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "delayed-commit-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "delayed-commit-tool",
+        "tool_input": { "command": "printf 'ai bash line\\n' >> delayed.txt" },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("codex pre-hook checkpoint should succeed");
+
+    fs::write(&file_path, "dirty pre-bash line\nai bash line\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "delayed-commit-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "delayed-commit-tool",
+        "tool_input": { "command": "printf 'ai bash line\\n' >> delayed.txt" },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("codex post-hook checkpoint should succeed");
+
+    repo.git_without_test_sync_for_test(
+        &[
+            "remote",
+            "add",
+            "delayed-side-effect",
+            "https://example.invalid/repo.git",
+        ],
+        &[],
+    )
+    .expect("remote add should succeed");
+    repo.git_without_test_sync_for_test(&["add", "-A"], &[])
+        .expect("add should succeed");
+    repo.git_without_test_sync_for_test(&["commit", "-m", "Delayed commit"], &[])
+        .expect("commit should succeed");
+
+    thread::sleep(Duration::from_millis(3500));
+    fs::write(
+        &file_path,
+        "dirty pre-bash line\nai bash line\nmanual edit after commit\n",
+    )
+    .unwrap();
+
+    let mut file = repo.filename("delayed.txt");
+    file.assert_committed_lines(lines!["dirty pre-bash line".ai(), "ai bash line".ai(),]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Capture changed-file mtime/ctime snapshots asynchronously for commit-like commands before delayed post-commit side effects run.
- Thread the captured timestamps into post-commit and amend attribution recovery, with the existing live-disk timestamp path as fallback.
- Add a delayed side-effect regression test that mutates the worktree after commit but before post-commit recovery runs.

## Tests
- `task fmt`
- `task test TEST_FILTER=bash_attribution`
- `task test`
- `task lint`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->