### PR TITLE
Fix mixed EOL post-commit attribution

### DIFF
--- a/src/authorship/imara_diff_utils.rs
+++ b/src/authorship/imara_diff_utils.rs
@@ -264,6 +264,19 @@ pub(crate) fn normalize_line_endings(s: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(s.replace("\r\n", "\n"))
 }
 
+/// Compare two strings while treating CRLF and LF line endings as equivalent.
+pub(crate) fn content_eq_ignoring_line_endings(a: &str, b: &str) -> bool {
+    a == b || normalize_line_endings(a) == normalize_line_endings(b)
+}
+
+/// Split content into terminator-preserving lines normalized for CRLF/LF comparisons.
+pub(crate) fn split_lines_normalized_terminators(s: &str) -> Vec<std::borrow::Cow<'_, str>> {
+    split_lines_with_terminators(s)
+        .into_iter()
+        .map(normalize_line_endings)
+        .collect()
+}
+
 /// Splits a string into lines, preserving line terminators.
 fn split_lines_with_terminators(s: &str) -> Vec<&str> {
     let mut lines = Vec::new();

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -4,6 +4,9 @@ use crate::authorship::attribution_tracker::{
 };
 use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord, SessionRecord};
 use crate::authorship::hunk_shift::{DiffHunk, apply_hunk_shifts_to_line_attributions};
+use crate::authorship::imara_diff_utils::{
+    content_eq_ignoring_line_endings, split_lines_normalized_terminators,
+};
 use crate::authorship::working_log::CheckpointKind;
 use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
 use crate::error::GitAiError;
