### PR TITLE
[codex] Handle zero-arg pull aliases in reflog matching

### DIFF
--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -2518,6 +2518,8 @@ fn pull_reflog_action(cmd: &NormalizedCommand) -> String {
     let parsed = parse_git_cli_args(&raw_args);
     let args = if parsed.command.as_deref() == Some("pull") {
         parsed.command_args
+    } else if cmd.invoked_command.as_deref() == Some("pull") {
+        cmd.invoked_args.clone()
     } else {
         command_args(cmd)
     };
@@ -5317,6 +5319,17 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn pull_reflog_action_uses_expanded_command_for_zero_arg_alias() {
+        let family = FamilyKey::new("/repo/.git".to_string());
+        let mut cmd = command_with_worktree(&family, None, &["up"]);
+        cmd.primary_command = Some("pull".to_string());
+        cmd.invoked_command = Some("pull".to_string());
+        cmd.invoked_args.clear();
+
+        assert_eq!(pull_reflog_action(&cmd), "pull");
     }
 
     #[test]

--- a/src/metrics/local_stats.rs
+++ b/src/metrics/local_stats.rs
@@ -1478,7 +1478,16 @@ mod tests {
 
     #[test]
     fn derived_summary_from_records() {
-        let now = now_ts();
+        let now = Local
+            .from_local_datetime(
+                &Local::now()
+                    .date_naive()
+                    .and_hms_opt(12, 0, 0)
+                    .expect("local noon should exist"),
+            )
+            .single()
+            .expect("local noon should be unambiguous")
+            .timestamp() as u32;
         let repo = "github.com/acme/project";
         // Two sessions: one spanning ~1h, one a single event.
         let session_start = now.saturating_sub(7200);

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -712,6 +712,46 @@ fn test_pull_rebase_via_alias_preserves_committed_ai_authorship() {
     ]);
 }
 
+#[test]
+fn test_pull_rebase_via_zero_arg_alias_and_git_config_preserves_committed_ai_authorship() {
+    // Regression: `git up` where `up = pull` and `pull.rebase=true`. The alias
+    // expands to `pull` with no explicit args, so the normalized invocation must
+    // still keep `pull` visible instead of falling back to the raw alias token.
+    let setup = setup_divergent_pull_test();
+    let local = setup.local;
+
+    local
+        .git(&["config", "alias.up", "pull"])
+        .expect("set alias.up should succeed");
+    local
+        .git(&["config", "pull.rebase", "true"])
+        .expect("set pull.rebase should succeed");
+
+    local.git(&["up"]).expect("aliased pull should succeed");
+
+    assert!(
+        local.read_file("upstream_change.txt").is_some(),
+        "Should have upstream_change.txt after aliased config-driven pull --rebase"
+    );
+
+    let new_head = local
+        .git(&["rev-parse", "HEAD"])
+        .expect("rev-parse should succeed")
+        .trim()
+        .to_string();
+
+    assert_ne!(
+        new_head, setup.local_ai_commit_sha,
+        "HEAD should have a new SHA after rebase"
+    );
+
+    let mut ai_file = local.filename("ai_feature.txt");
+    ai_file.assert_lines_and_blame(vec![
+        "AI generated feature line 1".ai(),
+        "AI generated feature line 2".ai(),
+    ]);
+}
+
 // =============================================================================
 // Pull --rebase --autostash with uncommitted changes
 // =============================================================================
@@ -1941,6 +1981,7 @@ crate::reuse_tests_in_worktree!(
     test_fast_forward_pull_without_local_changes,
     test_pull_rebase_preserves_committed_ai_authorship,
     test_pull_rebase_via_git_config_preserves_committed_ai_authorship,
+    test_pull_rebase_via_zero_arg_alias_and_git_config_preserves_committed_ai_authorship,
     test_pull_rebase_autostash_preserves_uncommitted_ai_attribution,
     test_pull_rebase_autostash_with_mixed_attribution,
     test_pull_rebase_autostash_via_git_config,


### PR DESCRIPTION
## Summary

This follow-up fixes the remaining zero-argument pull alias case from the pull-rebase alias work.

When `alias.up = pull` and `pull.rebase=true`, Git expands `git up` to `pull` before writing rebase reflog entries, but the daemon's pull reflog action reconstruction could still fall back to the raw alias token. That made the matcher look for `pull up` instead of Git's `pull (start)` / `pull (finish)` entries.

The fix makes `pull_reflog_action()` use the alias-expanded `invoked_command` when raw argv is still an alias token, while keeping `invoked_args` as true command arguments.

The PR also includes a small test-only stabilization for `derived_summary_from_records`, which was using wall-clock `now` near midnight and could spread synthetic records across two local calendar days.

## Validation

- `task test TEST_FILTER=pull_reflog_action_uses_expanded_command_for_zero_arg_alias CARGO_TEST_ARGS="--lib"`
- `task test TEST_FILTER=test_pull_rebase_via_zero_arg_alias_and_git_config_preserves_committed_ai_authorship`
- `task test TEST_FILTER=test_pull_rebase_via_`
- `task test TEST_FILTER=metrics::local_stats::tests::derived_summary_from_records CARGO_TEST_ARGS="--lib"`
- `task fmt`
- `task lint`