### PR TITLE
Start package daemon at login

### DIFF
--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -38,10 +38,12 @@ COMPONENT_PKG="$WORK_DIR/git-ai-component.pkg"
 OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$OUTPUT")"
 
 rm -rf "$WORK_DIR"
-mkdir -p "$PAYLOAD/opt/git-ai/bin" "$PAYLOAD/usr/local/bin" "$(dirname "$OUTPUT_ABS")"
-cp "$BINARY" "$PAYLOAD/opt/git-ai/bin/git-ai"
-chmod 0755 "$PAYLOAD/opt/git-ai/bin/git-ai"
+mkdir -p "$PAYLOAD/opt/git-ai/bin" "$PAYLOAD/usr/local/bin" "$PAYLOAD/Library/LaunchAgents" "$(dirname "$OUTPUT_ABS")"
+install -m 0755 "$BINARY" "$PAYLOAD/opt/git-ai/bin/git-ai"
+install -m 0755 "$ROOT/packaging/macos/launchagents/git-ai-daemon-launcher" "$PAYLOAD/opt/git-ai/bin/git-ai-daemon-launcher"
 ln -s /opt/git-ai/bin/git-ai "$PAYLOAD/usr/local/bin/git-ai"
+install -m 0644 "$ROOT/packaging/macos/launchagents/com.git-ai.daemon.plist" "$PAYLOAD/Library/LaunchAgents/com.git-ai.daemon.plist"
+xattr -cr "$PAYLOAD" 2>/dev/null || true
 
 pkgbuild \
   --root "$PAYLOAD" \

--- a/packaging/macos/launchagents/com.git-ai.daemon.plist
+++ b/packaging/macos/launchagents/com.git-ai.daemon.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.git-ai.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/git-ai/bin/git-ai-daemon-launcher</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>

--- a/packaging/macos/launchagents/git-ai-daemon-launcher
+++ b/packaging/macos/launchagents/git-ai-daemon-launcher
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ -n "${HOME:-}" ] && [ -x "$HOME/.git-ai/bin/git-ai" ]; then
+  exec "$HOME/.git-ai/bin/git-ai" bg run
+fi
+
+exec /opt/git-ai/bin/git-ai bg run

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -16,6 +16,7 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
 $wxsPath = Join-Path $PSScriptRoot 'git-ai.wxs'
 $stageDir = Join-Path $repoRoot "target\package\msi-$Architecture"
 $stagedExe = Join-Path $stageDir 'git-ai.exe'
+$stagedLoginLauncher = Join-Path $stageDir 'git-ai-login.cmd'
 $outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
 $outputDir = [System.IO.Path]::GetDirectoryName($outputFullPath)
 $upgradeCode = '4B6D731B-CB6B-48F2-8A0A-A4344C91E1E0'
@@ -23,6 +24,7 @@ $upgradeCode = '4B6D731B-CB6B-48F2-8A0A-A4344C91E1E0'
 New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
 New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
 Copy-Item -Force -LiteralPath $BinaryPath -Destination $stagedExe
