### PR TITLE
Add `git-ai analyze`: research AI coding activity and grade prompts at scale

### DIFF
--- a/src/commands/analyze/cube.rs
+++ b/src/commands/analyze/cube.rs
@@ -18,6 +18,9 @@ const CUBE_TIMEOUT_SECS: u64 = 120;
 pub struct CubeClient {
     base_url: String,
     api_key: String,
+    /// Built once and reused so successive cube calls share a connection pool
+    /// (and skip rebuilding the native-TLS connector per request).
+    agent: ureq::Agent,
 }
 
 #[derive(Debug)]
@@ -71,6 +74,7 @@ impl CubeClient {
         Ok(Self {
             base_url: cfg.api_base_url().trim_end_matches('/').to_string(),
             api_key,
+            agent: http::build_agent(Some(CUBE_TIMEOUT_SECS)),
         })
     }
 
@@ -80,8 +84,8 @@ impl CubeClient {
 
     /// POST a JSON body to a cube path and parse the response.
     fn post(&self, path: &str, body: &Value) -> Result<Value, CubeError> {
-        let agent = http::build_agent(Some(CUBE_TIMEOUT_SECS));
-        let request = agent
+        let request = self
+            .agent
             .post(&self.url(path))
             .set("x-api-key", &self.api_key)
             .set("Content-Type", "application/json");
@@ -92,8 +96,10 @@ impl CubeClient {
 
     /// GET a cube path and parse the response.
     fn get(&self, path: &str) -> Result<Value, CubeError> {
-        let agent = http::build_agent(Some(CUBE_TIMEOUT_SECS));
-        let request = agent.get(&self.url(path)).set("x-api-key", &self.api_key);
+        let request = self
+            .agent
+            .get(&self.url(path))
+            .set("x-api-key", &self.api_key);
         let response = http::send(request).map_err(CubeError::Transport)?;
         Self::parse(response)
     }

--- a/src/commands/analyze/cube.rs
+++ b/src/commands/analyze/cube.rs
@@ -1,0 +1,406 @@
+//! Minimal Cube API client for `git-ai analyze`.
+//!
+//! Talks to the Next.js cube proxy at `<api_base_url>/api/cube/*` using the
+//! org API key in the `x-api-key` header. We build requests directly over
+//! [`crate::http`] rather than going through `ApiContext::post_json` so that we
+//! send ONLY the API key to the cube proxy — never a `git-ai login` OAuth
+//! bearer, which the proxy does not expect on this route.
+
+use crate::config;
+use crate::http;
+use serde_json::{Map, Value, json};
+
+/// Cube can take a while to compile + run large queries; be generous.
+const CUBE_TIMEOUT_SECS: u64 = 120;
+
+/// A configured client pointed at one org's cube data (scoping is derived from
+/// the API key by the proxy — we never pass an org id).
+pub struct CubeClient {
+    base_url: String,
+    api_key: String,
+}
+
+#[derive(Debug)]
+pub enum CubeError {
+    /// No API key configured (env `GIT_AI_API_KEY` or config `api_key`).
+    MissingApiKey,
+    /// Transport-level failure (network, DNS, TLS).
+    Transport(String),
+    /// Auth/proxy error (401/403, "Path not supported", etc.).
+    Http { status: u16, body: String },
+    /// Cube returned an `error` field (e.g. `UserError`: bad measure/dimension).
+    Cube(String),
+    /// Response body was not valid JSON.
+    Json(String),
+}
+
+impl std::fmt::Display for CubeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CubeError::MissingApiKey => write!(
+                f,
+                "no API key configured. Set GIT_AI_API_KEY or add \"api_key\" to \
+                 ~/.git-ai/config.json (the key needs organization:admin:read; \
+                 create one in your Git AI org settings)."
+            ),
+            CubeError::Transport(e) => write!(f, "request failed: {}", e),
+            CubeError::Http { status, body } => {
+                let hint = match status {
+                    401 => " (unauthorized — check the API key)",
+                    403 => " (forbidden — the key needs organization:admin:read)",
+                    _ => "",
+                };
+                write!(f, "HTTP {}{}: {}", status, hint, body.trim())
+            }
+            CubeError::Cube(msg) => write!(f, "cube error: {}", msg),
+            CubeError::Json(e) => write!(f, "invalid JSON response: {}", e),
+        }
+    }
+}
+
+impl CubeClient {
+    /// Build a client from the resolved config. Returns `MissingApiKey` if no
+    /// API key is available.
+    pub fn from_config() -> Result<Self, CubeError> {
+        let cfg = config::Config::fresh();
+        let api_key = cfg
+            .api_key()
+            .map(|s| s.to_string())
+            .filter(|s| !s.is_empty())
+            .ok_or(CubeError::MissingApiKey)?;
+        Ok(Self {
+            base_url: cfg.api_base_url().trim_end_matches('/').to_string(),
+            api_key,
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}/api/cube/{}", self.base_url, path)
+    }
+
+    /// POST a JSON body to a cube path and parse the response.
+    fn post(&self, path: &str, body: &Value) -> Result<Value, CubeError> {
+        let agent = http::build_agent(Some(CUBE_TIMEOUT_SECS));
+        let request = agent
+            .post(&self.url(path))
+            .set("x-api-key", &self.api_key)
+            .set("Content-Type", "application/json");
+        let body_str = serde_json::to_string(body).map_err(|e| CubeError::Json(e.to_string()))?;
+        let response = http::send_with_body(request, &body_str).map_err(CubeError::Transport)?;
+        Self::parse(response)
+    }
+
+    /// GET a cube path and parse the response.
+    fn get(&self, path: &str) -> Result<Value, CubeError> {
+        let agent = http::build_agent(Some(CUBE_TIMEOUT_SECS));
+        let request = agent.get(&self.url(path)).set("x-api-key", &self.api_key);
+        let response = http::send(request).map_err(CubeError::Transport)?;
+        Self::parse(response)
+    }
+
+    fn parse(response: http::Response) -> Result<Value, CubeError> {
+        let status = response.status_code;
+        let text = response
+            .as_str()
+            .map_err(|e| CubeError::Json(e.to_string()))?
+            .to_string();
+        // Empty body with an error status: surface the status alone.
+        let parsed: Value = if text.trim().is_empty() {
+            if status >= 400 {
+                return Err(CubeError::Http {
+                    status,
+                    body: String::new(),
+                });
+            }
+            Value::Null
+        } else {
+            serde_json::from_str(&text).map_err(|_| CubeError::Http {
+                status,
+                body: text.clone(),
+            })?
+        };
+        // Auth/permission failures come from the proxy with a 401/403; surface
+        // them as Http so the "check the API key / needs organization:admin:read"
+        // hint is shown, even though the body also carries an `error` field.
+        if status == 401 || status == 403 {
+            let body = parsed
+                .get("error")
+                .and_then(|e| e.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or(text);
+            return Err(CubeError::Http { status, body });
+        }
+        // Cube signals query failures via an `error` field (often with HTTP 200);
+        // surface it regardless of status so the agent sees the real message.
+        if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
+            let kind = parsed
+                .get("type")
+                .and_then(|t| t.as_str())
+                .map(|t| format!("{}: ", t))
+                .unwrap_or_default();
+            return Err(CubeError::Cube(format!("{}{}", kind, err)));
+        }
+        if status >= 400 {
+            return Err(CubeError::Http { status, body: text });
+        }
+        Ok(parsed)
+    }
+
+    /// Run a query against `/api/cube/load`. `query` is the inner Cube query
+    /// object (we wrap it in `{"query": ...}`). Returns the full response value.
+    pub fn load(&self, query: &Value) -> Result<Value, CubeError> {
+        self.post("load", &json!({ "query": query }))
+    }
+
+    /// Run a query against `/api/cube/load` and return just the `data` rows.
+    pub fn load_rows(&self, query: &Value) -> Result<Vec<Value>, CubeError> {
+        let resp = self.load(query)?;
+        Ok(resp
+            .get("data")
+            .and_then(|d| d.as_array())
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    /// List cubes, measures, and dimensions (`/api/cube/meta`).
+    pub fn meta(&self) -> Result<Value, CubeError> {
+        self.get("meta")
+    }
+}
+
+/// Structured inputs for building a Cube query from CLI flags.
+#[derive(Debug, Default, Clone)]
+pub struct QueryArgs {
+    pub measures: Vec<String>,
+    pub dimensions: Vec<String>,
+    pub time_dimension: Option<String>,
+    pub granularity: Option<String>,
+    /// Cube `dateRange` (e.g. "last 30 days", "2024-01-01,2024-02-01").
+    pub date_range: Option<String>,
+    /// Raw JSON array of Cube filter objects (escape hatch for complex filters).
+    pub filters_json: Option<String>,
+    /// (member, direction) pairs.
+    pub order: Vec<(String, String)>,
+    pub limit: Option<u64>,
+    pub offset: Option<u64>,
+}
+
+impl QueryArgs {
+    /// Build the inner Cube query object. Returns an error for invalid combos
+    /// (e.g. a date range without a time dimension) or malformed `--filters`.
+    pub fn to_query(&self) -> Result<Value, String> {
+        let mut q = Map::new();
+
+        if !self.measures.is_empty() {
+            q.insert("measures".into(), json!(self.measures));
+        }
+        if !self.dimensions.is_empty() {
+            q.insert("dimensions".into(), json!(self.dimensions));
+        }
+
+        match (&self.time_dimension, &self.date_range, &self.granularity) {
+            (Some(dim), range, gran) => {
+                let mut td = Map::new();
+                td.insert("dimension".into(), json!(dim));
+                if let Some(g) = gran {
+                    td.insert("granularity".into(), json!(g));
+                }
+                if let Some(r) = range {
+                    td.insert("dateRange".into(), json!(parse_date_range(r)));
+                }
+                q.insert("timeDimensions".into(), json!([Value::Object(td)]));
+            }
+            (None, Some(_), _) => {
+                return Err("--since/--date-range requires --time-dimension <member>".to_string());
+            }
+            (None, None, Some(_)) => {
+                return Err("--granularity requires --time-dimension <member>".to_string());
+            }
+            (None, None, None) => {}
+        }
+
+        if let Some(raw) = &self.filters_json {
+            let parsed: Value = serde_json::from_str(raw)
+                .map_err(|e| format!("--filters is not valid JSON: {}", e))?;
+            if !parsed.is_array() {
+                return Err("--filters must be a JSON array of filter objects".to_string());
+            }
+            q.insert("filters".into(), parsed);
+        }
+
+        if !self.order.is_empty() {
+            let arr: Vec<Value> = self.order.iter().map(|(m, d)| json!([m, d])).collect();
+            q.insert("order".into(), json!(arr));
+        }
+        if let Some(l) = self.limit {
+            q.insert("limit".into(), json!(l));
+        }
+        if let Some(o) = self.offset {
+            q.insert("offset".into(), json!(o));
+        }
+
+        Ok(Value::Object(q))
+    }
+}
+
+/// Cube `dateRange` accepts relative strings ("last 30 days") as-is, or an
+/// explicit `start,end` pair which we turn into a two-element array.
+fn parse_date_range(raw: &str) -> Value {
+    let trimmed = raw.trim();
+    if let Some((start, end)) = trimmed.split_once(',') {
+        let start = start.trim();
+        let end = end.trim();
+        if !start.is_empty() && !end.is_empty() {
+            return json!([start, end]);
+        }
+    }
+    json!(trimmed)
+}
+
+/// Render an array of cube data rows (objects of `member -> value`) as TSV.
+/// Column order is the union of keys across rows, first-seen order preserved.
+pub fn rows_to_tsv(rows: &[Value]) -> String {
+    let mut columns: Vec<String> = Vec::new();
+    for row in rows {
+        if let Some(obj) = row.as_object() {
+            for key in obj.keys() {
+                if !columns.iter().any(|c| c == key) {
+                    columns.push(key.clone());
+                }
+            }
+        }
+    }
+    let mut out = String::new();
+    out.push_str(&columns.join("\t"));
+    out.push('\n');
+    for row in rows {
+        let obj = row.as_object();
+        let line: Vec<String> = columns
+            .iter()
+            .map(|col| {
+                obj.and_then(|o| o.get(col))
+                    .map(value_to_cell)
+                    .unwrap_or_default()
+            })
+            .collect();
+        out.push_str(&line.join("\t"));
+        out.push('\n');
+    }
+    out
+}
+
+/// Render a single JSON value as a flat TSV/table cell (strings unquoted).
+fn value_to_cell(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_basic_measure_query() {
+        let args = QueryArgs {
+            measures: vec!["public_v1_sessions.total_sessions".into()],
+            ..Default::default()
+        };
+        let q = args.to_query().unwrap();
+        assert_eq!(
+            q,
+            json!({ "measures": ["public_v1_sessions.total_sessions"] })
+        );
+    }
+
+    #[test]
+    fn builds_time_dimension_with_range_and_granularity() {
+        let args = QueryArgs {
+            measures: vec!["public_v1_pull_requests.ai_assisted_pull_requests".into()],
+            time_dimension: Some("public_v1_pull_requests.opened_time".into()),
+            granularity: Some("month".into()),
+            date_range: Some("last 6 months".into()),
+            ..Default::default()
+        };
+        let q = args.to_query().unwrap();
+        assert_eq!(
+            q["timeDimensions"],
+            json!([{
+                "dimension": "public_v1_pull_requests.opened_time",
+                "granularity": "month",
+                "dateRange": "last 6 months"
+            }])
+        );
+    }
+
+    #[test]
+    fn explicit_date_range_pair_becomes_array() {
+        let args = QueryArgs {
+            time_dimension: Some("public_v1_sessions.session_start_time".into()),
+            date_range: Some("2024-01-01, 2024-02-01".into()),
+            ..Default::default()
+        };
+        let q = args.to_query().unwrap();
+        assert_eq!(
+            q["timeDimensions"][0]["dateRange"],
+            json!(["2024-01-01", "2024-02-01"])
+        );
+    }
+
+    #[test]
+    fn date_range_without_time_dimension_errors() {
+        let args = QueryArgs {
+            date_range: Some("last 7 days".into()),
+            ..Default::default()
+        };
+        assert!(args.to_query().is_err());
+    }
+
+    #[test]
+    fn order_and_limit_and_filters() {
+        let args = QueryArgs {
+            measures: vec!["public_v1_sessions.total_sessions".into()],
+            order: vec![("public_v1_sessions.total_sessions".into(), "desc".into())],
+            limit: Some(25),
+            filters_json: Some(
+                r#"[{"member":"public_v1_sessions.agent","operator":"equals","values":["claude-code"]}]"#
+                    .into(),
+            ),
+            ..Default::default()
+        };
+        let q = args.to_query().unwrap();
+        assert_eq!(
+            q["order"],
+            json!([["public_v1_sessions.total_sessions", "desc"]])
+        );
+        assert_eq!(q["limit"], json!(25));
+        assert_eq!(q["filters"][0]["operator"], json!("equals"));
+    }
+
+    #[test]
+    fn invalid_filters_json_errors() {
+        let args = QueryArgs {
+            filters_json: Some("not json".into()),
+            ..Default::default()
+        };
+        assert!(args.to_query().is_err());
+
+        let args = QueryArgs {
+            filters_json: Some(r#"{"not":"an array"}"#.into()),
+            ..Default::default()
+        };
+        assert!(args.to_query().is_err());
+    }
+
+    #[test]
+    fn tsv_uses_union_of_columns() {
+        let rows = vec![json!({"a": "1", "b": "2"}), json!({"a": "3", "c": "4"})];
+        let tsv = rows_to_tsv(&rows);
+        let mut lines = tsv.lines();
+        assert_eq!(lines.next().unwrap(), "a\tb\tc");
+        assert_eq!(lines.next().unwrap(), "1\t2\t");
+        assert_eq!(lines.next().unwrap(), "3\t\t4");
+    }
+}

--- a/src/commands/analyze/mod.rs
+++ b/src/commands/analyze/mod.rs
@@ -1,0 +1,342 @@
+//! `git-ai analyze` — query Git AI's backend analytics (Cube semantic layer)
+//! and pull/grade coding sessions at scale.
+//!
+//! This command is the agent-facing replacement for the old local `prompts.db`
+//! flow. Prompts now live in the backend; `analyze` wraps the Cube API (so an
+//! agent uses it instead of `curl`) and provides a session-grading pipeline
+//! backed by a scratch SQLite DB.
+
+mod cube;
+mod sessions;
+
+use cube::{CubeClient, QueryArgs};
+use serde_json::Value;
+
+pub fn handle_analyze(args: &[String]) {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    let rest = if args.is_empty() { &[][..] } else { &args[1..] };
+
+    // `--help`/`-h` anywhere in the args prints help, exactly like running the
+    // command raw — except for `sessions`, which we delegate to so its own
+    // (more specific) help is shown.
+    if sub != "sessions" && args.iter().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return;
+    }
+
+    let result = match sub {
+        "" | "help" | "--help" | "-h" => {
+            print_help();
+            return;
+        }
+        "query" => cmd_query(rest),
+        "docs" => cmd_docs(rest),
+        "sessions" => {
+            sessions::handle_sessions(rest);
+            return;
+        }
+        other => Err(format!(
+            "unknown analyze subcommand: {}\nRun `git-ai analyze` for help.",
+            other
+        )),
+    };
+
+    if let Err(msg) = result {
+        eprintln!("Error: {}", msg);
+        std::process::exit(1);
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Format {
+    Json,
+    Tsv,
+    Raw,
+}
+
+fn cmd_query(args: &[String]) -> Result<(), String> {
+    let mut q = QueryArgs::default();
+    let mut format = Format::Json;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--measures" | "-m" => {
+                q.measures
+                    .extend(split_csv(&take_value(args, &mut i, "--measures")?));
+            }
+            "--dimensions" | "-d" => {
+                q.dimensions
+                    .extend(split_csv(&take_value(args, &mut i, "--dimensions")?));
+            }
+            "--time-dimension" | "--td" => {
+                q.time_dimension = Some(take_value(args, &mut i, "--time-dimension")?);
+            }
+            "--granularity" | "-g" => {
+                q.granularity = Some(take_value(args, &mut i, "--granularity")?);
+            }
+            "--since" | "--date-range" => {
+                q.date_range = Some(take_value(args, &mut i, "--since")?);
+            }
+            "--filters" | "-f" => {
+                q.filters_json = Some(take_value(args, &mut i, "--filters")?);
+            }
+            "--order" | "-o" => {
+                q.order
+                    .push(parse_order(&take_value(args, &mut i, "--order")?)?);
+            }
+            "--limit" | "-l" => {
+                q.limit = Some(
+                    take_value(args, &mut i, "--limit")?
+                        .parse()
+                        .map_err(|_| "--limit must be a number".to_string())?,
+                );
+            }
+            "--offset" => {
+                q.offset = Some(
+                    take_value(args, &mut i, "--offset")?
+                        .parse()
+                        .map_err(|_| "--offset must be a number".to_string())?,
+                );
+            }
+            "--tsv" => format = Format::Tsv,
+            "--raw" => format = Format::Raw,
+            "--json" => format = Format::Json,
+            "--format" => {
+                format = match take_value(args, &mut i, "--format")?.as_str() {
+                    "json" => Format::Json,
+                    "tsv" => Format::Tsv,
+                    "raw" => Format::Raw,
+                    other => return Err(format!("unknown --format: {} (json|tsv|raw)", other)),
+                };
+            }
+            "--help" | "-h" => {
+                print_help();
+                return Ok(());
+            }
+            other => return Err(format!("unknown query flag: {}", other)),
+        }
+        i += 1;
+    }
+
+    if q.measures.is_empty() && q.dimensions.is_empty() && q.time_dimension.is_none() {
+        return Err(
+            "nothing to query: pass at least --measures, --dimensions, or --time-dimension \
+             (try `git-ai analyze docs` to discover members)"
+                .to_string(),
+        );
+    }
+
+    let query = q.to_query()?;
+    let client = CubeClient::from_config().map_err(|e| e.to_string())?;
+
+    let response = client.load(&query).map_err(|e| e.to_string())?;
+
+    render(&response, format);
+    Ok(())
+}
+
+fn cmd_docs(args: &[String]) -> Result<(), String> {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return Ok(());
+    }
+    let client = CubeClient::from_config().map_err(|e| e.to_string())?;
+    let meta = client.meta().map_err(|e| e.to_string())?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&meta).unwrap_or_default()
+    );
+    Ok(())
+}
+
+/// Render a `/load` response per the requested format.
+fn render(response: &Value, format: Format) {
+    match format {
+        Format::Raw => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(response).unwrap_or_default()
+            );
+        }
+        Format::Json => {
+            let data = response.get("data").cloned().unwrap_or(Value::Null);
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&data).unwrap_or_default()
+            );
+        }
+        Format::Tsv => {
+            let empty = Vec::new();
+            let rows = response
+                .get("data")
+                .and_then(|d| d.as_array())
+                .unwrap_or(&empty);
+            print!("{}", cube::rows_to_tsv(rows));
+        }
+    }
+}
+
+fn split_csv(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .collect()
+}
+
+/// Parse `--order member[:dir]` into (member, direction). Defaults to `asc`.
+fn parse_order(s: &str) -> Result<(String, String), String> {
+    let (member, dir) = match s.split_once(':') {
+        Some((m, d)) => (m.trim(), d.trim().to_lowercase()),
+        None => (s.trim(), "asc".to_string()),
+    };
+    if member.is_empty() {
+        return Err("--order requires a member name".to_string());
+    }
+    if dir != "asc" && dir != "desc" {
+        return Err(format!(
+            "--order direction must be asc or desc, got: {}",
+            dir
+        ));
+    }
+    Ok((member.to_string(), dir))
+}
+
+fn take_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| format!("{} requires a value", flag))
+}
+
+fn print_help() {
+    let help = r#"git-ai analyze - research AI coding activity and analyze prompts at scale
+
+You are an analyst. Your job is to answer questions about how AI is used to write
+code in this org — prompting patterns, acceptance/productivity, model and agent
+comparisons, who/what/when — using real data from Git AI's backend. Don't guess or
+generalize: pull the actual sessions and read the transcripts.
+
+Assume Git AI attribution is correct and what you're seeing reflects actual
+performance of agents — do not explain anomalies away as instrumentation or
+attribution gaps.
+
+Two modes, and you'll usually use both:
+  1. RESEARCH with aggregate queries. Use `query` to slice the warehouse (counts,
+     rates, lines, breakdowns by agent/model/repo/time). Start broad to find where
+     the interesting signal is — which agents, which time range, which outliers.
+  2. ITERATE over specific sessions. Once a query points you at the population you
+     care about, pull those exact sessions with `sessions pull` (carry your filters
+     over: --since, --agent, --repo, --user), then walk them one at a time with
+     `sessions next`, read each transcript, and write your findings back into the
+     scratch DB so they can be aggregated. This is how you analyze prompts.
+
+Typical loop: docs (discover members) → query (find the signal) → sessions pull
+(grab that slice) → fan out subagents over `sessions next` (grade/categorize each
+transcript) → exec a synthesis query over the columns you added. See
+`git-ai analyze sessions --help` for the full pull/next/iterate workflow.
+
+Data lives in a shared Cube.js semantic layer behind https://usegitai.com/api/cube.
+Auth uses an org API key (organization:admin:read) sent as the x-api-key header;
+set it via the GIT_AI_API_KEY env var or "api_key" in ~/.git-ai/config.json. Your
+org is derived from the key — data is always scoped to your org.
+
+Scoping to a specific person ("my sessions", "the work I did", "what Jane wrote"):
+  Every cube keys on an opaque user_id, NOT an email — so resolve the person to a
+  user_id FIRST, then filter by it. For the CURRENT user ("my"/"mine"/"that I did"),
+  read their git email and look it up via public_v1_user_status (user_id +
+  author_email):
+    EMAIL=$(git config user.email)
+    git-ai analyze query -d public_v1_user_status.user_id,public_v1_user_status.author_email \
+      -f '[{"member":"public_v1_user_status.author_email","operator":"equals","values":["'"$EMAIL"'"]}]'
+  Take the user_id from that row and carry it everywhere: as a -d/-f on `query`, or
+  as `sessions pull --user <user_id>`. For someone else, swap in their email. If the
+  email returns no row, say so rather than guessing a user_id.
+
+Usage: git-ai analyze <command> [flags]
+
+Commands:
+  query [flags]      Run a Cube query and print rows (the curl replacement)
+  docs               List all cubes, measures, and dimensions (discovery)
+  sessions <sub>     Pull specific sessions + transcripts and grade them at scale
+                     (see `analyze sessions --help`)
+
+query flags:
+  -m, --measures a,b        Measures (fully-qualified, e.g. public_v1_sessions.total_sessions)
+  -d, --dimensions c,d      Dimensions to group by
+      --time-dimension M    Time dimension member (enables --since/--granularity)
+  -g, --granularity G       day | week | month | … (needs --time-dimension)
+      --since "<range>"     Cube dateRange, e.g. "last 30 days" or "2024-01-01,2024-02-01"
+  -f, --filters '<json>'    Raw JSON array of Cube filter objects (escape hatch)
+  -o, --order M[:asc|desc]  Order by a member (repeatable)
+  -l, --limit N             Row limit
+      --offset N            Row offset
+      --format json|tsv|raw json (default, prints data array) | tsv table | raw full response
+
+Gotchas:
+  - Member names are fully qualified: public_v1_pull_requests.pull_requests (no bare names).
+  - There is no .count on public_v1_pull_requests — use .pull_requests.
+  - Numeric measures come back as strings in JSON; cast as needed.
+  - Run `git-ai analyze docs` to discover every cube/measure/dimension.
+  - Don't assume a dimension's MEANING or value distribution from its name. A
+    `pr_state` dimension does not imply the cube holds non-merged rows; a cube may
+    be scoped to one slice (e.g. public_v1_production_hunks is production-only by
+    construction). Before you reason from a dimension, run a tiny query to SEE its
+    actual values (e.g. -d <dim> -m <count> -l 20) instead of guessing — guessing
+    here is the #1 way this analysis talks itself into a wrong conclusion.
+  - Before reading transcripts to answer "how much committed code didn't ship",
+    check the funnel MEASURES first — public_v1_sessions exposes committed →
+    pr_opened → merged → production as per-session line measures, so the stage
+    where work leaks is queryable in aggregate. Transcripts are only needed for
+    the *why* (open vs. reverted vs. superseded). `sessions pull` even
+    precomputes the gap columns; see `analyze sessions --help`.
+
+Examples:
+  git-ai analyze docs
+  git-ai analyze query -m public_v1_sessions.total_sessions
+  git-ai analyze query -m public_v1_pull_requests.ai_assisted_pull_requests \
+      --time-dimension public_v1_pull_requests.opened_time -g month --since "last 6 months" --tsv
+  git-ai analyze query -m public_v1_sessions.total_generated_lines \
+      -d public_v1_sessions.agent -o public_v1_sessions.total_generated_lines:desc -l 10
+
+Common cubes: public_v1_pull_requests, public_v1_sessions, public_v1_session_models,
+  public_v1_normalized_events, public_v1_token_usage, public_v1_production_hunks,
+  public_v1_ai_checkpoint_events, public_v1_repos, public_v1_user_status (+ more via docs).
+
+Pull + analyze specific sessions/prompts (read the transcripts, grade at scale):
+  `git-ai analyze sessions --help`.
+"#;
+    eprint!("{help}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_order_with_and_without_direction() {
+        assert_eq!(
+            parse_order("public_v1_sessions.total_sessions:desc").unwrap(),
+            ("public_v1_sessions.total_sessions".into(), "desc".into())
+        );
+        assert_eq!(
+            parse_order("member").unwrap(),
+            ("member".into(), "asc".into())
+        );
+        assert!(parse_order("member:sideways").is_err());
+        assert!(parse_order(":desc").is_err());
+    }
+
+    #[test]
+    fn splits_csv_and_trims() {
+        assert_eq!(split_csv("a, b ,c"), vec!["a", "b", "c"]);
+        assert_eq!(split_csv(" , "), Vec::<String>::new());
+    }
+
+    #[test]
+    fn render_json_extracts_data_array() {
+        // Smoke test the data-extraction path doesn't panic on missing data.
+        render(&serde_json::json!({"foo": 1}), Format::Json);
+        render(&serde_json::json!({"data": [{"a": "1"}]}), Format::Tsv);
+    }
+}

