### PR TITLE
fix: require auth credentials for metrics upload on all API URLs

### DIFF
--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -16,12 +16,11 @@ static LAST_METRICS_UPLOAD_STARTED_AT: OnceLock<Mutex<Option<Instant>>> = OnceLo
 
 /// Returns whether metrics are allowed to upload for the current API context.
 ///
-/// Keep this in sync with user-facing status output: the default hosted API
-/// requires either OAuth login or an API key, while custom API URLs are assumed
-/// to be intentionally configured for delivery.
-pub fn metrics_upload_allowed(api_base_url: &str, client: &ApiClient) -> bool {
-    let using_default_api = api_base_url == crate::config::DEFAULT_API_BASE_URL;
-    !using_default_api || client.is_logged_in() || client.has_api_key()
+/// The server always requires authentication (API key or OAuth login).
+/// Without credentials the request will be rejected with 401, so we skip
+/// the upload entirely to avoid wasteful retries and memory pressure.
+pub fn metrics_upload_allowed(_api_base_url: &str, client: &ApiClient) -> bool {
+    client.is_logged_in() || client.has_api_key()
 }
 
 fn wait_for_metrics_upload_rate_limit() -> Result<(), GitAiError> {

--- a/src/commands/flush_metrics_db.rs
+++ b/src/commands/flush_metrics_db.rs
@@ -16,7 +16,7 @@ pub fn handle_flush_metrics_db(_args: &[String]) {
     let client = ApiClient::new(context);
 
     if !metrics_upload_allowed(&api_base_url, &client) {
-        eprintln!("flush-metrics-db: skipping (not logged in and using default API)");
+        eprintln!("flush-metrics-db: skipping (requires an API key or login)");
         return;
     }
 

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -219,14 +219,14 @@ fn login_status(auth: &AuthStatus, api_client: &ApiClient) -> String {
 
 fn metrics_delivery_status(api_base_url: &str, api_client: &ApiClient) -> String {
     if !metrics_upload_allowed(api_base_url, api_client) {
-        return "off (default API requires an API key or login)".to_string();
+        return "off (requires an API key or login)".to_string();
     }
 
     match (api_client.has_api_key(), api_client.is_logged_in()) {
         (true, true) => "on (API key and login connected)".to_string(),
         (true, false) => "on (API key configured)".to_string(),
         (false, true) => "on (login connected)".to_string(),
-        (false, false) => "on (custom API URL configured)".to_string(),
+        (false, false) => unreachable!("metrics_upload_allowed requires auth"),
     }
 }
 
@@ -431,8 +431,6 @@ mod tests {
             "API access: not connected (login credentials found, but no usable access token)"
         ));
         assert!(output.contains("Login: logged in"));
-        assert!(
-            output.contains("Metrics delivery: off (default API requires an API key or login)")
-        );
+        assert!(output.contains("Metrics delivery: off (requires an API key or login)"));
     }
 }


### PR DESCRIPTION
## Summary

Root cause fix for metrics delivery failure when using non-default API URLs (e.g. `dev.usegitai.com`).

`metrics_upload_allowed()` previously bypassed auth checks for non-default URLs:

```rust
// Before: non-default URL → always true, even without credentials
pub fn metrics_upload_allowed(api_base_url: &str, client: &ApiClient) -> bool {
    let using_default_api = api_base_url == DEFAULT_API_BASE_URL;
    !using_default_api || client.is_logged_in() || client.has_api_key()
}

// After: credentials required for all URLs
pub fn metrics_upload_allowed(_api_base_url: &str, client: &ApiClient) -> bool {
    client.is_logged_in() || client.has_api_key()
}
```

The server (`resolveWorkerUploadAuth`) always requires either an API key or Bearer token — there is no anonymous upload mode. Without credentials the POST gets a guaranteed 401, the daemon retries every 3s with new events, and the deserialization of large batches causes the memory spike.

This was a legacy artifact from when telemetry delivery didn't require auth. Enterprise rollouts always set an API key so they're unaffected. Users without credentials will now correctly see `Metrics delivery: off (requires an API key or login)` in `git-ai status` instead of the misleading `on (custom API URL configured)`.

Also fixed a stale skip message in `flush-metrics-db` that incorrectly blamed "using default API" when the auth requirement now applies to all URLs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->