### PR TITLE
feat(config): CLI coverage for allow_superuser, transcript lookback, custom_attributes

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -115,6 +115,11 @@ fn print_config_help() {
     println!("  include_prompts_in_repositories  Repos to include for prompt storage (array)");
     println!("  default_prompt_storage       Fallback storage mode for non-included repos");
     println!("  quiet                        Suppress chart output after commits (bool)");
+    println!("  allow_superuser              Allow running git-ai as root/superuser (bool)");
+    println!(
+        "  transcript_streaming_lookback_days  Days to look back when sweeping transcripts (0 = unlimited)"
+    );
+    println!("  custom_attributes            Custom telemetry attributes, string->string (object)");
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
     println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
     println!("  notes_backend.kind           Notes backend kind (git_notes/http)");
@@ -146,6 +151,10 @@ fn print_config_help() {
     println!("  git-ai config --add feature_flags.my_flag true");
     println!("  git-ai config --add git_ai_hooks.post_notes_updated \"./my-hook.sh\"");
     println!("  git-ai config set codex_hooks_format hooks_json");
+    println!("  git-ai config set allow_superuser true");
+    println!("  git-ai config set transcript_streaming_lookback_days 1");
+    println!("  git-ai config set custom_attributes '{{\"team\":\"platform\"}}'");
+    println!("  git-ai config --add custom_attributes.team platform");
     println!("  git-ai config unset exclude_repositories");
     println!();
     std::process::exit(0);
@@ -194,6 +203,7 @@ pub fn handle_config(args: &[String]) {
             }
             if key == "feature_flags.transcript_streaming"
                 || key == "feature_flags.transcript_sweep"
+                || key == "transcript_streaming_lookback_days"
             {
                 println!("Run `git-ai bg restart` for changes to take effect.");
             }
@@ -347,6 +357,29 @@ fn show_all_config() -> Result<(), String> {
         Value::String(runtime_config.codex_hooks_format().as_str().to_string()),
     );
 
+    effective_config.insert(
+        "allow_superuser".to_string(),
+        Value::Bool(runtime_config.allow_superuser()),
+    );
+
+    // transcript_streaming_lookback_days: runtime normalizes 0 -> None (unlimited).
+    // Surface unlimited as 0 so it round-trips through `config set`.
+    effective_config.insert(
+        "transcript_streaming_lookback_days".to_string(),
+        Value::Number(
+            runtime_config
+                .transcript_streaming_lookback_days()
+                .unwrap_or(0)
+                .into(),
+        ),
+    );
+
+    effective_config.insert(
+        "custom_attributes".to_string(),
+        serde_json::to_value(runtime_config.custom_attributes())
+            .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
+    );
+
     // Feature flags - show effective flags with defaults applied
     let flags_value = serde_json::to_value(runtime_config.get_feature_flags())
         .unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
@@ -463,6 +496,15 @@ fn get_config_value(key: &str) -> Result<(), String> {
             "codex_hooks_format" => {
                 Value::String(runtime_config.codex_hooks_format().as_str().to_string())
             }
+            "allow_superuser" => Value::Bool(runtime_config.allow_superuser()),
+            "transcript_streaming_lookback_days" => Value::Number(
+                runtime_config
+                    .transcript_streaming_lookback_days()
+                    .unwrap_or(0)
+                    .into(),
+            ),
+            "custom_attributes" => serde_json::to_value(runtime_config.custom_attributes())
+                .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
             "notes_backend" => {
                 let nb = runtime_config.notes_backend();
                 let mut map = serde_json::Map::new();
@@ -554,8 +596,26 @@ fn get_config_value(key: &str) -> Result<(), String> {
         return Ok(());
     }
 
+    if key_path[0] == "custom_attributes" {
+        if key_path.len() != 2 {
+            return Err(
+                "custom_attributes requires an attribute name (e.g., custom_attributes.team)"
+                    .to_string(),
+            );
+        }
+        let value = runtime_config
+            .custom_attributes()
+            .get(&key_path[1])
+            .map(|v| Value::String(v.clone()))
+            .unwrap_or(Value::Null);
+        let json = serde_json::to_string_pretty(&value)
+            .map_err(|e| format!("Failed to serialize value: {}", e))?;
+        println!("{}", json);
+        return Ok(());
+    }
+
     Err(
-        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, and author"
+        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, author, and custom_attributes"
             .to_string(),
     )
 }
@@ -729,6 +789,31 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 crate::config::save_file_config(&file_config)?;
                 println!("[codex_hooks_format]: {}", format.as_str());
             }
+            "allow_superuser" => {
+                let bool_value = parse_bool(value)?;
+                file_config.allow_superuser = Some(bool_value);
+                crate::config::save_file_config(&file_config)?;
+                println!("[allow_superuser]: {}", bool_value);
+            }
+            "transcript_streaming_lookback_days" => {
+                let days = value.trim().parse::<u32>().map_err(|_| {
+                    format!(
+                        "Invalid transcript_streaming_lookback_days value '{}'. Expected a non-negative integer (0 = unlimited)",
+                        value
+                    )
+                })?;
+                file_config.transcript_streaming_lookback_days = Some(days);
+                crate::config::save_file_config(&file_config)?;
+                println!("[transcript_streaming_lookback_days]: {}", days);
+            }
+            "custom_attributes" => {
+                if add_mode {
+                    return Err("Cannot use --add with custom_attributes at top level. Use dot notation: custom_attributes.key".to_string());
+                }
+                file_config.custom_attributes = Some(parse_custom_attributes_object(value)?);
+                crate::config::save_file_config(&file_config)?;
+                println!("[custom_attributes]: {}", value);
+            }
             _ => return Err(format!("Unknown config key: {}", key)),
         }
 
@@ -872,8 +957,28 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
         return Ok(());
     }
 
