### PR TITLE
Add best-effort daemon log upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Signal forwarding: On Unix, the git proxy installs signal handlers (SIGTERM, SIG
 
 `Config` is a global `OnceLock` singleton accessed via `Config::get()`. It reads from `~/.git-ai/config.json`. In tests, `GIT_AI_TEST_CONFIG_PATCH` env var allows overriding specific config fields without a real config file. Feature flags follow precedence: environment vars (`GIT_AI_*` prefix via `envy`) > config file > defaults.
 
-Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false).
+Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true).
 
 ### Error handling
 

--- a/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
+++ b/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
@@ -9,14 +9,18 @@ This document describes the Git AI client-side daemon diagnostics upload path.
   the existing API client/auth headers.
 - A heartbeat event is generated roughly every 15 minutes while the daemon is
   running.
-- Upload is best-effort. Failed batches are retried from the bounded in-memory
-  buffer; if the buffer exceeds its cap, the oldest events are dropped.
-- Events are dropped without retry when upload is disabled or the current API
-  auth/configuration does not permit upload.
+- Upload is best-effort and fire-and-forget. The telemetry worker dispatches at
+  most one daemon-log upload at a time on a detached thread and does not await
+  endpoint availability.
+- If another daemon-log upload is already in flight, the current batch is
+  requeued into the bounded in-memory buffer. If the buffer exceeds its cap, the
+  oldest events are dropped.
+- Events are dropped without retry when upload is disabled, the current API
+  auth/configuration does not permit upload, or a dispatched upload fails.
 - `feature_flags.daemon_log_upload` disables capture and upload when set to
   `false`. The flag defaults to enabled in debug and release builds.
 - Each event keeps at most 64 structured fields. Field names and string values
-  are length-limited before buffering.
+  are bounded, secret-redacted, and length-limited before buffering.
 
 ## Endpoint
 

--- a/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
+++ b/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
@@ -15,6 +15,8 @@ This document describes the Git AI client-side daemon diagnostics upload path.
   auth/configuration does not permit upload.
 - `feature_flags.daemon_log_upload` disables capture and upload when set to
   `false`. The flag defaults to enabled in debug and release builds.
+- Each event keeps at most 64 structured fields. Field names and string values
+  are length-limited before buffering.
 
 ## Endpoint
 

--- a/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
+++ b/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
@@ -1,0 +1,185 @@
+# Daemon Log Upload Client
+
+This document describes the Git AI client-side daemon diagnostics upload path.
+
+## Behavior
+
+- The daemon captures tracing events through `DaemonLogUploadLayer`.
+- Events are buffered in memory by the daemon telemetry worker and flushed with
+  the existing API client/auth headers.
+- A heartbeat event is generated roughly every 15 minutes while the daemon is
+  running.
+- Upload is best-effort. Failed batches are retried from the bounded in-memory
+  buffer; if the buffer exceeds its cap, the oldest events are dropped.
+- Events are dropped without retry when upload is disabled or the current API
+  auth/configuration does not permit upload.
+- `feature_flags.daemon_log_upload` disables capture and upload when set to
+  `false`. The flag defaults to enabled in debug and release builds.
+
+## Endpoint
+
+The daemon posts to:
+
+```text
+POST /worker/logs/upload
+```
+
+Authentication uses the same headers as metrics upload:
+
+- API key mode: `X-API-Key`, `X-Author-Identity`, `X-Distinct-ID`
+- OAuth mode: `Authorization: Bearer <token>`, `X-Distinct-ID`
+
+## Payload
+
+```json
+{
+  "version": 1,
+  "git_ai_version": "1.6.5",
+  "daemon_id": "daemon-run-uuid",
+  "install_id": "install-distinct-id",
+  "events": [
+    {
+      "id": "event-uuid",
+      "kind": "heartbeat",
+      "timestamp": "2026-06-29T12:00:00Z",
+      "level": "info",
+      "target": "git_ai::daemon",
+      "message": "alive",
+      "fields": {
+        "uptime_seconds": 900,
+        "os": "linux",
+        "arch": "x86_64"
+      }
+    }
+  ]
+}
+```
+
+## Verification
+
+Run focused tests:
+
+```bash
+task test TEST_FILTER=daemon_log
+task test TEST_FILTER=telemetry_buffer_caps_daemon_logs_to_latest_events
+```
+
+Run normal pre-PR checks:
+
+```bash
+task fmt
+task lint
+task test
+```
+
+## Practical Smoke Test
+
+This checks the installed/debug `git-ai` binary against a local mock HTTP
+endpoint. It validates the daemon sends real log events to
+`/worker/logs/upload` with the expected auth header and payload shape.
+
+```bash
+task build
+
+tmp="$(mktemp -d)"
+port_file="$tmp/port"
+requests_file="$tmp/requests.jsonl"
+
+python3 - "$port_file" "$requests_file" <<'PY' &
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port_file, requests_file = sys.argv[1:3]
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        events = payload.get("events", [])
+        with open(requests_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "path": self.path,
+                "api_key": self.headers.get("x-api-key"),
+                "version": payload.get("version"),
+                "daemon_id_present": bool(payload.get("daemon_id")),
+                "install_id_present": bool(payload.get("install_id")),
+                "event_count": len(events),
+                "kinds": [event.get("kind") for event in events],
+                "messages": [event.get("message") for event in events],
+            }) + "\n")
+        body = json.dumps({
+            "accepted": len(events),
+            "dropped": 0,
+            "enqueued": True,
+            "errors": [],
+        }).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_):
+        pass
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as f:
+    f.write(str(server.server_port))
+server.serve_forever()
+PY
+
+server_pid=$!
+trap 'target/debug/git-ai bg shutdown >/dev/null 2>&1 || true; kill "$server_pid" >/dev/null 2>&1 || true; rm -rf "$tmp"' EXIT
+
+while [ ! -s "$port_file" ]; do sleep 0.1; done
+api_url="http://127.0.0.1:$(cat "$port_file")"
+
+repo="$tmp/repo"
+git init -q "$repo"
+git -C "$repo" config user.email smoke@example.com
+git -C "$repo" config user.name Smoke
+printf 'hello\n' > "$repo/example.txt"
+
+export GIT_AI_API_BASE_URL="$api_url"
+export GIT_AI_API_KEY="local-smoke-key"
+export GIT_AI_DAEMON_HOME="$tmp/daemon"
+export GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=86400
+export GIT_AI_DAEMON_MAX_UPTIME_SECS=86400
+
+target/debug/git-ai bg start
+target/debug/git-ai checkpoint human "$repo/example.txt"
+sleep 4
+target/debug/git-ai bg shutdown
+
+python3 - "$requests_file" <<'PY'
+import json
+import sys
+
+rows = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8")]
+print("requests=", len(rows), sep="")
+for row in rows:
+    print("path=", row["path"], sep="")
+    print("api_key=", row["api_key"], sep="")
+    print("version=", row["version"], sep="")
+    print("daemon_id_present=", row["daemon_id_present"], sep="")
+    print("install_id_present=", row["install_id_present"], sep="")
+    print("event_count=", row["event_count"], sep="")
+    print("kinds=", ",".join(row["kinds"]), sep="")
+    print("messages=", ",".join(row["messages"]), sep="")
+PY
+```
+
+Expected output has one or more daemon log events sent to the upload endpoint:
+
+```text
+requests=1
+path=/worker/logs/upload
+api_key=local-smoke-key
+version=1
+daemon_id_present=True
+install_id_present=True
+event_count=6
+kinds=log,log,log,log,log,log
+messages=transcript worker spawned,socket health check started,transcript worker started,sweep completed,checkpoint start,checkpoint done
+```

