### PR TITLE
[codex] add commit metric timestamps and patch id

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -13,7 +13,7 @@ use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry
 use crate::config::Config;
 use crate::error::GitAiError;
 use crate::git::notes_api::write_note as notes_add;
-use crate::git::repository::{Repository, batch_read_paths_at_treeishes};
+use crate::git::repository::{Repository, batch_read_paths_at_treeishes, exec_git};
 use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
 
@@ -1020,17 +1020,65 @@ pub(crate) fn metric_tool_model_breakdown(
     })
 }
 
-pub(crate) fn commit_subject_and_body(
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CommitMetricMetadata {
+    pub subject: Option<String>,
+    pub body: Option<String>,
+    pub author_ts: Option<u64>,
+    pub commit_ts: Option<u64>,
+}
+
+pub(crate) fn commit_metric_metadata(
     repo: &Repository,
     commit_sha: &str,
-) -> (Option<String>, Option<String>) {
-    let Ok(commit) = repo.find_commit(commit_sha.to_string()) else {
-        return (None, None);
+) -> Result<CommitMetricMetadata, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "show".to_string(),
+        "-s".to_string(),
+        "--no-notes".to_string(),
+        "--encoding=UTF-8".to_string(),
+        "--format=%s%x00%b%x00%at%x00%ct".to_string(),
+        commit_sha.to_string(),
+    ]);
+    let output = exec_git(&args)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok(parse_commit_metric_metadata_output(&stdout))
+}
+
+fn parse_commit_metric_metadata_output(output: &str) -> CommitMetricMetadata {
+    let mut parts = output.splitn(4, '\0');
+    let Some(subject) = parts.next() else {
+        return CommitMetricMetadata::default();
     };
-    let subject = Some(commit.summary().unwrap_or_default());
-    let body = commit.body().unwrap_or_default();
-    let body = if body.is_empty() { None } else { Some(body) };
-    (subject, body)
+    let Some(body) = parts.next() else {
+        return CommitMetricMetadata::default();
+    };
+    let Some(author_ts) = parts.next() else {
+        return CommitMetricMetadata::default();
+    };
+    let Some(commit_ts) = parts.next() else {
+        return CommitMetricMetadata::default();
+    };
+
+    let subject = subject.trim().to_string();
+    let body = body.trim().to_string();
+
+    CommitMetricMetadata {
+        subject: Some(subject),
+        body: (!body.is_empty()).then_some(body),
+        author_ts: author_ts.trim().parse::<u64>().ok(),
+        commit_ts: commit_ts.trim().parse::<u64>().ok(),
+    }
+}
+
+pub(crate) fn stable_patch_id_for_commit(repo: &Repository, commit_sha: &str) -> Option<String> {
+    crate::authorship::rewrite_cherry_pick::stable_patch_ids_for_commits(
+        repo,
+        &[commit_sha.to_string()],
+    )
+    .ok()
+    .and_then(|patch_ids| patch_ids.get(commit_sha).cloned())
 }
 
 pub(crate) fn commit_metric_attrs(
@@ -1096,14 +1144,26 @@ fn record_commit_metrics(
         values.first_checkpoint_ts_null()
     };
 
-    let (subject, body) = commit_subject_and_body(repo, commit_sha);
-    let values = match subject {
+    let metadata = commit_metric_metadata(repo, commit_sha).unwrap_or_default();
+    let values = match metadata.subject {
         Some(subject) => values.commit_subject(subject),
         None => values.commit_subject_null(),
     };
-    let values = match body {
+    let values = match metadata.body {
         Some(body) => values.commit_body(body),
         None => values.commit_body_null(),
+    };
+    let values = match metadata.author_ts {
+        Some(author_ts) => values.author_ts(author_ts),
+        None => values.author_ts_null(),
+    };
+    let values = match metadata.commit_ts {
+        Some(commit_ts) => values.commit_ts(commit_ts),
+        None => values.commit_ts_null(),
+    };
+    let values = match stable_patch_id_for_commit(repo, commit_sha) {
+        Some(patch_id) => values.patch_id(patch_id),
+        None => values.patch_id_null(),
     }
     .authorship_note(authorship_note);
 
@@ -1122,6 +1182,45 @@ fn record_commit_metrics(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_commit_metric_metadata_output_reads_subject_body_and_timestamps() {
+        let metadata = parse_commit_metric_metadata_output(concat!(
+            "Subject line",
+            "\0",
+            "Body line one\n\nBody line two",
+            "\0",
+            "1704067200",
+            "\0",
+            "1704067260\n"
+        ));
+
+        assert_eq!(metadata.subject, Some("Subject line".to_string()));
+        assert_eq!(
+            metadata.body,
+            Some("Body line one\n\nBody line two".to_string())
+        );
+        assert_eq!(metadata.author_ts, Some(1_704_067_200));
+        assert_eq!(metadata.commit_ts, Some(1_704_067_260));
+    }
+
+    #[test]
+    fn parse_commit_metric_metadata_output_uses_null_body_for_empty_body() {
+        let metadata = parse_commit_metric_metadata_output(concat!(
+            "Subject line",
+            "\0",
+            "",
+            "\0",
+            "1704067200",
+            "\0",
+            "1704067260\n"
+        ));
+
+        assert_eq!(metadata.subject, Some("Subject line".to_string()));
+        assert_eq!(metadata.body, None);
+        assert_eq!(metadata.author_ts, Some(1_704_067_200));
+        assert_eq!(metadata.commit_ts, Some(1_704_067_260));
+    }
 
     #[test]
     fn test_count_line_ranges_handles_scattered_and_contiguous_lines() {

--- a/src/authorship/rewrite_cherry_pick.rs
+++ b/src/authorship/rewrite_cherry_pick.rs
@@ -96,6 +96,24 @@ fn compute_patch_ids(
         return Ok(HashMap::new());
     }
 
+    stable_patch_ids_for_commits(repo, &commits)
+}
+
+pub(crate) fn stable_patch_ids_for_commits(
+    repo: &Repository,
+    commit_shas: &[String],
+) -> Result<HashMap<String, String>, crate::error::GitAiError> {
+    let mut commits = Vec::new();
+    let mut seen = HashSet::new();
+    for sha in commit_shas {
+        if seen.insert(sha.clone()) {
+            commits.push(sha.clone());
+        }
+    }
+    if commits.is_empty() {
+        return Ok(HashMap::new());
+    }
+
     let mut log_args = repo.global_args_for_exec();
     log_args.extend([
         "log".to_string(),
@@ -103,6 +121,7 @@ fn compute_patch_ids(
         "--no-walk".to_string(),
         "--reverse".to_string(),
         "--no-ext-diff".to_string(),
+        "--no-textconv".to_string(),
         "--no-color".to_string(),
         "--format=medium".to_string(),
         "-p".to_string(),
@@ -135,6 +154,12 @@ fn compute_patch_ids(
 
 #[cfg(test)]
 mod tests {
+    use super::stable_patch_ids_for_commits;
+
+    fn looks_like_hex_id(value: &str) -> bool {
+        matches!(value.len(), 40 | 64) && value.chars().all(|c| c.is_ascii_hexdigit())
+    }
+
     #[test]
     fn match_cherry_pick_pairs_empty_sources() {
         // Cannot call with a real repo in unit tests, but we can verify the early return
@@ -190,6 +215,27 @@ mod tests {
         let pairs = positional_pair(&sources, &new_commits);
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0], ("a".repeat(40), "d".repeat(40)));
+    }
+
+    #[test]
+    fn stable_patch_ids_for_commits_batches_multiple_commits() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        tmp.write_file("one.txt", "one\n", false)
+            .expect("write first");
+        let first = tmp.commit_all("first").expect("first commit");
+        tmp.write_file("two.txt", "two\n", false)
+            .expect("write second");
+        let second = tmp.commit_all("second").expect("second commit");
+
+        let patch_ids =
+            stable_patch_ids_for_commits(tmp.gitai_repo(), &[first.clone(), second.clone()])
+                .expect("patch ids");
+
+        let first_patch_id = patch_ids.get(&first).expect("first patch id");
+        let second_patch_id = patch_ids.get(&second).expect("second patch id");
+        assert!(looks_like_hex_id(first_patch_id));
+        assert!(looks_like_hex_id(second_patch_id));
+        assert_ne!(first_patch_id, second_patch_id);
     }
 
     /// Helper that simulates pass-2 positional pairing without patch-id (for unit testing).

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -29,6 +29,9 @@ pub mod committed_pos {
     pub const COMMIT_BODY: usize = 12; // String (null if empty)
     pub const AUTHORSHIP_NOTE: usize = 13; // String (full serialized authorship note)
     pub const HUNKS: usize = 14; // String (JSON array of DiffJsonHunk)
+    pub const AUTHOR_TS: usize = 15; // u64 (git author timestamp, %at)
+    pub const COMMIT_TS: usize = 16; // u64 (git committer timestamp, %ct)
+    pub const PATCH_ID: usize = 17; // String (git patch-id --stable)
 }
 
 /// Values for Event ID 1: committed
@@ -57,6 +60,9 @@ pub mod committed_pos {
 /// | 12 | commit_body | String |
 /// | 13 | authorship_note | String |
 /// | 14 | hunks | String |
+/// | 15 | author_ts | u64 |
+/// | 16 | commit_ts | u64 |
+/// | 17 | patch_id | String |
 #[derive(Debug, Clone, Default)]
 pub struct CommittedValues {
     // Scalar fields
@@ -75,6 +81,9 @@ pub struct CommittedValues {
     pub commit_body: PosField<String>,
     pub authorship_note: PosField<String>,
     pub hunks: PosField<String>,
+    pub author_ts: PosField<u64>,
+    pub commit_ts: PosField<u64>,
+    pub patch_id: PosField<String>,
 }
 
 impl CommittedValues {
@@ -203,6 +212,36 @@ impl CommittedValues {
         self.hunks = Some(None);
         self
     }
+
+    pub fn author_ts(mut self, value: u64) -> Self {
+        self.author_ts = Some(Some(value));
+        self
+    }
+
+    pub fn author_ts_null(mut self) -> Self {
+        self.author_ts = Some(None);
+        self
+    }
+
+    pub fn commit_ts(mut self, value: u64) -> Self {
+        self.commit_ts = Some(Some(value));
+        self
+    }
+
+    pub fn commit_ts_null(mut self) -> Self {
+        self.commit_ts = Some(None);
+        self
+    }
+
+    pub fn patch_id(mut self, value: impl Into<String>) -> Self {
+        self.patch_id = Some(Some(value.into()));
+        self
+    }
+
+    pub fn patch_id_null(mut self) -> Self {
+        self.patch_id = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for CommittedValues {
@@ -265,6 +304,21 @@ impl PosEncoded for CommittedValues {
             string_to_json(&self.authorship_note),
         );
         sparse_set(&mut map, committed_pos::HUNKS, string_to_json(&self.hunks));
+        sparse_set(
+            &mut map,
+            committed_pos::AUTHOR_TS,
+            u64_to_json(&self.author_ts),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::COMMIT_TS,
+            u64_to_json(&self.commit_ts),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::PATCH_ID,
+            string_to_json(&self.patch_id),
+        );
 
         map
     }
@@ -287,6 +341,9 @@ impl PosEncoded for CommittedValues {
             commit_body: sparse_get_string(arr, committed_pos::COMMIT_BODY),
             authorship_note: sparse_get_string(arr, committed_pos::AUTHORSHIP_NOTE),
             hunks: sparse_get_string(arr, committed_pos::HUNKS),
+            author_ts: sparse_get_u64(arr, committed_pos::AUTHOR_TS),
+            commit_ts: sparse_get_u64(arr, committed_pos::COMMIT_TS),
+            patch_id: sparse_get_string(arr, committed_pos::PATCH_ID),
         }
     }
 }
@@ -1049,6 +1106,28 @@ mod tests {
     }
 
     #[test]
+    fn test_committed_values_with_commit_timestamps_and_patch_id() {
+        use super::PosEncoded;
+
+        let values = CommittedValues::new()
+            .author_ts(1_704_067_200)
+            .commit_ts(1_704_067_260)
+            .patch_id("abc123");
+
+        let sparse = PosEncoded::to_sparse(&values);
+
+        assert_eq!(
+            sparse.get("15"),
+            Some(&Value::Number(1_704_067_200u64.into()))
+        );
+        assert_eq!(
+            sparse.get("16"),
+            Some(&Value::Number(1_704_067_260u64.into()))
+        );
+        assert_eq!(sparse.get("17"), Some(&Value::String("abc123".to_string())));
+    }
+
+    #[test]
     fn test_committed_values_from_sparse() {
         use super::PosEncoded;
 
@@ -1171,7 +1250,10 @@ mod tests {
             .human_additions(25)
             .first_checkpoint_ts(1700000000)
             .commit_subject("Test commit")
-            .commit_body_null();
+            .commit_body_null()
+            .author_ts(1700000100)
+            .commit_ts(1700000200)
+            .patch_id("stable-patch-id");
 
         let sparse = PosEncoded::to_sparse(&original);
         let restored = <CommittedValues as PosEncoded>::from_sparse(&sparse);
@@ -1183,6 +1265,9 @@ mod tests {
             Some(Some("Test commit".to_string()))
         );
         assert_eq!(restored.commit_body, Some(None));
+        assert_eq!(restored.author_ts, Some(Some(1700000100)));
+        assert_eq!(restored.commit_ts, Some(Some(1700000200)));
+        assert_eq!(restored.patch_id, Some(Some("stable-patch-id".to_string())));
     }
 
     #[test]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -62,25 +62,24 @@ pub fn log_message(message: &str, level: &str, context: Option<serde_json::Value
 /// Log a batch of metric events (via daemon telemetry worker).
 ///
 /// Events are batched into envelopes of up to 1000 events each.
-pub fn log_metrics(
-    #[cfg_attr(any(test, feature = "test-support"), allow(unused))] events: Vec<MetricEvent>,
-) {
+pub fn log_metrics(events: Vec<MetricEvent>) {
     #[cfg(any(test, feature = "test-support"))]
-    return;
-
-    #[cfg(not(any(test, feature = "test-support")))]
     {
-        if events.is_empty() {
+        if std::env::var_os("GIT_AI_TEST_METRICS_DB_PATH").is_none() {
             return;
         }
+    }
 
-        // Split into chunks of MAX_METRICS_PER_ENVELOPE
-        for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-            let envelope = crate::daemon::TelemetryEnvelope::Metrics {
-                events: chunk.to_vec(),
-            };
-            submit_telemetry_envelope(vec![envelope]);
-        }
+    if events.is_empty() {
+        return;
+    }
+
+    // Split into chunks of MAX_METRICS_PER_ENVELOPE
+    for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
+        let envelope = crate::daemon::TelemetryEnvelope::Metrics {
+            events: chunk.to_vec(),
+        };
+        submit_telemetry_envelope(vec![envelope]);
     }
 }
 

--- a/tests/integration/commit_metric_metadata.rs
+++ b/tests/integration/commit_metric_metadata.rs
@@ -1,0 +1,146 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::MetricEvent;
+use git_ai::metrics::attrs::attr_pos;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::events::committed_pos;
+use git_ai::metrics::types::{MetricEventId, SparseArray};
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
+    let path = dir.path().join("metrics.db");
+    (dir, path.to_string_lossy().to_string())
+}
+
+fn codex_checkpoint(
+    repo: &TestRepo,
+    file_path: &Path,
+    session_id: &str,
+    hook_event_name: &str,
+    tool_use_id: &str,
+) {
+    let hook_input = json!({
+        "session_id": session_id,
+        "cwd": repo.canonical_path().to_string_lossy().to_string(),
+        "hook_event_name": hook_event_name,
+        "tool_name": "apply_patch",
+        "tool_use_id": tool_use_id,
+        "model": "gpt-5",
+        "tool_input": {
+            "patch": format!("*** Update File: {}\n", file_path.to_string_lossy())
+        },
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
+        .expect("codex checkpoint should succeed");
+}
+
+fn sparse_str(values: &SparseArray, pos: usize) -> Option<&str> {
+    values
+        .get(&pos.to_string())
+        .and_then(|value| value.as_str())
+}
+
+fn sparse_u64(values: &SparseArray, pos: usize) -> Option<u64> {
+    values
+        .get(&pos.to_string())
+        .and_then(|value| value.as_u64())
+}
+
+fn committed_metric_for_commit(db_path: &str, commit_sha: &str) -> MetricEvent {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let db = MetricsDatabase::open_at_path(Path::new(db_path))
+            .expect("metrics db should open at isolated path");
+        let records = db
+            .get_metric_history(0, None, &[MetricEventId::Committed as u16])
+            .expect("metric history should load");
+        if let Some(record) = records.into_iter().find(|record| {
+            sparse_str(&record.event.attrs, attr_pos::COMMIT_SHA) == Some(commit_sha)
+        }) {
+            return record.event;
+        }
+
+        if Instant::now() >= deadline {
+            panic!("committed metric for {commit_sha} was not persisted");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn looks_like_patch_id(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[test]
+fn committed_metric_includes_git_author_commit_timestamps_and_patch_id() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+
+    let file_path = repo.path().join("generated.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit")
+        .expect("initial commit should succeed");
+
+    codex_checkpoint(
+        &repo,
+        &file_path,
+        "metric-metadata-session",
+        "PreToolUse",
+        "tool-use-metric-metadata",
+    );
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    codex_checkpoint(
+        &repo,
+        &file_path,
+        "metric-metadata-session",
+        "PostToolUse",
+        "tool-use-metric-metadata",
+    );
+
+    let commit = repo
+        .stage_all_and_commit_with_env(
+            "AI commit with deterministic dates",
+            &[
+                ("GIT_AUTHOR_DATE", "2030-01-03T00:00:00Z"),
+                ("GIT_COMMITTER_DATE", "2030-01-03T00:00:42Z"),
+            ],
+        )
+        .expect("AI commit should succeed");
+
+    let expected_times = repo
+        .git(&["show", "-s", "--format=%at%x00%ct", &commit.commit_sha])
+        .expect("commit timestamps should be readable");
+    let mut parts = expected_times.trim().split('\0');
+    let expected_author_ts = parts
+        .next()
+        .expect("author ts")
+        .parse::<u64>()
+        .expect("author ts should parse");
+    let expected_commit_ts = parts
+        .next()
+        .expect("commit ts")
+        .parse::<u64>()
+        .expect("commit ts should parse");
+
+    let event = committed_metric_for_commit(&metrics_db_path, &commit.commit_sha);
+    assert_eq!(
+        sparse_u64(&event.values, committed_pos::AUTHOR_TS),
+        Some(expected_author_ts)
+    );
+    assert_eq!(
+        sparse_u64(&event.values, committed_pos::COMMIT_TS),
+        Some(expected_commit_ts)
+    );
+    let patch_id = sparse_str(&event.values, committed_pos::PATCH_ID).expect("patch id");
+    assert!(looks_like_patch_id(patch_id), "patch_id={patch_id}");
+
+    let mut file = repo.filename("generated.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -43,6 +43,7 @@ mod claude_code;
 mod cli_parser_rebase_args;
 mod codex;
 mod cold_trace2_repo;
+mod commit_metric_metadata;
 mod commit_post_stats_benchmark;
 mod config_cli_coverage;
 mod config_pattern_detection;


### PR DESCRIPTION
## Summary
- add author_ts, commit_ts, and patch_id to committed MetricEvent values
- read commit subject/body/timestamps in one post-commit metadata call
- reuse a batched stable patch-id helper for commit metric enrichment
- add TestRepo coverage for persisted committed metrics with deterministic Git dates

## Validation
- task test TEST_FILTER=commit_metric_metadata
- targeted unit tests for committed value encoding, metadata parsing, patch-id helper, and log_metrics
- task build
- task fmt
- task lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->