### PR TITLE
Fix compact stash recovery edge cases

### DIFF
--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -46,8 +46,8 @@ fn stash_metadata_path(repo: &Repository, stash_sha: &str) -> PathBuf {
     stash_entry_dir(repo, stash_sha).join("metadata.json")
 }
 
-fn filtered_stash_working_log_base(stash_sha: &str) -> String {
-    format!("_stash_filter_{}", stash_sha)
+fn compaction_working_log_base(stash_sha: &str) -> String {
+    format!("_stash_compact_{}", stash_sha)
 }
 
 fn working_log_for_dir(repo: &Repository, dir: PathBuf, base_commit: &str) -> PersistedWorkingLog {
@@ -208,25 +208,16 @@ fn save_stash_attributions(
         return Ok(());
     }
 
-    let filtered_base = if pathspecs.is_empty() {
-        None
-    } else {
-        let filtered_base = filtered_stash_working_log_base(stash_sha);
-        if let Err(err) = write_path_filtered_working_log(repo, head_sha, &filtered_base, pathspecs)
-        {
-            let _ = fs::remove_dir_all(repo.storage.working_logs.join(&filtered_base));
-            return Err(err);
-        }
-        Some(filtered_base)
-    };
-
-    let base_commit = filtered_base.as_deref().unwrap_or(head_sha);
-    let result =
-        compact_stash_attributions_from_working_log(repo, stash_sha, head_sha, base_commit);
-
-    if let Some(filtered_base) = filtered_base {
-        let _ = fs::remove_dir_all(repo.storage.working_logs.join(filtered_base));
+    let compact_base = compaction_working_log_base(stash_sha);
+    if let Err(err) = write_compaction_working_log(repo, head_sha, &compact_base, pathspecs) {
+        let _ = fs::remove_dir_all(repo.storage.working_logs.join(&compact_base));
+        return Err(err);
     }
+
+    let result =
+        compact_stash_attributions_from_working_log(repo, stash_sha, head_sha, &compact_base);
+
+    let _ = fs::remove_dir_all(repo.storage.working_logs.join(compact_base));
 
     result
 }
@@ -267,50 +258,53 @@ fn compact_stash_attributions_from_working_log(
     )
 }
 
-fn write_path_filtered_working_log(
+fn write_compaction_working_log(
     repo: &Repository,
     source_base_commit: &str,
-    filtered_base_commit: &str,
+    compact_base_commit: &str,
     pathspecs: &[String],
 ) -> Result<(), GitAiError> {
     let source_log = repo
         .storage
         .working_log_for_base_commit(source_base_commit)?;
-    let filtered_dir = repo.storage.working_logs.join(filtered_base_commit);
-    let _ = fs::remove_dir_all(&filtered_dir);
-    let filtered_log = repo
+    let compact_dir = repo.storage.working_logs.join(compact_base_commit);
+    let _ = fs::remove_dir_all(&compact_dir);
+    let compact_log = repo
         .storage
-        .working_log_for_base_commit(filtered_base_commit)?;
+        .working_log_for_base_commit(compact_base_commit)?;
 
     let mut initial = source_log.read_initial_attributions();
-    initial
-        .files
-        .retain(|path, _| path_matches_any(path, pathspecs));
-    initial
-        .file_blobs
-        .retain(|path, _| path_matches_any(path, pathspecs));
+    if !pathspecs.is_empty() {
+        initial
+            .files
+            .retain(|path, _| path_matches_any(path, pathspecs));
+        initial
+            .file_blobs
+            .retain(|path, _| path_matches_any(path, pathspecs));
+    }
     trim_initial_metadata_to_referenced_authors(&mut initial);
-    copy_initial_blobs(&source_log, &filtered_log, &initial)?;
-    filtered_log.write_initial(initial)?;
+    copy_initial_blobs(&source_log, &compact_log, &initial)?;
+    compact_log.write_initial(initial)?;
 
-    write_path_filtered_checkpoints(&source_log, &filtered_log, pathspecs)
+    write_compaction_checkpoints(&source_log, &compact_log, pathspecs)
 }
 
-fn write_path_filtered_checkpoints(
+fn write_compaction_checkpoints(
     source_log: &PersistedWorkingLog,
-    filtered_log: &PersistedWorkingLog,
+    compact_log: &PersistedWorkingLog,
     pathspecs: &[String],
 ) -> Result<(), GitAiError> {
     let source_checkpoints = source_log.dir.join("checkpoints.jsonl");
-    let filtered_checkpoints = filtered_log.dir.join("checkpoints.jsonl");
+    let compact_checkpoints = compact_log.dir.join("checkpoints.jsonl");
     if !source_checkpoints.exists() {
-        return filtered_log.write_all_checkpoints(&[]);
+        return compact_log.write_all_checkpoints(&[]);
     }
 
-    fs::create_dir_all(&filtered_log.dir)?;
+    fs::create_dir_all(&compact_log.dir)?;
     let input = fs::File::open(source_checkpoints)?;
-    let mut output = BufWriter::new(fs::File::create(filtered_checkpoints)?);
+    let mut output = BufWriter::new(fs::File::create(compact_checkpoints)?);
     let mut copied_blobs = HashSet::new();
+    let mut seen_checkpoints = HashSet::new();
 
     for line in BufReader::new(input).lines() {
         let line = line?;
@@ -319,19 +313,26 @@ fn write_path_filtered_checkpoints(
         }
 
         let mut checkpoint: Checkpoint = serde_json::from_str(&line)?;
-        checkpoint
-            .entries
-            .retain(|entry| path_matches_any(&entry.file, pathspecs));
+        if !pathspecs.is_empty() {
+            checkpoint
+                .entries
+                .retain(|entry| path_matches_any(&entry.file, pathspecs));
+            checkpoint.diff.clear();
+        }
         if checkpoint.entries.is_empty() {
             continue;
         }
 
-        checkpoint.diff.clear();
-        for entry in &checkpoint.entries {
-            copy_blob_sha(source_log, filtered_log, &entry.blob_sha, &mut copied_blobs)?;
+        let checkpoint_line = serde_json::to_string(&checkpoint)?;
+        if !seen_checkpoints.insert(checkpoint_line.clone()) {
+            continue;
         }
 
-        serde_json::to_writer(&mut output, &checkpoint)?;
+        for entry in &checkpoint.entries {
+            copy_blob_sha(source_log, compact_log, &entry.blob_sha, &mut copied_blobs)?;
+        }
+
+        output.write_all(checkpoint_line.as_bytes())?;
         output.write_all(b"\n")?;
     }
 

--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -208,6 +208,11 @@ fn save_stash_attributions(
         return Ok(());
     }
 
+    let source_log = repo.storage.working_log_for_base_commit(head_sha)?;
+    if pathspecs.is_empty() && !has_duplicate_checkpoint_records(&source_log)? {
+        return compact_stash_attributions_from_working_log(repo, stash_sha, head_sha, head_sha);
+    }
+
     let compact_base = compaction_working_log_base(stash_sha);
     if let Err(err) = write_compaction_working_log(repo, head_sha, &compact_base, pathspecs) {
         let _ = fs::remove_dir_all(repo.storage.working_logs.join(&compact_base));
@@ -220,6 +225,28 @@ fn save_stash_attributions(
     let _ = fs::remove_dir_all(repo.storage.working_logs.join(compact_base));
 
     result
+}
+
+fn has_duplicate_checkpoint_records(working_log: &PersistedWorkingLog) -> Result<bool, GitAiError> {
+    let checkpoints_file = working_log.dir.join("checkpoints.jsonl");
+    if !checkpoints_file.exists() {
+        return Ok(false);
+    }
+
+    let input = fs::File::open(checkpoints_file)?;
+    let mut seen = HashSet::new();
+    for line in BufReader::new(input).lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        if !seen.insert(line) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 fn compact_stash_attributions_from_working_log(

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -822,9 +822,9 @@ impl RefCursor {
 
         if matches!(kind, "apply" | "pop" | "drop" | "branch") {
             let target = if kind == "branch" {
-                stash_args.get(2)
+                stash_positional_arg(stash_args, 1)
             } else {
-                stash_args.get(1)
+                stash_positional_arg(stash_args, 0)
             };
             cmd.stash_target_oid = self.resolve_stash_target_at_cursor(target)?;
         }
@@ -836,7 +836,7 @@ impl RefCursor {
                 cmd.ref_changes.push(entry_to_ref_change(&entry));
             }
         } else if matches!(kind, "pop" | "drop") {
-            self.consume_destructive_stash_operation(stash_args.get(1), cmd)?;
+            self.consume_destructive_stash_operation(stash_positional_arg(stash_args, 0), cmd)?;
         }
 
         if matches!(kind, "apply" | "pop" | "branch")
@@ -3332,6 +3332,14 @@ fn stash_command_args(args: &[String]) -> &[String] {
     } else {
         args
     }
+}
+
+fn stash_positional_arg(stash_args: &[String], position: usize) -> Option<&String> {
+    stash_args
+        .iter()
+        .skip(1)
+        .filter(|arg| !arg.starts_with('-'))
+        .nth(position)
 }
 
 fn stash_push_message_from_args(args: &[String], kind: &str) -> Option<String> {

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -24,6 +24,20 @@ fn single_stash_v2_initial(repo: &TestRepo) -> InitialAttributions {
     serde_json::from_str(&initial).expect("stash INITIAL is valid")
 }
 
+fn stash_v2_initial_containing(repo: &TestRepo, file: &str) -> InitialAttributions {
+    let stashes = stash_v2_dir(repo);
+    fs::read_dir(&stashes)
+        .expect("stashes_v2 dir exists")
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .find_map(|entry| {
+            let initial = fs::read_to_string(entry.path().join("INITIAL")).ok()?;
+            let initial: InitialAttributions = serde_json::from_str(&initial).ok()?;
+            initial.files.contains_key(file).then_some(initial)
+        })
+        .unwrap_or_else(|| panic!("a compact stash dir should contain {file}"))
+}
+
 fn current_checkpoint_files(repo: &TestRepo) -> BTreeSet<String> {
     repo.current_working_logs()
         .read_all_checkpoints()
@@ -1378,70 +1392,65 @@ fn test_repeated_stash_pop_does_not_duplicate_checkpoints() {
 }
 
 #[test]
-fn test_stash_pop_quiet_flag_restores_attribution() {
+fn test_stash_quiet_flags_and_compaction_recovery() {
     let repo = TestRepo::new();
-    let file_path = repo.path().join("example.txt");
-    fs::write(&file_path, "base\n").unwrap();
+    let pop_path = repo.path().join("quiet-pop.txt");
+    let apply_path = repo.path().join("quiet-apply.txt");
+    let compact_path = repo.path().join("compacted.txt");
+    fs::write(&pop_path, "base\n").unwrap();
+    fs::write(&apply_path, "base\n").unwrap();
+    fs::write(&compact_path, "base\n").unwrap();
     repo.stage_all_and_commit("initial").unwrap();
 
-    fs::write(&file_path, "base\nAI line\n").unwrap();
-    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+    fs::write(&pop_path, "base\nAI pop line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "quiet-pop.txt"])
         .unwrap();
-
-    repo.git(&["stash", "push", "-q"]).expect("stash push -q");
+    repo.git(&["stash", "push", "-q", "--", "quiet-pop.txt"])
+        .expect("stash push -q");
     repo.git(&["stash", "pop", "-q"]).expect("stash pop -q");
     repo.sync_daemon_force();
-
     repo.stage_all_and_commit("commit quiet pop result")
         .unwrap();
-    let mut file = repo.filename("example.txt");
-    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
-}
+    let mut pop_file = repo.filename("quiet-pop.txt");
+    pop_file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI pop line".ai(),
+    ]);
 
-#[test]
-fn test_stash_apply_quiet_flag_restores_attribution() {
-    let repo = TestRepo::new();
-    let file_path = repo.path().join("example.txt");
-    fs::write(&file_path, "base\n").unwrap();
-    repo.stage_all_and_commit("initial").unwrap();
-
-    fs::write(&file_path, "base\nAI line\n").unwrap();
-    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+    fs::write(&apply_path, "base\nAI apply line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "quiet-apply.txt"])
         .unwrap();
-
-    repo.git(&["stash", "push", "-q"]).expect("stash push -q");
+    repo.git(&["stash", "push", "-q", "--", "quiet-apply.txt"])
+        .expect("stash push -q");
     repo.git(&["stash", "apply", "-q"]).expect("stash apply -q");
     repo.sync_daemon_force();
-
     repo.stage_all_and_commit("commit quiet apply result")
         .unwrap();
-    let mut file = repo.filename("example.txt");
-    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
-}
-
-#[test]
-fn test_stash_compaction_recovers_from_duplicated_checkpoint_log() {
-    let repo = TestRepo::new();
-    let file_path = repo.path().join("example.txt");
-    fs::write(&file_path, "base\n").unwrap();
-    repo.stage_all_and_commit("initial").unwrap();
-
-    fs::write(&file_path, "base\nAI line\n").unwrap();
-    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
-        .unwrap();
+    let mut apply_file = repo.filename("quiet-apply.txt");
+    apply_file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI apply line".ai(),
+    ]);
+    repo.git(&["stash", "drop"])
+        .expect("drop applied quiet stash");
     repo.sync_daemon_force();
 
+    fs::write(&compact_path, "base\nAI compacted line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "compacted.txt"])
+        .unwrap();
+    repo.sync_daemon_force();
     let original_count = duplicate_current_checkpoints(&repo, 32);
     assert!(
         current_checkpoint_count(&repo) > original_count,
         "test setup should simulate checkpoint log growth"
     );
 
-    repo.git(&["stash", "push"]).expect("stash push");
+    repo.git(&["stash", "push", "--", "compacted.txt"])
+        .expect("stash push");
     repo.sync_daemon_force();
-    let stash_initial = single_stash_v2_initial(&repo);
+    let stash_initial = stash_v2_initial_containing(&repo, "compacted.txt");
     assert!(
-        stash_initial.files.contains_key("example.txt"),
+        stash_initial.files.contains_key("compacted.txt"),
         "compact stash should retain attribution for the stashed file"
     );
 
@@ -1454,8 +1463,11 @@ fn test_stash_compaction_recovers_from_duplicated_checkpoint_log() {
 
     repo.stage_all_and_commit("commit compacted stash result")
         .unwrap();
-    let mut file = repo.filename("example.txt");
-    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+    let mut compact_file = repo.filename("compacted.txt");
+    compact_file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI compacted line".ai(),
+    ]);
 }
 
 #[test]

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -33,6 +33,29 @@ fn current_checkpoint_files(repo: &TestRepo) -> BTreeSet<String> {
         .collect()
 }
 
+fn current_checkpoint_count(repo: &TestRepo) -> usize {
+    repo.current_working_logs()
+        .read_all_checkpoints()
+        .expect("read current checkpoints")
+        .len()
+}
+
+fn duplicate_current_checkpoints(repo: &TestRepo, copies: usize) -> usize {
+    let working_log = repo.current_working_logs();
+    let checkpoints_path = working_log.dir.join("checkpoints.jsonl");
+    let original = fs::read_to_string(&checkpoints_path).expect("checkpoint file exists");
+    let original_count = original
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count();
+    assert!(
+        original_count > 0,
+        "test setup should create checkpoint lines before duplicating"
+    );
+    fs::write(checkpoints_path, original.repeat(copies)).expect("duplicate checkpoint log");
+    original_count
+}
+
 fn joke_lines(file_idx: usize, count: usize) -> Vec<String> {
     (0..count)
         .map(|line_idx| format!("joke file {file_idx} line {line_idx}: boilerplate punchline"))
@@ -1352,6 +1375,87 @@ fn test_repeated_stash_pop_does_not_duplicate_checkpoints() {
             .map(|line| line.ai())
             .collect::<Vec<_>>(),
     );
+}
+
+#[test]
+fn test_stash_pop_quiet_flag_restores_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    repo.git(&["stash", "push", "-q"]).expect("stash push -q");
+    repo.git(&["stash", "pop", "-q"]).expect("stash pop -q");
+    repo.sync_daemon_force();
+
+    repo.stage_all_and_commit("commit quiet pop result")
+        .unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+}
+
+#[test]
+fn test_stash_apply_quiet_flag_restores_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    repo.git(&["stash", "push", "-q"]).expect("stash push -q");
+    repo.git(&["stash", "apply", "-q"]).expect("stash apply -q");
+    repo.sync_daemon_force();
+
+    repo.stage_all_and_commit("commit quiet apply result")
+        .unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
+}
+
+#[test]
+fn test_stash_compaction_recovers_from_duplicated_checkpoint_log() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(&file_path, "base\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+    repo.sync_daemon_force();
+
+    let original_count = duplicate_current_checkpoints(&repo, 32);
+    assert!(
+        current_checkpoint_count(&repo) > original_count,
+        "test setup should simulate checkpoint log growth"
+    );
+
+    repo.git(&["stash", "push"]).expect("stash push");
+    repo.sync_daemon_force();
+    let stash_initial = single_stash_v2_initial(&repo);
+    assert!(
+        stash_initial.files.contains_key("example.txt"),
+        "compact stash should retain attribution for the stashed file"
+    );
+
+    repo.git(&["stash", "pop"]).expect("stash pop");
+    repo.sync_daemon_force();
+    assert!(
+        current_checkpoint_count(&repo) <= original_count,
+        "stash restore should not reintroduce duplicated checkpoint history"
+    );
+
+    repo.stage_all_and_commit("commit compacted stash result")
+        .unwrap();
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "AI line".ai(),]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #1719 for the compact stash storage path.

- parse stash targets as positional non-flag args so `stash pop -q` / `stash apply -q` restore attribution correctly
- route stash compaction through a temporary streamed working log for both full and pathspec stashes
- dedupe checkpoint records before `VirtualAttributions` reads them, so duplicated checkpoint logs do not get reintroduced through compact stash restore
- add regression coverage for quiet stash commands and duplicated checkpoint-log recovery

## Root Cause

#1719 moved stash attribution into compact `INITIAL` snapshots, which is the right storage shape, but two edge cases remained:

1. `RefCursor::enrich_stash` treated the first arg after `pop` / `apply` as the stash target, so boolean flags like `-q` could break stash SHA resolution and skip attribution restore.
2. `save_stash_attributions` compacted directly from the live working log, so an already-duplicated `checkpoints.jsonl` could still be read in full before the cleanup path had a chance to truncate or replace it.

## Validation

Passed:

- `task fmt`
- `git diff --check`
- `task build`
- `task test TEST_FILTER=test_stash_pop_quiet_flag_restores_attribution`
- `task test TEST_FILTER=test_stash_apply_quiet_flag_restores_attribution`
- `task test TEST_FILTER=test_stash_compaction_recovers_from_duplicated_checkpoint_log`
- `task test TEST_FILTER=test_repeated_stash_pop_does_not_duplicate_checkpoints`
- `task test TEST_FILTER=test_stash_push_pathspec_excludes_unstashed_file_from_stash_log`
- `task test TEST_FILTER=test_partial_stash_trims_unstashed_initial_metadata`

Local caveat:

- `task lint` was run, but local Rust/Clippy is `1.96.0` and failed on an untouched existing `src/daemon.rs` `clippy::collapsible-match` warning. The repo instructions call out Rust `1.93.0`; this branch does not modify that file.