+    if key_path[0] == "custom_attributes" {
+        if key_path.len() != 2 {
+            return Err(
+                "custom_attributes requires an attribute name (e.g., custom_attributes.team)"
+                    .to_string(),
+            );
+        }
+        let attr_name = key_path[1].trim();
+        if attr_name.is_empty() {
+            return Err("custom_attributes attribute name cannot be empty".to_string());
+        }
+        let mut attrs = file_config.custom_attributes.unwrap_or_default();
+        attrs.insert(attr_name.to_string(), value.to_string());
+        file_config.custom_attributes = Some(attrs);
+        crate::config::save_file_config(&file_config)?;
+        let prefix = if add_mode { "+ " } else { "" };
+        println!("{}[custom_attributes.{}]: {}", prefix, attr_name, value);
+        return Ok(());
+    }
+
     Err(
-        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, and author"
+        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, author, and custom_attributes"
             .to_string(),
     )
 }
@@ -1022,6 +1127,27 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                     println!("- [codex_hooks_format]: {}", v);
                 }
             }
+            "allow_superuser" => {
+                let old_value = file_config.allow_superuser.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [allow_superuser]: {}", v);
+                }
+            }
+            "transcript_streaming_lookback_days" => {
+                let old_value = file_config.transcript_streaming_lookback_days.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [transcript_streaming_lookback_days]: {}", v);
+                }
+            }
+            "custom_attributes" => {
+                let old_value = file_config.custom_attributes.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [custom_attributes]: {:?}", v);
+                }
+            }
             _ => return Err(format!("Unknown config key: {}", key)),
         }
 
@@ -1167,8 +1293,32 @@ fn unset_config_value(key: &str) -> Result<(), String> {
         return Ok(());
     }
 
