### PR TITLE
[codex] Fix stale deferred rewrite state

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1877,6 +1877,72 @@ fn apply_cherry_pick_no_commit_rewrite(
     crate::authorship::rewrite::shift_authorship_notes_merging_existing(repo, &mappings)
 }
 
+fn added_content_keys_between(
+    repo: &crate::git::repository::Repository,
+    from: &str,
+    to: &str,
+) -> Result<HashSet<(String, String)>, GitAiError> {
+    let hunks = crate::commands::diff::get_diff_with_line_numbers(repo, from, to)?;
+    let mut keys = HashSet::new();
+    for hunk in hunks {
+        for content in hunk.added_contents {
+            keys.insert((hunk.file_path.clone(), content));
+        }
+    }
+    Ok(keys)
+}
+
+fn first_parent_or_empty_tree(
+    repo: &crate::git::repository::Repository,
+    commit_sha: &str,
+) -> Result<String, GitAiError> {
+    let commit = repo.revparse_single(commit_sha)?.peel_to_commit()?;
+    if commit.parent_count()? == 0 {
+        Ok("4b825dc642cb6eb9a060e54bf8d69288fbee4904".to_string())
+    } else {
+        Ok(commit.parent(0)?.id())
+    }
+}
+
+fn source_added_content_overlaps_target(
+    source_keys: &HashSet<(String, String)>,
+    target_keys: &HashSet<(String, String)>,
+) -> bool {
+    !source_keys.is_empty() && source_keys.iter().any(|key| target_keys.contains(key))
+}
+
+fn squash_merge_source_content_present_in_commit(
+    repo: &crate::git::repository::Repository,
+    onto: &str,
+    source_head: &str,
+    squash_commit: &str,
+) -> Result<bool, GitAiError> {
+    let source_keys = added_content_keys_between(repo, onto, source_head)?;
+    let target_keys = added_content_keys_between(repo, onto, squash_commit)?;
+    Ok(source_added_content_overlaps_target(
+        &source_keys,
+        &target_keys,
+    ))
+}
+
+fn cherry_pick_no_commit_source_content_present_in_commit(
+    repo: &crate::git::repository::Repository,
+    sources: &[String],
+    head: &str,
+    commit_sha: &str,
+) -> Result<bool, GitAiError> {
+    let mut source_keys = HashSet::new();
+    for source in sources {
+        let parent = first_parent_or_empty_tree(repo, source)?;
+        source_keys.extend(added_content_keys_between(repo, &parent, source)?);
+    }
+    let target_keys = added_content_keys_between(repo, head, commit_sha)?;
+    Ok(source_added_content_overlaps_target(
+        &source_keys,
+        &target_keys,
+    ))
+}
+
 fn strict_rebase_original_head_from_command(
     cmd: &crate::daemon::domain::NormalizedCommand,
     semantic_old_head: &str,
@@ -5085,20 +5151,6 @@ impl ActorDaemonCoordinator {
                     }
                     crate::daemon::domain::SemanticEvent::CommitCreated { base, new_head } => {
                         let mut handled_as_squash_merge = false;
-                        // DEFERRED (code-review #4): a pending `merge --squash` is
-                        // matched to the next commit by `base == pending.onto`
-                        // alone. If the user ABORTS the squash (e.g. `git reset
-                        // --hard` / `git checkout -- .`) and later makes an
-                        // unrelated commit on the same base, that commit is
-                        // mistaken for the squash and the source ref's session
-                        // metadata leaks into its note (inflating `git-ai stats`;
-                        // line-level blame stays correct). A robust fix is
-                        // non-trivial: the abandon commands (reset/checkout) are
-                        // not currently sequenced into this side-effect layer, so
-                        // we cannot clear the pending state on abort here, and a
-                        // metadata-prune alternative collides with the intentional
-                        // prompt-only-note feature. Left as-is pending one of
-                        // those two mechanisms.
                         if !new_head.is_empty()
                             && cmd.primary_command.as_deref() == Some("commit")
                             && let Some(pending) =
@@ -5106,21 +5158,37 @@ impl ActorDaemonCoordinator {
                         {
                             if base.as_deref().is_some_and(|base| base == pending.onto) {
                                 let repo = find_repository_in_path(&worktree)?;
-                                crate::authorship::rewrite::handle_rewrite_event(
+                                if squash_merge_source_content_present_in_commit(
                                     &repo,
-                                    crate::authorship::rewrite::RewriteEvent::SquashMerge {
-                                        source_head: pending.source_head,
-                                        squash_commit: new_head.clone(),
-                                        onto: pending.onto,
-                                    },
-                                )?;
-                                handled_as_squash_merge = true;
+                                    &pending.onto,
+                                    &pending.source_head,
+                                    new_head,
+                                )? {
+                                    crate::authorship::rewrite::handle_rewrite_event(
+                                        &repo,
+                                        crate::authorship::rewrite::RewriteEvent::SquashMerge {
+                                            source_head: pending.source_head,
+                                            squash_commit: new_head.clone(),
+                                            onto: pending.onto,
+                                        },
+                                    )?;
+                                    handled_as_squash_merge = true;
+                                } else {
+                                    tracing::debug!(
+                                        commit = %new_head,
+                                        source_head = %pending.source_head,
+                                        onto = %pending.onto,
+                                        "dropping stale pending squash merge state"
+                                    );
+                                }
                             } else {
-                                self.set_pending_squash_merge_for_worktree(
-                                    worktree.as_ref(),
-                                    pending.source_head,
-                                    pending.onto,
-                                )?;
+                                tracing::debug!(
+                                    commit = %new_head,
+                                    base = ?base,
+                                    source_head = %pending.source_head,
+                                    onto = %pending.onto,
+                                    "dropping pending squash merge state after non-matching commit"
+                                );
                             }
                         }
 
@@ -5173,17 +5241,33 @@ impl ActorDaemonCoordinator {
                                     )?
                             {
                                 if base.as_deref().is_some_and(|base| base == pending.head) {
-                                    apply_cherry_pick_no_commit_rewrite(
+                                    if cherry_pick_no_commit_source_content_present_in_commit(
                                         &repo,
                                         &pending.source_commits,
+                                        &pending.head,
                                         new_head,
-                                    )?;
+                                    )? {
+                                        apply_cherry_pick_no_commit_rewrite(
+                                            &repo,
+                                            &pending.source_commits,
+                                            new_head,
+                                        )?;
+                                    } else {
+                                        tracing::debug!(
+                                            commit = %new_head,
+                                            head = %pending.head,
+                                            sources = ?pending.source_commits,
+                                            "dropping stale pending cherry-pick --no-commit state"
+                                        );
+                                    }
                                 } else {
-                                    self.set_pending_cherry_pick_no_commit_for_worktree(
-                                        worktree.as_ref(),
-                                        pending.source_commits,
-                                        pending.head,
-                                    )?;
+                                    tracing::debug!(
+                                        commit = %new_head,
+                                        base = ?base,
+                                        head = %pending.head,
+                                        sources = ?pending.source_commits,
+                                        "dropping pending cherry-pick --no-commit state after non-matching commit"
+                                    );
                                 }
                             }
                         }

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -1223,6 +1223,66 @@ fn test_cherry_pick_no_commit_defers_to_final_commit_tree() {
     ]);
 }
 
