### PR TITLE
fix: resolve nightly agent test failures for droid and opencode

### DIFF
--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -120,14 +120,13 @@ jobs:
                       continue
                   npm_pkg = f"{info['pkg']}@{ver}" if channel == "stable" else f"{info['pkg']}@next"
                   bin_name = resolve_binary_name(npm_pkg, agent)
-                  headless_cmd = headless_cmds[agent].replace(agent, bin_name, 1) if bin_name != agent else headless_cmds[agent]
                   matrix["include"].append({
                       "agent":       agent,
                       "channel":     channel,
                       "npm_pkg":     npm_pkg,
                       "version":     ver,
                       "api_key_var": info["key"],
-                      "headless_cmd": headless_cmd,
+                      "headless_cmd": headless_cmds[agent],
                       "binary_name": bin_name,
                   })
 

--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -62,13 +62,6 @@ jobs:
               allowed = {a.strip() for a in agents_filter.split(",")}
               agents = {k: v for k, v in agents.items() if k in allowed}
 
-          headless_cmds = {
-              "claude":   "claude -p --dangerously-skip-permissions --max-turns 3",
-              "codex":    "codex exec --full-auto",
-              "gemini":   "gemini --approval-mode=yolo",
-              "opencode": "opencode run --command",
-          }
-
           def resolve_binary_name(pkg_spec, default_name):
               """Resolve the primary binary name from an npm package spec."""
               try:
@@ -126,7 +119,6 @@ jobs:
                       "npm_pkg":     npm_pkg,
                       "version":     ver,
                       "api_key_var": info["key"],
-                      "headless_cmd": headless_cmds[agent],
                       "binary_name": bin_name,
                   })
 
@@ -139,7 +131,6 @@ jobs:
                   "npm_pkg":     "",
                   "version":     "latest",
                   "api_key_var": "FACTORY_API_KEY",
-                  "headless_cmd": "droid exec --auto high",
                   "binary_name": "droid",
               })
 

--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -69,6 +69,24 @@ jobs:
               "opencode": "opencode run --command",
           }
 
+          def resolve_binary_name(pkg_spec, default_name):
+              """Resolve the primary binary name from an npm package spec."""
+              try:
+                  out = subprocess.check_output(
+                      ["npm", "view", pkg_spec, "bin", "--json"],
+                      text=True, stderr=subprocess.DEVNULL
+                  ).strip()
+                  if out:
+                      bins = json.loads(out)
+                      if isinstance(bins, dict) and bins:
+                          # Return first binary name; prefer the default if present
+                          if default_name in bins:
+                              return default_name
+                          return next(iter(bins))
+              except (subprocess.CalledProcessError, json.JSONDecodeError):
+                  pass
+              return default_name
+
           matrix = {"include": []}
           for agent, info in agents.items():
               try:
@@ -101,13 +119,16 @@ jobs:
                   if channel == "latest" and latest_ver == stable_ver:
                       continue
                   npm_pkg = f"{info['pkg']}@{ver}" if channel == "stable" else f"{info['pkg']}@next"
+                  bin_name = resolve_binary_name(npm_pkg, agent)
+                  headless_cmd = headless_cmds[agent].replace(agent, bin_name, 1) if bin_name != agent else headless_cmds[agent]
                   matrix["include"].append({
                       "agent":       agent,
                       "channel":     channel,
                       "npm_pkg":     npm_pkg,
                       "version":     ver,
                       "api_key_var": info["key"],
-                      "headless_cmd": headless_cmds[agent],
+                      "headless_cmd": headless_cmd,
+                      "binary_name": bin_name,
                   })
 
           # Droid uses curl installer (latest only, no npm version pinning)
@@ -120,6 +141,7 @@ jobs:
                   "version":     "latest",
                   "api_key_var": "FACTORY_API_KEY",
                   "headless_cmd": "droid exec --auto high",
+                  "binary_name": "droid",
               })
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
@@ -175,12 +197,10 @@ jobs:
 
       - name: Verify agent binary is present
         run: |
+          BIN="${{ matrix.binary_name }}"
           case "${{ matrix.agent }}" in
