### PR TITLE
Speed up `git-ai stats` range mode by batching authorship-note reads

### DIFF
--- a/src/authorship/diff_ai_accepted.rs
+++ b/src/authorship/diff_ai_accepted.rs
@@ -49,6 +49,9 @@ pub fn diff_ai_accepted_stats(
             options.line_ranges = line_ranges;
             options.no_output = true;
             options.use_prompt_hashes_as_names = true;
+            // Only the per-line authors are used below; the blame hunks are discarded,
+            // so skip the ai_human_author population pass (a redundant per-commit note read).
+            options.skip_human_author_population = true;
         }
 
         let blame_result = repo.blame(&file_path, &options);

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -3412,6 +3412,9 @@ fn compute_attributions_for_file(
         ai_blame_opts.newest_commit = Some(base_commit.to_string());
         ai_blame_opts.oldest_commit = blame_start_commit;
         ai_blame_opts.oldest_date = Some(*OLDEST_AI_BLAME_DATE);
+        // Only the per-line blame authors are consumed below; the hunks are discarded,
+        // so skip the ai_human_author population pass (a redundant per-commit note read).
+        ai_blame_opts.skip_human_author_population = true;
     }
 
     // Run blame at the base commit

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -170,6 +170,15 @@ pub struct GitAiBlameOptions {
     // When true, a single git blame hunk may be split into multiple hunks
     // if different lines were authored by different humans working with AI
     pub split_hunks_by_ai_author: bool,
+
+    // Skip populating `ai_human_author` on blame hunks (the `populate_ai_human_authors`
+    // pass). That pass reads each blamed commit's authorship note and runs per-line
+    // attribution purely to annotate hunks. Callers that consume only `line_authors` /
+    // `prompt_records` from `blame()` (e.g. range stats via `diff_ai_accepted_stats`
+    // and `VirtualAttributions`) discard the hunks, so for them the pass is dead work.
+    // It is output-invariant to skip because `overlay_ai_authorship` derives
+    // `line_authors` per line independently of hunk grouping/`ai_human_author`.
+    pub skip_human_author_population: bool,
 }
 
 impl Default for GitAiBlameOptions {
@@ -216,6 +225,7 @@ impl Default for GitAiBlameOptions {
             mark_unknown: false,
             show_prompt: false,
             split_hunks_by_ai_author: true,
+            skip_human_author_population: false,
         }
     }
 }
@@ -929,8 +939,24 @@ impl Repository {
 
         self.populate_hunk_abbrev_shas(&mut hunks, options);
 
-        // Post-process hunks to populate ai_human_author from authorship logs
-        let hunks = self.populate_ai_human_authors(hunks, file_path, options)?;
+        // Post-process hunks to populate ai_human_author from authorship logs.
+        // Callers that consume only line_authors/prompt_records and discard the hunks
+        // (range stats) opt out of this pass — it is dead work for them and skipping it
+        // avoids a second per-commit authorship-note read over every blamed commit.
+        //
+        // Guard the safe-use contract: skipping drops `ai_human_author` and hunk
+        // splitting, which only stays output-invariant for callers that discard the
+        // hunks. Every current opt-in (diff_ai_accepted_stats, VirtualAttributions) is a
+        // `no_output` path, so assert that here to catch future misuse in debug builds.
+        debug_assert!(
+            !options.skip_human_author_population || options.no_output,
+            "skip_human_author_population is only safe on hunk-discarding (no_output) blame paths"
+        );
+        let hunks = if options.skip_human_author_population {
+            hunks
+        } else {
+            self.populate_ai_human_authors(hunks, file_path, options)?
+        };
 
         Ok(hunks)
     }
