### PR TITLE
fix(ignore): allow overriding the built-in **/vendor/** exclusion (#1664)

### DIFF
--- a/src/authorship/ignore.rs
+++ b/src/authorship/ignore.rs
@@ -40,8 +40,27 @@ const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
 
 #[derive(Clone, Debug)]
 enum CompiledPattern {
-    Glob(Pattern),
-    Exact(String),
+    Glob { pattern: Pattern, negated: bool },
+    Exact { value: String, negated: bool },
+}
+
+impl CompiledPattern {
+    fn negated(&self) -> bool {
+        match self {
+            CompiledPattern::Glob { negated, .. } | CompiledPattern::Exact { negated, .. } => {
+                *negated
+            }
+        }
+    }
+
+    fn matches(&self, path: &str, filename: &str) -> bool {
+        match self {
+            CompiledPattern::Glob { pattern, .. } => {
+                pattern.matches(path) || pattern.matches(filename)
+            }
+            CompiledPattern::Exact { value, .. } => value == path || value == filename,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -53,27 +72,58 @@ impl IgnoreMatcher {
     pub fn new(patterns: &[String]) -> Self {
         let patterns = patterns
             .iter()
-            .map(|pattern| match Pattern::new(pattern) {
-                Ok(glob) => CompiledPattern::Glob(glob),
-                Err(_) => CompiledPattern::Exact(pattern.clone()),
+            .map(|raw| {
+                let (negated, body) = split_negation(raw);
+                match Pattern::new(&body) {
+                    Ok(glob) => CompiledPattern::Glob {
+                        pattern: glob,
+                        negated,
+                    },
+                    Err(_) => CompiledPattern::Exact {
+                        value: body,
+                        negated,
+                    },
+                }
             })
             .collect();
 
         Self { patterns }
     }
 
+    /// Returns whether `path` should be ignored.
+    ///
+    /// Patterns are evaluated in order and the **last** matching pattern wins,
+    /// mirroring `.gitignore` semantics. A pattern prefixed with `!` re-includes
+    /// (un-ignores) paths matched by an earlier pattern, which is how a user can
+    /// override a built-in default such as `**/vendor/**`.
     pub fn is_ignored(&self, path: &str) -> bool {
         let filename = std::path::Path::new(path)
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("");
 
-        self.patterns.iter().any(|pattern| match pattern {
-            CompiledPattern::Glob(glob_pattern) => {
-                glob_pattern.matches(path) || glob_pattern.matches(filename)
+        let mut ignored = false;
+        for pattern in &self.patterns {
+            if pattern.matches(path, filename) {
+                ignored = !pattern.negated();
             }
-            CompiledPattern::Exact(pattern) => filename == pattern || path == pattern,
-        })
+        }
+        ignored
+    }
+}
+
+/// Split a leading `!` negation marker from a pattern.
+///
+/// Returns `(negated, body)` where `body` is the pattern with the marker
+/// removed. A literal leading `!` can still be matched by escaping it as `\!`,
+/// mirroring `.gitignore` syntax.
+fn split_negation(raw: &str) -> (bool, String) {
+    if let Some(rest) = raw.strip_prefix('!') {
+        (true, rest.to_string())
+    } else if let Some(rest) = raw.strip_prefix("\\!") {
+        (false, format!("!{rest}"))
+    } else {
+        (false, raw.to_string())
     }
 }
 
@@ -106,50 +156,103 @@ pub fn load_linguist_generated_patterns_from_root_gitattributes(repo: &Repositor
     parse_linguist_generated_patterns(&contents)
 }
 
+pub fn load_linguist_vendored_patterns_from_root_gitattributes(repo: &Repository) -> Vec<String> {
+    let Some(contents) = load_root_gitattributes_contents(repo) else {
+        return Vec::new();
+    };
+    parse_linguist_vendored_patterns(&contents)
+}
+
 fn parse_linguist_generated_patterns(contents: &str) -> Vec<String> {
     let mut patterns = Vec::new();
 
     for raw_line in contents.lines() {
-        let line = raw_line.trim();
-        if line.is_empty() || line.starts_with('#') {
+        let Some((path_pattern, attrs)) = parse_gitattributes_line(raw_line) else {
             continue;
-        }
+        };
 
-        let tokens = split_gitattributes_tokens(line);
-        if tokens.len() < 2 {
-            continue;
-        }
-
-        let path_pattern = &tokens[0];
-        if path_pattern.starts_with("[attr]") {
-            continue;
-        }
-        let mut state: Option<bool> = None;
-
-        for attr in &tokens[1..] {
-            if attr == "linguist-generated" {
-                state = Some(true);
-                continue;
-            }
-            if attr == "-linguist-generated" || attr == "!linguist-generated" {
-                state = Some(false);
-                continue;
-            }
-            if let Some(value) = attr.strip_prefix("linguist-generated=") {
-                if value.eq_ignore_ascii_case("true") || value == "1" {
-                    state = Some(true);
-                } else if value.eq_ignore_ascii_case("false") || value == "0" {
-                    state = Some(false);
-                }
-            }
-        }
-
-        if state == Some(true) {
-            patterns.push(path_pattern.to_string());
+        if attribute_state(&attrs, "linguist-generated") == Some(true) {
+            patterns.push(path_pattern);
         }
     }
 
     dedupe_patterns(patterns)
+}
+
+/// Parse `linguist-vendored` declarations from `.gitattributes` into ignore
+/// patterns.
+///
+/// `linguist-vendored` / `linguist-vendored=true` marks a path as vendored and
+/// yields a positive ignore pattern. `-linguist-vendored` / `!linguist-vendored`
+/// / `linguist-vendored=false` un-marks it and yields a **negation** pattern
+/// (`!path`), so a user can re-include first-party code that the built-in
+/// `**/vendor/**` default would otherwise exclude (see issue #1664).
+fn parse_linguist_vendored_patterns(contents: &str) -> Vec<String> {
+    let mut patterns = Vec::new();
+
+    for raw_line in contents.lines() {
+        let Some((path_pattern, attrs)) = parse_gitattributes_line(raw_line) else {
+            continue;
+        };
+
+        match attribute_state(&attrs, "linguist-vendored") {
+            Some(true) => patterns.push(path_pattern),
+            Some(false) => patterns.push(format!("!{path_pattern}")),
+            None => {}
+        }
+    }
+
+    dedupe_patterns(patterns)
+}
+
+/// Tokenize a single `.gitattributes` line into `(path_pattern, attributes)`.
+///
+/// Returns `None` for blank lines, comments, macro definitions (`[attr]…`), and
+/// lines without at least one attribute.
+fn parse_gitattributes_line(raw_line: &str) -> Option<(String, Vec<String>)> {
+    let line = raw_line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+
+    let mut tokens = split_gitattributes_tokens(line);
+    if tokens.len() < 2 {
+        return None;
+    }
+
+    let path_pattern = tokens.remove(0);
+    if path_pattern.starts_with("[attr]") {
+        return None;
+    }
+
+    Some((path_pattern, tokens))
+}
+
+/// Resolve the tri-state value of a boolean git attribute over a token list.
+///
+/// Recognizes `attr`, `-attr` / `!attr`, and `attr=true|false|1|0`. The last
+/// occurrence wins. Returns `None` when the attribute is absent.
+fn attribute_state(attrs: &[String], name: &str) -> Option<bool> {
+    let unset = format!("-{name}");
+    let unset_bang = format!("!{name}");
+    let value_prefix = format!("{name}=");
+
+    let mut state = None;
+    for attr in attrs {
+        if attr == name {
+            state = Some(true);
+        } else if attr == &unset || attr == &unset_bang {
+            state = Some(false);
+        } else if let Some(value) = attr.strip_prefix(&value_prefix) {
+            if value.eq_ignore_ascii_case("true") || value == "1" {
+                state = Some(true);
+            } else if value.eq_ignore_ascii_case("false") || value == "0" {
+                state = Some(false);
+            }
+        }
+    }
+
+    state
 }
 
 fn load_root_gitattributes_contents(repo: &Repository) -> Option<String> {
@@ -167,7 +270,9 @@ fn load_root_gitattributes_contents(repo: &Repository) -> Option<String> {
 
 /// Load ignore patterns from a `.git-ai-ignore` file at the repository root.
 /// The file follows `.gitignore` syntax: one glob pattern per line, blank lines
-/// and lines starting with `#` are skipped.
+/// and lines starting with `#` are skipped. A line prefixed with `!` negates an
+/// earlier pattern, e.g. `!src/main/java/com/acme/vendor/**` re-includes a
+/// first-party package that the built-in `**/vendor/**` default would exclude.
 pub fn load_git_ai_ignore_patterns(repo: &Repository) -> Vec<String> {
     let Some(contents) = load_root_git_ai_ignore_contents(repo) else {
         return Vec::new();
@@ -227,13 +332,29 @@ pub fn load_linguist_generated_patterns_from_path(repo_root: &Path) -> Vec<Strin
     }
 }
 
+/// Load linguist-vendored patterns from `.gitattributes` at a repo root path directly.
+/// Use this when you have a `&Path` but not a `Repository` (e.g. in snapshot capture code).
+/// Uses the same parser as `load_linguist_vendored_patterns_from_root_gitattributes`.
+pub fn load_linguist_vendored_patterns_from_path(repo_root: &Path) -> Vec<String> {
+    match fs::read_to_string(repo_root.join(".gitattributes")) {
+        Ok(contents) => parse_linguist_vendored_patterns(&contents),
+        Err(_) => Vec::new(),
+    }
+}
+
 pub fn effective_ignore_patterns(
     repo: &Repository,
     user_patterns: &[String],
     extra_patterns: &[String],
 ) -> Vec<String> {
+    // Order matters: built-in defaults come first so later sources (linguist
+    // attributes, `.git-ai-ignore`, user flags) can re-include paths via `!`
+    // negation under the last-match-wins semantics in `IgnoreMatcher`.
     let mut patterns = default_ignore_patterns();
     patterns.extend(load_linguist_generated_patterns_from_root_gitattributes(
+        repo,
+    ));
+    patterns.extend(load_linguist_vendored_patterns_from_root_gitattributes(
         repo,
     ));
     patterns.extend(load_git_ai_ignore_patterns(repo));
@@ -470,5 +591,102 @@ mod tests {
         assert!(!should_ignore_file_with_matcher("app.swift", &matcher));
         assert!(!should_ignore_file_with_matcher("widget.dart", &matcher));
         assert!(!should_ignore_file_with_matcher("Objective.m", &matcher));
+    }
+
+    #[test]
+    fn negation_reincludes_first_party_vendor_package() {
+        // Reproduces issue #1664: a first-party package named `vendor` is excluded
+        // by the built-in `**/vendor/**` default, and a `!` negation re-includes it.
+        let patterns = vec![
+            "**/vendor/**".to_string(),
+            "!src/main/java/com/acme/vendor/**".to_string(),
+        ];
+        let matcher = build_ignore_matcher(&patterns);
+
+        // First-party package re-included by the negation.
+        assert!(!should_ignore_file_with_matcher(
+            "src/main/java/com/acme/vendor/Probe.java",
+            &matcher
+        ));
+        // A genuine third-party vendor directory elsewhere stays ignored.
+        assert!(should_ignore_file_with_matcher(
+            "third_party/vendor/lib.js",
+            &matcher
+        ));
+    }
+
+    #[test]
+    fn negation_is_last_match_wins() {
+        // A positive pattern after a negation re-excludes the path.
+        let patterns = vec!["!**/vendor/**".to_string(), "**/vendor/**".to_string()];
+        let matcher = build_ignore_matcher(&patterns);
+        assert!(should_ignore_file_with_matcher(
+            "app/vendor/lib.js",
+            &matcher
+        ));
+    }
+
+    #[test]
+    fn escaped_bang_matches_literal_filename() {
+        // `\!` escapes the negation marker so a literal leading `!` can be matched.
+        let patterns = vec!["\\!important.txt".to_string()];
+        let matcher = build_ignore_matcher(&patterns);
+        assert!(should_ignore_file_with_matcher("!important.txt", &matcher));
+        assert!(!should_ignore_file_with_matcher("important.txt", &matcher));
+    }
+
+    #[test]
+    fn positive_only_patterns_unaffected_by_negation_support() {
+        // Regression guard: with no negation, behavior is still "ignored if any match".
+        let patterns = vec!["*.lock".to_string(), "**/node_modules/**".to_string()];
+        let matcher = build_ignore_matcher(&patterns);
+        assert!(should_ignore_file_with_matcher(
+            "backend/Cargo.lock",
+            &matcher
+        ));
+        assert!(should_ignore_file_with_matcher(
+            "web/node_modules/lodash/index.js",
+            &matcher
+        ));
+        assert!(!should_ignore_file_with_matcher("src/main.rs", &matcher));
+    }
+
+    #[test]
+    fn parses_linguist_vendored_true_as_positive_pattern() {
+        let contents = "\
+tools/bundled/** linguist-vendored
+libs/external/** linguist-vendored=true
+flags/** linguist-vendored=1
+";
+        let patterns = parse_linguist_vendored_patterns(contents);
+        assert!(patterns.contains(&"tools/bundled/**".to_string()));
+        assert!(patterns.contains(&"libs/external/**".to_string()));
+        assert!(patterns.contains(&"flags/**".to_string()));
+    }
+
+    #[test]
+    fn parses_linguist_vendored_false_as_negation_pattern() {
+        let contents = "\
+src/main/java/com/acme/vendor/** -linguist-vendored
+other/** linguist-vendored=false
+zero/** linguist-vendored=0
+bang/** !linguist-vendored
+";
+        let patterns = parse_linguist_vendored_patterns(contents);
+        assert!(patterns.contains(&"!src/main/java/com/acme/vendor/**".to_string()));
+        assert!(patterns.contains(&"!other/**".to_string()));
+        assert!(patterns.contains(&"!zero/**".to_string()));
+        assert!(patterns.contains(&"!bang/**".to_string()));
+    }
+
+    #[test]
+    fn linguist_vendored_macro_definitions_are_ignored() {
+        let contents = "\
+[attr]vendored linguist-vendored=true
+generated/** linguist-vendored=true
+";
+        let patterns = parse_linguist_vendored_patterns(contents);
+        assert!(patterns.contains(&"generated/**".to_string()));
+        assert!(!patterns.iter().any(|p| p.contains("[attr]")));
     }
 }

--- a/src/authorship/ignore.rs
+++ b/src/authorship/ignore.rs
@@ -363,16 +363,20 @@ pub fn effective_ignore_patterns(
     dedupe_patterns(patterns)
 }
 
+/// Remove duplicate patterns, keeping the **last** occurrence of each.
+///
+/// Under the last-match-wins semantics in `IgnoreMatcher`, the final occurrence
+/// of a pattern is the one that decides a path's fate. Keeping the last (rather
+/// than the first) occurrence preserves that position, so a pattern re-asserted
+/// after an intervening negation isn't collapsed onto an earlier duplicate.
 fn dedupe_patterns(patterns: Vec<String>) -> Vec<String> {
     let mut seen = HashSet::new();
-    let mut deduped = Vec::new();
-
-    for pattern in patterns {
-        if seen.insert(pattern.clone()) {
-            deduped.push(pattern);
-        }
-    }
-
+    let mut deduped: Vec<String> = patterns
+        .into_iter()
+        .rev()
+        .filter(|pattern| seen.insert(pattern.clone()))
+        .collect();
+    deduped.reverse();
     deduped
 }
 
@@ -688,5 +692,33 @@ generated/** linguist-vendored=true
         let patterns = parse_linguist_vendored_patterns(contents);
         assert!(patterns.contains(&"generated/**".to_string()));
         assert!(!patterns.iter().any(|p| p.contains("[attr]")));
+    }
+
+    #[test]
+    fn dedupe_keeps_last_occurrence() {
+        let deduped = dedupe_patterns(vec![
+            "a/**".to_string(),
+            "b/**".to_string(),
+            "a/**".to_string(),
+            "c/**".to_string(),
+        ]);
+        // Each pattern appears once, positioned at its last occurrence.
+        assert_eq!(deduped, vec!["b/**", "a/**", "c/**"]);
+    }
+
+    #[test]
+    fn reasserted_positive_after_negation_wins() {
+        // With last-match-wins dedupe keeping the last occurrence, a pattern
+        // re-asserted after a negation correctly re-excludes the path.
+        let patterns = dedupe_patterns(vec![
+            "**/vendor/**".to_string(),
+            "!**/vendor/**".to_string(),
+            "**/vendor/**".to_string(),
+        ]);
+        let matcher = build_ignore_matcher(&patterns);
+        assert!(should_ignore_file_with_matcher(
+            "app/vendor/lib.js",
+            &matcher
+        ));
     }
 }

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -473,14 +473,15 @@ fn is_wm_covered(
 pub fn build_gitignore(repo_root: &Path) -> Result<Gitignore, GitAiError> {
     let mut builder = GitignoreBuilder::new(repo_root);
 
-    // git-ai-specific patterns: same source of truth as non-bash checkpoints.
-    // Defaults first so later sources (`.git-ai-ignore`, linguist attributes) can
-    // re-include paths via `!` negation under GitignoreBuilder's last-match-wins.
+    // git-ai-specific patterns: same source of truth and ordering as
+    // `effective_ignore_patterns`. Defaults first, then linguist attributes, then
+    // `.git-ai-ignore` last so a user's `!` negation wins under GitignoreBuilder's
+    // last-match-wins semantics.
     let shared_patterns: Vec<String> = default_ignore_patterns()
         .into_iter()
-        .chain(load_git_ai_ignore_patterns_from_path(repo_root))
         .chain(load_linguist_generated_patterns_from_path(repo_root))
         .chain(load_linguist_vendored_patterns_from_path(repo_root))
+        .chain(load_git_ai_ignore_patterns_from_path(repo_root))
         .collect();
     for pattern in &shared_patterns {
         if let Err(e) = builder.add_line(None, pattern) {

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -5,7 +5,7 @@
 
 use crate::authorship::ignore::{
     default_ignore_patterns, load_git_ai_ignore_patterns_from_path,
-    load_linguist_generated_patterns_from_path,
+    load_linguist_generated_patterns_from_path, load_linguist_vendored_patterns_from_path,
 };
 use crate::authorship::working_log::AgentId;
 use crate::daemon::control_api::{BashSnapshotQueryResponse, ControlRequest};
@@ -474,10 +474,13 @@ pub fn build_gitignore(repo_root: &Path) -> Result<Gitignore, GitAiError> {
     let mut builder = GitignoreBuilder::new(repo_root);
 
     // git-ai-specific patterns: same source of truth as non-bash checkpoints.
+    // Defaults first so later sources (`.git-ai-ignore`, linguist attributes) can
+    // re-include paths via `!` negation under GitignoreBuilder's last-match-wins.
     let shared_patterns: Vec<String> = default_ignore_patterns()
         .into_iter()
         .chain(load_git_ai_ignore_patterns_from_path(repo_root))
         .chain(load_linguist_generated_patterns_from_path(repo_root))
+        .chain(load_linguist_vendored_patterns_from_path(repo_root))
         .collect();
     for pattern in &shared_patterns {
         if let Err(e) = builder.add_line(None, pattern) {

--- a/tests/integration/ignore_unit.rs
+++ b/tests/integration/ignore_unit.rs
@@ -1,7 +1,8 @@
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::ignore::{
-    effective_ignore_patterns, load_git_ai_ignore_patterns,
+    build_ignore_matcher, effective_ignore_patterns, load_git_ai_ignore_patterns,
     load_linguist_generated_patterns_from_root_gitattributes,
+    load_linguist_vendored_patterns_from_root_gitattributes, should_ignore_file_with_matcher,
 };
 use git_ai::git::repository::from_bare_repository;
 use std::fs;
@@ -298,6 +299,87 @@ fn effective_patterns_union_git_ai_ignore_and_user_patterns() {
     assert!(patterns.contains(&"*.lock".to_string()));
 }
 
+// Regression tests for issue #1664: a first-party package named `vendor` was
+// silently excluded by the built-in `**/vendor/**` default with no override.
+
+#[test]
+fn git_ai_ignore_negation_reincludes_first_party_vendor_package() {
+    let repo = TestRepo::new();
+    std::fs::write(
+        repo.path().join(".git-ai-ignore"),
+        "!src/main/java/com/acme/vendor/**\n",
+    )
+    .unwrap();
+    repo.git(&["add", ".git-ai-ignore"]).unwrap();
+    repo.stage_all_and_commit("add .git-ai-ignore").unwrap();
+
+    let gitai_repo =
+        git_ai::git::repository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let patterns = effective_ignore_patterns(&gitai_repo, &[], &[]);
+    // The negation flows through the effective pattern set.
+    assert!(patterns.contains(&"!src/main/java/com/acme/vendor/**".to_string()));
+
+    let matcher = build_ignore_matcher(&patterns);
+    // First-party `vendor` package is re-included (was 0% AI before the fix).
+    assert!(!should_ignore_file_with_matcher(
+        "src/main/java/com/acme/vendor/Probe.java",
+        &matcher
+    ));
+    // A genuine third-party vendor directory elsewhere stays excluded.
+    assert!(should_ignore_file_with_matcher(
+        "third_party/vendor/lib.js",
+        &matcher
+    ));
+}
+
+#[test]
+fn gitattributes_linguist_vendored_false_reincludes_first_party_package() {
+    let repo = TestRepo::new();
+    std::fs::write(
+        repo.path().join(".gitattributes"),
+        "src/main/java/com/acme/vendor/** -linguist-vendored\n",
+    )
+    .unwrap();
+    repo.git(&["add", ".gitattributes"]).unwrap();
+    repo.stage_all_and_commit("add gitattributes").unwrap();
+
+    let gitai_repo =
+        git_ai::git::repository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let vendored = load_linguist_vendored_patterns_from_root_gitattributes(&gitai_repo);
+    assert!(vendored.contains(&"!src/main/java/com/acme/vendor/**".to_string()));
+
+    let patterns = effective_ignore_patterns(&gitai_repo, &[], &[]);
+    let matcher = build_ignore_matcher(&patterns);
+    assert!(!should_ignore_file_with_matcher(
+        "src/main/java/com/acme/vendor/Probe.java",
+        &matcher
+    ));
+}
+
+#[test]
+fn gitattributes_linguist_vendored_true_excludes_path() {
+    let repo = TestRepo::new();
+    std::fs::write(
+        repo.path().join(".gitattributes"),
+        "tools/bundled/** linguist-vendored=true\n",
+    )
+    .unwrap();
+    repo.git(&["add", ".gitattributes"]).unwrap();
+    repo.stage_all_and_commit("add gitattributes").unwrap();
+
+    let gitai_repo =
+        git_ai::git::repository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let vendored = load_linguist_vendored_patterns_from_root_gitattributes(&gitai_repo);
+    assert!(vendored.contains(&"tools/bundled/**".to_string()));
+
+    let patterns = effective_ignore_patterns(&gitai_repo, &[], &[]);
+    let matcher = build_ignore_matcher(&patterns);
+    assert!(should_ignore_file_with_matcher(
+        "tools/bundled/helper.js",
+        &matcher
+    ));
+}
+
 // Bare repo tests (using make_bare_repo helpers)
 
 #[test]
@@ -361,6 +443,10 @@ crate::reuse_tests_in_worktree!(
     effective_patterns_include_git_ai_ignore,
     effective_patterns_union_gitattributes_and_git_ai_ignore,
     effective_patterns_union_git_ai_ignore_and_user_patterns,
+    // Issue #1664 regression tests
+    git_ai_ignore_negation_reincludes_first_party_vendor_package,
+    gitattributes_linguist_vendored_false_reincludes_first_party_package,
+    gitattributes_linguist_vendored_true_excludes_path,
     // Bare repo tests
     loads_linguist_generated_from_bare_repo_head,
     bare_repo_does_not_read_parent_directory_gitattributes,


### PR DESCRIPTION
## Summary

Fixes #1664.

The built-in `**/vendor/**` pattern in `DEFAULT_IGNORE_PATTERNS` is unanchored, so
it matches a `vendor/` path segment **anywhere** in the tree. A first-party
package named `vendor` (e.g. a Java `com.<org>.vendor` package living under
`src/main/java/com/<org>/vendor/…`) was therefore treated as vendored and
silently excluded from attribution (`git-ai stats` → 0% AI), with **no way to
override** it.

This implements the first two of @Siddhant-K-code's [suggested fixes](https://github.com/git-ai-project/git-ai/issues/1664#issuecomment-4830914817):

### 1. Negation support in `.git-ai-ignore`

`IgnoreMatcher` now evaluates patterns in order with **last-match-wins**
semantics (mirroring `.gitignore`). A `!`-prefixed pattern re-includes a path
that an earlier pattern excluded:

```gitignore
# .git-ai-ignore
!src/main/java/com/acme/vendor/**
```

A literal leading `!` can be escaped as `\!`, just like in `.gitignore`.

### 2. Honor `linguist-vendored` in `.gitattributes`

Parsed the same way `linguist-generated` already is:

- `linguist-vendored` / `linguist-vendored=true` → exclude the path
- `-linguist-vendored` / `!linguist-vendored` / `linguist-vendored=false` →
  re-include the path (emits a negation pattern)

```gitattributes
# .gitattributes
src/main/java/com/acme/vendor/** -linguist-vendored
```

Both overrides flow through every consumer of `effective_ignore_patterns`
(`stats` / `diff` / `status`) and the bash-checkpoint snapshot path
(`build_gitignore`).

## Behavior preserved

Positive-only pattern sets behave exactly as before — with no negation,
last-match-wins reduces to "ignored if any pattern matches". A genuine
third-party `vendor/` directory elsewhere in the tree stays excluded.

## Tests

- **Unit tests** (`src/authorship/ignore.rs`): negation re-include, last-match-wins
  ordering, escaped `\!`, a positive-only regression guard, and `linguist-vendored`
  true/false/macro parsing.
- **Integration tests** (`tests/integration/ignore_unit.rs`): end-to-end
  `.git-ai-ignore` negation and `.gitattributes` `linguist-vendored` override
  through `effective_ignore_patterns`, including the worktree variants.

## Not included (follow-up)

@Siddhant-K-code's third suggestion — surfacing "excluded as vendored" files in
`status`/`stats` so the exclusion isn't silent — is intentionally left for a
separate PR to keep this change focused on restoring the ability to override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->