-            claude)   claude --version ;;
-            codex)    codex --version ;;
-            gemini)   gemini --help 2>&1 | head -3 || true ;;
-            droid)    droid --version ;;
-            opencode) opencode --version ;;
+            gemini)   "$BIN" --help 2>&1 | head -3 || true ;;
+            *)        "$BIN" --version ;;
           esac
 
       - name: Create test repository
@@ -210,7 +230,7 @@ jobs:
       - name: Verify hook wiring
         run: |
           export PATH="$GITHUB_WORKSPACE/target/release:$PATH"
-          bash "$GITHUB_WORKSPACE/scripts/nightly/verify-hook-wiring.sh" "${{ matrix.agent }}"
+          bash "$GITHUB_WORKSPACE/scripts/nightly/verify-hook-wiring.sh" "${{ matrix.agent }}" "${{ matrix.binary_name }}"
 
       - name: Synthetic checkpoint test
         run: |
@@ -313,7 +333,7 @@ jobs:
           command: |
             export PATH="$GITHUB_WORKSPACE/target/release:$PATH"
             export ${{ matrix.api_key_var }}="${{ secrets[matrix.api_key_var] }}"
-            bash "$GITHUB_WORKSPACE/scripts/nightly/test-live-agent.sh" "${{ matrix.agent }}"
+            bash "$GITHUB_WORKSPACE/scripts/nightly/test-live-agent.sh" "${{ matrix.agent }}" "${{ matrix.binary_name }}"
         continue-on-error: ${{ matrix.channel == 'latest' }}
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/scripts/nightly/test-live-agent.sh
+++ b/scripts/nightly/test-live-agent.sh
@@ -69,21 +69,21 @@ echo "" | tee -a "$LOG"
 
 case "$AGENT" in
   claude)
-    timeout 300 claude -p \
+    timeout 300 "$BINARY_NAME" -p \
       --dangerously-skip-permissions \
       --max-turns 5 \
       "$PROMPT" 2>&1 | tee -a "$LOG" || warn "claude exited with non-zero status"
     ;;
 
   codex)
-    timeout 300 codex exec --full-auto "$PROMPT" 2>&1 | tee -a "$LOG" \
+    timeout 300 "$BINARY_NAME" exec --full-auto "$PROMPT" 2>&1 | tee -a "$LOG" \
       || warn "codex exited with non-zero status"
     ;;
 
   gemini)
     # Pre-install ripgrep to avoid Gemini CLI initialization hang on headless Linux
     which rg 2>/dev/null || sudo apt-get install -y ripgrep 2>/dev/null || true
-    timeout 300 gemini --approval-mode=yolo "$PROMPT" 2>&1 | tee -a "$LOG" \
+    timeout 300 "$BINARY_NAME" --approval-mode=yolo "$PROMPT" 2>&1 | tee -a "$LOG" \
       || warn "gemini exited with non-zero status"
     ;;
 

--- a/scripts/nightly/test-live-agent.sh
+++ b/scripts/nightly/test-live-agent.sh
@@ -9,7 +9,8 @@
 # Expects: relevant API key env var to be set by caller
 set -euo pipefail
 
-AGENT="${1:?Usage: $0 <agent>}"
+AGENT="${1:?Usage: $0 <agent> [binary_name]}"
+BINARY_NAME="${2:-$AGENT}"
 REPO_DIR="${TEST_REPO_DIR:-/tmp/test-repo}"
 RESULTS_DIR="${RESULTS_DIR:-/tmp/test-results}"
 mkdir -p "$RESULTS_DIR"
@@ -87,12 +88,12 @@ case "$AGENT" in
     ;;
 
   droid)
-    timeout 300 droid exec --auto high "$PROMPT" 2>&1 | tee -a "$LOG" \
+    timeout 300 "$BINARY_NAME" exec --auto high "$PROMPT" 2>&1 | tee -a "$LOG" \
       || warn "droid exited with non-zero status"
     ;;
 
   opencode)
