### PR TITLE
[codex] Recover unknown lines from commit metadata

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -7,7 +7,7 @@ use crate::commands::checkpoint_agent::bash_tool::StatEntry;
 use crate::daemon::bash_history_db::{BashCheckpointCall, distance_to_call_window};
 use crate::error::GitAiError;
 use crate::git::repo_state::worktree_root_for_path;
-use crate::git::repository::Repository;
+use crate::git::repository::{Repository, exec_git};
 use crate::metrics::db::SessionEventRecoveryCandidate;
 use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded};
 use serde_json::json;
@@ -22,8 +22,176 @@ pub(crate) const SESSION_EVENT_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
 const EDGE_EXTENSION_MAX_LINES: usize = 3;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
+const CODEX_TOOLS: &[&str] = &["codex", "codex-cloud"];
+const CLAUDE_TOOLS: &[&str] = &["claude", "claude-web"];
+const CURSOR_TOOLS: &[&str] = &["cursor", "cursor-agent"];
+const COPILOT_TOOLS: &[&str] = &[
+    "github-copilot",
+    "github-copilot-cli",
+    "github-copilot-agent",
+    "copilot",
+];
+const DEVIN_TOOLS: &[&str] = &["devin"];
+const DROID_TOOLS: &[&str] = &["droid"];
+const WINDSURF_TOOLS: &[&str] = &["windsurf"];
+const AMP_TOOLS: &[&str] = &["amp"];
+const OPENCODE_TOOLS: &[&str] = &["opencode"];
+const GEMINI_TOOLS: &[&str] = &["gemini"];
+const CONTINUE_TOOLS: &[&str] = &["continue-cli"];
+
+const CODEX_EMAILS: &[&str] = &["codex@openai.com"];
+const CLAUDE_EMAILS: &[&str] = &[];
+const CURSOR_EMAILS: &[&str] = &["cursoragent@cursor.com"];
+const COPILOT_EMAILS: &[&str] = &["+copilot@users.noreply.github.com"];
+const DEVIN_EMAILS: &[&str] = &["+devin-ai-integration[bot]@users.noreply.github.com"];
+const DROID_EMAILS: &[&str] = &["+factory-droid[bot]@users.noreply.github.com"];
+const WINDSURF_EMAILS: &[&str] = &["noreply@windsurf.com", "noreply@codeium.com"];
+const AMP_EMAILS: &[&str] = &[];
+const OPENCODE_EMAILS: &[&str] = &[];
+const GEMINI_EMAILS: &[&str] = &[];
+const CONTINUE_EMAILS: &[&str] = &[];
+
+const CODEX_MARKER_EMAILS: &[&str] = &["noreply@openai.com"];
+const CLAUDE_MARKER_EMAILS: &[&str] = &["noreply@anthropic.com"];
+const CURSOR_MARKER_EMAILS: &[&str] = &[];
+const COPILOT_MARKER_EMAILS: &[&str] = &[];
+const DEVIN_MARKER_EMAILS: &[&str] = &[];
+const DROID_MARKER_EMAILS: &[&str] = &[];
+const WINDSURF_MARKER_EMAILS: &[&str] = &[];
+const AMP_MARKER_EMAILS: &[&str] = &[];
+const OPENCODE_MARKER_EMAILS: &[&str] = &[];
+const GEMINI_MARKER_EMAILS: &[&str] = &[];
+const CONTINUE_MARKER_EMAILS: &[&str] = &[];
+
+const CODEX_MARKERS: &[&str] = &["codex"];
+const CLAUDE_MARKERS: &[&str] = &["claude"];
+const CURSOR_MARKERS: &[&str] = &["cursor"];
+const COPILOT_MARKERS: &[&str] = &["copilot", "github copilot"];
+const DEVIN_MARKERS: &[&str] = &["devin"];
+const DROID_MARKERS: &[&str] = &["droid", "factory-droid"];
+const WINDSURF_MARKERS: &[&str] = &["windsurf"];
+const AMP_MARKERS: &[&str] = &["ampcode", "amp code"];
+const OPENCODE_MARKERS: &[&str] = &["opencode", "open code"];
+const GEMINI_MARKERS: &[&str] = &["gemini"];
+const CONTINUE_MARKERS: &[&str] = &["continue-cli"];
+
+const KNOWN_COMMIT_AGENT_KINDS: &[CommitAgentKind] = &[
+    CommitAgentKind {
+        key: "codex",
+        tools: CODEX_TOOLS,
+        emails: CODEX_EMAILS,
+        marker_emails: CODEX_MARKER_EMAILS,
+        markers: CODEX_MARKERS,
+    },
+    CommitAgentKind {
+        key: "claude",
+        tools: CLAUDE_TOOLS,
+        emails: CLAUDE_EMAILS,
+        marker_emails: CLAUDE_MARKER_EMAILS,
+        markers: CLAUDE_MARKERS,
+    },
+    CommitAgentKind {
+        key: "cursor",
+        tools: CURSOR_TOOLS,
+        emails: CURSOR_EMAILS,
+        marker_emails: CURSOR_MARKER_EMAILS,
+        markers: CURSOR_MARKERS,
+    },
+    CommitAgentKind {
+        key: "github-copilot",
+        tools: COPILOT_TOOLS,
+        emails: COPILOT_EMAILS,
+        marker_emails: COPILOT_MARKER_EMAILS,
+        markers: COPILOT_MARKERS,
+    },
+    CommitAgentKind {
+        key: "devin",
+        tools: DEVIN_TOOLS,
+        emails: DEVIN_EMAILS,
+        marker_emails: DEVIN_MARKER_EMAILS,
+        markers: DEVIN_MARKERS,
+    },
+    CommitAgentKind {
+        key: "droid",
+        tools: DROID_TOOLS,
+        emails: DROID_EMAILS,
+        marker_emails: DROID_MARKER_EMAILS,
+        markers: DROID_MARKERS,
+    },
+    CommitAgentKind {
+        key: "windsurf",
+        tools: WINDSURF_TOOLS,
+        emails: WINDSURF_EMAILS,
+        marker_emails: WINDSURF_MARKER_EMAILS,
+        markers: WINDSURF_MARKERS,
+    },
+    CommitAgentKind {
+        key: "amp",
+        tools: AMP_TOOLS,
+        emails: AMP_EMAILS,
+        marker_emails: AMP_MARKER_EMAILS,
+        markers: AMP_MARKERS,
+    },
+    CommitAgentKind {
+        key: "opencode",
+        tools: OPENCODE_TOOLS,
+        emails: OPENCODE_EMAILS,
+        marker_emails: OPENCODE_MARKER_EMAILS,
+        markers: OPENCODE_MARKERS,
+    },
+    CommitAgentKind {
+        key: "gemini",
+        tools: GEMINI_TOOLS,
+        emails: GEMINI_EMAILS,
+        marker_emails: GEMINI_MARKER_EMAILS,
+        markers: GEMINI_MARKERS,
+    },
+    CommitAgentKind {
+        key: "continue-cli",
+        tools: CONTINUE_TOOLS,
+        emails: CONTINUE_EMAILS,
+        marker_emails: CONTINUE_MARKER_EMAILS,
+        markers: CONTINUE_MARKERS,
+    },
+];
+
 pub(crate) type FileTimestampsByPath = HashMap<String, Vec<u128>>;
 pub(crate) type UnknownLinesByFile = BTreeMap<String, Vec<u32>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CommitAgentKind {
+    key: &'static str,
+    tools: &'static [&'static str],
+    emails: &'static [&'static str],
+    marker_emails: &'static [&'static str],
+    markers: &'static [&'static str],
+}
+
+#[derive(Clone, Debug)]
+struct CommitAgentDetection {
+    kind: CommitAgentKind,
+    source: &'static str,
+    marker: String,
+}
+
+#[derive(Debug)]
+struct CommitMetadata {
+    message: String,
+    author_name: String,
+    author_email: String,
+}
+
+#[derive(Clone, Debug)]
+struct CommitMetadataSessionSelection {
+    session_id: String,
+    agent_id: AgentId,
+    tier: &'static str,
+    metric_row_id: Option<i64>,
+    distance_ns: Option<u128>,
+    event_ts: Option<u32>,
+    repo_url: Option<String>,
+    external_tool_use_id: Option<String>,
+}
 
 #[derive(Clone, Copy, Default)]
 pub(crate) struct AttributionRecoveryContext<'a> {
