### PR TITLE
[codex] Respect CODEX_HOME for Codex paths

### DIFF
--- a/src/commands/checkpoint_agent/presets/codex.rs
+++ b/src/commands/checkpoint_agent/presets/codex.rs
@@ -8,6 +8,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::authorship::working_log::AgentId;
 use crate::commands::checkpoint_agent::bash_tool::{self, Agent, ToolClass};
 use crate::error::GitAiError;
+use crate::mdm::utils::codex_home_dir;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -36,10 +37,9 @@ impl CodexPreset {
             return Some(tp.to_string());
         }
 
-        let codex_home = dirs::home_dir()?.join(".codex");
         crate::streams::agents::CodexAgent::find_rollout_path_for_session_in_home(
             session_id,
-            &codex_home,
+            &codex_home_dir(),
         )
         .ok()
         .flatten()

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -2,7 +2,7 @@ use crate::config::{CodexHooksFormat, Config};
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
-    binary_exists, generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic,
+    binary_exists, codex_home_dir, generate_diff, is_git_ai_checkpoint_command, write_atomic,
 };
 use serde_json::{Value as JsonValue, json};
 use sha2::{Digest, Sha256};
@@ -18,11 +18,11 @@ pub struct CodexInstaller;
 
 impl CodexInstaller {
     fn config_path() -> PathBuf {
-        home_dir().join(".codex").join("config.toml")
+        codex_home_dir().join("config.toml")
     }
 
     fn hooks_json_path() -> PathBuf {
-        home_dir().join(".codex").join("hooks.json")
+        codex_home_dir().join("hooks.json")
     }
 
     fn desired_command(binary_path: &Path) -> String {
@@ -679,7 +679,7 @@ impl HookInstaller for CodexInstaller {
 
     fn check_hooks(&self, params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let has_binary = binary_exists("codex");
-        let has_dotfiles = home_dir().join(".codex").exists();
+        let has_dotfiles = codex_home_dir().exists();
 
         if !has_binary && !has_dotfiles {
             return Ok(HookCheckResult {
@@ -969,11 +969,13 @@ mod tests {
 
         let prev_home = std::env::var_os("HOME");
         let prev_userprofile = std::env::var_os("USERPROFILE");
+        let prev_codex_home = std::env::var_os("CODEX_HOME");
 
         // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
         unsafe {
             std::env::set_var("HOME", &home);
             std::env::set_var("USERPROFILE", &home);
+            std::env::remove_var("CODEX_HOME");
         }
 
         f(&home);
@@ -987,6 +989,10 @@ mod tests {
             match prev_userprofile {
                 Some(v) => std::env::set_var("USERPROFILE", v),
                 None => std::env::remove_var("USERPROFILE"),
+            }
+            match prev_codex_home {
+                Some(v) => std::env::set_var("CODEX_HOME", v),
+                None => std::env::remove_var("CODEX_HOME"),
             }
         }
     }
@@ -1422,6 +1428,65 @@ codex_hooks = true
             assert!(
                 CodexInstaller::config_has_inline_hooks(&parsed),
                 "inline hooks should be in config.toml"
+            );
+
+            let check = installer
+                .check_hooks(&params)
+                .expect("check should succeed");
+            assert!(check.tool_installed);
+            assert!(check.hooks_installed);
+            assert!(check.hooks_up_to_date);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_install_hooks_respects_codex_home() {
+        with_temp_home(|home| {
+            let default_codex_dir = home.join(".codex");
+            let custom_codex_home = home.join("custom-codex-home");
+            fs::create_dir_all(&custom_codex_home).unwrap();
+
+            // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+            unsafe {
+                std::env::set_var("CODEX_HOME", &custom_codex_home);
+            }
+
+            let config_path = custom_codex_home.join("config.toml");
+            fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            let diff = installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+            assert!(diff.is_some(), "install should report a config diff");
+            assert!(
+                !default_codex_dir.exists(),
+                "default ~/.codex should not be touched when CODEX_HOME is set"
+            );
+
+            let content = fs::read_to_string(&config_path).unwrap();
+            let parsed = CodexInstaller::parse_config_toml(&content).unwrap();
+            assert!(
+                CodexInstaller::config_has_inline_hooks(&parsed),
+                "inline hooks should be in CODEX_HOME/config.toml"
+            );
+
+            let state = parsed
+                .get("hooks")
+                .and_then(|hooks| hooks.get("state"))
+                .and_then(|state| state.as_table())
+                .expect("hook trust state should be written");
+            let config_path_str = config_path.to_string_lossy();
+            assert!(
+                state
+                    .keys()
+                    .all(|key| key.starts_with(config_path_str.as_ref())),
+                "trust state keys should reference CODEX_HOME/config.toml"
             );
 
             let check = installer

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -436,6 +436,17 @@ pub fn claude_config_dir() -> PathBuf {
     home_dir().join(".claude")
 }
 
+/// Codex home directory, respecting the CODEX_HOME env var.
+/// Falls back to ~/.codex when unset.
+pub fn codex_home_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("CODEX_HOME")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir);
+    }
+    home_dir().join(".codex")
+}
+
 /// Write data to a file atomically (write to temp, then rename)
 /// If the path is a symlink, writes to the target file (preserving the symlink)
 pub fn write_atomic(path: &Path, data: &[u8]) -> Result<(), GitAiError> {
@@ -1335,6 +1346,58 @@ mod tests {
             std::env::remove_var("CLAUDE_CONFIG_DIR");
         }
         assert_eq!(dir, home_dir().join(".claude"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_codex_home_dir_defaults_to_home_dot_codex() {
+        let prev = std::env::var_os("CODEX_HOME");
+        unsafe {
+            std::env::remove_var("CODEX_HOME");
+        }
+        let dir = codex_home_dir();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("CODEX_HOME", value),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+        assert_eq!(dir, home_dir().join(".codex"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_codex_home_dir_respects_env_var() {
+        let prev = std::env::var_os("CODEX_HOME");
+        let custom = "/tmp/my-codex-home";
+        unsafe {
+            std::env::set_var("CODEX_HOME", custom);
+        }
+        let dir = codex_home_dir();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("CODEX_HOME", value),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+        assert_eq!(dir, PathBuf::from(custom));
+    }
+
+    #[test]
+    #[serial]
+    fn test_codex_home_dir_ignores_empty_env_var() {
+        let prev = std::env::var_os("CODEX_HOME");
+        unsafe {
+            std::env::set_var("CODEX_HOME", "");
+        }
+        let dir = codex_home_dir();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("CODEX_HOME", value),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
+        assert_eq!(dir, home_dir().join(".codex"));
     }
 
     /// Regression test for #1039: write_atomic should create parent directories

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -1,6 +1,7 @@
 //! Codex agent implementation with sweep discovery.
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
+use crate::mdm::utils::codex_home_dir;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
@@ -78,10 +79,7 @@ impl CodexAgent {
     fn scan_session_files() -> Vec<PathBuf> {
         let mut paths = Vec::new();
 
-        let codex_home = match dirs::home_dir() {
-            Some(home) => home.join(".codex"),
-            None => return paths,
-        };
+        let codex_home = codex_home_dir();
 
         for subdir in &["sessions", "archived_sessions"] {
             let search_dir = codex_home.join(subdir);


### PR DESCRIPTION
## Summary
- add a shared Codex home resolver that honors `CODEX_HOME` and falls back to `~/.codex`
- use that resolver for Codex config/hook writes, hook trust-state keys, install detection, transcript fallback lookup, and stream sweeping
- add regression coverage for the helper and Codex installer path behavior

## Why
Codex documents `CODEX_HOME` as the root for Codex state, including config, hooks, sessions, and related metadata. The Git AI Codex installer was still writing to `~/.codex`, so users running Codex with a custom home could miss installed hooks or trust-state updates.

## Validation
- `task fmt`
- `task lint`
- `task test TEST_FILTER=codex_home`
- `task test TEST_FILTER=test_install_hooks_respects_codex_home`
- `task test TEST_FILTER=codex`