+#[test]
+fn test_cherry_pick_no_commit_abandon_does_not_affect_later_unrelated_commit() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("file.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&file_path, "base\nAI picked line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "file.txt"]).unwrap();
+    repo.stage_all_and_commit("ai source").unwrap();
+    let source_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI picked line".ai(),
+    ]);
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    repo.git(&["cherry-pick", "--no-commit", &source_commit])
+        .unwrap();
+    repo.git_og_with_env(&["reset", "--hard"], &[("GIT_TRACE2_EVENT", "0")])
+        .unwrap();
+
+    fs::write(&file_path, "base\nunrelated human line\n").unwrap();
+    repo.git(&["add", "file.txt"]).unwrap();
+    let unrelated_commit = repo
+        .commit("unrelated commit after abandoned no-commit cherry-pick")
+        .unwrap();
+
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "unrelated human line".unattributed_human(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.ai_additions, 0,
+        "unrelated commit must not inherit AI stats"
+    );
+    assert_eq!(
+        stats.ai_accepted, 0,
+        "unrelated commit must not inherit AI lines"
+    );
+    if let Some(note) = repo.read_authorship_note(&unrelated_commit.commit_sha) {
+        let log = AuthorshipLog::deserialize_from_string(&note).expect("parse unrelated note");
+        assert!(
+            log.metadata.sessions.is_empty(),
+            "unrelated commit must not inherit cherry-pick session metadata"
+        );
+        assert!(
+            log.metadata.prompts.is_empty(),
+            "unrelated commit must not inherit cherry-pick prompt metadata"
+        );
+    }
+}
+
 crate::reuse_tests_in_worktree!(
     test_single_commit_cherry_pick,
     test_cherry_pick_preserves_human_only_commit_note_metadata,
@@ -1239,6 +1299,7 @@ crate::reuse_tests_in_worktree!(
     test_cherry_pick_from_remote_without_prefetched_notes,
     test_cherry_pick_from_remote_reports_notes_import_failure,
     test_cherry_pick_no_commit_defers_to_final_commit_tree,
+    test_cherry_pick_no_commit_abandon_does_not_affect_later_unrelated_commit,
     test_cherry_pick_skip_failed_next_conflict_advances_pending_remote_tracking_source,
     test_cherry_pick_skip_failed_next_conflict_does_not_double_skip_refcursor_sources,
 );

--- a/tests/integration/squash_merge.rs
+++ b/tests/integration/squash_merge.rs
@@ -2,6 +2,7 @@ use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use std::collections::HashMap;
+use std::fs;
 
 fn deterministic_commit_env(timestamp: &'static str) -> [(&'static str, &'static str); 2] {
     [
@@ -568,6 +569,64 @@ fn test_prepare_working_log_squash_multiple_sessions_standard_human() {
     );
 }
 
+#[test]
+fn test_abandoned_squash_merge_does_not_affect_later_unrelated_commit() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("file.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&file_path, "base\nAI squash line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "file.txt"]).unwrap();
+    repo.stage_all_and_commit("ai source").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI squash line".ai(),
+    ]);
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    repo.git_og_with_env(&["reset", "--hard"], &[("GIT_TRACE2_EVENT", "0")])
+        .unwrap();
+
+    fs::write(&file_path, "base\nunrelated human line\n").unwrap();
+    repo.git(&["add", "file.txt"]).unwrap();
+    let unrelated_commit = repo
+        .commit("unrelated commit after abandoned squash")
+        .unwrap();
+
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "unrelated human line".unattributed_human(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(
+        stats.ai_additions, 0,
+        "unrelated commit must not inherit AI stats"
+    );
+    assert_eq!(
+        stats.ai_accepted, 0,
+        "unrelated commit must not inherit AI lines"
+    );
+    if let Some(note) = repo.read_authorship_note(&unrelated_commit.commit_sha) {
+        let log = AuthorshipLog::deserialize_from_string(&note).expect("parse unrelated note");
+        assert!(
+            log.metadata.sessions.is_empty(),
+            "unrelated commit must not inherit squash session metadata"
+        );
+        assert!(
+            log.metadata.prompts.is_empty(),
+            "unrelated commit must not inherit squash prompt metadata"
+        );
+    }
+}
+
 crate::reuse_tests_in_worktree!(
     test_prepare_working_log_simple_squash,
     test_prepare_working_log_squash_with_main_changes,
@@ -575,4 +634,5 @@ crate::reuse_tests_in_worktree!(
     test_prepare_working_log_squash_with_mixed_additions,
     test_prepare_working_log_squash_with_main_changes_standard_human,
     test_prepare_working_log_squash_multiple_sessions_standard_human,
+    test_abandoned_squash_merge_does_not_affect_later_unrelated_commit,
 );


### PR DESCRIPTION
## Summary

Fix stale deferred rewrite state for operations that apply changes now and consume attribution on a later `git commit`.

- Add RED `TestRepo` regressions for abandoned `cherry-pick --no-commit` and abandoned `merge --squash` followed by an unrelated commit from the same base.
- Guard pending squash/no-commit cherry-pick consumption by requiring source added content to overlap the final commit's added content.
- Drop stale or base-mismatched pending state instead of reusing it for an unrelated commit.

## Root Cause

`merge --squash` and `cherry-pick --no-commit` stored worktree-scoped pending state and later consumed it on `git commit` using only a weak base match. If the actual operation was abandoned without a traced daemon event, a later unrelated commit from that same base could inherit stale source session metadata.

## Validation

RED checks before the fix:

- `task test TEST_FILTER=test_cherry_pick_no_commit_abandon_does_not_affect_later_unrelated_commit NO_CAPTURE=true` failed on stale cherry-pick session metadata.
- `task test TEST_FILTER=test_abandoned_squash_merge_does_not_affect_later_unrelated_commit NO_CAPTURE=true` failed on stale squash session metadata.

GREEN checks after the fix:

- `task fmt`
- `task lint`
- `task test TEST_FILTER=test_cherry_pick_no_commit_abandon_does_not_affect_later_unrelated_commit NO_CAPTURE=true`
- `task test TEST_FILTER=test_abandoned_squash_merge_does_not_affect_later_unrelated_commit NO_CAPTURE=true`
- `task test TEST_FILTER=test_cherry_pick_no_commit_defers_to_final_commit_tree NO_CAPTURE=true`
- `task test TEST_FILTER=test_prepare_working_log_simple_squash NO_CAPTURE=true`
- `task test TEST_FILTER=cherry_pick:: NO_CAPTURE=true`
- `task test TEST_FILTER=squash_merge:: NO_CAPTURE=true`
- `task test`