### PR TITLE
[codex] Bound fast-forward authorship hunks to final commit

### DIFF
--- a/src/authorship/diff_base.rs
+++ b/src/authorship/diff_base.rs
@@ -1,0 +1,17 @@
+pub(crate) const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/// Resolve the diff base for post-commit diff parsing so the diff is always
+/// bounded to the single commit being finalized.
+///
+/// The caller's `parent_sha` is normally the immediate parent already, but on
+/// the daemon's fast-forward `update-ref` path it can be the old branch tip from
+/// before a pull. Using `<commit_sha>^` lets Git resolve the finalized commit's
+/// first parent inside the existing diff spawn. Root commits use Git's empty
+/// tree hash because there is no parent revision.
+pub(crate) fn single_commit_diff_base(parent_sha: &str, commit_sha: &str) -> String {
+    if parent_sha == "initial" {
+        EMPTY_TREE_SHA.to_string()
+    } else {
+        format!("{commit_sha}^")
+    }
+}

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -6,6 +6,7 @@ pub mod authorship_log_serialization;
 pub mod background_agent;
 pub mod conflict_resolution;
 pub mod diff_ai_accepted;
+pub(crate) mod diff_base;
 pub mod git_ai_hooks;
 pub mod hunk_shift;
 pub mod ignore;

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -2,12 +2,13 @@ use crate::authorship::attribution_recovery::{
     AttributionRecoveryContext, FileTimestampsByPath, UnknownLinesByFile,
 };
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::diff_base::single_commit_diff_base;
 use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
 use crate::authorship::rewrite::DiffTreeResult;
 use crate::authorship::stats::{stats_for_commit_stats_from_hunks, write_stats_to_terminal};
-use crate::authorship::virtual_attribution::VirtualAttributions;
+use crate::authorship::virtual_attribution::{AuthorshipLogDiffContext, VirtualAttributions};
 use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry};
 use crate::config::Config;
 use crate::error::GitAiError;
@@ -32,8 +33,6 @@ pub const STATS_SKIP_MAX_FILES_WITH_ADDITIONS: usize = 200;
 /// near zero, so the cost was previously invisible to the estimator.
 #[doc(hidden)]
 pub const STATS_SKIP_MAX_DELETED_LINES: usize = 6000;
-
-const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]
@@ -316,6 +315,7 @@ where
         pathspecs.insert(file_path.clone());
     }
 
+    let committed_diff_base = single_commit_diff_base(&parent_sha, &commit_sha);
     let (mut authorship_log, initial_attributions, initial_file_contents) = working_va
         .to_authorship_log_and_initial_working_log_with_precomputed_diff(
             repo,
@@ -323,7 +323,10 @@ where
             &commit_sha,
             Some(&pathspecs),
             Some(&observed_snapshot),
-            context.precomputed_parent_diff,
+            AuthorshipLogDiffContext {
+                precomputed_parent_diff: context.precomputed_parent_diff,
+                fallback_committed_diff_base: Some(&committed_diff_base),
+            },
         )?;
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
@@ -584,33 +587,6 @@ fn commit_tree_snapshot_for_files(
     }
 
     Ok(snapshot)
