### PR TITLE
[codex] Fix stale pending rebase note rewrite

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1333,6 +1333,10 @@ fn rebase_new_tip_from_command(
         return Some(new_tip);
     }
 
+    if !rebase_is_control_mode(cmd) {
+        return None;
+    }
+
     let branch_ref_names = cmd
         .ref_changes
         .iter()
@@ -4060,12 +4064,10 @@ impl ActorDaemonCoordinator {
         // with the branch ref update as new_tip. This handles rebase --skip/--continue
         // where HEAD can contain extra checkout/detach movement that is not the
         // rebased branch tip.
-        if let Some((original_head, stored_onto)) = pending_original_head {
-            let new_tip = rebase_new_tip_from_command(cmd, &original_head);
-            if let Some(new_tip) = new_tip
-                && original_head != new_tip
-                && !is_ancestor_commit(&repo, &original_head, &new_tip)
-            {
+        if let Some((original_head, stored_onto)) = pending_original_head
+            && let Some(new_tip) = rebase_new_tip_from_command(cmd, &original_head)
+        {
+            if original_head != new_tip && !is_ancestor_commit(&repo, &original_head, &new_tip) {
                 let command_rebase_onto =
                     rebase_onto_from_command(cmd, &repo, &original_head, &new_tip);
                 let rebase_onto = stored_onto

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -786,6 +786,60 @@ fn test_rebase_patch_stack() {
     topic3_file.assert_lines_and_blame(crate::lines!["// AI topic 3".ai()]);
 }
 
+#[test]
+fn test_rebase_ignores_stale_pending_state_from_untraced_abort() {
+    let repo = TestRepo::new();
+
+    let mut stale_file = repo.filename("stale-conflict.txt");
+    stale_file.set_contents(crate::lines!["base"]);
+    let base_commit = repo.stage_all_and_commit("base").unwrap().commit_sha;
+    stale_file.assert_committed_lines(crate::lines!["base".human()]);
+
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "stale-topic"]).unwrap();
+    stale_file.replace_at(0, "stale side".ai());
+    let stale_tip = repo.stage_all_and_commit("stale topic").unwrap().commit_sha;
+    stale_file.assert_committed_lines(crate::lines!["stale side".ai()]);
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    stale_file.replace_at(0, "main side".human());
+    repo.stage_all_and_commit("main side").unwrap();
+    stale_file.assert_committed_lines(crate::lines!["main side".human()]);
+
+    repo.git(&["checkout", "stale-topic"]).unwrap();
+    let failed_rebase = repo.git(&["rebase", &default_branch]);
+    assert!(
+        failed_rebase.is_err(),
+        "stale-topic rebase should stop on the conflict that seeds pending daemon state"
+    );
+    repo.sync_daemon();
+
+    repo.git_og_with_env(&["rebase", "--abort"], &[("GIT_TRACE2_EVENT", "0")])
+        .expect("untraced rebase abort should restore Git state without clearing daemon memory");
+    let after_abort = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_eq!(after_abort, stale_tip);
+    stale_file.assert_committed_lines(crate::lines!["stale side".ai()]);
+
+    repo.git(&["checkout", "-b", "feature", &base_commit])
+        .unwrap();
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.set_contents(crate::lines!["feature ai".ai()]);
+    let original_feature = repo.stage_all_and_commit("feature ai").unwrap().commit_sha;
+    feature_file.assert_committed_lines(crate::lines!["feature ai".ai()]);
+    assert!(
+        repo.read_authorship_note(&original_feature).is_some(),
+        "original feature commit should have an authorship note before rebase"
+    );
+
+    repo.git(&["rebase", &default_branch])
+        .expect("ordinary feature rebase should succeed");
+    let rebased_feature = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(rebased_feature, original_feature);
+
+    feature_file.assert_lines_and_blame(crate::lines!["feature ai".ai()]);
+}
+
 /// Test rebase with no changes (already up to date)
 #[test]
 fn test_rebase_already_up_to_date() {


### PR DESCRIPTION
## Summary

Fix a daemon rebase note-rewrite bug where stale pending rebase state could override the actual branch ref transition for a later normal rebase.

## Root Cause

`detect_and_handle_non_ff_rewrites` consumed pending rebase state before handling explicit branch ref changes. For a normal successful rebase, `rebase_new_tip_from_command` could infer a new tip from the only changed branch ref even when that branch did not match the pending original head. That sent an unrelated old tip into range-diff and could synthesize very large bogus target notes.

## Changes

- Require normal rebase pending-state handling to match a branch ref whose old OID equals the pending original head.
- Restrict broader new-tip fallback inference to rebase control mode (`--continue` / `--skip`).
- Add a focused daemon regression that seeds stale pending state and verifies the actual feature branch note is preserved after a normal rebase branch transition.

## Validation

- `task fmt`
- `task lint`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=stale_pending_rebase_state_does_not_override_normal_rebase_branch_ref_change NO_CAPTURE=true`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=rebase NO_CAPTURE=true`
- `task test TEST_FILTER=test_rebase_metadata_only_notes_survive_slow_path NO_CAPTURE=true`