### PR TITLE
[codex] Enforce sqlite memory limits

### DIFF
--- a/scripts/create_test_vsc_db.py
+++ b/scripts/create_test_vsc_db.py
@@ -43,6 +43,8 @@ def create_test_database(source_db: str, target_db: str, data_filters: dict):
     # Connect to both databases
     source_conn = sqlite3.connect(source_db)
     target_conn = sqlite3.connect(target_db)
+    for conn in (source_conn, target_conn):
+        conn.execute("PRAGMA cache_size = -2000")
 
     source_cursor = source_conn.cursor()
     target_cursor = target_conn.cursor()

--- a/src/authorship/internal_db.rs
+++ b/src/authorship/internal_db.rs
@@ -115,7 +115,8 @@ impl InternalDatabase {
                     // Create a dummy connection that will fail on any operation
                     // This allows the program to continue even if DB init fails
                     let temp_path = std::env::temp_dir().join("git-ai-db-failed");
-                    let conn = Connection::open(&temp_path).expect("Failed to create temp DB");
+                    let conn = crate::sqlite::open_with_memory_limits(&temp_path)
+                        .expect("Failed to create temp DB");
                     Mutex::new(InternalDatabase {
                         conn,
                         _db_path: temp_path,
@@ -152,12 +153,11 @@ impl InternalDatabase {
         }
 
         // Open with WAL mode and performance optimizations
-        let conn = Connection::open(&db_path)?;
+        let conn = crate::sqlite::open_with_memory_limits(&db_path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
-            PRAGMA cache_size=-2000;
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
@@ -531,7 +531,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
 
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
 
         let mut db = InternalDatabase {
@@ -574,7 +574,7 @@ mod tests {
     fn test_initialize_schema_handles_preexisting_cas_cache_table() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("concurrent-init.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
 
         // Simulate a partial migration state from a concurrent process:
         // schema version indicates cas_cache is missing, but the table already exists.

--- a/src/commands/analyze/sessions.rs
+++ b/src/commands/analyze/sessions.rs
@@ -738,7 +738,7 @@ fn merge_filters(mut convenience: Vec<Value>, raw: Option<&str>) -> Result<Optio
 // ---------------------------------------------------------------------------
 
 fn open_db(path: &Path) -> Result<Connection, rusqlite::Error> {
-    let conn = Connection::open(path)?;
+    let conn = crate::sqlite::open_with_memory_limits(path)?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
     conn.execute_batch(SCHEMA)?;
     ensure_derived_columns(&conn)?;
@@ -1530,12 +1530,14 @@ Grading workflow:
 mod tests {
     use super::*;
 
-    fn mem_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
+    fn temp_db() -> (Connection, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("analyze-sessions.db");
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(SCHEMA).unwrap();
         // Mirror open_db so the derived funnel-gap columns are present in tests.
         ensure_derived_columns(&conn).unwrap();
-        conn
+        (conn, dir)
     }
 
     fn session_row(id: &str) -> Value {
@@ -1553,7 +1555,7 @@ mod tests {
 
     #[test]
     fn insert_sessions_dedupes_by_session_id() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         let rows = vec![session_row("s1"), session_row("s2")];
         assert_eq!(insert_sessions(&conn, &rows).unwrap(), 2);
         // Re-inserting the same ids adds nothing.
@@ -1567,7 +1569,7 @@ mod tests {
 
     #[test]
     fn derived_funnel_gaps_compute_from_stage_columns() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         insert_sessions(&conn, &[session_row("s1")]).unwrap();
         // Set a full funnel: 100 committed → 70 pr_opened → 40 merged → 30 prod.
         conn.execute(
@@ -1609,7 +1611,7 @@ mod tests {
 
     #[test]
     fn recompute_models_denormalizes_distinct_models() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
         // Two models for s1 (out of order), one for s2.
         conn.execute(
@@ -1640,7 +1642,7 @@ mod tests {
 
     #[test]
     fn recompute_pr_counts_counts_distinct_prs() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
         conn.execute(
             "INSERT INTO session_prs (session_id, repo_url, pr_number, ai_lines) VALUES \
@@ -1670,7 +1672,7 @@ mod tests {
 
     #[test]
     fn session_numbers_and_time_parse() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         insert_sessions(&conn, &[session_row("s1")]).unwrap();
         let (g, prod, net, start): (i64, i64, i64, i64) = conn
             .query_row(
@@ -1723,7 +1725,7 @@ mod tests {
 
     #[test]
     fn cursor_serves_each_row_exactly_once() {
-        let mut conn = mem_db();
+        let (mut conn, _db_dir) = temp_db();
         init_cursor(&conn, 100).unwrap();
         insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
 
@@ -1736,7 +1738,7 @@ mod tests {
 
     #[test]
     fn reset_rewinds_cursor_to_reserve_from_start() {
-        let mut conn = mem_db();
+        let (mut conn, _db_dir) = temp_db();
         init_cursor(&conn, 100).unwrap();
         insert_sessions(&conn, &[session_row("s1"), session_row("s2")]).unwrap();
         assert_eq!(claim_next(&mut conn), Some("s1".to_string()));
@@ -1752,7 +1754,7 @@ mod tests {
     #[test]
     fn pull_does_not_rewind_analysis_cursor() {
         // Re-running pull (init_cursor) must not reset analysis progress.
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         init_cursor(&conn, 100).unwrap();
         conn.execute("UPDATE cursor SET analyzed_seq=5 WHERE name='default'", [])
             .unwrap();
@@ -1769,7 +1771,7 @@ mod tests {
 
     #[test]
     fn events_persist_idempotently_and_round_trip() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         insert_sessions(&conn, &[session_row("s1")]).unwrap();
         let events = vec![
             json!({
@@ -1799,7 +1801,7 @@ mod tests {
 
     #[test]
     fn cursor_tracks_fetch_progress() {
-        let conn = mem_db();
+        let (conn, _db_dir) = temp_db();
         init_cursor(&conn, 100).unwrap();
         assert_eq!(get_fetched(&conn).unwrap(), 0);
         set_fetched(&conn, 50).unwrap();

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -89,7 +89,7 @@ const MIGRATIONS: &[&str] = &[
 "#,
 ];
 
-static BASH_HISTORY_DB: OnceLock<Mutex<BashHistoryDatabase>> = OnceLock::new();
+static BASH_HISTORY_DB: OnceLock<Result<Mutex<BashHistoryDatabase>, String>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct BashCallStart {
@@ -146,14 +146,27 @@ pub struct BashHistoryDatabase {
 
 impl BashHistoryDatabase {
     pub fn global() -> Result<&'static Mutex<BashHistoryDatabase>, GitAiError> {
-        let db_mutex = BASH_HISTORY_DB.get_or_init(|| match Self::new() {
-            Ok(db) => Mutex::new(db),
+        let db_result = BASH_HISTORY_DB.get_or_init(|| match Self::new() {
+            Ok(db) => Ok(Mutex::new(db)),
             Err(e) => {
                 eprintln!("[Error] Failed to initialize bash history database: {}", e);
-                Mutex::new(Self::fallback_database())
+                match Self::fallback_database() {
+                    Ok(db) => Ok(Mutex::new(db)),
+                    Err(fallback_error) => {
+                        let error_msg = format!(
+                            "Failed to initialize bash history database; primary error: {}; fallback error: {}",
+                            e, fallback_error
+                        );
+                        eprintln!("[Error] {}", error_msg);
+                        Err(error_msg)
+                    }
+                }
             }
         });
-        Ok(db_mutex)
+        match db_result {
+            Ok(db_mutex) => Ok(db_mutex),
+            Err(error_msg) => Err(GitAiError::Generic(error_msg.clone())),
+        }
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -165,49 +178,46 @@ impl BashHistoryDatabase {
 
     #[cfg(any(test, feature = "test-support"))]
     fn disabled_database() -> Self {
-        let conn = Connection::open_in_memory().expect("Failed to create disabled bash DB");
+        let temp_path = std::env::var_os("GIT_AI_TEST_DB_PATH")
+            .or_else(|| std::env::var_os("GITAI_TEST_DB_PATH"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::temp_dir().join("git-ai-bash-history-disabled.db"));
+        let db_path = temp_path.with_extension("bash-disabled.db");
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).expect("Failed to create disabled bash DB directory");
+        }
+        let conn = crate::sqlite::open_with_memory_limits(&db_path)
+            .expect("Failed to create disabled bash DB");
         BashHistoryDatabase {
             conn,
             enabled: false,
         }
     }
 
-    fn fallback_database() -> Self {
+    fn fallback_database() -> Result<Self, GitAiError> {
         let temp_path = std::env::temp_dir().join("git-ai-bash-history-db-failed");
         Self::fallback_database_at(&temp_path)
     }
 
-    fn fallback_database_at(path: &Path) -> Self {
-        match Self::open_at_path(path) {
-            Ok(db) => db,
-            Err(e) => {
-                eprintln!(
-                    "[Error] Failed to initialize fallback bash history database: {}",
-                    e
-                );
-                let conn =
-                    Connection::open_in_memory().expect("Failed to create in-memory bash DB");
-                let mut db = BashHistoryDatabase {
-                    conn,
-                    enabled: true,
-                };
-                db.initialize_schema()
-                    .expect("Failed to initialize in-memory bash DB schema");
-                db
-            }
-        }
+    fn fallback_database_at(path: &Path) -> Result<Self, GitAiError> {
+        Self::open_at_path(path).map_err(|e| {
+            GitAiError::Generic(format!(
+                "Failed to initialize fallback bash history database at {}: {}",
+                path.display(),
+                e
+            ))
+        })
     }
 
     pub fn open_at_path(path: &Path) -> Result<Self, GitAiError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let conn = Connection::open(path)?;
+        let conn = crate::sqlite::open_with_memory_limits(path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
-            PRAGMA cache_size=-2000;
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
@@ -881,12 +891,25 @@ mod tests {
     }
 
     #[test]
-    fn fallback_database_has_schema() {
+    fn fallback_database_at_file_has_schema() {
         let dir = tempfile::tempdir().unwrap();
-        let db = BashHistoryDatabase::fallback_database_at(dir.path());
+        let db =
+            BashHistoryDatabase::fallback_database_at(&dir.path().join("fallback.db")).unwrap();
 
         let calls = db.all_calls_for_test().unwrap();
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn fallback_database_returns_error_when_file_path_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        match BashHistoryDatabase::fallback_database_at(dir.path()) {
+            Ok(_) => panic!("fallback database unexpectedly opened a directory path"),
+            Err(err) => assert!(
+                err.to_string()
+                    .contains("Failed to initialize fallback bash history database")
+            ),
+        }
     }
 
     #[test]

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -1432,9 +1432,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_uploads_from_db_and_marks_delivered() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         let ts1 = now_ts().saturating_sub(2);
         let ts2 = now_ts().saturating_sub(1);
         db.borrow_mut()
@@ -1498,9 +1497,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_marks_invalid_rows_delivered() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         let ts = now_ts();
         db.borrow_mut()
             .insert_events(&["not-json".to_string(), event_json(ts)])
@@ -1563,9 +1561,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_marks_partial_server_errors_undeliverable() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         let ts1 = now_ts().saturating_sub(3);
         let ts2 = now_ts().saturating_sub(2);
         let ts3 = now_ts().saturating_sub(1);
@@ -1642,9 +1639,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_marks_all_server_errors_undeliverable() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         let ts1 = now_ts().saturating_sub(2);
         let ts2 = now_ts().saturating_sub(1);
         db.borrow_mut()
@@ -1718,9 +1714,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_retries_batch_for_invalid_server_error_index() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         db.borrow_mut()
             .insert_events(&[event_json(now_ts().saturating_sub(1))])
             .unwrap();
@@ -1772,9 +1767,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_keeps_rows_pending_after_upload_failure() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         let ts = now_ts();
         db.borrow_mut().insert_events(&[event_json(ts)]).unwrap();
 
@@ -1814,9 +1808,8 @@ mod tests {
 
     #[test]
     fn flush_pending_metric_records_uploads_new_rows_after_old_failure() {
-        let db = Rc::new(RefCell::new(
-            MetricsDatabase::new_in_memory_for_tests().unwrap(),
-        ));
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
         let old_ts = now_ts().saturating_sub(10);
         db.borrow_mut()
             .insert_events(&[event_json(old_ts)])

--- a/src/error.rs
+++ b/src/error.rs
@@ -173,8 +173,9 @@ mod tests {
 
     #[test]
     fn test_error_display_sqlite_error() {
-        use rusqlite::Connection;
-        let conn = Connection::open_in_memory().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("error.db");
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         let sql_err = conn.execute("INVALID SQL", []).unwrap_err();
         let err = GitAiError::from(sql_err);
         let display = format!("{}", err);
@@ -275,8 +276,9 @@ mod tests {
 
     #[test]
     fn test_error_clone_sqlite_converts_to_generic() {
-        use rusqlite::Connection;
-        let conn = Connection::open_in_memory().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("error.db");
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         let sql_err = conn.execute("BAD SQL", []).unwrap_err();
         let err = GitAiError::from(sql_err);
         let cloned = err.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod notes;
 pub mod observability;
 pub mod process_timeout;
 pub mod repo_url;
+pub mod sqlite;
 pub mod streams;
 pub mod tokio_runtime;
 pub mod utils;

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -158,7 +158,8 @@ impl MetricsDatabase {
                     eprintln!("[Error] Failed to initialize metrics database: {}", e);
                     // Create a dummy connection that will fail on any operation
                     let temp_path = std::env::temp_dir().join("git-ai-metrics-db-failed");
-                    let conn = Connection::open(&temp_path).expect("Failed to create temp DB");
+                    let conn = crate::sqlite::open_with_memory_limits(&temp_path)
+                        .expect("Failed to create temp DB");
                     Mutex::new(MetricsDatabase { conn })
                 }
             }
@@ -177,12 +178,11 @@ impl MetricsDatabase {
         }
 
         // Open with WAL mode and performance optimizations
-        let conn = Connection::open(&db_path)?;
+        let conn = crate::sqlite::open_with_memory_limits(&db_path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
-            PRAGMA cache_size=-2000;
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
@@ -194,8 +194,10 @@ impl MetricsDatabase {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_in_memory_for_tests() -> Result<Self, GitAiError> {
-        let conn = Connection::open_in_memory()?;
+    pub(crate) fn new_temp_for_tests() -> Result<(Self, tempfile::TempDir), GitAiError> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let db_path = temp_dir.path().join("metrics.db");
+        let conn = crate::sqlite::open_with_memory_limits(&db_path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
@@ -206,7 +208,7 @@ impl MetricsDatabase {
         let mut db = Self { conn };
         db.initialize_schema()?;
 
-        Ok(db)
+        Ok((db, temp_dir))
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -214,12 +216,11 @@ impl MetricsDatabase {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let conn = Connection::open(path)?;
+        let conn = crate::sqlite::open_with_memory_limits(path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
-            PRAGMA cache_size=-2000;
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
@@ -1481,7 +1482,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test-metrics.db");
 
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
 
         let mut db = MetricsDatabase { conn };
@@ -1673,7 +1674,7 @@ mod tests {
     fn test_initialize_schema_handles_preexisting_agent_usage_table() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("concurrent-init.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
 
         // Simulate a partial migration state from a concurrent process:
         // schema version indicates agent_usage_throttle is missing, but it already exists.
@@ -1715,7 +1716,7 @@ mod tests {
     fn test_migrates_version_2_to_row_level_retry_schema() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("v2.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             r#"
             CREATE TABLE schema_metadata (
@@ -1756,7 +1757,7 @@ mod tests {
     fn test_migrates_version_2_with_preexisting_retry_columns() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("v2-partial-retry.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             r#"
             CREATE TABLE schema_metadata (
@@ -1820,7 +1821,7 @@ mod tests {
     fn test_migrates_version_3_to_event_metadata_schema_without_sync_backfill() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("v3.db");
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             r#"
             CREATE TABLE schema_metadata (

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -70,7 +70,8 @@ impl NotesDatabase {
                 eprintln!("[Error] Failed to initialize notes database: {}", e);
                 // Fall back to a temp file so the process can continue running.
                 let temp_path = std::env::temp_dir().join("git-ai-notes-db-failed");
-                let conn = Connection::open(&temp_path).expect("Failed to create temp DB");
+                let conn = crate::sqlite::open_with_memory_limits(&temp_path)
+                    .expect("Failed to create temp DB");
                 Mutex::new(NotesDatabase { conn })
             }
         });
@@ -83,12 +84,11 @@ impl NotesDatabase {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let conn = Connection::open(path)?;
+        let conn = crate::sqlite::open_with_memory_limits(path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
-            PRAGMA cache_size=-2000;
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
@@ -105,12 +105,11 @@ impl NotesDatabase {
             std::fs::create_dir_all(parent)?;
         }
 
-        let conn = Connection::open(&db_path)?;
+        let conn = crate::sqlite::open_with_memory_limits(&db_path)?;
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;
             PRAGMA synchronous=NORMAL;
-            PRAGMA cache_size=-2000;
             PRAGMA temp_store=MEMORY;
             "#,
         )?;
@@ -581,7 +580,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test-notes.db");
 
-        let conn = Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             r#"
             PRAGMA journal_mode=WAL;

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,0 +1,58 @@
+use rusqlite::{Connection, OpenFlags};
+use std::path::Path;
+
+/// Negative SQLite cache_size values are kibibytes. Keep each connection's
+/// page cache capped at 2 MiB unless a caller deliberately changes it later.
+pub const MEMORY_LIMIT_CACHE_SIZE_KIB: i32 = -2000;
+
+pub fn apply_memory_limits(conn: &Connection) -> rusqlite::Result<()> {
+    conn.pragma_update(None, "cache_size", MEMORY_LIMIT_CACHE_SIZE_KIB)
+}
+
+pub fn open_with_memory_limits(path: impl AsRef<Path>) -> rusqlite::Result<Connection> {
+    let conn = Connection::open(path)?;
+    apply_memory_limits(&conn)?;
+    Ok(conn)
+}
+
+pub fn open_with_flags_and_memory_limits(
+    path: impl AsRef<Path>,
+    flags: OpenFlags,
+) -> rusqlite::Result<Connection> {
+    let conn = Connection::open_with_flags(path, flags)?;
+    apply_memory_limits(&conn)?;
+    Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_with_memory_limits_sets_cache_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("limited.db");
+
+        let conn = open_with_memory_limits(&db_path).unwrap();
+
+        let cache_size: i32 = conn
+            .pragma_query_value(None, "cache_size", |row| row.get(0))
+            .unwrap();
+        assert_eq!(cache_size, MEMORY_LIMIT_CACHE_SIZE_KIB);
+    }
+
+    #[test]
+    fn open_with_flags_and_memory_limits_sets_cache_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("limited-readonly.db");
+        drop(open_with_memory_limits(&db_path).unwrap());
+
+        let conn =
+            open_with_flags_and_memory_limits(&db_path, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+
+        let cache_size: i32 = conn
+            .pragma_query_value(None, "cache_size", |row| row.get(0))
+            .unwrap();
+        assert_eq!(cache_size, MEMORY_LIMIT_CACHE_SIZE_KIB);
+    }
+}

--- a/src/streams/agents/copilot_otel.rs
+++ b/src/streams/agents/copilot_otel.rs
@@ -350,7 +350,7 @@ mod tests {
     fn create_test_otel_db() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("traces.db");
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             "CREATE TABLE spans (
                 span_id TEXT PRIMARY KEY, trace_id TEXT NOT NULL, parent_span_id TEXT,
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn test_reads_spans_after_watermark() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         insert_span(&conn, "span1", 1000, 100, 50);
         insert_span(&conn, "span2", 2000, 200, 100);
         insert_span(&conn, "span3", 3000, 300, 150);
@@ -421,7 +421,7 @@ mod tests {
     #[test]
     fn test_batch_size_limits_results() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         for i in 1..=5 {
             insert_span(&conn, &format!("span{}", i), i * 1000, i * 100, i * 50);
         }
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn test_batch_resume_no_loss_no_repeats() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         for i in 1..=5 {
             insert_span(&conn, &format!("span{}", i), i * 1000, i * 100, i * 50);
         }
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn test_no_data_loss_with_duplicate_end_time_ms() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         // 5 spans all sharing the same end_time_ms
         for i in 1..=5 {
             insert_span(&conn, &format!("span{}", i), 3000, i * 100, i * 50);
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn test_attributes_denormalized() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         insert_span(&conn, "span1", 1000, 100, 50);
         conn.execute(
             "INSERT INTO span_attributes (span_id, key, value) VALUES ('span1', 'gen_ai.request.model', 'gpt-4.1')",
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn test_span_events_denormalized() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         insert_span(&conn, "span1", 1000, 100, 50);
         conn.execute(
             "INSERT INTO span_events (span_id, name, timestamp_ms, attributes) VALUES ('span1', 'tool_call', 500, '{\"tool\":\"read_file\"}')",
@@ -703,7 +703,7 @@ mod tests {
     #[test]
     fn test_spans_without_session_ids_are_filtered() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
 
         // Span WITH session ID (should be included)
         conn.execute(
@@ -763,7 +763,7 @@ mod tests {
     #[test]
     fn test_watermark_advances_correctly_after_batch() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         insert_span(&conn, "span-a", 5000, 100, 50);
         insert_span(&conn, "span-b", 7000, 200, 100);
         drop(conn);
@@ -826,7 +826,7 @@ mod tests {
     #[test]
     fn test_otel_json_structure_has_all_span_fields() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute(
             "INSERT INTO spans (span_id, trace_id, parent_span_id, name, start_time_ms, end_time_ms, \
              status_code, status_message, operation_name, provider_name, agent_name, \
@@ -876,7 +876,7 @@ mod tests {
     #[test]
     fn test_initial_watermark_uses_simple_greater_than() {
         let (_dir, db_path) = create_test_otel_db();
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         // Span at time 0 should still be found with initial watermark (end_time_ms > 0 fails for this!)
         // Actually initial watermark is timestamp_millis=0, so end_time_ms > 0 catches spans at ms=1+
         // Span at ms=0 would NOT be found since > 0 excludes it. This is OK since ms=0 means epoch.
@@ -898,7 +898,7 @@ mod tests {
     fn test_fractional_real_end_time_ms_no_infinite_loop() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("traces.db");
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             "CREATE TABLE spans (
                 span_id TEXT PRIMARY KEY, trace_id TEXT NOT NULL, parent_span_id TEXT,
@@ -962,7 +962,7 @@ mod tests {
     fn test_fractional_real_watermark_roundtrip_prevents_reread() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("traces.db");
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             "CREATE TABLE spans (
                 span_id TEXT PRIMARY KEY, trace_id TEXT NOT NULL, parent_span_id TEXT,

--- a/src/streams/agents/opencode.rs
+++ b/src/streams/agents/opencode.rs
@@ -28,13 +28,12 @@ impl OpenCodeAgent {
 
 pub fn open_sqlite_readonly(path: &Path) -> Result<Connection, StreamError> {
     let conn =
-        Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|e| {
-            StreamError::Fatal {
+        crate::sqlite::open_with_flags_and_memory_limits(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| StreamError::Fatal {
                 message: format!("Failed to open OpenCode database {}: {}", path.display(), e),
-            }
-        })?;
+            })?;
 
-    conn.execute_batch("PRAGMA cache_size = -2000; PRAGMA busy_timeout = 5000;")
+    conn.execute_batch("PRAGMA busy_timeout = 5000;")
         .map_err(|e| StreamError::Fatal {
             message: format!("Failed to set PRAGMAs: {}", e),
         })?;
@@ -356,7 +355,7 @@ mod tests {
     }
 
     fn create_test_db(path: &std::path::Path, message_count: usize) {
-        let conn = rusqlite::Connection::open(path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(path).unwrap();
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS message (
                 id TEXT PRIMARY KEY,
@@ -449,7 +448,7 @@ mod tests {
         assert_eq!(all.len(), 3);
 
         // Insert one more record with a later timestamp
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         let ts = 1000 + 3 * 1000i64;
         conn.execute(
             "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -481,7 +480,7 @@ mod tests {
         let (_, mut wm) = drain_all(&agent, &db_path);
 
         // Insert 3 more records
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         for i in 3..6usize {
             let ts = 1000 + (i as i64) * 1000;
             conn.execute(
@@ -527,11 +526,16 @@ mod tests {
 
     #[test]
     fn test_sqlite_open_sets_cache_size_pragma() {
-        let source = include_str!("opencode.rs");
-        assert!(
-            source.contains("PRAGMA cache_size"),
-            "open_sqlite_readonly must set PRAGMA cache_size to cap memory usage (PR #1120)"
-        );
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        drop(crate::sqlite::open_with_memory_limits(&db_path).unwrap());
+
+        let conn = open_sqlite_readonly(&db_path).unwrap();
+
+        let cache_size: i32 = conn
+            .pragma_query_value(None, "cache_size", |row| row.get(0))
+            .unwrap();
+        assert_eq!(cache_size, crate::sqlite::MEMORY_LIMIT_CACHE_SIZE_KIB);
     }
 
     #[test]

--- a/src/streams/db.rs
+++ b/src/streams/db.rs
@@ -149,8 +149,10 @@ pub struct StreamsDatabase {
 impl StreamsDatabase {
     /// Open or create the transcripts database at the given path.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, StreamError> {
-        let conn = Connection::open(path.as_ref()).map_err(|e| StreamError::Fatal {
-            message: format!("Failed to open database: {}", e),
+        let conn = crate::sqlite::open_with_memory_limits(path.as_ref()).map_err(|e| {
+            StreamError::Fatal {
+                message: format!("Failed to open database: {}", e),
+            }
         })?;
 
         // Enable WAL mode for better concurrency and crash resistance
@@ -163,10 +165,6 @@ impl StreamsDatabase {
         conn.pragma_update(None, "synchronous", "NORMAL")
             .map_err(|e| StreamError::Fatal {
                 message: format!("Failed to set synchronous mode: {}", e),
-            })?;
-        conn.pragma_update(None, "cache_size", -2000)
-            .map_err(|e| StreamError::Fatal {
-                message: format!("Failed to set cache size: {}", e),
             })?;
         conn.pragma_update(None, "temp_store", "MEMORY")
             .map_err(|e| StreamError::Fatal {
@@ -997,7 +995,7 @@ mod tests {
 
         // Manually create a v3 database
         {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
             // Run migrations 0..=2 (versions 1, 2, 3)
             for migration in &MIGRATIONS[..3] {
                 conn.execute_batch(migration).unwrap();
@@ -1068,7 +1066,7 @@ mod tests {
 
         // Create v3 DB with multiple sessions
         {
-            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
             for migration in &MIGRATIONS[..3] {
                 conn.execute_batch(migration).unwrap();
             }

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -344,7 +344,7 @@ mod tests {
     fn test_extract_model_opencode_assistant_message_format() {
         let dir = tempfile::TempDir::new().unwrap();
         let db_path = dir.path().join("opencode.db");
-        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
         conn.execute_batch(
             "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
              INSERT INTO message VALUES ('msg-1', 'sess-1', 1000, 1000, '{\"role\":\"assistant\",\"modelID\":\"claude-opus-4-6\",\"providerID\":\"anthropic\"}');",

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -120,6 +120,7 @@ mod sessions_cutover;
 mod show_prompt;
 mod simple_additions;
 mod simple_benchmark;
+mod sqlite_connection_policy;
 mod squash_merge;
 mod stale_prompt_carry;
 mod stash_attribution;

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -19,7 +19,7 @@ fn test_opencode_raw_event_fidelity() {
     use git_ai::streams::agent::Agent;
     use git_ai::streams::agents::OpenCodeAgent;
     use git_ai::streams::watermark::TimestampWatermark;
-    use rusqlite::{Connection, OpenFlags};
+    use rusqlite::OpenFlags;
 
     let opencode_root = opencode_sqlite_fixture_path();
     let fixture = opencode_root.join("opencode.db");
@@ -32,7 +32,11 @@ fn test_opencode_raw_event_fidelity() {
         .unwrap();
 
     // Independently query the SQLite DB to construct the same expected events.
-    let conn = Connection::open_with_flags(&fixture, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+    let conn = git_ai::sqlite::open_with_flags_and_memory_limits(
+        &fixture,
+        OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
 
     let watermark_millis = DateTime::<Utc>::UNIX_EPOCH.timestamp_millis();
 

--- a/tests/integration/sqlite_connection_policy.rs
+++ b/tests/integration/sqlite_connection_policy.rs
@@ -1,0 +1,59 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const ALLOWED_RAW_OPEN_FILE: &str = "src/sqlite.rs";
+const POLICY_TEST_FILE: &str = "tests/integration/sqlite_connection_policy.rs";
+
+#[test]
+fn sqlite_connections_go_through_memory_limited_helpers() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let roots = ["src", "tests", "benches"];
+    let forbidden_patterns = [
+        "Connection::open(",
+        "Connection::open_in_memory(",
+        "Connection::open_with_flags(",
+        "rusqlite::Connection::open(",
+        "rusqlite::Connection::open_in_memory(",
+        "rusqlite::Connection::open_with_flags(",
+    ];
+
+    let mut violations = Vec::new();
+    for root in roots {
+        collect_rust_files(&manifest_dir.join(root), &mut |path| {
+            let relative = path.strip_prefix(&manifest_dir).unwrap();
+            if relative == Path::new(ALLOWED_RAW_OPEN_FILE)
+                || relative == Path::new(POLICY_TEST_FILE)
+            {
+                return;
+            }
+
+            let contents = fs::read_to_string(path).unwrap();
+            for (line_number, line) in contents.lines().enumerate() {
+                if forbidden_patterns
+                    .iter()
+                    .any(|pattern| line.contains(pattern))
+                {
+                    violations.push(format!("{}:{}", relative.display(), line_number + 1));
+                }
+            }
+        });
+    }
+
+    assert!(
+        violations.is_empty(),
+        "SQLite connections must use src/sqlite.rs helpers so every open applies memory limits:\n{}",
+        violations.join("\n")
+    );
+}
+
+fn collect_rust_files(dir: &Path, visitor: &mut impl FnMut(&Path)) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rust_files(&path, visitor);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            visitor(&path);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Added `src/sqlite.rs` as the single Rust raw-open location for SQLite connections.
- Routed runtime DBs, fallback DBs, test DB setup, and read-only transcript DB opens through helpers that immediately apply `PRAGMA cache_size=-2000`.
- Removed Rust `open_in_memory` fallbacks; bash history now fails closed if even its file-backed fallback cannot initialize.
- Added a source-level integration policy test that rejects direct `rusqlite::Connection::open*` call sites outside the helper.
- Updated the VSCode fixture script to set the same cache-size PRAGMA on its Python sqlite connections.

## Why

In-memory SQLite fallback connections can grow without the file-backed limits we rely on elsewhere. Centralizing opens makes the memory cap automatic and keeps future connection sites from bypassing it.

## Validation

- `task fmt`
- `task build`
- `task lint`
- `task test`
- Focused checks: `sqlite_connections_go_through_memory_limited_helpers`, `open_with_memory_limits_sets_cache_size`, `open_with_flags_and_memory_limits_sets_cache_size`, `test_sqlite_open_sets_cache_size_pragma`, `test_performance_pragmas_set`, `fallback_database`, `flush_pending_metric_records`, `insert_sessions_dedupes_by_session_id`, `test_opencode_raw_event_fidelity`