-    timeout 240 opencode run --command "$PROMPT" 2>&1 | tee -a "$LOG" \
+    timeout 240 "$BINARY_NAME" run --command "$PROMPT" 2>&1 | tee -a "$LOG" \
       || warn "opencode exited with non-zero status"
     ;;
 

--- a/scripts/nightly/verify-hook-wiring.sh
+++ b/scripts/nightly/verify-hook-wiring.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # Verify that git-ai installed hooks correctly for the given agent.
-# Usage: verify-hook-wiring.sh <agent>
+# Usage: verify-hook-wiring.sh <agent> [binary_name]
 # Agent must be one of: claude, codex, gemini, droid, opencode
+# binary_name is optional; defaults to agent name. Used when a pre-release
+# renames its CLI binary (e.g. opencode-ai@next ships "opencode2").
 set -euo pipefail
 
-AGENT="${1:?Usage: $0 <agent>}"
+AGENT="${1:?Usage: $0 <agent> [binary_name]}"
+BINARY_NAME="${2:-$AGENT}"
 RESULTS_DIR="${RESULTS_DIR:-/tmp/test-results}"
 mkdir -p "$RESULTS_DIR"
 
@@ -14,7 +17,7 @@ LOG="$RESULTS_DIR/hook-wiring-${AGENT}.txt"
 pass() { echo "PASS: $1" | tee -a "$LOG"; }
 fail() { echo "FAIL: $1" | tee -a "$LOG"; exit 1; }
 
-echo "=== Verifying hook wiring for: $AGENT ===" | tee "$LOG"
+echo "=== Verifying hook wiring for: $AGENT (binary: $BINARY_NAME) ===" | tee "$LOG"
 
 case "$AGENT" in
   claude)