@@ -1386,12 +1389,12 @@ fn collect_unstaged_hunks_from_snapshot(
             .cloned()
             .unwrap_or_else(|| committed_content.clone());
 
-        if committed_content == final_content {
+        if content_eq_ignoring_line_endings(&committed_content, &final_content) {
             continue;
         }
 
-        let committed_lines = split_lines_preserving_terminators(&committed_content);
-        let final_lines = split_lines_preserving_terminators(&final_content);
+        let committed_lines = split_lines_normalized_terminators(&committed_content);
+        let final_lines = split_lines_normalized_terminators(&final_content);
         let diff_ops = crate::authorship::imara_diff_utils::capture_diff_slices(
             &committed_lines,
             &final_lines,
@@ -1460,8 +1463,8 @@ fn split_lines_preserving_terminators(s: &str) -> Vec<&str> {
 }
 
 fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
-    let old_lines = split_lines_preserving_terminators(old_content);
-    let new_lines = split_lines_preserving_terminators(new_content);
+    let old_lines = split_lines_normalized_terminators(old_content);
+    let new_lines = split_lines_normalized_terminators(new_content);
     crate::authorship::imara_diff_utils::capture_diff_slices(&old_lines, &new_lines)
         .into_iter()
         .filter_map(|op| match op {
@@ -1502,13 +1505,13 @@ fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<Diff
 }
 
 fn line_sequence_contains(needle: &str, haystack: &str) -> bool {
-    let needle_lines = split_lines_preserving_terminators(needle);
+    let needle_lines = split_lines_normalized_terminators(needle);
     if needle_lines.is_empty() {
         return true;
     }
 
     let mut next_needle = 0;
-    for haystack_line in split_lines_preserving_terminators(haystack) {
+    for haystack_line in split_lines_normalized_terminators(haystack) {
         if haystack_line == needle_lines[next_needle] {
             next_needle += 1;
             if next_needle == needle_lines.len() {
@@ -1529,16 +1532,19 @@ fn merged_carryover_content_pure(
     if committed_content == observed_content {
         return observed_content.to_string();
     }
+    if content_eq_ignoring_line_endings(committed_content, observed_content) {
+        return committed_content.to_string();
+    }
     if line_sequence_contains(committed_content, observed_content) {
         return observed_content.to_string();
     }
     if line_sequence_contains(observed_content, committed_content) {
         return committed_content.to_string();
     }
-    if committed_content == parent_content {
+    if content_eq_ignoring_line_endings(committed_content, parent_content) {
         return observed_content.to_string();
     }
-    if observed_content == parent_content {
+    if content_eq_ignoring_line_endings(observed_content, parent_content) {
         return committed_content.to_string();
     }
     carryover_merge_content(parent_content, committed_content, observed_content)
@@ -1559,21 +1565,31 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
     if committed == observed {
         return observed.to_string();
     }
-    if parent == committed {
+    if content_eq_ignoring_line_endings(committed, observed) {
+        return committed.to_string();
+    }
+    if content_eq_ignoring_line_endings(parent, committed) {
         return observed.to_string();
     }
-    if parent == observed {
+    if content_eq_ignoring_line_endings(parent, observed) {
         return committed.to_string();
     }
 
     let base_lines = split_lines_preserving_terminators(parent);
     let committed_lines = split_lines_preserving_terminators(committed);
     let observed_lines = split_lines_preserving_terminators(observed);
+    let base_cmp_lines = split_lines_normalized_terminators(parent);
+    let committed_cmp_lines = split_lines_normalized_terminators(committed);
+    let observed_cmp_lines = split_lines_normalized_terminators(observed);
 
     // For each side, map every base line index to its aligned index on that
     // side (None if the base line was changed/deleted on that side). Also record
     // each side's content so we can emit it for changed chunks.
-    fn align_to_base(base_len: usize, base: &[&str], side: &[&str]) -> Vec<Option<usize>> {
+    fn align_to_base<T: std::hash::Hash + Eq + Clone>(
+        base: &[T],
+        side: &[T],
+    ) -> Vec<Option<usize>> {
+        let base_len = base.len();
         let mut map = vec![None; base_len];
         for op in capture_diff_slices(base, side) {
             if let DiffOp::Equal {
@@ -1590,8 +1606,8 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
         map
     }
 
-    let committed_map = align_to_base(base_lines.len(), &base_lines, &committed_lines);
-    let observed_map = align_to_base(base_lines.len(), &base_lines, &observed_lines);
+    let committed_map = align_to_base(&base_cmp_lines, &committed_cmp_lines);
+    let observed_map = align_to_base(&base_cmp_lines, &observed_cmp_lines);
 
     // A base line is "stable" when both sides keep it aligned (unchanged on
     // both). We walk base lines; runs of stable lines are emitted verbatim,
@@ -3653,6 +3669,19 @@ mod tests {
             carryover_merge_content(parent, committed, observed),
             "a\nB\n"
         );
+    }
+
+    #[test]
+    fn carryover_merge_ignores_mixed_eol_when_content_matches_committed() {
+        let parent = "base one\nbase two\n";
+        let committed = "base one\nbase two\nai line\n";
+        let observed = "base one\r\nbase two\r\nai line\n";
+
+        assert_eq!(
+            merged_carryover_content_pure(parent, committed, observed),
+            committed
+        );
+        assert!(diff_hunks_between_contents(observed, committed).is_empty());
     }
 
     /// Differential test: the in-memory carryover merge must agree with real

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1652,7 +1652,9 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
             // Resolve pending region: if both sides inserted differing content,
             // favor observed; else take whichever inserted.
             if !c_pending.is_empty() && !o_pending.is_empty() {
-                if c_pending == o_pending {
+                if committed_cmp_lines[committed_i..c_anchor]
+                    == observed_cmp_lines[observed_i..o_anchor]
+                {
                     result.extend(c_pending);
                 } else {
                     result.extend(o_pending);
@@ -1697,8 +1699,11 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
                 .iter()
                 .map(|s| (*s).to_string())
                 .collect();
-            let committed_changed = committed_chunk != base_chunk;
-            let observed_changed = observed_chunk != base_chunk;
+            let base_cmp_chunk = &base_cmp_lines[chunk_base_start..base_i];
+            let committed_cmp_chunk = &committed_cmp_lines[committed_i..c_anchor];
+            let observed_cmp_chunk = &observed_cmp_lines[observed_i..o_anchor];
+            let committed_changed = committed_cmp_chunk != base_cmp_chunk;
+            let observed_changed = observed_cmp_chunk != base_cmp_chunk;
 
             match (committed_changed, observed_changed) {
                 (true, false) => result.extend(committed_chunk),
@@ -1706,7 +1711,7 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
                 (true, true) => {
                     // Two-sided change → favor observed (matches --theirs),
                     // unless both produced identical content.
-                    if committed_chunk == observed_chunk {
+                    if committed_cmp_chunk == observed_cmp_chunk {
                         result.extend(committed_chunk);
                     } else {
                         result.extend(observed_chunk);
@@ -1730,7 +1735,7 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
         .map(|s| (*s).to_string())
         .collect();
     if !c_tail.is_empty() && !o_tail.is_empty() {
-        if c_tail == o_tail {
+        if committed_cmp_lines[committed_i..] == observed_cmp_lines[observed_i..] {
             result.extend(c_tail);
         } else {
             result.extend(o_tail);
@@ -3682,6 +3687,18 @@ mod tests {
             committed
         );
         assert!(diff_hunks_between_contents(observed, committed).is_empty());
+    }
+
+    #[test]
+    fn carryover_merge_does_not_treat_crlf_only_observed_chunk_as_change() {
+        let parent = "a\nb\nc\n";
+        let committed = "A\nb\nC\n";
+        let observed = "a\r\nb\r\nD\r\n";
+
+        assert_eq!(
+            carryover_merge_content(parent, committed, observed),
+            "A\nb\nD\r\n"
+        );
     }
 
     /// Differential test: the in-memory carryover merge must agree with real

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -5,7 +5,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 #[cfg(not(any(test, feature = "test-support")))]
 use crate::authorship::authorship_log_serialization::generate_short_hash;
 use crate::authorship::imara_diff_utils::{
-    LineChangeTag, compute_line_changes, normalize_line_endings,
+    LineChangeTag, compute_line_changes, content_eq_ignoring_line_endings,
 };
 use crate::authorship::working_log::CheckpointKind;
 use crate::authorship::working_log::{Checkpoint, WorkingLogEntry};
@@ -524,14 +524,6 @@ fn get_previous_content_from_head(
     }
 }
 
-/// Compare file contents ignoring CRLF/LF differences.
-fn content_eq_normalized(a: &str, b: &str) -> bool {
-    if a == b {
-        return true;
-    }
-    normalize_line_endings(a) == normalize_line_endings(b)
-}
-
 #[doc(hidden)]
 pub fn is_ai_author_id(author_id: &str) -> bool {
     author_id != "human" && !author_id.starts_with("h_")
@@ -621,7 +613,7 @@ fn get_checkpoint_entry_for_file(
             get_previous_content_from_head(&repo, &file_path, head_tree_id.as_ref())
         };
 
-        if content_eq_normalized(&current_content, &previous_content) {
+        if content_eq_ignoring_line_endings(&current_content, &previous_content) {
             return Ok(None);
         }
 
@@ -651,7 +643,7 @@ fn get_checkpoint_entry_for_file(
 
         // Skip if no changes, UNLESS we have INITIAL attributions for this file
         // (in which case we need to create an entry to record those attributions)
-        if content_eq_normalized(&current_content, &previous_content)
+        if content_eq_ignoring_line_endings(&current_content, &previous_content)
             && initial_attrs_for_file.is_empty()
         {
             return Ok(None);
@@ -682,7 +674,7 @@ fn get_checkpoint_entry_for_file(
             let snapshot = initial_snapshot_content
                 .as_deref()
                 .unwrap_or(&previous_content);
-            if content_eq_normalized(snapshot, &current_content) {
+            if content_eq_ignoring_line_endings(snapshot, &current_content) {
                 &previous_content
             } else {
                 snapshot
@@ -743,7 +735,7 @@ fn get_checkpoint_entry_for_file(
 
     // Skip if no changes (but we already checked this earlier, accounting for INITIAL attributions)
     // For files from previous checkpoints, check if content has changed
-    if is_from_checkpoint && content_eq_normalized(&current_content, &previous_content) {
+    if is_from_checkpoint && content_eq_ignoring_line_endings(&current_content, &previous_content) {
         if current_content == previous_content {
             // Byte-identical — truly no change.
             return Ok(None);

--- a/tests/integration/post_commit_unit.rs
+++ b/tests/integration/post_commit_unit.rs
@@ -1,3 +1,4 @@
+use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 
@@ -35,6 +36,49 @@ fn test_post_commit_empty_repo_with_checkpoint() {
         note_result.is_some(),
         "post_commit should handle empty repo without errors"
     );
+}
+
+#[test]
+fn test_post_commit_preserves_ai_attribution_for_mixed_eol_worktree() {
+    let repo = TestRepo::new();
+    repo.git(&["config", "core.autocrlf", "true"]).unwrap();
+
+    let file_path = repo.path().join("eol.txt");
+    std::fs::write(&file_path, b"base one\r\nbase two\r\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    repo.git_ai(&["checkpoint", "human", "eol.txt"]).unwrap();
+
+    // Reproduce the Windows failure mode: existing checkout lines are CRLF, but
+    // the AI append writes LF, so the working tree becomes mixed while Git stores
+    // the committed blob as LF.
+    std::fs::write(&file_path, b"base one\r\nbase two\r\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "eol.txt"])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("AI mixed eol edit").unwrap();
+
+    let mut file = repo.filename("eol.txt");
+    file.assert_committed_lines(lines![
+        "base one".unattributed_human(),
+        "base two".unattributed_human(),
+        "ai line".ai(),
+    ]);
+
+    let initial_path = repo
+        .path()
+        .join(".git")
+        .join("ai")
+        .join("working_logs")
+        .join(commit.commit_sha)
+        .join("INITIAL");
+    if initial_path.exists() {
+        let initial = std::fs::read_to_string(initial_path).unwrap();
+        assert!(
+            !initial.contains("eol.txt"),
+            "mixed EOL normalization should not carry committed lines into INITIAL: {initial}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Normalize line terminators during post-commit virtual attribution comparisons
- Avoid treating CRLF-vs-LF-only differences as unstaged/carryover changes
- Centralize CRLF/LF content comparison helpers for checkpoint and virtual attribution paths
- Add mixed-EOL regression coverage for Windows/autocrlf workflows

## Tests
- Not run in this session: `cargo` is not available in the current environment.
- `git diff --check`

Historical validation before this branch cleanup:
- `cargo test carryover_merge_ignores_mixed_eol_when_content_matches_committed`
- `cargo test --test integration test_post_commit_preserves_ai_attribution_for_mixed_eol_worktree`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads 12` (Docker rust:1.93.0, non-root)