--- a/src/commands/analyze/mod.rs
+++ b/src/commands/analyze/mod.rs
@@ -110,10 +110,7 @@ fn cmd_query(args: &[String]) -> Result<(), String> {
                     other => return Err(format!("unknown --format: {} (json|tsv|raw)", other)),
                 };
             }
-            "--help" | "-h" => {
-                print_help();
-                return Ok(());
-            }
+            // `--help`/`-h` is handled by `handle_analyze` before dispatch.
             other => return Err(format!("unknown query flag: {}", other)),
         }
         i += 1;
@@ -136,11 +133,8 @@ fn cmd_query(args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
-fn cmd_docs(args: &[String]) -> Result<(), String> {
-    if args.iter().any(|a| a == "--help" || a == "-h") {
-        print_help();
-        return Ok(());
-    }
+fn cmd_docs(_args: &[String]) -> Result<(), String> {
+    // `--help`/`-h` is handled by `handle_analyze` before dispatch.
     let client = CubeClient::from_config().map_err(|e| e.to_string())?;
     let meta = client.meta().map_err(|e| e.to_string())?;
     println!(
@@ -202,7 +196,7 @@ fn parse_order(s: &str) -> Result<(String, String), String> {
     Ok((member.to_string(), dir))
 }
 
-fn take_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
+pub(super) fn take_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
     *i += 1;
     args.get(*i)
         .cloned()

--- a/src/commands/analyze/sessions.rs
+++ b/src/commands/analyze/sessions.rs
@@ -11,6 +11,7 @@
 //! and returns it inline. `reset` rewinds the analysis cursor to re-run.
 
 use super::cube::{CubeClient, QueryArgs};
+use super::take_value;
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use serde_json::{Map, Value, json};
 use std::path::{Path, PathBuf};
@@ -261,10 +262,7 @@ fn cmd_pull(args: &[String]) -> Result<(), String> {
             "--order" | "-o" => {
                 order.push(super::parse_order(&take_value(args, &mut i, "--order")?)?);
             }
-            "--help" | "-h" => {
-                print_help();
-                return Ok(());
-            }
+            // `--help`/`-h` is handled by `handle_sessions` before dispatch.
             other => return Err(format!("unknown pull flag: {}", other)),
         }
         i += 1;
@@ -413,10 +411,7 @@ fn cmd_next(args: &[String]) -> Result<(), String> {
                     .map_err(|_| "--max-events must be a number".to_string())?
             }
             "--no-transcript" => with_transcript = false,
-            "--help" | "-h" => {
-                print_help();
-                return Ok(());
-            }
+            // `--help`/`-h` is handled by `handle_sessions` before dispatch.
             other if !other.starts_with('-') && db_path.is_none() => {
                 db_path = Some(other.to_string())
             }
@@ -582,10 +577,7 @@ fn cmd_reset(args: &[String]) -> Result<(), String> {
                     .parse()
                     .map_err(|_| "--to must be a number".to_string())?
             }
-            "--help" | "-h" => {
-                print_help();
-                return Ok(());
-            }
+            // `--help`/`-h` is handled by `handle_sessions` before dispatch.
             other if !other.starts_with('-') && db_path.is_none() => {
                 db_path = Some(other.to_string())
             }
@@ -646,61 +638,66 @@ fn cmd_exec(args: &[String]) -> Result<(), String> {
 // Cube query field lists
 // ---------------------------------------------------------------------------
 
+/// Fully-qualify a list of cube members as `<cube>.<member>`.
+fn qualify(cube: &str, members: &[&str]) -> Vec<String> {
+    members.iter().map(|m| format!("{}.{}", cube, m)).collect()
+}
+
 fn session_dimensions() -> Vec<String> {
     // session_start_time is a plain dimension (not a bare timeDimension) so that
     // `order` by it is honored — Cube ignores ordering on a timeDimension that
     // has no granularity. The `--since` dateRange still filters via timeDimensions.
-    [
-        "session_id",
-        "user_id",
-        "agent",
-        "repo_url",
-        "parent_session_id",
-        "child_session_count",
-        "session_start_time",
-        "session_end_time",
-    ]
-    .iter()
-    .map(|d| format!("{}.{}", SESSIONS_CUBE, d))
-    .collect()
+    qualify(
+        SESSIONS_CUBE,
+        &[
+            "session_id",
+            "user_id",
+            "agent",
+            "repo_url",
+            "parent_session_id",
+            "child_session_count",
+            "session_start_time",
+            "session_end_time",
+        ],
+    )
 }
 
 fn session_measures() -> Vec<String> {
-    [
-        "total_generated_lines",
-        "total_deleted_lines",
-        "net_generated_lines",
-        "total_generated_sloc",
-        "total_committed_lines",
-        "total_pr_opened_lines",
-        "total_merged_lines",
-        "total_production_lines",
-        "total_checkpoints",
-        "total_events",
-        "total_usage_minutes",
-    ]
-    .iter()
-    .map(|m| format!("{}.{}", SESSIONS_CUBE, m))
-    .collect()
+    qualify(
+        SESSIONS_CUBE,
+        &[
+            "total_generated_lines",
+            "total_deleted_lines",
+            "net_generated_lines",
+            "total_generated_sloc",
+            "total_committed_lines",
+            "total_pr_opened_lines",
+            "total_merged_lines",
+            "total_production_lines",
+            "total_checkpoints",
+            "total_events",
+            "total_usage_minutes",
+        ],
+    )
 }
 
 fn event_dimensions() -> Vec<String> {
-    [
-        "event_kind",
-        "tool",
-        "tool_kind",
-        "model",
-        "target",
-        "text",
-        "summary",
-        "tool_input",
-        "tool_output",
-        "event_time",
-        "output_seq",
-    ]
-    .iter()
-    .map(|d| format!("{}.{}", EVENTS_CUBE, d))
-    .collect()
+    qualify(
+        EVENTS_CUBE,
+        &[
+            "event_kind",
+            "tool",
+            "tool_kind",
+            "model",
+            "target",
+            "text",
+            "summary",
+            "tool_input",
+            "tool_output",
+            "event_time",
+            "output_seq",
+        ],
+    )
 }
 
 /// Build Cube equals-filter objects from (member, optional value) pairs,
@@ -946,17 +943,17 @@ fn enrich_token_usage(
     conn: &Connection,
     session_ids: &[String],
 ) -> Result<(), String> {
-    let measures = [
-        "total_input_tokens",
-        "total_output_tokens",
-        "total_cache_read_tokens",
-        "total_cache_creation_tokens",
-        "total_reasoning_tokens",
-        "total_cost",
-    ]
-    .iter()
-    .map(|m| format!("{}.{}", TOKEN_USAGE_CUBE, m))
-    .collect();
+    let measures = qualify(
+        TOKEN_USAGE_CUBE,
+        &[
+            "total_input_tokens",
+            "total_output_tokens",
+            "total_cache_read_tokens",
+            "total_cache_creation_tokens",
+            "total_reasoning_tokens",
+            "total_cost",
+        ],
+    );
     let args = QueryArgs {
         measures,
         dimensions: vec![format!("{}.session_id", TOKEN_USAGE_CUBE)],
@@ -1048,10 +1045,10 @@ fn enrich_prs(
 ) -> Result<(), String> {
     let args = QueryArgs {
         measures: vec![format!("{}.total_ai_lines", PR_SESSIONS_CUBE)],
-        dimensions: ["session_id", "repo_url", "pr_number", "agent", "model_raw"]
-            .iter()
-            .map(|d| format!("{}.{}", PR_SESSIONS_CUBE, d))
-            .collect(),
+        dimensions: qualify(
+            PR_SESSIONS_CUBE,
+            &["session_id", "repo_url", "pr_number", "agent", "model_raw"],
+        ),
         filters_json: Some(id_filter(PR_SESSIONS_CUBE, session_ids)),
         // A session can land in several PRs; allow generous headroom per id.
         limit: Some((session_ids.len() as u64).saturating_mul(20).max(50)),
@@ -1166,6 +1163,19 @@ fn insert_events(
     Ok(inserted)
 }
 
+/// Build a JSON object from a SQLite row, keyed by the given (select-order)
+/// column names.
+fn row_to_json_object(
+    row: &rusqlite::Row,
+    cols: &[&str],
+) -> Result<Map<String, Value>, rusqlite::Error> {
+    let mut obj = Map::new();
+    for (idx, name) in cols.iter().enumerate() {
+        obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
+    }
+    Ok(obj)
+}
+
 /// Read one session row as a JSON object keyed by the public column names.
 fn session_row_json(
     conn: &Connection,
@@ -1176,11 +1186,7 @@ fn session_row_json(
         SESSION_COLUMNS.join(", ")
     );
     conn.query_row(&sql, params![session_id], |row| {
-        let mut obj = Map::new();
-        for (idx, name) in SESSION_COLUMNS.iter().enumerate() {
-            obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
-        }
-        Ok(obj)
+        row_to_json_object(row, SESSION_COLUMNS)
     })
 }
 
@@ -1206,11 +1212,7 @@ fn transcript_json(conn: &Connection, session_id: &str) -> Result<Vec<Value>, ru
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![session_id], |row| {
-        let mut obj = Map::new();
-        for (idx, name) in cols.iter().enumerate() {
-            obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
-        }
-        Ok(Value::Object(obj))
+        Ok(Value::Object(row_to_json_object(row, &cols)?))
     })?;
     rows.collect()
 }
@@ -1224,11 +1226,7 @@ fn session_prs_json(conn: &Connection, session_id: &str) -> Result<Vec<Value>, r
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params![session_id], |row| {
-        let mut obj = Map::new();
-        for (idx, name) in cols.iter().enumerate() {
-            obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
-        }
-        Ok(Value::Object(obj))
+        Ok(Value::Object(row_to_json_object(row, &cols)?))
     })?;
     rows.collect()
 }
@@ -1237,10 +1235,14 @@ fn session_prs_json(conn: &Connection, session_id: &str) -> Result<Vec<Value>, r
 // Value extraction / conversion
 // ---------------------------------------------------------------------------
 
+/// Look up a cube member (`<cube>.<field>`) in a row.
+fn member<'a>(row: &'a Value, cube: &str, field: &str) -> Option<&'a Value> {
+    row.get(format!("{}.{}", cube, field))
+}
+
 /// Get a cube member (`<cube>.<field>`) from a row as an owned String.
 fn member_str(row: &Value, cube: &str, field: &str) -> Option<String> {
-    let key = format!("{}.{}", cube, field);
-    match row.get(&key) {
+    match member(row, cube, field) {
         Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
         Some(Value::Number(n)) => Some(n.to_string()),
         _ => None,
@@ -1249,8 +1251,7 @@ fn member_str(row: &Value, cube: &str, field: &str) -> Option<String> {
 
 /// Get a numeric cube member. Cube returns numbers as strings, so parse both.
 fn member_int(row: &Value, cube: &str, field: &str) -> Option<i64> {
-    let key = format!("{}.{}", cube, field);
-    match row.get(&key) {
+    match member(row, cube, field) {
         Some(Value::String(s)) => s.trim().parse::<f64>().ok().map(|f| f as i64),
         Some(Value::Number(n)) => n.as_i64().or_else(|| n.as_f64().map(|f| f as i64)),
         _ => None,
@@ -1260,8 +1261,7 @@ fn member_int(row: &Value, cube: &str, field: &str) -> Option<i64> {
 /// Get a numeric cube member as f64 (e.g. cost). Cube returns numbers as
 /// strings, so parse both.
 fn member_float(row: &Value, cube: &str, field: &str) -> Option<f64> {
-    let key = format!("{}.{}", cube, field);
-    match row.get(&key) {
+    match member(row, cube, field) {
         Some(Value::String(s)) => s.trim().parse::<f64>().ok(),
         Some(Value::Number(n)) => n.as_f64(),
         _ => None,
@@ -1270,9 +1270,7 @@ fn member_float(row: &Value, cube: &str, field: &str) -> Option<f64> {
 
 /// Get a time-typed cube member (ISO8601 string) as unix seconds.
 fn member_time(row: &Value, cube: &str, field: &str) -> Option<i64> {
-    let key = format!("{}.{}", cube, field);
-    let s = row.get(&key)?.as_str()?;
-    parse_cube_time(s)
+    parse_cube_time(member(row, cube, field)?.as_str()?)
 }
 
 /// Parse a Cube time value (RFC3339 or `YYYY-MM-DDTHH:MM:SS[.fff]`) to unix secs.
@@ -1321,13 +1319,6 @@ fn value_ref_to_string(v: rusqlite::types::ValueRef) -> String {
 // ---------------------------------------------------------------------------
 // Misc
 // ---------------------------------------------------------------------------
-
-fn take_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
-    *i += 1;
-    args.get(*i)
-        .cloned()
-        .ok_or_else(|| format!("{} requires a value", flag))
-}
 
 fn single_db_arg(args: &[String], cmd: &str) -> Result<String, String> {
     args.iter()

--- a/src/commands/analyze/sessions.rs
+++ b/src/commands/analyze/sessions.rs
@@ -1,0 +1,1869 @@
+//! `git-ai analyze sessions …` — pull coding sessions from Cube into a scratch
+//! SQLite DB, then hand them out one at a time for grading at scale.
+//!
+//! Two cursors live in the DB, both in the `cursor` table: a **pull cursor**
+//! (`fetched`/`target`/`pull_complete` — how far we've paged through Cube) and
+//! an **analysis cursor** (`analyzed_seq` — the highest `sessions.seq_id` handed
+//! out). `sessions next` advances the analysis cursor by exactly one row inside
+//! an `IMMEDIATE` transaction, so concurrent subagents each get a distinct
+//! session exactly once with no dependency on anyone marking it complete; it
+//! then fetches and persists that session's transcript into `session_events`
+//! and returns it inline. `reset` rewinds the analysis cursor to re-run.
+
+use super::cube::{CubeClient, QueryArgs};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use serde_json::{Map, Value, json};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SESSIONS_CUBE: &str = "public_v1_sessions";
+const EVENTS_CUBE: &str = "public_v1_normalized_events";
+const TOKEN_USAGE_CUBE: &str = "public_v1_token_usage";
+const SESSION_MODELS_CUBE: &str = "public_v1_session_models";
+const PR_SESSIONS_CUBE: &str = "public_v1_pr_sessions";
+
+const DEFAULT_PULL_LIMIT: u64 = 100;
+const PULL_BATCH: u64 = 50;
+const DEFAULT_MAX_EVENTS: u64 = 2000;
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS sessions (
+    seq_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL UNIQUE,
+    user_id TEXT,
+    agent TEXT,
+    repo_url TEXT,
+    parent_session_id TEXT,
+    child_session_count INTEGER,
+    session_start_time INTEGER,
+    session_end_time INTEGER,
+    generated_lines INTEGER,
+    deleted_lines INTEGER,
+    net_generated_lines INTEGER,
+    generated_sloc INTEGER,
+    -- Funnel stages, in order: every line a session committed, then how many of
+    -- those reached a PR, got merged, and finally landed in production. The
+    -- stage-to-stage "gap" columns (committed_not_pr_opened, …) are derived from
+    -- these by `ensure_derived_columns` (see DERIVED_COLUMNS) so an analyst never
+    -- has to hand-compute "committed but didn't ship".
+    committed_lines INTEGER,
+    pr_opened_lines INTEGER,
+    merged_lines INTEGER,
+    production_lines INTEGER,
+    total_checkpoints INTEGER,
+    total_events INTEGER,
+    usage_minutes INTEGER,
+    -- Cross-cube baseline, backfilled at pull time (best-effort) so every
+    -- session carries the same comparable columns without re-querying:
+    --   models      : comma-joined distinct models used (see session_models)
+    --   *_tokens    : per-session token usage (public_v1_token_usage)
+    --   cost_usd    : per-session estimated cost (public_v1_token_usage)
+    --   pr_count    : how many PRs this session appears in (see session_prs)
+    models TEXT,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_read_tokens INTEGER,
+    cache_creation_tokens INTEGER,
+    reasoning_tokens INTEGER,
+    cost_usd REAL,
+    pr_count INTEGER,
+    created_at INTEGER NOT NULL
+);
+
+-- One row per (session, model). Backfilled from public_v1_session_models; the
+-- distinct models are also denormalized into sessions.models for quick filters.
+CREATE TABLE IF NOT EXISTS session_models (
+    session_id TEXT NOT NULL REFERENCES sessions(session_id),
+    model TEXT NOT NULL,
+    event_count INTEGER,
+    PRIMARY KEY (session_id, model)
+);
+CREATE INDEX IF NOT EXISTS idx_session_models_sid ON session_models(session_id);
+
+-- One row per (session, PR) the session contributed to. Backfilled from
+-- public_v1_pr_sessions; the count is denormalized into sessions.pr_count.
+CREATE TABLE IF NOT EXISTS session_prs (
+    session_id TEXT NOT NULL REFERENCES sessions(session_id),
+    repo_url TEXT NOT NULL DEFAULT '',
+    pr_number INTEGER NOT NULL,
+    agent TEXT,
+    model_raw TEXT,
+    ai_lines INTEGER,
+    PRIMARY KEY (session_id, repo_url, pr_number)
+);
+CREATE INDEX IF NOT EXISTS idx_session_prs_sid ON session_prs(session_id);
+
+CREATE TABLE IF NOT EXISTS session_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    output_seq INTEGER,
+    event_time INTEGER,
+    event_kind TEXT,
+    tool TEXT,
+    tool_kind TEXT,
+    model TEXT,
+    target TEXT,
+    text TEXT,
+    summary TEXT,
+    tool_input TEXT,
+    tool_output TEXT,
+    UNIQUE(session_id, output_seq, event_time, event_kind, tool)
+);
+CREATE INDEX IF NOT EXISTS idx_session_events_sid ON session_events(session_id);
+
+-- Two cursors live here:
+--   fetched/target/pull_complete : ingestion progress paging through Cube (pull)
+--   analyzed_seq                 : the analysis cursor — the highest sessions.seq_id
+--                                  handed out by `next`. `next` advances it atomically
+--                                  so every row is served exactly once; `reset` sets it
+--                                  back to 0 to start a fresh analysis pass.
+CREATE TABLE IF NOT EXISTS cursor (
+    name TEXT PRIMARY KEY DEFAULT 'default',
+    fetched INTEGER NOT NULL DEFAULT 0,
+    target INTEGER,
+    pull_complete INTEGER NOT NULL DEFAULT 0,
+    analyzed_seq INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT
+);
+"#;
+
+/// Session columns selected for output, in display order.
+const SESSION_COLUMNS: &[&str] = &[
+    "seq_id",
+    "session_id",
+    "user_id",
+    "agent",
+    "repo_url",
+    "parent_session_id",
+    "child_session_count",
+    "session_start_time",
+    "session_end_time",
+    "generated_lines",
+    "deleted_lines",
+    "net_generated_lines",
+    "generated_sloc",
+    "committed_lines",
+    "pr_opened_lines",
+    "merged_lines",
+    "production_lines",
+    // Derived funnel gaps (generated columns — see DERIVED_COLUMNS).
+    "committed_not_pr_opened",
+    "pr_opened_not_merged",
+    "merged_not_production",
+    "committed_not_production",
+    "production_rate",
+    "total_checkpoints",
+    "total_events",
+    "usage_minutes",
+    "models",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+    "reasoning_tokens",
+    "cost_usd",
+    "pr_count",
+];
+
+pub fn handle_sessions(args: &[String]) {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    let rest = if args.is_empty() { &[][..] } else { &args[1..] };
+    // `--help`/`-h` anywhere prints help, exactly like running `sessions` raw.
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return;
+    }
+    let result = match sub {
+        "pull" => cmd_pull(rest),
+        "next" => cmd_next(rest),
+        "stats" => cmd_stats(rest),
+        "reset" => cmd_reset(rest),
+        "exec" => cmd_exec(rest),
+        "help" | "--help" | "-h" | "" => {
+            print_help();
+            return;
+        }
+        other => Err(format!(
+            "unknown sessions subcommand: {}\nRun `git-ai analyze sessions --help`.",
+            other
+        )),
+    };
+    if let Err(msg) = result {
+        eprintln!("Error: {}", msg);
+        std::process::exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// pull
+// ---------------------------------------------------------------------------
+
+fn cmd_pull(args: &[String]) -> Result<(), String> {
+    let mut db_path: Option<String> = None;
+    let mut limit = DEFAULT_PULL_LIMIT;
+    let mut since: Option<String> = None;
+    let mut repo: Option<String> = None;
+    let mut user: Option<String> = None;
+    let mut agent: Option<String> = None;
+    // Default to top-level sessions only: a session with a parent is a subagent.
+    let mut include_subagents = false;
+    // Backfill the cross-cube baseline columns (tokens/cost/models/PRs) by
+    // default; --no-enrich skips the extra per-batch queries.
+    let mut enrich = true;
+    // Query-shaping flags, identical to `analyze query`: these layer extra
+    // dimensions/measures/filters/order on top of the canonical session columns
+    // so you can slice the session population on ANY Cube member.
+    let mut extra_measures: Vec<String> = Vec::new();
+    let mut extra_dimensions: Vec<String> = Vec::new();
+    let mut time_dimension: Option<String> = None;
+    let mut granularity: Option<String> = None;
+    let mut filters_json: Option<String> = None;
+    let mut order: Vec<(String, String)> = Vec::new();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => db_path = Some(take_value(args, &mut i, "--db")?),
+            "--limit" => {
+                limit = take_value(args, &mut i, "--limit")?
+                    .parse()
+                    .map_err(|_| "--limit must be a number".to_string())?
+            }
+            "--since" | "--date-range" => since = Some(take_value(args, &mut i, "--since")?),
+            "--repo" => repo = Some(take_value(args, &mut i, "--repo")?),
+            "--user" => user = Some(take_value(args, &mut i, "--user")?),
+            "--agent" => agent = Some(take_value(args, &mut i, "--agent")?),
+            "--include-subagents" => include_subagents = true,
+            "--no-enrich" => enrich = false,
+            "--measures" | "-m" => {
+                extra_measures.extend(super::split_csv(&take_value(args, &mut i, "--measures")?));
+            }
+            "--dimensions" | "-d" => {
+                extra_dimensions.extend(super::split_csv(&take_value(
+                    args,
+                    &mut i,
+                    "--dimensions",
+                )?));
+            }
+            "--time-dimension" | "--td" => {
+                time_dimension = Some(take_value(args, &mut i, "--time-dimension")?);
+            }
+            "--granularity" | "-g" => {
+                granularity = Some(take_value(args, &mut i, "--granularity")?);
+            }
+            "--filters" | "-f" => {
+                filters_json = Some(take_value(args, &mut i, "--filters")?);
+            }
+            "--order" | "-o" => {
+                order.push(super::parse_order(&take_value(args, &mut i, "--order")?)?);
+            }
+            "--help" | "-h" => {
+                print_help();
+                return Ok(());
+            }
+            other => return Err(format!("unknown pull flag: {}", other)),
+        }
+        i += 1;
+    }
+
+    let path = match db_path {
+        Some(p) => PathBuf::from(p),
+        None => random_db_path(),
+    };
+    let client = CubeClient::from_config().map_err(|e| e.to_string())?;
+    let conn = open_db(&path).map_err(|e| e.to_string())?;
+    init_cursor(&conn, limit).map_err(|e| e.to_string())?;
+
+    // Record provenance.
+    set_meta(&conn, "created_at", &now_secs().to_string()).ok();
+    set_meta(
+        &conn,
+        "pull_filters",
+        &json!({
+            "since": since, "repo": repo, "user": user, "agent": agent,
+            "limit": limit, "include_subagents": include_subagents,
+            "filters": filters_json, "dimensions": extra_dimensions,
+            "measures": extra_measures, "time_dimension": time_dimension,
+            "granularity": granularity,
+            "order": order.iter().map(|(m, d)| format!("{}:{}", m, d)).collect::<Vec<_>>(),
+        })
+        .to_string(),
+    )
+    .ok();
+
+    // The canonical session columns are ALWAYS selected so the SQLite schema
+    // stays fully populated; the caller's --dimensions/--measures layer on top.
+    let mut dimensions = session_dimensions();
+    for d in extra_dimensions {
+        if !dimensions.contains(&d) {
+            dimensions.push(d);
+        }
+    }
+    let mut measures = session_measures();
+    for m in extra_measures {
+        if !measures.contains(&m) {
+            measures.push(m);
+        }
+    }
+
+    // Convenience equals-filters (subagent/repo/user/agent) merge with any raw
+    // --filters array so both work together and you can slice on ANY member. A
+    // non-empty parent_session_id means a subagent session; '' (not NULL) is a
+    // top-level user session, so we exclude subagents by default.
+    let parent_filter = if include_subagents { None } else { Some("") };
+    let convenience = equals_filters(&[
+        (
+            format!("{}.parent_session_id", SESSIONS_CUBE),
+            parent_filter,
+        ),
+        (format!("{}.repo_url", SESSIONS_CUBE), repo.as_deref()),
+        (format!("{}.user_id", SESSIONS_CUBE), user.as_deref()),
+        (format!("{}.agent", SESSIONS_CUBE), agent.as_deref()),
+    ]);
+    let filters = merge_filters(convenience, filters_json.as_deref())?;
+
+    // A --since dateRange needs a time dimension; default to session_start_time
+    // unless the caller named their own. Ordering defaults to newest-first but
+    // an explicit --order wins.
+    let time_dimension = time_dimension.or_else(|| {
+        since
+            .as_ref()
+            .map(|_| format!("{}.session_start_time", SESSIONS_CUBE))
+    });
+    let order = if order.is_empty() {
+        vec![(
+            format!("{}.session_start_time", SESSIONS_CUBE),
+            "desc".into(),
+        )]
+    } else {
+        order
+    };
+
+    let mut fetched: u64 = get_fetched(&conn).map_err(|e| e.to_string())?;
+    let mut stored_now = 0usize;
+
+    while fetched < limit {
+        let batch = PULL_BATCH.min(limit - fetched);
+        let args = QueryArgs {
+            measures: measures.clone(),
+            dimensions: dimensions.clone(),
+            time_dimension: time_dimension.clone(),
+            granularity: granularity.clone(),
+            date_range: since.clone(),
+            filters_json: filters.clone(),
+            order: order.clone(),
+            limit: Some(batch),
+            offset: Some(fetched),
+        };
+        let query = args.to_query()?;
+        let rows = client.load_rows(&query).map_err(|e| e.to_string())?;
+        let returned = rows.len() as u64;
+        stored_now += insert_sessions(&conn, &rows).map_err(|e| e.to_string())?;
+        // Backfill the cross-cube baseline columns for this batch's sessions.
+        if enrich {
+            let batch_ids: Vec<String> = rows
+                .iter()
+                .filter_map(|r| member_str(r, SESSIONS_CUBE, "session_id"))
+                .collect();
+            enrich_sessions(&client, &conn, &batch_ids);
+        }
+        fetched += returned;
+        set_fetched(&conn, fetched).map_err(|e| e.to_string())?;
+        // Exhausted: cube returned fewer rows than asked for.
+        if returned < batch {
+            set_pull_complete(&conn).map_err(|e| e.to_string())?;
+            break;
+        }
+    }
+    if fetched >= limit {
+        set_pull_complete(&conn).map_err(|e| e.to_string())?;
+    }
+
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+    eprintln!(
+        "Pulled {} new session(s); {} total in db.",
+        stored_now, total
+    );
+    // The DB path goes to stdout so callers can capture it (`DB=$(… pull)`).
+    println!("{}", path.display());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// next
+// ---------------------------------------------------------------------------
+
+fn cmd_next(args: &[String]) -> Result<(), String> {
+    let mut db_path: Option<String> = None;
+    let mut max_events = DEFAULT_MAX_EVENTS;
+    let mut with_transcript = true;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--max-events" => {
+                max_events = take_value(args, &mut i, "--max-events")?
+                    .parse()
+                    .map_err(|_| "--max-events must be a number".to_string())?
+            }
+            "--no-transcript" => with_transcript = false,
+            "--help" | "-h" => {
+                print_help();
+                return Ok(());
+            }
+            other if !other.starts_with('-') && db_path.is_none() => {
+                db_path = Some(other.to_string())
+            }
+            other => return Err(format!("unknown next argument: {}", other)),
+        }
+        i += 1;
+    }
+    let path = db_path.ok_or("usage: git-ai analyze sessions next <db> [--max-events N]")?;
+    let mut conn = open_existing_db(&path)?;
+
+    // Hand out the next session by advancing the analysis cursor exactly one
+    // row. `BEGIN IMMEDIATE` takes the write lock before we read the cursor, so
+    // concurrent `next` callers are serialized — every row is returned exactly
+    // once and only once, with no dependency on the caller ever coming back.
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(|e| e.to_string())?;
+    let pos: i64 = tx
+        .query_row(
+            "SELECT analyzed_seq FROM cursor WHERE name='default'",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(|e| e.to_string())?
+        .unwrap_or(0);
+    // First row strictly past the cursor (gap-safe: skips any missing seq_ids).
+    let claimed: Option<(i64, String)> = tx
+        .query_row(
+            "SELECT seq_id, session_id FROM sessions WHERE seq_id > ?1 ORDER BY seq_id LIMIT 1",
+            params![pos],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()
+        .map_err(|e| e.to_string())?;
+    if let Some((seq_id, _)) = &claimed {
+        tx.execute(
+            "UPDATE cursor SET analyzed_seq=?1 WHERE name='default'",
+            params![seq_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    tx.commit().map_err(|e| e.to_string())?;
+
+    let session_id = match claimed {
+        Some((_, id)) => id,
+        None => {
+            println!("{}", json!({ "done": true }));
+            return Ok(());
+        }
+    };
+
+    // Fetch + persist the transcript (skip if we already have it, or disabled).
+    if with_transcript && !has_events(&conn, &session_id).map_err(|e| e.to_string())? {
+        match fetch_transcript(&session_id, max_events) {
+            Ok(events) => {
+                insert_events(&conn, &session_id, &events).map_err(|e| e.to_string())?;
+            }
+            Err(e) => {
+                // Don't lose the claim on a transient transcript-fetch failure;
+                // surface a warning and return metadata only.
+                eprintln!("Warning: failed to fetch transcript: {}", e);
+            }
+        }
+    }
+
+    let mut out = session_row_json(&conn, &session_id).map_err(|e| e.to_string())?;
+    // Attach the PRs this session appears in (empty array if none/un-enriched).
+    let prs = session_prs_json(&conn, &session_id).map_err(|e| e.to_string())?;
+    out.insert("prs".into(), Value::Array(prs));
+    if with_transcript {
+        let transcript = transcript_json(&conn, &session_id).map_err(|e| e.to_string())?;
+        out.insert("transcript".into(), Value::Array(transcript));
+    }
+    println!("{}", Value::Object(out));
+    Ok(())
+}
+
+fn fetch_transcript(session_id: &str, max_events: u64) -> Result<Vec<Value>, String> {
+    let client = CubeClient::from_config().map_err(|e| e.to_string())?;
+    let filters = json!([{
+        "member": format!("{}.session_id", EVENTS_CUBE),
+        "operator": "equals",
+        "values": [session_id],
+    }])
+    .to_string();
+    let args = QueryArgs {
+        dimensions: event_dimensions(),
+        filters_json: Some(filters),
+        order: vec![
+            (format!("{}.event_time", EVENTS_CUBE), "asc".into()),
+            (format!("{}.output_seq", EVENTS_CUBE), "asc".into()),
+        ],
+        limit: Some(max_events),
+        ..Default::default()
+    };
+    let query = args.to_query()?;
+    client.load_rows(&query).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// stats / reset / exec
+// ---------------------------------------------------------------------------
+
+fn cmd_stats(args: &[String]) -> Result<(), String> {
+    let path = single_db_arg(args, "stats")?;
+    let conn = open_existing_db(&path)?;
+
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+
+    let (fetched, target, complete, analyzed_seq): (i64, Option<i64>, i64, i64) = conn
+        .query_row(
+            "SELECT fetched, target, pull_complete, analyzed_seq FROM cursor WHERE name='default'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .optional()
+        .map_err(|e| e.to_string())?
+        .unwrap_or((0, None, 0, 0));
+    // Analysis progress: rows at or before the cursor are served; the rest remain.
+    let analyzed: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE seq_id <= ?1",
+            params![analyzed_seq],
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    let events: i64 = conn
+        .query_row("SELECT COUNT(*) FROM session_events", [], |r| r.get(0))
+        .map_err(|e| e.to_string())?;
+
+    println!("db: {}", path);
+    println!("sessions: {} total", total);
+    println!(
+        "analysis cursor: analyzed_seq={} ({}/{} served, {} remaining)",
+        analyzed_seq,
+        analyzed,
+        total,
+        total - analyzed
+    );
+    println!(
+        "pull cursor: fetched={} target={} complete={}",
+        fetched,
+        target.map(|t| t.to_string()).unwrap_or_else(|| "-".into()),
+        if complete != 0 { "yes" } else { "no" }
+    );
+    println!("transcript events stored: {}", events);
+    Ok(())
+}
+
+fn cmd_reset(args: &[String]) -> Result<(), String> {
+    let mut db_path: Option<String> = None;
+    let mut to: i64 = 0;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            // Rewind (or set) the analysis cursor; `next` will re-serve from here.
+            "--to" => {
+                to = take_value(args, &mut i, "--to")?
+                    .parse()
+                    .map_err(|_| "--to must be a number".to_string())?
+            }
+            "--help" | "-h" => {
+                print_help();
+                return Ok(());
+            }
+            other if !other.starts_with('-') && db_path.is_none() => {
+                db_path = Some(other.to_string())
+            }
+            other => return Err(format!("unknown reset argument: {}", other)),
+        }
+        i += 1;
+    }
+    let path = db_path.ok_or("usage: git-ai analyze sessions reset <db> [--to <seq>]")?;
+    let conn = open_existing_db(&path)?;
+
+    conn.execute(
+        "UPDATE cursor SET analyzed_seq=?1 WHERE name='default'",
+        params![to],
+    )
+    .map_err(|e| e.to_string())?;
+
+    eprintln!(
+        "Analysis cursor reset to {}; `next` will re-serve from there.",
+        to
+    );
+    Ok(())
+}
+
+fn cmd_exec(args: &[String]) -> Result<(), String> {
+    if args.len() < 2 {
+        return Err("usage: git-ai analyze sessions exec <db> \"<SQL>\"".to_string());
+    }
+    let path = &args[0];
+    let sql = &args[1];
+    let conn = open_existing_db(path)?;
+
+    let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
+    let col_count = stmt.column_count();
+    if col_count == 0 {
+        drop(stmt);
+        let n = conn.execute(sql, []).map_err(|e| e.to_string())?;
+        eprintln!("{} row(s) affected.", n);
+        return Ok(());
+    }
+
+    let names: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+    println!("{}", names.join("\t"));
+    let mut rows = stmt.query([]).map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+        let cells: Vec<String> = (0..col_count)
+            .map(|idx| {
+                row.get_ref(idx)
+                    .map(value_ref_to_string)
+                    .unwrap_or_default()
+            })
+            .collect();
+        println!("{}", cells.join("\t"));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Cube query field lists
+// ---------------------------------------------------------------------------
+
+fn session_dimensions() -> Vec<String> {
+    // session_start_time is a plain dimension (not a bare timeDimension) so that
+    // `order` by it is honored — Cube ignores ordering on a timeDimension that
+    // has no granularity. The `--since` dateRange still filters via timeDimensions.
+    [
+        "session_id",
+        "user_id",
+        "agent",
+        "repo_url",
+        "parent_session_id",
+        "child_session_count",
+        "session_start_time",
+        "session_end_time",
+    ]
+    .iter()
+    .map(|d| format!("{}.{}", SESSIONS_CUBE, d))
+    .collect()
+}
+
+fn session_measures() -> Vec<String> {
+    [
+        "total_generated_lines",
+        "total_deleted_lines",
+        "net_generated_lines",
+        "total_generated_sloc",
+        "total_committed_lines",
+        "total_pr_opened_lines",
+        "total_merged_lines",
+        "total_production_lines",
+        "total_checkpoints",
+        "total_events",
+        "total_usage_minutes",
+    ]
+    .iter()
+    .map(|m| format!("{}.{}", SESSIONS_CUBE, m))
+    .collect()
+}
+
+fn event_dimensions() -> Vec<String> {
+    [
+        "event_kind",
+        "tool",
+        "tool_kind",
+        "model",
+        "target",
+        "text",
+        "summary",
+        "tool_input",
+        "tool_output",
+        "event_time",
+        "output_seq",
+    ]
+    .iter()
+    .map(|d| format!("{}.{}", EVENTS_CUBE, d))
+    .collect()
+}
+
+/// Build Cube equals-filter objects from (member, optional value) pairs,
+/// skipping any pair whose value is `None`. Returned as a `Vec` so callers can
+/// merge these convenience filters with a raw `--filters` array before
+/// serializing the combined `filters` clause.
+fn equals_filters(pairs: &[(String, Option<&str>)]) -> Vec<Value> {
+    pairs
+        .iter()
+        .filter_map(|(member, value)| {
+            value.map(|v| json!({ "member": member, "operator": "equals", "values": [v] }))
+        })
+        .collect()
+}
+
+/// Merge the convenience equals-filters with the caller's raw `--filters` JSON
+/// array (the full `analyze query` escape hatch) into a single Cube `filters`
+/// clause. Returns `None` when there are no filters at all. The raw array must
+/// be a JSON array of filter objects; anything else is a user error.
+fn merge_filters(mut convenience: Vec<Value>, raw: Option<&str>) -> Result<Option<String>, String> {
+    if let Some(raw) = raw {
+        let parsed: Value =
+            serde_json::from_str(raw).map_err(|e| format!("--filters is not valid JSON: {}", e))?;
+        let extra = parsed
+            .as_array()
+            .ok_or("--filters must be a JSON array of filter objects")?;
+        convenience.extend(extra.iter().cloned());
+    }
+    if convenience.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Value::Array(convenience).to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SQLite helpers
+// ---------------------------------------------------------------------------
+
+fn open_db(path: &Path) -> Result<Connection, rusqlite::Error> {
+    let conn = Connection::open(path)?;
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
+    conn.execute_batch(SCHEMA)?;
+    ensure_derived_columns(&conn)?;
+    Ok(conn)
+}
+
+/// Derived "funnel gap" columns, computed straight from the raw stage measures
+/// (`committed_lines` → `pr_opened_lines` → `merged_lines` → `production_lines`)
+/// so an analyst can ask "what didn't ship, and where did it fall out?" with a
+/// plain SELECT — no hand arithmetic, no reaching for transcripts. Each gap is
+/// "lines that reached this stage but not the next"; `committed_not_production`
+/// is the headline "committed but never shipped" number, and `production_rate`
+/// is the share of committed work that landed in production. NULL bases are
+/// coalesced to 0 so the gaps are always clean integers. The *why* behind a gap
+/// (still-open PR vs. reverted vs. superseded) is NOT here — that genuinely
+/// needs the transcript.
+///
+/// `(name, sql_type, expression)`. Added as VIRTUAL generated columns, which
+/// (unlike STORED) can be introduced via `ALTER TABLE ADD COLUMN`, so old
+/// scratch DBs gain them on the next open too.
+const DERIVED_COLUMNS: &[(&str, &str, &str)] = &[
+    (
+        "committed_not_pr_opened",
+        "INTEGER",
+        "COALESCE(committed_lines, 0) - COALESCE(pr_opened_lines, 0)",
+    ),
+    (
+        "pr_opened_not_merged",
+        "INTEGER",
+        "COALESCE(pr_opened_lines, 0) - COALESCE(merged_lines, 0)",
+    ),
+    (
+        "merged_not_production",
+        "INTEGER",
+        "COALESCE(merged_lines, 0) - COALESCE(production_lines, 0)",
+    ),
+    (
+        "committed_not_production",
+        "INTEGER",
+        "COALESCE(committed_lines, 0) - COALESCE(production_lines, 0)",
+    ),
+    (
+        "production_rate",
+        "REAL",
+        "CAST(COALESCE(production_lines, 0) AS REAL) / NULLIF(committed_lines, 0)",
+    ),
+];
+
+/// Idempotently add the derived funnel-gap columns. Skips any that already
+/// exist (so it is safe to run on every `open_db`, new DB or old).
+fn ensure_derived_columns(conn: &Connection) -> Result<(), rusqlite::Error> {
+    for (name, sql_type, expr) in DERIVED_COLUMNS {
+        let sql = format!(
+            "ALTER TABLE sessions ADD COLUMN {} {} GENERATED ALWAYS AS ({}) VIRTUAL",
+            name, sql_type, expr
+        );
+        match conn.execute(&sql, []) {
+            Ok(_) => {}
+            // Already present (re-opening an existing DB): nothing to do.
+            Err(e) if e.to_string().contains("duplicate column name") => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+fn open_existing_db(path: &str) -> Result<Connection, String> {
+    if !Path::new(path).exists() {
+        return Err(format!(
+            "no such db: {} (run `git-ai analyze sessions pull` first)",
+            path
+        ));
+    }
+    open_db(Path::new(path)).map_err(|e| e.to_string())
+}
+
+fn init_cursor(conn: &Connection, target: u64) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO cursor (name, fetched, target, pull_complete) VALUES ('default', 0, ?1, 0) \
+         ON CONFLICT(name) DO UPDATE SET target=MAX(target, excluded.target), pull_complete=0",
+        params![target as i64],
+    )?;
+    Ok(())
+}
+
+fn get_fetched(conn: &Connection) -> Result<u64, rusqlite::Error> {
+    let v: i64 = conn
+        .query_row("SELECT fetched FROM cursor WHERE name='default'", [], |r| {
+            r.get(0)
+        })
+        .optional()?
+        .unwrap_or(0);
+    Ok(v.max(0) as u64)
+}
+
+fn set_fetched(conn: &Connection, fetched: u64) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE cursor SET fetched=?1 WHERE name='default'",
+        params![fetched as i64],
+    )?;
+    Ok(())
+}
+
+fn set_pull_complete(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute("UPDATE cursor SET pull_complete=1 WHERE name='default'", [])?;
+    Ok(())
+}
+
+fn set_meta(conn: &Connection, key: &str, value: &str) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES (?1, ?2) \
+         ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        params![key, value],
+    )?;
+    Ok(())
+}
+
+/// Insert session rows (deduped by session_id). Returns count newly inserted.
+fn insert_sessions(conn: &Connection, rows: &[Value]) -> Result<usize, rusqlite::Error> {
+    let now = now_secs();
+    let mut inserted = 0;
+    let tx = conn.unchecked_transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT OR IGNORE INTO sessions (
+                session_id, user_id, agent, repo_url, parent_session_id,
+                child_session_count, session_start_time, session_end_time,
+                generated_lines, deleted_lines, net_generated_lines, generated_sloc,
+                committed_lines, pr_opened_lines, merged_lines, production_lines,
+                total_checkpoints, total_events, usage_minutes, created_at
+            ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)",
+        )?;
+        for row in rows {
+            let session_id = match member_str(row, SESSIONS_CUBE, "session_id") {
+                Some(id) if !id.is_empty() => id,
+                _ => continue,
+            };
+            let n = stmt.execute(params![
+                session_id,
+                member_str(row, SESSIONS_CUBE, "user_id"),
+                member_str(row, SESSIONS_CUBE, "agent"),
+                member_str(row, SESSIONS_CUBE, "repo_url"),
+                member_str(row, SESSIONS_CUBE, "parent_session_id"),
+                member_int(row, SESSIONS_CUBE, "child_session_count"),
+                member_time(row, SESSIONS_CUBE, "session_start_time"),
+                member_time(row, SESSIONS_CUBE, "session_end_time"),
+                member_int(row, SESSIONS_CUBE, "total_generated_lines"),
+                member_int(row, SESSIONS_CUBE, "total_deleted_lines"),
+                member_int(row, SESSIONS_CUBE, "net_generated_lines"),
+                member_int(row, SESSIONS_CUBE, "total_generated_sloc"),
+                member_int(row, SESSIONS_CUBE, "total_committed_lines"),
+                member_int(row, SESSIONS_CUBE, "total_pr_opened_lines"),
+                member_int(row, SESSIONS_CUBE, "total_merged_lines"),
+                member_int(row, SESSIONS_CUBE, "total_production_lines"),
+                member_int(row, SESSIONS_CUBE, "total_checkpoints"),
+                member_int(row, SESSIONS_CUBE, "total_events"),
+                member_int(row, SESSIONS_CUBE, "total_usage_minutes"),
+                now,
+            ])?;
+            inserted += n;
+        }
+    }
+    tx.commit()?;
+    Ok(inserted)
+}
+
+// ---------------------------------------------------------------------------
+// Cross-cube baseline enrichment (tokens / cost / models / PRs)
+// ---------------------------------------------------------------------------
+
+/// Backfill the comparable baseline columns for a batch of freshly-pulled
+/// sessions: per-session token usage + cost, the models each session used, and
+/// the PRs it appears in. Best-effort — a failure in any one source warns but
+/// does not abort the pull, since the core session rows are already persisted.
+fn enrich_sessions(client: &CubeClient, conn: &Connection, session_ids: &[String]) {
+    if session_ids.is_empty() {
+        return;
+    }
+    if let Err(e) = enrich_token_usage(client, conn, session_ids) {
+        eprintln!("Warning: token-usage enrichment failed: {}", e);
+    }
+    if let Err(e) = enrich_models(client, conn, session_ids) {
+        eprintln!("Warning: model enrichment failed: {}", e);
+    }
+    if let Err(e) = enrich_prs(client, conn, session_ids) {
+        eprintln!("Warning: PR enrichment failed: {}", e);
+    }
+}
+
+/// Cube `equals` filter matching any of `session_ids` (IN semantics).
+fn id_filter(cube: &str, session_ids: &[String]) -> String {
+    json!([{
+        "member": format!("{}.session_id", cube),
+        "operator": "equals",
+        "values": session_ids,
+    }])
+    .to_string()
+}
+
+fn enrich_token_usage(
+    client: &CubeClient,
+    conn: &Connection,
+    session_ids: &[String],
+) -> Result<(), String> {
+    let measures = [
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_cache_read_tokens",
+        "total_cache_creation_tokens",
+        "total_reasoning_tokens",
+        "total_cost",
+    ]
+    .iter()
+    .map(|m| format!("{}.{}", TOKEN_USAGE_CUBE, m))
+    .collect();
+    let args = QueryArgs {
+        measures,
+        dimensions: vec![format!("{}.session_id", TOKEN_USAGE_CUBE)],
+        filters_json: Some(id_filter(TOKEN_USAGE_CUBE, session_ids)),
+        limit: Some(session_ids.len() as u64),
+        ..Default::default()
+    };
+    let rows = client
+        .load_rows(&args.to_query()?)
+        .map_err(|e| e.to_string())?;
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    {
+        let mut stmt = tx
+            .prepare(
+                "UPDATE sessions SET input_tokens=?2, output_tokens=?3, \
+                 cache_read_tokens=?4, cache_creation_tokens=?5, reasoning_tokens=?6, \
+                 cost_usd=?7 WHERE session_id=?1",
+            )
+            .map_err(|e| e.to_string())?;
+        for row in &rows {
+            let Some(sid) = member_str(row, TOKEN_USAGE_CUBE, "session_id") else {
+                continue;
+            };
+            stmt.execute(params![
+                sid,
+                member_int(row, TOKEN_USAGE_CUBE, "total_input_tokens"),
+                member_int(row, TOKEN_USAGE_CUBE, "total_output_tokens"),
+                member_int(row, TOKEN_USAGE_CUBE, "total_cache_read_tokens"),
+                member_int(row, TOKEN_USAGE_CUBE, "total_cache_creation_tokens"),
+                member_int(row, TOKEN_USAGE_CUBE, "total_reasoning_tokens"),
+                member_float(row, TOKEN_USAGE_CUBE, "total_cost"),
+            ])
+            .map_err(|e| e.to_string())?;
+        }
+    }
+    tx.commit().map_err(|e| e.to_string())
+}
+
+fn enrich_models(
+    client: &CubeClient,
+    conn: &Connection,
+    session_ids: &[String],
+) -> Result<(), String> {
+    let args = QueryArgs {
+        measures: vec![format!("{}.event_count", SESSION_MODELS_CUBE)],
+        dimensions: vec![
+            format!("{}.session_id", SESSION_MODELS_CUBE),
+            format!("{}.model", SESSION_MODELS_CUBE),
+        ],
+        filters_json: Some(id_filter(SESSION_MODELS_CUBE, session_ids)),
+        // A session can use several models; allow generous headroom per id.
+        limit: Some((session_ids.len() as u64).saturating_mul(20).max(50)),
+        ..Default::default()
+    };
+    let rows = client
+        .load_rows(&args.to_query()?)
+        .map_err(|e| e.to_string())?;
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT OR REPLACE INTO session_models (session_id, model, event_count) \
+                 VALUES (?1,?2,?3)",
+            )
+            .map_err(|e| e.to_string())?;
+        for row in &rows {
+            let Some(sid) = member_str(row, SESSION_MODELS_CUBE, "session_id") else {
+                continue;
+            };
+            let Some(model) = member_str(row, SESSION_MODELS_CUBE, "model") else {
+                continue;
+            };
+            stmt.execute(params![
+                sid,
+                model,
+                member_int(row, SESSION_MODELS_CUBE, "event_count"),
+            ])
+            .map_err(|e| e.to_string())?;
+        }
+    }
+    recompute_models(&tx).map_err(|e| e.to_string())?;
+    tx.commit().map_err(|e| e.to_string())
+}
+
+fn enrich_prs(
+    client: &CubeClient,
+    conn: &Connection,
+    session_ids: &[String],
+) -> Result<(), String> {
+    let args = QueryArgs {
+        measures: vec![format!("{}.total_ai_lines", PR_SESSIONS_CUBE)],
+        dimensions: ["session_id", "repo_url", "pr_number", "agent", "model_raw"]
+            .iter()
+            .map(|d| format!("{}.{}", PR_SESSIONS_CUBE, d))
+            .collect(),
+        filters_json: Some(id_filter(PR_SESSIONS_CUBE, session_ids)),
+        // A session can land in several PRs; allow generous headroom per id.
+        limit: Some((session_ids.len() as u64).saturating_mul(20).max(50)),
+        ..Default::default()
+    };
+    let rows = client
+        .load_rows(&args.to_query()?)
+        .map_err(|e| e.to_string())?;
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT OR REPLACE INTO session_prs \
+                 (session_id, repo_url, pr_number, agent, model_raw, ai_lines) \
+                 VALUES (?1,?2,?3,?4,?5,?6)",
+            )
+            .map_err(|e| e.to_string())?;
+        for row in &rows {
+            let Some(sid) = member_str(row, PR_SESSIONS_CUBE, "session_id") else {
+                continue;
+            };
+            let Some(pr) = member_int(row, PR_SESSIONS_CUBE, "pr_number") else {
+                continue;
+            };
+            stmt.execute(params![
+                sid,
+                // repo_url is part of the PK; coalesce to '' so NULLs don't
+                // produce duplicate rows for the same PR.
+                member_str(row, PR_SESSIONS_CUBE, "repo_url").unwrap_or_default(),
+                pr,
+                member_str(row, PR_SESSIONS_CUBE, "agent"),
+                member_str(row, PR_SESSIONS_CUBE, "model_raw"),
+                member_int(row, PR_SESSIONS_CUBE, "total_ai_lines"),
+            ])
+            .map_err(|e| e.to_string())?;
+        }
+    }
+    recompute_pr_counts(&tx).map_err(|e| e.to_string())?;
+    tx.commit().map_err(|e| e.to_string())
+}
+
+/// Denormalize the distinct models per session into `sessions.models` (a
+/// comma-joined, alphabetically-ordered list) for quick filtering.
+fn recompute_models(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE sessions SET models = (
+             SELECT group_concat(model, ',') FROM (
+                 SELECT model FROM session_models sm
+                 WHERE sm.session_id = sessions.session_id ORDER BY model
+             )
+         ) WHERE session_id IN (SELECT DISTINCT session_id FROM session_models)",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Denormalize the count of distinct PRs per session into `sessions.pr_count`.
+fn recompute_pr_counts(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE sessions SET pr_count = (
+             SELECT COUNT(*) FROM session_prs sp WHERE sp.session_id = sessions.session_id
+         ) WHERE session_id IN (SELECT DISTINCT session_id FROM session_prs)",
+        [],
+    )?;
+    Ok(())
+}
+
+fn has_events(conn: &Connection, session_id: &str) -> Result<bool, rusqlite::Error> {
+    let n: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM session_events WHERE session_id=?1",
+        params![session_id],
+        |r| r.get(0),
+    )?;
+    Ok(n > 0)
+}
+
+fn insert_events(
+    conn: &Connection,
+    session_id: &str,
+    rows: &[Value],
+) -> Result<usize, rusqlite::Error> {
+    let mut inserted = 0;
+    let tx = conn.unchecked_transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT OR IGNORE INTO session_events (
+                session_id, output_seq, event_time, event_kind, tool, tool_kind,
+                model, target, text, summary, tool_input, tool_output
+            ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+        )?;
+        for row in rows {
+            let n = stmt.execute(params![
+                session_id,
+                member_int(row, EVENTS_CUBE, "output_seq"),
+                member_time(row, EVENTS_CUBE, "event_time"),
+                // event_kind/tool are part of the dedup key; coalesce to '' so
+                // re-fetching is idempotent (SQLite treats NULLs as distinct).
+                member_str(row, EVENTS_CUBE, "event_kind").unwrap_or_default(),
+                member_str(row, EVENTS_CUBE, "tool").unwrap_or_default(),
+                member_str(row, EVENTS_CUBE, "tool_kind"),
+                member_str(row, EVENTS_CUBE, "model"),
+                member_str(row, EVENTS_CUBE, "target"),
+                member_str(row, EVENTS_CUBE, "text"),
+                member_str(row, EVENTS_CUBE, "summary"),
+                member_str(row, EVENTS_CUBE, "tool_input"),
+                member_str(row, EVENTS_CUBE, "tool_output"),
+            ])?;
+            inserted += n;
+        }
+    }
+    tx.commit()?;
+    Ok(inserted)
+}
+
+/// Read one session row as a JSON object keyed by the public column names.
+fn session_row_json(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Map<String, Value>, rusqlite::Error> {
+    let sql = format!(
+        "SELECT {} FROM sessions WHERE session_id=?1",
+        SESSION_COLUMNS.join(", ")
+    );
+    conn.query_row(&sql, params![session_id], |row| {
+        let mut obj = Map::new();
+        for (idx, name) in SESSION_COLUMNS.iter().enumerate() {
+            obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
+        }
+        Ok(obj)
+    })
+}
+
+/// Read a session's transcript from `session_events`, ordered chronologically.
+fn transcript_json(conn: &Connection, session_id: &str) -> Result<Vec<Value>, rusqlite::Error> {
+    let cols = [
+        "output_seq",
+        "event_time",
+        "event_kind",
+        "tool",
+        "tool_kind",
+        "model",
+        "target",
+        "text",
+        "summary",
+        "tool_input",
+        "tool_output",
+    ];
+    let sql = format!(
+        "SELECT {} FROM session_events WHERE session_id=?1 \
+         ORDER BY event_time ASC, output_seq ASC, id ASC",
+        cols.join(", ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![session_id], |row| {
+        let mut obj = Map::new();
+        for (idx, name) in cols.iter().enumerate() {
+            obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
+        }
+        Ok(Value::Object(obj))
+    })?;
+    rows.collect()
+}
+
+/// Read the PRs a session appears in from `session_prs`, ordered by PR number.
+fn session_prs_json(conn: &Connection, session_id: &str) -> Result<Vec<Value>, rusqlite::Error> {
+    let cols = ["repo_url", "pr_number", "agent", "model_raw", "ai_lines"];
+    let sql = format!(
+        "SELECT {} FROM session_prs WHERE session_id=?1 ORDER BY repo_url, pr_number",
+        cols.join(", ")
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![session_id], |row| {
+        let mut obj = Map::new();
+        for (idx, name) in cols.iter().enumerate() {
+            obj.insert((*name).to_string(), value_ref_to_json(row.get_ref(idx)?));
+        }
+        Ok(Value::Object(obj))
+    })?;
+    rows.collect()
+}
+
+// ---------------------------------------------------------------------------
+// Value extraction / conversion
+// ---------------------------------------------------------------------------
+
+/// Get a cube member (`<cube>.<field>`) from a row as an owned String.
+fn member_str(row: &Value, cube: &str, field: &str) -> Option<String> {
+    let key = format!("{}.{}", cube, field);
+    match row.get(&key) {
+        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        Some(Value::Number(n)) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// Get a numeric cube member. Cube returns numbers as strings, so parse both.
+fn member_int(row: &Value, cube: &str, field: &str) -> Option<i64> {
+    let key = format!("{}.{}", cube, field);
+    match row.get(&key) {
+        Some(Value::String(s)) => s.trim().parse::<f64>().ok().map(|f| f as i64),
+        Some(Value::Number(n)) => n.as_i64().or_else(|| n.as_f64().map(|f| f as i64)),
+        _ => None,
+    }
+}
+
+/// Get a numeric cube member as f64 (e.g. cost). Cube returns numbers as
+/// strings, so parse both.
+fn member_float(row: &Value, cube: &str, field: &str) -> Option<f64> {
+    let key = format!("{}.{}", cube, field);
+    match row.get(&key) {
+        Some(Value::String(s)) => s.trim().parse::<f64>().ok(),
+        Some(Value::Number(n)) => n.as_f64(),
+        _ => None,
+    }
+}
+
+/// Get a time-typed cube member (ISO8601 string) as unix seconds.
+fn member_time(row: &Value, cube: &str, field: &str) -> Option<i64> {
+    let key = format!("{}.{}", cube, field);
+    let s = row.get(&key)?.as_str()?;
+    parse_cube_time(s)
+}
+
+/// Parse a Cube time value (RFC3339 or `YYYY-MM-DDTHH:MM:SS[.fff]`) to unix secs.
+fn parse_cube_time(s: &str) -> Option<i64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.timestamp());
+    }
+    for fmt in [
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%d %H:%M:%S%.f",
+    ] {
+        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(dt.and_utc().timestamp());
+        }
+    }
+    None
+}
+
+fn value_ref_to_json(v: rusqlite::types::ValueRef) -> Value {
+    use rusqlite::types::ValueRef;
+    match v {
+        ValueRef::Null => Value::Null,
+        ValueRef::Integer(i) => json!(i),
+        ValueRef::Real(f) => json!(f),
+        ValueRef::Text(t) => Value::String(String::from_utf8_lossy(t).into_owned()),
+        ValueRef::Blob(b) => Value::String(String::from_utf8_lossy(b).into_owned()),
+    }
+}
+
+fn value_ref_to_string(v: rusqlite::types::ValueRef) -> String {
+    use rusqlite::types::ValueRef;
+    match v {
+        ValueRef::Null => String::new(),
+        ValueRef::Integer(i) => i.to_string(),
+        ValueRef::Real(f) => f.to_string(),
+        ValueRef::Text(t) => String::from_utf8_lossy(t).into_owned(),
+        ValueRef::Blob(b) => String::from_utf8_lossy(b).into_owned(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Misc
+// ---------------------------------------------------------------------------
+
+fn take_value(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| format!("{} requires a value", flag))
+}
+
+fn single_db_arg(args: &[String], cmd: &str) -> Result<String, String> {
+    args.iter()
+        .find(|a| !a.starts_with('-'))
+        .cloned()
+        .ok_or_else(|| format!("usage: git-ai analyze sessions {} <db>", cmd))
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Pick a fresh, scrutable DB path like `git-ai-analysis-001.db` in the temp
+/// dir. Scans existing `git-ai-analysis-NNN.db` files and uses the next free
+/// number so repeated pulls are easy to tell apart and reference.
+fn random_db_path() -> PathBuf {
+    let dir = std::env::temp_dir();
+    let highest = std::fs::read_dir(&dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let name = name.to_str()?;
+            let num = name.strip_prefix("git-ai-analysis-")?.strip_suffix(".db")?;
+            num.parse::<u32>().ok()
+        })
+        .max()
+        .unwrap_or(0);
+    // Advance past any existing file (covers gaps / concurrent creators).
+    let mut n = highest + 1;
+    loop {
+        let path = dir.join(format!("git-ai-analysis-{:03}.db", n));
+        if !path.exists() {
+            return path;
+        }
+        n += 1;
+    }
+}
+
+fn print_help() {
+    let help = r#"git-ai analyze sessions - pull coding sessions into a scratch DB and grade them
+
+Subcommands:
+  pull [flags]            Create/fill a SQLite DB with sessions (latest-first)
+  next <db> [flags]       Return the next session + transcript and advance the cursor +1
+  stats <db>              Show pull progress and where the analysis cursor is
+  reset <db> [--to N]     Rewind the analysis cursor (default 0) to re-run from the start
+  exec <db> "<SQL>"       Run SQL against the DB (writeback for analysis columns)
+
+pull flags:
+  --db <path>     Target DB (default: a fresh /tmp/git-ai-analysis-NNN.db, printed to stdout)
+  --limit <n>     Max sessions to pull (default 100)
+  --since <range> Cube dateRange on session_start_time (e.g. "last 30 days")
+  --repo <url>    Filter by repo_url (convenience equals-filter)
+  --user <id>     Filter by user_id (convenience equals-filter)
+  --agent <name>  Filter by agent, e.g. claude-code, cursor (convenience equals-filter)
+  --include-subagents  Include subagent sessions (default: top-level sessions only)
+  --no-enrich     Skip the per-batch tokens/cost/models/PR backfill (faster, fewer columns)
+
+Analyzing your OWN (or one person's) sessions ("my sessions", "what I did"):
+  user_id is opaque — resolve it from an email first, then pull with --user:
+    EMAIL=$(git config user.email)
+    UID=$(git-ai analyze query --tsv -d public_v1_user_status.user_id \
+      -f '[{"member":"public_v1_user_status.author_email","operator":"equals","values":["'"$EMAIL"'"]}]' \
+      | tail -n +2 | head -1)
+    DB=$(git-ai analyze sessions pull --user "$UID" --since "last 30 days")
+  Swap in a different email for someone else. If the lookup is empty, stop and say so.
+
+  Full query surface — same flags as `analyze query`, layered on top of the
+  canonical session columns so you can slice the population on ANY member:
+  -f, --filters '<json>'    Raw Cube filter array (combines with --repo/--user/--agent)
+  -d, --dimensions a,b      Extra dimensions to select alongside the session columns
+  -m, --measures a,b        Extra measures to select
+      --time-dimension M    Time dimension member (default: session_start_time with --since)
+  -g, --granularity G       Granularity for the time dimension
+  -o, --order M[:asc|desc]  Order rows (default: session_start_time:desc)
+
+  Examples:
+    # only sessions that generated >100 net lines, made with cursor:
+    git-ai analyze sessions pull --agent cursor \
+      -f '[{"member":"public_v1_sessions.net_generated_lines","operator":"gt","values":["100"]}]'
+    # sessions whose work reached production, newest committed first:
+    git-ai analyze sessions pull \
+      -f '[{"member":"public_v1_sessions.total_production_lines","operator":"gt","values":["0"]}]' \
+      -o public_v1_sessions.session_end_time:desc
+
+next flags:
+  --max-events <n>   Cap transcript events fetched (default 2000)
+  --no-transcript    Return session metadata only (no transcript fetch)
+
+What `sessions next` prints (one JSON object, or {"done": true} when exhausted):
+  All the `sessions` columns (session_id, agent, repo_url, generated_lines,
+  committed_lines, total_events, models, cost_usd, pr_count, …), plus:
+    "prs":        array of the PRs this session appears in (repo_url, pr_number,
+                  agent, model_raw, ai_lines)
+    "transcript": array of events in chronological order — THE PROMPTS + ACTIONS.
+  Each transcript event is a flat object; which fields are set depends on event_kind:
+    output_seq    int, ordering within an event_time bucket
+    event_time    unix seconds
+    event_kind    the message type. The transcript is an interleaved, ordered
+                  stream dominated by three kinds:
+                    user_message       a human turn (the PROMPT) — has .text
+                    assistant_message  the agent's reply prose      — has .text
+                    tool_call          an action the agent took — has .tool/.tool_kind/
+                                       .target/.tool_input/.tool_output
+                  and occasionally: skill_load | skill_mention | skill_invoked |
+                  pr_created | context_compacted | turn_aborted | session_model_change
+    text          message body (user_message / assistant_message)
+    summary       short summary when present
+    model         model in effect for the event
+    tool          tool name for tool_call (e.g. Edit, Read, Bash, Grep)
+    tool_kind     shell | file_read | file_edit | web_search | sub_agent | mcp | other
+    target        file/path or other target the tool acted on
+    tool_input    arguments passed to the tool (string)
+    tool_output   result returned by the tool (string)
+  So a user's PROMPTS are the event_kind='user_message' .text values, in order; the
+  agent's work is the tool_call / assistant_message stream between them. You do NOT
+  need to pull a sample session to learn the shape — it is exactly the above.
+
+reset flags:
+  --to <seq>         Cursor position to rewind to (default 0 = re-serve everything)
+
+The work funnel (already columns — DO NOT read transcripts to derive these):
+  Every session carries its full delivery funnel as plain columns, in order:
+    committed_lines → pr_opened_lines → merged_lines → production_lines
+  plus the stage-to-stage GAPS, precomputed so you never hand-derive "what
+  didn't ship":
+    committed_not_pr_opened    committed locally but never opened in a PR
+    pr_opened_not_merged       reached a PR but not merged (open OR torn out)
+    merged_not_production      merged but not in production
+    committed_not_production   headline: committed that never shipped
+    production_rate            share of committed lines that reached production
+  So "how much did this session commit that didn't ship, and where did it fall
+  out?" is a SELECT, not a transcript read:
+    git-ai analyze sessions exec "$DB" \
+      "SELECT agent, SUM(committed_not_production), AVG(production_rate) \
+       FROM sessions GROUP BY agent ORDER BY 2 DESC"
+  What these columns CANNOT tell you is the *why* behind a gap — still-open PR
+  vs. reverted-as-bad vs. superseded-by-a-rewrite. That distinction lives only
+  in the session narrative, so reach for the transcript ONLY for the why, after
+  the funnel columns have told you which sessions leak and by how much.
+
+Baseline schema (every pulled session carries these, no extra work):
+  sessions columns include the canonical metrics — agent, generated_lines,
+  committed_lines, merged_lines, production_lines, total_events (# turns),
+  usage_minutes — PLUS the cross-cube baseline backfilled at pull time:
+    models                                     comma-joined distinct models used
+    input_tokens, output_tokens,               per-session token usage
+      cache_read_tokens, cache_creation_tokens,
+      reasoning_tokens
+    cost_usd                                   per-session estimated cost
+    pr_count                                   # of PRs this session appears in
+  Two child tables (foreign-keyed on session_id) hold the detail to JOIN against:
+    session_models(session_id, model, event_count)
+    session_prs(session_id, repo_url, pr_number, agent, model_raw, ai_lines)
+  So you can aggregate immediately, e.g.:
+    git-ai analyze sessions exec "$DB" \
+      "SELECT agent, SUM(cost_usd), AVG(total_events) FROM sessions GROUP BY agent"
+    git-ai analyze sessions exec "$DB" \
+      "SELECT model, COUNT(*) FROM session_models GROUP BY model ORDER BY 2 DESC"
+  (`sessions next` also returns a "prs" array per session.)
+
+How the analysis cursor works:
+  Each session row has an auto-increment seq_id. `next` advances a single cursor
+  by one and returns that row — atomically, so every row is handed out EXACTLY
+  ONCE across any number of concurrent subagents. Nothing to mark "done": once a
+  row is served the cursor has already moved past it. Start a new analysis pass
+  with `reset` (cursor → 0). `pull` only adds rows; it never moves the cursor.
+
+Grading workflow:
+  1. Pull the sessions:
+       DB=$(git-ai analyze sessions pull --limit 100 --since "last 30 days")
+
+  2. DESIGN YOUR ANALYSIS SCHEMA FIRST. Turn the user's question into concrete
+     columns and ADD them up front — do not just print findings to chat, persist
+     them so they can be aggregated. Decide your own criteria for the task:
+       - Grading? Derive the rubric, then make a column per criterion plus an
+         overall, e.g. clarity_score, correctness_score, grade, rationale.
+       - Categorizing? One column for the label plus a notes/evidence column.
+     Add them once (TEXT or INTEGER), before iterating:
+       git-ai analyze sessions exec "$DB" "ALTER TABLE sessions ADD COLUMN grade TEXT"
+       git-ai analyze sessions exec "$DB" "ALTER TABLE sessions ADD COLUMN clarity_score INTEGER"
+       git-ai analyze sessions exec "$DB" "ALTER TABLE sessions ADD COLUMN rationale TEXT"
+
+  3. Dispatch N subagents. Each loops, and MUST write its results back into the
+     columns you added (not just return prose). The session_id comes from the
+     JSON that `next` prints:
+       git-ai analyze sessions next "$DB"          # returns one session + transcript JSON
+       # …analyze the transcript against your criteria…
+       git-ai analyze sessions exec "$DB" \
+         "UPDATE sessions SET grade='A', clarity_score=4, rationale='…' \
+          WHERE session_id='<id>'"
+     Loop until `next` prints {"done": true}.
+
+  4. Watch progress:  git-ai analyze sessions stats "$DB"   # shows cursor position
+  5. Synthesize over the enriched columns:
+       git-ai analyze sessions exec "$DB" \
+         "SELECT grade, COUNT(*), AVG(clarity_score) FROM sessions \
+          WHERE grade IS NOT NULL GROUP BY grade ORDER BY grade"
+"#;
+    eprint!("{help}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(SCHEMA).unwrap();
+        // Mirror open_db so the derived funnel-gap columns are present in tests.
+        ensure_derived_columns(&conn).unwrap();
+        conn
+    }
+
+    fn session_row(id: &str) -> Value {
+        json!({
+            "public_v1_sessions.session_id": id,
+            "public_v1_sessions.user_id": "u1",
+            "public_v1_sessions.agent": "claude-code",
+            "public_v1_sessions.repo_url": "https://example.com/repo",
+            "public_v1_sessions.session_start_time": "2024-06-01T12:00:00.000",
+            "public_v1_sessions.total_generated_lines": "240",
+            "public_v1_sessions.total_production_lines": "180",
+            "public_v1_sessions.net_generated_lines": "-5",
+        })
+    }
+
+    #[test]
+    fn insert_sessions_dedupes_by_session_id() {
+        let conn = mem_db();
+        let rows = vec![session_row("s1"), session_row("s2")];
+        assert_eq!(insert_sessions(&conn, &rows).unwrap(), 2);
+        // Re-inserting the same ids adds nothing.
+        let rows2 = vec![session_row("s1"), session_row("s3")];
+        assert_eq!(insert_sessions(&conn, &rows2).unwrap(), 1);
+        let total: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn derived_funnel_gaps_compute_from_stage_columns() {
+        let conn = mem_db();
+        insert_sessions(&conn, &[session_row("s1")]).unwrap();
+        // Set a full funnel: 100 committed → 70 pr_opened → 40 merged → 30 prod.
+        conn.execute(
+            "UPDATE sessions SET committed_lines=100, pr_opened_lines=70, \
+             merged_lines=40, production_lines=30 WHERE session_id='s1'",
+            [],
+        )
+        .unwrap();
+        let (c_npr, pr_nm, m_np, c_np, rate): (i64, i64, i64, i64, f64) = conn
+            .query_row(
+                "SELECT committed_not_pr_opened, pr_opened_not_merged, \
+                 merged_not_production, committed_not_production, production_rate \
+                 FROM sessions WHERE session_id='s1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(c_npr, 30); // 100 - 70
+        assert_eq!(pr_nm, 30); // 70 - 40
+        assert_eq!(m_np, 10); // 40 - 30
+        assert_eq!(c_np, 70); // 100 - 30
+        assert!((rate - 0.30).abs() < 1e-9); // 30 / 100
+
+        // NULL stage columns coalesce to 0 (clean integer gaps), and a 0/NULL
+        // committed denominator yields a NULL rate rather than a divide error.
+        insert_sessions(&conn, &[session_row("s2")]).unwrap();
+        let (c_np2, rate2): (i64, Option<f64>) = conn
+            .query_row(
+                "SELECT committed_not_production, production_rate \
+                 FROM sessions WHERE session_id='s2'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        // s2 has production=180 but committed is NULL → 0 - 180 = -180.
+        assert_eq!(c_np2, -180);
+        assert_eq!(rate2, None);
+    }
+
+    #[test]
+    fn recompute_models_denormalizes_distinct_models() {
+        let conn = mem_db();
+        insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
+        // Two models for s1 (out of order), one for s2.
+        conn.execute(
+            "INSERT INTO session_models (session_id, model, event_count) VALUES \
+             ('s1','sonnet',3),('s1','opus',1),('s2','opus',2)",
+            [],
+        )
+        .unwrap();
+        recompute_models(&conn).unwrap();
+        let m1: String = conn
+            .query_row(
+                "SELECT models FROM sessions WHERE session_id='s1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // Alphabetically ordered, comma-joined.
+        assert_eq!(m1, "opus,sonnet");
+        let m2: String = conn
+            .query_row(
+                "SELECT models FROM sessions WHERE session_id='s2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(m2, "opus");
+    }
+
+    #[test]
+    fn recompute_pr_counts_counts_distinct_prs() {
+        let conn = mem_db();
+        insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
+        conn.execute(
+            "INSERT INTO session_prs (session_id, repo_url, pr_number, ai_lines) VALUES \
+             ('s1','r',1,10),('s1','r',2,20)",
+            [],
+        )
+        .unwrap();
+        recompute_pr_counts(&conn).unwrap();
+        let (c1, c2): (i64, Option<i64>) = (
+            conn.query_row(
+                "SELECT pr_count FROM sessions WHERE session_id='s1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap(),
+            conn.query_row(
+                "SELECT pr_count FROM sessions WHERE session_id='s2'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap(),
+        );
+        assert_eq!(c1, 2);
+        // s2 has no PRs, so it stays NULL (untouched by recompute).
+        assert_eq!(c2, None);
+    }
+
+    #[test]
+    fn session_numbers_and_time_parse() {
+        let conn = mem_db();
+        insert_sessions(&conn, &[session_row("s1")]).unwrap();
+        let (g, prod, net, start): (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT generated_lines, production_lines, net_generated_lines, session_start_time \
+                 FROM sessions WHERE session_id='s1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(g, 240);
+        assert_eq!(prod, 180);
+        assert_eq!(net, -5);
+        // 2024-06-01T12:00:00Z
+        assert_eq!(start, 1_717_243_200);
+    }
+
+    /// Mirror of cmd_next's atomic cursor advance: read analyzed_seq, take the
+    /// first row past it, persist the new position. Returns the served id.
+    fn claim_next(conn: &mut Connection) -> Option<String> {
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+        let pos: i64 = tx
+            .query_row(
+                "SELECT analyzed_seq FROM cursor WHERE name='default'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .unwrap()
+            .unwrap_or(0);
+        let row: Option<(i64, String)> = tx
+            .query_row(
+                "SELECT seq_id, session_id FROM sessions WHERE seq_id > ?1 ORDER BY seq_id LIMIT 1",
+                params![pos],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .unwrap();
+        if let Some((seq, _)) = &row {
+            tx.execute(
+                "UPDATE cursor SET analyzed_seq=?1 WHERE name='default'",
+                params![seq],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+        row.map(|(_, id)| id)
+    }
+
+    #[test]
+    fn cursor_serves_each_row_exactly_once() {
+        let mut conn = mem_db();
+        init_cursor(&conn, 100).unwrap();
+        insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
+
+        assert_eq!(claim_next(&mut conn), Some("s1".to_string()));
+        assert_eq!(claim_next(&mut conn), Some("s2".to_string()));
+        // Past the end: nothing more, and it stays exhausted.
+        assert_eq!(claim_next(&mut conn), None);
+        assert_eq!(claim_next(&mut conn), None);
+    }
+
+    #[test]
+    fn reset_rewinds_cursor_to_reserve_from_start() {
+        let mut conn = mem_db();
+        init_cursor(&conn, 100).unwrap();
+        insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
+        assert_eq!(claim_next(&mut conn), Some("s1".to_string()));
+        assert_eq!(claim_next(&mut conn), Some("s2".to_string()));
+
+        // reset <db> sets the cursor back to 0.
+        conn.execute("UPDATE cursor SET analyzed_seq=0 WHERE name='default'", [])
+            .unwrap();
+        // next now re-serves from the top.
+        assert_eq!(claim_next(&mut conn), Some("s1".to_string()));
+    }
+
+    #[test]
+    fn pull_does_not_rewind_analysis_cursor() {
+        // Re-running pull (init_cursor) must not reset analysis progress.
+        let conn = mem_db();
+        init_cursor(&conn, 100).unwrap();
+        conn.execute("UPDATE cursor SET analyzed_seq=5 WHERE name='default'", [])
+            .unwrap();
+        init_cursor(&conn, 100).unwrap();
+        let pos: i64 = conn
+            .query_row(
+                "SELECT analyzed_seq FROM cursor WHERE name='default'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(pos, 5);
+    }
+
+    #[test]
+    fn events_persist_idempotently_and_round_trip() {
+        let conn = mem_db();
+        insert_sessions(&conn, &[session_row("s1")]).unwrap();
+        let events = vec![
+            json!({
+                "public_v1_normalized_events.event_kind": "user_message",
+                "public_v1_normalized_events.text": "fix the bug",
+                "public_v1_normalized_events.event_time": "2024-06-01T12:00:00.000",
+                "public_v1_normalized_events.output_seq": "0",
+            }),
+            json!({
+                "public_v1_normalized_events.event_kind": "tool_call",
+                "public_v1_normalized_events.tool": "Edit",
+                "public_v1_normalized_events.tool_input": "...",
+                "public_v1_normalized_events.event_time": "2024-06-01T12:00:05.000",
+                "public_v1_normalized_events.output_seq": "1",
+            }),
+        ];
+        assert_eq!(insert_events(&conn, "s1", &events).unwrap(), 2);
+        // Idempotent: re-inserting the same events adds nothing.
+        assert_eq!(insert_events(&conn, "s1", &events).unwrap(), 0);
+
+        let transcript = transcript_json(&conn, "s1").unwrap();
+        assert_eq!(transcript.len(), 2);
+        assert_eq!(transcript[0]["event_kind"], json!("user_message"));
+        assert_eq!(transcript[0]["text"], json!("fix the bug"));
+        assert_eq!(transcript[1]["tool"], json!("Edit"));
+    }
+
+    #[test]
+    fn cursor_tracks_fetch_progress() {
+        let conn = mem_db();
+        init_cursor(&conn, 100).unwrap();
+        assert_eq!(get_fetched(&conn).unwrap(), 0);
+        set_fetched(&conn, 50).unwrap();
+        assert_eq!(get_fetched(&conn).unwrap(), 50);
+        set_pull_complete(&conn).unwrap();
+        let complete: i64 = conn
+            .query_row(
+                "SELECT pull_complete FROM cursor WHERE name='default'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(complete, 1);
+    }
+
+    #[test]
+    fn equals_filters_skips_unset() {
+        assert!(equals_filters(&[("m".into(), None)]).is_empty());
+        let f = equals_filters(&[
+            ("public_v1_sessions.agent".into(), Some("cursor")),
+            ("public_v1_sessions.repo_url".into(), None),
+        ]);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0]["values"][0], json!("cursor"));
+    }
+
+    #[test]
+    fn merge_filters_combines_convenience_and_raw() {
+        // No filters at all -> None.
+        assert_eq!(merge_filters(vec![], None).unwrap(), None);
+
+        // Convenience-only passes through.
+        let conv = equals_filters(&[("public_v1_sessions.agent".into(), Some("cursor"))]);
+        let only_conv = merge_filters(conv.clone(), None).unwrap().unwrap();
+        let v: Value = serde_json::from_str(&only_conv).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+
+        // Convenience + raw --filters are concatenated so both apply, letting you
+        // slice on any member (here: net_generated_lines) alongside --agent.
+        let raw = r#"[{"member":"public_v1_sessions.net_generated_lines","operator":"gt","values":["100"]}]"#;
+        let merged = merge_filters(conv, Some(raw)).unwrap().unwrap();
+        let v: Value = serde_json::from_str(&merged).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["member"], json!("public_v1_sessions.agent"));
+        assert_eq!(
+            arr[1]["member"],
+            json!("public_v1_sessions.net_generated_lines")
+        );
+        assert_eq!(arr[1]["operator"], json!("gt"));
+    }
+
+    #[test]
+    fn merge_filters_rejects_non_array_raw() {
+        assert!(merge_filters(vec![], Some("not json")).is_err());
+        assert!(merge_filters(vec![], Some(r#"{"not":"an array"}"#)).is_err());
+    }
+}

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -343,9 +343,7 @@ fn print_help() {
     eprintln!("  usage              Show local AI usage statistics");
     eprintln!("    --period <1d|3d|7d|30d>  Time window (default: 30d)");
     eprintln!("    --json                 Output in JSON format");
-    eprintln!("  analyze            Query backend analytics (Cube) and grade sessions");
-    eprintln!("    query|dry-run|meta     Run/validate a Cube query or list members");
-    eprintln!("    sessions <sub>         Pull + grade coding sessions at scale");
+    eprintln!("  analyze [beta]      Analyze agent sessions and effectiveness");
     eprintln!("  status             Show uncommitted AI authorship status (debug)");
     eprintln!("    --json                 Output in JSON format");
     eprintln!(

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -112,6 +112,12 @@ pub fn handle_git_ai(args: &[String]) {
         "usage" => {
             commands::usage::handle_usage(&args[1..]);
         }
+        "analyze" => {
+            commands::analyze::handle_analyze(&args[1..]);
+            if is_interactive_terminal() {
+                log_message("analyze", "info", None)
+            }
+        }
         "status" => {
             commands::status::handle_status(&args[1..]);
         }
@@ -337,6 +343,9 @@ fn print_help() {
     eprintln!("  usage              Show local AI usage statistics");
     eprintln!("    --period <1d|3d|7d|30d>  Time window (default: 30d)");
     eprintln!("    --json                 Output in JSON format");
+    eprintln!("  analyze            Query backend analytics (Cube) and grade sessions");
+    eprintln!("    query|dry-run|meta     Run/validate a Cube query or list members");
+    eprintln!("    sessions <sub>         Pull + grade coding sessions at scale");
     eprintln!("  status             Show uncommitted AI authorship status (debug)");
     eprintln!("    --json                 Output in JSON format");
     eprintln!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod analyze;
 pub mod blame;
 pub mod checkpoint_agent;
 pub mod ci_handlers;


### PR DESCRIPTION
## `git-ai analyze` — research AI coding activity and grade prompts at scale

This adds a new agent-facing command, `git-ai analyze`, that replaces the old local `prompts.db` flow. Prompts now live in Git AI's backend, and `analyze` gives an agent a first-class way to (1) ask the analytics backend aggregate questions and (2) pull the exact coding sessions behind an answer, read their transcripts, and grade/categorize them at scale into a scratch SQLite DB.

The command is **designed to be driven by a coding agent**, not memorized by a human. The help text is written as a set of instructions to the agent itself.

### How to run it

You don't run the subcommands by hand. **Just tell your agent to run** — point it at a question and let it discover the rest from the built-in help:

> "Use `git-ai analyze` to find out which agent committed the most code that never shipped to production last month, then read a sample of those sessions and tell me why."

The agent runs `git-ai analyze` (and `git-ai analyze sessions --help`) to learn the full workflow, then loops on its own: see what's available → pull the numbers that answer the question → pull that slice of sessions → fan out subagents over the transcripts → write findings back → summarize.

**One-time setup:** an org API key (`organization:admin:read`) is required. Set it via the `GIT_AI_API_KEY` env var or `"api_key"` in `~/.git-ai/config.json`. Your org is derived from the key — data is always scoped to your org.

### The subcommands

#### `git-ai analyze query`
Asks the analytics backend a question and prints the answer as rows — counts, rates, lines of code, broken down by agent, model, repo, or over time. This is the aggregate view: "how many AI-assisted PRs per month," "which agent generated the most committed lines," etc. Flags let the agent pick what to count, how to slice it, a date range, sort order, a row limit, and the output format (table or JSON).

#### `git-ai analyze docs`
Prints the catalog of everything the backend can answer questions about — the exact names to use in `query`. The agent reads this instead of guessing names.

#### `git-ai analyze sessions <sub>`
The drill-down view. Pulls the individual coding sessions behind a slice into a scratch SQLite DB, hands them out one at a time across any number of concurrent subagents, and lets you write graded columns back so they can be summarized.

- **`pull`** — create/fill a SQLite DB with sessions (newest first), filtered by date / repo / user / agent (or anything `query` can slice on). Each session arrives with its full delivery funnel and baseline stats already filled in — tokens, cost, models, PR count, and how much committed code did vs. didn't reach production — so "what didn't ship" is a plain DB lookup, not a transcript read. Prints the DB path.
- **`next`** — return the next session plus its full transcript (the prompts and the agent's actions) as one JSON object, advancing a single shared cursor by one. Because the cursor is atomic, every session is handed out exactly once even across many subagents. Prints `{"done": true}` when exhausted.
- **`stats`** — show how many sessions were pulled and where the cursor is.
- **`reset`** — rewind the cursor to re-run an analysis pass.
- **`exec`** — run SQL against the DB. This is how the agent adds its grading columns (`ALTER TABLE … ADD COLUMN`), writes results back (`UPDATE … SET grade=…`), and runs the final summary query.

### Typical loop

```
docs (see what's available)
  → query (find the signal)
    → sessions pull (grab that slice)
      → fan out subagents over `sessions next` (grade/categorize each transcript)
        → sessions exec (summarize over the columns you added)
```

See `git-ai analyze` and `git-ai analyze sessions --help` for the complete, self-documenting workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