--- a/src/api/logs.rs
+++ b/src/api/logs.rs
@@ -1,0 +1,64 @@
+//! Daemon diagnostics upload API.
+
+use crate::api::client::ApiClient;
+use crate::api::metrics::metrics_upload_allowed;
+use crate::api::types::{ApiErrorResponse, DaemonLogsUploadRequest, DaemonLogsUploadResponse};
+use crate::error::GitAiError;
+
+/// Returns whether daemon log uploads are allowed for the current API context.
+///
+/// This intentionally matches metrics delivery: the hosted API requires either
+/// OAuth login or an API key, while custom API URLs are assumed to be deliberate.
+pub fn daemon_logs_upload_allowed(api_base_url: &str, client: &ApiClient) -> bool {
+    metrics_upload_allowed(api_base_url, client)
+}
+
+impl ApiClient {
+    /// Upload a batch of daemon diagnostics to the server.
+    pub fn upload_daemon_logs(
+        &self,
+        request: &DaemonLogsUploadRequest,
+    ) -> Result<DaemonLogsUploadResponse, GitAiError> {
+        let response = self.context().post_json("/worker/logs/upload", request)?;
+        let status_code = response.status_code;
+
+        let body = response
+            .as_str()
+            .map_err(|e| GitAiError::Generic(format!("Failed to read response body: {}", e)))?;
+
+        match status_code {
+            200 => {
+                let logs_response: DaemonLogsUploadResponse =
+                    serde_json::from_str(body).map_err(GitAiError::JsonError)?;
+                Ok(logs_response)
+            }
+            400 => {
+                let error_response: ApiErrorResponse =
+                    serde_json::from_str(body).unwrap_or_else(|_| ApiErrorResponse {
+                        error: "Invalid request body".to_string(),
+                        details: Some(serde_json::Value::String(body.to_string())),
+                    });
+                Err(GitAiError::Generic(format!(
+                    "Bad Request: {}",
+                    error_response.error
+                )))
+            }
+            401 => Err(GitAiError::Generic("Unauthorized".to_string())),
+            500 => {
+                let error_response: ApiErrorResponse =
+                    serde_json::from_str(body).unwrap_or_else(|_| ApiErrorResponse {
+                        error: "Internal server error".to_string(),
+                        details: None,
+                    });
+                Err(GitAiError::Generic(format!(
+                    "Internal Server Error: {}",
+                    error_response.error
+                )))
+            }
+            _ => Err(GitAiError::Generic(format!(
+                "Unexpected status code {}: {}",
+                status_code, body
+            ))),
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,10 +1,12 @@
 pub mod bundle;
 pub mod cas;
 pub mod client;
+pub mod logs;
 pub mod metrics;
 pub mod notes;
 pub mod types;
 
 pub use client::{ApiClient, ApiContext};
+pub use logs::daemon_logs_upload_allowed;
 pub use metrics::{metrics_upload_allowed, upload_metrics_with_retry};
 pub use types::*;

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,7 +1,7 @@
 use crate::authorship::authorship_log::{LineRange, PromptRecord};
 use crate::commands::diff::FileDiffJson;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// File record for API - converts LineRange annotations to API format
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -161,6 +161,120 @@ pub struct CAPromptStoreReadResponse {
     pub results: Vec<CAPromptStoreReadResult>,
     pub success_count: usize,
     pub failure_count: usize,
+}
+
+/// Daemon diagnostics upload protocol version.
+pub const DAEMON_LOGS_UPLOAD_VERSION: u8 = 1;
+
+/// Kind of daemon diagnostic event accepted by `/worker/logs/upload`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DaemonLogKind {
+    Log,
+    Heartbeat,
+}
+
+/// Log level accepted by `/worker/logs/upload`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DaemonLogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// Primitive daemon log field value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum DaemonLogFieldValue {
+    String(String),
+    Number(serde_json::Number),
+    Bool(bool),
+    Null,
+}
+
+impl From<String> for DaemonLogFieldValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<&str> for DaemonLogFieldValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<u64> for DaemonLogFieldValue {
+    fn from(value: u64) -> Self {
+        Self::Number(serde_json::Number::from(value))
+    }
+}
+
+impl From<i64> for DaemonLogFieldValue {
+    fn from(value: i64) -> Self {
+        Self::Number(serde_json::Number::from(value))
+    }
+}
+
+impl From<bool> for DaemonLogFieldValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+/// Single daemon diagnostic event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DaemonLogEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub kind: DaemonLogKind,
+    pub timestamp: String,
+    pub level: DaemonLogLevel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, DaemonLogFieldValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_ai_version: Option<String>,
+}
+
+/// Request body for uploading daemon diagnostics to the HTTP backend.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DaemonLogsUploadRequest {
+    pub version: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_ai_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_url: Option<String>,
+    pub events: Vec<DaemonLogEvent>,
+}
+
+/// Error entry returned from daemon log upload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonLogsUploadError {
+    pub index: Option<usize>,
+    pub error: String,
+}
+
+/// Response from daemon log upload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonLogsUploadResponse {
+    pub accepted: usize,
+    pub dropped: usize,
+    pub enqueued: bool,
+    #[serde(default)]
+    pub errors: Vec<DaemonLogsUploadError>,
 }
 
 #[cfg(test)]
@@ -444,5 +558,53 @@ mod tests {
 
         let deserialized: CasMessagesObject = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.messages.len(), 1);
+    }
+
+    #[test]
+    fn daemon_logs_upload_request_serializes_contract_fields() {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "uptime_seconds".to_string(),
+            DaemonLogFieldValue::from(900_u64),
+        );
+        fields.insert("healthy".to_string(), DaemonLogFieldValue::from(true));
+
+        let request = DaemonLogsUploadRequest {
+            version: DAEMON_LOGS_UPLOAD_VERSION,
+            git_ai_version: Some("1.2.3".to_string()),
+            daemon_id: Some("daemon-1".to_string()),
+            install_id: Some("install-1".to_string()),
+            repo_url: None,
+            events: vec![DaemonLogEvent {
+                id: Some("event-1".to_string()),
+                kind: DaemonLogKind::Heartbeat,
+                timestamp: "2026-06-26T12:00:00.000Z".to_string(),
+                level: DaemonLogLevel::Info,
+                target: Some("git_ai::daemon".to_string()),
+                message: "alive".to_string(),
+                fields,
+                repo_url: None,
+                git_ai_version: None,
+            }],
+        };
+
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["version"], 1);
+        assert_eq!(value["git_ai_version"], "1.2.3");
+        assert_eq!(value["daemon_id"], "daemon-1");
+        assert_eq!(value["events"][0]["kind"], "heartbeat");
+        assert_eq!(value["events"][0]["level"], "info");
+        assert_eq!(value["events"][0]["fields"]["uptime_seconds"], 900);
+        assert_eq!(value["events"][0]["fields"]["healthy"], true);
+    }
+
+    #[test]
+    fn daemon_logs_upload_response_accepts_null_error_index() {
+        let response: DaemonLogsUploadResponse = serde_json::from_str(
+            r#"{"accepted":0,"dropped":0,"enqueued":false,"errors":[{"index":null,"error":"bad"}]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(response.errors[0].index, None);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -55,6 +55,7 @@ pub mod bash_sessions;
 pub mod checkpoint;
 pub mod control_api;
 pub mod coordinator;
+pub mod daemon_log_layer;
 pub mod domain;
 pub mod family_actor;
 pub mod git_backend;
@@ -6986,6 +6987,7 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                     .with_writer(std::io::stderr),
             )
             .with(crate::daemon::sentry_layer::SentryLayer)
+            .with(crate::daemon::daemon_log_layer::DaemonLogUploadLayer)
             .init();
     }
 

