### PR TITLE
[codex] Fetch HTTP notes during pull

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1053,16 +1053,49 @@ fn apply_pull_notes_sync_side_effect(
     command: Option<&str>,
     args: &[String],
 ) -> Result<(), GitAiError> {
+    use crate::config::NotesBackendKind;
+
     let repo = find_repository_in_path(worktree)?;
     let parsed = parsed_invocation_for_side_effect(command, args);
     let remote = fetch_remote_from_args(&repo, &parsed)?;
+    let notes_backend = crate::config::Config::fresh().notes_backend_kind();
+
+    tracing::info!(
+        command = command.unwrap_or("pull"),
+        remote = %remote,
+        backend = %notes_backend,
+        worktree = %worktree,
+        "handling pull notes sync"
+    );
+
+    if notes_backend == NotesBackendKind::Http {
+        return crate::git::notes_api::warm_cache_for_remote(&repo, &remote);
+    }
+
     fetch_authorship_notes(&repo, &remote)?;
     Ok(())
 }
 
 fn apply_clone_notes_sync_side_effect(worktree: &str) -> Result<(), GitAiError> {
+    use crate::config::NotesBackendKind;
+
     let repo = find_repository_in_path(worktree)?;
-    fetch_authorship_notes(&repo, "origin")?;
+    let remote = "origin";
+    let notes_backend = crate::config::Config::fresh().notes_backend_kind();
+
+    tracing::info!(
+        command = "clone",
+        remote = %remote,
+        backend = %notes_backend,
+        worktree = %worktree,
+        "handling clone notes sync"
+    );
+
+    if notes_backend == NotesBackendKind::Http {
+        return crate::git::notes_api::warm_cache_for_remote(&repo, remote);
+    }
+
+    fetch_authorship_notes(&repo, remote)?;
     Ok(())
 }
 
@@ -6219,7 +6252,8 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                 tracing_subscriber::fmt::layer()
                     .with_target(false)
                     .with_thread_ids(false)
-                    .with_ansi(false),
+                    .with_ansi(false)
+                    .with_writer(std::io::stderr),
             )
             .with(crate::daemon::sentry_layer::SentryLayer)
             .init();

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -437,6 +437,12 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
         return Ok(());
     }
 
