### PR TITLE
[codex] Disable trace2 for internal git spawns

### DIFF
--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -6,7 +6,7 @@ use crate::git::repository::{
     GitAuthorIdentity, GitConfigIdentityResolution, GitIdentityResolution,
     global_git_config_identity_resolution,
 };
-use crate::process_timeout::{TimedCommandOutput, run_command_with_timeout};
+use crate::process_timeout::{TimedCommandOutput, run_command_with_timeout_and_env};
 use std::env;
 use std::fmt::Write as _;
 use std::fs;
@@ -100,8 +100,8 @@ fn build_debug_report(options: DebugOptions) -> String {
     let git_diagnostics = collect_git_diagnostics(&git_cmd, options);
     debug_progress("collecting system and configuration details");
     debug_progress("checking git versions");
-    let git_version = run_command_capture(&git_cmd, &["--version"]);
-    let shell_git_version = run_command_capture("git", &["--version"]);
+    let git_version = run_git_command_capture(&git_cmd, &["--version"]);
+    let shell_git_version = run_git_command_capture("git", &["--version"]);
     debug_progress("collecting git config");
     let git_config = collect_git_config_dump(&git_cmd);
     debug_progress("collecting git-ai config and login state");
@@ -875,19 +875,48 @@ fn run_command_capture(program: &str, args: &[&str]) -> Result<String, String> {
     run_command_capture_with_timeout(program, args, DEBUG_COMMAND_TIMEOUT)
 }
 
+fn run_git_command_capture(program: &str, args: &[&str]) -> Result<String, String> {
+    run_git_command_capture_with_timeout(program, args, DEBUG_COMMAND_TIMEOUT)
+}
+
 fn run_command_capture_with_timeout(
     program: &str,
     args: &[&str],
     timeout: Duration,
 ) -> Result<String, String> {
+    run_command_capture_with_timeout_and_env(program, args, timeout, &[], &[])
+}
+
+fn run_git_command_capture_with_timeout(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<String, String> {
+    run_command_capture_with_timeout_and_env(
+        program,
+        args,
+        timeout,
+        crate::git::repository::INTERNAL_GIT_ENV_REMOVE,
+        crate::git::repository::INTERNAL_GIT_ENV_SET,
+    )
+}
+
+fn run_command_capture_with_timeout_and_env(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+    env_remove: &[&str],
+    env_set: &[(&str, &str)],
+) -> Result<String, String> {
     let command = format_command_for_error(program, args);
-    let output = run_command_with_timeout(
+    let output = run_command_with_timeout_and_env(
         program,
         args,
         None,
         timeout,
         DEBUG_COMMAND_POLL_INTERVAL,
-        &[],
+        env_remove,
+        env_set,
     )
     .map_err(|e| {
         format!(
@@ -1226,7 +1255,7 @@ fn collect_git_config_dump(git_cmd: &str) -> GitConfigDump {
 
     let mut last_error = String::new();
     for args in attempts {
-        match run_command_capture(git_cmd, args) {
+        match run_git_command_capture(git_cmd, args) {
             Ok(output) => {
                 let redacted = output
                     .lines()

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -1209,11 +1209,14 @@ fn discover_dirty_files_from_status(cwd: &std::path::Path) -> Vec<String> {
         .and_then(|r| r.workdir().ok())
         .unwrap_or_else(|| cwd.to_path_buf());
 
-    let output = std::process::Command::new(crate::config::Config::get().git_cmd())
-        .args(["status", "--porcelain", "-uall"])
-        .current_dir(cwd)
-        .output()
-        .ok();
+    let args = vec![
+        "-C".to_string(),
+        cwd.to_string_lossy().to_string(),
+        "status".to_string(),
+        "--porcelain".to_string(),
+        "-uall".to_string(),
+    ];
+    let output = crate::git::repository::exec_git(&args).ok();
     let Some(output) = output else {
         return vec![];
     };

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -198,11 +198,14 @@ fn find_running_pids(process_names: &[&str]) -> Vec<(u32, String)> {
 }
 
 fn set_global_git_config_value(git_cmd: &str, key: &str, value: &str) -> Result<(), GitAiError> {
-    let status = Command::new(git_cmd)
+    let mut command = Command::new(git_cmd);
+    command
         .args(["config", "--global", key, value])
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
+        .stderr(Stdio::null());
+    crate::git::repository::apply_internal_git_env(&mut command);
+
+    let status = command.status()?;
     if status.success() {
         Ok(())
     } else {
@@ -229,11 +232,14 @@ fn ensure_global_git_config_dirs() -> Result<(), GitAiError> {
 }
 
 fn remove_global_git_config_section(git_cmd: &str, section: &str) -> Result<(), GitAiError> {
-    let status = Command::new(git_cmd)
+    let mut command = Command::new(git_cmd);
+    command
         .args(["config", "--global", "--remove-section", section])
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()?;
+        .stderr(Stdio::null());
+    crate::git::repository::apply_internal_git_env(&mut command);
+
+    let status = command.status()?;
     // Exit code 128 means the section doesn't exist, which is fine.
     if status.success() || status.code() == Some(128) {
         Ok(())
@@ -725,11 +731,14 @@ fn parse_git_version(output: &str) -> Option<(u32, u32, u32)> {
 
 /// Print a loud warning if the installed git version is older than MIN_GIT_VERSION.
 fn warn_if_git_version_too_old() {
-    let output = Command::new("git")
+    let mut command = Command::new("git");
+    command
         .args(["--version"])
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .output();
+        .stderr(Stdio::null());
+    crate::git::repository::apply_internal_git_env(&mut command);
+
+    let output = command.output();
 
     let version = match output {
         Ok(o) => {

--- a/src/commands/notes_migrate.rs
+++ b/src/commands/notes_migrate.rs
@@ -302,6 +302,7 @@ fn cat_file_batch(
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
+    crate::git::repository::apply_internal_git_env(&mut cmd);
 
     let mut child = cmd
         .spawn()

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2741,8 +2741,7 @@ pub fn spawn_git_stdout(args: &[String]) -> Result<Child, GitAiError> {
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::inherit());
-    cmd.env_remove("GIT_EXTERNAL_DIFF");
-    cmd.env_remove("GIT_DIFF_OPTS");
+    apply_internal_git_env(&mut cmd);
 
     #[cfg(windows)]
     {
@@ -2768,8 +2767,7 @@ pub fn spawn_git_passthrough(args: &[String]) -> Result<Child, GitAiError> {
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());
-    cmd.env_remove("GIT_EXTERNAL_DIFF");
-    cmd.env_remove("GIT_DIFF_OPTS");
+    apply_internal_git_env(&mut cmd);
 
     #[cfg(windows)]
     {
@@ -2781,14 +2779,31 @@ pub fn spawn_git_passthrough(args: &[String]) -> Result<Child, GitAiError> {
     cmd.spawn().map_err(GitAiError::IoError)
 }
 
-fn apply_internal_git_env(cmd: &mut Command) {
-    cmd.env_remove("GIT_EXTERNAL_DIFF");
-    cmd.env_remove("GIT_DIFF_OPTS");
-    cmd.env_remove("GIT_TRACE");
-    cmd.env_remove("GIT_TRACE2");
-    cmd.env_remove("GIT_TRACE2_BRIEF");
-    cmd.env_remove("GIT_TRACE2_PERF");
-    cmd.env("GIT_TRACE2_EVENT", "0");
+pub(crate) const INTERNAL_GIT_ENV_REMOVE: &[&str] = &[
+    "GIT_EXTERNAL_DIFF",
+    "GIT_DIFF_OPTS",
+    "GIT_TRACE",
+    "GIT_TRACE2_BRIEF",
+    "GIT_TRACE2_CONFIG_PARAMS",
+    "GIT_TRACE2_ENV_VARS",
+    "GIT_TRACE2_EVENT_NESTING",
+    "GIT_TRACE2_PARENT_NAME",
+    "GIT_TRACE2_PARENT_SID",
+];
+
+pub(crate) const INTERNAL_GIT_ENV_SET: &[(&str, &str)] = &[
+    ("GIT_TRACE2", "0"),
+    ("GIT_TRACE2_EVENT", "0"),
+    ("GIT_TRACE2_PERF", "0"),
+];
+
+pub(crate) fn apply_internal_git_env(cmd: &mut Command) {
+    for key in INTERNAL_GIT_ENV_REMOVE {
+        cmd.env_remove(key);
+    }
+    for (key, value) in INTERNAL_GIT_ENV_SET {
+        cmd.env(key, value);
+    }
 }
 
 /// Helper to execute a git command with an explicit internal profile.
@@ -3148,6 +3163,35 @@ fn parse_hunk_header_counts(line: &str) -> Option<(u32, u32, u32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn explicit_command_env(cmd: &Command, key: &str) -> Option<Option<String>> {
+        cmd.get_envs()
+            .find(|(name, _)| *name == key)
+            .map(|(_, value)| value.map(|v| v.to_string_lossy().to_string()))
+    }
+
+    #[test]
+    fn internal_git_env_disables_trace2_targets() {
+        let mut cmd = Command::new("git");
+        for key in INTERNAL_GIT_ENV_REMOVE {
+            cmd.env(key, "inherited");
+        }
+        for (key, _) in INTERNAL_GIT_ENV_SET {
+            cmd.env(key, "inherited");
+        }
+
+        apply_internal_git_env(&mut cmd);
+
+        for key in INTERNAL_GIT_ENV_REMOVE {
+            assert_eq!(explicit_command_env(&cmd, key), Some(None));
+        }
+        for (key, value) in INTERNAL_GIT_ENV_SET {
+            assert_eq!(
+                explicit_command_env(&cmd, key),
+                Some(Some((*value).to_string()))
+            );
+        }
+    }
 
     #[test]
     fn author_config_overlays_full_identity() {

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -250,6 +250,26 @@ mod tests {
         }
     }
 
+    fn with_empty_path<F: FnOnce()>(f: F) {
+        let temp_dir = TempDir::new().unwrap();
+        let prev_path = std::env::var_os("PATH");
+
+        // SAFETY: tests are serialized via #[serial], so mutating process env is safe.
+        unsafe {
+            std::env::set_var("PATH", temp_dir.path());
+        }
+
+        f();
+
+        // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
+        unsafe {
+            match prev_path {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+
     #[test]
     fn test_opencode_install_plugin_creates_file_from_scratch() {
         let (_temp_dir, plugin_path) = setup_test_env();
@@ -429,15 +449,17 @@ mod tests {
     #[serial]
     fn test_opencode_no_binary_no_config_not_detected() {
         with_temp_home(|_home| {
-            let installer = OpenCodeInstaller;
-            let params = HookInstallerParams {
-                binary_path: create_test_binary_path(),
-            };
-            let result = installer.check_hooks(&params).unwrap();
-            assert!(
-                !result.tool_installed,
-                "no binary and no config should mean tool_installed=false"
-            );
+            with_empty_path(|| {
+                let installer = OpenCodeInstaller;
+                let params = HookInstallerParams {
+                    binary_path: create_test_binary_path(),
+                };
+                let result = installer.check_hooks(&params).unwrap();
+                assert!(
+                    !result.tool_installed,
+                    "no binary and no config should mean tool_installed=false"
+                );
+            });
         });
     }
 

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -65,6 +65,18 @@ pub(crate) fn run_command_with_timeout(
     poll_interval: Duration,
     env_remove: &[&str],
 ) -> Result<TimedCommandOutput, String> {
+    run_command_with_timeout_and_env(program, args, cwd, timeout, poll_interval, env_remove, &[])
+}
+
+pub(crate) fn run_command_with_timeout_and_env(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    timeout: Duration,
+    poll_interval: Duration,
+    env_remove: &[&str],
+    env_set: &[(&str, &str)],
+) -> Result<TimedCommandOutput, String> {
     let mut command = Command::new(program);
     command
         .args(args)
@@ -72,6 +84,9 @@ pub(crate) fn run_command_with_timeout(
         .stderr(Stdio::piped());
     for key in env_remove {
         command.env_remove(key);
+    }
+    for (key, value) in env_set {
+        command.env(key, value);
     }
     if let Some(cwd) = cwd {
         command.current_dir(cwd);

--- a/tests/integration/internal_spawn_safety.rs
+++ b/tests/integration/internal_spawn_safety.rs
@@ -1,5 +1,11 @@
+#[cfg(unix)]
+use crate::repos::test_file::ExpectedLineExt;
+#[cfg(unix)]
+use crate::repos::test_repo::{TestRepo, real_git_executable};
 use regex::Regex;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
@@ -88,6 +94,79 @@ fn internal_spawn_helper_calls_must_provide_guard_env() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn internal_git_spawns_disable_trace2_env() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("plain.txt"), "plain log content\n").unwrap();
+    repo.stage_all_and_commit("feat: plain log").unwrap();
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(lines!["plain log content".unattributed_human()]);
+
+    let wrapper_path = repo.test_home_path().join("recording-git");
+    let env_log_path = repo.test_home_path().join("internal-git-env.log");
+    fs::write(
+        &wrapper_path,
+        r#"#!/bin/sh
+{
+  printf 'argv=%s\n' "$*"
+  printf 'GIT_TRACE2=%s\n' "${GIT_TRACE2-<unset>}"
+  printf 'GIT_TRACE2_EVENT=%s\n' "${GIT_TRACE2_EVENT-<unset>}"
+  printf 'GIT_TRACE2_PERF=%s\n' "${GIT_TRACE2_PERF-<unset>}"
+} >> "$GIT_AI_INTERNAL_GIT_ENV_LOG"
+exec "$GIT_AI_REAL_GIT" "$@"
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&wrapper_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&wrapper_path, permissions).unwrap();
+
+    let config_path = repo.test_home_path().join(".git-ai").join("config.json");
+    fs::write(
+        &config_path,
+        serde_json::json!({
+            "git_path": wrapper_path,
+            "prompt_storage": "notes",
+            "exclude_prompts_in_repositories": [],
+            "disable_version_checks": true
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let env_log = env_log_path.to_string_lossy().to_string();
+    let real_git = real_git_executable().to_string();
+    repo.git_ai_with_env(
+        &["log", "--no-pager", "--plain", "-n", "1"],
+        &[
+            ("GIT_AI_INTERNAL_GIT_ENV_LOG", env_log.as_str()),
+            ("GIT_AI_REAL_GIT", real_git.as_str()),
+            ("GIT_TRACE2", "1"),
+            ("GIT_TRACE2_EVENT", "1"),
+            ("GIT_TRACE2_PERF", "1"),
+        ],
+    )
+    .expect("git-ai log --plain should succeed through recording git");
+
+    let env_log = fs::read_to_string(&env_log_path).expect("recording git should write env log");
+    assert!(
+        env_log.contains("argv=") && env_log.contains(" log "),
+        "expected recording git to capture a git log invocation:\n{}",
+        env_log
+    );
+
+    for line in env_log.lines() {
+        if line.starts_with("GIT_TRACE2=") {
+            assert_eq!(line, "GIT_TRACE2=0", "env log:\n{}", env_log);
+        } else if line.starts_with("GIT_TRACE2_EVENT=") {
+            assert_eq!(line, "GIT_TRACE2_EVENT=0", "env log:\n{}", env_log);
+        } else if line.starts_with("GIT_TRACE2_PERF=") {
+            assert_eq!(line, "GIT_TRACE2_PERF=0", "env log:\n{}", env_log);
+        }
+    }
+}
+
 #[test]
 fn direct_git_command_spawns_are_centralized() {
     let src_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
@@ -95,7 +174,8 @@ fn direct_git_command_spawns_are_centralized() {
     collect_rs_files(&src_root, &mut files);
 
     let allowed_suffixes = ["src/git/repository.rs", "src/commands/git_handlers.rs"];
-    let pattern = Regex::new(r#"Command::new\(config::Config::get\(\)\.git_cmd\(\)\)"#).unwrap();
+    let pattern =
+        Regex::new(r#"Command::new\((?:crate::)?config::Config::get\(\)\.git_cmd\(\)\)"#).unwrap();
 
     for file in files {
         let file_str = file.to_string_lossy().replace('\\', "/");


### PR DESCRIPTION
## Summary

Internal git subprocesses should not feed Trace2 events back into git-ai's daemon. This change centralizes the internal git environment setup so buffered, streaming, and one-off internal git calls consistently disable Trace2 while preserving the user-facing git proxy and explicit Trace2 diagnostics.

## Changes

- Expands the shared internal git env helper to set Trace2 targets to `0` and remove inherited Trace2 metadata variables.
- Applies that helper to streaming git spawns, dirty-file discovery, install-time git config/version calls, notes migration `cat-file --batch`, and debug-report git probes.
- Adds a unit guard for the shared helper and a `TestRepo` regression with a recording git wrapper that verifies internal git children see Trace2 disabled.

## Validation

- `task fmt`
- `task test TEST_FILTER=internal_spawn_safety`
- `task test TEST_FILTER=internal_git_env_disables_trace2_targets CARGO_TEST_ARGS="--lib"`
- `task test TEST_FILTER=commands::debug CARGO_TEST_ARGS="--lib"`
- `task build`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->