### PR TITLE
fix(stash): stop exponential checkpoints.jsonl growth on stash push/pop cycles

### DIFF
--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -19,8 +19,22 @@ pub struct StashMetadata {
     pub pathspecs: Vec<String>,
 }
 
+// Versioned so upgrades can't resurrect pre-fix stash data: v1 ("stashes")
+// could balloon to GBs (push copied the working log without clearing it and
+// pop re-appended it, doubling checkpoints.jsonl per cycle). Restoring such a
+// worklog would slurp it all into memory, so we abandon the old dir entirely.
 fn stashes_dir(repo: &Repository) -> PathBuf {
-    repo.storage.ai_dir.join("stashes")
+    repo.storage.ai_dir.join("stashes_v2")
+}
+
+/// Delete the legacy (pre-versioning) stash dir if present, sacrificing any
+/// attribution stashed by pre-fix versions in exchange for guaranteeing its
+/// potentially multi-GB worklogs are never restored or loaded again.
+fn cleanup_legacy_stashes_dir(repo: &Repository) {
+    let legacy_dir = repo.storage.ai_dir.join("stashes");
+    if legacy_dir.exists() {
+        let _ = fs::remove_dir_all(&legacy_dir);
+    }
 }
 
 fn path_matches_any(path: &str, pathspecs: &[String]) -> bool {
@@ -53,6 +67,11 @@ fn clean_working_log_for_stash(
     if pathspecs.is_empty() {
         initial.files.clear();
         initial.file_blobs.clear();
+        // A full stash leaves the tree matching HEAD, so the live log must be
+        // emptied too -- the stash copy carries the attribution until restore.
+        // Truncate without reading so a push on an already-bloated log never
+        // loads it into memory.
+        persisted.write_all_checkpoints(&[])?;
     } else {
         initial
             .files
@@ -60,6 +79,17 @@ fn clean_working_log_for_stash(
         initial
             .file_blobs
             .retain(|path, _| !path_matches_any(path, pathspecs));
+        // Complement of filter_stash_checkpoints_to_pathspecs: the stash copy
+        // keeps the matching paths, the live log keeps everything else.
+        persisted.mutate_all_checkpoints(|checkpoints| {
+            for checkpoint in checkpoints.iter_mut() {
+                checkpoint
+                    .entries
+                    .retain(|entry| !path_matches_any(&entry.file, pathspecs));
+            }
+            checkpoints.retain(|checkpoint| !checkpoint.entries.is_empty());
+            Ok(())
+        })?;
     }
 
     persisted.write_initial(initial)?;
@@ -72,6 +102,8 @@ pub fn handle_stash_create(
     head_sha: &str,
     pathspecs: Vec<String>,
 ) -> Result<(), GitAiError> {
+    cleanup_legacy_stashes_dir(repo);
+
     let metadata = StashMetadata {
         base_commit: head_sha.to_string(),
         timestamp: SystemTime::now()
@@ -102,6 +134,8 @@ pub fn handle_stash_pop_or_apply_with_head(
     is_pop: bool,
     target_head: Option<&str>,
 ) -> Result<(), GitAiError> {
+    cleanup_legacy_stashes_dir(repo);
+
     let dir = stashes_dir(repo);
     let metadata_path = dir.join(format!("{}.json", stash_sha));
 
@@ -134,6 +168,8 @@ pub fn handle_stash_pop_or_apply_with_head(
 }
 
 pub fn handle_stash_drop(repo: &Repository, stash_sha: &str) -> Result<(), GitAiError> {
+    cleanup_legacy_stashes_dir(repo);
+
     let dir = stashes_dir(repo);
     let metadata_path = dir.join(format!("{}.json", stash_sha));
     if metadata_path.exists() {
@@ -250,6 +286,47 @@ fn filter_stash_initial_to_pathspecs(
     Ok(())
 }
 
+/// Append stash-copy checkpoint lines onto the live log, skipping lines the
+/// live log already contains byte-identically. `Checkpoint.diff` is a content
+/// hash and lines carry timestamps, so distinct checkpoints never collide;
+/// this keeps repeated `stash apply` (and the conflict-tolerant re-restore
+/// after a non-zero git exit) from duplicating checkpoints. Known bounded
+/// imprecision: the 7->16-char hash migration in read_all_checkpoints can
+/// rewrite a live line so the stash copy differs byte-wise -- worst case one
+/// extra copy, cleared by the next stash push.
+fn append_checkpoint_lines_deduped(
+    dst_path: &std::path::Path,
+    stash_content: &str,
+) -> Result<(), GitAiError> {
+    use std::io::Write;
+
+    let existing = fs::read_to_string(dst_path).unwrap_or_default();
+    let existing_lines: HashSet<&str> = existing
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let mut to_append = String::new();
+    for line in stash_content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || existing_lines.contains(trimmed) {
+            continue;
+        }
+        to_append.push_str(line);
+        to_append.push('\n');
+    }
+
+    if !to_append.is_empty() {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dst_path)?;
+        f.write_all(to_append.as_bytes())?;
+    }
+    Ok(())
+}
+
 fn restore_stash_attributions(
     repo: &Repository,
     stash_sha: &str,
@@ -275,12 +352,7 @@ fn restore_stash_attributions(
                 let _ = copy_dir_recursive(&src_path, &dst_path);
             } else if file_name == "checkpoints.jsonl" {
                 if let Ok(stash_content) = fs::read_to_string(&src_path) {
-                    use std::io::Write;
-                    let mut f = std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(&dst_path)?;
-                    f.write_all(stash_content.as_bytes())?;
+                    append_checkpoint_lines_deduped(&dst_path, &stash_content)?;
                 }
             } else if file_name == "INITIAL" && dst_path.exists() {
                 merge_initial_files(&src_path, &dst_path)?;

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -822,9 +822,9 @@ impl RefCursor {
 
         if matches!(kind, "apply" | "pop" | "drop" | "branch") {
             let target = if kind == "branch" {
-                stash_args.get(2)
+                stash_positional_arg(stash_args, 1)
             } else {
-                stash_args.get(1)
+                stash_positional_arg(stash_args, 0)
             };
             cmd.stash_target_oid = self.resolve_stash_target_at_cursor(target)?;
         }
@@ -836,7 +836,7 @@ impl RefCursor {
                 cmd.ref_changes.push(entry_to_ref_change(&entry));
             }
         } else if matches!(kind, "pop" | "drop") {
-            self.consume_destructive_stash_operation(stash_args.get(1), cmd)?;
+            self.consume_destructive_stash_operation(stash_positional_arg(stash_args, 0), cmd)?;
         }
 
         if matches!(kind, "apply" | "pop" | "branch")
@@ -3332,6 +3332,20 @@ fn stash_command_args(args: &[String]) -> &[String] {
     } else {
         args
     }
+}
+
+/// Positional (non-flag) argument after the stash subcommand. pop/apply/drop
+/// take only boolean flags (`-q`, `--index`), so the stash target is the
+/// first positional, not literally `args[1]` -- `git stash pop -q` must not
+/// treat `-q` as the target (that made resolution fail and skipped the
+/// attribution restore entirely). For `branch` the branch name is positional 0
+/// and the optional stash target is positional 1.
+fn stash_positional_arg(stash_args: &[String], position: usize) -> Option<&String> {
+    stash_args
+        .iter()
+        .skip(1)
+        .filter(|arg| !arg.starts_with('-'))
+        .nth(position)
 }
 
 fn stash_push_message_from_args(args: &[String], kind: &str) -> Option<String> {

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -250,8 +250,30 @@ impl RepoStorage {
         }
         new_log.write_initial(merged_initial)?;
 
+        // A log can carry the same checkpoints on both sides (e.g. merged
+        // forward and back across HEAD moves), so dedup by identity key --
+        // `diff` is a content hash, so (kind, diff, timestamp, author) never
+        // collides for distinct checkpoints.
         let mut checkpoints = old_log.read_all_checkpoints()?;
-        checkpoints.extend(new_log.read_all_checkpoints()?);
+        let seen: HashSet<(String, String, u64, String)> = checkpoints
+            .iter()
+            .map(|c| {
+                (
+                    c.kind.to_string(),
+                    c.diff.clone(),
+                    c.timestamp,
+                    c.author.clone(),
+                )
+            })
+            .collect();
+        checkpoints.extend(new_log.read_all_checkpoints()?.into_iter().filter(|c| {
+            !seen.contains(&(
+                c.kind.to_string(),
+                c.diff.clone(),
+                c.timestamp,
+                c.author.clone(),
+            ))
+        }));
         new_log.write_all_checkpoints(&checkpoints)?;
         Ok(())
     }
@@ -874,5 +896,71 @@ mod tests {
         // Both sides' unique entries survive.
         assert!(merged.files.contains_key("old_only.txt"));
         assert!(merged.files.contains_key("new_only.txt"));
+    }
+
+    fn checkpoint(diff: &str, timestamp: u64) -> Checkpoint {
+        let entry = crate::authorship::working_log::WorkingLogEntry::new(
+            "file.txt".to_string(),
+            "blobsha".to_string(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let mut cp = Checkpoint::new(
+            CheckpointKind::AiAgent,
+            diff.to_string(),
+            "author".to_string(),
+            vec![entry],
+        );
+        cp.timestamp = timestamp;
+        cp
+    }
+
+    /// When both working logs carry the same checkpoints (e.g. a log that was
+    /// merged forward and back across HEAD moves), merging must not duplicate
+    /// them -- only checkpoints missing from the destination are appended.
+    #[test]
+    fn test_merge_working_log_dirs_dedups_identical_checkpoints() {
+        let tmp = TempDir::new().unwrap();
+        let workdir = tmp.path().join("workdir");
+        fs::create_dir_all(&workdir).unwrap();
+        let ai_dir = tmp.path().join("ai");
+        let storage = RepoStorage::for_repo_path(&ai_dir, &workdir).unwrap();
+
+        let old_sha = "1111111111111111111111111111111111111111";
+        let new_sha = "2222222222222222222222222222222222222222";
+
+        let shared_a = checkpoint("diff-shared-a", 100);
+        let shared_b = checkpoint("diff-shared-b", 200);
+        let old_only = checkpoint("diff-old-only", 300);
+        let new_only = checkpoint("diff-new-only", 400);
+
+        let old_log = storage.working_log_for_base_commit(old_sha).unwrap();
+        old_log
+            .write_all_checkpoints(&[shared_a.clone(), shared_b.clone(), old_only])
+            .unwrap();
+        let new_log = storage.working_log_for_base_commit(new_sha).unwrap();
+        new_log
+            .write_all_checkpoints(&[shared_a, shared_b, new_only])
+            .unwrap();
+
+        storage.rename_working_log(old_sha, new_sha).unwrap();
+
+        let merged = storage
+            .working_log_for_base_commit(new_sha)
+            .unwrap()
+            .read_all_checkpoints()
+            .unwrap();
+        let mut diffs: Vec<&str> = merged.iter().map(|c| c.diff.as_str()).collect();
+        diffs.sort_unstable();
+        assert_eq!(
+            diffs,
+            vec![
+                "diff-new-only",
+                "diff-old-only",
+                "diff-shared-a",
+                "diff-shared-b"
+            ],
+            "shared checkpoints must not duplicate on merge"
+        );
     }
 }

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -1241,7 +1241,7 @@ fn test_stash_push_pathspec_excludes_unstashed_file_from_stash_log() {
     repo.sync_daemon_force();
 
     // Collect every file referenced by the stash worklog's checkpoints.jsonl.
-    let stashes = repo.path().join(".git").join("ai").join("stashes");
+    let stashes = repo.path().join(".git").join("ai").join("stashes_v2");
     let mut stashed_files = std::collections::BTreeSet::new();
     let worklog_dir = std::fs::read_dir(&stashes)
         .expect("stashes dir exists")
@@ -1278,6 +1278,421 @@ fn test_stash_push_pathspec_excludes_unstashed_file_from_stash_log() {
         "stash must NOT carry the unstashed file b.txt, got {:?}",
         stashed_files
     );
+}
+
+/// Count non-empty lines in the live working log's checkpoints.jsonl for HEAD.
+fn live_checkpoint_line_count(repo: &TestRepo) -> usize {
+    let head = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let path = repo
+        .path()
+        .join(".git")
+        .join("ai")
+        .join("working_logs")
+        .join(head)
+        .join("checkpoints.jsonl");
+    fs::read_to_string(path)
+        .map(|c| c.lines().filter(|l| !l.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+/// Files referenced by entries in the live working log's checkpoints.jsonl.
+fn live_checkpoint_files(repo: &TestRepo) -> std::collections::BTreeSet<String> {
+    let head = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let path = repo
+        .path()
+        .join(".git")
+        .join("ai")
+        .join("working_logs")
+        .join(head)
+        .join("checkpoints.jsonl");
+    let mut files = std::collections::BTreeSet::new();
+    if let Ok(content) = fs::read_to_string(path) {
+        for line in content.lines().filter(|l| !l.trim().is_empty()) {
+            let v: serde_json::Value = serde_json::from_str(line).expect("valid checkpoint json");
+            if let Some(entries) = v.get("entries").and_then(|e| e.as_array()) {
+                for entry in entries {
+                    if let Some(f) = entry.get("file").and_then(|f| f.as_str()) {
+                        files.insert(f.to_string());
+                    }
+                }
+            }
+        }
+    }
+    files
+}
+
+/// Count `*_worklog` stash dirs across current and legacy stash dir versions.
+fn stash_worklog_dir_count(repo: &TestRepo) -> usize {
+    let ai_dir = repo.path().join(".git").join("ai");
+    ["stashes", "stashes_v2"]
+        .iter()
+        .map(|d| {
+            fs::read_dir(ai_dir.join(d))
+                .map(|entries| {
+                    entries
+                        .flatten()
+                        .filter(|e| {
+                            e.path().is_dir()
+                                && e.file_name()
+                                    .to_str()
+                                    .is_some_and(|s| s.ends_with("_worklog"))
+                        })
+                        .count()
+                })
+                .unwrap_or(0)
+        })
+        .sum()
+}
+
+/// Non-empty checkpoints.jsonl line count inside the (single) stash worklog copy.
+fn stash_copy_checkpoint_line_count(repo: &TestRepo) -> usize {
+    let ai_dir = repo.path().join(".git").join("ai");
+    let worklog_dir = ["stashes", "stashes_v2"]
+        .iter()
+        .filter_map(|d| fs::read_dir(ai_dir.join(d)).ok())
+        .flat_map(|entries| entries.flatten().map(|e| e.path()))
+        .find(|p| {
+            p.is_dir()
+                && p.file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.ends_with("_worklog"))
+        })
+        .expect("a *_worklog dir should exist after stash push");
+    fs::read_to_string(worklog_dir.join("checkpoints.jsonl"))
+        .map(|c| c.lines().filter(|l| !l.trim().is_empty()).count())
+        .unwrap_or(0)
+}
+
+/// Regression: repeated stash push/pop at the same HEAD used to double
+/// checkpoints.jsonl every cycle (push copied the working log into the stash
+/// without clearing it; pop raw-appended the copy back), growing it to GBs.
+#[test]
+fn test_stash_pop_cycles_do_not_grow_checkpoints() {
+    let repo = TestRepo::new();
+    let a_path = repo.path().join("a.txt");
+    let b_path = repo.path().join("b.txt");
+    fs::write(&a_path, "base a\n").unwrap();
+    fs::write(&b_path, "base b\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&a_path, "base a\nAI a 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+    fs::write(&b_path, "base b\nAI b 1\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "b.txt"]).unwrap();
+    fs::write(&a_path, "base a\nAI a 1\nAI a 2\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+
+    repo.sync_daemon_force();
+    let baseline = live_checkpoint_line_count(&repo);
+    assert!(
+        baseline >= 3,
+        "expected at least 3 checkpoint lines before cycling, got {baseline}"
+    );
+
+    for _ in 0..5 {
+        repo.git(&["stash", "push"]).expect("stash push");
+        repo.git(&["stash", "pop"]).expect("stash pop");
+    }
+    repo.sync_daemon_force();
+
+    let after = live_checkpoint_line_count(&repo);
+    assert_eq!(
+        after, baseline,
+        "checkpoints.jsonl must not grow across stash push/pop cycles (was {baseline} lines, now {after})"
+    );
+    assert_eq!(
+        stash_worklog_dir_count(&repo),
+        0,
+        "pop must remove the stash worklog copy"
+    );
+
+    repo.stage_all_and_commit("commit after stash cycles")
+        .unwrap();
+    let mut a = repo.filename("a.txt");
+    a.assert_committed_lines(crate::lines![
+        "base a".unattributed_human(),
+        "AI a 1".ai(),
+        "AI a 2".ai(),
+    ]);
+    let mut b = repo.filename("b.txt");
+    b.assert_committed_lines(crate::lines!["base b".unattributed_human(), "AI b 1".ai(),]);
+}
+
+/// A full `git stash push` leaves the tree matching HEAD, so the live working
+/// log must be emptied (the stash copy carries the attribution); pop restores it.
+#[test]
+fn test_stash_push_clears_live_checkpoints_and_pop_restores() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    repo.sync_daemon_force();
+    let baseline = live_checkpoint_line_count(&repo);
+    assert!(baseline >= 1, "expected checkpoint lines, got {baseline}");
+
+    repo.git(&["stash", "push"]).expect("stash push");
+    repo.sync_daemon_force();
+    assert_eq!(
+        live_checkpoint_line_count(&repo),
+        0,
+        "stash push must clear the live checkpoints.jsonl"
+    );
+    assert_eq!(
+        stash_copy_checkpoint_line_count(&repo),
+        baseline,
+        "the stash copy must carry the stashed checkpoints"
+    );
+
+    repo.git(&["stash", "pop"]).expect("stash pop");
+    repo.sync_daemon_force();
+    assert_eq!(
+        live_checkpoint_line_count(&repo),
+        baseline,
+        "stash pop must restore exactly the stashed checkpoints"
+    );
+
+    repo.stage_all_and_commit("commit popped stash").unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+}
+
+/// `stash apply` keeps the stash entry (and our worklog copy) around, and the
+/// daemon restores attribution even when git exits non-zero. Repeated applies
+/// must not re-append the same checkpoints.
+#[test]
+fn test_stash_apply_repeated_is_idempotent() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    repo.sync_daemon_force();
+    let baseline = live_checkpoint_line_count(&repo);
+    assert!(baseline >= 1, "expected checkpoint lines, got {baseline}");
+
+    repo.git(&["stash", "push"]).expect("stash push");
+    repo.git(&["stash", "apply"]).expect("stash apply");
+    // Second apply may fail (changes already present); the daemon still runs
+    // its conflict-tolerant restore, which must not duplicate checkpoints.
+    let _ = repo.git(&["stash", "apply"]);
+    repo.sync_daemon_force();
+
+    let after = live_checkpoint_line_count(&repo);
+    assert_eq!(
+        after, baseline,
+        "repeated stash apply must not duplicate checkpoints (was {baseline} lines, now {after})"
+    );
+
+    repo.stage_all_and_commit("commit applied stash").unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+}
+
+/// `git stash push -- <pathspec>` only stashes matching paths, so the live
+/// working log must keep checkpoints for the unstashed files and drop the
+/// stashed ones (complement of what the stash copy keeps).
+#[test]
+fn test_stash_push_pathspec_keeps_unstashed_checkpoints_in_live_log() {
+    let repo = TestRepo::new();
+    let a_path = repo.path().join("a.txt");
+    let b_path = repo.path().join("b.txt");
+    fs::write(&a_path, "base a\n").unwrap();
+    fs::write(&b_path, "base b\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&a_path, "base a\nAI a\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+    fs::write(&b_path, "base b\nAI b\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "b.txt"]).unwrap();
+
+    repo.git(&["stash", "push", "--", "a.txt"])
+        .expect("stash push -- a.txt");
+    repo.sync_daemon_force();
+
+    let live_files = live_checkpoint_files(&repo);
+    assert!(
+        live_files.contains("b.txt"),
+        "live log must keep the unstashed file b.txt, got {live_files:?}"
+    );
+    assert!(
+        !live_files.contains("a.txt"),
+        "live log must drop the stashed file a.txt, got {live_files:?}"
+    );
+
+    repo.git(&["stash", "pop"]).expect("stash pop");
+    repo.sync_daemon_force();
+    let live_files = live_checkpoint_files(&repo);
+    assert!(
+        live_files.contains("a.txt") && live_files.contains("b.txt"),
+        "after pop both files must be attributed in the live log, got {live_files:?}"
+    );
+
+    repo.stage_all_and_commit("commit both").unwrap();
+    let mut a = repo.filename("a.txt");
+    a.assert_committed_lines(crate::lines!["base a".unattributed_human(), "AI a".ai(),]);
+    let mut b = repo.filename("b.txt");
+    b.assert_committed_lines(crate::lines!["base b".unattributed_human(), "AI b".ai(),]);
+}
+
+/// Shifted pop (HEAD moved between push and pop) consolidates the stash copy
+/// into INITIAL attributions -- it must not append stash checkpoint lines to
+/// the new HEAD's checkpoints.jsonl, and attribution must survive the commit.
+#[test]
+fn test_stash_pop_after_head_move_stays_bounded() {
+    let repo = TestRepo::new();
+    let a_path = repo.path().join("a.txt");
+    fs::write(&a_path, "base a\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&a_path, "base a\nAI stashed\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "a.txt"]).unwrap();
+    repo.git(&["stash", "push"]).expect("stash push");
+
+    let b_path = repo.path().join("b.txt");
+    fs::write(&b_path, "human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "b.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("move head").unwrap();
+
+    repo.sync_daemon_force();
+    let before_pop = live_checkpoint_line_count(&repo);
+
+    repo.git(&["stash", "pop"]).expect("stash pop");
+    repo.sync_daemon_force();
+
+    let after_pop = live_checkpoint_line_count(&repo);
+    assert_eq!(
+        after_pop, before_pop,
+        "shifted pop must not append stash checkpoint lines to the new HEAD's log"
+    );
+    assert_eq!(
+        stash_worklog_dir_count(&repo),
+        0,
+        "pop must remove the stash worklog copy"
+    );
+
+    repo.stage_all_and_commit("commit shifted pop").unwrap();
+    let mut a = repo.filename("a.txt");
+    a.assert_committed_lines(crate::lines![
+        "base a".unattributed_human(),
+        "AI stashed".ai(),
+    ]);
+}
+
+/// Pre-fix versions could leave a multi-GB `.git/ai/stashes` dir behind (the
+/// old unversioned layout). Any stash operation must delete the legacy dir --
+/// dropping its (potentially exploded) attribution data -- and use the
+/// versioned dir for new stashes, so old bloated worklogs can never be
+/// re-appended or loaded into memory.
+#[test]
+fn test_legacy_stashes_dir_is_removed() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    // Simulate a leftover legacy stash dir from a pre-fix version.
+    let legacy_dir = repo.path().join(".git").join("ai").join("stashes");
+    let legacy_worklog = legacy_dir.join("deadbeef_worklog");
+    fs::create_dir_all(&legacy_worklog).unwrap();
+    fs::write(
+        legacy_worklog.join("checkpoints.jsonl"),
+        "{\"stale\":\"data\"}\n",
+    )
+    .unwrap();
+    fs::write(legacy_dir.join("deadbeef.json"), "{}").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+    repo.git(&["stash", "push"]).expect("stash push");
+    repo.sync_daemon_force();
+
+    assert!(
+        !legacy_dir.exists(),
+        "legacy .git/ai/stashes dir must be deleted by stash operations"
+    );
+    let versioned_dir = repo.path().join(".git").join("ai").join("stashes_v2");
+    assert!(
+        versioned_dir.exists(),
+        "new stash attribution data must live in the versioned stash dir"
+    );
+
+    repo.git(&["stash", "pop"]).expect("stash pop");
+    repo.sync_daemon_force();
+
+    repo.stage_all_and_commit("commit popped stash").unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+}
+
+/// `git stash pop -q`: the ref-cursor used to treat the first arg after the
+/// subcommand as the stash target, so `-q` broke stash-sha resolution and the
+/// restore never ran. Before push cleared the live log this was masked (the
+/// checkpoints were still there, doubled); now the restore must fire.
+#[test]
+fn test_stash_pop_quiet_flag_restores_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    repo.sync_daemon_force();
+    let baseline = live_checkpoint_line_count(&repo);
+    assert!(baseline >= 1, "expected checkpoint lines, got {baseline}");
+
+    repo.git(&["stash", "push", "-q"]).expect("stash push -q");
+    repo.git(&["stash", "pop", "-q"]).expect("stash pop -q");
+    repo.sync_daemon_force();
+
+    assert_eq!(
+        live_checkpoint_line_count(&repo),
+        baseline,
+        "quiet pop must still restore the stashed checkpoints"
+    );
+    assert_eq!(
+        stash_worklog_dir_count(&repo),
+        0,
+        "quiet pop must remove the stash worklog copy"
+    );
+
+    repo.stage_all_and_commit("commit popped stash").unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+}
+
+/// Same flag-vs-target confusion for `git stash apply -q`.
+#[test]
+fn test_stash_apply_quiet_flag_restores_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    repo.git(&["stash", "push", "-q"]).expect("stash push -q");
+    repo.git(&["stash", "apply", "-q"]).expect("stash apply -q");
+    repo.sync_daemon_force();
+
+    repo.stage_all_and_commit("commit applied stash").unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
 }
 
 crate::reuse_tests_in_worktree!(


### PR DESCRIPTION
## Problem

Since v1.5.9 (the rewrite-ops merge that introduced content-based stash attribution), repeated `git stash` / `git stash pop` cycles cause **exponential growth** of `.git/ai/working_logs/<head>/checkpoints.jsonl` and daemon RSS explosions (reported 18GB file / 20GB+ RSS after ~20 stash/unstash cycles by a coding agent).

## Root cause

1. **Push copies but never clears.** `save_stash_attributions` copies the whole working log (checkpoints.jsonl + blobs) into `.git/ai/stashes/<sha>_worklog/`, but `clean_working_log_for_stash` only cleared INITIAL — the live `checkpoints.jsonl` kept all N lines.
2. **Pop raw-appends.** `restore_stash_attributions` appended the stash copy onto the never-cleared live file with no dedup: N → 2N → 4N → ... 20 cycles ≈ 10^6×.
3. **RAM amplifier.** `append_checkpoint` reads and rewrites the entire file on every checkpoint, so once the file is GBs every checkpoint costs multi-GB allocations — the observed RSS explosion.

## Fix

All in the async side-effect layer — nothing added to the ingestion path, no new git spawns:

- **`clean_working_log_for_stash`** now truncates the live `checkpoints.jsonl` on a full stash (via `write_all_checkpoints(&[])` *without reading it first*, so a push on an already-bloated log is an O(1) self-heal), and complement-filters it on pathspec'd stash — the exact mirror of `filter_stash_checkpoints_to_pathspecs` on the stash copy.
- **`restore_stash_attributions`** dedups byte-identical lines on append, making repeated `stash apply` and conflict-tolerant re-restores idempotent.
- **Versioned stash dir (`stashes` → `stashes_v2`) + legacy dir deletion** on any stash op. Pre-fix users may carry multi-GB `_worklog` dirs; restoring one would slurp it into RAM. We deliberately sacrifice pre-fix stash attribution data to guarantee those can never be re-appended or loaded again.
- **`merge_working_log_dirs`** dedups checkpoints by `(kind, diff, timestamp, author)` so HEAD-move merges can't duplicate either.
- **Bonus bug found during end-to-end verification:** `git stash pop -q` / `apply -q` never restored attribution at all — `enrich_stash` treated the first arg after the subcommand as the stash target, so boolean flags broke stash-sha resolution and the restore silently no-op'd. Agents typically pass `-q`, which is why the doubling (rather than missing restores) was the visible symptom. Fixed with a flag-skipping positional lookup.

## Testing (TDD)

Every fix landed behind a test that was watched fail first:

- `test_stash_pop_cycles_do_not_grow_checkpoints` — the repro: 5 push/pop cycles, line count must stay constant (was 32× before the fix)
- `test_stash_push_clears_live_checkpoints_and_pop_restores`
- `test_stash_apply_repeated_is_idempotent`
- `test_stash_push_pathspec_keeps_unstashed_checkpoints_in_live_log`
- `test_stash_pop_after_head_move_stays_bounded` (shifted-pop path)
- `test_legacy_stashes_dir_is_removed`
- `test_stash_pop_quiet_flag_restores_attribution` / `test_stash_apply_quiet_flag_restores_attribution`
- `test_merge_working_log_dirs_dedups_identical_checkpoints` (unit)

End-to-end verification with a real installed daemon: 10 files × 300 lines with AI checkpoints, 20 manual `stash push -q` / `pop -q` cycles → `checkpoints.jsonl` byte-identical to baseline (7,931 bytes), daemon RSS flat (3.5MB), zero leftover stash dirs, legacy `stashes/` dir removed, and `git-ai blame` shows full AI attribution after commit.

Full test suite, `task lint`, and `task fmt` are green.

## Deferred (follow-up PRs)

- `append_checkpoint`'s O(n²) read-all/write-all (latency-sensitive checkpoint path; needs a `prune_old_char_attributions` redesign — with the log now staying small it's cheap again)
- `--keep-index` attribution retention (pre-existing INITIAL semantics, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->