@@ -75,6 +243,16 @@ pub(crate) fn recover_attribution(
     }
 
     recover_session_event_mtime(
+        repo,
+        parent_sha,
+        commit_sha,
+        human_author,
+        authorship_log,
+        committed_hunks,
+        context.file_timestamps,
+    )?;
+
+    recover_commit_metadata(
         repo,
         parent_sha,
         commit_sha,
@@ -334,6 +512,608 @@ fn recover_session_event_mtime(
     }
 
     Ok(())
+}
+
+fn recover_commit_metadata(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    human_author: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    captured_file_timestamps: Option<&FileTimestampsByPath>,
+) -> Result<(), GitAiError> {
+    let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
+    if unknown_by_file.is_empty() {
+        return Ok(());
+    }
+
+    let commit_metadata = read_commit_metadata(repo, commit_sha)?;
+    let detections = detect_commit_metadata_agents(&commit_metadata);
+    if detections.is_empty() {
+        return Ok(());
+    }
+
+    let workdir = repo.workdir()?;
+    let target_repo_url = crate::repo_url::resolve_repo_url_from_repo(repo);
+    let (timestamps_by_file, latest_timestamps) =
+        latest_timestamps_for_unknown_files(&workdir, &unknown_by_file, captured_file_timestamps);
+    let Some(selection) = select_commit_metadata_session(
+        authorship_log,
+        &detections,
+        &latest_timestamps,
+        target_repo_url.as_deref(),
+    )?
+    else {
+        return Ok(());
+    };
+
+    authorship_log
+        .metadata
+        .sessions
+        .entry(selection.session_id.clone())
+        .or_insert_with(|| SessionRecord {
+            agent_id: selection.agent_id.clone(),
+            human_author: Some(human_author.to_string()),
+            custom_attributes: None,
+        });
+
+    let detected_agents = detections
+        .iter()
+        .map(|detection| {
+            json!({
+                "agent": detection.kind.key,
+                "source": detection.source,
+                "marker": detection.marker,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for (file_path, unknown_lines) in unknown_by_file {
+        let trace_id = generate_trace_id();
+        let author_id = format!("{}::{}", selection.session_id, trace_id);
+        add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
+
+        let file_timestamps = timestamps_by_file
+            .get(&file_path)
+            .cloned()
+            .unwrap_or_default();
+        let metadata = json!({
+            "solver": "commit_metadata",
+            "file_path": file_path.as_str(),
+            "unknown_lines": &unknown_lines,
+            "detected_agents": &detected_agents,
+            "commit_author_name": commit_metadata.author_name.as_str(),
+            "commit_author_email": commit_metadata.author_email.as_str(),
+            "selection_tier": selection.tier,
+            "selected_session_id": selection.session_id.as_str(),
+            "selected_tool": selection.agent_id.tool.as_str(),
+            "selected_model": selection.agent_id.model.as_str(),
+            "selected_external_session_id": selection.agent_id.id.as_str(),
+            "selected_external_tool_use_id": selection.external_tool_use_id.as_deref(),
+            "selected_repo_url": selection.repo_url.as_deref(),
+            "target_repo_url": target_repo_url.as_deref(),
+            "selected_metric_row_id": selection.metric_row_id,
+            "selected_event_ts": selection.event_ts,
+            "distance_ns": selection.distance_ns,
+            "file_timestamps_ns": file_timestamps,
+            "latest_file_timestamps_ns": latest_timestamps,
+        });
+        record_recovery_metric(RecoveryMetricInput {
+            repo,
+            parent_sha,
+            commit_sha,
+            file_path: &file_path,
+            author_id: &author_id,
+            session_id: &selection.session_id,
+            trace_id: &trace_id,
+            tool: &selection.agent_id.tool,
+            model: &selection.agent_id.model,
+            external_session_id: &selection.agent_id.id,
+            external_tool_use_id: selection.external_tool_use_id.as_deref(),
+            edit_kind: "attribution_recovery_commit_metadata",
+            checkpoint_type: "recovered_commit_metadata",
+            recovered_line_count: unknown_lines.len() as u32,
+            metadata,
+            event_ts: selection.event_ts,
+        });
+    }
+
+    Ok(())
+}
+
+fn read_commit_metadata(repo: &Repository, commit_sha: &str) -> Result<CommitMetadata, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "show".to_string(),
+        "-s".to_string(),
+        "--format=%an%x00%ae%x00%B".to_string(),
+        commit_sha.to_string(),
+    ]);
+    let output = exec_git(&args)?;
+    let raw = String::from_utf8(output.stdout)?;
+    let mut parts = raw.splitn(3, '\0');
+    let author_name = parts.next().unwrap_or_default().trim().to_string();
+    let author_email = parts.next().unwrap_or_default().trim().to_string();
+    let message = parts.next().unwrap_or_default().to_string();
+
+    Ok(CommitMetadata {
+        message,
+        author_name,
+        author_email,
+    })
+}
+
+fn detect_commit_metadata_agents(metadata: &CommitMetadata) -> Vec<CommitAgentDetection> {
+    let mut detections = Vec::new();
+    for line in metadata.message.lines() {
+        let trimmed = line.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        if let Some((name, value)) = trimmed.split_once(':') {
+            let name_lower = name.trim().to_ascii_lowercase();
+            if name_lower == "co-authored-by" {
+                if let Some(kind) = detect_agent_from_identity(value) {
+                    push_commit_agent_detection(
+                        &mut detections,
+                        kind,
+                        "co_authored_by",
+                        value.trim(),
+                    );
+                }
+                continue;
+            }
+        }
+
+        if lower.starts_with("claude-session:") {
+            push_commit_agent_detection(
+                &mut detections,
+                commit_agent_kind_by_key("claude"),
+                "session_trailer",
+                trimmed,
+            );
+        } else if lower.starts_with("codex-session:") {
+            push_commit_agent_detection(
+                &mut detections,
+                commit_agent_kind_by_key("codex"),
+                "session_trailer",
+                trimmed,
+            );
+        } else if lower.starts_with("cursor-session:") {
+            push_commit_agent_detection(
+                &mut detections,
+                commit_agent_kind_by_key("cursor"),
+                "session_trailer",
+                trimmed,
+            );
+        }
+    }
+
+    let author_identity = format!("{} <{}>", metadata.author_name, metadata.author_email);
+    if let Some(kind) = detect_agent_from_identity(&author_identity) {
+        push_commit_agent_detection(&mut detections, kind, "author_identity", &author_identity);
+    }
+
+    detections
+}
+
+fn commit_agent_kind_by_key(key: &str) -> CommitAgentKind {
+    KNOWN_COMMIT_AGENT_KINDS
+        .iter()
+        .copied()
+        .find(|kind| kind.key == key)
+        .expect("known commit agent key should exist")
+}
+
+fn push_commit_agent_detection(
+    detections: &mut Vec<CommitAgentDetection>,
+    kind: CommitAgentKind,
+    source: &'static str,
+    marker: &str,
+) {
+    if detections
+        .iter()
+        .any(|detection| detection.kind.key == kind.key)
+    {
+        return;
+    }
+    detections.push(CommitAgentDetection {
+        kind,
+        source,
+        marker: marker.to_string(),
+    });
+}
+
+fn detect_agent_from_identity(identity: &str) -> Option<CommitAgentKind> {
+    let lower = identity.to_ascii_lowercase();
+    let email = email_from_identity(identity);
+    if let Some(email) = email.as_deref()
+        && let Some(kind) = detect_agent_from_email(email)
+    {
+        return Some(kind);
+    }
+
+    KNOWN_COMMIT_AGENT_KINDS.iter().copied().find(|kind| {
+        let marker_matches = kind
+            .markers
+            .iter()
+            .any(|marker| contains_identity_marker(&lower, marker));
+        if !marker_matches {
+            return false;
+        }
+
+        match email.as_deref() {
+            Some(email) => kind
+                .marker_emails
+                .iter()
+                .any(|pattern| email_matches_pattern(email, pattern)),
+            None => true,
+        }
+    })
+}
+
+fn contains_identity_marker(identity_lower: &str, marker: &str) -> bool {
+    let marker_lower = marker.to_ascii_lowercase();
+    let mut search_start = 0;
+    while let Some(relative_start) = identity_lower[search_start..].find(&marker_lower) {
+        let start = search_start + relative_start;
+        let end = start + marker_lower.len();
+        let before = identity_lower[..start].chars().next_back();
+        let after = identity_lower[end..].chars().next();
+        let before_boundary = before.is_none_or(|ch| !ch.is_ascii_alphanumeric());
+        let after_boundary = after.is_none_or(|ch| !ch.is_ascii_alphanumeric());
+        if before_boundary && after_boundary {
+            return true;
+        }
+        search_start = end;
+    }
+    false
+}
+
+fn detect_agent_from_email(email: &str) -> Option<CommitAgentKind> {
+    let email = email.trim().trim_matches('<').trim_matches('>');
+    if email.is_empty() {
+        return None;
+    }
+
+    KNOWN_COMMIT_AGENT_KINDS.iter().copied().find(|kind| {
+        kind.emails
+            .iter()
+            .any(|pattern| email_matches_pattern(email, pattern))
+    })
+}
+
+fn email_matches_pattern(email: &str, pattern: &str) -> bool {
+    let email_lower = email.trim().to_ascii_lowercase();
+    let pattern_lower = pattern.to_ascii_lowercase();
+    if pattern_lower.starts_with('+') {
+        email_lower.ends_with(&pattern_lower)
+    } else {
+        email_lower == pattern_lower
+    }
+}
+
+fn email_from_identity(identity: &str) -> Option<String> {
+    let start = identity.find('<')?;
+    let end = identity[start + 1..].find('>')? + start + 1;
+    Some(identity[start + 1..end].trim().to_string())
+}
+
+fn latest_timestamps_for_unknown_files(
+    workdir: &std::path::Path,
+    unknown_by_file: &UnknownLinesByFile,
+    captured_file_timestamps: Option<&FileTimestampsByPath>,
+) -> (HashMap<String, Vec<u128>>, Vec<u128>) {
+    let mut timestamps_by_file = HashMap::new();
+    let mut latest_timestamp = None;
+    for file_path in unknown_by_file.keys() {
+        let timestamps = captured_file_timestamps
+            .and_then(|timestamps| timestamps.get(file_path))
+            .filter(|timestamps| !timestamps.is_empty())
+            .cloned()
+            .unwrap_or_else(|| file_timestamps_ns(workdir, file_path));
+        if let Some(file_latest) = timestamps.iter().copied().max() {
+            latest_timestamp = Some(
+                latest_timestamp.map_or(file_latest, |current: u128| current.max(file_latest)),
+            );
+            timestamps_by_file.insert(file_path.clone(), timestamps);
+        }
+    }
+
+    let latest_timestamps = latest_timestamp
+        .map(|latest| {
+            let mut timestamps = timestamps_by_file
+                .values()
+                .filter(|file_timestamps| file_timestamps.iter().copied().max() == Some(latest))
+                .flat_map(|file_timestamps| file_timestamps.iter().copied())
+                .collect::<Vec<_>>();
+            timestamps.sort_unstable();
+            timestamps.dedup();
+            timestamps
+        })
+        .unwrap_or_default();
+
+    (timestamps_by_file, latest_timestamps)
+}
+
+fn select_commit_metadata_session(
+    authorship_log: &AuthorshipLog,
+    detections: &[CommitAgentDetection],
+    latest_timestamps: &[u128],
+    target_repo_url: Option<&str>,
+) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
+    if detections.is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(selection) = select_existing_commit_metadata_session(authorship_log, detections) {
+        return Ok(Some(selection));
+    }
+    if let Some(selection) = select_nearest_commit_metadata_metric_session(
+        detections,
+        latest_timestamps,
+        target_repo_url,
+    )? {
+        return Ok(Some(selection));
+    }
+    if let Some(selection) =
+        select_latest_commit_metadata_metric_session(detections, target_repo_url)?
+    {
+        return Ok(Some(selection));
+    }
+
+    Ok(Some(synthesized_commit_metadata_session(
+        &detections[0].kind,
+    )))
+}
+
+fn select_existing_commit_metadata_session(
+    authorship_log: &AuthorshipLog,
+    detections: &[CommitAgentDetection],
+) -> Option<CommitMetadataSessionSelection> {
+    let mut best: Option<(usize, usize, String, AgentId)> = None;
+    for (detection_index, detection) in detections.iter().enumerate() {
+        for (session_id, session) in &authorship_log.metadata.sessions {
+            if !agent_kind_matches_tool(&detection.kind, &session.agent_id.tool) {
+                continue;
+            }
+            let attested_count = attested_line_count_for_session(authorship_log, session_id);
+            let replace = best.as_ref().is_none_or(
+                |(best_detection_index, best_attested_count, best_session_id, _)| {
+                    detection_index < *best_detection_index
+                        || (detection_index == *best_detection_index
+                            && (attested_count > *best_attested_count
+                                || (attested_count == *best_attested_count
+                                    && session_id < best_session_id)))
+                },
+            );
+            if replace {
+                best = Some((
+                    detection_index,
+                    attested_count,
+                    session_id.clone(),
+                    session.agent_id.clone(),
+                ));
+            }
+        }
+    }
+
+    best.map(
+        |(_, _, session_id, agent_id)| CommitMetadataSessionSelection {
+            session_id,
+            agent_id,
+            tier: "existing_commit_session",
+            metric_row_id: None,
+            distance_ns: None,
+            event_ts: None,
+            repo_url: None,
+            external_tool_use_id: None,
+        },
+    )
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommitMetadataMetricRepoTier {
+    SameRepoUrl,
+    UnknownRepoUrl,
+}
+
+impl CommitMetadataMetricRepoTier {
+    fn score(self) -> u8 {
+        match self {
+            Self::SameRepoUrl => 0,
+            Self::UnknownRepoUrl => 1,
+        }
+    }
+}
+
+fn commit_metadata_metric_repo_tier(
+    candidate: &SessionEventRecoveryCandidate,
+    target_repo_url: Option<&str>,
+) -> Option<CommitMetadataMetricRepoTier> {
+    match (target_repo_url, candidate.repo_url.as_deref()) {
+        (Some(target), Some(candidate_url)) if candidate_url == target => {
+            Some(CommitMetadataMetricRepoTier::SameRepoUrl)
+        }
+        (Some(_), Some(_)) => None,
+        _ => Some(CommitMetadataMetricRepoTier::UnknownRepoUrl),
+    }
+}
+
+fn attested_line_count_for_session(authorship_log: &AuthorshipLog, session_id: &str) -> usize {
+    authorship_log
+        .attestations
+        .iter()
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| ai_session_key(&entry.hash) == session_id)
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
+        .count()
+}
+
+fn select_nearest_commit_metadata_metric_session(
+    detections: &[CommitAgentDetection],
+    latest_timestamps: &[u128],
+    target_repo_url: Option<&str>,
+) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
+    if latest_timestamps.is_empty() {
+        return Ok(None);
+    }
+
+    let candidates = match crate::metrics::db::MetricsDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(db) => db.session_event_candidates_near_timestamps(
+                latest_timestamps,
+                SESSION_EVENT_RECOVERY_WINDOW_NS,
+            )?,
+            Err(_) => Vec::new(),
+        },
+        Err(_) => Vec::new(),
+    };
+
+    let mut best: Option<(
+        usize,
+        CommitMetadataMetricRepoTier,
+        u128,
+        i64,
+        CommitMetadataSessionSelection,
+    )> = None;
+    for candidate in &candidates {
+        let Some((detection_index, _)) = detections
+            .iter()
+            .enumerate()
+            .find(|(_, detection)| agent_kind_matches_tool(&detection.kind, &candidate.tool))
+        else {
+            continue;
+        };
+        let Some(distance_ns) = session_event_distance(candidate, latest_timestamps) else {
+            continue;
+        };
+        if distance_ns > SESSION_EVENT_RECOVERY_WINDOW_NS {
+            continue;
+        }
+        let Some(repo_tier) = commit_metadata_metric_repo_tier(candidate, target_repo_url) else {
+            continue;
+        };
+
+        let selection = commit_metadata_selection_from_metric_candidate(
+            candidate,
+            "nearest_file_timestamp",
+            Some(distance_ns),
+        );
+        let replace = best.as_ref().is_none_or(
+            |(best_detection_index, best_repo_tier, best_distance_ns, best_row_id, _)| {
+                detection_index < *best_detection_index
+                    || (detection_index == *best_detection_index
+                        && (repo_tier.score() < best_repo_tier.score()
+                            || (repo_tier.score() == best_repo_tier.score()
+                                && (distance_ns < *best_distance_ns
+                                    || (distance_ns == *best_distance_ns
+                                        && candidate.row_id > *best_row_id)))))
+            },
+        );
+        if replace {
+            best = Some((
+                detection_index,
+                repo_tier,
+                distance_ns,
+                candidate.row_id,
+                selection,
+            ));
+        }
+    }
+
+    Ok(best.map(|(_, _, _, _, selection)| selection))
+}
+
+fn select_latest_commit_metadata_metric_session(
+    detections: &[CommitAgentDetection],
+    target_repo_url: Option<&str>,
+) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
+    let db = match crate::metrics::db::MetricsDatabase::global() {
+        Ok(db) => db,
+        Err(_) => return Ok(None),
+    };
+    let db = match db.lock() {
+        Ok(db) => db,
+        Err(_) => return Ok(None),
+    };
+
+    for detection in detections {
+        let candidates = db.latest_session_event_candidates_for_tools(detection.kind.tools)?;
+        if let Some((candidate, _)) = candidates
+            .iter()
+            .filter_map(|candidate| {
+                let repo_tier = commit_metadata_metric_repo_tier(candidate, target_repo_url)?;
+                Some((candidate, repo_tier))
+            })
+            .min_by(
+                |(left_candidate, left_tier), (right_candidate, right_tier)| {
+                    left_tier
+                        .score()
+                        .cmp(&right_tier.score())
+                        .then_with(|| right_candidate.event_ts.cmp(&left_candidate.event_ts))
+                        .then_with(|| right_candidate.row_id.cmp(&left_candidate.row_id))
+                },
+            )
+        {
+            return Ok(Some(commit_metadata_selection_from_metric_candidate(
+                candidate,
+                "latest_matching_tool_session",
+                None,
+            )));
+        }
+    }
+
+    Ok(None)
+}
+
+fn commit_metadata_selection_from_metric_candidate(
+    candidate: &SessionEventRecoveryCandidate,
+    tier: &'static str,
+    distance_ns: Option<u128>,
+) -> CommitMetadataSessionSelection {
+    CommitMetadataSessionSelection {
+        session_id: candidate.session_id.clone(),
+        agent_id: AgentId {
+            tool: candidate.tool.clone(),
+            id: candidate.external_session_id.clone(),
+            model: session_event_model(candidate),
+        },
+        tier,
+        metric_row_id: Some(candidate.row_id),
+        distance_ns,
+        event_ts: Some(candidate.event_ts),
+        repo_url: candidate.repo_url.clone(),
+        external_tool_use_id: candidate.external_tool_use_id.clone(),
+    }
+}
+
+fn synthesized_commit_metadata_session(kind: &CommitAgentKind) -> CommitMetadataSessionSelection {
+    let session_id = generate_random_session_id();
+    CommitMetadataSessionSelection {
+        session_id: session_id.clone(),
+        agent_id: AgentId {
+            tool: kind.tools.first().copied().unwrap_or(kind.key).to_string(),
+            id: session_id,
+            model: "unknown".to_string(),
+        },
+        tier: "synthesized_session",
+        metric_row_id: None,
+        distance_ns: None,
+        event_ts: None,
+        repo_url: None,
+        external_tool_use_id: None,
+    }
+}
+
+fn generate_random_session_id() -> String {
+    let trace_id = generate_trace_id();
+    format!("s_{}", &trace_id[2..])
+}
+
+fn agent_kind_matches_tool(kind: &CommitAgentKind, tool: &str) -> bool {
+    kind.tools
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(tool))
 }
 
 fn recover_adjacent_edges(

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -9,7 +9,7 @@ use crate::metrics::attrs::attr_pos;
 use crate::metrics::events::{checkpoint_pos, otel_trace_pos, session_event_pos};
 use crate::metrics::pos_encoded::sparse_get_string;
 use crate::metrics::types::{MetricEvent, MetricEventId};
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use serde_json::{Map, Value};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
@@ -1049,6 +1049,101 @@ impl MetricsDatabase {
             candidates.push(SessionEventRecoveryCandidate {
                 row_id,
                 event_ts,
+                session_id,
+                trace_id,
+                tool,
+                model,
+                external_session_id,
+                external_tool_use_id,
+                repo_url,
+            });
+        }
+
+        Ok(candidates)
+    }
+
+    pub(crate) fn latest_session_event_candidates_for_tools(
+        &self,
+        tools: &[&str],
+    ) -> Result<Vec<SessionEventRecoveryCandidate>, GitAiError> {
+        if tools.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders = std::iter::repeat_n("?", tools.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            r#"
+            SELECT
+                id,
+                event_json,
+                event_ts,
+                session_id,
+                trace_id,
+                tool,
+                external_session_id,
+                external_tool_use_id
+            FROM metrics
+            WHERE event_kind = ?1
+              AND tool IN ({placeholders})
+              AND event_ts IS NOT NULL
+              AND session_id IS NOT NULL
+              AND session_id != ''
+              AND tool IS NOT NULL
+              AND tool != ''
+              AND tool != 'mock_ai'
+              AND external_session_id IS NOT NULL
+              AND external_session_id != ''
+            ORDER BY event_ts DESC, id DESC
+            LIMIT 100
+            "#
+        );
+
+        let mut values = Vec::with_capacity(tools.len() + 1);
+        values.push(rusqlite::types::Value::Integer(
+            MetricEventId::SessionEvent as i64,
+        ));
+        values.extend(
+            tools
+                .iter()
+                .map(|tool| rusqlite::types::Value::Text((*tool).to_string())),
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(values.iter()), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, Option<String>>(7)?,
+            ))
+        })?;
+
+        let mut candidates = Vec::new();
+        for row in rows {
+            let (
+                row_id,
+                event_json,
+                event_ts,
+                session_id,
+                trace_id,
+                tool,
+                external_session_id,
+                external_tool_use_id,
+            ) = row?;
+            if event_ts < 0 || event_ts > u32::MAX as i64 {
+                continue;
+            }
+
+            let (repo_url, model) = recovery_attrs_from_event_json(&event_json);
+            candidates.push(SessionEventRecoveryCandidate {
+                row_id,
+                event_ts: event_ts as u32,
                 session_id,
                 trace_id,
                 tool,

--- a/tests/integration/session_event_attribution.rs
+++ b/tests/integration/session_event_attribution.rs
@@ -1,6 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
-use git_ai::authorship::authorship_log_serialization::generate_session_id;
+use git_ai::authorship::authorship_log::LineRange;
+use git_ai::authorship::authorship_log_serialization::{AuthorshipLog, generate_session_id};
 use git_ai::authorship::working_log::AgentId;
 use git_ai::daemon::bash_history_db::{BashCallEnd, BashCallStart, BashHistoryDatabase};
 use git_ai::metrics::db::MetricsDatabase;
@@ -35,7 +36,24 @@ fn insert_session_event(
     external_tool_use_id: &str,
     repo_url: Option<&str>,
 ) -> String {
-    let tool = "codex";
+    insert_session_event_for_tool(
+        db_path,
+        event_ts,
+        "codex",
+        external_session_id,
+        external_tool_use_id,
+        repo_url,
+    )
+}
+
+fn insert_session_event_for_tool(
+    db_path: &str,
+    event_ts: u32,
+    tool: &str,
+    external_session_id: &str,
+    external_tool_use_id: &str,
+    repo_url: Option<&str>,
+) -> String {
     let session_id = generate_session_id(external_session_id, tool);
     let values = SessionEventValues::with_ids(
         json!({
@@ -64,6 +82,73 @@ fn insert_session_event(
         .expect("session event should insert");
 
     session_id
+}
+
+fn codex_checkpoint(
+    repo: &TestRepo,
+    file_path: &Path,
+    session_id: &str,
+    hook_event_name: &str,
+    tool_use_id: &str,
+) {
+    let hook_input = json!({
+        "session_id": session_id,
+        "cwd": repo.canonical_path().to_string_lossy().to_string(),
+        "hook_event_name": hook_event_name,
+        "tool_name": "apply_patch",
+        "tool_use_id": tool_use_id,
+        "model": "gpt-5",
+        "tool_input": {
+            "patch": format!("*** Update File: {}\n", file_path.to_string_lossy())
+        },
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
+        .expect("codex checkpoint should succeed");
+}
+
+fn attested_lines_for_session(
+    authorship_log: &AuthorshipLog,
+    file_path: &str,
+    session_id: &str,
+) -> Vec<u32> {
+    let mut lines = authorship_log
+        .attestations
+        .iter()
+        .filter(|attestation| attestation.file_path == file_path)
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| entry.hash.split("::").next() == Some(session_id))
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
+        .collect::<Vec<_>>();
+    lines.sort_unstable();
+    lines.dedup();
+    lines
+}
+
+fn assert_session_attests_lines(
+    authorship_log: &AuthorshipLog,
+    file_path: &str,
+    session_id: &str,
+    expected_lines: &[u32],
+) {
+    assert_eq!(
+        attested_lines_for_session(authorship_log, file_path, session_id),
+        expected_lines,
+        "expected {session_id} to attest lines {expected_lines:?}"
+    );
+}
+
+fn session_ids_for_tool(authorship_log: &AuthorshipLog, tool: &str) -> Vec<String> {
+    let mut session_ids = authorship_log
+        .metadata
+        .sessions
+        .iter()
+        .filter(|(_, session)| session.agent_id.tool == tool)
+        .map(|(session_id, _)| session_id.clone())
+        .collect::<Vec<_>>();
+    session_ids.sort();
+    session_ids
 }
 
 fn isolated_bash_history_db_path() -> (tempfile::TempDir, String) {
@@ -328,4 +413,464 @@ fn test_session_event_recovery_rejects_time_only_sessions() {
             .contains_key(&recovered_session_id),
         "time-only session events must not recover attribution"
     );
+}
+
+#[test]
+fn test_commit_metadata_recovery_uses_existing_matching_session_after_edge_expansion() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+    let file_path = repo.path().join("metadata-existing.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial base")
+        .expect("initial commit should succeed");
+    let mut file = repo.filename("metadata-existing.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let external_session_id = "codex-existing-metadata-session";
+    codex_checkpoint(
+        &repo,
+        &file_path,
+        external_session_id,
+        "PreToolUse",
+        "metadata-existing-tool",
+    );
+
+    fs::write(&file_path, "base\ncodex line\n").unwrap();
+    codex_checkpoint(
+        &repo,
+        &file_path,
+        external_session_id,
+        "PostToolUse",
+        "metadata-existing-tool",
+    );
+
+    fs::write(
+        &file_path,
+        "\
+base
+codex line
+unknown 1
+unknown 2
+unknown 3
+unknown 4
+unknown 5
+unknown 6
+",
+    )
+    .unwrap();
+
+    let commit = repo
+        .stage_all_and_commit(
+            "Recover from Codex trailer\n\nCo-authored-by: Codex <noreply@openai.com>",
+        )
+        .expect("commit should succeed");
+
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "codex line".ai(),
+        "unknown 1".ai(),
+        "unknown 2".ai(),
+        "unknown 3".ai(),
+        "unknown 4".ai(),
+        "unknown 5".ai(),
+        "unknown 6".ai(),
+    ]);
+    let expected_session_id = generate_session_id(external_session_id, "codex");
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-existing.txt",
+        &expected_session_id,
+        &[2, 3, 4, 5, 6, 7, 8],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_skips_when_edge_expansion_recovers_all_unknown_lines() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+    let file_path = repo.path().join("metadata-edge-skip.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial base")
+        .expect("initial commit should succeed");
+    let mut file = repo.filename("metadata-edge-skip.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let external_session_id = "codex-edge-skip-session";
+    codex_checkpoint(
+        &repo,
+        &file_path,
+        external_session_id,
+        "PreToolUse",
+        "metadata-edge-skip-tool",
+    );
+
+    fs::write(&file_path, "base\ncodex line\n").unwrap();
+    codex_checkpoint(
+        &repo,
+        &file_path,
+        external_session_id,
+        "PostToolUse",
+        "metadata-edge-skip-tool",
+    );
+
+    fs::write(
+        &file_path,
+        "\
+base
+codex line
+edge 1
+edge 2
+edge 3
+",
+    )
+    .unwrap();
+
+    let commit = repo
+        .stage_all_and_commit(
+            "Edge should win before metadata\n\nCo-authored-by: Claude <noreply@anthropic.com>",
+        )
+        .expect("commit should succeed");
+
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "codex line".ai(),
+        "edge 1".ai(),
+        "edge 2".ai(),
+        "edge 3".ai(),
+    ]);
+    let expected_session_id = generate_session_id(external_session_id, "codex");
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-edge-skip.txt",
+        &expected_session_id,
+        &[2, 3, 4, 5],
+    );
+    assert!(
+        session_ids_for_tool(&commit.authorship_log, "claude").is_empty(),
+        "commit metadata should not synthesize a Claude session after edge recovery removes all unknown lines"
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_uses_nearest_matching_tool_session_event() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("metadata-nearest.txt");
+    fs::write(&file_path, "cursor recovered from trailer\n").unwrap();
+    let file_ts = file_mtime_secs(&file_path);
+    let far_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(2),
+        "cursor",
+        "cursor-far-session",
+        "cursor-far-tool",
+        None,
+    );
+    let near_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts,
+        "cursor",
+        "cursor-near-session",
+        "cursor-near-tool",
+        None,
+    );
+
+    let commit = repo
+        .stage_all_and_commit(
+            "Recover from Cursor trailer\n\nCo-authored-by: Cursor <cursoragent@cursor.com>",
+        )
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("metadata-nearest.txt");
+    file.assert_committed_lines(lines!["cursor recovered from trailer".ai()]);
+    assert!(
+        !commit
+            .authorship_log
+            .metadata
+            .sessions
+            .contains_key(&far_session_id),
+        "nearest timestamp recovery should not select the farther Cursor session"
+    );
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-nearest.txt",
+        &near_session_id,
+        &[1],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_falls_back_to_most_recent_matching_tool_session() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("metadata-latest.txt");
+    fs::write(&file_path, "claude recovered from trailer\n").unwrap();
+    let file_ts = file_mtime_secs(&file_path);
+    let older_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(200),
+        "claude",
+        "claude-older-session",
+        "claude-older-tool",
+        None,
+    );
+    let latest_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(100),
+        "claude",
+        "claude-latest-session",
+        "claude-latest-tool",
+        None,
+    );
+
+    let commit = repo
+        .stage_all_and_commit(
+            "Recover from Claude trailer\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>",
+        )
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("metadata-latest.txt");
+    file.assert_committed_lines(lines!["claude recovered from trailer".ai()]);
+    assert!(
+        !commit
+            .authorship_log
+            .metadata
+            .sessions
+            .contains_key(&older_session_id),
+        "latest fallback should not select an older Claude session"
+    );
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-latest.txt",
+        &latest_session_id,
+        &[1],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_latest_matching_tool_prefers_current_repo_url() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/metadata-repo-url.git",
+    ])
+    .expect("remote add should succeed");
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("metadata-latest-repo-url.txt");
+    fs::write(&file_path, "cursor recovered with repo url\n").unwrap();
+    let file_ts = file_mtime_secs(&file_path);
+    let other_repo_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(100),
+        "cursor",
+        "cursor-other-repo-session",
+        "cursor-other-repo-tool",
+        Some("https://github.com/acme/other-repo"),
+    );
+    let same_repo_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(200),
+        "cursor",
+        "cursor-same-repo-session",
+        "cursor-same-repo-tool",
+        Some("https://github.com/acme/metadata-repo-url"),
+    );
+
+    let commit = repo
+        .stage_all_and_commit(
+            "Recover from Cursor trailer\n\nCo-authored-by: Cursor <cursoragent@cursor.com>",
+        )
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("metadata-latest-repo-url.txt");
+    file.assert_committed_lines(lines!["cursor recovered with repo url".ai()]);
+    assert!(
+        !commit
+            .authorship_log
+            .metadata
+            .sessions
+            .contains_key(&other_repo_session_id),
+        "latest fallback should reject an explicit session event from another repo"
+    );
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-latest-repo-url.txt",
+        &same_repo_session_id,
+        &[1],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_synthesizes_session_from_agent_author_email() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("metadata-author-email.txt");
+    fs::write(&file_path, "codex author email fallback\n").unwrap();
+
+    let commit = repo
+        .stage_all_and_commit_with_env(
+            "Recover from author email",
+            &[
+                ("GIT_AUTHOR_NAME", "Codex"),
+                ("GIT_AUTHOR_EMAIL", "codex@openai.com"),
+            ],
+        )
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("metadata-author-email.txt");
+    file.assert_committed_lines(lines!["codex author email fallback".ai()]);
+
+    let codex_sessions = session_ids_for_tool(&commit.authorship_log, "codex");
+    assert_eq!(
+        codex_sessions.len(),
+        1,
+        "author-email fallback should synthesize one Codex session"
+    );
+    assert!(
+        codex_sessions[0].starts_with("s_"),
+        "synthesized session ids should use the session id namespace"
+    );
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-author-email.txt",
+        &codex_sessions[0],
+        &[1],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_ignores_freeform_message_agent_mentions() {
+    let repo = TestRepo::new();
+
+    let file_path = repo.path().join("metadata-freeform-agent-mention.txt");
+    fs::write(&file_path, "freeform codex mention should stay unknown\n").unwrap();
+
+    let commit = repo
+        .stage_all_and_commit_with_env(
+            "codex did things",
+            &[
+                ("GIT_AUTHOR_NAME", "Sasha Varlamov"),
+                ("GIT_AUTHOR_EMAIL", "sasha@sashavarlamov.com"),
+            ],
+        )
+        .expect("freeform mention commit should succeed");
+
+    let mut file = repo.filename("metadata-freeform-agent-mention.txt");
+    file.assert_committed_lines(lines![
+        "freeform codex mention should stay unknown".unattributed_human()
+    ]);
+    assert!(
+        commit.authorship_log.metadata.sessions.is_empty(),
+        "freeform message text mentioning Codex should not synthesize an AI session"
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_ignores_ambiguous_identity_markers() {
+    let repo = TestRepo::new();
+
+    let amp_file_path = repo.path().join("metadata-ambiguous-amp.txt");
+    fs::write(&amp_file_path, "ambiguous amp trailer\n").unwrap();
+    let amp_commit = repo
+        .stage_all_and_commit("Ambiguous AMP trailer\n\nCo-authored-by: AMP Team <team@amp.dev>")
+        .expect("amp trailer commit should succeed");
+
+    let mut amp_file = repo.filename("metadata-ambiguous-amp.txt");
+    amp_file.assert_committed_lines(lines!["ambiguous amp trailer".unattributed_human()]);
+    assert!(
+        amp_commit.authorship_log.metadata.sessions.is_empty(),
+        "ambiguous AMP identity should not synthesize an AI session"
+    );
+
+    let continue_file_path = repo.path().join("metadata-ambiguous-continue.txt");
+    fs::write(&continue_file_path, "ambiguous continue trailer\n").unwrap();
+    let continue_commit = repo
+        .stage_all_and_commit(
+            "Ambiguous Continue trailer\n\nCo-authored-by: Continue Project <dev@continue.dev>",
+        )
+        .expect("continue trailer commit should succeed");
+
+    let mut continue_file = repo.filename("metadata-ambiguous-continue.txt");
+    continue_file.assert_committed_lines(lines!["ambiguous continue trailer".unattributed_human()]);
+    assert!(
+        continue_commit.authorship_log.metadata.sessions.is_empty(),
+        "ambiguous Continue identity should not synthesize an AI session"
+    );
+
+    let openai_file_path = repo.path().join("metadata-ambiguous-openai.txt");
+    fs::write(&openai_file_path, "generic openai noreply trailer\n").unwrap();
+    let openai_commit = repo
+        .stage_all_and_commit(
+            "Ambiguous OpenAI trailer\n\nCo-authored-by: OpenAI Release Bot <noreply@openai.com>",
+        )
+        .expect("generic OpenAI noreply trailer commit should succeed");
+
+    let mut openai_file = repo.filename("metadata-ambiguous-openai.txt");
+    openai_file.assert_committed_lines(lines![
+        "generic openai noreply trailer".unattributed_human()
+    ]);
+    assert!(
+        openai_commit.authorship_log.metadata.sessions.is_empty(),
+        "generic OpenAI noreply identity should not synthesize a Codex session"
+    );
+
+    for (file_name, line, identity, message) in [
+        (
+            "metadata-ambiguous-claude.txt",
+            "human named claude trailer",
+            "Claude Smith <claude.smith@example.com>",
+            "ambiguous Claude human identity should not synthesize an AI session",
+        ),
+        (
+            "metadata-ambiguous-devin.txt",
+            "human named devin trailer",
+            "Devin Patel <devin.patel@example.com>",
+            "ambiguous Devin human identity should not synthesize an AI session",
+        ),
+        (
+            "metadata-ambiguous-gemini.txt",
+            "human named gemini trailer",
+            "Gemini Jones <gemini.jones@example.com>",
+            "ambiguous Gemini human identity should not synthesize an AI session",
+        ),
+    ] {
+        let path = repo.path().join(file_name);
+        fs::write(&path, format!("{line}\n")).unwrap();
+        let commit = repo
+            .stage_all_and_commit(&format!(
+                "Ambiguous human trailer\n\nCo-authored-by: {identity}"
+            ))
+            .expect("ambiguous human identity commit should succeed");
+
+        let mut file = repo.filename(file_name);
+        file.assert_committed_lines(lines![line.unattributed_human()]);
+        assert!(
+            commit.authorship_log.metadata.sessions.is_empty(),
+            "{message}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Recover remaining unknown committed lines from AI-identifying commit metadata after cheaper recovery paths, including edge expansion, have already run. The new fallback detects known coding agents from co-author trailers, session trailers, and known agent author identities, then attributes any remaining unknown lines using the requested session selection order:

1. existing same-commit session for the detected agent
2. nearest matching metrics DB session using recent file timestamps, preferring same-repo metadata
3. latest matching metrics DB session for that agent, preferring same-repo metadata
4. synthesized session when no usable session metadata exists

This also records recovery metrics for the commit-metadata path, adds a metrics DB helper for latest matching session-event lookup, tightens ambiguous identity/email matching after Devin review feedback, rejects explicit different-repo metrics candidates, and skips commit-metadata work entirely when edge expansion removes all unknown lines.

## Tests

- `task fmt`
- `task lint`
- `task test TEST_FILTER=test_commit_metadata_recovery`
- `task test TEST_FILTER=edge_extension`
- `task test TEST_FILTER=session_event_attribution` (earlier run before latest ordering/repo-url tweaks; latest focused filters cover the changed behavior)
- `task test` (earlier run before Devin/order follow-ups; latest focused filters cover those follow-ups)