### PR TITLE
fix(memory): bound attribution-recovery diff + cap oversized metric events (PD-23)

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -583,6 +583,27 @@ fn commit_tree_snapshot_for_files(
     Ok(snapshot)
 }
 
+/// Resolve the diff base for recovery so the diff is always bounded to the
+/// single commit being finalized.
+///
+/// Returns the immediate first parent of `commit_sha` when it can be resolved
+/// and differs from the supplied `parent_sha` (i.e. `parent_sha` is a far-behind
+/// ancestor, as on the daemon fast-forward `update-ref` path). Otherwise returns
+/// `None`, signalling the caller to keep using `parent_sha` unchanged — which is
+/// already the immediate parent in the normal and amend cases.
+fn immediate_parent_diff_base(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+) -> Option<String> {
+    let commit = repo.find_commit(commit_sha.to_string()).ok()?;
+    if commit.parent_count().ok()? == 0 {
+        return None;
+    }
+    let first_parent = commit.parent(0).ok()?.id();
+    (first_parent != parent_sha).then_some(first_parent)
+}
+
 fn recovery_committed_hunks(
     repo: &Repository,
     parent_sha: &str,
@@ -595,10 +616,21 @@ fn recovery_committed_hunks(
         );
     }
 
-    let diff_base = if parent_sha == "initial" {
+    // Recovery only attributes lines added by the commit being finalized, so the
+    // diff must be bounded to that single commit's immediate parent. The caller's
+    // `parent_sha` is normally the immediate parent already, but on the daemon's
+    // fast-forward `update-ref` path it is the *old branch tip* from before a
+    // `git pull` — potentially thousands of commits back. Diffing that full range
+    // buffers the entire history delta of `git diff` into memory (the 20GB+ leak
+    // in PD-23 / #1677). Resolving the immediate parent caps the diff to one
+    // commit while leaving the normal/uncheckpointed-recovery cases unchanged
+    // (there `parent_sha` already equals the immediate parent).
+    let immediate_parent = immediate_parent_diff_base(repo, parent_sha, commit_sha);
+    let diff_base = immediate_parent.as_deref().unwrap_or(parent_sha);
+    let diff_base = if diff_base == "initial" {
         "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
     } else {
-        parent_sha
+        diff_base
     };
     let added_lines = repo.diff_added_lines(diff_base, commit_sha, None)?;
     Ok(added_lines
@@ -1118,6 +1150,62 @@ fn record_commit_metrics(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_recovery_committed_hunks_bounds_diff_to_immediate_parent() {
+        use crate::git::test_utils::TmpRepo;
+
+        let repo = TmpRepo::new().expect("tmp repo");
+        repo.write_file("base.txt", "base\n", false).unwrap();
+        // `old_tip` simulates the local branch tip from before a `git pull`.
+        let old_tip = repo.commit_all("old tip").unwrap();
+
+        // A long run of intervening commits, each touching a distinct file, as a
+        // fast-forward pull would drag in. Diffing old_tip..final across all of
+        // these is exactly the unbounded full-range diff PD-23 hit.
+        for i in 0..8 {
+            repo.write_file(
+                &format!("upstream_{i}.txt"),
+                &format!("upstream {i}\n"),
+                false,
+            )
+            .unwrap();
+            repo.commit_all(&format!("upstream commit {i}")).unwrap();
+        }
+
+        // The final (newly pulled) commit only changes `final.txt`.
+        repo.write_file("final.txt", "final change\n", false)
+            .unwrap();
+        let final_sha = repo.commit_all("final").unwrap();
+
+        let gitai = repo.gitai_repo();
+
+        // Passing the far-behind `old_tip` as parent (the daemon fast-forward
+        // update-ref path) must still only diff the final commit's own changes,
+        // not the entire old_tip..final range.
+        let hunks = recovery_committed_hunks(gitai, &old_tip, &final_sha, None).unwrap();
+        assert!(
+            hunks.contains_key("final.txt"),
+            "recovery must see the finalized commit's own changes"
+        );
+        for i in 0..8 {
+            assert!(
+                !hunks.contains_key(&format!("upstream_{i}.txt")),
+                "recovery diff must be bounded to the immediate parent, not the full pull range"
+            );
+        }
+
+        // The immediate-parent helper resolves the far-behind ancestor to the
+        // commit's real first parent, and returns None when already immediate.
+        assert!(immediate_parent_diff_base(gitai, &old_tip, &final_sha).is_some());
+        let real_parent = gitai
+            .find_commit(final_sha.clone())
+            .unwrap()
+            .parent(0)
+            .unwrap()
+            .id();
+        assert!(immediate_parent_diff_base(gitai, &real_parent, &final_sha).is_none());
+    }
 
     #[test]
     fn test_count_line_ranges_handles_scattered_and_contiguous_lines() {

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -1349,7 +1349,7 @@ fn truncate_oversized_event_json(event_json: &str) -> std::borrow::Cow<'_, str> 
     let mut truncated_any = false;
     if let Some(values) = value.get_mut("v").and_then(Value::as_object_mut) {
         for entry in values.values_mut() {
-            truncate_heavy_strings_in_value(entry, per_field_budget, &mut truncated_any);
+            truncated_any |= truncate_heavy_strings_in_value(entry, per_field_budget);
         }
     }
 
@@ -1368,7 +1368,12 @@ fn truncate_oversized_event_json(event_json: &str) -> std::borrow::Cow<'_, str> 
 /// and the enclosing object is flagged with [`TRUNCATED_CONTENT_MARKER`]. Object
 /// keys and numeric/boolean fields (token counts, model names, ids) are left
 /// intact.
-fn truncate_heavy_strings_in_value(value: &mut Value, budget: usize, truncated_any: &mut bool) {
+///
+/// Returns `true` when this subtree had at least one string truncated. Each
+/// object is marked based on whether *its own* descendants were truncated, so
+/// sibling objects are flagged independently (a shared mutable flag would only
+/// mark the first truncated sibling — see PD-23 / #1697 review).
+fn truncate_heavy_strings_in_value(value: &mut Value, budget: usize) -> bool {
     match value {
         Value::String(text) if text.len() > budget => {
             let mut end = budget;
@@ -1376,27 +1381,26 @@ fn truncate_heavy_strings_in_value(value: &mut Value, budget: usize, truncated_a
                 end -= 1;
             }
             text.truncate(end);
-            *truncated_any = true;
+            true
         }
         Value::Array(items) => {
+            let mut truncated = false;
             for item in items.iter_mut() {
-                truncate_heavy_strings_in_value(item, budget, truncated_any);
+                truncated |= truncate_heavy_strings_in_value(item, budget);
             }
+            truncated
         }
         Value::Object(map) => {
-            let mut marked = false;
+            let mut truncated = false;
             for child in map.values_mut() {
-                let before = *truncated_any;
-                truncate_heavy_strings_in_value(child, budget, truncated_any);
-                if *truncated_any && !before {
-                    marked = true;
-                }
+                truncated |= truncate_heavy_strings_in_value(child, budget);
             }
-            if marked {
+            if truncated {
                 map.insert(TRUNCATED_CONTENT_MARKER.to_string(), Value::Bool(true));
             }
+            truncated
         }
-        _ => {}
+        _ => false,
     }
 }
 
@@ -3012,6 +3016,34 @@ mod tests {
             metric_metadata_rows(&db),
             vec![(Some(event_ts as i64), Some(5))]
         );
+    }
+
+    #[test]
+    fn test_truncate_marks_every_truncated_sibling_object() {
+        // Two sibling entries under "v", each an object with an oversized string.
+        // Both must receive the truncation marker — a shared monotonic flag would
+        // only mark the first one (PD-23 / #1697 review regression).
+        let budget = 8;
+        let mut value = serde_json::json!({
+            "0": {"content": "x".repeat(100)},
+            "1": {"content": "y".repeat(100)},
+        });
+
+        let truncated = truncate_heavy_strings_in_value(&mut value, budget);
+        assert!(truncated, "truncation should be reported for the subtree");
+
+        for key in ["0", "1"] {
+            let entry = value.get(key).and_then(Value::as_object).unwrap();
+            assert_eq!(
+                entry.get(TRUNCATED_CONTENT_MARKER),
+                Some(&Value::Bool(true)),
+                "sibling object {key} should be flagged as truncated"
+            );
+            assert!(
+                entry.get("content").and_then(Value::as_str).unwrap().len() <= budget,
+                "sibling object {key} content should be truncated to budget"
+            );
+        }
     }
 
     #[test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -22,6 +22,23 @@ const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
+/// Maximum size of a serialized event JSON we will persist to the metrics DB.
+///
+/// Session events carry raw transcript JSON; assistant messages with full file
+/// contents routinely reach 50-150KB+. Persisting them verbatim turns the
+/// metrics DB into an unbounded sink during the transcript sweep (especially
+/// when upload is unavailable and rows never drain), driving the daemon's
+/// memory/disk footprint into the GBs. Events above this size have their heavy
+/// content field truncated before insertion; everything the local stats and
+/// server ETL read (token usage, model, ids, timestamps) lives in small
+/// sibling fields and is preserved. The original transcript `.jsonl` on disk
+/// always retains the full content.
+const MAX_PERSISTED_EVENT_JSON_BYTES: usize = 16 * 1024;
+
+/// Marker key added to a message whose `content` field was truncated, so
+/// downstream consumers can tell the stored content is partial.
+const TRUNCATED_CONTENT_MARKER: &str = "_git_ai_content_truncated";
+
 /// Database migrations - each migration upgrades the schema by one version
 const MIGRATIONS: &[&str] = &[
     // Migration 0 -> 1: Initial schema with metrics table
@@ -495,6 +512,12 @@ impl MetricsDatabase {
             )?;
 
             for event_json in events {
+                // Bound the persisted payload so a single oversized transcript
+                // event cannot bloat the DB (and, transitively, daemon memory).
+                // Metadata is extracted from the (possibly truncated) JSON so the
+                // indexed columns stay consistent with what we store.
+                let event_json = truncate_oversized_event_json(event_json);
+                let event_json = event_json.as_ref();
                 let metadata = extract_metric_event_metadata(event_json);
                 let event_ts = metadata.as_ref().map(|m| i64::from(m.event_ts));
                 let event_kind = metadata.as_ref().map(|m| i64::from(m.event_kind));
@@ -1297,6 +1320,84 @@ fn extract_metric_event_ts_from_value(value: &Value) -> Option<u32> {
         .and_then(Value::as_u64)
         .filter(|ts| *ts <= u32::MAX as u64)
         .map(|ts| ts as u32)
+}
+
+/// Bound the size of an event JSON before persistence.
+///
+/// Returns the input unchanged (borrowed) when it is already within
+/// [`MAX_PERSISTED_EVENT_JSON_BYTES`]. Otherwise the heavy free-text fields in
+/// the event values are truncated and the event is re-serialized. The metadata
+/// fields the rest of the system relies on (event kind, timestamp, ids, token
+/// usage, model) are small and untouched. If the JSON cannot be parsed or stays
+/// oversized after truncation, it is returned as-is so callers never lose an
+/// event purely because it could not be shrunk.
+fn truncate_oversized_event_json(event_json: &str) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+
+    if event_json.len() <= MAX_PERSISTED_EVENT_JSON_BYTES {
+        return Cow::Borrowed(event_json);
+    }
+
+    let Ok(mut value) = serde_json::from_str::<Value>(event_json) else {
+        return Cow::Borrowed(event_json);
+    };
+
+    // Budget per text field so that even an event with several heavy fields
+    // stays comfortably bounded. Token usage / model / ids are separate small
+    // fields and are never touched.
+    let per_field_budget = MAX_PERSISTED_EVENT_JSON_BYTES / 4;
+    let mut truncated_any = false;
+    if let Some(values) = value.get_mut("v").and_then(Value::as_object_mut) {
+        for entry in values.values_mut() {
+            truncate_heavy_strings_in_value(entry, per_field_budget, &mut truncated_any);
+        }
+    }
+
+    if !truncated_any {
+        return Cow::Borrowed(event_json);
+    }
+
+    match serde_json::to_string(&value) {
+        Ok(serialized) => Cow::Owned(serialized),
+        Err(_) => Cow::Borrowed(event_json),
+    }
+}
+
+/// Recursively truncate oversized string values inside a transcript event value
+/// tree. Strings longer than `budget` bytes are shortened (on a UTF-8 boundary)
+/// and the enclosing object is flagged with [`TRUNCATED_CONTENT_MARKER`]. Object
+/// keys and numeric/boolean fields (token counts, model names, ids) are left
+/// intact.
+fn truncate_heavy_strings_in_value(value: &mut Value, budget: usize, truncated_any: &mut bool) {
+    match value {
+        Value::String(text) if text.len() > budget => {
+            let mut end = budget;
+            while end > 0 && !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            text.truncate(end);
+            *truncated_any = true;
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                truncate_heavy_strings_in_value(item, budget, truncated_any);
+            }
+        }
+        Value::Object(map) => {
+            let mut marked = false;
+            for child in map.values_mut() {
+                let before = *truncated_any;
+                truncate_heavy_strings_in_value(child, budget, truncated_any);
+                if *truncated_any && !before {
+                    marked = true;
+                }
+            }
+            if marked {
+                map.insert(TRUNCATED_CONTENT_MARKER.to_string(), Value::Bool(true));
+            }
+        }
+        _ => {}
+    }
 }
 
 fn extract_metric_event_metadata(event_json: &str) -> Option<MetricEventMetadata> {
@@ -2794,5 +2895,155 @@ mod tests {
             db.should_emit_agent_usage(prompt_id, 1_700_000_301, 300)
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_insert_truncates_oversized_session_event_content_but_keeps_metadata() {
+        let (mut db, _temp_dir) = create_test_db();
+        let event_ts = days_ago(1);
+
+        // An assistant session event whose message.content is a multi-hundred-KB
+        // blob, exactly the shape that bloats the metrics DB during a transcript
+        // sweep. Token usage / model / id live in small sibling fields.
+        let huge_content = "x".repeat(500_000);
+        let event_json = format!(
+            r#"{{
+                "t":{event_ts},
+                "e":5,
+                "v":{{"0":{{"message":{{"role":"assistant","id":"msg-1","model":"claude-opus-4-8","content":"{huge_content}","usage":{{"input_tokens":10,"output_tokens":20}}}}}}}},
+                "a":{{"20":"claude","24":"session-1","25":"trace-1"}}
+            }}"#
+        );
+        assert!(event_json.len() > 500_000);
+
+        db.insert_events(&[event_json]).unwrap();
+
+        // The stored row must be bounded well below the raw blob size.
+        let stored_json: String = db
+            .conn
+            .query_row("SELECT event_json FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert!(
+            stored_json.len() <= MAX_PERSISTED_EVENT_JSON_BYTES,
+            "stored event_json should be truncated, was {} bytes",
+            stored_json.len()
+        );
+
+        // Metadata that local usage stats + server ETL read must survive.
+        let value: Value = serde_json::from_str(&stored_json).unwrap();
+        let message = value.pointer("/v/0/message").expect("message preserved");
+        assert_eq!(
+            message.pointer("/role").and_then(Value::as_str),
+            Some("assistant")
+        );
+        assert_eq!(
+            message.pointer("/id").and_then(Value::as_str),
+            Some("msg-1")
+        );
+        assert_eq!(
+            message.pointer("/model").and_then(Value::as_str),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(
+            message
+                .pointer("/usage/input_tokens")
+                .and_then(Value::as_u64),
+            Some(10)
+        );
+        assert_eq!(
+            message
+                .pointer("/usage/output_tokens")
+                .and_then(Value::as_u64),
+            Some(20)
+        );
+        // The heavy content field is truncated, not preserved in full.
+        let content_len = message
+            .pointer("/content")
+            .and_then(Value::as_str)
+            .map(str::len)
+            .unwrap_or(0);
+        assert!(
+            content_len < 500_000,
+            "content should be truncated, was {content_len} bytes"
+        );
+
+        // Event-kind metadata column is still populated for indexing/recovery.
+        assert_eq!(
+            metric_metadata_rows(&db),
+            vec![(Some(event_ts as i64), Some(5))]
+        );
+    }
+
+    #[test]
+    fn test_insert_truncates_oversized_array_content_blocks() {
+        let (mut db, _temp_dir) = create_test_db();
+        let event_ts = days_ago(1);
+
+        // Claude content is frequently an array of blocks; a tool_result block can
+        // carry a huge string. Ensure array element truncation also bounds the row.
+        let huge_block = "y".repeat(400_000);
+        let event_json = format!(
+            r#"{{
+                "t":{event_ts},
+                "e":5,
+                "v":{{"0":{{"message":{{"role":"assistant","id":"msg-2","model":"m","content":[{{"type":"text","text":"{huge_block}"}}]}}}}}},
+                "a":{{"20":"claude","24":"session-2","25":"trace-2"}}
+            }}"#
+        );
+
+        db.insert_events(&[event_json]).unwrap();
+
+        let stored_json: String = db
+            .conn
+            .query_row("SELECT event_json FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert!(
+            stored_json.len() <= MAX_PERSISTED_EVENT_JSON_BYTES,
+            "stored event_json should be truncated, was {} bytes",
+            stored_json.len()
+        );
+        let value: Value = serde_json::from_str(&stored_json).unwrap();
+        assert_eq!(
+            value.pointer("/v/0/message/id").and_then(Value::as_str),
+            Some("msg-2")
+        );
+        // Event metadata column still derived correctly from truncated JSON.
+        assert_eq!(
+            metric_metadata_rows(&db),
+            vec![(Some(event_ts as i64), Some(5))]
+        );
+    }
+
+    #[test]
+    fn test_truncate_oversized_event_json_borrows_when_small() {
+        let small = r#"{"t":1,"e":5,"v":{"0":"x"},"a":{}}"#;
+        assert!(matches!(
+            truncate_oversized_event_json(small),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn test_truncate_oversized_event_json_returns_unparseable_input_as_is() {
+        // Oversized but not valid JSON: must be returned unchanged (never dropped).
+        let junk = "z".repeat(MAX_PERSISTED_EVENT_JSON_BYTES + 10);
+        let out = truncate_oversized_event_json(&junk);
+        assert_eq!(out.as_ref(), junk.as_str());
+    }
+
+    #[test]
+    fn test_insert_leaves_small_events_unmodified() {
+        let (mut db, _temp_dir) = create_test_db();
+        let event_ts = days_ago(1);
+        let event_json = session_event_json(event_ts, "s1", "ext-s1", "claude", None);
+
+        db.insert_events(std::slice::from_ref(&event_json)).unwrap();
+
+        let stored_json: String = db
+            .conn
+            .query_row("SELECT event_json FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        // Small events are stored byte-for-byte (no rewrite).
+        assert_eq!(stored_json, event_json);
     }
 }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -74,11 +74,14 @@ pub fn log_metrics(
             return;
         }
 
-        // Split into chunks of MAX_METRICS_PER_ENVELOPE
-        for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-            let envelope = crate::daemon::TelemetryEnvelope::Metrics {
-                events: chunk.to_vec(),
-            };
+        // Split into chunks of MAX_METRICS_PER_ENVELOPE, consuming the input so
+        // we never hold a second copy of the (potentially large) transcript
+        // events. `chunks(..).to_vec()` would clone every event; draining the
+        // owned Vec moves them instead, halving peak memory during a sweep.
+        let mut iter = events.into_iter().peekable();
+        while iter.peek().is_some() {
+            let chunk: Vec<MetricEvent> = iter.by_ref().take(MAX_METRICS_PER_ENVELOPE).collect();
+            let envelope = crate::daemon::TelemetryEnvelope::Metrics { events: chunk };
             submit_telemetry_envelope(vec![envelope]);
         }
     }


### PR DESCRIPTION
## Summary

Fixes the 20GB+ daemon memory leak in [PD-23](https://linear.app/git-ai/issue/PD-23) / https://github.com/git-ai-project/git-ai/issues/1677. Two changes, the first being the primary RSS fix:

### 1. Bound the attribution-recovery diff to the immediate parent (primary RSS fix)

The attribution-recovery path added in the late-June releases (`attribution_recovery::recover_attribution`, a new file) runs `recovery_committed_hunks` on every post-commit, which calls `diff_added_lines(parent_sha, commit_sha, None)` — **no pathspec, no range cap** — buffering the entire `git diff` output into a `String` plus one `u32` per added line into HashMaps.

For ordinary commits `parent_sha` is the immediate parent, so the diff is a single commit. But the daemon's fast-forward `update-ref` handler calls `post_commit_from_working_log(repo, Some(old), new, …)` where `old` is the **local branch tip from before a `git pull`**. After checking out an old branch and pulling forward, `old..new` spans the entire intervening history, so recovery buffered the whole multi-GB history delta into memory — the reported spike. (This is the deterministic macOS repro: check out an old branch, `git pull`, watch git-ai RSS.)

**Why the sudden onset:** at v1.5.13 (last good release) the same unbounded `diff_added_lines(.., None)` existed, but it ran *only* inside the background-agent block (`if background_agent::detect() != None/WithHooks`) — i.e. only in Devin / Codex-Cloud environments, never for a normal user. The new recovery path (PR #1654, attribution-recovery, +1371 lines) runs it for **everyone**, so a normal user's `git pull` fast-forward went from "no full-range diff" to "buffer the entire old→latest diff in RAM".

**Fix:** recovery only attributes lines added by the commit being finalized, so the diff must be bounded to that commit. `immediate_parent_diff_base` resolves the commit's real first parent and uses it as the diff base whenever the supplied `parent_sha` is a far-behind ancestor (the fast-forward case), capping the diff to a single commit. Normal and amend paths are unchanged (`parent_sha` already equals the immediate parent there).

Note: pathspec-scoping the recovery diff (an alternative considered) would have **broken** the legitimate uncheckpointed-AI recovery feature, whose commits have an *empty* working log → empty pathspecs → nothing recovered. The immediate-parent bound preserves that feature.

Regression test `test_recovery_committed_hunks_bounds_diff_to_immediate_parent`: old tip + 8 intervening commits + a final commit; asserts recovery sees only the final commit's own file, never the intervening range.

### 2. Truncate oversized transcript events before metrics-db persistence (complementary disk hygiene)

Independent of the RSS spike, the metrics SQLite DB grows unboundedly on disk: the transcript sweep persists every session event, and assistant events carry raw transcript JSON whose `message.content` is 50–150KB+. When upload is unavailable (offline / not logged in / sqlite perms), rows are retained indefinitely (delivered rows kept as history; prune runs every 24h / 365-day retention), so the table (and its page cache) reach GBs (2.4GB DB from 1.9GB of transcripts in repro).

`insert_events_with_delivered_ts` now passes each event through `truncate_oversized_event_json`: events ≤16KB are stored byte-for-byte; larger ones have their heavy free-text string fields (e.g. `message.content`, content-block `text`) recursively truncated while **preserving every field local usage stats and server ETL read** — token usage, model, message id, role, timestamps (all small sibling fields). Truncated objects are flagged with `_git_ai_content_truncated`; the full content always remains in the original transcript `.jsonl`. Unparseable / still-oversized payloads are stored as-is so an event is never silently dropped.

Also drops the per-chunk `.to_vec()` clone in `observability::log_metrics` by draining the owned Vec (halves peak memory while chunking a sweep batch).

### Tests

- `test_recovery_committed_hunks_bounds_diff_to_immediate_parent` (primary fix)
- `test_insert_truncates_oversized_session_event_content_but_keeps_metadata`, `test_insert_truncates_oversized_array_content_blocks`, `test_truncate_oversized_event_json_borrows_when_small`, `test_truncate_oversized_event_json_returns_unparseable_input_as_is`, `test_insert_leaves_small_events_unmodified`
- All `metrics::*` + `post_commit::*` lib tests, `pull_rebase_ff` (39) and `session_event_attribution` (5) integration suites pass; `task lint` + `task fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)