### PR TITLE
Add signed package installer scaffolding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release Build
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -195,6 +196,37 @@ jobs:
         run: |
           cp target/${{ matrix.target }}/release/git-ai release/${{ matrix.artifact_name }}
 
+      - name: Sign macOS binary
+        if: contains(matrix.os, 'macos')
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Skipping macOS binary signing for dry run because signing secrets are not configured."
+              exit 0
+            fi
+            echo "::error::Missing Apple Developer ID Application signing secrets."
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > app-signing.p12
+          security import app-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          codesign --force --timestamp --options runtime --sign "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" "release/${{ matrix.artifact_name }}"
+          codesign --verify --strict --verbose=2 "release/${{ matrix.artifact_name }}"
+
       - name: Upload artifact (Windows)
         if: contains(matrix.os, 'windows')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -271,6 +303,36 @@ jobs:
         run: |
           cp target/x86_64-apple-darwin/release/git-ai release/git-ai-macos-x64
 
+      - name: Sign macOS binary
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Skipping macOS binary signing for dry run because signing secrets are not configured."
+              exit 0
+            fi
+            echo "::error::Missing Apple Developer ID Application signing secrets."
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > app-signing.p12
+          security import app-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          codesign --force --timestamp --options runtime --sign "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" release/git-ai-macos-x64
+          codesign --verify --strict --verbose=2 release/git-ai-macos-x64
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -278,9 +340,254 @@ jobs:
           path: release/git-ai-macos-x64
           retention-days: 30
 