--- a/src/mdm/agents/droid.rs
+++ b/src/mdm/agents/droid.rs
@@ -403,6 +403,7 @@ impl HookInstaller for DroidInstaller {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
@@ -411,6 +412,72 @@ mod tests {
         let settings_path = temp_dir.path().join(".factory").join("settings.json");
         fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
         (temp_dir, settings_path)
+    }
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().to_path_buf();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+        }
+
+        f(&home);
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
+
+    fn with_fake_binary_on_path<F: FnOnce(&Path)>(binary_name: &str, f: F) {
+        let temp_dir = TempDir::new().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let fake_bin = bin_dir.join(binary_name);
+        fs::write(&fake_bin, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&fake_bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let prev_path = std::env::var_os("PATH");
+        let new_path = match &prev_path {
+            Some(p) => {
+                let mut paths = vec![bin_dir.clone()];
+                paths.extend(std::env::split_paths(p));
+                std::env::join_paths(paths).unwrap()
+            }
+            None => bin_dir.clone().into(),
+        };
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("PATH", &new_path);
+        }
+
+        f(temp_dir.path());
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_path {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
     }
 
     fn binary_path() -> PathBuf {
@@ -1100,5 +1167,75 @@ mod tests {
     fn jsonc_parse_empty_returns_empty_object() {
         let val = parse_jsonc_settings("").unwrap();
         assert_eq!(val, json!({}));
+    }
+
+    // ---- Detection / check_hooks ----
+
+    #[test]
+    #[serial]
+    fn c4_binary_on_path_without_dotfiles_detects_tool() {
+        with_temp_home(|_home| {
+            with_fake_binary_on_path("droid", |_| {
+                let installer = DroidInstaller;
+                let result = installer.check_hooks(&params()).unwrap();
+                assert!(
+                    result.tool_installed,
+                    "droid binary on PATH should be detected even without ~/.factory"
+                );
+                assert!(!result.hooks_installed);
+                assert!(!result.hooks_up_to_date);
+            });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn c5_no_binary_no_dotfiles_not_detected() {
+        with_temp_home(|_home| {
+            let installer = DroidInstaller;
+            let result = installer.check_hooks(&params()).unwrap();
+            assert!(
+                !result.tool_installed,
+                "no binary and no ~/.factory should mean tool_installed=false"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn c6_dotfiles_without_binary_detects_tool() {
+        with_temp_home(|home| {
+            fs::create_dir_all(home.join(".factory")).unwrap();
+            let installer = DroidInstaller;
+            let result = installer.check_hooks(&params()).unwrap();
+            assert!(
+                result.tool_installed,
+                "~/.factory dir should be enough to detect tool even without binary"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn c7_binary_on_path_install_creates_settings() {
+        with_temp_home(|_home| {
+            with_fake_binary_on_path("droid", |_| {
+                let installer = DroidInstaller;
+                let result = installer.install_hooks(&params(), false).unwrap();
+                assert!(result.is_some(), "install_hooks should produce a diff");
+
+                let settings_path = DroidInstaller::settings_path();
+                assert!(
+                    settings_path.exists(),
+                    "install_hooks should create ~/.factory/settings.json"
+                );
+
+                let content = fs::read_to_string(&settings_path).unwrap();
+                assert!(
+                    content.contains("checkpoint droid"),
+                    "settings.json should contain the checkpoint hook command"
+                );
+            });
+        });
     }
 }

--- a/src/mdm/agents/droid.rs
+++ b/src/mdm/agents/droid.rs
@@ -1,6 +1,8 @@
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
-use crate::mdm::utils::{generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic};
+use crate::mdm::utils::{
+    binary_exists, generate_diff, home_dir, is_git_ai_checkpoint_command, write_atomic,
+};
 use jsonc_parser::ParseOptions;
 use serde_json::{Value, json};
 use std::fs;
@@ -350,9 +352,10 @@ impl HookInstaller for DroidInstaller {
     }
 
     fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let has_binary = binary_exists("droid");
         let has_dotfiles = home_dir().join(".factory").exists();
 
-        if !has_dotfiles {
+        if !has_binary && !has_dotfiles {
             return Ok(HookCheckResult {
                 tool_installed: false,
                 hooks_installed: false,

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -165,6 +165,7 @@ impl HookInstaller for OpenCodeInstaller {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
@@ -181,6 +182,72 @@ mod tests {
 
     fn create_test_binary_path() -> PathBuf {
         PathBuf::from("/usr/local/bin/git-ai")
+    }
+
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        let temp_dir = TempDir::new().unwrap();
+        let home = temp_dir.path().to_path_buf();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+        }
+
+        f(&home);
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_userprofile {
+                Some(v) => std::env::set_var("USERPROFILE", v),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
+
+    fn with_fake_binary_on_path<F: FnOnce(&Path)>(binary_name: &str, f: F) {
+        let temp_dir = TempDir::new().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let fake_bin = bin_dir.join(binary_name);
+        fs::write(&fake_bin, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&fake_bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let prev_path = std::env::var_os("PATH");
+        let new_path = match &prev_path {
+            Some(p) => {
+                let mut paths = vec![bin_dir.clone()];
+                paths.extend(std::env::split_paths(p));
+                std::env::join_paths(paths).unwrap()
+            }
+            None => bin_dir.clone().into(),
+        };
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("PATH", &new_path);
+        }
+
+        f(temp_dir.path());
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_path {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
     }
 
     #[test]
@@ -321,5 +388,83 @@ mod tests {
         let content = fs::read_to_string(&plugin_path).unwrap();
         assert!(content.contains("GitAiPlugin"));
         assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+    }
+
+    // ---- Detection / process_names / check_hooks ----
+
+    #[test]
+    fn test_opencode_process_names_includes_opencode2() {
+        let installer = OpenCodeInstaller;
+        let names = installer.process_names();
+        assert!(
+            names.contains(&"opencode"),
+            "process_names should include 'opencode'"
+        );
+        assert!(
+            names.contains(&"opencode2"),
+            "process_names should include 'opencode2' for @next pre-release support"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_opencode2_binary_detected_as_tool_installed() {
+        with_temp_home(|_home| {
+            with_fake_binary_on_path("opencode2", |_| {
+                let installer = OpenCodeInstaller;
+                let params = HookInstallerParams {
+                    binary_path: create_test_binary_path(),
+                };
+                let result = installer.check_hooks(&params).unwrap();
+                assert!(
+                    result.tool_installed,
+                    "opencode2 binary on PATH should be detected as tool_installed"
+                );
+                assert!(!result.hooks_installed);
+            });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_opencode_no_binary_no_config_not_detected() {
+        with_temp_home(|_home| {
+            let installer = OpenCodeInstaller;
+            let params = HookInstallerParams {
+                binary_path: create_test_binary_path(),
+            };
+            let result = installer.check_hooks(&params).unwrap();
+            assert!(
+                !result.tool_installed,
+                "no binary and no config should mean tool_installed=false"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_opencode2_binary_install_creates_plugin() {
+        with_temp_home(|_home| {
+            with_fake_binary_on_path("opencode2", |_| {
+                let installer = OpenCodeInstaller;
+                let params = HookInstallerParams {
+                    binary_path: create_test_binary_path(),
+                };
+                let result = installer.install_hooks(&params, false).unwrap();
+                assert!(result.is_some(), "install_hooks should produce a diff");
+
+                let plugin_path = OpenCodeInstaller::plugin_path();
+                assert!(
+                    plugin_path.exists(),
+                    "install_hooks should create the plugin file"
+                );
+
+                let content = fs::read_to_string(&plugin_path).unwrap();
+                assert!(
+                    content.contains("GitAiPlugin"),
+                    "plugin should contain GitAiPlugin"
+                );
+            });
+        });
     }
 }

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -39,11 +39,11 @@ impl HookInstaller for OpenCodeInstaller {
     }
 
     fn process_names(&self) -> Vec<&str> {
-        vec!["opencode"]
+        vec!["opencode", "opencode2"]
     }
 
     fn check_hooks(&self, params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
-        let has_binary = binary_exists("opencode");
+        let has_binary = binary_exists("opencode") || binary_exists("opencode2");
         let has_global_config = home_dir().join(".config").join("opencode").exists();
         let has_local_config = Path::new(".opencode").exists();
 


### PR DESCRIPTION
## Summary

Fixes the persistent nightly failures in "Tier 1: droid latest" and "Tier 1: opencode latest" jobs (failing daily since at least 2026-06-22). Closes #1723.

**Droid — `settings.json not found`**: `DroidInstaller::check_hooks` only checked `~/.factory` dir existence. When droid CLI installs to `~/.local/bin` without creating `~/.factory/`, `check_hooks` returned `tool_installed: false` and `git-ai install` skipped hook setup entirely.

```diff
 fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+    let has_binary = binary_exists("droid");
     let has_dotfiles = home_dir().join(".factory").exists();
-    if !has_dotfiles {
+    if !has_binary && !has_dotfiles {
         return Ok(HookCheckResult { tool_installed: false, ... });
```

This matches the pattern already used by `GeminiInstaller` and `OpenCodeInstaller`.

**OpenCode — `command not found` (exit 127)**: `opencode-ai@next` renamed its binary from `opencode` to `opencode2`. The workflow hardcoded `opencode --version` in verification.

Fix: resolve binary names dynamically via `npm view <pkg> bin --json` at matrix build time, pass `matrix.binary_name` through, and use it in:
- "Verify agent binary is present" step (uses `${{ matrix.binary_name }}` instead of hardcoded case)
- `verify-hook-wiring.sh` (accepts optional `binary_name` arg)
- `test-live-agent.sh` (all five agents now use `$BINARY_NAME` consistently)

Also updated `OpenCodeInstaller::check_hooks` to detect `opencode2` via `binary_exists("opencode") || binary_exists("opencode2")` and added `"opencode2"` to `process_names()`.

**Tests**: Added 8 new `#[serial]` unit tests covering detection logic for both installers — binary-on-PATH without dotfiles, no-binary-no-dotfiles, dotfiles-only, and full install flows from binary detection. Uses `with_temp_home` + `with_fake_binary_on_path` helpers following the existing `gemini.rs` pattern.

**Cleanup**: Removed dead `headless_cmd` binary-name replacement computation (pre-existing dead field; no longer adding unnecessary `.replace()` on top).

Link to Devin session: https://app.devin.ai/sessions/593476fb73c54d249654129305965de2
Requested by: @Siddhant-K-code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->