+    if key_path[0] == "custom_attributes" {
+        if key_path.len() != 2 {
+            return Err(
+                "custom_attributes requires an attribute name (e.g., custom_attributes.team)"
+                    .to_string(),
+            );
+        }
+        let attr_name = &key_path[1];
+        let mut attrs = file_config
+            .custom_attributes
+            .ok_or_else(|| format!("Config key not found: {}", key))?;
+        let old_value = attrs.remove(attr_name);
+        if old_value.is_none() {
+            return Err(format!("Config key not found: {}", key));
+        }
+
+        file_config.custom_attributes = if attrs.is_empty() { None } else { Some(attrs) };
+        crate::config::save_file_config(&file_config)?;
+        if let Some(v) = old_value {
+            println!("- [custom_attributes.{}]: {}", attr_name, v);
+        }
+        return Ok(());
+    }
+
     Err(
-        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, and author"
+        "Nested keys are only supported for feature_flags, git_ai_hooks, notes_backend, author, and custom_attributes"
             .to_string(),
     )
 }
@@ -1284,6 +1434,38 @@ fn parse_git_ai_hooks_object(value: &str) -> Result<HashMap<String, Vec<String>>
         hooks.insert(name.to_string(), commands);
     }
     Ok(hooks)
+}
+
+/// Parse a JSON object of custom telemetry attributes.
+/// Accepts string/number/bool values (coerced to strings), mirroring how the
+/// `GIT_AI_CUSTOM_ATTRIBUTES` env var override is interpreted at config load time.
+fn parse_custom_attributes_object(value: &str) -> Result<HashMap<String, String>, String> {
+    let parsed: Value = serde_json::from_str(value)
+        .map_err(|e| format!("Invalid JSON for custom_attributes: {}", e))?;
+    let obj = parsed
+        .as_object()
+        .ok_or_else(|| "custom_attributes must be a JSON object".to_string())?;
+
+    let mut attrs = HashMap::new();
+    for (attr_name, attr_value) in obj {
+        let name = attr_name.trim();
+        if name.is_empty() {
+            return Err("custom_attributes contains an empty attribute name".to_string());
+        }
+        let coerced = match attr_value {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            Value::Bool(b) => b.to_string(),
+            _ => {
+                return Err(format!(
+                    "custom_attributes value for '{}' must be a string, number, or boolean",
+                    name
+                ));
+            }
+        };
+        attrs.insert(name.to_string(), coerced);
+    }
+    Ok(attrs)
 }
 
 fn parse_hook_command_values(value: &str) -> Result<Vec<String>, String> {
@@ -1512,6 +1694,38 @@ mod tests {
             hooks.get("post_notes_updated"),
             Some(&vec!["./hook-a.sh".to_string(), "./hook-b.sh".to_string()])
         );
+    }
+
+    #[test]
+    fn test_parse_custom_attributes_object_string_values() {
+        let attrs = parse_custom_attributes_object(r#"{"team":"platform","env":"prod"}"#).unwrap();
+        assert_eq!(attrs.get("team"), Some(&"platform".to_string()));
+        assert_eq!(attrs.get("env"), Some(&"prod".to_string()));
+    }
+
+    #[test]
+    fn test_parse_custom_attributes_object_coerces_number_and_bool() {
+        let attrs = parse_custom_attributes_object(r#"{"count":3,"enabled":true}"#).unwrap();
+        assert_eq!(attrs.get("count"), Some(&"3".to_string()));
+        assert_eq!(attrs.get("enabled"), Some(&"true".to_string()));
+    }
+
+    #[test]
+    fn test_parse_custom_attributes_object_rejects_non_object() {
+        let err = parse_custom_attributes_object(r#"["a","b"]"#).unwrap_err();
+        assert!(err.contains("custom_attributes must be a JSON object"));
+    }
+
+    #[test]
+    fn test_parse_custom_attributes_object_rejects_nested_value() {
+        let err = parse_custom_attributes_object(r#"{"team":{"nested":"x"}}"#).unwrap_err();
+        assert!(err.contains("must be a string, number, or boolean"));
+    }
+
+    #[test]
+    fn test_parse_custom_attributes_object_rejects_empty_name() {
+        let err = parse_custom_attributes_object(r#"{"  ":"x"}"#).unwrap_err();
+        assert!(err.contains("empty attribute name"));
     }
 
     // --- Additional comprehensive tests ---

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -810,7 +810,11 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 if add_mode {
                     return Err("Cannot use --add with custom_attributes at top level. Use dot notation: custom_attributes.key".to_string());
                 }
-                file_config.custom_attributes = Some(parse_custom_attributes_object(value)?);
+                let attrs = parse_custom_attributes_object(value)?;
+                // Mirror the `author`/`git_ai_hooks` convention: an empty object
+                // is stored as None so the key is omitted from the config file
+                // rather than persisted as a redundant `{}`.
+                file_config.custom_attributes = if attrs.is_empty() { None } else { Some(attrs) };
                 crate::config::save_file_config(&file_config)?;
                 println!("[custom_attributes]: {}", value);
             }
@@ -1300,7 +1304,10 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                     .to_string(),
             );
         }
-        let attr_name = &key_path[1];
+        // Trim to match the nested `set` path, which stores the trimmed name;
+        // otherwise an attribute set as `custom_attributes. team` (stored as
+        // `team`) could not be removed by the same dotted key.
+        let attr_name = key_path[1].trim();
         let mut attrs = file_config
             .custom_attributes
             .ok_or_else(|| format!("Config key not found: {}", key))?;
@@ -1437,8 +1444,12 @@ fn parse_git_ai_hooks_object(value: &str) -> Result<HashMap<String, Vec<String>>
 }
 
 /// Parse a JSON object of custom telemetry attributes.
-/// Accepts string/number/bool values (coerced to strings), mirroring how the
-/// `GIT_AI_CUSTOM_ATTRIBUTES` env var override is interpreted at config load time.
+///
+/// String/number/bool values are coerced to strings using the same rules as the
+/// `GIT_AI_CUSTOM_ATTRIBUTES` env var override (see `build_custom_attributes`).
+/// Unlike the env path, which silently drops non-scalar values, the CLI rejects
+/// them so a malformed `config set` fails loudly rather than persisting a
+/// partially-applied object.
 fn parse_custom_attributes_object(value: &str) -> Result<HashMap<String, String>, String> {
     let parsed: Value = serde_json::from_str(value)
         .map_err(|e| format!("Invalid JSON for custom_attributes: {}", e))?;

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -603,9 +603,10 @@ fn get_config_value(key: &str) -> Result<(), String> {
                     .to_string(),
             );
         }
+        let attr_key = key_path[1].trim();
         let value = runtime_config
             .custom_attributes()
-            .get(&key_path[1])
+            .get(attr_key)
             .map(|v| Value::String(v.clone()))
             .unwrap_or(Value::Null);
         let json = serde_json::to_string_pretty(&value)

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -1,0 +1,308 @@
+//! Integration coverage for `git-ai config` keys that previously had no CLI
+//! handling: `allow_superuser`, `transcript_streaming_lookback_days`, and
+//! `custom_attributes` (including its nested `custom_attributes.<key>` form).
+//!
+//! These run the real binary against an isolated test HOME, so `config set`
+//! writes land in the sandboxed `~/.git-ai/config.json` rather than the user's.
+
+use crate::repos::test_repo::TestRepo;
+use git_ai::config::{AuthorConfig, FileConfig, NotesBackendConfig};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Parse the JSON emitted by `git-ai config <key>` into a serde value.
+fn get_json(repo: &TestRepo, key: &str) -> Value {
+    let out = repo
+        .git_ai(&["config", key])
+        .unwrap_or_else(|e| panic!("config get {key} failed: {e}"));
+    serde_json::from_str(out.trim())
+        .unwrap_or_else(|e| panic!("config get {key} returned non-JSON {out:?}: {e}"))
+}
+
+#[test]
+fn test_config_allow_superuser_set_get_unset() {
+    let repo = TestRepo::new();
+
+    // Default is false.
+    assert_eq!(get_json(&repo, "allow_superuser"), Value::Bool(false));
+
+    repo.git_ai(&["config", "set", "allow_superuser", "true"])
+        .expect("set allow_superuser");
+    assert_eq!(get_json(&repo, "allow_superuser"), Value::Bool(true));
+
+    repo.git_ai(&["config", "unset", "allow_superuser"])
+        .expect("unset allow_superuser");
+    assert_eq!(get_json(&repo, "allow_superuser"), Value::Bool(false));
+}
+
+#[test]
+fn test_config_transcript_streaming_lookback_days_set_get_unset() {
+    let repo = TestRepo::new();
+
+    // Default is 7 days.
+    assert_eq!(
+        get_json(&repo, "transcript_streaming_lookback_days"),
+        Value::Number(7.into())
+    );
+
+    repo.git_ai(&["config", "set", "transcript_streaming_lookback_days", "1"])
+        .expect("set lookback to 1");
+    assert_eq!(
+        get_json(&repo, "transcript_streaming_lookback_days"),
+        Value::Number(1.into())
+    );
+
+    // 0 means unlimited; runtime normalizes to None and we surface it as 0.
+    repo.git_ai(&["config", "set", "transcript_streaming_lookback_days", "0"])
+        .expect("set lookback to 0");
+    assert_eq!(
+        get_json(&repo, "transcript_streaming_lookback_days"),
+        Value::Number(0.into())
+    );
+
+    // Non-numeric input is rejected.
+    assert!(
+        repo.git_ai(&["config", "set", "transcript_streaming_lookback_days", "abc"])
+            .is_err()
+    );
+
+    repo.git_ai(&["config", "unset", "transcript_streaming_lookback_days"])
+        .expect("unset lookback");
+    assert_eq!(
+        get_json(&repo, "transcript_streaming_lookback_days"),
+        Value::Number(7.into())
+    );
+}
+
+#[test]
+fn test_config_custom_attributes_object_set_get_unset() {
+    let repo = TestRepo::new();
+
+    // Default is an empty object.
+    assert_eq!(
+        get_json(&repo, "custom_attributes"),
+        Value::Object(serde_json::Map::new())
+    );
+
+    repo.git_ai(&[
+        "config",
+        "set",
+        "custom_attributes",
+        r#"{"team":"platform","env":"prod"}"#,
+    ])
+    .expect("set custom_attributes object");
+
+    let value = get_json(&repo, "custom_attributes");
+    assert_eq!(value["team"], Value::String("platform".to_string()));
+    assert_eq!(value["env"], Value::String("prod".to_string()));
+
+    repo.git_ai(&["config", "unset", "custom_attributes"])
+        .expect("unset custom_attributes");
+    assert_eq!(
+        get_json(&repo, "custom_attributes"),
+        Value::Object(serde_json::Map::new())
+    );
+}
+
+#[test]
+fn test_config_custom_attributes_nested_set_get_unset() {
+    let repo = TestRepo::new();
+
+    // Set a single attribute via dot notation.
+    repo.git_ai(&["config", "set", "custom_attributes.team", "platform"])
+        .expect("set custom_attributes.team");
+    assert_eq!(
+        get_json(&repo, "custom_attributes.team"),
+        Value::String("platform".to_string())
+    );
+
+    // --add upserts another attribute without clobbering the first.
+    repo.git_ai(&["config", "--add", "custom_attributes.env", "prod"])
+        .expect("add custom_attributes.env");
+    let value = get_json(&repo, "custom_attributes");
+    assert_eq!(value["team"], Value::String("platform".to_string()));
+    assert_eq!(value["env"], Value::String("prod".to_string()));
+
+    // Unknown nested attribute reads back as null.
+    assert_eq!(get_json(&repo, "custom_attributes.missing"), Value::Null);
+
+    // Unset one attribute leaves the other intact.
+    repo.git_ai(&["config", "unset", "custom_attributes.team"])
+        .expect("unset custom_attributes.team");
+    let value = get_json(&repo, "custom_attributes");
+    assert!(value.get("team").is_none());
+    assert_eq!(value["env"], Value::String("prod".to_string()));
+
+    // Unsetting a missing attribute is an error.
+    assert!(
+        repo.git_ai(&["config", "unset", "custom_attributes.team"])
+            .is_err()
+    );
+}
+
+#[test]
+fn test_config_show_all_includes_new_keys() {
+    let repo = TestRepo::new();
+    let out = repo.git_ai(&["config"]).expect("show all config");
+    let value: Value =
+        serde_json::from_str(out.trim()).expect("config show-all should emit valid JSON");
+
+    assert!(value.get("allow_superuser").is_some());
+    assert!(value.get("transcript_streaming_lookback_days").is_some());
+    assert!(value.get("custom_attributes").is_some());
+}
+
+/// Map a `FileConfig` field name to the CLI key used to read it back, when the
+/// two differ. Most fields share a name with their CLI key; the exceptions are
+/// enumerated here so the divergence stays explicit and reviewed.
+fn cli_key_for_field(field: &str) -> &str {
+    match field {
+        // `telemetry_oss` is written by the file/CLI but read back as the
+        // effective `telemetry_oss_disabled` boolean.
+        "telemetry_oss" => "telemetry_oss_disabled",
+        other => other,
+    }
+}
+
+/// Fields that are intentionally mutated only via dot-notation subkeys
+/// (e.g. `notes_backend.kind`) and have no bare top-level `set`/`unset` arm.
+/// They remain fully readable via `config <field>` and show-all; only the
+/// mutation handlers are nested-only. Listed explicitly so the exception is
+/// reviewed rather than silently assumed.
+fn is_nested_only_for_mutation(field: &str) -> bool {
+    matches!(field, "notes_backend")
+}
+
+/// Build a `FileConfig` with every field populated so serde emits all of them
+/// (Optional fields skip when `None`). This is the source-of-truth field list
+/// for the coverage guard below.
+fn fully_populated_file_config() -> FileConfig {
+    let mut custom_attributes = HashMap::new();
+    custom_attributes.insert("k".to_string(), "v".to_string());
+    let mut git_ai_hooks = HashMap::new();
+    git_ai_hooks.insert(
+        "post_notes_updated".to_string(),
+        vec!["./hook.sh".to_string()],
+    );
+
+    FileConfig {
+        git_path: Some("git".to_string()),
+        exclude_prompts_in_repositories: Some(vec!["*".to_string()]),
+        include_prompts_in_repositories: Some(vec!["*".to_string()]),
+        allow_repositories: Some(vec!["*".to_string()]),
+        exclude_repositories: Some(vec!["*".to_string()]),
+        telemetry_oss: Some("off".to_string()),
+        telemetry_enterprise_dsn: Some("https://example.com".to_string()),
+        disable_version_checks: Some(true),
+        disable_auto_updates: Some(true),
+        update_channel: Some("latest".to_string()),
+        feature_flags: Some(serde_json::json!({"transcript_sweep": true})),
+        api_base_url: Some("https://usegitai.com".to_string()),
+        prompt_storage: Some("default".to_string()),
+        default_prompt_storage: Some("local".to_string()),
+        api_key: Some("secret-key".to_string()),
+        quiet: Some(true),
+        allow_superuser: Some(true),
+        author: Some(AuthorConfig {
+            name: Some("Alice".to_string()),
+            email: Some("alice@example.com".to_string()),
+        }),
+        custom_attributes: Some(custom_attributes),
+        git_ai_hooks: Some(git_ai_hooks),
+        codex_hooks_format: Some("config_toml".to_string()),
+        notes_backend: Some(NotesBackendConfig::default()),
+        transcript_streaming_lookback_days: Some(7),
+    }
+}
+
+fn file_config_field_names() -> Vec<String> {
+    let serialized =
+        serde_json::to_value(fully_populated_file_config()).expect("serialize FileConfig");
+    serialized
+        .as_object()
+        .expect("FileConfig serializes to an object")
+        .keys()
+        .cloned()
+        .collect()
+}
+
+/// Regression guard: every persisted `FileConfig` field must be reachable through
+/// the `git-ai config` CLI read path (`config <key>`).
+///
+/// The field list is derived from a fully-populated `FileConfig` via serde rather
+/// than hardcoded, so adding a new persisted field WILL break this test until the
+/// CLI handlers (and this guard's expectations) are updated. That is the point:
+/// CLI read coverage cannot silently regress.
+///
+/// `get_config_value` has a top-level match arm for every field plus a catch-all
+/// that returns "Unknown config key", making it the canonical completeness check:
+/// it is the one read path that must handle every field as a bare key (show-all
+/// hides unset optionals; mutation handlers are nested-only for some fields).
+#[test]
+fn test_every_file_config_field_has_cli_get_coverage() {
+    let fields = file_config_field_names();
+
+    // Sanity: serde actually emitted every field (none silently skipped).
+    assert!(
+        fields.len() >= 23,
+        "expected all FileConfig fields to serialize, got {}: {:?}",
+        fields.len(),
+        fields
+    );
+
+    let repo = TestRepo::new();
+    let mut unknown_to_get = Vec::new();
+
+    for field in &fields {
+        let get_key = cli_key_for_field(field);
+        // We tolerate any success output; we only fail on the explicit
+        // "Unknown config key" rejection produced by the get catch-all.
+        match repo.git_ai(&["config", get_key]) {
+            Ok(_) => {}
+            Err(e) if e.contains("Unknown config key") => {
+                unknown_to_get.push(format!("{field} (cli key: {get_key}): {e}"));
+            }
+            // Other errors (e.g. environment-specific) are not coverage gaps.
+            Err(_) => {}
+        }
+    }
+
+    assert!(
+        unknown_to_get.is_empty(),
+        "FileConfig fields rejected by `git-ai config <key>` as unknown \
+         (add them to get_config_value): {unknown_to_get:?}"
+    );
+}
+
+/// Regression guard: every persisted `FileConfig` field must be mutable through
+/// the `git-ai config unset <key>` write path, except fields documented as
+/// nested-only (see `is_nested_only_for_mutation`).
+///
+/// `unset` needs no value and is non-destructive against the isolated test
+/// config, so it cleanly exercises the write handler's top-level coverage. A new
+/// field added without a `set`/`unset` arm trips the catch-all here.
+#[test]
+fn test_every_file_config_field_has_cli_unset_coverage() {
+    let repo = TestRepo::new();
+    let mut unknown_to_unset = Vec::new();
+
+    for field in &file_config_field_names() {
+        if is_nested_only_for_mutation(field) {
+            continue;
+        }
+        match repo.git_ai(&["config", "unset", field]) {
+            Ok(_) => {}
+            Err(e) if e.contains("Unknown config key") => {
+                unknown_to_unset.push(format!("{field}: {e}"));
+            }
+            Err(_) => {}
+        }
+    }
+
+    assert!(
+        unknown_to_unset.is_empty(),
+        "FileConfig fields rejected by `git-ai config unset <key>` as unknown \
+         (add them to set_config_value and unset_config_value, or document them \
+         in is_nested_only_for_mutation): {unknown_to_unset:?}"
+    );
+}

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -176,6 +176,12 @@ fn test_config_custom_attributes_nested_unset_trims_name() {
         Value::String("platform".to_string())
     );
 
+    // Get with the same (untrimmed) dotted key must return the stored value.
+    assert_eq!(
+        get_json(&repo, "custom_attributes. team"),
+        Value::String("platform".to_string())
+    );
+
     // Unset with the same (untrimmed) dotted key must succeed symmetrically.
     repo.git_ai(&["config", "unset", "custom_attributes. team"])
         .expect("unset custom_attributes. team should match trimmed name");

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -141,6 +141,48 @@ fn test_config_custom_attributes_nested_set_get_unset() {
 }
 
 #[test]
+fn test_config_custom_attributes_set_empty_object_is_omitted() {
+    let repo = TestRepo::new();
+
+    // Setting an empty object should normalize to "unset" (mirrors `author`),
+    // not persist a redundant `{}`.
+    repo.git_ai(&["config", "set", "custom_attributes", "{}"])
+        .expect("set empty custom_attributes");
+    assert_eq!(
+        get_json(&repo, "custom_attributes"),
+        Value::Object(serde_json::Map::new())
+    );
+
+    // The config file should not carry a `custom_attributes` key at all.
+    let config_path = repo.test_home_path().join(".git-ai").join("config.json");
+    if let Ok(contents) = std::fs::read_to_string(&config_path) {
+        let parsed: Value = serde_json::from_str(&contents).unwrap_or(Value::Null);
+        assert!(
+            parsed.get("custom_attributes").is_none(),
+            "empty custom_attributes should be omitted from config file, got: {contents}"
+        );
+    }
+}
+
+#[test]
+fn test_config_custom_attributes_nested_unset_trims_name() {
+    let repo = TestRepo::new();
+
+    // Set with a leading space in the attribute name; the set path trims it.
+    repo.git_ai(&["config", "set", "custom_attributes. team", "platform"])
+        .expect("set custom_attributes. team");
+    assert_eq!(
+        get_json(&repo, "custom_attributes.team"),
+        Value::String("platform".to_string())
+    );
+
+    // Unset with the same (untrimmed) dotted key must succeed symmetrically.
+    repo.git_ai(&["config", "unset", "custom_attributes. team"])
+        .expect("unset custom_attributes. team should match trimmed name");
+    assert_eq!(get_json(&repo, "custom_attributes.team"), Value::Null);
+}
+
+#[test]
 fn test_config_show_all_includes_new_keys() {
     let repo = TestRepo::new();
     let out = repo.git_ai(&["config"]).expect("show all config");

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -44,6 +44,7 @@ mod cli_parser_rebase_args;
 mod codex;
 mod cold_trace2_repo;
 mod commit_post_stats_benchmark;
+mod config_cli_coverage;
 mod config_pattern_detection;
 mod continue_cli;
 mod cross_repo_cwd_attribution;


### PR DESCRIPTION
## Summary

Three persisted `FileConfig` fields had **no** `git-ai config` CLI handling — they could only be configured by hand-editing `~/.git-ai/config.json` or via env vars:

- `allow_superuser` (bool) — allow running git-ai as root/superuser
- `transcript_streaming_lookback_days` (`u32`, `0` = unlimited) — how far back transcript sweeps look
- `custom_attributes` (`string → string` object) — custom telemetry attributes, plus nested `custom_attributes.<key>`

This PR wires all three through the CLI's `show-all`, `get`, `set`, and `unset` paths (plus the nested get/set/unset path for `custom_attributes`), matching the conventions of the existing fields.

### Notable details

- **Restart hint**: `git-ai config set transcript_streaming_lookback_days <n>` now prints the same `Run \`git-ai bg restart\`` hint as the transcript feature flags, because the daemon reads this value once at worker startup (`Config::get()`).
- **`0 = unlimited`**: the runtime normalizes `0` → `None`; show-all/get surface unlimited as `0` so it round-trips through `set`.
- **`custom_attributes` value coercion**: object values accept string/number/bool (coerced to strings), mirroring how the `GIT_AI_CUSTOM_ATTRIBUTES` env override is parsed at config load.

## Regression guard (cannot silently regress)

`tests/integration/config_cli_coverage.rs` adds a guard that **derives the field list from a fully-populated `FileConfig` via serde** (not a hardcoded list) and asserts every field is reachable through the *real* CLI:

- `test_every_file_config_field_has_cli_get_coverage` — `get_config_value` has an arm for every field + an "Unknown config key" catch-all, making it the canonical completeness check.
- `test_every_file_config_field_has_cli_unset_coverage` — exercises the write-handler catch-all (`notes_backend` is documented as nested-only via an explicit allowlist).

Adding a new persisted `FileConfig` field without CLI wiring now fails the suite. Verified by temporarily deleting the `allow_superuser` arm — the guard fails with a precise pointer to the missing handler.

Also covers set/get/unset roundtrips for the three new keys (incl. `--add` upsert and invalid-input rejection).

## Testing

- `task fmt` ✅
- `task lint` ✅ (clippy `-D warnings`)
- `task test TEST_FILTER=config` ✅ (all config unit + integration tests pass)
- New unit tests for `parse_custom_attributes_object` + 7 integration tests in `config_cli_coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)