--- a/src/daemon/daemon_log_layer.rs
+++ b/src/daemon/daemon_log_layer.rs
@@ -1,0 +1,178 @@
+//! Tracing layer that forwards daemon log events to the telemetry worker.
+
+use crate::api::types::{DaemonLogEvent, DaemonLogFieldValue, DaemonLogKind, DaemonLogLevel};
+use crate::authorship::secrets::redact_secrets_in_text;
+use crate::config::Config;
+use std::collections::BTreeMap;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+
+const MAX_MESSAGE_LENGTH: usize = 16_000;
+const MAX_TARGET_LENGTH: usize = 512;
+const MAX_FIELD_KEY_LENGTH: usize = 256;
+const MAX_FIELD_VALUE_LENGTH: usize = 4096;
+
+/// Captures tracing events for best-effort daemon diagnostics upload.
+pub struct DaemonLogUploadLayer;
+
+struct DaemonLogVisitor {
+    message: String,
+    fields: BTreeMap<String, DaemonLogFieldValue>,
+}
+
+impl DaemonLogVisitor {
+    fn new() -> Self {
+        Self {
+            message: String::new(),
+            fields: BTreeMap::new(),
+        }
+    }
+
+    fn record_string(&mut self, field: &Field, value: String) {
+        if field.name() == "message" {
+            self.message = sanitize_log_string(&value, MAX_MESSAGE_LENGTH);
+            return;
+        }
+
+        self.record_field_value(field, DaemonLogFieldValue::String(value));
+    }
+
+    fn record_field_value(&mut self, field: &Field, value: DaemonLogFieldValue) {
+        self.record_named_field_value(field.name(), value);
+    }
+
+    fn record_named_field_value(&mut self, name: &str, value: DaemonLogFieldValue) {
+        let key = truncate_string(name, MAX_FIELD_KEY_LENGTH);
+        let value = sanitize_field_value(value);
+        self.fields.insert(key, value);
+    }
+}
+
+impl Visit for DaemonLogVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.record_string(field, format!("{:?}", value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.record_string(field, value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.record_field_value(field, DaemonLogFieldValue::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record_field_value(field, DaemonLogFieldValue::from(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.record_field_value(field, DaemonLogFieldValue::from(value));
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.record_string(field, value.to_string());
+    }
+}
+
+impl<S: Subscriber> Layer<S> for DaemonLogUploadLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        if !Config::get().get_feature_flags().daemon_log_upload {
+            return;
+        }
+
+        let metadata = event.metadata();
+        let mut visitor = DaemonLogVisitor::new();
+        event.record(&mut visitor);
+
+        if let Some(file) = metadata.file() {
+            visitor.record_named_field_value("file", DaemonLogFieldValue::from(file));
+        }
+        if let Some(line) = metadata.line() {
+            visitor.record_named_field_value("line", DaemonLogFieldValue::from(u64::from(line)));
+        }
+        if let Some(module_path) = metadata.module_path() {
+            visitor.record_named_field_value("module_path", DaemonLogFieldValue::from(module_path));
+        }
+
+        let log_event = DaemonLogEvent {
+            id: Some(crate::uuid::generate_v4()),
+            kind: DaemonLogKind::Log,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            level: daemon_log_level_from_tracing(metadata.level()),
+            target: Some(sanitize_log_string(metadata.target(), MAX_TARGET_LENGTH)),
+            message: visitor.message,
+            fields: visitor.fields,
+            repo_url: None,
+            git_ai_version: None,
+        };
+
+        crate::daemon::telemetry_worker::submit_daemon_internal_daemon_logs(vec![log_event]);
+    }
+}
+
+fn daemon_log_level_from_tracing(level: &Level) -> DaemonLogLevel {
+    match *level {
+        Level::TRACE => DaemonLogLevel::Trace,
+        Level::DEBUG => DaemonLogLevel::Debug,
+        Level::INFO => DaemonLogLevel::Info,
+        Level::WARN => DaemonLogLevel::Warn,
+        Level::ERROR => DaemonLogLevel::Error,
+    }
+}
+
+fn sanitize_field_value(value: DaemonLogFieldValue) -> DaemonLogFieldValue {
+    match value {
+        DaemonLogFieldValue::String(raw) => {
+            DaemonLogFieldValue::String(sanitize_log_string(&raw, MAX_FIELD_VALUE_LENGTH))
+        }
+        other => other,
+    }
+}
+
+fn sanitize_log_string(value: &str, max_len: usize) -> String {
+    let (redacted, _) = redact_secrets_in_text(value);
+    truncate_string(&redacted, max_len)
+}
+
+fn truncate_string(value: &str, max_len: usize) -> String {
+    if value.chars().count() <= max_len {
+        return value.to_string();
+    }
+
+    value.chars().take(max_len).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_log_string_redacts_and_truncates() {
+        let secret = "sk_test_4eC39HqLyjWDarjtT1zdp7dc";
+        let value = format!("token={secret}");
+
+        let sanitized = sanitize_log_string(&value, 12);
+
+        assert_eq!(sanitized.chars().count(), 12);
+        assert!(!sanitized.contains(secret));
+    }
+
+    #[test]
+    fn visitor_collects_primitive_fields() {
+        let mut visitor = DaemonLogVisitor::new();
+        visitor.record_named_field_value("repo", DaemonLogFieldValue::from("example"));
+        visitor.record_named_field_value("count", DaemonLogFieldValue::from(3_u64));
+        visitor.record_named_field_value("ok", DaemonLogFieldValue::from(true));
+
+        assert!(visitor.fields.contains_key("repo"));
+        assert_eq!(
+            visitor.fields.get("count"),
+            Some(&DaemonLogFieldValue::from(3_u64))
+        );
+        assert_eq!(
+            visitor.fields.get("ok"),
+            Some(&DaemonLogFieldValue::from(true))
+        );
+    }
+}

--- a/src/daemon/daemon_log_layer.rs
+++ b/src/daemon/daemon_log_layer.rs
@@ -4,6 +4,9 @@ use crate::api::types::{DaemonLogEvent, DaemonLogFieldValue, DaemonLogKind, Daem
 use crate::authorship::secrets::redact_secrets_in_text;
 use crate::config::Config;
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
@@ -13,9 +16,16 @@ const MAX_TARGET_LENGTH: usize = 512;
 const MAX_FIELD_KEY_LENGTH: usize = 256;
 const MAX_FIELD_VALUE_LENGTH: usize = 4096;
 const MAX_FIELDS_PER_EVENT: usize = 64;
+const MAX_SECRET_SCAN_TOKEN_LENGTH: usize = 90;
+const DAEMON_LOG_CAPTURE_ELIGIBILITY_TTL: Duration = Duration::from_secs(30);
 
 /// Captures tracing events for best-effort daemon diagnostics upload.
 pub struct DaemonLogUploadLayer;
+
+struct CaptureEligibilityCache {
+    checked_at: Instant,
+    enabled: bool,
+}
 
 struct DaemonLogVisitor {
     message: String,
@@ -55,11 +65,13 @@ impl DaemonLogVisitor {
 
 impl Visit for DaemonLogVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        self.record_string(field, format!("{:?}", value));
+        let max_len = max_string_len_for_field(field);
+        self.record_string(field, bounded_debug_string(value, max_len));
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        self.record_string(field, value.to_string());
+        let max_len = max_string_len_for_field(field);
+        self.record_string(field, bounded_copy(value, max_len));
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
@@ -75,13 +87,14 @@ impl Visit for DaemonLogVisitor {
     }
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.record_string(field, value.to_string());
+        let max_len = max_string_len_for_field(field);
+        self.record_string(field, bounded_display_string(value, max_len));
     }
 }
 
 impl<S: Subscriber> Layer<S> for DaemonLogUploadLayer {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-        if !Config::get().get_feature_flags().daemon_log_upload {
+        if !daemon_log_capture_enabled() {
             return;
         }
 
@@ -115,6 +128,59 @@ impl<S: Subscriber> Layer<S> for DaemonLogUploadLayer {
     }
 }
 
+fn daemon_log_capture_enabled() -> bool {
+    static CACHE: OnceLock<Mutex<Option<CaptureEligibilityCache>>> = OnceLock::new();
+
+    let cache = CACHE.get_or_init(|| Mutex::new(None));
+    let now = Instant::now();
+    if let Ok(mut guard) = cache.lock() {
+        if let Some(cached) = guard.as_ref()
+            && now.duration_since(cached.checked_at) < DAEMON_LOG_CAPTURE_ELIGIBILITY_TTL
+        {
+            return cached.enabled;
+        }
+
+        let enabled = compute_daemon_log_capture_enabled();
+        *guard = Some(CaptureEligibilityCache {
+            checked_at: now,
+            enabled,
+        });
+        return enabled;
+    }
+
+    compute_daemon_log_capture_enabled()
+}
+
+fn compute_daemon_log_capture_enabled() -> bool {
+    let config = Config::fresh();
+    let flags = config.get_feature_flags();
+    if !flags.daemon_log_upload {
+        return false;
+    }
+
+    daemon_log_capture_allowed_for_config(
+        config.api_base_url(),
+        config.api_key().is_some(),
+        has_unexpired_auth_credentials(),
+    )
+}
+
+fn daemon_log_capture_allowed_for_config(
+    api_base_url: &str,
+    has_api_key: bool,
+    has_unexpired_auth: bool,
+) -> bool {
+    api_base_url != crate::config::DEFAULT_API_BASE_URL || has_api_key || has_unexpired_auth
+}
+
+fn has_unexpired_auth_credentials() -> bool {
+    crate::auth::CredentialStore::new()
+        .load()
+        .ok()
+        .flatten()
+        .is_some_and(|credentials| !credentials.is_refresh_token_expired())
+}
+
 fn daemon_log_level_from_tracing(level: &Level) -> DaemonLogLevel {
     match *level {
         Level::TRACE => DaemonLogLevel::Trace,
@@ -139,17 +205,97 @@ fn sanitize_log_string(value: &str, max_len: usize) -> String {
     truncate_string(&redacted, max_len)
 }
 
+fn max_string_len_for_field(field: &Field) -> usize {
+    if field.name() == "message" {
+        MAX_MESSAGE_LENGTH
+    } else {
+        MAX_FIELD_VALUE_LENGTH
+    }
+}
+
+fn bounded_raw_len(max_len: usize) -> usize {
+    max_len.saturating_add(MAX_SECRET_SCAN_TOKEN_LENGTH)
+}
+
+fn bounded_copy(value: &str, max_len: usize) -> String {
+    truncate_string(value, bounded_raw_len(max_len))
+}
+
+fn bounded_debug_string(value: &dyn std::fmt::Debug, max_len: usize) -> String {
+    let mut writer = BoundedStringWriter::new(bounded_raw_len(max_len));
+    let _ = write!(&mut writer, "{value:?}");
+    writer.into_string()
+}
+
+fn bounded_display_string(value: &dyn std::fmt::Display, max_len: usize) -> String {
+    let mut writer = BoundedStringWriter::new(bounded_raw_len(max_len));
+    let _ = write!(&mut writer, "{value}");
+    writer.into_string()
+}
+
 fn truncate_string(value: &str, max_len: usize) -> String {
-    if value.chars().count() <= max_len {
-        return value.to_string();
+    if max_len == 0 {
+        return String::new();
     }
 
-    value.chars().take(max_len).collect()
+    let mut count = 0;
+    for (index, _) in value.char_indices() {
+        count += 1;
+        if count > max_len {
+            return value[..index].to_string();
+        }
+    }
+
+    value.to_string()
+}
+
+struct BoundedStringWriter {
+    value: String,
+    max_chars: usize,
+    chars: usize,
+}
+
+impl BoundedStringWriter {
+    fn new(max_chars: usize) -> Self {
+        Self {
+            value: String::new(),
+            max_chars,
+            chars: 0,
+        }
+    }
+
+    fn into_string(self) -> String {
+        self.value
+    }
+}
+
+impl std::fmt::Write for BoundedStringWriter {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        let remaining = self.max_chars.saturating_sub(self.chars);
+        if remaining == 0 {
+            return Err(std::fmt::Error);
+        }
+
+        let mut written = 0;
+        let mut chars = s.chars();
+        for ch in chars.by_ref().take(remaining) {
+            self.value.push(ch);
+            written += 1;
+        }
+        self.chars += written;
+
+        if chars.next().is_some() || self.chars >= self.max_chars {
+            return Err(std::fmt::Error);
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn sanitize_log_string_redacts_and_truncates() {
@@ -195,5 +341,71 @@ mod tests {
         assert!(visitor.fields.contains_key("field-0"));
         assert!(visitor.fields.contains_key("field-63"));
         assert!(!visitor.fields.contains_key("field-64"));
+    }
+
+    #[test]
+    fn bounded_debug_string_stops_formatting_after_cap() {
+        struct NoisyDebug<'a> {
+            writes: &'a AtomicUsize,
+        }
+
+        impl std::fmt::Debug for NoisyDebug<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                for index in 0..10_000 {
+                    self.writes.fetch_add(1, Ordering::SeqCst);
+                    write!(f, "field-{index}-")?;
+                }
+                Ok(())
+            }
+        }
+
+        let writes = AtomicUsize::new(0);
+        let formatted = bounded_debug_string(&NoisyDebug { writes: &writes }, 16);
+
+        assert_eq!(
+            formatted.chars().count(),
+            bounded_raw_len(16),
+            "bounded formatting should only keep cap plus redaction slack"
+        );
+        assert!(
+            writes.load(Ordering::SeqCst) < 100,
+            "formatter should stop invoking Debug once the bounded writer is full"
+        );
+    }
+
+    #[test]
+    fn bounded_string_fields_are_redacted_and_truncated() {
+        let mut visitor = DaemonLogVisitor::new();
+        let secret = "sk_test_4eC39HqLyjWDarjtT1zdp7dc";
+        visitor.record_named_field_value(
+            "token",
+            DaemonLogFieldValue::String(format!("token={secret}")),
+        );
+
+        let value = visitor.fields.get("token").unwrap();
+        let DaemonLogFieldValue::String(value) = value else {
+            panic!("expected string field");
+        };
+        assert!(!value.contains(secret));
+        assert!(value.chars().count() <= MAX_FIELD_VALUE_LENGTH);
+    }
+
+    #[test]
+    fn daemon_log_capture_skips_default_api_without_auth_or_key() {
+        assert!(!daemon_log_capture_allowed_for_config(
+            crate::config::DEFAULT_API_BASE_URL,
+            false,
+            false,
+        ));
+        assert!(daemon_log_capture_allowed_for_config(
+            crate::config::DEFAULT_API_BASE_URL,
+            true,
+            false,
+        ));
+        assert!(daemon_log_capture_allowed_for_config(
+            "https://api.example.com",
+            false,
+            false,
+        ));
     }
 }

--- a/src/daemon/daemon_log_layer.rs
+++ b/src/daemon/daemon_log_layer.rs
@@ -12,6 +12,7 @@ const MAX_MESSAGE_LENGTH: usize = 16_000;
 const MAX_TARGET_LENGTH: usize = 512;
 const MAX_FIELD_KEY_LENGTH: usize = 256;
 const MAX_FIELD_VALUE_LENGTH: usize = 4096;
+const MAX_FIELDS_PER_EVENT: usize = 64;
 
 /// Captures tracing events for best-effort daemon diagnostics upload.
 pub struct DaemonLogUploadLayer;
@@ -44,6 +45,9 @@ impl DaemonLogVisitor {
 
     fn record_named_field_value(&mut self, name: &str, value: DaemonLogFieldValue) {
         let key = truncate_string(name, MAX_FIELD_KEY_LENGTH);
+        if !self.fields.contains_key(&key) && self.fields.len() >= MAX_FIELDS_PER_EVENT {
+            return;
+        }
         let value = sanitize_field_value(value);
         self.fields.insert(key, value);
     }
@@ -174,5 +178,22 @@ mod tests {
             visitor.fields.get("ok"),
             Some(&DaemonLogFieldValue::from(true))
         );
+    }
+
+    #[test]
+    fn visitor_caps_field_count() {
+        let mut visitor = DaemonLogVisitor::new();
+
+        for index in 0..=MAX_FIELDS_PER_EVENT {
+            visitor.record_named_field_value(
+                &format!("field-{index}"),
+                DaemonLogFieldValue::from(index as u64),
+            );
+        }
+
+        assert_eq!(visitor.fields.len(), MAX_FIELDS_PER_EVENT);
+        assert!(visitor.fields.contains_key("field-0"));
+        assert!(visitor.fields.contains_key("field-63"));
+        assert!(!visitor.fields.contains_key("field-64"));
     }
 }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -3,8 +3,14 @@
 //! Runs inside the daemon process using tokio. Accumulates telemetry envelopes
 //! and CAS payloads, then flushes them to their destinations every 3 seconds.
 
+use crate::api::logs::daemon_logs_upload_allowed;
 use crate::api::metrics::{MetricsUploadResponse, metrics_upload_allowed};
+use crate::api::types::{
+    DAEMON_LOGS_UPLOAD_VERSION, DaemonLogEvent, DaemonLogFieldValue, DaemonLogKind, DaemonLogLevel,
+    DaemonLogsUploadRequest,
+};
 use crate::api::{ApiClient, ApiContext, CasObject, CasUploadRequest};
+use crate::authorship::authorship_log_serialization::GIT_AI_VERSION;
 use crate::config::{Config, get_or_create_distinct_id};
 use crate::daemon::control_api::{CasSyncPayload, TelemetryEnvelope};
 use crate::error::GitAiError;
@@ -19,6 +25,9 @@ use tokio::sync::Mutex;
 use tokio::time::{Duration, interval};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(3);
+const DAEMON_LOG_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const MAX_DAEMON_LOG_EVENTS_PER_UPLOAD: usize = 1000;
+const MAX_DAEMON_LOG_BUFFER_EVENTS: usize = 5000;
 
 static METRICS_UPLOAD_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static METRICS_METADATA_BACKFILL_STARTED: AtomicBool = AtomicBool::new(false);
@@ -30,6 +39,7 @@ struct TelemetryBuffer {
     messages: Vec<MessageEvent>,
     metrics: Vec<MetricEvent>,
     cas_records: Vec<CasSyncPayload>,
+    daemon_logs: Vec<DaemonLogEvent>,
 }
 
 struct ErrorEvent {
@@ -61,6 +71,7 @@ impl TelemetryBuffer {
             messages: Vec::new(),
             metrics: Vec::new(),
             cas_records: Vec::new(),
+            daemon_logs: Vec::new(),
         }
     }
 
@@ -70,6 +81,7 @@ impl TelemetryBuffer {
             && self.messages.is_empty()
             && self.metrics.is_empty()
             && self.cas_records.is_empty()
+            && self.daemon_logs.is_empty()
     }
 
     fn ingest_envelopes(&mut self, envelopes: Vec<TelemetryEnvelope>) {
@@ -125,6 +137,17 @@ impl TelemetryBuffer {
         self.cas_records.extend(records);
     }
 
+    fn ingest_daemon_logs(&mut self, events: Vec<DaemonLogEvent>) {
+        self.daemon_logs.extend(events);
+        let overflow = self
+            .daemon_logs
+            .len()
+            .saturating_sub(MAX_DAEMON_LOG_BUFFER_EVENTS);
+        if overflow > 0 {
+            self.daemon_logs.drain(0..overflow);
+        }
+    }
+
     fn take(&mut self) -> TelemetryBuffer {
         TelemetryBuffer {
             errors: std::mem::take(&mut self.errors),
@@ -132,6 +155,7 @@ impl TelemetryBuffer {
             messages: std::mem::take(&mut self.messages),
             metrics: std::mem::take(&mut self.metrics),
             cas_records: std::mem::take(&mut self.cas_records),
+            daemon_logs: std::mem::take(&mut self.daemon_logs),
         }
     }
 }
@@ -172,6 +196,14 @@ impl DaemonTelemetryWorkerHandle {
     /// Submit CAS records for batched upload.
     pub async fn submit_cas(&self, records: Vec<CasSyncPayload>) {
         self.buffer.lock().await.ingest_cas(records);
+    }
+
+    /// Submit daemon diagnostic events for batched upload.
+    pub async fn submit_daemon_logs(&self, events: Vec<DaemonLogEvent>) {
+        if events.is_empty() {
+            return;
+        }
+        self.buffer.lock().await.ingest_daemon_logs(events);
     }
 
     /// Returns the current number of metrics waiting for upload.
@@ -231,6 +263,16 @@ impl DaemonTelemetryWorkerHandle {
     pub fn submit_cas_sync(&self, records: Vec<CasSyncPayload>) {
         if let Ok(mut buf) = self.buffer.try_lock() {
             buf.ingest_cas(records);
+        }
+    }
+
+    /// Submit daemon diagnostic events synchronously (best-effort, non-blocking).
+    pub fn submit_daemon_logs_sync(&self, events: Vec<DaemonLogEvent>) {
+        if events.is_empty() {
+            return;
+        }
+        if let Ok(mut buf) = self.buffer.try_lock() {
+            buf.ingest_daemon_logs(events);
         }
     }
 }
@@ -307,6 +349,24 @@ pub fn submit_daemon_internal_cas(records: Vec<CasSyncPayload>) -> bool {
     }
 }
 
+/// Submit daemon diagnostic events from within the daemon process.
+/// Returns true if the handle was available and events were submitted.
+pub fn submit_daemon_internal_daemon_logs(events: Vec<DaemonLogEvent>) -> bool {
+    if let Some(handle) = DAEMON_INTERNAL_TELEMETRY.get() {
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            let handle = handle.clone();
+            runtime.spawn(async move {
+                handle.submit_daemon_logs(events).await;
+            });
+        } else {
+            handle.submit_daemon_logs_sync(events);
+        }
+        true
+    } else {
+        false
+    }
+}
+
 /// Spawn the telemetry worker task. Returns a handle for submitting events.
 ///
 /// The worker runs a flush loop every 3 seconds, sending accumulated events
@@ -316,11 +376,12 @@ pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
     let handle = DaemonTelemetryWorkerHandle {
         buffer: buffer.clone(),
     };
+    let daemon_id = crate::uuid::generate_v4();
 
     spawn_metrics_metadata_backfill();
 
     tokio::spawn(async move {
-        telemetry_flush_loop(buffer).await;
+        telemetry_flush_loop(buffer, daemon_id).await;
     });
 
     handle
@@ -363,16 +424,31 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
     Ok(())
 }
 
-async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>) {
+async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: String) {
     let mut ticker = interval(FLUSH_INTERVAL);
+    let started_at = std::time::Instant::now();
+    let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
     // The first tick completes immediately; skip it.
     ticker.tick().await;
 
     loop {
         ticker.tick().await;
 
+        let now = std::time::Instant::now();
+        let heartbeat = if now >= next_heartbeat_at && daemon_log_upload_enabled() {
+            while next_heartbeat_at <= now {
+                next_heartbeat_at += DAEMON_LOG_HEARTBEAT_INTERVAL;
+            }
+            Some(daemon_heartbeat_event(started_at.elapsed()))
+        } else {
+            None
+        };
+
         let snapshot = {
             let mut buf = buffer.lock().await;
+            if let Some(event) = heartbeat {
+                buf.ingest_daemon_logs(vec![event]);
+            }
             if buf.is_empty() {
                 None
             } else {
@@ -381,26 +457,39 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>) {
         };
 
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
-        tokio::task::spawn_blocking(move || {
+        let daemon_id_for_flush = daemon_id.clone();
+        let failed_daemon_logs = tokio::task::spawn_blocking(move || {
+            let mut failed_daemon_logs = Vec::new();
             if let Some(snapshot) = snapshot {
-                flush_telemetry_batch(snapshot);
+                failed_daemon_logs = flush_telemetry_batch(snapshot, &daemon_id_for_flush);
             }
             flush_pending_metrics();
+            failed_daemon_logs
         })
         .await
         .unwrap_or_else(|e| {
             tracing::error!(%e, "telemetry flush task panicked");
+            Vec::new()
         });
+
+        if !failed_daemon_logs.is_empty() {
+            buffer.lock().await.ingest_daemon_logs(failed_daemon_logs);
+        }
     }
 }
 
-fn flush_telemetry_batch(batch: TelemetryBuffer) {
+fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
     let config = Config::get();
     let distinct_id = get_or_create_distinct_id();
+    let mut failed_daemon_logs = Vec::new();
 
     // Flush metrics (always processed — uploaded or stored in SQLite)
     if !batch.metrics.is_empty() {
         flush_metrics(&batch.metrics);
+    }
+
+    if !batch.daemon_logs.is_empty() {
+        failed_daemon_logs = flush_daemon_logs(batch.daemon_logs, daemon_id, &distinct_id);
     }
 
     // Flush Sentry events (errors, performance, messages)
@@ -424,6 +513,8 @@ fn flush_telemetry_batch(batch: TelemetryBuffer) {
 
     // Flush pending notes (reads directly from notes-db; no-op when kind != Http).
     flush_notes();
+
+    failed_daemon_logs
 }
 
 fn flush_metrics(events: &[MetricEvent]) {
@@ -677,6 +768,77 @@ fn current_unix_ts() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn daemon_log_upload_enabled() -> bool {
+    Config::fresh().get_feature_flags().daemon_log_upload
+}
+
+fn daemon_heartbeat_event(uptime: std::time::Duration) -> DaemonLogEvent {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "uptime_seconds".to_string(),
+        DaemonLogFieldValue::from(uptime.as_secs()),
+    );
+    fields.insert(
+        "os".to_string(),
+        DaemonLogFieldValue::from(std::env::consts::OS),
+    );
+    fields.insert(
+        "arch".to_string(),
+        DaemonLogFieldValue::from(std::env::consts::ARCH),
+    );
+
+    DaemonLogEvent {
+        id: Some(crate::uuid::generate_v4()),
+        kind: DaemonLogKind::Heartbeat,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        level: DaemonLogLevel::Info,
+        target: Some("git_ai::daemon".to_string()),
+        message: "alive".to_string(),
+        fields,
+        repo_url: None,
+        git_ai_version: None,
+    }
+}
+
+fn flush_daemon_logs(
+    events: Vec<DaemonLogEvent>,
+    daemon_id: &str,
+    install_id: &str,
+) -> Vec<DaemonLogEvent> {
+    if !daemon_log_upload_enabled() {
+        return Vec::new();
+    }
+
+    let context = ApiContext::new(None);
+    let api_base_url = context.base_url.clone();
+    let client = ApiClient::new(context);
+
+    if !daemon_logs_upload_allowed(&api_base_url, &client) {
+        // These diagnostics are intentionally best-effort and only live in memory.
+        // If the current API/auth setup cannot upload, do not keep re-flushing the
+        // same buffered events every few seconds.
+        return Vec::new();
+    }
+
+    let mut retry_events = Vec::new();
+    for chunk in events.chunks(MAX_DAEMON_LOG_EVENTS_PER_UPLOAD) {
+        let request = DaemonLogsUploadRequest {
+            version: DAEMON_LOGS_UPLOAD_VERSION,
+            git_ai_version: Some(GIT_AI_VERSION.to_string()),
+            daemon_id: Some(daemon_id.to_string()),
+            install_id: Some(install_id.to_string()),
+            repo_url: None,
+            events: chunk.to_vec(),
+        };
+
+        if client.upload_daemon_logs(&request).is_err() {
+            retry_events.extend_from_slice(chunk);
+        }
+    }
+
+    retry_events
 }
 
 fn flush_sentry_and_posthog(
@@ -1636,5 +1798,54 @@ mod tests {
         assert_eq!(db.borrow().count().unwrap(), 1);
         let history = db.borrow().get_metric_history(0, None, &[1]).unwrap();
         assert!(history.iter().any(|record| record.ts == old_ts));
+    }
+
+    fn sample_daemon_log_event(message: impl Into<String>) -> DaemonLogEvent {
+        DaemonLogEvent {
+            id: Some(crate::uuid::generate_v4()),
+            kind: DaemonLogKind::Log,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            level: DaemonLogLevel::Info,
+            target: Some("git_ai::test".to_string()),
+            message: message.into(),
+            fields: BTreeMap::new(),
+            repo_url: None,
+            git_ai_version: None,
+        }
+    }
+
+    #[test]
+    fn telemetry_buffer_caps_daemon_logs_to_latest_events() {
+        let mut buffer = TelemetryBuffer::new();
+        let total = MAX_DAEMON_LOG_BUFFER_EVENTS + 2;
+        let events = (0..total)
+            .map(|index| sample_daemon_log_event(index.to_string()))
+            .collect();
+
+        buffer.ingest_daemon_logs(events);
+
+        assert_eq!(buffer.daemon_logs.len(), MAX_DAEMON_LOG_BUFFER_EVENTS);
+        assert_eq!(buffer.daemon_logs.first().unwrap().message, "2");
+        assert_eq!(
+            buffer.daemon_logs.last().unwrap().message,
+            (total - 1).to_string()
+        );
+    }
+
+    #[test]
+    fn daemon_heartbeat_event_uses_upload_contract_shape() {
+        let event = daemon_heartbeat_event(std::time::Duration::from_secs(900));
+
+        assert!(event.id.is_some());
+        assert_eq!(event.kind, DaemonLogKind::Heartbeat);
+        assert_eq!(event.level, DaemonLogLevel::Info);
+        assert_eq!(event.target.as_deref(), Some("git_ai::daemon"));
+        assert_eq!(event.message, "alive");
+        assert_eq!(
+            event.fields.get("uptime_seconds"),
+            Some(&DaemonLogFieldValue::from(900_u64))
+        );
+        assert!(event.fields.contains_key("os"));
+        assert!(event.fields.contains_key("arch"));
     }
 }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -139,6 +139,16 @@ impl TelemetryBuffer {
 
     fn ingest_daemon_logs(&mut self, events: Vec<DaemonLogEvent>) {
         self.daemon_logs.extend(events);
+        self.cap_daemon_logs();
+    }
+
+    fn requeue_failed_daemon_logs(&mut self, mut failed_events: Vec<DaemonLogEvent>) {
+        failed_events.append(&mut self.daemon_logs);
+        self.daemon_logs = failed_events;
+        self.cap_daemon_logs();
+    }
+
+    fn cap_daemon_logs(&mut self) {
         let overflow = self
             .daemon_logs
             .len()
@@ -473,7 +483,10 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
         });
 
         if !failed_daemon_logs.is_empty() {
-            buffer.lock().await.ingest_daemon_logs(failed_daemon_logs);
+            buffer
+                .lock()
+                .await
+                .requeue_failed_daemon_logs(failed_daemon_logs);
         }
     }
 }
@@ -1829,6 +1842,32 @@ mod tests {
         assert_eq!(
             buffer.daemon_logs.last().unwrap().message,
             (total - 1).to_string()
+        );
+    }
+
+    #[test]
+    fn telemetry_buffer_requeues_failed_daemon_logs_without_dropping_newer_events() {
+        let mut buffer = TelemetryBuffer::new();
+        buffer.ingest_daemon_logs(vec![
+            sample_daemon_log_event("new-1"),
+            sample_daemon_log_event("new-2"),
+        ]);
+
+        let failed_events = (0..MAX_DAEMON_LOG_BUFFER_EVENTS)
+            .map(|index| sample_daemon_log_event(format!("old-{index}")))
+            .collect();
+
+        buffer.requeue_failed_daemon_logs(failed_events);
+
+        assert_eq!(buffer.daemon_logs.len(), MAX_DAEMON_LOG_BUFFER_EVENTS);
+        assert_eq!(buffer.daemon_logs.first().unwrap().message, "old-2");
+        assert_eq!(
+            buffer.daemon_logs[MAX_DAEMON_LOG_BUFFER_EVENTS - 2].message,
+            "new-1"
+        );
+        assert_eq!(
+            buffer.daemon_logs[MAX_DAEMON_LOG_BUFFER_EVENTS - 1].message,
+            "new-2"
         );
     }
 

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -31,6 +31,8 @@ const MAX_DAEMON_LOG_BUFFER_EVENTS: usize = 5000;
 
 static METRICS_UPLOAD_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static METRICS_METADATA_BACKFILL_STARTED: AtomicBool = AtomicBool::new(false);
+static DAEMON_LOG_UPLOAD_IN_FLIGHT: std::sync::OnceLock<Arc<AtomicBool>> =
+    std::sync::OnceLock::new();
 
 /// Accumulated telemetry events waiting to be flushed.
 struct TelemetryBuffer {
@@ -468,13 +470,13 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
 
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
         let daemon_id_for_flush = daemon_id.clone();
-        let failed_daemon_logs = tokio::task::spawn_blocking(move || {
-            let mut failed_daemon_logs = Vec::new();
+        let requeue_daemon_logs = tokio::task::spawn_blocking(move || {
             if let Some(snapshot) = snapshot {
-                failed_daemon_logs = flush_telemetry_batch(snapshot, &daemon_id_for_flush);
+                flush_telemetry_batch(snapshot, &daemon_id_for_flush)
+            } else {
+                flush_pending_metrics();
+                Vec::new()
             }
-            flush_pending_metrics();
-            failed_daemon_logs
         })
         .await
         .unwrap_or_else(|e| {
@@ -482,11 +484,11 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
             Vec::new()
         });
 
-        if !failed_daemon_logs.is_empty() {
+        if !requeue_daemon_logs.is_empty() {
             buffer
                 .lock()
                 .await
-                .requeue_failed_daemon_logs(failed_daemon_logs);
+                .requeue_failed_daemon_logs(requeue_daemon_logs);
         }
     }
 }
@@ -494,15 +496,10 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
 fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
     let config = Config::get();
     let distinct_id = get_or_create_distinct_id();
-    let mut failed_daemon_logs = Vec::new();
 
     // Flush metrics (always processed — uploaded or stored in SQLite)
     if !batch.metrics.is_empty() {
         flush_metrics(&batch.metrics);
-    }
-
-    if !batch.daemon_logs.is_empty() {
-        failed_daemon_logs = flush_daemon_logs(batch.daemon_logs, daemon_id, &distinct_id);
     }
 
     // Flush Sentry events (errors, performance, messages)
@@ -527,7 +524,13 @@ fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonL
     // Flush pending notes (reads directly from notes-db; no-op when kind != Http).
     flush_notes();
 
-    failed_daemon_logs
+    flush_pending_metrics();
+
+    if batch.daemon_logs.is_empty() {
+        Vec::new()
+    } else {
+        dispatch_daemon_log_upload(batch.daemon_logs, daemon_id, &distinct_id)
+    }
 }
 
 fn flush_metrics(events: &[MetricEvent]) {
@@ -815,13 +818,81 @@ fn daemon_heartbeat_event(uptime: std::time::Duration) -> DaemonLogEvent {
     }
 }
 
-fn flush_daemon_logs(
+fn daemon_log_upload_in_flight_flag() -> Arc<AtomicBool> {
+    DAEMON_LOG_UPLOAD_IN_FLIGHT
+        .get_or_init(|| Arc::new(AtomicBool::new(false)))
+        .clone()
+}
+
+struct DaemonLogUploadInFlightGuard {
+    in_flight: Arc<AtomicBool>,
+}
+
+impl Drop for DaemonLogUploadInFlightGuard {
+    fn drop(&mut self) {
+        self.in_flight.store(false, Ordering::Release);
+    }
+}
+
+fn dispatch_daemon_log_upload(
     events: Vec<DaemonLogEvent>,
     daemon_id: &str,
     install_id: &str,
 ) -> Vec<DaemonLogEvent> {
-    if !daemon_log_upload_enabled() {
+    let daemon_id = daemon_id.to_string();
+    let install_id = install_id.to_string();
+
+    dispatch_daemon_log_upload_with(events, daemon_log_upload_in_flight_flag(), move |events| {
+        let failed_events = flush_daemon_logs(events, &daemon_id, &install_id);
+        if failed_events > 0 {
+            tracing::debug!(
+                failed_events,
+                "daemon log upload failed after fire-and-forget dispatch"
+            );
+        }
+    })
+}
+
+fn dispatch_daemon_log_upload_with<Upload>(
+    events: Vec<DaemonLogEvent>,
+    in_flight: Arc<AtomicBool>,
+    upload: Upload,
+) -> Vec<DaemonLogEvent>
+where
+    Upload: FnOnce(Vec<DaemonLogEvent>) + Send + 'static,
+{
+    if events.is_empty() {
         return Vec::new();
+    }
+
+    if in_flight
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return events;
+    }
+
+    let in_flight_for_task = in_flight.clone();
+    let spawn_result = std::thread::Builder::new()
+        .name("git-ai-daemon-log-upload".to_string())
+        .spawn(move || {
+            let _guard = DaemonLogUploadInFlightGuard {
+                in_flight: in_flight_for_task,
+            };
+            upload(events);
+        });
+
+    if let Err(error) = spawn_result {
+        in_flight.store(false, Ordering::Release);
+        tracing::debug!(%error, "failed to spawn daemon log upload task");
+    }
+
+    Vec::new()
+}
+
+fn flush_daemon_logs(events: Vec<DaemonLogEvent>, daemon_id: &str, install_id: &str) -> usize {
+    if !daemon_log_upload_enabled() {
+        return 0;
     }
 
     let context = ApiContext::new(None);
@@ -832,26 +903,42 @@ fn flush_daemon_logs(
         // These diagnostics are intentionally best-effort and only live in memory.
         // If the current API/auth setup cannot upload, do not keep re-flushing the
         // same buffered events every few seconds.
-        return Vec::new();
+        return 0;
     }
 
-    let mut retry_events = Vec::new();
-    for chunk in events.chunks(MAX_DAEMON_LOG_EVENTS_PER_UPLOAD) {
-        let request = DaemonLogsUploadRequest {
-            version: DAEMON_LOGS_UPLOAD_VERSION,
-            git_ai_version: Some(GIT_AI_VERSION.to_string()),
-            daemon_id: Some(daemon_id.to_string()),
-            install_id: Some(install_id.to_string()),
-            repo_url: None,
-            events: chunk.to_vec(),
-        };
+    upload_daemon_log_chunk(events, daemon_id, install_id, |request| {
+        client.upload_daemon_logs(request).map(|_| ())
+    })
+}
 
-        if client.upload_daemon_logs(&request).is_err() {
-            retry_events.extend_from_slice(chunk);
-        }
+fn upload_daemon_log_chunk<Upload>(
+    events: Vec<DaemonLogEvent>,
+    daemon_id: &str,
+    install_id: &str,
+    mut upload: Upload,
+) -> usize
+where
+    Upload: FnMut(&DaemonLogsUploadRequest) -> Result<(), GitAiError>,
+{
+    let Some(chunk) = events.chunks(MAX_DAEMON_LOG_EVENTS_PER_UPLOAD).next() else {
+        return 0;
+    };
+
+    let mut failed_events = events.len().saturating_sub(chunk.len());
+    let request = DaemonLogsUploadRequest {
+        version: DAEMON_LOGS_UPLOAD_VERSION,
+        git_ai_version: Some(GIT_AI_VERSION.to_string()),
+        daemon_id: Some(daemon_id.to_string()),
+        install_id: Some(install_id.to_string()),
+        repo_url: None,
+        events: chunk.to_vec(),
+    };
+
+    if upload(&request).is_err() {
+        failed_events += chunk.len();
     }
 
-    retry_events
+    failed_events
 }
 
 fn flush_sentry_and_posthog(
@@ -1268,6 +1355,7 @@ mod tests {
     use crate::api::metrics::MetricsUploadError;
     use std::cell::RefCell;
     use std::rc::Rc;
+    use std::sync::Arc;
 
     fn event_json(ts: u32) -> String {
         format!(r#"{{"t":{ts},"e":1,"v":{{}},"a":{{}}}}"#)
@@ -1825,6 +1913,77 @@ mod tests {
             repo_url: None,
             git_ai_version: None,
         }
+    }
+
+    #[test]
+    fn upload_daemon_log_chunk_counts_events_past_per_upload_cap() {
+        let events = (0..MAX_DAEMON_LOG_EVENTS_PER_UPLOAD + 2)
+            .map(|index| sample_daemon_log_event(index.to_string()))
+            .collect::<Vec<_>>();
+        let uploaded_batch_sizes = Rc::new(RefCell::new(Vec::new()));
+
+        let failed_events = upload_daemon_log_chunk(events, "daemon-id", "install-id", {
+            let uploaded_batch_sizes = Rc::clone(&uploaded_batch_sizes);
+            move |request| {
+                uploaded_batch_sizes.borrow_mut().push(request.events.len());
+                Ok(())
+            }
+        });
+
+        assert_eq!(
+            *uploaded_batch_sizes.borrow(),
+            vec![MAX_DAEMON_LOG_EVENTS_PER_UPLOAD]
+        );
+        assert_eq!(failed_events, 2);
+    }
+
+    #[test]
+    fn daemon_log_dispatch_requeues_when_upload_is_already_in_flight() {
+        let in_flight = Arc::new(AtomicBool::new(true));
+        let events = vec![sample_daemon_log_event("queued")];
+
+        let retry_events = dispatch_daemon_log_upload_with(events, in_flight, |_events| {
+            panic!("upload task should not run while another upload is running")
+        });
+
+        assert_eq!(retry_events.len(), 1);
+        assert_eq!(retry_events[0].message, "queued");
+    }
+
+    #[test]
+    fn daemon_log_dispatch_does_not_wait_for_upload_task() {
+        let (upload_started_tx, upload_started_rx) = std::sync::mpsc::channel();
+        let (release_upload_tx, release_upload_rx) = std::sync::mpsc::channel();
+        let in_flight = Arc::new(AtomicBool::new(false));
+
+        let started_at = std::time::Instant::now();
+        let retry_events = dispatch_daemon_log_upload_with(
+            vec![sample_daemon_log_event("blocked")],
+            Arc::clone(&in_flight),
+            move |_events| {
+                upload_started_tx.send(()).unwrap();
+                let _ = release_upload_rx.recv_timeout(Duration::from_secs(2));
+            },
+        );
+
+        assert!(retry_events.is_empty());
+        assert!(
+            started_at.elapsed() < Duration::from_millis(500),
+            "dispatch should return promptly while daemon log upload is blocked"
+        );
+
+        upload_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("upload task should start");
+        assert!(in_flight.load(Ordering::Acquire));
+
+        release_upload_tx.send(()).unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while in_flight.load(Ordering::Acquire) && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!in_flight.load(Ordering::Acquire));
     }
 
     #[test]

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -82,6 +82,7 @@ define_feature_flags!(
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = true,
     checkpoint_debug_log: checkpoint_debug_log, debug = false, release = false,
+    daemon_log_upload: daemon_log_upload, debug = true, release = true,
 );
 
 impl FeatureFlags {
@@ -135,6 +136,7 @@ mod tests {
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
             assert!(!flags.checkpoint_debug_log);
+            assert!(flags.daemon_log_upload);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -142,6 +144,7 @@ mod tests {
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
             assert!(!flags.checkpoint_debug_log);
+            assert!(flags.daemon_log_upload);
         }
     }
 
@@ -191,6 +194,7 @@ mod tests {
             transcript_streaming: true,
             transcript_sweep: true,
             checkpoint_debug_log: false,
+            daemon_log_upload: true,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -198,6 +202,7 @@ mod tests {
         assert!(serialized.contains("transcript_streaming"));
         assert!(serialized.contains("transcript_sweep"));
         assert!(serialized.contains("checkpoint_debug_log"));
+        assert!(serialized.contains("daemon_log_upload"));
     }
 
     #[test]
@@ -207,12 +212,14 @@ mod tests {
             transcript_streaming: true,
             transcript_sweep: true,
             checkpoint_debug_log: true,
+            daemon_log_upload: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.auth_keyring, flags.auth_keyring);
         assert_eq!(cloned.transcript_streaming, flags.transcript_streaming);
         assert_eq!(cloned.transcript_sweep, flags.transcript_sweep);
         assert_eq!(cloned.checkpoint_debug_log, flags.checkpoint_debug_log);
+        assert_eq!(cloned.daemon_log_upload, flags.daemon_log_upload);
     }
 
     #[test]

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -19,6 +19,7 @@ fn setup() {
         transcript_streaming: true,
         transcript_sweep: true,
         checkpoint_debug_log: false,
+        daemon_log_upload: true,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());


### PR DESCRIPTION
## Summary

Adds the Git AI client-side sender for daemon diagnostics.

The daemon captures Rust tracing events, redacts/truncates them, buffers them in memory, and uploads them best-effort to:

```text
POST /worker/logs/upload
```

It also emits a periodic heartbeat so the backend can distinguish "daemon is alive" from "no recent log events".

## Minimal Change Set

- Adds daemon log upload API types and `ApiClient::upload_daemon_logs()`.
- Adds `DaemonLogUploadLayer`, a tracing layer that converts daemon tracing events into uploadable log events only when upload can actually be used.
- Extends the daemon telemetry worker with:
  - bounded in-memory daemon log buffering,
  - 1,000-event upload cap per detached upload task,
  - one fire-and-forget daemon-log upload in flight at a time,
  - requeue only when another daemon-log upload is already in flight,
  - 15-minute heartbeat events.
- Adds `feature_flags.daemon_log_upload`, default enabled in debug and release.
- Documents the endpoint contract, payload shape, and smoke-test flow.

## Reviewer Notes

- This is intentionally client-side only. It does not add a server endpoint, queue, ClickHouse table, or migration in this repo.
- Daemon log upload is best-effort and in-memory only. A dispatched upload is never awaited by the telemetry flush path, so a slow or unavailable log endpoint cannot block notes, CAS, Sentry/PostHog, or metrics flushing.
- If a daemon-log upload is already in flight, the current batch is requeued inside the bounded buffer. If a detached upload fails after dispatch, those events are dropped.
- Events are dropped without retry when upload is disabled or the current API/auth configuration does not permit upload.
- String fields are bounded before formatting/redaction, secret-redacted, length-limited, and field-count-limited before buffering.
- The existing daemon tracing filter still controls which levels are captured (`info` normally, `debug` when enabled).

## Scope Validation

I validated this against the intended client-side scope: the missing open-source piece is daemon/CLI emission of log events plus heartbeat, using the existing API auth shape and a user-disableable feature flag. Backend ingestion/storage remains a separate concern.

## Docs

Full contract and copy-paste practical smoke test:

- `docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md`

## Practical Smoke Test

The docs include the full local mock-server script. The important reviewer flow is:

```bash
task build

export GIT_AI_API_BASE_URL="http://127.0.0.1:<mock-port>"
export GIT_AI_API_KEY="local-smoke-key"
export GIT_AI_DAEMON_HOME="$(mktemp -d)"
export GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=86400
export GIT_AI_DAEMON_MAX_UPTIME_SECS=86400

target/debug/git-ai bg start
target/debug/git-ai checkpoint human "$repo/example.txt"
sleep 4
target/debug/git-ai bg shutdown
```

Observed output from the mock receiver:

```text
requests=1
path=/worker/logs/upload
api_key=local-smoke-key
version=1
daemon_id_present=True
install_id_present=True
event_count=6
kinds=log,log,log,log,log,log
messages=transcript worker spawned,socket health check started,transcript worker started,sweep completed,checkpoint start,checkpoint done
```

This validates a real daemon process sending a real upload request to the expected path with API-key auth and the expected payload envelope. The heartbeat shape is covered by the focused unit test because waiting for the 15-minute timer is not useful in normal review.

## Verification Run

```bash
task fmt
task test TEST_FILTER=telemetry_worker CARGO_TEST_ARGS="--lib"
task test TEST_FILTER=daemon_log CARGO_TEST_ARGS="--lib"
task lint
task build
git diff --check
task test
```

Results:

- Focused telemetry/log tests: passed.
- `task lint`: passed.
- `task build`: passed.
- `git diff --check`: passed.
- Prior full `task test`: passed; 1972 lib tests passed, main integration binary 3172 passed / 85 ignored, notes sync regression 20 passed, doctests 4 passed / 2 ignored.
