### PR TITLE
[codex] Bound transcript metrics persistence

### DIFF
--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -1114,13 +1114,15 @@ impl StreamWorker {
                 })
                 .collect();
 
-            crate::observability::log_metrics(metric_events);
+            if let Err(e) = telemetry.persist_metrics_blocking(&metric_events) {
+                tracing::warn!(%e, "telemetry: failed to persist transcript metrics locally");
+            }
 
-            // Backpressure: if the telemetry buffer has accumulated too many
-            // events, poll briefly to let the 3-second flush cycle drain it.
+            // Backpressure: after synchronous local persistence, this mainly
+            // throttles when metrics upload is available and pending DB rows
+            // are accumulating faster than the flush loop can deliver them.
             // Short sleeps (~100ms) keep shutdown latency low since this runs
-            // inside spawn_blocking. Capped at ~4s to avoid blocking forever
-            // if the flush loop is stuck (API down, etc.).
+            // inside spawn_blocking. Capped at ~4s to avoid blocking forever.
             const BACKPRESSURE_THRESHOLD: usize = 5_000;
             const BACKPRESSURE_MAX_WAITS: usize = 40;
             for _ in 0..BACKPRESSURE_MAX_WAITS {

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -248,6 +248,17 @@ impl DaemonTelemetryWorkerHandle {
         buffered.saturating_add(pending)
     }
 
+    /// Persist metrics directly from an existing blocking worker.
+    ///
+    /// Transcript sweeps can emit many batches in a tight loop. Routing those
+    /// through the async telemetry entrypoint creates one fire-and-forget
+    /// `spawn_blocking` task per batch, so a fast producer can retain many raw
+    /// transcript events while SQLite writes catch up. This path keeps the
+    /// producer coupled to the metrics DB write and bounds peak memory.
+    pub fn persist_metrics_blocking(&self, events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
+        store_metrics_in_db(events)
+    }
+
     /// Submit telemetry envelopes synchronously (best-effort, non-blocking).
     ///
     /// Used by the daemon process's own `observability::log_*()` calls which


### PR DESCRIPTION
## Summary
- Persist transcript sweep metrics synchronously from the existing blocking worker.
- Keep normal telemetry submission unchanged for small/non-transcript metric paths.
- Bound release-build memory during fresh transcript DB imports by preventing queued metric write tasks from accumulating raw transcript batches.

## Root Cause
The v1.6.0 metrics path made inserts heavier while transcript sweeps still submitted one fire-and-forget blocking DB write per batch. In optimized release builds, the transcript producer could outrun SQLite and retain many queued batches in memory.

## Verification
- task fmt
- task build
- task test TEST_FILTER=telemetry_worker CARGO_TEST_ARGS="--lib"
- task test TEST_FILTER=stream_worker CARGO_TEST_ARGS="--lib"
- cargo build --release --bin git-ai
- task lint
- git diff --check