### PR TITLE
[codex] block daemon startup in restricted security sandboxes

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -106,6 +106,17 @@ fn ensure_daemon_running_attached(timeout: Duration) -> Result<DaemonConfig, Str
         return Ok(config);
     }
 
+    if let Some(restriction) =
+        crate::daemon::sandbox::detect_security_sandbox_home_restriction(&config)
+    {
+        crate::daemon::sandbox::log_security_sandbox_home_restriction(
+            "daemon_start_attached",
+            &config,
+            &restriction,
+        );
+        return Err(restriction.user_message());
+    }
+
     remove_stale_daemon_files(&config);
 
     if daemon_startup_is_blocked(&config) {
@@ -308,6 +319,17 @@ fn start_daemon_detached_with_config(
 ) -> Result<DaemonConfig, String> {
     if daemon_is_up(&config) {
         return Ok(config);
+    }
+
+    if let Some(restriction) =
+        crate::daemon::sandbox::detect_security_sandbox_home_restriction(&config)
+    {
+        crate::daemon::sandbox::log_security_sandbox_home_restriction(
+            "daemon_autostart",
+            &config,
+            &restriction,
+        );
+        return Err(restriction.user_message());
     }
 
     remove_stale_daemon_files(&config);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -65,6 +65,7 @@ pub mod global_actor;
 pub mod reducer;
 pub mod ref_cursor;
 pub mod rewrite_metrics;
+pub mod sandbox;
 pub mod sentry_layer;
 pub mod stream_worker;
 pub mod sweep_coordinator;
@@ -7180,6 +7181,16 @@ pub(crate) fn daemon_run_pending_self_update() -> DaemonSelfUpdateOutcome {
 pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction, GitAiError> {
     sanitize_git_env_for_daemon();
     disable_trace2_for_daemon_process();
+    if let Some(restriction) =
+        crate::daemon::sandbox::detect_security_sandbox_home_restriction(&config)
+    {
+        crate::daemon::sandbox::log_security_sandbox_home_restriction(
+            "daemon_run",
+            &config,
+            &restriction,
+        );
+        return Err(GitAiError::Generic(restriction.user_message()));
+    }
     config.ensure_parent_dirs()?;
     remove_stale_daemon_files(&config);
     let _lock = DaemonLock::acquire(&config.lock_path)?;

--- a/src/daemon/sandbox.rs
+++ b/src/daemon/sandbox.rs
@@ -1,0 +1,454 @@
+//! Security sandbox detection for daemon startup.
+
+use crate::api::types::{DaemonLogEvent, DaemonLogFieldValue, DaemonLogKind, DaemonLogLevel};
+use crate::daemon::DaemonConfig;
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+
+const PROBE_FILE_PREFIX: &str = ".git-ai-daemon-sandbox-probe-";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SecuritySandboxHomeRestriction {
+    pub(crate) sandbox: &'static str,
+    pub(crate) env_signal: String,
+    pub(crate) path: PathBuf,
+    pub(crate) operation: &'static str,
+    pub(crate) error: String,
+}
+
+impl SecuritySandboxHomeRestriction {
+    pub(crate) fn user_message(&self) -> String {
+        format!(
+            "daemon startup refused: detected {} security sandbox and git-ai daemon home is not accessible ({} {} failed for {}: {}). Whitelist ~/.git-ai or set GIT_AI_DAEMON_HOME to a writable path outside the sandbox.",
+            self.sandbox,
+            self.operation,
+            if self.operation == "create_dir_all" {
+                "at"
+            } else {
+                "in"
+            },
+            self.path.display(),
+            self.error
+        )
+    }
+}
+
+/// Detects the issue described in #909: a security sandbox can allow the
+/// git-ai binary to run while blocking access to `~/.git-ai`, which makes
+/// trace2 silently fail. Keep this check conservative by requiring both an
+/// explicit security-sandbox signal and an actual daemon-home access failure.
+///
+/// Only use documented child-process sandbox markers or git-ai's explicit
+/// opt-in marker here. Generic agent identity, cloud-agent identity, and OS
+/// backend names are not enough to distinguish this issue from unrelated
+/// permission failures.
+pub(crate) fn detect_security_sandbox_home_restriction(
+    config: &DaemonConfig,
+) -> Option<SecuritySandboxHomeRestriction> {
+    let (sandbox, env_signal) = detect_security_sandbox_env()?;
+    probe_daemon_paths(config)
+        .err()
+        .map(|failure| SecuritySandboxHomeRestriction {
+            sandbox,
+            env_signal,
+            path: failure.path,
+            operation: failure.operation,
+            error: failure.error,
+        })
+}
+
+pub(crate) fn log_security_sandbox_home_restriction(
+    context: &'static str,
+    config: &DaemonConfig,
+    restriction: &SecuritySandboxHomeRestriction,
+) {
+    let message = "daemon startup refused in security sandbox with restricted git-ai home";
+    eprintln!("[git-ai] {}", restriction.user_message());
+    tracing::error!(
+        context,
+        sandbox = restriction.sandbox,
+        env_signal = %restriction.env_signal,
+        path = %restriction.path.display(),
+        operation = restriction.operation,
+        error = %restriction.error,
+        internal_dir = %config.internal_dir.display(),
+        lock_path = %config.lock_path.display(),
+        control_socket_path = %config.control_socket_path.display(),
+        trace_socket_path = %config.trace_socket_path.display(),
+        "{message}"
+    );
+
+    let event = daemon_log_event(context, config, restriction, message);
+    let _ = crate::daemon::telemetry_worker::flush_daemon_log_event_now(event);
+}
+
+fn detect_security_sandbox_env() -> Option<(&'static str, String)> {
+    if env_var_has_non_empty_value("CURSOR_SANDBOX") {
+        return Some(("Cursor", "CURSOR_SANDBOX".to_string()));
+    }
+    if env_var_has_non_empty_value("CODEX_SANDBOX") {
+        return Some(("Codex", "CODEX_SANDBOX".to_string()));
+    }
+
+    for key in ["GIT_AI_SECURITY_SANDBOX", "GIT_AI_AGENT_SECURITY_SANDBOX"] {
+        if env_var_is_truthy(key) {
+            return Some(("git-ai configured", key.to_string()));
+        }
+    }
+
+    None
+}
+
+fn env_var_has_non_empty_value(key: &str) -> bool {
+    std::env::var_os(key).is_some_and(|value| !value.to_string_lossy().trim().is_empty())
+}
+
+fn env_var_is_truthy(key: &str) -> bool {
+    std::env::var(key)
+        .ok()
+        .is_some_and(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
+struct PathProbeFailure {
+    path: PathBuf,
+    operation: &'static str,
+    error: String,
+}
+
+fn probe_daemon_paths(config: &DaemonConfig) -> Result<(), PathProbeFailure> {
+    probe_writable_dir(&config.internal_dir)?;
+
+    if let Some(lock_parent) = config.lock_path.parent() {
+        probe_writable_dir(lock_parent)?;
+    }
+    #[cfg(not(windows))]
+    {
+        if let Some(control_parent) = config.control_socket_path.parent() {
+            probe_writable_dir(control_parent)?;
+        }
+        if let Some(trace_parent) = config.trace_socket_path.parent() {
+            probe_writable_dir(trace_parent)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn probe_writable_dir(path: &Path) -> Result<(), PathProbeFailure> {
+    fs::create_dir_all(path).map_err(|error| PathProbeFailure {
+        path: path.to_path_buf(),
+        operation: "create_dir_all",
+        error: error.to_string(),
+    })?;
+
+    let probe_path = path.join(format!("{}{}", PROBE_FILE_PREFIX, std::process::id()));
+    match OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&probe_path)
+    {
+        Ok(_) => {
+            let _ = fs::remove_file(&probe_path);
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(PathProbeFailure {
+            path: path.to_path_buf(),
+            operation: "create_probe_file",
+            error: error.to_string(),
+        }),
+    }
+}
+
+fn daemon_log_event(
+    context: &'static str,
+    config: &DaemonConfig,
+    restriction: &SecuritySandboxHomeRestriction,
+    message: &str,
+) -> DaemonLogEvent {
+    let mut fields = BTreeMap::new();
+    fields.insert("context".to_string(), DaemonLogFieldValue::from(context));
+    fields.insert(
+        "sandbox".to_string(),
+        DaemonLogFieldValue::from(restriction.sandbox),
+    );
+    fields.insert(
+        "env_signal".to_string(),
+        DaemonLogFieldValue::from(restriction.env_signal.clone()),
+    );
+    fields.insert(
+        "operation".to_string(),
+        DaemonLogFieldValue::from(restriction.operation),
+    );
+    fields.insert(
+        "path".to_string(),
+        DaemonLogFieldValue::from(restriction.path.display().to_string()),
+    );
+    fields.insert(
+        "error".to_string(),
+        DaemonLogFieldValue::from(restriction.error.clone()),
+    );
+    fields.insert(
+        "internal_dir".to_string(),
+        DaemonLogFieldValue::from(config.internal_dir.display().to_string()),
+    );
+    fields.insert(
+        "lock_path".to_string(),
+        DaemonLogFieldValue::from(config.lock_path.display().to_string()),
+    );
+    fields.insert(
+        "control_socket_path".to_string(),
+        DaemonLogFieldValue::from(config.control_socket_path.display().to_string()),
+    );
+    fields.insert(
+        "trace_socket_path".to_string(),
+        DaemonLogFieldValue::from(config.trace_socket_path.display().to_string()),
+    );
+
+    DaemonLogEvent {
+        id: Some(crate::uuid::generate_v4()),
+        kind: DaemonLogKind::Log,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        level: DaemonLogLevel::Error,
+        target: Some("git_ai::daemon::sandbox".to_string()),
+        message: message.to_string(),
+        fields,
+        repo_url: None,
+        git_ai_version: Some(
+            crate::authorship::authorship_log_serialization::GIT_AI_VERSION.to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    const SANDBOX_ENV_KEYS: &[&str] = &[
+        "CODEX_THREAD_ID",
+        "CODEX_CI",
+        "CODEX_SANDBOX",
+        "CODEX_SANDBOX_NETWORK_DISABLED",
+        "CODEX_MANAGED_BY_NPM",
+        "CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
+        "CLAUDE_CODE_REMOTE",
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDECODE",
+        "ANTHROPIC_PRODUCT",
+        "CURSOR_AGENT",
+        "CURSOR_SANDBOX",
+        "CURSOR_CONFIG_DIR",
+        "CURSOR_TRACE_ID",
+        "HOSTNAME",
+        "GIT_AI_CLOUD_AGENT",
+        "AGENT_OS",
+        "SEATBELT_PROFILE",
+        "SEATBELT_EXEC_PATH",
+        "APP_SANDBOX_CONTAINER_ID",
+        "GIT_AI_SECURITY_SANDBOX",
+        "GIT_AI_AGENT_SECURITY_SANDBOX",
+    ];
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: these tests are serialized, so there are no concurrent
+            // environment mutations while this guard is alive.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            // SAFETY: these tests are serialized, so there are no concurrent
+            // environment mutations while this guard is alive.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    struct ClearedSandboxEnv {
+        previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+        cloud_agent_previous: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+    }
+
+    impl ClearedSandboxEnv {
+        fn new() -> Self {
+            let previous = SANDBOX_ENV_KEYS
+                .iter()
+                .map(|key| (*key, std::env::var_os(key)))
+                .collect::<Vec<_>>();
+            let cloud_agent_previous = std::env::vars_os()
+                .filter(|(key, _)| {
+                    key.to_string_lossy()
+                        .to_ascii_uppercase()
+                        .starts_with("CLOUD_AGENT_")
+                })
+                .collect::<Vec<_>>();
+
+            // SAFETY: these tests are serialized, so there are no concurrent
+            // environment mutations while this guard is alive.
+            unsafe {
+                for key in SANDBOX_ENV_KEYS {
+                    std::env::remove_var(key);
+                }
+                for (key, _) in &cloud_agent_previous {
+                    std::env::remove_var(key);
+                }
+            }
+
+            Self {
+                previous,
+                cloud_agent_previous,
+            }
+        }
+    }
+
+    impl Drop for ClearedSandboxEnv {
+        fn drop(&mut self) {
+            // SAFETY: these tests are serialized, so there are no concurrent
+            // environment mutations while this guard is alive.
+            unsafe {
+                for (key, value) in &self.previous {
+                    match value {
+                        Some(value) => std::env::set_var(key, value),
+                        None => std::env::remove_var(key),
+                    }
+                }
+                for (key, value) in &self.cloud_agent_previous {
+                    std::env::set_var(key, value);
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn detects_security_sandbox_only_when_daemon_home_is_inaccessible() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let _env = ScopedEnvVar::set("CURSOR_SANDBOX", "native");
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_home = temp.path().join("not-a-directory");
+        fs::write(&blocked_home, "file").unwrap();
+
+        let config = DaemonConfig::from_home(&blocked_home);
+        let restriction = detect_security_sandbox_home_restriction(&config).unwrap();
+
+        assert_eq!(restriction.sandbox, "Cursor");
+        assert_eq!(restriction.env_signal, "CURSOR_SANDBOX");
+        assert_eq!(restriction.operation, "create_dir_all");
+        assert!(
+            restriction
+                .user_message()
+                .contains("daemon startup refused")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn allows_security_sandbox_when_daemon_home_is_writable() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let _env = ScopedEnvVar::set("CURSOR_SANDBOX", "native");
+        let temp = tempfile::tempdir().unwrap();
+        let config = DaemonConfig::from_home(temp.path());
+
+        assert!(detect_security_sandbox_home_restriction(&config).is_none());
+        assert!(config.internal_dir.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn ignores_restricted_home_without_security_sandbox_signal() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_home = temp.path().join("not-a-directory");
+        fs::write(&blocked_home, "file").unwrap();
+
+        let config = DaemonConfig::from_home(&blocked_home);
+
+        assert!(detect_security_sandbox_home_restriction(&config).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn ignores_cloud_agent_and_undocumented_backend_signals() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let _codex_thread = ScopedEnvVar::set("CODEX_THREAD_ID", "test-thread");
+        let _codex_network = ScopedEnvVar::set("CODEX_SANDBOX_NETWORK_DISABLED", "1");
+        let _cloud_agent = ScopedEnvVar::set("CLOUD_AGENT_ID", "test-cloud-agent");
+        let _git_ai_cloud_agent = ScopedEnvVar::set("GIT_AI_CLOUD_AGENT", "1");
+        let _agent_os = ScopedEnvVar::set("AGENT_OS", "linux");
+        let _seatbelt_profile = ScopedEnvVar::set("SEATBELT_PROFILE", "agent");
+        let _seatbelt_exec = ScopedEnvVar::set("SEATBELT_EXEC_PATH", "/usr/bin/sandbox-exec");
+        let _app_sandbox = ScopedEnvVar::set("APP_SANDBOX_CONTAINER_ID", "container");
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_home = temp.path().join("not-a-directory");
+        fs::write(&blocked_home, "file").unwrap();
+
+        let config = DaemonConfig::from_home(&blocked_home);
+
+        assert!(detect_security_sandbox_home_restriction(&config).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn detects_codex_security_sandbox_signal() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let _env = ScopedEnvVar::set("CODEX_SANDBOX", "seatbelt");
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_home = temp.path().join("not-a-directory");
+        fs::write(&blocked_home, "file").unwrap();
+
+        let config = DaemonConfig::from_home(&blocked_home);
+        let restriction = detect_security_sandbox_home_restriction(&config).unwrap();
+
+        assert_eq!(restriction.sandbox, "Codex");
+        assert_eq!(restriction.env_signal, "CODEX_SANDBOX");
+    }
+
+    #[test]
+    #[serial]
+    fn ignores_empty_or_false_security_sandbox_signals() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let _cursor = ScopedEnvVar::set("CURSOR_SANDBOX", " ");
+        let _codex = ScopedEnvVar::set("CODEX_SANDBOX", " ");
+        let _git_ai = ScopedEnvVar::set("GIT_AI_SECURITY_SANDBOX", "0");
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_home = temp.path().join("not-a-directory");
+        fs::write(&blocked_home, "file").unwrap();
+
+        let config = DaemonConfig::from_home(&blocked_home);
+
+        assert!(detect_security_sandbox_home_restriction(&config).is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn detects_explicit_git_ai_security_sandbox_signal() {
+        let _sandbox_env = ClearedSandboxEnv::new();
+        let _env = ScopedEnvVar::set("GIT_AI_SECURITY_SANDBOX", "1");
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_home = temp.path().join("not-a-directory");
+        fs::write(&blocked_home, "file").unwrap();
+
+        let config = DaemonConfig::from_home(&blocked_home);
+        let restriction = detect_security_sandbox_home_restriction(&config).unwrap();
+
+        assert_eq!(restriction.sandbox, "git-ai configured");
+        assert_eq!(restriction.env_signal, "GIT_AI_SECURITY_SANDBOX");
+    }
+}

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -932,6 +932,27 @@ fn flush_daemon_logs(events: Vec<DaemonLogEvent>, daemon_id: &str, install_id: &
     })
 }
 
+/// Best-effort synchronous daemon diagnostic upload for startup paths that
+/// intentionally exit before the telemetry worker is running.
+pub(crate) fn flush_daemon_log_event_now(event: DaemonLogEvent) -> bool {
+    if !daemon_log_upload_enabled() {
+        return false;
+    }
+
+    let context = ApiContext::new(None);
+    let api_base_url = context.base_url.clone();
+    let client = ApiClient::new(context);
+    if !daemon_logs_upload_allowed(&api_base_url, &client) {
+        return false;
+    }
+
+    let daemon_id = format!("startup-{}", std::process::id());
+    let install_id = get_or_create_distinct_id();
+    upload_daemon_log_chunk(vec![event], &daemon_id, &install_id, |request| {
+        client.upload_daemon_logs(request).map(|_| ())
+    }) == 0
+}
+
 fn upload_daemon_log_chunk<Upload>(
     events: Vec<DaemonLogEvent>,
     daemon_id: &str,

--- a/tests/integration/daemon_sandbox.rs
+++ b/tests/integration/daemon_sandbox.rs
@@ -1,0 +1,45 @@
+use crate::repos::test_repo::get_binary_path;
+use std::process::Command;
+
+#[test]
+fn daemon_start_refuses_security_sandbox_with_inaccessible_daemon_home() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let blocked_daemon_home = temp.path().join("daemon-home-file");
+    std::fs::write(&blocked_daemon_home, "not a directory").unwrap();
+
+    let output = Command::new(get_binary_path())
+        .args(["bg", "start"])
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("HOMEDRIVE", "")
+        .env("HOMEPATH", "")
+        .env("GIT_AI_DAEMON_HOME", &blocked_daemon_home)
+        .env_remove("GIT_AI_DAEMON_CONTROL_SOCKET")
+        .env_remove("GIT_AI_DAEMON_TRACE_SOCKET")
+        .env("GIT_AI_DAEMON_LOG_UPLOAD", "0")
+        .env("CURSOR_SANDBOX", "native")
+        .env_remove("GIT_AI_API_KEY")
+        .env_remove("GIT_AI_TEST_CONFIG_PATCH")
+        .output()
+        .expect("run git-ai bg start");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("daemon startup refused"),
+        "stderr should include refusal message, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("Cursor security sandbox"),
+        "stderr should identify Cursor sandbox, got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("GIT_AI_DAEMON_HOME"),
+        "stderr should include mitigation, got: {}",
+        stderr
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -51,6 +51,7 @@ mod continue_cli;
 mod cross_repo_cwd_attribution;
 mod cursor;
 mod daemon_commit_carryover;
+mod daemon_sandbox;
 mod diff;
 mod diff_comprehensive;
 mod diff_ignore_binary;


### PR DESCRIPTION
## Summary

Fixes #909 by refusing to start or autostart the daemon when git-ai is running inside a recognized security sandbox and the daemon home under `~/.git-ai` is not usable.

## What changed

- Added shared daemon sandbox-home detection for documented child-process security sandbox markers: Cursor `CURSOR_SANDBOX`, Codex `CODEX_SANDBOX`, and git-ai explicit opt-in markers `GIT_AI_SECURITY_SANDBOX` / `GIT_AI_AGENT_SECURITY_SANDBOX`.
- Kept the guard conservative: ordinary agent/cloud identity and backend-only signals do not trigger it without a security-sandbox signal and an actual daemon-home access failure.
- Wired the shared check into wrapper autostart, attached `bg start`, and `bg run` daemon startup.
- Emits a structured daemon diagnostic event for this refusal path and flushes it synchronously through the existing daemon log upload code when upload is eligible.
- Added focused unit coverage for the detector, including negative cloud-agent/network-only signal cases, and an integration test for the CLI-facing `git-ai bg start` refusal.

## Validation

- `task fmt`
- `task lint`
- `task build`
- `git diff --check`
- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=sandbox`
- `task test TEST_FILTER=daemon_start_refuses_security_sandbox_with_inaccessible_daemon_home`