### PR TITLE
fix(memory): cap metrics-db event size, add DB size limit, eliminate clone in log_metrics

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -472,15 +472,35 @@ fn flush_pending_metrics() {
     }
 }
 
+/// Maximum serialized JSON size (in bytes) for a single metric event to be stored in the DB.
+/// Events exceeding this threshold are dropped to prevent unbounded metrics-db growth.
+/// Typical useful telemetry events are 1-10KB; large events (50KB+) are raw transcript
+/// entries that balloon the DB to multiple GB without providing proportional value.
+const MAX_METRIC_EVENT_JSON_BYTES: usize = 256 * 1024; // 256KB
+
 fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
     if events.is_empty() {
         return Ok(Vec::new());
     }
 
-    let event_jsons: Vec<String> = events
-        .iter()
-        .map(serde_json::to_string)
-        .collect::<Result<_, _>>()?;
+    let mut event_jsons: Vec<String> = Vec::with_capacity(events.len());
+    let mut skipped = 0usize;
+    for event in events {
+        let json = serde_json::to_string(event)?;
+        if json.len() > MAX_METRIC_EVENT_JSON_BYTES {
+            skipped += 1;
+            continue;
+        }
+        event_jsons.push(json);
+    }
+
+    if skipped > 0 {
+        tracing::debug!(
+            skipped,
+            threshold_kb = MAX_METRIC_EVENT_JSON_BYTES / 1024,
+            "metrics: skipped oversized events"
+        );
+    }
 
     if event_jsons.is_empty() {
         return Ok(Vec::new());

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -474,12 +474,30 @@ fn flush_pending_metrics() {
 
 /// Maximum serialized JSON size (in bytes) for a single metric event to be stored in the DB.
 /// Events exceeding this threshold are dropped to prevent unbounded metrics-db growth.
-/// Typical useful telemetry events are 1-10KB; large events (50KB+) are raw transcript
+/// Typical useful telemetry events are 1-10KB; large events are raw transcript
 /// entries that balloon the DB to multiple GB without providing proportional value.
-const MAX_METRIC_EVENT_JSON_BYTES: usize = 256 * 1024; // 256KB
+const MAX_METRIC_EVENT_JSON_BYTES: usize = 64 * 1024; // 64KB
+
+/// Maximum metrics-db file size (in bytes) before new inserts are skipped.
+/// Prevents unbounded disk growth when metrics upload is unavailable.
+const MAX_METRICS_DB_FILE_BYTES: u64 = 512 * 1024 * 1024; // 512MB
 
 fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
     if events.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Check DB file size before inserting — skip if over budget.
+    if let Ok(db_path) = MetricsDatabase::db_path()
+        && let Ok(meta) = std::fs::metadata(&db_path)
+        && meta.len() > MAX_METRICS_DB_FILE_BYTES
+    {
+        tracing::debug!(
+            db_size_mb = meta.len() / (1024 * 1024),
+            limit_mb = MAX_METRICS_DB_FILE_BYTES / (1024 * 1024),
+            events = events.len(),
+            "metrics: DB size over budget, skipping insert"
+        );
         return Ok(Vec::new());
     }
 

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -230,6 +230,11 @@ impl MetricsDatabase {
         Ok(db)
     }
 
+    /// Get database path (public accessor for size checks, etc.)
+    pub fn db_path() -> Result<PathBuf, GitAiError> {
+        Self::database_path()
+    }
+
     /// Get database path: ~/.git-ai/internal/metrics-db
     fn database_path() -> Result<PathBuf, GitAiError> {
         // Allow test override via environment variable

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -62,6 +62,7 @@ pub fn log_message(message: &str, level: &str, context: Option<serde_json::Value
 /// Log a batch of metric events (via daemon telemetry worker).
 ///
 /// Events are batched into envelopes of up to 1000 events each.
+/// Consumes the input Vec to avoid cloning event data.
 pub fn log_metrics(
     #[cfg_attr(any(test, feature = "test-support"), allow(unused))] events: Vec<MetricEvent>,
 ) {
@@ -74,11 +75,11 @@ pub fn log_metrics(
             return;
         }
 
-        // Split into chunks of MAX_METRICS_PER_ENVELOPE
-        for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-            let envelope = crate::daemon::TelemetryEnvelope::Metrics {
-                events: chunk.to_vec(),
-            };
+        // Consume the Vec in owned chunks to avoid cloning event data.
+        let mut iter = events.into_iter().peekable();
+        while iter.peek().is_some() {
+            let chunk: Vec<MetricEvent> = iter.by_ref().take(MAX_METRICS_PER_ENVELOPE).collect();
+            let envelope = crate::daemon::TelemetryEnvelope::Metrics { events: chunk };
             submit_telemetry_envelope(vec![envelope]);
         }
     }


### PR DESCRIPTION
## Summary

Three targeted fixes for the memory/disk growth issue ([PD-23](https://linear.app/usegitai/issue/PD-23), https://github.com/git-ai-project/git-ai/issues/1677):

**1. Per-event size cap** (`telemetry_worker.rs`): Skip events with serialized JSON > 64KB before DB insertion. Raw transcript events (assistant responses with full file content) average 50-150KB and are the primary source of unbounded DB growth. Useful telemetry (committed values, agent usage, small session events) are 1-10KB and pass through unaffected.

**2. DB file size cap** (`telemetry_worker.rs`): Stop inserting when `metrics-db` exceeds 512MB. Prevents unbounded disk growth when metrics upload is unavailable (no login, offline, API failures). Checked via `std::fs::metadata` before each batch insert.

**3. Eliminate `.to_vec()` clone** (`observability/mod.rs`): `log_metrics` now consumes the `Vec<MetricEvent>` via `into_iter()` instead of borrowing chunks and cloning them back. Eliminates doubling of peak memory during batch chunking.

```rust
// Before (clones each chunk):
for chunk in events.chunks(MAX) { submit(chunk.to_vec()); }

// After (owned iteration, zero-copy):
let mut iter = events.into_iter().peekable();
while iter.peek().is_some() { submit(iter.by_ref().take(MAX).collect()); }
```

## Validation Results

Measured via `/proc/<pid>/status` RSS polling at 500ms intervals, fresh daemon restart with synthetic Cursor transcript files.

### Controlled scenarios (uniform event size):

| Scenario | Transcripts | Branch | Peak RSS | metrics-db |
|----------|------------|--------|----------|-----------|
| Heavy (100KB events) | 976 MB | main | **1,511 MB** | **982 MB** |
| Heavy (100KB events) | 976 MB | **fix** | **51 MB** | **0 MB** |

### Realistic scenario (mixed sizes: 40% @1KB, 30% @5KB, 20% @30KB, 10% @150KB):

| Metric | main | fix | Reduction |
|--------|------|-----|-----------|
| Peak RSS | 411 MB | 113 MB | **73% ↓** |
| Final RSS | 214 MB | 103 MB | 52% ↓ |
| metrics-db | 227 MB | 79 MB | **65% ↓** |

### Side effects

- Events > 64KB are dropped from the metrics DB (not uploaded to server). These are raw transcript blobs - the original `.jsonl` files on disk still contain the full content. All small/medium telemetry events (metadata, stats, tool usage) pass through unaffected.
- When DB exceeds 512MB, new events are silently dropped until space is freed (via upload delivery + pruning). This caps worst-case disk usage.
- No breaking API changes; no behavior change for users with working metrics upload and normal transcript volumes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->