+    tracing::info!(
+        remote = %remote,
+        backend = %"http",
+        uncached_commits = uncached.len(),
+        "fetching authorship notes"
+    );
     tracing::debug!(
         "warm_cache_for_remote: fetching notes for {} uncached commits",
         uncached.len()

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -199,6 +199,12 @@ pub fn fetch_authorship_notes(
     // Generate tracking ref for this remote
     let tracking_ref = tracking_ref_for_remote(remote_name);
 
+    tracing::info!(
+        remote = %remote_name,
+        backend = %"git_notes",
+        tracking_ref = %tracking_ref,
+        "fetching authorship notes"
+    );
     tracing::debug!(
         "fetching authorship notes for remote '{}' to tracking ref '{}'",
         remote_name,

--- a/tests/notes_sync_regression.rs
+++ b/tests/notes_sync_regression.rs
@@ -2,7 +2,9 @@
 #[path = "integration/repos/mod.rs"]
 mod repos;
 
-use repos::test_repo::real_git_executable;
+use git_ai::notes::db::NotesDatabase;
+use git_ai::notes::reference_server::ReferenceServer;
+use repos::test_repo::{DaemonTestScope, TestRepo, real_git_executable};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -459,6 +461,95 @@ worktree_test_wrappers! {
             seed_sha
         );
     }
+}
+
+#[test]
+fn notes_sync_http_backend_clone_warms_notes_cache() {
+    let server = ReferenceServer::start("127.0.0.1:0").expect("start notes reference server");
+    let backend_url = server.base_url();
+
+    let source = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+        ("GIT_AI_NOTES_BACKEND_URL", backend_url.as_str()),
+        ("GIT_AI_API_KEY", "notes-sync-http-clone-test-key"),
+    ]);
+    let notes_db_path = source
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("notes-db");
+    let upstream = TestRepo::new_bare_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let upstream_str = upstream.path().to_string_lossy().to_string();
+
+    source
+        .git_og(&["remote", "add", "origin", upstream_str.as_str()])
+        .expect("add origin should succeed");
+    fs::write(source.path().join("http-clone-seed.txt"), "seed\n")
+        .expect("failed to write HTTP clone seed file");
+    source
+        .git_og(&["add", "http-clone-seed.txt"])
+        .expect("add should succeed");
+    source
+        .git_og(&["commit", "-m", "HTTP clone seed commit"])
+        .expect("seed commit should succeed");
+    source
+        .git_og(&["push", "-u", "origin", "HEAD"])
+        .expect("initial push should succeed");
+
+    let seed_sha = source
+        .git_og(&["rev-parse", "HEAD"])
+        .expect("rev-parse should succeed")
+        .trim()
+        .to_string();
+    let remote_note = "http-clone-seed-note".to_string();
+    server.store().put(seed_sha.clone(), remote_note.clone());
+
+    {
+        let db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db");
+        assert_eq!(
+            db.get_note(&seed_sha).expect("read note before clone"),
+            None,
+            "HTTP notes cache should be empty before clone"
+        );
+    }
+
+    let clone_dir = unique_temp_path("notes-sync-http-clone");
+    let clone_dir_str = clone_dir.to_string_lossy().to_string();
+    let _ = fs::remove_dir_all(&clone_dir);
+    source
+        .git(&["clone", upstream_str.as_str(), clone_dir_str.as_str()])
+        .expect("clone should succeed");
+
+    let db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db after clone");
+    assert_eq!(
+        db.get_note(&seed_sha).expect("read note after clone"),
+        Some(remote_note),
+        "clone with HTTP notes backend should warm the local notes cache for {}",
+        seed_sha
+    );
+
+    let daemon_log_path = source
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("daemon")
+        .join("daemon.test.stderr.log");
+    let daemon_log =
+        fs::read_to_string(&daemon_log_path).expect("read test daemon stderr log after clone");
+    assert!(
+        daemon_log.contains("handling clone notes sync"),
+        "daemon log should record the clone notes side effect\npath: {}\ncontents:\n{}",
+        daemon_log_path.display(),
+        daemon_log
+    );
+    assert!(
+        daemon_log.contains("fetching authorship notes")
+            && daemon_log.contains("backend=http")
+            && daemon_log.contains("remote=origin"),
+        "daemon log should record the HTTP notes fetch\npath: {}\ncontents:\n{}",
+        daemon_log_path.display(),
+        daemon_log
+    );
 }
 
 worktree_test_wrappers! {
@@ -1073,6 +1164,134 @@ worktree_test_wrappers! {
             remote_sha
         );
     }