@@ -952,6 +978,21 @@ impl Repository {
         let mut foreign_prompts_cache: HashMap<String, Option<PromptRecord>> = HashMap::new();
 
         let mut result_hunks: Vec<BlameHunk> = Vec::new();
+
+        // Batch-resolve all blamed commits' authorship notes up front (one `cat-file
+        // --batch` instead of a `git notes show` per unique commit), then read from the
+        // cache in the loop below. Identical results to the per-commit lazy path.
+        let unique_commit_shas: Vec<String> = hunks
+            .iter()
+            .map(|hunk| hunk.commit_sha.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        for (sha, authorship) in
+            crate::git::notes_api::read_authorship_v3_batch(self, &unique_commit_shas)
+        {
+            commit_authorship_cache.entry(sha).or_insert(authorship);
+        }
 
         for hunk in hunks {
             // Get or fetch the authorship log for this commit
@@ -1076,6 +1117,23 @@ fn overlay_ai_authorship(
     let mut simulated_authorship_logs: HashMap<String, AuthorshipLog> = HashMap::new();
     // Cache for foreign prompts to avoid repeated grepping
     let mut foreign_prompts_cache: HashMap<String, Option<PromptRecord>> = HashMap::new();
+
+    // Resolve every blamed commit's authorship note in a single batched read instead of
+    // one `git notes show` subprocess per unique commit. This is the dominant cost of
+    // `git-ai stats` over a range; the per-hunk loop below then only reads from the cache.
+    // The batch produces values identical to the per-commit get_reference_as_authorship_log_v3.
+    let unique_commit_shas: Vec<String> = blame_hunks
+        .iter()
+        .map(|hunk| hunk.commit_sha.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+    for (sha, authorship) in
+        crate::git::notes_api::read_authorship_v3_batch(repo, &unique_commit_shas)
+    {
+        commit_authorship_cache.entry(sha).or_insert(authorship);
+    }
+
     for hunk in blame_hunks {
         // Check if we've already looked up this commit's authorship
         let authorship_log = if let Some(cached) = commit_authorship_cache.get(&hunk.commit_sha) {

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -128,6 +128,76 @@ pub fn read_authorship_v3(
     }
 }
 
+/// Batch-resolve v3 authorship logs for many commits at once.
+///
+/// For every requested commit SHA the returned map contains the SAME value that
+/// `read_authorship_v3(repo, sha).ok()` would produce — `Some(log)` when the commit
+/// has a parseable, version-compatible note and `None` otherwise. The difference is
+/// purely in cost: on the `GitNotes` backend this resolves all note blobs with a
+/// couple of batched `git ls-tree` calls plus a single `git cat-file --batch`,
+/// instead of spawning one `git notes show` per commit. That fan-out is the dominant
+/// cost of `git-ai stats` over a commit range, where blame attributes lines to many
+/// distinct commits and each one's note was previously re-read in its own subprocess.
+///
+/// The `Http` backend already serves notes from a fast local cache (no subprocess
+/// per commit), and its cache-hit path intentionally skips the version check that the
+/// git path applies; to preserve those exact semantics we delegate per commit there.
+///
+/// Parity boundary (intentional): on `GitNotes` the batched read decodes each note
+/// blob with `from_utf8_lossy` (the same decode the existing `CommitAuthorship` note
+/// path uses), whereas the per-commit `show_authorship_note` decodes strictly and
+/// treats a non-UTF8 blob as absent. git-ai always serializes notes as valid UTF-8
+/// JSON, and a blob that is invalid UTF-8 cannot lossily decode into a schema-valid
+/// v3 `AuthorshipLog`, so the two paths agree for every real note; the only theoretical
+/// divergence is a corrupt/hand-crafted non-UTF8 blob, which neither path can render as
+/// usable authorship data. Duplicate SHAs are tolerated — the result holds one entry
+/// per unique commit — though both current callers already pass a deduplicated set.
+pub fn read_authorship_v3_batch(
+    repo: &Repository,
+    commit_shas: &[String],
+) -> HashMap<String, Option<AuthorshipLog>> {
+    let mut out: HashMap<String, Option<AuthorshipLog>> = HashMap::with_capacity(commit_shas.len());
+    if commit_shas.is_empty() {
+        return out;
+    }
+
+    match Config::get().notes_backend_kind() {
+        NotesBackendKind::GitNotes => {
+            // GitNotes: read_authorship_v3 == refs::get_reference_as_authorship_log_v3
+            // (deserialize + version check + base_commit_sha). Batch the note-content
+            // reads, then parse each through the exact same helper so results are
+            // byte-for-byte identical to the per-commit path.
+            match crate::git::refs::notes_for_commits(repo, commit_shas) {
+                Ok(contents) => {
+                    for sha in commit_shas {
+                        let parsed = contents.get(sha).and_then(|content| {
+                            crate::git::refs::parse_reference_as_authorship_log_v3(content, sha)
+                                .ok()
+                        });
+                        out.entry(sha.clone()).or_insert(parsed);
+                    }
+                }
+                Err(_) => {
+                    // Rare: a batched read failure (e.g. a missing referenced blob).
+                    // Fall back to the per-commit path so behavior never changes.
+                    for sha in commit_shas {
+                        out.entry(sha.clone())
+                            .or_insert_with(|| read_authorship_v3(repo, sha).ok());
+                    }
+                }
+            }
+        }
+        NotesBackendKind::Http => {
+            for sha in commit_shas {
+                out.entry(sha.clone())
+                    .or_insert_with(|| read_authorship_v3(repo, sha).ok());
+            }
+        }
+    }
+
+    out
+}
+
 /// Return a map of commit SHA → note-blob OID for the given commits.
 ///
 /// # Audit results (Phase 2)

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -696,8 +696,23 @@ pub fn get_reference_as_authorship_log_v3(
     let content = show_authorship_note(repo, commit_sha)
         .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
 
+    parse_reference_as_authorship_log_v3(&content, commit_sha)
+}
+
+/// Parse raw authorship-note content into a v3 `AuthorshipLog`.
+///
+/// This is the parsing half of [`get_reference_as_authorship_log_v3`], split out so
+/// that batched note readers (which fetch many note blobs in a single `cat-file
+/// --batch` instead of one `git notes show` per commit) can produce results that are
+/// byte-for-byte identical to the per-commit path. Any change to deserialization,
+/// version checking, or `base_commit_sha` normalization MUST stay in this one place
+/// so the batched and per-commit paths cannot drift.
+pub fn parse_reference_as_authorship_log_v3(
+    content: &str,
+    commit_sha: &str,
+) -> Result<AuthorshipLog, GitAiError> {
     // Try to deserialize as AuthorshipLog
-    let mut authorship_log = match AuthorshipLog::deserialize_from_string(&content) {
+    let mut authorship_log = match AuthorshipLog::deserialize_from_string(content) {
         Ok(log) => log,
         Err(_) => {
             return Err(GitAiError::Generic(

--- a/tests/integration/range_authorship_unit.rs
+++ b/tests/integration/range_authorship_unit.rs
@@ -1033,3 +1033,166 @@ fn test_range_authorship_with_glob_patterns() {
     assert_eq!(stats.range_stats.git_diff_added_lines, 1);
     assert_eq!(stats.range_stats.ai_additions, 1);
 }
+
+/// Regression guard for the `git-ai stats` range-mode speedup: the batched
+/// `read_authorship_v3_batch` (which resolves many commits' authorship notes in one
+/// `cat-file --batch` instead of a `git notes show` per commit) MUST return exactly
+/// what the per-commit `read_authorship_v3(..).ok()` path returns for every commit —
+/// including commits with a note, commits without one, and non-existent commits.
+#[test]
+fn test_read_authorship_v3_batch_matches_per_commit() {
+    use git_ai::git::notes_api::{read_authorship_v3, read_authorship_v3_batch};
+
+    let repo = TestRepo::new();
+
+    // Commit 1: AI work -> gets an authorship note.
+    std::fs::write(repo.path().join("a.txt"), "AI line 1\n").unwrap();
+    repo.git(&["add", "a.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+    repo.stage_all_and_commit("AI commit").unwrap();
+
+    // Commit 2: known-human work -> gets an authorship note.
+    std::fs::write(repo.path().join("a.txt"), "AI line 1\nHuman line 2\n").unwrap();
+    repo.git(&["add", "a.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "a.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Human commit").unwrap();
+
+    // Commit 3: untracked edit with NO checkpoint -> no authorship note.
+    std::fs::write(
+        repo.path().join("a.txt"),
+        "AI line 1\nHuman line 2\nUntracked line 3\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("Untracked commit").unwrap();
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+
+    // Every commit in history, plus a well-formed but non-existent SHA to force the
+    // "no note" path even though all real commits here happen to have content.
+    let mut shas: Vec<String> = repo
+        .git_og(&["rev-list", "HEAD"])
+        .unwrap()
+        .lines()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect();
+    shas.push("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string());
+
+    let batch = read_authorship_v3_batch(&gitai_repo, &shas);
+
+    // The map must contain an entry for every requested commit.
+    assert_eq!(
+        batch.len(),
+        shas.len(),
+        "batch must return an entry per requested commit"
+    );
+
+    let mut with_note = 0usize;
+    let mut without_note = 0usize;
+    for sha in &shas {
+        let per_commit = read_authorship_v3(&gitai_repo, sha).ok();
+        let batched = batch.get(sha).cloned().flatten();
+        assert_eq!(
+            batched, per_commit,
+            "batched read diverged from per-commit read for {sha}"
+        );
+        match per_commit {
+            Some(_) => with_note += 1,
+            None => without_note += 1,
+        }
+    }
+
+    // Make sure the test actually exercised both branches; otherwise it could pass
+    // trivially if, say, no notes were ever written.
+    assert!(
+        with_note >= 2,
+        "expected >=2 commits with notes, got {with_note}"
+    );
+    assert!(
+        without_note >= 1,
+        "expected >=1 commit without a note, got {without_note}"
+    );
+
+    // Coverage note: this exercises the GitNotes-batched path, the only path that does
+    // anything different from the per-commit read. The `Http` arm and the batched-read
+    // error fallback both delegate per commit to `read_authorship_v3(repo, sha).ok()`,
+    // so they equal the reference by construction.
+}
+
+/// The empty-commit-list fast path returns an empty map (and spawns no git).
+#[test]
+fn test_read_authorship_v3_batch_empty_input() {
+    use git_ai::git::notes_api::read_authorship_v3_batch;
+
+    let repo = TestRepo::new();
+    std::fs::write(repo.path().join("a.txt"), "x\n").unwrap();
+    repo.git(&["add", "a.txt"]).unwrap();
+    repo.stage_all_and_commit("init").unwrap();
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let out = read_authorship_v3_batch(&gitai_repo, &[]);
+    assert!(out.is_empty(), "empty input must yield an empty map");
+}
+
+/// Direct regression guard for the `skip_human_author_population` gate: a `blame()`
+/// over the stats path must return identical `line_authors` and `prompt_records`
+/// whether or not the `populate_ai_human_authors` pass runs. This is the automated
+/// proof of the "skipping the dead pass is output-invariant" claim.
+#[test]
+fn test_skip_human_author_population_preserves_blame_output() {
+    use git_ai::commands::blame::GitAiBlameOptions;
+    use std::collections::BTreeSet;
+
+    let repo = TestRepo::new();
+
+    // A file whose final state blends human and AI lines across several commits, so
+    // blame attributes multiple commits/authors to it.
+    std::fs::write(repo.path().join("f.txt"), "human 1\n").unwrap();
+    repo.git(&["add", "f.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "f.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("c1 human").unwrap();
+
+    std::fs::write(repo.path().join("f.txt"), "human 1\nai 2\nai 3\n").unwrap();
+    repo.git(&["add", "f.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "f.txt"]).unwrap();
+    repo.stage_all_and_commit("c2 ai").unwrap();
+
+    std::fs::write(repo.path().join("f.txt"), "human 1\nai 2\nai 3\nhuman 4\n").unwrap();
+    repo.git(&["add", "f.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "f.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("c3 human").unwrap();
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+
+    // Whole-file blame (empty line_ranges => whole file) on the no_output programmatic
+    // path the stats callers use.
+    let opts_off = GitAiBlameOptions {
+        no_output: true,
+        use_prompt_hashes_as_names: true,
+        ..Default::default()
+    };
+    let opts_on = GitAiBlameOptions {
+        skip_human_author_population: true,
+        ..opts_off.clone()
+    };
+
+    let (authors_off, prompts_off) = gitai_repo.blame("f.txt", &opts_off).unwrap();
+    let (authors_on, prompts_on) = gitai_repo.blame("f.txt", &opts_on).unwrap();
+
+    assert!(
+        !authors_off.is_empty(),
+        "expected blame to attribute at least one line"
+    );
+    assert_eq!(
+        authors_off, authors_on,
+        "skip_human_author_population changed blame line authors"
+    );
+    assert_eq!(
+        prompts_off.keys().collect::<BTreeSet<_>>(),
+        prompts_on.keys().collect::<BTreeSet<_>>(),
+        "skip_human_author_population changed the blame prompt records"
+    );
+}


### PR DESCRIPTION
## Summary

Makes `git-ai stats <a>..<b>` (range mode) faster — **~1.7× on a 100-commit range up to ~2.5× on a 1000-commit range** — by removing redundant git-subprocess fan-out in the blame path. `range_stats` output is byte-identical.

Profiling (release build, real repo) showed the cost is **git subprocesses, not SQLite** — the default `GitNotes` backend touches **0 ms of SQLite** on this path, so a #1630-style index would not help `git-ai stats`. The range path blames every changed file **three times** (`diff_ai_accepted_stats` + start/end `VirtualAttributions`), and each blame re-read every blamed commit's authorship note with a separate `git notes --ref=ai show` — thousands of per-commit note spawns, uncached across files and passes.

## Changes (both output-preserving)

1. **Batch the note reads.** New `notes_api::read_authorship_v3_batch` resolves many commits' notes with one `git ls-tree` + `cat-file --batch` (via `refs::notes_for_commits`) instead of one `git notes show` per commit. It returns exactly what `read_authorship_v3(repo, sha).ok()` yields per commit — the v3 parse is factored into `refs::parse_reference_as_authorship_log_v3` and shared by both paths, and the `Http` backend delegates per commit to preserve its cache-hit semantics. Both blame overlays (`overlay_ai_authorship`, `populate_ai_human_authors`) pre-seed their existing per-commit cache from one batched read.
2. **Skip dead work on the stats path.** `blame()` with `no_output` discards the blame hunks, so the `populate_ai_human_authors` pass that annotates them with `ai_human_author` (a second per-commit note read) is wasted there. Adds `GitAiBlameOptions::skip_human_author_population` (default `false`, debug-asserted to only be set on `no_output` paths) and sets it on the two stats blame call sites. It is output-invariant because `overlay_ai_authorship` derives `line_authors` per line independently of hunk grouping.

## Performance (release build, real repo, same-run A/B, `range_stats` byte-identical)

The speedup grows with range size because it eliminates per-commit note fan-out, which scales with the number of blamed commits:

| command | baseline (same run) | optimized | speedup |
|---|---|---|---|
| `git-ai stats HEAD~100..HEAD` | 69.0 s (noisy: 69–93 s across runs) | 40.0 s | ~1.7× |
| `git-ai stats HEAD~1000..HEAD` | 272.3 s | 110.2 s | ~2.5× |

Under a subprocess-counting harness on `HEAD~100..HEAD`, per-commit `git notes show` collapses from ~7,200 to ~50 (the remainder shifts into batched `cat-file`/`ls-tree`); total git spawns ~14.5k → ~9.3k same-harness. (Exact spawn totals are method-sensitive; the `notes show` collapse and the wall-time deltas are the robust figures.)

## Validation

- `task fmt`, `task lint` (clippy `-D warnings`), full `task test` — green.
- Same-run A/B byte-identical check of `range_stats` on real data across 100- and 1000-commit ranges (range_1000 = 120,390 AI lines across 32 tool/model combos — identical before/after).
- Regression tests: batched read ≡ per-commit read (commits with notes, without notes, non-existent); empty-input fast path; and skip-dead-pass gate output-invariance (blame line authors identical with the pass on vs off).
- Two independent adversarial reviews (the batching, and the skip-dead-pass gate) — no blockers. Documented parity boundary: on GitNotes the batched read decodes note blobs with `from_utf8_lossy` (matching the existing `CommitAuthorship` path) vs the per-commit strict decode — unreachable for real notes (always valid UTF-8 JSON). The `Http` and batch-error fallback arms delegate per commit to the existing reader (equivalent by construction; not exercised by tests).

## Note

The #1630 index pattern still applies — just to a different command, `git-ai usage` (`MetricsDatabase::get_metric_history` is a full-table scan that deserializes every row). Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
