### PR TITLE
Fix memory growth from transcript metrics

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -14,11 +14,15 @@ use crate::authorship::authorship_log_serialization::GIT_AI_VERSION;
 use crate::config::{Config, get_or_create_distinct_id};
 use crate::daemon::control_api::{CasSyncPayload, TelemetryEnvelope};
 use crate::error::GitAiError;
-use crate::metrics::db::{METADATA_BACKFILL_BATCH_SIZE, MetricRecord, MetricsDatabase};
+use crate::metrics::db::{
+    MAX_METRIC_EVENT_JSON_BYTES, MAX_METRICS_DB_FILE_BYTES, METADATA_BACKFILL_BATCH_SIZE,
+    MetricRecord, MetricsDatabase,
+};
 use crate::metrics::{MetricEvent, MetricsBatch};
 use crate::observability::MAX_METRICS_PER_ENVELOPE;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
@@ -584,10 +588,28 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
         return Ok(Vec::new());
     }
 
-    let event_jsons: Vec<String> = events
-        .iter()
-        .map(serde_json::to_string)
-        .collect::<Result<_, _>>()?;
+    if let Ok(db_path) = MetricsDatabase::db_path() {
+        let db_size = sqlite_db_total_size(&db_path);
+        if db_size > MAX_METRICS_DB_FILE_BYTES {
+            tracing::debug!(
+                db_size_mb = db_size / (1024 * 1024),
+                limit_mb = MAX_METRICS_DB_FILE_BYTES / (1024 * 1024),
+                events = events.len(),
+                "metrics: DB size over budget, skipping insert"
+            );
+            return Ok(Vec::new());
+        }
+    }
+
+    let (event_jsons, skipped) = serialize_metric_events_under_size(events)?;
+
+    if skipped > 0 {
+        tracing::debug!(
+            skipped,
+            threshold_kb = MAX_METRIC_EVENT_JSON_BYTES / 1024,
+            "metrics: skipped oversized events"
+        );
+    }
 
     if event_jsons.is_empty() {
         return Ok(Vec::new());
@@ -598,6 +620,37 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
         .lock()
         .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
     db_lock.insert_events(&event_jsons)
+}
+
+fn sqlite_db_total_size(path: &Path) -> u64 {
+    sqlite_db_paths(path)
+        .iter()
+        .filter_map(|path| std::fs::metadata(path).ok().map(|meta| meta.len()))
+        .sum()
+}
+
+fn sqlite_db_paths(path: &Path) -> [std::path::PathBuf; 3] {
+    let mut wal = path.as_os_str().to_os_string();
+    wal.push("-wal");
+    let mut shm = path.as_os_str().to_os_string();
+    shm.push("-shm");
+    [path.to_path_buf(), wal.into(), shm.into()]
+}
+
+fn serialize_metric_events_under_size(
+    events: &[MetricEvent],
+) -> Result<(Vec<String>, usize), GitAiError> {
+    let mut event_jsons = Vec::with_capacity(events.len());
+    let mut skipped = 0usize;
+    for event in events {
+        let json = serde_json::to_string(event)?;
+        if json.len() > MAX_METRIC_EVENT_JSON_BYTES {
+            skipped += 1;
+            continue;
+        }
+        event_jsons.push(json);
+    }
+    Ok((event_jsons, skipped))
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -1379,6 +1432,45 @@ mod tests {
             level: "info".to_string(),
             context: None,
         }
+    }
+
+    fn metric_event_with_payload(payload_len: usize) -> MetricEvent {
+        let mut values = std::collections::HashMap::new();
+        values.insert(
+            "0".to_string(),
+            serde_json::Value::String("x".repeat(payload_len)),
+        );
+        MetricEvent {
+            timestamp: now_ts(),
+            event_id: crate::metrics::types::MetricEventId::SessionEvent as u16,
+            values,
+            attrs: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn serialize_metric_events_under_size_skips_oversized_events() {
+        let events = vec![
+            metric_event_with_payload(64),
+            metric_event_with_payload(MAX_METRIC_EVENT_JSON_BYTES),
+        ];
+
+        let (jsons, skipped) = serialize_metric_events_under_size(&events).unwrap();
+
+        assert_eq!(jsons.len(), 1);
+        assert_eq!(skipped, 1);
+        assert!(jsons[0].contains("\"e\":5"));
+    }
+
+    #[test]
+    fn sqlite_db_total_size_includes_wal_and_shm_files() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("metrics-db");
+        std::fs::write(&path, vec![0; 10]).unwrap();
+        std::fs::write(path.with_file_name("metrics-db-wal"), vec![0; 20]).unwrap();
+        std::fs::write(path.with_file_name("metrics-db-shm"), vec![0; 30]).unwrap();
+
+        assert_eq!(sqlite_db_total_size(&path), 60);
     }
 
     #[tokio::test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -20,6 +20,10 @@ const SCHEMA_VERSION: usize = 4;
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
+/// Maximum serialized JSON size for a metric row retained locally.
+pub(crate) const MAX_METRIC_EVENT_JSON_BYTES: usize = 64 * 1024;
+/// Maximum metrics DB size before best-effort writers skip new rows.
+pub(crate) const MAX_METRICS_DB_FILE_BYTES: u64 = 512 * 1024 * 1024;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
 /// Database migrations - each migration upgrades the schema by one version
@@ -228,6 +232,10 @@ impl MetricsDatabase {
         db.initialize_schema()?;
 
         Ok(db)
+    }
+
+    pub(crate) fn db_path() -> Result<PathBuf, GitAiError> {
+        Self::database_path()
     }
 
     /// Get database path: ~/.git-ai/internal/metrics-db
@@ -542,6 +550,8 @@ impl MetricsDatabase {
             return Ok(Vec::new());
         }
 
+        self.prune_oversized_metric_rows()?;
+
         let now = current_unix_ts();
         self.release_stale_processing_locks(now)?;
 
@@ -829,6 +839,8 @@ impl MetricsDatabase {
     /// rows cannot be aged by event timestamp, so delivered malformed rows fall back to
     /// `delivered_ts`.
     fn prune_old_metrics_if_due(&mut self) -> Result<(), GitAiError> {
+        self.prune_oversized_metric_rows()?;
+
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -870,9 +882,11 @@ impl MetricsDatabase {
 
     fn old_metric_row_ids(&self, cutoff: u64) -> Result<Vec<i64>, GitAiError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, event_json, event_ts, delivered_ts FROM metrics ORDER BY id ASC",
+            "SELECT id, event_json, event_ts, delivered_ts FROM metrics \
+             WHERE LENGTH(event_json) <= ?1 \
+             ORDER BY id ASC",
         )?;
-        let rows = stmt.query_map([], |row| {
+        let rows = stmt.query_map(params![MAX_METRIC_EVENT_JSON_BYTES as i64], |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 row.get::<_, String>(1)?,
@@ -890,6 +904,14 @@ impl MetricsDatabase {
         }
 
         Ok(ids)
+    }
+
+    fn prune_oversized_metric_rows(&mut self) -> Result<usize, GitAiError> {
+        let deleted = self.conn.execute(
+            "DELETE FROM metrics WHERE LENGTH(event_json) > ?1",
+            params![MAX_METRIC_EVENT_JSON_BYTES as i64],
+        )?;
+        Ok(deleted)
     }
 
     /// Get count of pending metrics.
@@ -913,16 +935,22 @@ impl MetricsDatabase {
         repo_filter: Option<&str>,
         event_ids: &[u16],
     ) -> Result<Vec<MetricHistoryRecord>, GitAiError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT event_json, event_ts, event_kind FROM metrics WHERE event_ts IS NULL OR event_ts >= ?1 ORDER BY id ASC")?;
-        let rows = stmt.query_map(params![since_ts as i64], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, Option<i64>>(1)?,
-                row.get::<_, Option<i64>>(2)?,
-            ))
-        })?;
+        let mut stmt = self.conn.prepare(
+            "SELECT event_json, event_ts, event_kind FROM metrics \
+                 WHERE (event_ts IS NULL OR event_ts >= ?1) \
+                   AND LENGTH(event_json) <= ?2 \
+                 ORDER BY id ASC",
+        )?;
+        let rows = stmt.query_map(
+            params![since_ts as i64, MAX_METRIC_EVENT_JSON_BYTES as i64],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                ))
+            },
+        )?;
 
         let mut records = Vec::new();
         for row in rows {
@@ -1000,6 +1028,7 @@ impl MetricsDatabase {
               AND tool != 'mock_ai'
               AND external_session_id IS NOT NULL
               AND external_session_id != ''
+              AND LENGTH(event_json) <= ?4
             ORDER BY id ASC
             "#,
         )?;
@@ -1007,7 +1036,8 @@ impl MetricsDatabase {
             params![
                 MetricEventId::SessionEvent as i64,
                 min_event_ts as i64,
-                max_event_ts as i64
+                max_event_ts as i64,
+                MAX_METRIC_EVENT_JSON_BYTES as i64
             ],
             |row| {
                 Ok((
@@ -1105,15 +1135,18 @@ impl MetricsDatabase {
         }
 
         let rows = {
+            self.prune_oversized_metric_rows()?;
             let mut stmt = self.conn.prepare(
                 "SELECT id, event_json FROM metrics \
                  WHERE id > ?1 AND (event_ts IS NULL OR event_kind IS NULL) \
+                   AND LENGTH(event_json) <= ?3 \
                  ORDER BY id ASC \
                  LIMIT ?2",
             )?;
-            let mapped = stmt.query_map(params![after_id, limit as i64], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-            })?;
+            let mapped = stmt.query_map(
+                params![after_id, limit as i64, MAX_METRIC_EVENT_JSON_BYTES as i64],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )?;
             mapped.collect::<Result<Vec<_>, _>>()?
         };
 
@@ -2215,6 +2248,39 @@ mod tests {
     }
 
     #[test]
+    fn test_backfill_prunes_oversized_legacy_rows_before_hydration() {
+        let (mut db, _temp_dir) = create_test_db();
+        let ts = days_ago(1);
+        let oversized_payload = "x".repeat(MAX_METRIC_EVENT_JSON_BYTES);
+        let oversized = format!(
+            r#"{{"t":{ts},"e":5,"v":{{"0":{{"payload":"{oversized_payload}"}}}},"a":{{}}}}"#
+        );
+
+        db.conn
+            .execute(
+                "INSERT INTO metrics (event_json) VALUES (?1), (?2)",
+                params![event_json(ts), oversized],
+            )
+            .unwrap();
+
+        let summary = db.backfill_event_metadata_batch(100).unwrap();
+
+        assert_eq!(
+            summary,
+            MetricMetadataBackfillSummary {
+                scanned: 1,
+                updated: 1,
+            }
+        );
+        let total: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(total, 1);
+        assert_eq!(metric_metadata_rows(&db), vec![(Some(ts as i64), Some(1))]);
+    }
+
+    #[test]
     fn test_backfill_event_metadata_batch_after_advances_cursor() {
         let (mut db, _temp_dir) = create_test_db();
         let ts1 = days_ago(3);
@@ -2289,6 +2355,32 @@ mod tests {
             .unwrap();
         assert_eq!(db.count().unwrap(), 1);
         assert_eq!(db.count_retryable().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_dequeue_pending_batch_prunes_oversized_legacy_rows() {
+        let (mut db, _temp_dir) = create_test_db();
+        let ts = days_ago(1);
+        let oversized_payload = "x".repeat(MAX_METRIC_EVENT_JSON_BYTES);
+        let oversized = format!(
+            r#"{{"t":{ts},"e":5,"v":{{"0":{{"payload":"{oversized_payload}"}}}},"a":{{}}}}"#
+        );
+        db.conn
+            .execute(
+                "INSERT INTO metrics (event_json) VALUES (?1), (?2)",
+                params![event_json(ts), oversized],
+            )
+            .unwrap();
+
+        let batch = db.dequeue_pending_batch(10).unwrap();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].event_json, event_json(ts));
+        let total: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(total, 1);
     }
 
     #[test]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -62,6 +62,7 @@ pub fn log_message(message: &str, level: &str, context: Option<serde_json::Value
 /// Log a batch of metric events (via daemon telemetry worker).
 ///
 /// Events are batched into envelopes of up to 1000 events each.
+/// Consumes the input vector so large transcript payloads are not cloned.
 pub fn log_metrics(
     #[cfg_attr(any(test, feature = "test-support"), allow(unused))] events: Vec<MetricEvent>,
 ) {
@@ -74,11 +75,10 @@ pub fn log_metrics(
             return;
         }
 
-        // Split into chunks of MAX_METRICS_PER_ENVELOPE
-        for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-            let envelope = crate::daemon::TelemetryEnvelope::Metrics {
-                events: chunk.to_vec(),
-            };
+        let mut iter = events.into_iter().peekable();
+        while iter.peek().is_some() {
+            let chunk: Vec<MetricEvent> = iter.by_ref().take(MAX_METRICS_PER_ENVELOPE).collect();
+            let envelope = crate::daemon::TelemetryEnvelope::Metrics { events: chunk };
             submit_telemetry_envelope(vec![envelope]);
         }
     }

--- a/src/streams/agents/claude.rs
+++ b/src/streams/agents/claude.rs
@@ -188,6 +188,7 @@ impl Agent for ClaudeAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
 
         let mut line = String::new();
         loop {
@@ -202,6 +203,7 @@ impl Agent for ClaudeAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -223,7 +225,11 @@ impl Agent for ClaudeAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
@@ -465,6 +471,41 @@ mod tests {
         assert_eq!(events.len(), 5);
         let ids: Vec<u64> = events.iter().map(|e| e["id"].as_u64().unwrap()).collect();
         assert_eq!(ids, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_jsonl_batches_are_bounded_by_raw_bytes() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        let payload = "x".repeat(crate::streams::types::MAX_JSONL_BATCH_BYTES / 3);
+        for i in 0..4 {
+            writeln!(
+                file,
+                r#"{{"type":"user","id":{},"message":{{"content":"{}"}}}}"#,
+                i, payload
+            )
+            .unwrap();
+        }
+        file.flush().unwrap();
+
+        let agent = ClaudeAgent::with_batch_size(1000);
+        let batch = agent
+            .read_incremental(
+                file.path(),
+                Box::new(ByteOffsetWatermark::new(0)),
+                "test-session",
+            )
+            .unwrap();
+
+        assert!(!batch.events.is_empty());
+        assert!(batch.events.len() < 4);
+
+        let next_batch = agent
+            .read_incremental(file.path(), batch.new_watermark, "test-session")
+            .unwrap();
+        assert!(!next_batch.events.is_empty());
     }
 
     #[test]

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -242,6 +242,7 @@ impl Agent for CodexAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
         let mut line = String::new();
 
         loop {
@@ -256,6 +257,7 @@ impl Agent for CodexAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -277,7 +279,11 @@ impl Agent for CodexAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -529,6 +529,7 @@ pub(super) fn read_event_stream(
     let mut events = Vec::with_capacity(batch_limit);
     let mut current_offset = start_offset;
     let mut line_number = 0;
+    let mut batch_bytes = 0usize;
 
     // Read lines from watermark position
     let mut line = String::new();
@@ -544,6 +545,7 @@ pub(super) fn read_event_stream(
             crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                 line_number += 1;
                 current_offset += bytes_read as u64;
+                batch_bytes = batch_bytes.saturating_add(bytes_read);
             }
         }
 
@@ -565,7 +567,8 @@ pub(super) fn read_event_stream(
         };
 
         events.push(entry);
-        if events.len() >= batch_limit {
+        if crate::streams::types::jsonl_batch_limit_reached(events.len(), batch_limit, batch_bytes)
+        {
             break;
         }
     }

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -160,6 +160,7 @@ impl Agent for CursorAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
 
         let mut line = String::new();
         loop {
@@ -174,6 +175,7 @@ impl Agent for CursorAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -195,7 +197,11 @@ impl Agent for CursorAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }

--- a/src/streams/agents/droid.rs
+++ b/src/streams/agents/droid.rs
@@ -167,6 +167,7 @@ impl Agent for DroidAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
         let mut latest_timestamp: Option<chrono::DateTime<chrono::Utc>> =
             hybrid_watermark.timestamp;
 
@@ -184,6 +185,7 @@ impl Agent for DroidAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -226,7 +228,11 @@ impl Agent for DroidAgent {
 
             // Push raw JSON entry
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }

--- a/src/streams/agents/gemini.rs
+++ b/src/streams/agents/gemini.rs
@@ -161,6 +161,7 @@ impl Agent for GeminiAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
 
         let mut line = String::new();
         loop {
@@ -175,6 +176,7 @@ impl Agent for GeminiAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -196,7 +198,11 @@ impl Agent for GeminiAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }

--- a/src/streams/agents/pi.rs
+++ b/src/streams/agents/pi.rs
@@ -93,6 +93,7 @@ impl Agent for PiAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
 
         let mut line = String::new();
         loop {
@@ -107,6 +108,7 @@ impl Agent for PiAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -128,7 +130,11 @@ impl Agent for PiAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }

--- a/src/streams/agents/windsurf.rs
+++ b/src/streams/agents/windsurf.rs
@@ -93,6 +93,7 @@ impl Agent for WindsurfAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
 
         let mut line = String::new();
         loop {
@@ -107,6 +108,7 @@ impl Agent for WindsurfAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                    batch_bytes = batch_bytes.saturating_add(bytes_read);
                 }
             }
 
@@ -128,7 +130,11 @@ impl Agent for WindsurfAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -3,6 +3,9 @@
 use std::io::BufRead;
 use std::time::Duration;
 
+/// Maximum raw JSONL bytes to accumulate in a single transcript batch.
+pub const MAX_JSONL_BATCH_BYTES: usize = 8 * 1024 * 1024;
+
 /// Result of reading a single line from a JSONL reader.
 pub enum JsonlLineState {
     /// End of file reached.
@@ -30,6 +33,10 @@ pub fn read_jsonl_line(
         return Ok(JsonlLineState::Partial);
     }
     Ok(JsonlLineState::Complete(bytes_read))
+}
+
+pub fn jsonl_batch_limit_reached(event_count: usize, event_limit: usize, raw_bytes: usize) -> bool {
+    event_count >= event_limit || (event_count > 0 && raw_bytes >= MAX_JSONL_BATCH_BYTES)
 }
 
 /// Errors that can occur during transcript processing.


### PR DESCRIPTION
## Summary

Fixes the likely post-v1.5.13 memory growth path in transcript/session metrics handling:

- bounds JSONL transcript sweep batches by raw bytes, not only event count
- avoids cloning large metric payload batches when forwarding telemetry envelopes
- skips newly serialized metric rows over 64KB and stops writing when the metrics DB is already over 512MB including WAL/SHM
- prunes legacy oversized metric rows before metadata backfill, retry upload dequeue, and normal retention pruning
- filters history/session recovery queries so they do not hydrate oversized legacy rows

## Investigation notes

The most plausible regression came from the recent combination of transcript sweep/session recovery and metrics metadata backfill. Large raw transcript/session events could be stored in the local metrics DB, then reloaded in 1000-row batches on restart/backfill or upload retry. Permission or upload failures would make this worse because rows remain local and restart can repeat the read path.

The pull/fetch report is consistent with a trigger rather than a direct cause: post-commit/post-push sweep/recovery paths can run around normal git activity, and notes/pull changes increased the amount of daemon-side work around those commands.

## Tests

- `task fmt`
- `task lint`
- `task build`
- `task test TEST_FILTER=metrics::db`
- `task test TEST_FILTER=daemon::telemetry_worker`
- `task test TEST_FILTER=streams::agents::claude`
- `task test TEST_FILTER=streams::agents`
- `task test`
