### PR TITLE
Add per-user MSI and PKG packaging

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,18 @@
+# Git AI packaging
+
+This directory contains MSI and PKG installer scaffolding for Git AI.
+
+Package outputs must install `git-ai` only. They must not install a `git`
+wrapper, `git.exe` shim, `git-og`, or any other executable that changes Git
+command routing. Per-user trace2 and editor/agent setup remains the
+responsibility of `git-ai install-hooks` or `git-ai setup-package`.
+
+The release workflow builds signed/notarized production packages when the
+required Apple and Azure signing secrets are configured. Dry-run releases can
+build unsigned packages for validation.
+
+The Windows MSI is per-user: it installs under the current user's local app
+data directory and changes only that user's `PATH`. It has no all-users or
+Administrator install mode. The macOS PKG installs an immutable bootstrap
+binary, then runs any per-user setup as the active console user rather than
+root.

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: build-pkg.sh --binary <path> --arch <x64|arm64> --version <version> --output <path>
+USAGE
+}
+
+BINARY=""
+ARCH=""
+VERSION=""
+OUTPUT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --binary) BINARY="${2:-}"; shift 2 ;;
+    --arch) ARCH="${2:-}"; shift 2 ;;
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+[ -n "$BINARY" ] && [ -n "$ARCH" ] && [ -n "$VERSION" ] && [ -n "$OUTPUT" ] || { usage; exit 2; }
+[ -f "$BINARY" ] || { echo "binary not found: $BINARY" >&2; exit 1; }
+
+case "$ARCH" in
+  x64|arm64) ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 2 ;;
+esac
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="$ROOT/target/package/pkg-$ARCH"
+PAYLOAD="$WORK_DIR/payload"
+SCRIPTS="$ROOT/packaging/macos/scripts"
+COMPONENT_PKG="$WORK_DIR/git-ai-component.pkg"
+OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$OUTPUT")"
+
+rm -rf "$WORK_DIR"
+mkdir -p "$PAYLOAD/opt/git-ai/bin" "$PAYLOAD/usr/local/bin" "$(dirname "$OUTPUT_ABS")"
+cp "$BINARY" "$PAYLOAD/opt/git-ai/bin/git-ai"
+chmod 0755 "$PAYLOAD/opt/git-ai/bin/git-ai"
+ln -s /opt/git-ai/bin/git-ai "$PAYLOAD/usr/local/bin/git-ai"
+
+pkgbuild \
+  --root "$PAYLOAD" \
+  --scripts "$SCRIPTS" \
+  --identifier "com.git-ai.git-ai" \
+  --version "$VERSION" \
+  --install-location "/" \
+  "$COMPONENT_PKG"
+
+if [ -n "${APPLE_DEVELOPER_ID_INSTALLER_IDENTITY:-}" ]; then
+  productsign \
+    --sign "$APPLE_DEVELOPER_ID_INSTALLER_IDENTITY" \
+    "$COMPONENT_PKG" \
+    "$OUTPUT_ABS"
+else
+  cp "$COMPONENT_PKG" "$OUTPUT_ABS"
+fi
+
+echo "Built PKG: $OUTPUT_ABS"

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+GIT_AI_BIN="/opt/git-ai/bin/git-ai"
+
+if [ ! -x "$GIT_AI_BIN" ]; then
+  echo "git-ai binary missing at $GIT_AI_BIN" >&2
+  exit 1
+fi
+
+CONSOLE_USER="$(/usr/sbin/scutil <<'EOF' | /usr/bin/awk '/Name :/ { print $3 }'
+show State:/Users/ConsoleUser
+EOF
+)"
+
+if [ -n "${CONSOLE_USER:-}" ] && [ "$CONSOLE_USER" != "loginwindow" ] && [ "$CONSOLE_USER" != "_mbsetupuser" ] && /usr/bin/id "$CONSOLE_USER" >/dev/null 2>&1; then
+  /usr/bin/su - "$CONSOLE_USER" -c "$GIT_AI_BIN setup-package --manager pkg --target-user '$CONSOLE_USER'" || true
+else
+  echo "Git AI installed. Run 'git-ai install-hooks' as each developer user to enable trace2 integration and editor/agent setup."
+fi
+
+exit 0

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exit 0

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -1,0 +1,47 @@
+param(
+    [Parameter(Mandatory = $true)][string]$BinaryPath,
+    [Parameter(Mandatory = $true)][ValidateSet('x64', 'arm64')][string]$Architecture,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if (-not (Test-Path -LiteralPath $BinaryPath)) {
+    throw "Binary not found: $BinaryPath"
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$wxsPath = Join-Path $PSScriptRoot 'git-ai.wxs'
+$stageDir = Join-Path $repoRoot "target\package\msi-$Architecture"
+$stagedExe = Join-Path $stageDir 'git-ai.exe'
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
+$outputDir = [System.IO.Path]::GetDirectoryName($outputFullPath)
+$upgradeCode = '4B6D731B-CB6B-48F2-8A0A-A4344C91E1E0'
+
+New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+Copy-Item -Force -LiteralPath $BinaryPath -Destination $stagedExe
+
+$wix = Get-Command wix -ErrorAction SilentlyContinue
+if (-not $wix) {
+    Write-Host 'Installing WiX .NET tool...'
+    dotnet tool update --global wix | Out-Host
+    $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
+    $wix = Get-Command wix -ErrorAction Stop
+}
+
+$platform = if ($Architecture -eq 'arm64') { 'arm64' } else { 'x64' }
+& $wix.Source build $wxsPath `
+    -arch $platform `
+    -d "ProductVersion=$Version" `
+    -d "GitAiExe=$stagedExe" `
+    -d "UpgradeCode={$upgradeCode}" `
+    -o $outputFullPath
+
+if ($LASTEXITCODE -ne 0) {
+    throw "WiX failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Built MSI: $outputFullPath"

--- a/packaging/windows/git-ai.wxs
+++ b/packaging/windows/git-ai.wxs
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+    Name="Git AI"
+    Manufacturer="Git AI"
+    Version="$(var.ProductVersion)"
+    UpgradeCode="$(var.UpgradeCode)"
+    Scope="perUser">
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Git AI is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="INSTALLFOLDER" Name="Git AI" />
+    </StandardDirectory>
+
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="GitAiExeComponent" Guid="{95D3C11E-6881-43AB-9E5B-4462AA59E0E2}">
+        <File Id="GitAiExe" Source="$(var.GitAiExe)" Name="git-ai.exe" KeyPath="yes" />
+        <Environment
+          Id="GitAiPath"
+          Name="PATH"
+          Value="[INSTALLFOLDER]"
+          Permanent="no"
+          Part="last"
+          System="no"
+          Action="set" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="DefaultFeature" Title="Git AI" Level="1">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+</Wix>

--- a/tests/package_installers.rs
+++ b/tests/package_installers.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+fn packaging_path(path: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("packaging")
+        .join(path)
+}
+
+#[test]
+fn msi_is_per_user_and_updates_only_the_user_path() {
+    let wix = std::fs::read_to_string(packaging_path("windows/git-ai.wxs")).unwrap();
+
+    assert!(wix.contains("Scope=\"perUser\""));
+    assert!(wix.contains("StandardDirectory Id=\"LocalAppDataFolder\""));
+    assert!(wix.contains("System=\"no\""));
+    assert!(!wix.contains("perMachine"));
+    assert!(!wix.contains("ProgramFiles"));
+    assert!(!wix.contains("System=\"yes\""));
+}
+
+#[test]
+fn packaging_supports_only_msi_and_pkg() {
+    assert!(packaging_path("windows").is_dir());
+    assert!(packaging_path("macos").is_dir());
+    assert!(!packaging_path("debian/build-deb.sh").exists());
+    assert!(!packaging_path("homebrew/update-formula.sh").exists());
+}


### PR DESCRIPTION
## Summary

- Keeps only MSI and PKG packaging assets.
- Makes the MSI per-user under local app data and updates only the user PATH.
- Removes deb and Homebrew packaging.
- Keeps PKG setup in the active console user context, not root.

## Validation

- `task test CARGO_TEST_ARGS="--test package_installers"`
- `task lint`
- MSI WiX XML parse

## Stack

Depends on #1840.