+  package-msi:
+    name: Build Windows MSI installers
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download Windows x64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-windows-x64
+          path: artifacts
+
+      - name: Download Windows ARM64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-windows-arm64
+          path: artifacts
+
+      - name: Build MSI installers
+        shell: pwsh
+        run: |
+          $version = "${{ needs.build.outputs.version }}".TrimStart('v')
+          New-Item -ItemType Directory -Force -Path release | Out-Null
+          .\packaging\windows\build-msi.ps1 -BinaryPath "artifacts\git-ai-windows-x64.exe" -Architecture x64 -Version $version -OutputPath "release\git-ai-windows-x64.msi"
+          .\packaging\windows\build-msi.ps1 -BinaryPath "artifacts\git-ai-windows-arm64.exe" -Architecture arm64 -Version $version -OutputPath "release\git-ai-windows-arm64.msi"
+
+      - name: Azure login for MSI signing
+        if: inputs.dry_run != true
+        uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign MSI installers
+        if: inputs.dry_run != true
+        uses: azure/artifact-signing-action@c0ae2c1d0c1847ab81ac0ab8521bee597cfedd30 # v2
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERT_PROFILE }}
+          files-folder: ${{ github.workspace }}\release
+          files-folder-filter: msi
+          file-digest: SHA256
+
+      - name: Upload MSI artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-ai-windows-msi
+          path: release/*.msi
+          retention-days: 30
+
+  package-pkg:
+    name: Build macOS PKG installers
+    needs: [build, build-macos-intel]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download macOS ARM64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-arm64
+          path: artifacts
+
+      - name: Download macOS x64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-x64
+          path: artifacts
+
+      - name: Import Apple installer certificate
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
+          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_IDENTITY}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Skipping PKG signing for dry run because signing secrets are not configured."
+              exit 0
+            fi
+            echo "::error::Missing Apple Developer ID Installer signing secrets."
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64" | base64 --decode > installer-signing.p12
+          security import installer-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD" -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+      - name: Build PKG installers
+        shell: bash
+        env:
+          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="${VERSION#v}"
+          mkdir -p release
+          chmod +x artifacts/git-ai-macos-arm64 artifacts/git-ai-macos-x64
+          packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-arm64 --arch arm64 --version "$VERSION" --output release/git-ai-macos-arm64.pkg
+          packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-x64 --arch x64 --version "$VERSION" --output release/git-ai-macos-x64.pkg
+
+      - name: Notarize PKG installers
+        if: inputs.dry_run != true
+        shell: bash
+        env:
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_NOTARY_KEY_ID}" || -z "${APPLE_NOTARY_ISSUER_ID}" || -z "${APPLE_NOTARY_KEY_P8_BASE64}" ]]; then
+            echo "::error::Missing Apple notarization secrets."
+            exit 1
+          fi
+          mkdir -p private_keys
+          echo "$APPLE_NOTARY_KEY_P8_BASE64" | base64 --decode > "private_keys/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+          for pkg in release/*.pkg; do
+            xcrun notarytool submit "$pkg" --key "private_keys/AuthKey_${APPLE_NOTARY_KEY_ID}.p8" --key-id "$APPLE_NOTARY_KEY_ID" --issuer "$APPLE_NOTARY_ISSUER_ID" --wait
+            xcrun stapler staple "$pkg"
+            xcrun stapler validate "$pkg"
+          done
+
+      - name: Upload PKG artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-ai-macos-pkg
+          path: release/*.pkg
+          retention-days: 30
+
+  package-deb:
+    name: Build Debian packages
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download Linux x64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-linux-x64
+          path: artifacts
+
+      - name: Download Linux ARM64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-linux-arm64
+          path: artifacts
+
+      - name: Build deb packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="${VERSION#v}"
+          mkdir -p release
+          chmod +x artifacts/git-ai-linux-x64 artifacts/git-ai-linux-arm64
+          packaging/debian/build-deb.sh --binary artifacts/git-ai-linux-x64 --arch amd64 --version "$VERSION" --output "release/git-ai_${VERSION}_amd64.deb"
+          packaging/debian/build-deb.sh --binary artifacts/git-ai-linux-arm64 --arch arm64 --version "$VERSION" --output "release/git-ai_${VERSION}_arm64.deb"
+
+      - name: Upload deb artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-ai-linux-deb
+          path: release/*.deb
+          retention-days: 30
+
+  test-msi:
+    name: Test Windows MSI installer
+    needs: package-msi
+    runs-on: windows-latest
+    steps:
+      - name: Download MSI artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-windows-msi
+          path: release
+
+      - name: Install and uninstall MSI
+        shell: pwsh
+        run: |
+          $msi = (Get-ChildItem release\git-ai-windows-x64.msi).FullName
+          $install = Start-Process msiexec -ArgumentList "/i `"$msi`" /qn /norestart" -Wait -PassThru
+          if ($install.ExitCode -ne 0) { throw "MSI install failed with exit code $($install.ExitCode)" }
+          & "C:\Program Files\Git AI\git-ai.exe" --version
+          if (Test-Path "C:\Program Files\Git AI\git.exe") { throw "MSI installed a git.exe shim" }
+          $uninstall = Start-Process msiexec -ArgumentList "/x `"$msi`" /qn /norestart" -Wait -PassThru
+          if ($uninstall.ExitCode -ne 0) { throw "MSI uninstall failed with exit code $($uninstall.ExitCode)" }
+
+  test-pkg:
+    name: Test macOS PKG installer
+    needs: package-pkg
+    runs-on: macos-latest
+    steps:
+      - name: Download PKG artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-pkg
+          path: release
+
+      - name: Install PKG
+        run: |
+          if [ "$(uname -m)" = "arm64" ]; then
+            PKG=release/git-ai-macos-arm64.pkg
+          else
+            PKG=release/git-ai-macos-x64.pkg
+          fi
+          sudo installer -pkg "$PKG" -target /
+          /usr/local/bin/git-ai --version
+          test ! -e /usr/local/bin/git
+          pkgutil --pkg-info com.git-ai.git-ai
+
+  test-deb:
+    name: Test Debian package
+    needs: package-deb
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download deb artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-linux-deb
+          path: release
+
+      - name: Install and remove deb
+        run: |
+          sudo dpkg -i release/*_amd64.deb
+          /usr/bin/git-ai --version
+          test ! -e /usr/bin/git
+          dpkg -L git-ai
+          sudo apt-get remove -y git-ai
+          test ! -e /usr/bin/git-ai
+
   create-release:
     name: Create Release
-    needs: [build, build-macos-intel]
+    needs: [build, build-macos-intel, package-msi, package-pkg, package-deb, test-msi, test-pkg, test-deb]
     runs-on: ubuntu-latest
     if: success() && inputs.dry_run != true
     environment: release
@@ -327,7 +634,7 @@ jobs:
 
       - name: Move artifacts to release directory
         run: |
-          find artifacts -name "git-ai-*" -exec cp {} release/ \;
+          find artifacts -type f \( -name "git-ai-*" -o -name "git-ai_*" \) -exec cp {} release/ \;
 
       - name: List available artifacts
         run: |
@@ -337,8 +644,10 @@ jobs:
       - name: Create checksums
         run: |
           cd release
-          if ls git-ai-* 1> /dev/null 2>&1; then
-            sha256sum git-ai-* > SHA256SUMS
+          shopt -s nullglob
+          artifacts=(git-ai-* git-ai_*)
+          if [ ${#artifacts[@]} -gt 0 ]; then
+            sha256sum "${artifacts[@]}" | sort > SHA256SUMS
           else
             echo "No binaries found to create checksums for"
             touch SHA256SUMS
@@ -348,6 +657,15 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           path: repo
+
+      - name: Generate Homebrew formula
+        run: |
+          VERSION="${{ steps.release-meta.outputs.tag_name }}"
+          VERSION="${VERSION#v}"
+          repo/packaging/homebrew/update-formula.sh \
+            --version "$VERSION" \
+            --checksums release/SHA256SUMS \
+            --output release/git-ai.rb
 
       - name: Generate version-pinned install script
         run: |
@@ -390,15 +708,17 @@ jobs:
       - name: Add install scripts to SHA256SUMS
         run: |
           cd release
-          sha256sum install.sh install.ps1 >> SHA256SUMS
+          sha256sum install.sh install.ps1 git-ai.rb >> SHA256SUMS
 
       - name: Generate attestations for release artifacts
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             release/git-ai-*
+            release/git-ai_*
             release/install.sh
             release/install.ps1
+            release/git-ai.rb
             release/SHA256SUMS
 
       - name: Create Release
@@ -435,10 +755,17 @@ jobs:
             ### Downloads
             - **Linux (x64)**: `git-ai-linux-x64`
             - **Linux (ARM64)**: `git-ai-linux-arm64`
+            - **Linux deb (amd64)**: `git-ai_*_amd64.deb`
+            - **Linux deb (arm64)**: `git-ai_*_arm64.deb`
             - **Windows (x64)**: `git-ai-windows-x64.exe`
             - **Windows (ARM64)**: `git-ai-windows-arm64.exe`
+            - **Windows MSI (x64)**: `git-ai-windows-x64.msi`
+            - **Windows MSI (ARM64)**: `git-ai-windows-arm64.msi`
             - **macOS (Intel)**: `git-ai-macos-x64`
             - **macOS (Apple Silicon)**: `git-ai-macos-arm64`
+            - **macOS PKG (Intel)**: `git-ai-macos-x64.pkg`
+            - **macOS PKG (Apple Silicon)**: `git-ai-macos-arm64.pkg`
+            - **Homebrew formula**: `git-ai.rb`
 
             ### SHA256 Checksums
             ```
@@ -452,9 +779,11 @@ jobs:
             ```
           files: |
             release/git-ai-*
+            release/git-ai_*
             release/SHA256SUMS
             release/install.sh
             release/install.ps1
+            release/git-ai.rb
           draft: false
           prerelease: ${{ steps.release-meta.outputs.prerelease == 'true' }}
           make_latest: ${{ steps.release-meta.outputs.make_latest }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,6 +52,37 @@ tasks:
     cmds:
       - cargo build
 
+  package:msi:
+    desc: Build a Windows MSI from an existing release binary
+    cmds:
+      - powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File packaging/windows/build-msi.ps1 -BinaryPath "{{.BINARY}}" -Architecture "{{.ARCH}}" -Version "{{.VERSION}}" -OutputPath "{{.OUTPUT}}"
+    platforms: [windows]
+    requires:
+      vars: [BINARY, ARCH, VERSION, OUTPUT]
+
+  package:pkg:
+    desc: Build a macOS PKG from an existing release binary
+    cmds:
+      - packaging/macos/build-pkg.sh --binary "{{.BINARY}}" --arch "{{.ARCH}}" --version "{{.VERSION}}" --output "{{.OUTPUT}}"
+    platforms: [darwin]
+    requires:
+      vars: [BINARY, ARCH, VERSION, OUTPUT]
+
+  package:deb:
+    desc: Build a Debian package from an existing release binary
+    cmds:
+      - packaging/debian/build-deb.sh --binary "{{.BINARY}}" --arch "{{.ARCH}}" --version "{{.VERSION}}" --output "{{.OUTPUT}}"
+    platforms: [linux]
+    requires:
+      vars: [BINARY, ARCH, VERSION, OUTPUT]
+
+  package:brew-formula:
+    desc: Render the Homebrew formula from release checksums
+    cmds:
+      - packaging/homebrew/update-formula.sh --version "{{.VERSION}}" --checksums "{{.CHECKSUMS}}" --output "{{.OUTPUT}}"
+    requires:
+      vars: [VERSION, CHECKSUMS, OUTPUT]
+
   test:base:
     internal: true
     cmds:

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,12 @@
+# Git AI packaging
+
+This directory contains package-manager installer scaffolding for Git AI.
+
+Package outputs must install `git-ai` only. They must not install a `git`
+wrapper, `git.exe` shim, `git-og`, or any other executable that changes Git
+command routing. Per-user trace2 and editor/agent setup remains the
+responsibility of `git-ai install-hooks` or `git-ai setup-package`.
+
+The release workflow builds signed/notarized production packages when the
+required Apple and Azure signing secrets are configured. Dry-run releases can
+build unsigned packages for validation.

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: build-deb.sh --binary <path> --arch <amd64|arm64> --version <version> --output <path>
+USAGE
+}
+
+BINARY=""
+ARCH=""
+VERSION=""
+OUTPUT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --binary) BINARY="${2:-}"; shift 2 ;;
+    --arch) ARCH="${2:-}"; shift 2 ;;
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+[ -n "$BINARY" ] && [ -n "$ARCH" ] && [ -n "$VERSION" ] && [ -n "$OUTPUT" ] || { usage; exit 2; }
+[ -f "$BINARY" ] || { echo "binary not found: $BINARY" >&2; exit 1; }
+
+case "$ARCH" in
+  amd64|arm64) ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 2 ;;
+esac
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="$ROOT/target/package/deb-$ARCH"
+PKG_ROOT="$WORK_DIR/root"
+DEBIAN_DIR="$PKG_ROOT/DEBIAN"
+OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$OUTPUT")"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$DEBIAN_DIR" "$PKG_ROOT/usr/bin" "$PKG_ROOT/usr/share/doc/git-ai" "$(dirname "$OUTPUT_ABS")"
+install -m 0755 "$BINARY" "$PKG_ROOT/usr/bin/git-ai"
+install -m 0644 "$ROOT/README.md" "$PKG_ROOT/usr/share/doc/git-ai/README.md"
+
+sed \
+  -e "s/@VERSION@/$VERSION/g" \
+  -e "s/@ARCH@/$ARCH/g" \
+  "$ROOT/packaging/debian/control" > "$DEBIAN_DIR/control"
+install -m 0755 "$ROOT/packaging/debian/postinst" "$DEBIAN_DIR/postinst"
+install -m 0755 "$ROOT/packaging/debian/prerm" "$DEBIAN_DIR/prerm"
+find "$PKG_ROOT" -type d -exec chmod 0755 {} +
+
+dpkg-deb --build --root-owner-group "$PKG_ROOT" "$OUTPUT_ABS"
+echo "Built deb: $OUTPUT_ABS"

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,0 +1,10 @@
+Package: git-ai
+Version: @VERSION@
+Section: devel
+Priority: optional
+Architecture: @ARCH@
+Maintainer: Git AI <support@usegitai.com>
+Depends: git
+Homepage: https://github.com/git-ai-project/git-ai
+Description: Git extension for AI authorship attribution
+ Git AI tracks AI-generated code attribution through Git notes and trace2.

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo "Git AI installed."
+echo "Run 'git-ai install-hooks' as each developer user to enable trace2 integration and editor/agent setup."
+
+if [ "${GIT_AI_RUN_PACKAGE_USER_SETUP:-}" = "1" ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+  su - "$SUDO_USER" -c "git-ai setup-package --manager apt --target-user '$SUDO_USER'" || true
+fi
+
+exit 0

--- a/packaging/debian/prerm
+++ b/packaging/debian/prerm
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+exit 0

--- a/packaging/homebrew/git-ai.rb.template
+++ b/packaging/homebrew/git-ai.rb.template
@@ -1,0 +1,44 @@
+class GitAi < Formula
+  desc "Git extension that tracks AI-generated code attribution"
+  homepage "https://github.com/git-ai-project/git-ai"
+  license "Apache-2.0"
+  version "@VERSION@"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/git-ai-project/git-ai/releases/download/v@VERSION@/git-ai-macos-arm64"
+      sha256 "@SHA256_MACOS_ARM64@"
+    end
+
+    on_intel do
+      url "https://github.com/git-ai-project/git-ai/releases/download/v@VERSION@/git-ai-macos-x64"
+      sha256 "@SHA256_MACOS_X64@"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/git-ai-project/git-ai/releases/download/v@VERSION@/git-ai-linux-arm64"
+      sha256 "@SHA256_LINUX_ARM64@"
+    end
+
+    on_intel do
+      url "https://github.com/git-ai-project/git-ai/releases/download/v@VERSION@/git-ai-linux-x64"
+      sha256 "@SHA256_LINUX_X64@"
+    end
+  end
+
+  def install
+    bin.install Dir["git-ai-*"].first => "git-ai"
+  end
+
+  def caveats
+    <<~EOS
+      Run `git-ai install-hooks` as each developer user to enable trace2 integration and editor/agent setup.
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/git-ai --version")
+  end
+end

--- a/packaging/homebrew/update-formula.sh
+++ b/packaging/homebrew/update-formula.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: update-formula.sh --version <version> --checksums <SHA256SUMS> --output <Formula/git-ai.rb>
+USAGE
+}
+
+VERSION=""
+CHECKSUMS=""
+OUTPUT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --checksums) CHECKSUMS="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+[ -n "$VERSION" ] && [ -n "$CHECKSUMS" ] && [ -n "$OUTPUT" ] || { usage; exit 2; }
+[ -f "$CHECKSUMS" ] || { echo "checksums file not found: $CHECKSUMS" >&2; exit 1; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$ROOT/packaging/homebrew/git-ai.rb.template"
+
+checksum_for() {
+  local name="$1"
+  awk -v wanted="$name" '$2 == wanted { print $1 }' "$CHECKSUMS"
+}
+
+SHA256_MACOS_ARM64="$(checksum_for git-ai-macos-arm64)"
+SHA256_MACOS_X64="$(checksum_for git-ai-macos-x64)"
+SHA256_LINUX_ARM64="$(checksum_for git-ai-linux-arm64)"
+SHA256_LINUX_X64="$(checksum_for git-ai-linux-x64)"
+
+for value_name in SHA256_MACOS_ARM64 SHA256_MACOS_X64 SHA256_LINUX_ARM64 SHA256_LINUX_X64; do
+  if [ -z "${!value_name}" ]; then
+    echo "missing checksum for $value_name" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$(dirname "$OUTPUT")"
+sed \
+  -e "s/@VERSION@/$VERSION/g" \
+  -e "s/@SHA256_MACOS_ARM64@/$SHA256_MACOS_ARM64/g" \
+  -e "s/@SHA256_MACOS_X64@/$SHA256_MACOS_X64/g" \
+  -e "s/@SHA256_LINUX_ARM64@/$SHA256_LINUX_ARM64/g" \
+  -e "s/@SHA256_LINUX_X64@/$SHA256_LINUX_X64/g" \
+  "$TEMPLATE" > "$OUTPUT"
+
+echo "Rendered Homebrew formula: $OUTPUT"

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: build-pkg.sh --binary <path> --arch <x64|arm64> --version <version> --output <path>
+USAGE
+}
+
+BINARY=""
+ARCH=""
+VERSION=""
+OUTPUT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --binary) BINARY="${2:-}"; shift 2 ;;
+    --arch) ARCH="${2:-}"; shift 2 ;;
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+[ -n "$BINARY" ] && [ -n "$ARCH" ] && [ -n "$VERSION" ] && [ -n "$OUTPUT" ] || { usage; exit 2; }
+[ -f "$BINARY" ] || { echo "binary not found: $BINARY" >&2; exit 1; }
+
+case "$ARCH" in
+  x64|arm64) ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 2 ;;
+esac
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="$ROOT/target/package/pkg-$ARCH"
+PAYLOAD="$WORK_DIR/payload"
+SCRIPTS="$ROOT/packaging/macos/scripts"
+COMPONENT_PKG="$WORK_DIR/git-ai-component.pkg"
+OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$OUTPUT")"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$PAYLOAD/opt/git-ai/bin" "$PAYLOAD/usr/local/bin" "$(dirname "$OUTPUT_ABS")"
+cp "$BINARY" "$PAYLOAD/opt/git-ai/bin/git-ai"
+chmod 0755 "$PAYLOAD/opt/git-ai/bin/git-ai"
+ln -s /opt/git-ai/bin/git-ai "$PAYLOAD/usr/local/bin/git-ai"
+
+pkgbuild \
+  --root "$PAYLOAD" \
+  --scripts "$SCRIPTS" \
+  --identifier "com.git-ai.git-ai" \
+  --version "$VERSION" \
+  --install-location "/" \
+  "$COMPONENT_PKG"
+
+if [ -n "${APPLE_DEVELOPER_ID_INSTALLER_IDENTITY:-}" ]; then
+  productsign \
+    --sign "$APPLE_DEVELOPER_ID_INSTALLER_IDENTITY" \
+    "$COMPONENT_PKG" \
+    "$OUTPUT_ABS"
+else
+  cp "$COMPONENT_PKG" "$OUTPUT_ABS"
+fi
+
+echo "Built PKG: $OUTPUT_ABS"

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+GIT_AI_BIN="/opt/git-ai/bin/git-ai"
+
+if [ ! -x "$GIT_AI_BIN" ]; then
+  echo "git-ai binary missing at $GIT_AI_BIN" >&2
+  exit 1
+fi
+
+CONSOLE_USER="$(/usr/sbin/scutil <<'EOF' | /usr/bin/awk '/Name :/ { print $3 }'
+show State:/Users/ConsoleUser
+EOF
+)"
+
+if [ -n "${CONSOLE_USER:-}" ] && [ "$CONSOLE_USER" != "loginwindow" ] && [ "$CONSOLE_USER" != "_mbsetupuser" ] && /usr/bin/id "$CONSOLE_USER" >/dev/null 2>&1; then
+  /usr/bin/su - "$CONSOLE_USER" -c "$GIT_AI_BIN setup-package --manager pkg --target-user '$CONSOLE_USER'" || true
+else
+  echo "Git AI installed. Run 'git-ai install-hooks' as each developer user to enable trace2 integration and editor/agent setup."
+fi
+
+exit 0

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exit 0

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -1,0 +1,47 @@
+param(
+    [Parameter(Mandatory = $true)][string]$BinaryPath,
+    [Parameter(Mandatory = $true)][ValidateSet('x64', 'arm64')][string]$Architecture,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -LiteralPath $BinaryPath)) {
+    throw "Binary not found: $BinaryPath"
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$wxsPath = Join-Path $PSScriptRoot 'git-ai.wxs'
+$stageDir = Join-Path $repoRoot "target\package\msi-$Architecture"
+$stagedExe = Join-Path $stageDir 'git-ai.exe'
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
+$outputDir = [System.IO.Path]::GetDirectoryName($outputFullPath)
+$upgradeCode = '4B6D731B-CB6B-48F2-8A0A-A4344C91E1E0'
+
+New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+Copy-Item -Force -LiteralPath $BinaryPath -Destination $stagedExe
+
+$wix = Get-Command wix -ErrorAction SilentlyContinue
+if (-not $wix) {
+    Write-Host 'Installing WiX .NET tool...'
+    dotnet tool update --global wix | Out-Host
+    $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
+    $wix = Get-Command wix -ErrorAction Stop
+}
+
+$platform = if ($Architecture -eq 'arm64') { 'arm64' } else { 'x64' }
+& $wix.Source build $wxsPath `
+    -arch $platform `
+    -d "ProductVersion=$Version" `
+    -d "GitAiExe=$stagedExe" `
+    -d "UpgradeCode={$upgradeCode}" `
+    -o $outputFullPath
+
+if ($LASTEXITCODE -ne 0) {
+    throw "WiX failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Built MSI: $outputFullPath"

--- a/packaging/windows/git-ai.wxs
+++ b/packaging/windows/git-ai.wxs
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+    Name="Git AI"
+    Manufacturer="Git AI"
+    Version="$(var.ProductVersion)"
+    UpgradeCode="$(var.UpgradeCode)"
+    Scope="perMachine">
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Git AI is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="Git AI" />
+    </StandardDirectory>
+
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="GitAiExeComponent" Guid="{95D3C11E-6881-43AB-9E5B-4462AA59E0E2}">
+        <File Id="GitAiExe" Source="$(var.GitAiExe)" Name="git-ai.exe" KeyPath="yes" />
+        <Environment
+          Id="GitAiPath"
+          Name="PATH"
+          Value="[INSTALLFOLDER]"
+          Permanent="no"
+          Part="last"
+          System="yes"
+          Action="set" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="DefaultFeature" Title="Git AI" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+</Wix>

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -52,6 +52,7 @@ pub fn handle_git_ai(args: &[String]) {
             | "upgrade"
             | "install-hooks"
             | "install"
+            | "setup-package"
             | "uninstall-hooks"
             | "usage"
     );
@@ -165,6 +166,17 @@ pub fn handle_git_ai(args: &[String]) {
             }
             Err(e) => {
                 eprintln!("Install hooks failed: {}", e);
+                std::process::exit(1);
+            }
+        },
+        "setup-package" => match commands::package_setup::run(&args[1..]) {
+            Ok(statuses) => {
+                if let Ok(statuses_value) = serde_json::to_value(&statuses) {
+                    log_message("setup-package", "info", Some(statuses_value));
+                }
+            }
+            Err(e) => {
+                eprintln!("Package setup failed: {}", e);
                 std::process::exit(1);
             }
         },
@@ -364,6 +376,7 @@ fn print_help() {
     eprintln!("  debug              Print support/debug diagnostics");
     eprintln!("  bg                 Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
+    eprintln!("  setup-package      Complete per-user setup after a package-manager install");
     eprintln!("    --skills               Also install agent skill files");
     eprintln!("    --visual-studio-extension");
     eprintln!("                           Also install the Visual Studio extension on Windows");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod log;
 pub mod login;
 pub mod logout;
 pub mod notes_migrate;
+pub mod package_setup;
 pub mod personal_dashboard;
 pub mod show;
 pub mod show_prompt;

--- a/src/commands/package_setup.rs
+++ b/src/commands/package_setup.rs
@@ -1,0 +1,188 @@
+use crate::commands::install_hooks;
+use crate::error::GitAiError;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PackageManager {
+    Apt,
+    Brew,
+    Msi,
+    Pkg,
+}
+
+impl PackageManager {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "apt" => Some(Self::Apt),
+            "brew" => Some(Self::Brew),
+            "msi" => Some(Self::Msi),
+            "pkg" => Some(Self::Pkg),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Apt => "apt",
+            Self::Brew => "brew",
+            Self::Msi => "msi",
+            Self::Pkg => "pkg",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PackageSetupOptions {
+    manager: PackageManager,
+    dry_run: bool,
+    target_user: Option<String>,
+}
+
+pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
+    let options = parse_options(args)?;
+
+    if should_skip_user_setup(&options) {
+        print_manual_setup_message(options.manager);
+        return Ok(HashMap::from([(
+            "package_setup".to_string(),
+            "skipped_system_context".to_string(),
+        )]));
+    }
+
+    let mut install_args = vec!["--dry-run=false".to_string()];
+    if options.dry_run {
+        install_args[0] = "--dry-run=true".to_string();
+    }
+    install_hooks::run(&install_args)
+}
+
+fn parse_options(args: &[String]) -> Result<PackageSetupOptions, GitAiError> {
+    let mut manager = None;
+    let mut dry_run = false;
+    let mut target_user = None;
+    let mut iter = args.iter();
+
+    while let Some(arg) = iter.next() {
+        if let Some(value) = arg.strip_prefix("--manager=") {
+            manager = PackageManager::parse(value);
+        } else if arg == "--manager" {
+            let value = iter
+                .next()
+                .ok_or_else(|| GitAiError::Generic("missing value for --manager".to_string()))?;
+            manager = PackageManager::parse(value);
+        } else if let Some(value) = arg.strip_prefix("--target-user=") {
+            target_user = non_empty_value(value);
+        } else if arg == "--target-user" {
+            let value = iter.next().ok_or_else(|| {
+                GitAiError::Generic("missing value for --target-user".to_string())
+            })?;
+            target_user = non_empty_value(value);
+        } else if arg == "--dry-run" || arg == "--dry-run=true" {
+            dry_run = true;
+        } else if arg == "--dry-run=false" {
+            dry_run = false;
+        } else {
+            return Err(GitAiError::Generic(format!(
+                "unknown setup-package option: {arg}"
+            )));
+        }
+    }
+
+    let manager =
+        manager.ok_or_else(|| GitAiError::Generic("missing required --manager".to_string()))?;
+    Ok(PackageSetupOptions {
+        manager,
+        dry_run,
+        target_user,
+    })
+}
+
+fn non_empty_value(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn should_skip_user_setup(options: &PackageSetupOptions) -> bool {
+    if options.dry_run || !crate::utils::is_running_as_superuser() {
+        return false;
+    }
+
+    !matches!(
+        (&options.target_user, current_username()),
+        (Some(target_user), Some(current_user)) if target_user == &current_user
+    )
+}
+
+fn current_username() -> Option<String> {
+    #[cfg(windows)]
+    {
+        std::env::var("USERNAME")
+            .ok()
+            .filter(|value| !value.is_empty())
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var("USER").ok().filter(|value| !value.is_empty())
+    }
+}
+
+fn print_manual_setup_message(manager: PackageManager) {
+    eprintln!(
+        "Git AI was installed by {manager}. Run `git-ai install-hooks` as each developer user to enable trace2 integration and editor/agent setup.",
+        manager = manager.as_str()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| arg.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_options_accepts_manager_equals() {
+        let options = parse_options(&strings(&["--manager=msi"])).unwrap();
+        assert_eq!(options.manager, PackageManager::Msi);
+        assert!(!options.dry_run);
+        assert_eq!(options.target_user, None);
+    }
+
+    #[test]
+    fn parse_options_accepts_manager_value_and_dry_run() {
+        let options = parse_options(&strings(&[
+            "--manager",
+            "pkg",
+            "--target-user",
+            "alice",
+            "--dry-run",
+        ]))
+        .unwrap();
+        assert_eq!(options.manager, PackageManager::Pkg);
+        assert!(options.dry_run);
+        assert_eq!(options.target_user.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_options_rejects_missing_manager() {
+        let err = parse_options(&strings(&["--dry-run"])).unwrap_err();
+        assert!(err.to_string().contains("missing required --manager"));
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_manager() {
+        let err = parse_options(&strings(&["--manager", "rpm"])).unwrap_err();
+        assert!(err.to_string().contains("missing required --manager"));
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_option() {
+        let err = parse_options(&strings(&["--manager", "apt", "--shim"])).unwrap_err();
+        assert!(err.to_string().contains("unknown setup-package option"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn is_superuser_exempt_command(args: &[String]) -> bool {
             | "-v"
             | "upgrade"
             | "debug"
+            | "setup-package"
             | "uninstall-hooks"
     ) || (first == "bg" || first == "d" || first == "daemon")
         && args


### PR DESCRIPTION
## Summary

Adds the first signed/package-manager installer implementation pass:

- `git-ai setup-package --manager <msi|pkg|apt|brew>` for conservative per-user setup after package-manager installs
- MSI, PKG, deb, and Homebrew formula packaging scaffolding with no `git`/`git.exe` shim installation
- release workflow jobs for macOS binary signing, MSI build/sign, PKG build/notarize, deb build/test, and generated `git-ai.rb`
- package smoke tests in CI for MSI/PKG/deb artifacts

This intentionally starts fresh instead of continuing `#1322`: new installers must not install Git shims or intercept `git`.

## Secrets/vars needed before production release

Apple:

1. In Apple Developer, create `Developer ID Application` and `Developer ID Installer` certificates from a CSR.
2. Import each `.cer` into Keychain, export each cert+private key as `.p12`, then base64 encode it.
3. In App Store Connect, create a notarization API key and base64 encode the `.p8`.
4. Add GitHub Actions environment secrets under `Settings -> Environments -> release -> Environment secrets`:
   - `APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64`
   - `APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD`
   - `APPLE_DEVELOPER_ID_APPLICATION_IDENTITY` (`Developer ID Application: ...`)
   - `APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64`
   - `APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD`
   - `APPLE_DEVELOPER_ID_INSTALLER_IDENTITY` (`Developer ID Installer: ...`)
   - `APPLE_NOTARY_KEY_ID`
   - `APPLE_NOTARY_ISSUER_ID`
   - `APPLE_NOTARY_KEY_P8_BASE64`

Azure Artifact Signing:

1. Create/verify the Artifact Signing account, completed public identity validation, and Public Trust certificate profile.
2. Create a GitHub OIDC app registration/federated credential for this repo's `release` environment.
3. Grant it `Artifact Signing Certificate Profile Signer` on the signing account/profile.
4. Add GitHub Actions environment secrets under `Settings -> Environments -> release -> Environment secrets`:
   - `AZURE_CLIENT_ID`
   - `AZURE_TENANT_ID`
   - `AZURE_SUBSCRIPTION_ID`
5. Add GitHub Actions environment variables under `Settings -> Environments -> release -> Environment variables`:
   - `AZURE_ARTIFACT_SIGNING_ENDPOINT`
   - `AZURE_ARTIFACT_SIGNING_ACCOUNT`
   - `AZURE_ARTIFACT_SIGNING_CERT_PROFILE`

## Quarantine cleanup

This PR does **not** remove the macOS `xattr -d com.apple.quarantine` fallback from `install.sh`. Remove it only after a production release with signed macOS binaries and signed/notarized PKGs has shipped and fresh install/upgrade paths are verified.

## Validation

- `cargo fmt`
- `task test TEST_FILTER=package_setup CARGO_TEST_ARGS="--lib"`
- `task build`
- `bash -n packaging/debian/build-deb.sh packaging/macos/build-pkg.sh packaging/homebrew/update-formula.sh packaging/debian/postinst packaging/debian/prerm packaging/macos/scripts/postinstall packaging/macos/scripts/preinstall`
- YAML parse via `python3`/PyYAML
- local deb smoke build from `target/debug/git-ai`
- Homebrew formula render smoke test
- `task lint`


---

fixes PD-10
followup #1322
