### PR TITLE
[gemini] Respect GEMINI_CLI_HOME for Gemini paths

### DIFF
--- a/src/mdm/agents/gemini.rs
+++ b/src/mdm/agents/gemini.rs
@@ -1,7 +1,7 @@
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
-    binary_exists, generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic,
+    binary_exists, gemini_config_dir, generate_diff, is_git_ai_checkpoint_command, write_atomic,
 };
 use serde_json::{Value, json};
 use std::fs;
@@ -16,7 +16,7 @@ pub struct GeminiInstaller;
 
 impl GeminiInstaller {
     fn settings_path() -> PathBuf {
-        home_dir().join(".gemini").join("settings.json")
+        gemini_config_dir().join("settings.json")
     }
 
     /// Returns `(hooks_installed, hooks_up_to_date)` from a parsed settings value.
@@ -325,7 +325,7 @@ impl HookInstaller for GeminiInstaller {
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
         let has_binary = binary_exists("gemini");
-        let has_dotfiles = home_dir().join(".gemini").exists();
+        let has_dotfiles = gemini_config_dir().exists();
 
         if !has_binary && !has_dotfiles {
             return Ok(HookCheckResult {
@@ -375,6 +375,7 @@ impl HookInstaller for GeminiInstaller {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
@@ -383,6 +384,40 @@ mod tests {
         let settings_path = temp_dir.path().join(".gemini").join("settings.json");
         fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
         (temp_dir, settings_path)
+    }
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().to_path_buf();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+        let prev_gemini_cli_home = std::env::var_os("GEMINI_CLI_HOME");
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+            std::env::remove_var("GEMINI_CLI_HOME");
+        }
+
+        f(&home);
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+            match prev_gemini_cli_home {
+                Some(v) => std::env::set_var("GEMINI_CLI_HOME", v),
+                None => std::env::remove_var("GEMINI_CLI_HOME"),
+            }
+        }
     }
 
     fn binary_path() -> PathBuf {
@@ -457,6 +492,49 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_install_hooks_respects_gemini_cli_home() {
+        with_temp_home(|home| {
+            let default_gemini_dir = home.join(".gemini");
+            let custom_gemini_home = home.join("custom-gemini-home");
+            fs::create_dir_all(&custom_gemini_home).unwrap();
+
+            // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+            unsafe {
+                std::env::set_var("GEMINI_CLI_HOME", &custom_gemini_home);
+            }
+
+            let settings_path = custom_gemini_home.join(".gemini").join("settings.json");
+            fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+            fs::write(&settings_path, "{}").unwrap();
+
+            let installer = GeminiInstaller;
+            let result = installer.install_hooks(&params(), false).unwrap();
+            assert!(result.is_some(), "install should report a settings diff");
+            assert!(
+                !default_gemini_dir.exists(),
+                "default ~/.gemini should not be touched when GEMINI_CLI_HOME is set"
+            );
+
+            let settings = read_settings(&settings_path);
+            assert_eq!(settings["tools"]["enableHooks"], true);
+            assert_eq!(
+                hooks_in_catch_all(&settings, "BeforeTool")[0]["command"],
+                expected_before_cmd()
+            );
+            assert_eq!(
+                hooks_in_catch_all(&settings, "AfterTool")[0]["command"],
+                expected_after_cmd()
+            );
+
+            let check = installer.check_hooks(&params()).unwrap();
+            assert!(check.tool_installed);
+            assert!(check.hooks_installed);
+            assert!(check.hooks_up_to_date);
+        });
     }
 
     #[test]

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -447,6 +447,17 @@ pub fn codex_home_dir() -> PathBuf {
     home_dir().join(".codex")
 }
 
+/// Gemini CLI config directory, respecting the GEMINI_CLI_HOME env var.
+/// GEMINI_CLI_HOME points to the user home root, and Gemini stores config under .gemini.
+pub fn gemini_config_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("GEMINI_CLI_HOME")
+        && !dir.is_empty()
+    {
+        return PathBuf::from(dir).join(".gemini");
+    }
+    home_dir().join(".gemini")
+}
+
 /// Write data to a file atomically (write to temp, then rename)
 /// If the path is a symlink, writes to the target file (preserving the symlink)
 pub fn write_atomic(path: &Path, data: &[u8]) -> Result<(), GitAiError> {
@@ -1367,6 +1378,23 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_gemini_config_dir_defaults_to_home_dot_gemini() {
+        let prev = std::env::var_os("GEMINI_CLI_HOME");
+        unsafe {
+            std::env::remove_var("GEMINI_CLI_HOME");
+        }
+        let dir = gemini_config_dir();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("GEMINI_CLI_HOME", value),
+                None => std::env::remove_var("GEMINI_CLI_HOME"),
+            }
+        }
+        assert_eq!(dir, home_dir().join(".gemini"));
+    }
+
+    #[test]
+    #[serial]
     fn test_codex_home_dir_respects_env_var() {
         let prev = std::env::var_os("CODEX_HOME");
         let custom = "/tmp/my-codex-home";
@@ -1385,6 +1413,24 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_gemini_config_dir_respects_env_var() {
+        let prev = std::env::var_os("GEMINI_CLI_HOME");
+        let custom = "/tmp/my-gemini-home";
+        unsafe {
+            std::env::set_var("GEMINI_CLI_HOME", custom);
+        }
+        let dir = gemini_config_dir();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("GEMINI_CLI_HOME", value),
+                None => std::env::remove_var("GEMINI_CLI_HOME"),
+            }
+        }
+        assert_eq!(dir, PathBuf::from(custom).join(".gemini"));
+    }
+
+    #[test]
+    #[serial]
     fn test_codex_home_dir_ignores_empty_env_var() {
         let prev = std::env::var_os("CODEX_HOME");
         unsafe {
@@ -1398,6 +1444,23 @@ mod tests {
             }
         }
         assert_eq!(dir, home_dir().join(".codex"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_gemini_config_dir_ignores_empty_env_var() {
+        let prev = std::env::var_os("GEMINI_CLI_HOME");
+        unsafe {
+            std::env::set_var("GEMINI_CLI_HOME", "");
+        }
+        let dir = gemini_config_dir();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("GEMINI_CLI_HOME", value),
+                None => std::env::remove_var("GEMINI_CLI_HOME"),
+            }
+        }
+        assert_eq!(dir, home_dir().join(".gemini"));
     }
 
     /// Regression test for #1039: write_atomic should create parent directories

--- a/src/streams/agents/gemini.rs
+++ b/src/streams/agents/gemini.rs
@@ -1,6 +1,7 @@
 //! Gemini agent implementation with sweep discovery.
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
+use crate::mdm::utils::gemini_config_dir;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
@@ -11,7 +12,8 @@ use std::time::Duration;
 
 /// Gemini agent that discovers conversations from Gemini CLI session storage.
 ///
-/// Gemini CLI stores JSONL chat transcripts under `~/.gemini/tmp/<project>/chats/`.
+/// Gemini CLI stores JSONL chat transcripts under `.gemini/tmp/<project>/chats/`
+/// within the configured Gemini CLI home.
 pub struct GeminiAgent {
     batch_size: usize,
 }
@@ -28,13 +30,12 @@ impl GeminiAgent {
 
     /// Scan for Gemini session files in standard locations.
     ///
-    /// Searches `~/.gemini/tmp/*/chats/session-*.jsonl`.
+    /// Searches `.gemini/tmp/*/chats/session-*.jsonl` under the configured Gemini CLI home.
     fn scan_session_files() -> Vec<PathBuf> {
         let mut paths = Vec::new();
 
-        if let Some(gemini_tmp) = dirs::home_dir().map(|p| p.join(".gemini/tmp"))
-            && gemini_tmp.exists()
-        {
+        let gemini_tmp = gemini_config_dir().join("tmp");
+        if gemini_tmp.exists() {
             let Ok(project_dirs) = fs::read_dir(&gemini_tmp) else {
                 return paths;
             };
@@ -236,6 +237,7 @@ impl Agent for GeminiAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn test_sweep_strategy() {
@@ -244,6 +246,41 @@ mod tests {
             agent.sweep_strategy(),
             SweepStrategy::Periodic(Duration::from_secs(30 * 60))
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_scan_session_files_respects_gemini_cli_home() {
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let gemini_home = temp_dir.path().join("gemini-home");
+        let chats_dir = gemini_home
+            .join(".gemini")
+            .join("tmp")
+            .join("project")
+            .join("chats");
+        fs::create_dir_all(&chats_dir).unwrap();
+        let session_path = chats_dir.join("session-test.jsonl");
+        let mut file = fs::File::create(&session_path).unwrap();
+        writeln!(file, "{}", make_gemini_line(0)).unwrap();
+
+        let prev = std::env::var_os("GEMINI_CLI_HOME");
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("GEMINI_CLI_HOME", &gemini_home);
+        }
+        let paths = GeminiAgent::scan_session_files();
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("GEMINI_CLI_HOME", value),
+                None => std::env::remove_var("GEMINI_CLI_HOME"),
+            }
+        }
+
+        assert_eq!(paths, vec![session_path]);
     }
 
     fn make_gemini_line(i: usize) -> String {


### PR DESCRIPTION
## Summary
- add a Gemini config directory resolver that honors `GEMINI_CLI_HOME` as a home root and falls back to `~/.gemini`
- use the resolver for Gemini hook settings detection and writes
- use the same resolver for Gemini transcript sweep discovery under `.gemini/tmp`
- add regression coverage for helper semantics, installer behavior, and stream discovery

## Why
Gemini CLI documents `GEMINI_CLI_HOME` as the home override used for its `.gemini` state directory. Git AI previously always read and wrote `~/.gemini`, so hook installation and transcript sweeping could miss users running Gemini with a custom home.

## Validation
- `task fmt`
- `task lint`
- `task test TEST_FILTER=gemini_config_dir`
- `task test TEST_FILTER=test_install_hooks_respects_gemini_cli_home`
- `task test TEST_FILTER=test_scan_session_files_respects_gemini_cli_home`
- `task test TEST_FILTER=gemini`