+Copy-Item -Force -LiteralPath (Join-Path $PSScriptRoot 'git-ai-login.cmd') -Destination $stagedLoginLauncher
 
 $wix = Get-Command wix -ErrorAction SilentlyContinue
 if (-not $wix) {
@@ -34,9 +36,11 @@ if (-not $wix) {
 
 $platform = if ($Architecture -eq 'arm64') { 'arm64' } else { 'x64' }
 & $wix.Source build $wxsPath `
+    -acceptEula wix7 `
     -arch $platform `
     -d "ProductVersion=$Version" `
     -d "GitAiExe=$stagedExe" `
+    -d "GitAiLoginLauncher=$stagedLoginLauncher" `
     -d "UpgradeCode={$upgradeCode}" `
     -o $outputFullPath
 

--- a/packaging/windows/git-ai-login.cmd
+++ b/packaging/windows/git-ai-login.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+
+set "GIT_AI_USER_BINARY=%USERPROFILE%\.git-ai\bin\git-ai.exe"
+if exist "%GIT_AI_USER_BINARY%" (
+  "%GIT_AI_USER_BINARY%" bg start
+  exit /b %ERRORLEVEL%
+)
+
+"%~dp0git-ai.exe" bg start

--- a/packaging/windows/git-ai.wxs
+++ b/packaging/windows/git-ai.wxs
@@ -18,6 +18,7 @@
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="GitAiExeComponent" Guid="{95D3C11E-6881-43AB-9E5B-4462AA59E0E2}">
         <File Id="GitAiExe" Source="$(var.GitAiExe)" Name="git-ai.exe" KeyPath="yes" />
+        <File Id="GitAiLoginLauncher" Source="$(var.GitAiLoginLauncher)" Name="git-ai-login.cmd" />
         <Environment
           Id="GitAiPath"
           Name="PATH"
@@ -26,6 +27,13 @@
           Part="last"
           System="no"
           Action="set" />
+        <RegistryValue
+          Id="GitAiRunAtLogin"
+          Root="HKCU"
+          Key="Software\Microsoft\Windows\CurrentVersion\Run"
+          Name="Git AI"
+          Value="&quot;[INSTALLFOLDER]git-ai-login.cmd&quot;"
+          Type="string" />
       </Component>
     </ComponentGroup>
 

--- a/tests/package_login_startup.rs
+++ b/tests/package_login_startup.rs
@@ -1,0 +1,38 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+#[test]
+fn macos_pkg_installs_a_user_session_launch_agent() {
+    let build_pkg = read("packaging/macos/build-pkg.sh");
+
+    assert!(build_pkg.contains("\"$PAYLOAD/Library/LaunchAgents\""));
+    assert!(build_pkg.contains("git-ai-daemon-launcher"));
+    assert!(build_pkg.contains("com.git-ai.daemon.plist"));
+
+    let plist = read("packaging/macos/launchagents/com.git-ai.daemon.plist");
+    assert!(plist.contains("<string>com.git-ai.daemon</string>"));
+    assert!(plist.contains("<key>RunAtLoad</key>"));
+
+    let launcher = read("packaging/macos/launchagents/git-ai-daemon-launcher");
+    assert!(launcher.contains("$HOME/.git-ai/bin/git-ai"));
+    assert!(launcher.contains("exec /opt/git-ai/bin/git-ai bg run"));
+}
+
+#[test]
+fn windows_msi_registers_login_startup_per_user() {
+    let wix = read("packaging/windows/git-ai.wxs");
+
+    assert!(wix.contains("File Id=\"GitAiLoginLauncher\""));
+    assert!(wix.contains("Root=\"HKCU\""));
+    assert!(wix.contains("Key=\"Software\\Microsoft\\Windows\\CurrentVersion\\Run\""));
+    assert!(!wix.contains("Root=\"HKLM\""));
+    assert!(wix.contains("Value=\"&quot;[INSTALLFOLDER]git-ai-login.cmd&quot;\""));
+
+    let launcher = read("packaging/windows/git-ai-login.cmd");
+    assert!(launcher.contains("%USERPROFILE%\\.git-ai\\bin\\git-ai.exe"));
+    assert!(launcher.contains("\"%GIT_AI_USER_BINARY%\" bg start"));
+    assert!(launcher.contains("\"%~dp0git-ai.exe\" bg start"));
+}


### PR DESCRIPTION
## Summary

- Adds a macOS LaunchAgent that starts the daemon in the user session.
- Adds a per-user Windows Run key and launcher. It does not use HKLM.
- Launchers prefer the user-updated runtime when present.
- Does not change release publishing, signing, package setup, or the updater.

## Stack

Follows #1838 → #1840 → #1714 → #1841 → #1839.

## Validation

- `task test CARGO_TEST_ARGS="--test package_login_startup"`
- `task test CARGO_TEST_ARGS="--test package_installers"`
- `task lint`