+}
+
+#[test]
+fn notes_sync_http_backend_plain_pull_warms_notes_cache() {
+    let server = ReferenceServer::start("127.0.0.1:0").expect("start notes reference server");
+    let backend_url = server.base_url();
+
+    let local = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+        ("GIT_AI_NOTES_BACKEND_URL", backend_url.as_str()),
+        ("GIT_AI_API_KEY", "notes-sync-http-pull-test-key"),
+    ]);
+    let notes_db_path = local
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("notes-db");
+    let upstream = TestRepo::new_bare_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let default_branch = local.current_branch();
+    let upstream_str = upstream.path().to_string_lossy().to_string();
+
+    local
+        .git_og(&["remote", "add", "origin", upstream_str.as_str()])
+        .expect("add origin should succeed");
+    fs::write(local.path().join("http-pull-base.txt"), "base\n")
+        .expect("failed to write HTTP pull base file");
+    local
+        .git_og(&["add", "http-pull-base.txt"])
+        .expect("add should succeed");
+    local
+        .git_og(&["commit", "-m", "base commit"])
+        .expect("base commit should succeed");
+    local
+        .git_og(&["push", "-u", "origin", "HEAD"])
+        .expect("initial push should succeed");
+    local
+        .git(&["config", "pull.ff", "only"])
+        .expect("configure plain pull as fast-forward-only");
+
+    let remote_clone = unique_temp_path("notes-sync-http-pull-remote");
+    let remote_clone_str = remote_clone.to_string_lossy().to_string();
+    let _ = fs::remove_dir_all(&remote_clone);
+
+    run_git(&["clone", upstream_str.as_str(), remote_clone_str.as_str()]);
+    run_git(&[
+        "-C",
+        remote_clone_str.as_str(),
+        "config",
+        "user.name",
+        "Test User",
+    ]);
+    run_git(&[
+        "-C",
+        remote_clone_str.as_str(),
+        "config",
+        "user.email",
+        "test@example.com",
+    ]);
+
+    fs::write(remote_clone.join("http-pull-remote.txt"), "remote\n")
+        .expect("failed to write HTTP pull remote file");
+    run_git(&[
+        "-C",
+        remote_clone_str.as_str(),
+        "add",
+        "http-pull-remote.txt",
+    ]);
+    run_git(&[
+        "-C",
+        remote_clone_str.as_str(),
+        "commit",
+        "-m",
+        "remote HTTP pull commit",
+    ]);
+    let remote_sha = run_git(&["-C", remote_clone_str.as_str(), "rev-parse", "HEAD"]);
+    let remote_note = "http-pull-remote-note".to_string();
+    server.store().put(remote_sha.clone(), remote_note.clone());
+
+    run_git(&[
+        "-C",
+        remote_clone_str.as_str(),
+        "push",
+        "origin",
+        default_branch.as_str(),
+    ]);
+
+    {
+        let db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db");
+        assert_eq!(
+            db.get_note(&remote_sha).expect("read note before pull"),
+            None,
+            "HTTP notes cache should be empty before pull"
+        );
+    }
+
+    local.git(&["pull"]).expect("plain pull should succeed");
+    local.sync_daemon_force();
+
+    let db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db after pull");
+    assert_eq!(
+        db.get_note(&remote_sha).expect("read note after pull"),
+        Some(remote_note),
+        "plain pull with HTTP notes backend should warm the local notes cache for {}",
+        remote_sha
+    );
+
+    let daemon_log_path = local
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("daemon")
+        .join("daemon.test.stderr.log");
+    let daemon_log =
+        fs::read_to_string(&daemon_log_path).expect("read test daemon stderr log after pull");
+    assert!(
+        daemon_log.contains("handling pull notes sync"),
+        "daemon log should record the pull notes side effect\npath: {}\ncontents:\n{}",
+        daemon_log_path.display(),
+        daemon_log
+    );
+    assert!(
+        daemon_log.contains("fetching authorship notes")
+            && daemon_log.contains("backend=http")
+            && daemon_log.contains("remote=origin"),
+        "daemon log should record the HTTP notes fetch\npath: {}\ncontents:\n{}",
+        daemon_log_path.display(),
+        daemon_log
+    );
 }
 
 worktree_test_wrappers! {


### PR DESCRIPTION
## Summary

- Route daemon-driven `git pull` and `git clone` notes sync through the HTTP notes backend when configured.
- Emit daemon `info` logs when pull/clone notes sync is handled and when authorship notes are fetched, so these events land in daemon logs by default.
- Add TestRepo regressions proving plain fast-forward `git pull` and `git clone` warm the local HTTP notes cache and record the daemon log entries.

## Root Cause

The daemon's pull and clone side effects always used the git-notes fetch path. That worked for the git notes backend, but skipped `warm_cache_for_remote` when `notes_backend.kind=http`, so HTTP-backed notes were not fetched during normal pull or clone flows.

## Validation

- `task test TEST_FILTER=notes_sync_http_backend_clone_warms_notes_cache NO_CAPTURE=true` failed before the clone fix and passed after it.
- `task test TEST_FILTER=notes_sync_http_backend_plain_pull_warms_notes_cache NO_CAPTURE=true` failed before the pull fix and passed after it.
- `task test TEST_FILTER=notes_sync`
- `task fmt`
- `task lint`
- `task test`