-}
-
-/// Resolve the diff base for post-commit diff parsing so the diff is always
-/// bounded to the single commit being finalized — without any extra git spawn
-/// or object lookup.
-///
-/// The caller's `parent_sha` is normally the immediate parent already, but on
-/// the daemon's fast-forward `update-ref` path it is the *old branch tip* from
-/// before a `git pull` — potentially thousands of commits back. Diffing that
-/// full range buffers the entire history delta into memory (the 20GB+ blow-up
-/// in PD-23 / #1677).
-///
-/// Rather than resolving the parent OID (which costs `find_commit` +
-/// `parent(0)` git spawns on *every* post-commit), we express "the immediate
-/// first parent" as the rev-expression `<commit_sha>^`. Git resolves it inside
-/// the `git diff` spawn that already runs, so this adds zero spawns. For root
-/// commits there is no `^`, signalled by `parent_sha == "initial"`, in which
-/// case we diff against the empty tree exactly as before.
-fn single_commit_diff_base(parent_sha: &str, commit_sha: &str) -> String {
-    if parent_sha == "initial" {
-        EMPTY_TREE_SHA.to_string()
-    } else {
-        // `^` is `^1`, the first parent — matches the previous `parent(0)`
-        // resolution for merges (first-parent diff) and is identical to
-        // `parent_sha` on the normal/amend paths.
-        format!("{commit_sha}^")
-    }
 }
 
 fn recovery_committed_hunks(

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -34,6 +34,12 @@ pub struct VirtualAttributions {
     pub sessions: BTreeMap<String, SessionRecord>,
 }
 
+#[derive(Clone, Copy, Default)]
+pub(crate) struct AuthorshipLogDiffContext<'a> {
+    pub precomputed_parent_diff: Option<&'a crate::authorship::rewrite::DiffTreeResult>,
+    pub fallback_committed_diff_base: Option<&'a str>,
+}
+
 impl VirtualAttributions {
     /// Create a new VirtualAttributions for the given base commit with initial pathspecs
     pub async fn new_for_base_commit(
@@ -2073,7 +2079,7 @@ impl VirtualAttributions {
             commit_sha,
             pathspecs,
             final_state_snapshot,
-            None,
+            AuthorshipLogDiffContext::default(),
         )
     }
 
@@ -2081,8 +2087,11 @@ impl VirtualAttributions {
     /// pre-computed parent→commit `DiffTreeResult` so a batched caller (e.g. the
     /// rebase conflict-resolution driver) can supply renames + committed hunks
     /// from a single batched `diff-tree` instead of this method spawning its own
-    /// per-commit `git diff` / `git diff-tree`. When `None`, behavior is
-    /// identical to the unbatched path (used by every single-commit caller).
+    /// per-commit `git diff` / `git diff-tree`.
+    ///
+    /// When the context has no precomputed diff, it may override the diff base
+    /// used only for committed-hunk and rename classification. Other
+    /// reconciliation still uses `parent_sha`.
     pub(crate) fn to_authorship_log_and_initial_working_log_with_precomputed_diff(
         &self,
         repo: &Repository,
@@ -2090,7 +2099,7 @@ impl VirtualAttributions {
         commit_sha: &str,
         pathspecs: Option<&HashSet<String>>,
         final_state_snapshot: Option<&HashMap<String, String>>,
-        precomputed_parent_diff: Option<&crate::authorship::rewrite::DiffTreeResult>,
+        diff_context: AuthorshipLogDiffContext<'_>,
     ) -> Result<
         (
             crate::authorship::authorship_log_serialization::AuthorshipLog,
@@ -2129,10 +2138,19 @@ impl VirtualAttributions {
         // Detect renames so we can look up committed hunks by new path when
         // the working log references the old path. A batched caller may supply
         // the parent→commit diff (renames included); otherwise spawn per-commit.
+        //
+        // The persisted working-log base can be an older ref tip on daemon
+        // fast-forward paths. Diff classification must still be bounded to the
+        // finalized commit, while carryover reconciliation below continues to
+        // use the original working-log base.
+        let precomputed_parent_diff = diff_context.precomputed_parent_diff;
+        let fallback_diff_base = diff_context
+            .fallback_committed_diff_base
+            .unwrap_or(parent_sha);
         let rename_map = if let Some(diff) = precomputed_parent_diff {
             diff.renames.iter().cloned().collect()
         } else if parent_sha != "initial" {
-            detect_renames_in_commit(repo, parent_sha, commit_sha).unwrap_or_default()
+            detect_renames_in_commit(repo, fallback_diff_base, commit_sha).unwrap_or_default()
         } else {
             HashMap::new()
         };
@@ -2158,7 +2176,7 @@ impl VirtualAttributions {
         let committed_hunks = if let Some(diff) = precomputed_parent_diff {
             committed_hunks_from_diff_result(diff, effective_pathspecs)
         } else {
-            collect_committed_hunks(repo, parent_sha, commit_sha, effective_pathspecs)?
+            collect_committed_hunks(repo, fallback_diff_base, commit_sha, effective_pathspecs)?
         };
         let carryover_snapshot = if let Some(snapshot) = final_state_snapshot {
             Some(build_carryover_snapshot(

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -70,6 +70,28 @@ fn assert_note_has_ai_for_file(repo: &TestRepo, commit_sha: &str, file_path: &st
     );
 }
 
+fn ai_attested_lines_for_file(
+    log: &AuthorshipLog,
+    file_path: &str,
+) -> std::collections::BTreeSet<u32> {
+    log.attestations
+        .iter()
+        .find(|attestation| attestation.file_path == file_path)
+        .map(|attestation| {
+            attestation
+                .entries
+                .iter()
+                .filter(|entry| {
+                    let author_id = entry.hash.split("::").next().unwrap_or(&entry.hash);
+                    log.metadata.sessions.contains_key(author_id)
+                        || log.metadata.prompts.contains_key(&entry.hash)
+                })
+                .flat_map(|entry| entry.line_ranges.iter().flat_map(|range| range.expand()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn raw_traced_git(repo: &TestRepo, args: &[&str]) -> String {
     let mut command = Command::new(real_git_executable());
     command.arg("-C").arg(repo.path()).args(args);
@@ -1753,6 +1775,85 @@ fn test_update_ref_current_branch_with_new_content_preserves_attribution() {
 
     let mut feature_file = repo.filename("branch-plumbing.txt");
     feature_file.assert_lines_and_blame(lines!["branch ai".ai()]);
+}
+
+#[test]
+fn test_update_ref_fast_forward_bounds_committed_hunks_to_final_commit() {
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+
+    let file_rel = "ff-overlap.txt";
+    let file_path = repo.path().join(file_rel);
+    fs::write(&file_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", file_rel])
+        .unwrap();
+    repo.stage_all_and_commit("add fast-forward overlap base")
+        .unwrap();
+    let mut file = repo.filename(file_rel);
+    file.assert_committed_lines(lines!["base".human()]);
+
+    let old_tip = head_sha(&repo);
+    let final_content = "base\nintermediate pulled line\nfinal checkpointed line\n";
+    fs::write(&file_path, final_content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", file_rel]).unwrap();
+    repo.sync_daemon();
+
+    fs::write(&file_path, "base\nintermediate pulled line\n").unwrap();
+    raw_untraced_git(&repo, &["add", file_rel]);
+    let intermediate_tree = raw_untraced_git(&repo, &["write-tree"]).trim().to_string();
+    let intermediate_commit = raw_untraced_git(
+        &repo,
+        &[
+            "commit-tree",
+            &intermediate_tree,
+            "-p",
+            &old_tip,
+            "-m",
+            "intermediate pulled commit",
+        ],
+    )
+    .trim()
+    .to_string();
+
+    fs::write(&file_path, final_content).unwrap();
+    raw_untraced_git(&repo, &["add", file_rel]);
+    let final_tree = raw_untraced_git(&repo, &["write-tree"]).trim().to_string();
+    let final_commit = raw_untraced_git(
+        &repo,
+        &[
+            "commit-tree",
+            &final_tree,
+            "-p",
+            &intermediate_commit,
+            "-m",
+            "final pulled commit",
+        ],
+    )
+    .trim()
+    .to_string();
+
+    repo.git(&["update-ref", "HEAD", &final_commit, &old_tip])
+        .unwrap();
+    let note = repo
+        .read_authorship_note(&final_commit)
+        .expect("fast-forward final commit should have an authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse authorship note");
+    let ai_lines = ai_attested_lines_for_file(&log, file_rel);
+
+    assert!(
+        !ai_lines.contains(&2),
+        "intermediate pulled line must not be attributed from the old-tip..new-head diff: {ai_lines:?}"
+    );
+    assert!(
+        ai_lines.contains(&3),
+        "final commit line should remain attributed to the checkpointed AI edit: {ai_lines:?}"
+    );
+
+    file.assert_committed_lines(lines![
+        "base".human(),
+        "intermediate pulled line".human(),
+        "final checkpointed line".ai(),
+    ]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes a follow-up from PR #1699: when the daemon handles a fast-forward `update-ref` and finalizes a working log from the old branch tip, the main authorship conversion now bounds fallback diff classification to the finalized commit's first parent instead of diffing the whole old-tip..new-head range.

This keeps committed hunk and rename fallback detection consistent with the recovery and stats paths from PR #1699, while preserving the original working-log base for carryover reconciliation.

## Validation

- `task fmt`
- `task lint`
- `task test TEST_FILTER=test_update_ref_fast_forward_bounds_committed_hunks_to_final_commit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->