### PR TITLE
[codex] Mark pure no-signal commits as known human

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -1,6 +1,6 @@
-use crate::authorship::authorship_log::{LineRange, SessionRecord};
+use crate::authorship::authorship_log::{HumanRecord, LineRange, SessionRecord};
 use crate::authorship::authorship_log_serialization::{
-    AuthorshipLog, generate_session_id, generate_trace_id,
+    AuthorshipLog, generate_human_short_hash, generate_session_id, generate_trace_id,
 };
 use crate::authorship::working_log::{AgentId, CheckpointKind};
 use crate::commands::checkpoint_agent::bash_tool::StatEntry;
@@ -14,11 +14,13 @@ use serde_json::json;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::path::Path;
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
 const BASH_RECOVERY_COARSE_TIMESTAMP_NS: u128 = 1_000_000_000;
 pub(crate) const SESSION_EVENT_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
+const PURE_HUMAN_RECOVERY_MAX_ADDED_LINES: usize = 1000;
 const EDGE_EXTENSION_MAX_LINES: usize = 3;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
@@ -157,6 +159,7 @@ const KNOWN_COMMIT_AGENT_KINDS: &[CommitAgentKind] = &[
 
 pub(crate) type FileTimestampsByPath = HashMap<String, Vec<u128>>;
 pub(crate) type UnknownLinesByFile = BTreeMap<String, Vec<u32>>;
+type LineRangesByFile = BTreeMap<String, Vec<LineRange>>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct CommitAgentKind {
@@ -176,9 +179,23 @@ struct CommitAgentDetection {
 
 #[derive(Debug)]
 struct CommitMetadata {
+    parent_shas: Vec<String>,
     message: String,
     author_name: String,
     author_email: String,
+}
+
+impl CommitMetadata {
+    fn immediate_parent(&self) -> Option<&str> {
+        self.parent_shas.first().map(String::as_str)
+    }
+
+    fn author_identity(&self) -> Option<String> {
+        if self.author_name.is_empty() || self.author_email.is_empty() {
+            return None;
+        }
+        Some(format!("{} <{}>", self.author_name, self.author_email))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -212,56 +229,83 @@ pub(crate) fn recover_attribution(
         return Ok(());
     }
 
-    if unknown_lines_by_file(authorship_log, committed_hunks).is_empty() {
+    if committed_untracked_line_ranges_by_file(authorship_log, committed_hunks).is_empty() {
         return Ok(());
     }
 
-    recover_bash_mtime(
-        repo,
-        parent_sha,
-        commit_sha,
-        human_author,
-        authorship_log,
-        committed_hunks,
-        context.file_timestamps,
-    )?;
+    finish_recovery_with_metrics(
+        RecoveryMetricBatch::new(parent_sha, commit_sha),
+        |recovery_metrics| {
+            recover_bash_mtime(
+                repo,
+                human_author,
+                authorship_log,
+                committed_hunks,
+                context.file_timestamps,
+                recovery_metrics,
+            )?;
 
-    recover_adjacent_edges(
-        repo,
-        parent_sha,
-        commit_sha,
-        authorship_log,
-        committed_hunks,
-    );
-    let unknown_after_edges = unknown_lines_by_file(authorship_log, committed_hunks);
-    if unknown_after_edges.is_empty() {
-        return Ok(());
-    }
+            recover_adjacent_edges(repo, authorship_log, committed_hunks, recovery_metrics);
+            let unknown_after_edges = unknown_lines_by_file(authorship_log, committed_hunks);
 
-    if let Some(before_external_recovery) = context.before_external_recovery {
-        before_external_recovery(&unknown_after_edges);
-    }
+            if !unknown_after_edges.is_empty()
+                && let Some(before_external_recovery) = context.before_external_recovery
+            {
+                before_external_recovery(&unknown_after_edges);
+            }
 
-    recover_session_event_mtime(
-        repo,
-        parent_sha,
-        commit_sha,
-        human_author,
-        authorship_log,
-        committed_hunks,
-        context.file_timestamps,
-    )?;
+            let mut commit_metadata = None;
+            if !unknown_after_edges.is_empty() {
+                recover_session_event_mtime(
+                    repo,
+                    human_author,
+                    authorship_log,
+                    committed_hunks,
+                    context.file_timestamps,
+                    recovery_metrics,
+                )?;
 
-    recover_commit_metadata(
-        repo,
-        parent_sha,
-        commit_sha,
-        human_author,
-        authorship_log,
-        committed_hunks,
-        context.file_timestamps,
-    )?;
-    Ok(())
+                let metadata = read_commit_metadata(repo, commit_sha)?;
+                recover_commit_metadata(
+                    repo,
+                    human_author,
+                    &metadata,
+                    authorship_log,
+                    committed_hunks,
+                    context.file_timestamps,
+                    recovery_metrics,
+                )?;
+                commit_metadata = Some(metadata);
+            }
+
+            if !committed_untracked_line_ranges_by_file(authorship_log, committed_hunks).is_empty()
+            {
+                let metadata = match commit_metadata {
+                    Some(metadata) => metadata,
+                    None => read_commit_metadata(repo, commit_sha)?,
+                };
+                recover_known_human_remaining_lines(
+                    repo,
+                    &metadata,
+                    authorship_log,
+                    committed_hunks,
+                    context.file_timestamps,
+                    recovery_metrics,
+                )?;
+
+                recover_pure_human_no_ai_signals(
+                    repo,
+                    &metadata,
+                    authorship_log,
+                    committed_hunks,
+                    context.file_timestamps,
+                    recovery_metrics,
+                )?;
+            }
+            Ok(())
+        },
+        crate::observability::log_metrics,
+    )
 }
 
 pub(crate) fn matching_session_event_candidate_exists(
@@ -288,12 +332,11 @@ pub(crate) fn matching_session_event_candidate_exists(
 
 fn recover_bash_mtime(
     repo: &Repository,
-    parent_sha: &str,
-    commit_sha: &str,
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
     captured_file_timestamps: Option<&FileTimestampsByPath>,
+    recovery_metrics: &mut RecoveryMetricBatch,
 ) -> Result<(), GitAiError> {
     let repo_work_dir = repo_worktree_key(repo)?;
     let workdir = repo.workdir()?;
@@ -378,24 +421,25 @@ fn recover_bash_mtime(
             "selection_tier": selection.tier.as_str(),
             "candidate_count": candidates.len(),
         });
-        record_recovery_metric(RecoveryMetricInput {
+        recovery_metrics.record(
             repo,
-            parent_sha,
-            commit_sha,
-            file_path: &file_path,
-            author_id: &author_id,
-            session_id: &session_id,
-            trace_id: &trace_id,
-            tool: &candidate.agent_id.tool,
-            model: &candidate.agent_id.model,
-            external_session_id: &candidate.agent_id.id,
-            external_tool_use_id: Some(&candidate.tool_use_id),
-            edit_kind: "bash",
-            checkpoint_type: "recovered_bash",
-            recovered_line_count: unknown_lines.len() as u32,
-            metadata,
-            event_ts: Some((candidate.start_time_ns / 1_000_000_000) as u32),
-        });
+            RecoveryMetricInput {
+                file_path: &file_path,
+                author_id: &author_id,
+                session_id: &session_id,
+                trace_id: &trace_id,
+                tool: &candidate.agent_id.tool,
+                model: &candidate.agent_id.model,
+                external_session_id: &candidate.agent_id.id,
+                external_tool_use_id: Some(&candidate.tool_use_id),
+                edit_kind: "bash",
+                checkpoint_type: "recovered_bash",
+                checkpoint_kind: CheckpointKind::AiAgent,
+                recovered_line_count: unknown_lines.len() as u32,
+                metadata,
+                event_ts: Some((candidate.start_time_ns / 1_000_000_000) as u32),
+            },
+        );
     }
 
     Ok(())
@@ -403,12 +447,11 @@ fn recover_bash_mtime(
 
 fn recover_session_event_mtime(
     repo: &Repository,
-    parent_sha: &str,
-    commit_sha: &str,
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
     captured_file_timestamps: Option<&FileTimestampsByPath>,
+    recovery_metrics: &mut RecoveryMetricBatch,
 ) -> Result<(), GitAiError> {
     let workdir = repo.workdir()?;
     let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
@@ -491,24 +534,25 @@ fn recover_session_event_mtime(
             "selection_tier": selection.tier.as_str(),
             "candidate_count": candidates.len(),
         });
-        record_recovery_metric(RecoveryMetricInput {
+        recovery_metrics.record(
             repo,
-            parent_sha,
-            commit_sha,
-            file_path: &file_path,
-            author_id: &author_id,
-            session_id: &candidate.session_id,
-            trace_id: &trace_id,
-            tool: &candidate.tool,
-            model: &selected_model,
-            external_session_id: &candidate.external_session_id,
-            external_tool_use_id: candidate.external_tool_use_id.as_deref(),
-            edit_kind: "attribution_recovery_session_event",
-            checkpoint_type: "recovered_session_event_mtime",
-            recovered_line_count: unknown_lines.len() as u32,
-            metadata,
-            event_ts: Some(candidate.event_ts),
-        });
+            RecoveryMetricInput {
+                file_path: &file_path,
+                author_id: &author_id,
+                session_id: &candidate.session_id,
+                trace_id: &trace_id,
+                tool: &candidate.tool,
+                model: &selected_model,
+                external_session_id: &candidate.external_session_id,
+                external_tool_use_id: candidate.external_tool_use_id.as_deref(),
+                edit_kind: "attribution_recovery_session_event",
+                checkpoint_type: "recovered_session_event_mtime",
+                checkpoint_kind: CheckpointKind::AiAgent,
+                recovered_line_count: unknown_lines.len() as u32,
+                metadata,
+                event_ts: Some(candidate.event_ts),
+            },
+        );
     }
 
     Ok(())
@@ -516,20 +560,19 @@ fn recover_session_event_mtime(
 
 fn recover_commit_metadata(
     repo: &Repository,
-    parent_sha: &str,
-    commit_sha: &str,
     human_author: &str,
+    commit_metadata: &CommitMetadata,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
     captured_file_timestamps: Option<&FileTimestampsByPath>,
+    recovery_metrics: &mut RecoveryMetricBatch,
 ) -> Result<(), GitAiError> {
     let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
     if unknown_by_file.is_empty() {
         return Ok(());
     }
 
-    let commit_metadata = read_commit_metadata(repo, commit_sha)?;
-    let detections = detect_commit_metadata_agents(&commit_metadata);
+    let detections = detect_commit_metadata_agents(commit_metadata);
     if detections.is_empty() {
         return Ok(());
     }
@@ -599,24 +642,248 @@ fn recover_commit_metadata(
             "file_timestamps_ns": file_timestamps,
             "latest_file_timestamps_ns": latest_timestamps,
         });
-        record_recovery_metric(RecoveryMetricInput {
+        recovery_metrics.record(
             repo,
-            parent_sha,
-            commit_sha,
-            file_path: &file_path,
-            author_id: &author_id,
-            session_id: &selection.session_id,
-            trace_id: &trace_id,
-            tool: &selection.agent_id.tool,
-            model: &selection.agent_id.model,
-            external_session_id: &selection.agent_id.id,
-            external_tool_use_id: selection.external_tool_use_id.as_deref(),
-            edit_kind: "attribution_recovery_commit_metadata",
-            checkpoint_type: "recovered_commit_metadata",
-            recovered_line_count: unknown_lines.len() as u32,
-            metadata,
-            event_ts: selection.event_ts,
+            RecoveryMetricInput {
+                file_path: &file_path,
+                author_id: &author_id,
+                session_id: &selection.session_id,
+                trace_id: &trace_id,
+                tool: &selection.agent_id.tool,
+                model: &selection.agent_id.model,
+                external_session_id: &selection.agent_id.id,
+                external_tool_use_id: selection.external_tool_use_id.as_deref(),
+                edit_kind: "attribution_recovery_commit_metadata",
+                checkpoint_type: "recovered_commit_metadata",
+                checkpoint_kind: CheckpointKind::AiAgent,
+                recovered_line_count: unknown_lines.len() as u32,
+                metadata,
+                event_ts: selection.event_ts,
+            },
+        );
+    }
+
+    Ok(())
+}
+
+fn recover_pure_human_no_ai_signals(
+    repo: &Repository,
+    commit_metadata: &CommitMetadata,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    captured_file_timestamps: Option<&FileTimestampsByPath>,
+    recovery_metrics: &mut RecoveryMetricBatch,
+) -> Result<(), GitAiError> {
+    if committed_hunks.is_empty()
+        || total_added_line_count(committed_hunks) >= PURE_HUMAN_RECOVERY_MAX_ADDED_LINES
+    {
+        return Ok(());
+    }
+
+    if committed_hunks_have_ai_authorship(authorship_log, committed_hunks) {
+        return Ok(());
+    }
+
+    let human_ranges_by_file =
+        committed_untracked_line_ranges_by_file(authorship_log, committed_hunks);
+    if human_ranges_by_file.is_empty() {
+        return Ok(());
+    }
+
+    let workdir = repo.workdir()?;
+    let (timestamps_by_file, all_timestamps) =
+        timestamps_for_recovery_files(&workdir, &human_ranges_by_file, captured_file_timestamps);
+    if all_timestamps.is_empty() || external_ai_signal_near_timestamps(&all_timestamps)? {
+        return Ok(());
+    }
+
+    let Some(human_author) = commit_metadata.author_identity() else {
+        return Ok(());
+    };
+    let human_id = generate_human_short_hash(&human_author);
+
+    for (file_path, ranges) in human_ranges_by_file {
+        let Some(file_timestamps) = timestamps_by_file.get(&file_path).cloned() else {
+            continue;
+        };
+        let recovered_line_count = line_ranges_total_count_u32(&ranges);
+        let recovered_range_count = ranges.len();
+        if !add_human_attestation_ranges(
+            authorship_log,
+            &file_path,
+            &human_id,
+            &human_author,
+            ranges,
+        ) {
+            continue;
+        }
+        let event_ts = latest_event_ts_from_timestamps(&file_timestamps);
+        let trace_id = generate_trace_id();
+        let metadata = json!({
+            "solver": "pure_human_no_ai_signals",
+            "file_path": file_path.as_str(),
+            "recovered_line_count": recovered_line_count,
+            "recovered_range_count": recovered_range_count,
+            "human_author": human_author.as_str(),
+            "human_id": human_id.as_str(),
+            "file_timestamps_ns": file_timestamps,
+            "session_event_window_ns": SESSION_EVENT_RECOVERY_WINDOW_NS,
+            "bash_window_ns": BASH_RECOVERY_WINDOW_NS,
         });
+        recovery_metrics.record(
+            repo,
+            RecoveryMetricInput {
+                file_path: &file_path,
+                author_id: &human_id,
+                session_id: "",
+                trace_id: &trace_id,
+                tool: "",
+                model: "",
+                external_session_id: "",
+                external_tool_use_id: None,
+                edit_kind: "attribution_recovery_pure_human",
+                checkpoint_type: "recovered_pure_human_no_ai_signals",
+                checkpoint_kind: CheckpointKind::KnownHuman,
+                recovered_line_count,
+                metadata,
+                event_ts,
+            },
+        );
+    }
+
+    Ok(())
+}
+
+fn recover_known_human_remaining_lines(
+    repo: &Repository,
+    commit_metadata: &CommitMetadata,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    captured_file_timestamps: Option<&FileTimestampsByPath>,
+    recovery_metrics: &mut RecoveryMetricBatch,
+) -> Result<(), GitAiError> {
+    let untracked_ranges_by_file =
+        committed_untracked_line_ranges_by_file(authorship_log, committed_hunks);
+    if untracked_ranges_by_file.is_empty() {
+        return Ok(());
+    }
+    if total_added_line_count(committed_hunks) >= PURE_HUMAN_RECOVERY_MAX_ADDED_LINES
+        || committed_hunks_have_ai_authorship(authorship_log, committed_hunks)
+    {
+        return Ok(());
+    }
+    let Some(current_human_author) = commit_metadata.author_identity() else {
+        return Ok(());
+    };
+    let current_human_id = generate_human_short_hash(&current_human_author);
+
+    let (mut recovery_candidates, parent_candidate_ranges) =
+        partition_current_known_human_candidates(
+            authorship_log,
+            untracked_ranges_by_file,
+            &current_human_id,
+        );
+    let parent_authorship_log = (!parent_candidate_ranges.is_empty())
+        .then(|| {
+            commit_metadata
+                .immediate_parent()
+                .and_then(|parent| crate::git::notes_api::read_authorship_v3(repo, parent).ok())
+        })
+        .flatten();
+    for (file_path, ranges) in parent_candidate_ranges {
+        let Some(selection) = known_human_for_current_contributor(
+            authorship_log,
+            parent_authorship_log.as_ref(),
+            &file_path,
+            &current_human_id,
+        ) else {
+            continue;
+        };
+        let human_id = selection.human_id().to_string();
+        let identity_source = match selection {
+            KnownHumanSelection::CurrentCheckpoint(_) => "current_checkpoint",
+            KnownHumanSelection::MatchingParent(_) => "matching_parent",
+        };
+        recovery_candidates.push((file_path, ranges, human_id, identity_source));
+    }
+
+    if recovery_candidates.is_empty() {
+        return Ok(());
+    }
+
+    let candidate_ranges_by_file = recovery_candidates
+        .iter()
+        .map(|(file_path, ranges, _, _)| (file_path.clone(), ranges.clone()))
+        .collect();
+    let workdir = repo.workdir()?;
+    let (timestamps_by_file, all_timestamps) = timestamps_for_recovery_files(
+        &workdir,
+        &candidate_ranges_by_file,
+        captured_file_timestamps,
+    );
+    if all_timestamps.is_empty() || external_ai_signal_near_timestamps(&all_timestamps)? {
+        return Ok(());
+    }
+
+    let recoveries = recovery_candidates
+        .into_iter()
+        .filter(|(file_path, _, _, _)| timestamps_by_file.contains_key(file_path));
+    for (file_path, ranges, human_id, identity_source) in recoveries {
+        let human_author = authorship_log
+            .metadata
+            .humans
+            .get(&human_id)
+            .or_else(|| {
+                parent_authorship_log
+                    .as_ref()
+                    .and_then(|parent| parent.metadata.humans.get(&human_id))
+            })
+            .map(|record| record.author.clone())
+            .filter(|author| !author.is_empty())
+            .or_else(|| (human_id == current_human_id).then(|| current_human_author.clone()));
+        let Some(human_author) = human_author else {
+            continue;
+        };
+        let recovered_line_count = line_ranges_total_count_u32(&ranges);
+        let recovered_range_count = ranges.len();
+        if !add_human_attestation_ranges(
+            authorship_log,
+            &file_path,
+            &human_id,
+            &human_author,
+            ranges,
+        ) {
+            continue;
+        }
+        let trace_id = generate_trace_id();
+        let metadata = json!({
+            "solver": "known_human_existing_attribution",
+            "file_path": file_path.as_str(),
+            "recovered_line_count": recovered_line_count,
+            "recovered_range_count": recovered_range_count,
+            "human_author": human_author.as_str(),
+            "human_id": human_id.as_str(),
+            "identity_source": identity_source,
+        });
+        recovery_metrics.record(
+            repo,
+            RecoveryMetricInput {
+                file_path: &file_path,
+                author_id: &human_id,
+                session_id: "",
+                trace_id: &trace_id,
+                tool: "",
+                model: "",
+                external_session_id: "",
+                external_tool_use_id: None,
+                edit_kind: "attribution_recovery_known_human",
+                checkpoint_type: "recovered_known_human_remaining_lines",
+                checkpoint_kind: CheckpointKind::KnownHuman,
+                recovered_line_count,
+                metadata,
+                event_ts: None,
+            },
+        );
     }
 
     Ok(())
@@ -627,17 +894,24 @@ fn read_commit_metadata(repo: &Repository, commit_sha: &str) -> Result<CommitMet
     args.extend([
         "show".to_string(),
         "-s".to_string(),
-        "--format=%an%x00%ae%x00%B".to_string(),
+        "--format=%P%x00%an%x00%ae%x00%B".to_string(),
         commit_sha.to_string(),
     ]);
     let output = exec_git(&args)?;
     let raw = String::from_utf8(output.stdout)?;
-    let mut parts = raw.splitn(3, '\0');
+    let mut parts = raw.splitn(4, '\0');
+    let parent_shas = parts
+        .next()
+        .unwrap_or_default()
+        .split_whitespace()
+        .map(ToString::to_string)
+        .collect();
     let author_name = parts.next().unwrap_or_default().trim().to_string();
     let author_email = parts.next().unwrap_or_default().trim().to_string();
     let message = parts.next().unwrap_or_default().to_string();
 
     Ok(CommitMetadata {
+        parent_shas,
         message,
         author_name,
         author_email,
@@ -833,6 +1107,94 @@ fn latest_timestamps_for_unknown_files(
         .unwrap_or_default();
 
     (timestamps_by_file, latest_timestamps)
+}
+
+fn timestamps_for_recovery_files(
+    workdir: &std::path::Path,
+    ranges_by_file: &LineRangesByFile,
+    captured_file_timestamps: Option<&FileTimestampsByPath>,
+) -> (HashMap<String, Vec<u128>>, Vec<u128>) {
+    let mut timestamps_by_file = HashMap::new();
+    let mut all_timestamps = Vec::new();
+    for file_path in ranges_by_file.keys() {
+        let timestamps = match captured_file_timestamps {
+            Some(captured) => captured
+                .get(file_path)
+                .filter(|timestamps| !timestamps.is_empty())
+                .cloned()
+                .unwrap_or_default(),
+            None => file_timestamps_ns(workdir, file_path),
+        };
+        if !timestamps.is_empty() {
+            all_timestamps.extend(timestamps.iter().copied());
+            timestamps_by_file.insert(file_path.clone(), timestamps);
+        }
+    }
+    all_timestamps.sort_unstable();
+    all_timestamps.dedup();
+
+    (timestamps_by_file, all_timestamps)
+}
+
+fn latest_event_ts_from_timestamps(timestamps_ns: &[u128]) -> Option<u32> {
+    timestamps_ns
+        .iter()
+        .copied()
+        .max()
+        .map(|timestamp| (timestamp / NS_PER_SECOND).min(u128::from(u32::MAX)) as u32)
+}
+
+fn external_ai_signal_near_timestamps(timestamps_ns: &[u128]) -> Result<bool, GitAiError> {
+    if timestamps_ns.is_empty() {
+        return Ok(false);
+    }
+
+    let metrics_store = crate::metrics::db::MetricsDatabase::global();
+    let session_event_found = signal_store_has_candidates(
+        crate::metrics::db::MetricsDatabase::recovery_signals_available(),
+        metrics_store,
+        |db| {
+            Ok(!db
+                .session_event_candidates_near_timestamps(
+                    timestamps_ns,
+                    SESSION_EVENT_RECOVERY_WINDOW_NS,
+                )?
+                .is_empty())
+        },
+    );
+    if session_event_found {
+        return Ok(true);
+    }
+
+    let bash_store = crate::daemon::bash_history_db::BashHistoryDatabase::global();
+    let bash_candidate_found = signal_store_has_candidates(
+        crate::daemon::bash_history_db::BashHistoryDatabase::recovery_signals_available(),
+        bash_store,
+        |db| {
+            Ok(!db
+                .candidates_near_timestamps(timestamps_ns, BASH_RECOVERY_WINDOW_NS)?
+                .is_empty())
+        },
+    );
+
+    Ok(bash_candidate_found)
+}
+
+fn signal_store_has_candidates<T>(
+    available: bool,
+    store: Result<&Mutex<T>, GitAiError>,
+    query: impl FnOnce(&T) -> Result<bool, GitAiError>,
+) -> bool {
+    if !available {
+        return true;
+    }
+    let Ok(store) = store else {
+        return true;
+    };
+    let Ok(store) = store.lock() else {
+        return true;
+    };
+    query(&store).unwrap_or(true)
 }
 
 fn select_commit_metadata_session(
@@ -1118,10 +1480,9 @@ fn agent_kind_matches_tool(kind: &CommitAgentKind, tool: &str) -> bool {
 
 fn recover_adjacent_edges(
     repo: &Repository,
-    parent_sha: &str,
-    commit_sha: &str,
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
+    recovery_metrics: &mut RecoveryMetricBatch,
 ) {
     let unknown = unknown_lines_by_file(authorship_log, committed_hunks);
     for (file_path, unknown_lines) in unknown {
@@ -1157,24 +1518,25 @@ fn recover_adjacent_edges(
                 "source_author": &recovery.source_author,
                 "recovered_lines": &recovery.lines,
             });
-            record_recovery_metric(RecoveryMetricInput {
+            recovery_metrics.record(
                 repo,
-                parent_sha,
-                commit_sha,
-                file_path: &file_path,
-                author_id: &recovered_author,
-                session_id: &source_session,
-                trace_id: &trace_id,
-                tool: "",
-                model: "",
-                external_session_id: "",
-                external_tool_use_id: None,
-                edit_kind: "attribution_recovery_edge",
-                checkpoint_type: "recovered_edge_extension",
-                recovered_line_count,
-                metadata,
-                event_ts: None,
-            });
+                RecoveryMetricInput {
+                    file_path: &file_path,
+                    author_id: &recovered_author,
+                    session_id: &source_session,
+                    trace_id: &trace_id,
+                    tool: "",
+                    model: "",
+                    external_session_id: "",
+                    external_tool_use_id: None,
+                    edit_kind: "attribution_recovery_edge",
+                    checkpoint_type: "recovered_edge_extension",
+                    checkpoint_kind: CheckpointKind::AiAgent,
+                    recovered_line_count,
+                    metadata,
+                    event_ts: None,
+                },
+            );
         }
     }
 }
@@ -1529,6 +1891,233 @@ fn unknown_lines_by_file(
     result
 }
 
+fn total_added_line_count(committed_hunks: &HashMap<String, Vec<LineRange>>) -> usize {
+    committed_hunks
+        .values()
+        .map(|ranges| line_ranges_total_count(ranges))
+        .sum()
+}
+
+fn line_ranges_total_count(ranges: &[LineRange]) -> usize {
+    ranges.iter().map(line_range_len).sum()
+}
+
+fn line_ranges_total_count_u32(ranges: &[LineRange]) -> u32 {
+    line_ranges_total_count(ranges).min(u32::MAX as usize) as u32
+}
+
+fn line_range_len(range: &LineRange) -> usize {
+    match range {
+        LineRange::Single(_) => 1,
+        LineRange::Range(start, end) => end.saturating_sub(*start).saturating_add(1) as usize,
+    }
+}
+
+fn committed_untracked_line_ranges_by_file(
+    authorship_log: &AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+) -> LineRangesByFile {
+    committed_line_ranges_matching_author(authorship_log, committed_hunks, |author| match author {
+        None => true,
+        Some("human") => true,
+        Some(_) => false,
+    })
+}
+
+fn committed_line_ranges_matching_author<F>(
+    authorship_log: &AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    mut predicate: F,
+) -> LineRangesByFile
+where
+    F: FnMut(Option<&str>) -> bool,
+{
+    let latest_authors = latest_authors_by_file(authorship_log);
+    let mut result = BTreeMap::new();
+    for (file_path, ranges) in committed_hunks {
+        let file_authors = latest_authors.get(file_path.as_str());
+        let mut matching_ranges = Vec::new();
+        for_each_line_in_ranges(ranges, |line| {
+            let author = file_authors.and_then(|authors| authors.get(&line)).copied();
+            if predicate(author) {
+                push_line_as_compressed_range(&mut matching_ranges, line);
+            }
+        });
+        if !matching_ranges.is_empty() {
+            result.insert(file_path.clone(), matching_ranges);
+        }
+    }
+    result
+}
+
+fn committed_hunks_have_ai_authorship(
+    authorship_log: &AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+) -> bool {
+    let latest_authors = latest_authors_by_file(authorship_log);
+    for (file_path, ranges) in committed_hunks {
+        let file_authors = latest_authors.get(file_path.as_str());
+        let mut has_ai = false;
+        for_each_line_in_ranges(ranges, |line| {
+            if file_authors
+                .and_then(|authors| authors.get(&line))
+                .copied()
+                .is_some_and(is_ai_attestation)
+            {
+                has_ai = true;
+            }
+        });
+        if has_ai {
+            return true;
+        }
+    }
+    false
+}
+
+fn latest_authors_by_file(authorship_log: &AuthorshipLog) -> HashMap<&str, HashMap<u32, &str>> {
+    let mut latest_authors = HashMap::new();
+    for attestation in &authorship_log.attestations {
+        let file_authors = latest_authors
+            .entry(attestation.file_path.as_str())
+            .or_insert_with(HashMap::new);
+        for entry in &attestation.entries {
+            for line in entry.line_ranges.iter().flat_map(LineRange::expand) {
+                file_authors.insert(line, entry.hash.as_str());
+            }
+        }
+    }
+    latest_authors
+}
+
+#[cfg(test)]
+fn unique_known_human_for_file(
+    authorship_log: &AuthorshipLog,
+    parent_authorship_log: Option<&AuthorshipLog>,
+    file_path: &str,
+) -> Option<String> {
+    let mut known_humans = known_humans_for_file(authorship_log, file_path);
+    if let Some(parent) = parent_authorship_log {
+        known_humans.extend(known_humans_for_file(parent, file_path));
+    }
+    (known_humans.len() == 1)
+        .then(|| known_humans.into_iter().next())
+        .flatten()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum KnownHumanSelection {
+    CurrentCheckpoint(String),
+    MatchingParent(String),
+}
+
+type KnownHumanRecoveryCandidate = (String, Vec<LineRange>, String, &'static str);
+
+impl KnownHumanSelection {
+    fn human_id(&self) -> &str {
+        match self {
+            Self::CurrentCheckpoint(human_id) | Self::MatchingParent(human_id) => human_id,
+        }
+    }
+}
+
+fn partition_current_known_human_candidates(
+    authorship_log: &AuthorshipLog,
+    untracked_ranges_by_file: LineRangesByFile,
+    current_human_id: &str,
+) -> (Vec<KnownHumanRecoveryCandidate>, LineRangesByFile) {
+    let mut current_candidates = Vec::new();
+    let mut parent_candidates = LineRangesByFile::new();
+    for (file_path, ranges) in untracked_ranges_by_file {
+        match known_human_for_current_contributor(
+            authorship_log,
+            None,
+            &file_path,
+            current_human_id,
+        ) {
+            Some(selection) => current_candidates.push((
+                file_path,
+                ranges,
+                selection.human_id().to_string(),
+                "current_checkpoint",
+            )),
+            None if known_humans_for_file(authorship_log, &file_path).is_empty() => {
+                parent_candidates.insert(file_path, ranges);
+            }
+            None => {}
+        }
+    }
+    (current_candidates, parent_candidates)
+}
+
+fn known_human_for_current_contributor(
+    authorship_log: &AuthorshipLog,
+    parent_authorship_log: Option<&AuthorshipLog>,
+    file_path: &str,
+    current_human_id: &str,
+) -> Option<KnownHumanSelection> {
+    let current_humans = known_humans_for_file(authorship_log, file_path);
+    if current_humans.len() > 1 {
+        return None;
+    }
+    if let Some(explicit_human) = current_humans.into_iter().next() {
+        return Some(KnownHumanSelection::CurrentCheckpoint(explicit_human));
+    }
+
+    let parent_humans = parent_authorship_log
+        .map(|log| known_humans_for_file(log, file_path))
+        .unwrap_or_default();
+    (parent_humans.len() == 1 && parent_humans.contains(current_human_id))
+        .then(|| KnownHumanSelection::MatchingParent(current_human_id.to_string()))
+}
+
+fn known_humans_for_file(authorship_log: &AuthorshipLog, file_path: &str) -> HashSet<String> {
+    authorship_log
+        .attestations
+        .iter()
+        .find(|attestation| attestation.file_path == file_path)
+        .into_iter()
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| entry.hash.starts_with("h_"))
+        .map(|entry| entry.hash.clone())
+        .collect()
+}
+
+fn for_each_line_in_ranges<F>(ranges: &[LineRange], mut visit: F)
+where
+    F: FnMut(u32),
+{
+    for range in ranges {
+        match range {
+            LineRange::Single(line) => visit(*line),
+            LineRange::Range(start, end) => {
+                for line in *start..=*end {
+                    visit(line);
+                }
+            }
+        }
+    }
+}
+
+fn push_line_as_compressed_range(ranges: &mut Vec<LineRange>, line: u32) {
+    if let Some(last) = ranges.last_mut() {
+        match last {
+            LineRange::Single(previous) if *previous == line => return,
+            LineRange::Single(previous) if previous.checked_add(1) == Some(line) => {
+                let start = *previous;
+                *last = LineRange::Range(start, line);
+                return;
+            }
+            LineRange::Range(_, end) if *end >= line => return,
+            LineRange::Range(_, end) if end.checked_add(1) == Some(line) => {
+                *end = line;
+                return;
+            }
+            _ => {}
+        }
+    }
+    ranges.push(LineRange::Single(line));
+}
+
 fn covered_lines_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, HashSet<u32>> {
     let mut covered = HashMap::new();
     for file_attestation in &authorship_log.attestations {
@@ -1673,10 +2262,46 @@ fn add_attestation(
         .add_entry(entry);
 }
 
+fn add_attestation_ranges(
+    authorship_log: &mut AuthorshipLog,
+    file_path: &str,
+    author_id: &str,
+    ranges: Vec<LineRange>,
+) {
+    if ranges.is_empty() {
+        return;
+    }
+    let entry = crate::authorship::authorship_log_serialization::AttestationEntry::new(
+        author_id.to_string(),
+        ranges,
+    );
+    authorship_log
+        .get_or_create_file(file_path)
+        .add_entry(entry);
+}
+
+fn add_human_attestation_ranges(
+    authorship_log: &mut AuthorshipLog,
+    file_path: &str,
+    human_id: &str,
+    human_author: &str,
+    ranges: Vec<LineRange>,
+) -> bool {
+    if ranges.is_empty() {
+        return false;
+    }
+    authorship_log
+        .metadata
+        .humans
+        .entry(human_id.to_string())
+        .or_insert_with(|| HumanRecord {
+            author: human_author.to_string(),
+        });
+    add_attestation_ranges(authorship_log, file_path, human_id, ranges);
+    true
+}
+
 struct RecoveryMetricInput<'a> {
-    repo: &'a Repository,
-    parent_sha: &'a str,
-    commit_sha: &'a str,
     file_path: &'a str,
     author_id: &'a str,
     session_id: &'a str,
@@ -1687,64 +2312,101 @@ struct RecoveryMetricInput<'a> {
     external_tool_use_id: Option<&'a str>,
     edit_kind: &'a str,
     checkpoint_type: &'a str,
+    checkpoint_kind: CheckpointKind,
     recovered_line_count: u32,
     metadata: serde_json::Value,
     event_ts: Option<u32>,
 }
 
-fn record_recovery_metric(input: RecoveryMetricInput<'_>) {
-    if input.tool == "mock_ai" {
-        return;
+struct RecoveryMetricBatch {
+    base_attrs: EventAttributes,
+    repo_attrs_resolved: bool,
+    events: Vec<MetricEvent>,
+}
+
+fn finish_recovery_with_metrics<T>(
+    mut recovery_metrics: RecoveryMetricBatch,
+    recover: impl FnOnce(&mut RecoveryMetricBatch) -> Result<T, GitAiError>,
+    submit: impl FnOnce(Vec<MetricEvent>),
+) -> Result<T, GitAiError> {
+    let result = recover(&mut recovery_metrics);
+    submit(recovery_metrics.events);
+    result
+}
+
+impl RecoveryMetricBatch {
+    fn new(parent_sha: &str, commit_sha: &str) -> Self {
+        let base_attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+            .base_commit_sha(parent_sha)
+            .commit_sha(commit_sha);
+        Self {
+            base_attrs,
+            repo_attrs_resolved: false,
+            events: Vec::new(),
+        }
     }
 
-    let checkpoint_ts = input.event_ts.map(u64::from).unwrap_or_else(|| {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-    });
-    let mut values = CheckpointValues::new()
-        .checkpoint_ts(checkpoint_ts)
-        .kind(CheckpointKind::AiAgent.to_str())
-        .file_path(input.file_path)
-        .lines_added(input.recovered_line_count)
-        .lines_deleted(0)
-        .lines_added_sloc(input.recovered_line_count)
-        .lines_deleted_sloc(0)
-        .edit_kind(input.edit_kind)
-        .checkpoint_type(input.checkpoint_type)
-        .attribution_recovery_metadata(input.metadata.to_string());
-    if let Some(tool_use_id) = input.external_tool_use_id {
-        values = values.external_tool_use_id(tool_use_id);
-    }
+    fn record(&mut self, repo: &Repository, input: RecoveryMetricInput<'_>) {
+        if input.tool == "mock_ai" {
+            return;
+        }
 
-    let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
-        .base_commit_sha(input.parent_sha)
-        .commit_sha(input.commit_sha)
-        .session_id(input.session_id)
-        .trace_id(input.trace_id);
+        if !self.repo_attrs_resolved {
+            if let Some(url) = crate::repo_url::resolve_repo_url_from_repo(repo) {
+                self.base_attrs = self.base_attrs.clone().repo_url(url);
+            }
+            if let Ok(head_ref) = repo.head()
+                && let Ok(short_branch) = head_ref.shorthand()
+            {
+                self.base_attrs = self.base_attrs.clone().branch(short_branch);
+            }
+            self.repo_attrs_resolved = true;
+        }
 
-    if !input.tool.is_empty() {
-        attrs = attrs.tool(input.tool);
-    }
-    if !input.model.is_empty() {
-        attrs = attrs.model(input.model);
-    }
-    if !input.external_session_id.is_empty() {
-        attrs = attrs.external_session_id(input.external_session_id);
-    }
-    if let Some(url) = crate::repo_url::resolve_repo_url_from_repo(input.repo) {
-        attrs = attrs.repo_url(url);
-    }
-    if let Ok(head_ref) = input.repo.head()
-        && let Ok(short_branch) = head_ref.shorthand()
-    {
-        attrs = attrs.branch(short_branch);
-    }
-    attrs = attrs.author(input.author_id);
+        let checkpoint_ts = input.event_ts.map(u64::from).unwrap_or_else(|| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+        });
+        let mut values = CheckpointValues::new()
+            .checkpoint_ts(checkpoint_ts)
+            .kind(input.checkpoint_kind.to_str())
+            .file_path(input.file_path)
+            .lines_added(input.recovered_line_count)
+            .lines_deleted(0)
+            .lines_added_sloc(input.recovered_line_count)
+            .lines_deleted_sloc(0)
+            .edit_kind(input.edit_kind)
+            .checkpoint_type(input.checkpoint_type)
+            .attribution_recovery_metadata(input.metadata.to_string());
+        if let Some(tool_use_id) = input.external_tool_use_id {
+            values = values.external_tool_use_id(tool_use_id);
+        }
 
-    let event = MetricEvent::from_values_with_timestamp(values, attrs.to_sparse(), input.event_ts);
-    crate::observability::log_metrics(vec![event]);
+        let mut attrs = self.base_attrs.clone();
+
+        if !input.session_id.is_empty() {
+            attrs = attrs.session_id(input.session_id);
+        }
+        if !input.trace_id.is_empty() {
+            attrs = attrs.trace_id(input.trace_id);
+        }
+        if !input.tool.is_empty() {
+            attrs = attrs.tool(input.tool);
+        }
+        if !input.model.is_empty() {
+            attrs = attrs.model(input.model);
+        }
+        if !input.external_session_id.is_empty() {
+            attrs = attrs.external_session_id(input.external_session_id);
+        }
+        attrs = attrs.author(input.author_id);
+
+        let event =
+            MetricEvent::from_values_with_timestamp(values, attrs.to_sparse(), input.event_ts);
+        self.events.push(event);
+    }
 }
 
 #[cfg(test)]
@@ -1754,6 +2416,55 @@ mod tests {
         AttestationEntry, AuthorshipLog, FileAttestation,
     };
     use crate::authorship::working_log::AgentId;
+
+    #[test]
+    fn recovery_metric_batch_defers_repo_attributes_until_an_event_is_recorded() {
+        let batch = RecoveryMetricBatch::new("base", "commit");
+
+        assert!(!batch.repo_attrs_resolved);
+        assert!(batch.events.is_empty());
+    }
+
+    #[test]
+    fn empty_human_recovery_does_not_register_a_contributor() {
+        let mut log = AuthorshipLog::new();
+
+        add_human_attestation_ranges(
+            &mut log,
+            "empty.txt",
+            "h_alice",
+            "Alice <alice@example.com>",
+            Vec::new(),
+        );
+
+        assert!(log.metadata.humans.is_empty());
+        assert!(log.attestations.is_empty());
+    }
+
+    #[test]
+    fn recovery_metrics_are_submitted_before_a_later_error_is_propagated() {
+        let metric = MetricEvent {
+            timestamp: 1,
+            event_id: 4,
+            values: HashMap::new(),
+            attrs: HashMap::new(),
+        };
+        let batch = RecoveryMetricBatch {
+            base_attrs: EventAttributes::default(),
+            repo_attrs_resolved: false,
+            events: vec![metric],
+        };
+        let mut submitted_event_count = 0;
+
+        let result: Result<(), GitAiError> = finish_recovery_with_metrics(
+            batch,
+            |_| Err(GitAiError::Generic("later solver failed".to_string())),
+            |events| submitted_event_count = events.len(),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(submitted_event_count, 1);
+    }
 
     fn test_agent(external_session_id: &str) -> AgentId {
         AgentId {
@@ -1852,6 +2563,200 @@ mod tests {
 
         let unknown = unknown_lines_by_file(&log, &committed);
         assert_eq!(unknown.get("a.txt").unwrap(), &vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn committed_untracked_ranges_stay_compressed_and_use_latest_author() {
+        let mut log = AuthorshipLog::new();
+        log.attestations.push(FileAttestation {
+            file_path: "a.txt".to_string(),
+            entries: vec![
+                AttestationEntry::new("human".to_string(), vec![LineRange::Range(1, 12)]),
+                AttestationEntry::new("h_alice".to_string(), vec![LineRange::Range(3, 4)]),
+                AttestationEntry::new("s_ai::t_ai".to_string(), vec![LineRange::Single(7)]),
+            ],
+        });
+        let committed = HashMap::from([("a.txt".to_string(), vec![LineRange::Range(1, 12)])]);
+
+        let untracked = committed_untracked_line_ranges_by_file(&log, &committed);
+
+        assert_eq!(
+            untracked.get("a.txt").unwrap(),
+            &vec![
+                LineRange::Range(1, 2),
+                LineRange::Range(5, 6),
+                LineRange::Range(8, 12),
+            ]
+        );
+        assert!(committed_hunks_have_ai_authorship(&log, &committed));
+        assert_eq!(
+            unique_known_human_for_file(&log, None, "a.txt").as_deref(),
+            Some("h_alice")
+        );
+    }
+
+    #[test]
+    fn unique_known_human_for_file_rejects_multiple_humans() {
+        let mut log = AuthorshipLog::new();
+        log.attestations.push(FileAttestation {
+            file_path: "a.txt".to_string(),
+            entries: vec![
+                AttestationEntry::new("h_alice".to_string(), vec![LineRange::Single(1)]),
+                AttestationEntry::new("h_bob".to_string(), vec![LineRange::Single(2)]),
+            ],
+        });
+
+        assert_eq!(unique_known_human_for_file(&log, None, "a.txt"), None);
+    }
+
+    #[test]
+    fn inherited_known_human_must_match_current_contributor() {
+        let mut parent = AuthorshipLog::new();
+        parent.attestations.push(FileAttestation {
+            file_path: "shared.txt".to_string(),
+            entries: vec![AttestationEntry::new(
+                "h_alice".to_string(),
+                vec![LineRange::Single(1)],
+            )],
+        });
+        let current = AuthorshipLog::new();
+
+        assert_eq!(
+            known_human_for_current_contributor(&current, Some(&parent), "shared.txt", "h_bob"),
+            None
+        );
+        assert_eq!(
+            known_human_for_current_contributor(&current, Some(&parent), "shared.txt", "h_alice")
+                .as_ref()
+                .map(KnownHumanSelection::human_id),
+            Some("h_alice"),
+        );
+        assert!(matches!(
+            known_human_for_current_contributor(&current, Some(&parent), "shared.txt", "h_alice"),
+            Some(KnownHumanSelection::MatchingParent(_))
+        ));
+    }
+
+    #[test]
+    fn current_checkpoint_establishes_human_even_when_commit_identity_differs() {
+        let mut current = AuthorshipLog::new();
+        current.attestations.push(FileAttestation {
+            file_path: "shared.txt".to_string(),
+            entries: vec![AttestationEntry::new(
+                "h_editor_identity".to_string(),
+                vec![LineRange::Single(1)],
+            )],
+        });
+
+        assert_eq!(
+            known_human_for_current_contributor(&current, None, "shared.txt", "h_commit_identity")
+                .as_ref()
+                .map(KnownHumanSelection::human_id),
+            Some("h_editor_identity"),
+        );
+        assert!(matches!(
+            known_human_for_current_contributor(&current, None, "shared.txt", "h_commit_identity"),
+            Some(KnownHumanSelection::CurrentCheckpoint(_))
+        ));
+    }
+
+    #[test]
+    fn current_human_candidates_do_not_require_a_parent_note_lookup() {
+        let mut current = AuthorshipLog::new();
+        current.attestations.push(FileAttestation {
+            file_path: "checkpointed.txt".to_string(),
+            entries: vec![AttestationEntry::new(
+                "h_editor_identity".to_string(),
+                vec![LineRange::Single(1)],
+            )],
+        });
+        let untracked_ranges = BTreeMap::from([
+            ("checkpointed.txt".to_string(), vec![LineRange::Single(2)]),
+            ("inherited.txt".to_string(), vec![LineRange::Single(1)]),
+        ]);
+
+        let (current_candidates, parent_candidates) = partition_current_known_human_candidates(
+            &current,
+            untracked_ranges,
+            "h_commit_identity",
+        );
+
+        assert_eq!(current_candidates.len(), 1);
+        assert_eq!(current_candidates[0].0, "checkpointed.txt");
+        assert_eq!(current_candidates[0].2, "h_editor_identity");
+        assert_eq!(current_candidates[0].3, "current_checkpoint");
+        assert_eq!(
+            parent_candidates,
+            BTreeMap::from([("inherited.txt".to_string(), vec![LineRange::Single(1)])])
+        );
+    }
+
+    #[test]
+    fn finalized_commit_metadata_exposes_first_parent_and_author_identity() {
+        let metadata = CommitMetadata {
+            parent_shas: vec!["first-parent".to_string(), "second-parent".to_string()],
+            message: "merge".to_string(),
+            author_name: "Remote Contributor".to_string(),
+            author_email: "remote@example.com".to_string(),
+        };
+
+        assert_eq!(metadata.immediate_parent(), Some("first-parent"));
+        assert_eq!(
+            metadata.author_identity().as_deref(),
+            Some("Remote Contributor <remote@example.com>")
+        );
+    }
+
+    #[test]
+    fn recovery_timestamps_do_not_fall_back_to_live_files_after_partial_capture() {
+        let workdir = tempfile::tempdir().unwrap();
+        fs::write(workdir.path().join("captured.txt"), "captured\n").unwrap();
+        fs::write(workdir.path().join("missing.txt"), "missing\n").unwrap();
+        let ranges = BTreeMap::from([
+            ("captured.txt".to_string(), vec![LineRange::Single(1)]),
+            ("missing.txt".to_string(), vec![LineRange::Single(1)]),
+        ]);
+        let captured = HashMap::from([("captured.txt".to_string(), vec![123_000_000_000u128])]);
+
+        let (timestamps_by_file, all_timestamps) =
+            timestamps_for_recovery_files(workdir.path(), &ranges, Some(&captured));
+
+        assert_eq!(
+            timestamps_by_file,
+            HashMap::from([("captured.txt".to_string(), vec![123_000_000_000u128])])
+        );
+        assert_eq!(all_timestamps, vec![123_000_000_000u128]);
+    }
+
+    #[test]
+    fn unavailable_or_failed_signal_store_fails_closed() {
+        let unavailable: Result<&Mutex<()>, GitAiError> =
+            Err(GitAiError::Generic("unavailable".to_string()));
+        assert!(signal_store_has_candidates(true, unavailable, |_| Ok(
+            false
+        )));
+
+        let available = Mutex::new(());
+        assert!(signal_store_has_candidates(false, Ok(&available), |_| Ok(
+            false
+        )));
+        assert!(signal_store_has_candidates(true, Ok(&available), |_| {
+            Err(GitAiError::Generic("query failed".to_string()))
+        }));
+        assert!(!signal_store_has_candidates(true, Ok(&available), |_| Ok(
+            false
+        )));
+    }
+
+    #[test]
+    fn poisoned_signal_store_fails_closed() {
+        let store = Mutex::new(());
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = store.lock().unwrap();
+            panic!("poison signal store");
+        });
+
+        assert!(signal_store_has_candidates(true, Ok(&store), |_| Ok(false)));
     }
 
     #[test]

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -3,7 +3,10 @@ use crate::error::GitAiError;
 use rusqlite::{Connection, OptionalExtension, params};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{
+    Mutex, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 const SCHEMA_VERSION: usize = 2;
 const RETENTION_SECS: u64 = 30 * 24 * 3600;
@@ -90,6 +93,7 @@ const MIGRATIONS: &[&str] = &[
 ];
 
 static BASH_HISTORY_DB: OnceLock<Result<Mutex<BashHistoryDatabase>, String>> = OnceLock::new();
+static BASH_RECOVERY_SIGNALS_AVAILABLE: AtomicBool = AtomicBool::new(true);
 
 #[derive(Debug, Clone)]
 pub struct BashCallStart {
@@ -149,6 +153,7 @@ impl BashHistoryDatabase {
         let db_result = BASH_HISTORY_DB.get_or_init(|| match Self::new() {
             Ok(db) => Ok(Mutex::new(db)),
             Err(e) => {
+                BASH_RECOVERY_SIGNALS_AVAILABLE.store(false, Ordering::Relaxed);
                 eprintln!("[Error] Failed to initialize bash history database: {}", e);
                 match Self::fallback_database() {
                     Ok(db) => Ok(Mutex::new(db)),
@@ -167,6 +172,10 @@ impl BashHistoryDatabase {
             Ok(db_mutex) => Ok(db_mutex),
             Err(error_msg) => Err(GitAiError::Generic(error_msg.clone())),
         }
+    }
+
+    pub(crate) fn recovery_signals_available() -> bool {
+        BASH_RECOVERY_SIGNALS_AVAILABLE.load(Ordering::Relaxed)
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -12,7 +12,10 @@ use crate::metrics::types::{MetricEvent, MetricEventId};
 use rusqlite::{Connection, OptionalExtension, params, params_from_iter};
 use serde_json::{Map, Value};
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{
+    Mutex, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 /// Current schema version (must match MIGRATIONS.len())
 const SCHEMA_VERSION: usize = 5;
@@ -93,6 +96,7 @@ const MIGRATIONS: &[&str] = &[
 
 /// Global database singleton
 static METRICS_DB: OnceLock<Mutex<MetricsDatabase>> = OnceLock::new();
+static METRICS_RECOVERY_SIGNALS_AVAILABLE: AtomicBool = AtomicBool::new(true);
 
 /// Record returned from database queries
 #[derive(Debug, Clone)]
@@ -177,6 +181,7 @@ impl MetricsDatabase {
         let db_mutex = METRICS_DB.get_or_init(|| match Self::new() {
             Ok(db) => Mutex::new(db),
             Err(e) => {
+                METRICS_RECOVERY_SIGNALS_AVAILABLE.store(false, Ordering::Relaxed);
                 eprintln!("[Error] Failed to initialize metrics database: {}", e);
                 Mutex::new(
                     Self::new_fallback().expect("Failed to create fallback metrics database"),
@@ -185,6 +190,10 @@ impl MetricsDatabase {
         });
 
         Ok(db_mutex)
+    }
+
+    pub(crate) fn recovery_signals_available() -> bool {
+        METRICS_RECOVERY_SIGNALS_AVAILABLE.load(Ordering::Relaxed)
     }
 
     /// Create a new database connection

--- a/tests/integration/cold_trace2_repo.rs
+++ b/tests/integration/cold_trace2_repo.rs
@@ -132,8 +132,9 @@ fn assert_note_has_no_ai_authorship(commit_sha: &str, note: &str) {
     assert!(
         log.attestations
             .iter()
-            .all(|attestation| attestation.entries.is_empty()),
-        "cold raw setup should not create attestations for {}: {:?}",
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "cold raw setup should not create AI attestations for {}: {:?}",
         commit_sha,
         log.attestations
     );

--- a/tests/integration/continue_cli.rs
+++ b/tests/integration/continue_cli.rs
@@ -1,6 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use crate::test_utils::fixture_path;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
 use git_ai::streams::agent::Agent;
 use git_ai::streams::agents::ContinueAgent;
@@ -10,6 +11,22 @@ use std::fs;
 
 fn parse_continue(hook_input: &str) -> Result<Vec<ParsedHookEvent>, git_ai::error::GitAiError> {
     resolve_preset("continue-cli")?.parse(hook_input, "t_test")
+}
+
+fn assert_no_ai_attestations(log: &AuthorshipLog) {
+    assert!(
+        log.attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "Human checkpoint should not create AI attestations: {:?}",
+        log.attestations
+    );
+    assert!(
+        log.metadata.prompts.is_empty() && log.metadata.sessions.is_empty(),
+        "Human checkpoint should not create AI metadata: {:?}",
+        log.metadata
+    );
 }
 
 #[test]
@@ -386,11 +403,7 @@ fn test_continue_cli_e2e_human_checkpoint() {
         "console.log('human edit');".human(),
     ]);
 
-    assert_eq!(
-        commit.authorship_log.attestations.len(),
-        0,
-        "Human checkpoint should not create AI attestations"
-    );
+    assert_no_ai_attestations(&commit.authorship_log);
 }
 
 #[test]

--- a/tests/integration/fuzzer/model.rs
+++ b/tests/integration/fuzzer/model.rs
@@ -266,6 +266,71 @@ impl FileModel {
         }
     }
 
+    pub fn apply_known_human_recovery_for_added_lines(
+        &mut self,
+        registry: &mut AttrRegistry,
+        added_lines: &[u32],
+    ) {
+        let mut added_indices = added_lines
+            .iter()
+            .filter_map(|line| line.checked_sub(1).map(|idx| idx as usize))
+            .filter(|&idx| idx < self.resolved_attrs.len())
+            .collect::<Vec<_>>();
+        added_indices.sort_unstable();
+        added_indices.dedup();
+
+        if !added_indices
+            .iter()
+            .any(|&idx| self.resolved_attrs[idx] == LineAttribution::KnownHuman)
+        {
+            return;
+        }
+
+        for idx in added_indices {
+            if self.resolved_attrs[idx] == LineAttribution::Untracked {
+                self.resolved_attrs[idx] = LineAttribution::KnownHuman;
+                self.resolved_ai_sessions[idx] = None;
+                registry.register_record(
+                    self.lines[idx],
+                    AttrRecord::new(LineAttribution::KnownHuman),
+                );
+            }
+        }
+    }
+
+    pub fn apply_pure_human_recovery_for_added_lines(
+        &mut self,
+        registry: &mut AttrRegistry,
+        added_lines: &[u32],
+    ) {
+        let mut added_indices = added_lines
+            .iter()
+            .filter_map(|line| line.checked_sub(1).map(|idx| idx as usize))
+            .filter(|&idx| idx < self.resolved_attrs.len())
+            .collect::<Vec<_>>();
+        added_indices.sort_unstable();
+        added_indices.dedup();
+
+        if added_indices.is_empty()
+            || added_indices
+                .iter()
+                .any(|&idx| self.resolved_attrs[idx] == LineAttribution::Ai)
+        {
+            return;
+        }
+
+        for idx in added_indices {
+            if self.resolved_attrs[idx] == LineAttribution::Untracked {
+                self.resolved_attrs[idx] = LineAttribution::KnownHuman;
+                self.resolved_ai_sessions[idx] = None;
+                registry.register_record(
+                    self.lines[idx],
+                    AttrRecord::new(LineAttribution::KnownHuman),
+                );
+            }
+        }
+    }
+
     fn pending_record_at_index(&self, idx: usize) -> Option<AttrRecord> {
         self.lines
             .get(idx)

--- a/tests/integration/fuzzer/operations.rs
+++ b/tests/integration/fuzzer/operations.rs
@@ -185,6 +185,8 @@ pub fn commit(
 
     op_log.push(format!("commit(\"{}\")", msg));
     model.apply_edge_recovery_for_added_lines(registry, &added_lines);
+    model.apply_known_human_recovery_for_added_lines(registry, &added_lines);
+    model.apply_pure_human_recovery_for_added_lines(registry, &added_lines);
     model.reconcile(repo);
     model.assert_blame(repo, op_log, seed);
     model.clear_pending_attestations();
@@ -210,6 +212,8 @@ pub fn amend(
     op_log.push("amend".to_string());
     model.sync_from_disk(repo, registry);
     model.apply_edge_recovery_for_added_lines(registry, &added_lines);
+    model.apply_known_human_recovery_for_added_lines(registry, &added_lines);
+    model.apply_pure_human_recovery_for_added_lines(registry, &added_lines);
     model.reconcile(repo);
     model.assert_blame(repo, op_log, seed);
     model.clear_pending_attestations();
@@ -255,6 +259,8 @@ pub fn rebase(
     let side_added_lines = staged_added_lines(repo, &model.filename, Some("HEAD"));
     repo.git(&["commit", "-m", "rebase: side commit"]).unwrap();
     model.apply_edge_recovery_for_added_lines(registry, &side_added_lines);
+    model.apply_known_human_recovery_for_added_lines(registry, &side_added_lines);
+    model.apply_pure_human_recovery_for_added_lines(registry, &side_added_lines);
     model.clear_pending_attestations();
     op_log.push("commit(\"rebase: side commit\")".to_string());
 
@@ -309,6 +315,8 @@ pub fn cherry_pick(
     repo.git(&["commit", "-m", "cherry-pick: side commit"])
         .unwrap();
     model.apply_edge_recovery_for_added_lines(registry, &side_added_lines);
+    model.apply_known_human_recovery_for_added_lines(registry, &side_added_lines);
+    model.apply_pure_human_recovery_for_added_lines(registry, &side_added_lines);
     model.clear_pending_attestations();
     let side_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
 

--- a/tests/integration/gemini.rs
+++ b/tests/integration/gemini.rs
@@ -1,6 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use crate::test_utils::fixture_path;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
 use git_ai::error::GitAiError;
 use git_ai::streams::agent::Agent;
@@ -11,6 +12,22 @@ use std::fs;
 
 fn parse_gemini(hook_input: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
     resolve_preset("gemini")?.parse(hook_input, "t_test")
+}
+
+fn assert_no_ai_attestations(log: &AuthorshipLog) {
+    assert!(
+        log.attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "Human checkpoint should not create AI attestations: {:?}",
+        log.attestations
+    );
+    assert!(
+        log.metadata.prompts.is_empty() && log.metadata.sessions.is_empty(),
+        "Human checkpoint should not create AI metadata: {:?}",
+        log.metadata
+    );
 }
 
 #[test]
@@ -353,7 +370,7 @@ fn test_gemini_e2e_human_checkpoint() {
         "console.log('human edit');".human(),
     ]);
 
-    assert_eq!(commit.authorship_log.attestations.len(), 0);
+    assert_no_ai_attestations(&commit.authorship_log);
 }
 
 #[test]

--- a/tests/integration/post_commit_unit.rs
+++ b/tests/integration/post_commit_unit.rs
@@ -1,6 +1,22 @@
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 
+fn assert_no_ai_attestations(log: &AuthorshipLog) {
+    assert!(
+        log.attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "Expected no AI attestations: {:?}",
+        log.attestations
+    );
+    assert!(
+        log.metadata.prompts.is_empty() && log.metadata.sessions.is_empty(),
+        "Expected no AI metadata: {:?}",
+        log.metadata
+    );
+}
+
 #[test]
 fn test_post_commit_empty_repo_with_checkpoint() {
     // Create an empty repo (no commits yet)
@@ -60,12 +76,9 @@ fn test_post_commit_empty_repo_no_checkpoint() {
     let note = repo.read_authorship_note(&head_sha);
     assert!(note.is_some(), "Should have authorship note");
 
-    // No checkpoints = no AI attribution, so note should have empty attestations
+    // No checkpoints = no AI attribution. Pure human recovery may add h_ attestations.
     let log = AuthorshipLog::deserialize_from_string(&note.unwrap()).unwrap();
-    assert!(
-        log.attestations.is_empty(),
-        "Should have empty attestations when no checkpoints exist"
-    );
+    assert_no_ai_attestations(&log);
 }
 
 #[test]

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -1,12 +1,23 @@
-use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+use git_ai::authorship::authorship_log::LineRange;
+use git_ai::authorship::authorship_log_serialization::{
+    AttestationEntry, AuthorshipLog, generate_human_short_hash,
+};
 use git_ai::authorship::working_log::AgentId;
 use git_ai::daemon::bash_history_db::{BashCallEnd, BashCallStart, BashHistoryDatabase};
+use git_ai::git::notes_api::write_note;
+use git_ai::git::repository::find_repository_in_path;
 
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use serde_json::json;
 use std::collections::{BTreeSet, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
+    let path = dir.path().join("metrics.db");
+    (dir, path.to_string_lossy().to_string())
+}
 
 /// Helper struct that provides a local repo with an upstream containing seeded commits.
 /// The local repo is initially behind the upstream (no divergence — fast-forward possible).
@@ -495,6 +506,140 @@ fn test_fast_forward_update_ref_bounds_recovery_to_new_tip_parent() {
     assert!(
         !attested_files.contains("pulled_early_2.txt"),
         "recovery must not attribute earlier pulled commits to the local session"
+    );
+}
+
+#[test]
+fn test_fast_forward_update_ref_uses_finalized_commit_author_for_human_recovery() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let local = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ]);
+    let upstream_dir = tempfile::tempdir().expect("upstream temp dir");
+    let upstream_path = upstream_dir.path().join("upstream.git");
+    let upstream = upstream_path.to_string_lossy().to_string();
+
+    local.git_og(&["init", "--bare", &upstream]).unwrap();
+    local.git(&["remote", "add", "origin", &upstream]).unwrap();
+    std::fs::write(local.path().join("base.txt"), "base\n").unwrap();
+    let old_tip = local.stage_all_and_commit("old tip").unwrap().commit_sha;
+    let branch = local.current_branch();
+    local.git(&["push", "-u", "origin", "HEAD"]).unwrap();
+    local
+        .git_og(&[
+            "--git-dir",
+            &upstream,
+            "symbolic-ref",
+            "HEAD",
+            &format!("refs/heads/{branch}"),
+        ])
+        .unwrap();
+
+    // A working log makes the daemon finalize the fast-forward update-ref. Use
+    // an untracked checkpoint so this identity test has no nearby AI signal.
+    std::fs::write(local.path().join("local-only.txt"), "Local only\n").unwrap();
+    local
+        .git_ai(&["checkpoint", "human", "local-only.txt"])
+        .unwrap();
+
+    let contributor_dir = tempfile::tempdir().expect("contributor temp dir");
+    let contributor_path = contributor_dir.path().join("contributor");
+    local
+        .git_og(&["clone", &upstream, contributor_path.to_str().unwrap()])
+        .unwrap();
+    let contributor =
+        TestRepo::new_at_path_with_daemon_scope(&contributor_path, DaemonTestScope::NoDaemon);
+    contributor
+        .git_og(&["config", "user.name", "Remote Contributor"])
+        .unwrap();
+    contributor
+        .git_og(&["config", "user.email", "remote@example.com"])
+        .unwrap();
+    std::fs::write(
+        contributor.path().join("remote.txt"),
+        "remote contribution\n",
+    )
+    .unwrap();
+    contributor.git_og(&["add", "-A"]).unwrap();
+    contributor
+        .git_og(&["commit", "-m", "remote baseline"])
+        .unwrap();
+    let immediate_parent = contributor.git_og(&["rev-parse", "HEAD"]).unwrap();
+    let immediate_parent = immediate_parent.trim().to_string();
+    std::fs::write(
+        contributor.path().join("remote.txt"),
+        "remote contribution\nremote follow-up\n",
+    )
+    .unwrap();
+    contributor.git_og(&["add", "-A"]).unwrap();
+    contributor
+        .git_og(&["commit", "-m", "remote final"])
+        .unwrap();
+    contributor
+        .git_og(&["push", "origin", &format!("HEAD:{branch}")])
+        .unwrap();
+
+    local.git(&["fetch", "origin", &branch]).unwrap();
+    let new_tip = local.git(&["rev-parse", "FETCH_HEAD"]).unwrap();
+    let new_tip = new_tip.trim().to_string();
+    let remote_identity = "Remote Contributor <remote@example.com>";
+    let remote_id = generate_human_short_hash(remote_identity);
+    let mut parent_log = AuthorshipLog::new();
+    parent_log.metadata.base_commit_sha = immediate_parent.clone();
+    parent_log
+        .get_or_create_file("remote.txt")
+        .add_entry(AttestationEntry::new(
+            remote_id.clone(),
+            vec![LineRange::Single(1)],
+        ));
+    let git_ai_repo = find_repository_in_path(local.path().to_str().unwrap()).unwrap();
+    write_note(
+        &git_ai_repo,
+        &immediate_parent,
+        &parent_log.serialize_to_string().unwrap(),
+    )
+    .unwrap();
+
+    std::fs::write(
+        local.path().join("remote.txt"),
+        "remote contribution\nremote follow-up\n",
+    )
+    .unwrap();
+    local
+        .git(&[
+            "update-ref",
+            &format!("refs/heads/{branch}"),
+            &new_tip,
+            &old_tip,
+        ])
+        .unwrap();
+
+    let note = local
+        .read_authorship_note(&new_tip)
+        .expect("fast-forward finalization should write an authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).unwrap();
+    let remote_lines = log
+        .attestations
+        .iter()
+        .filter(|attestation| attestation.file_path == "remote.txt")
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| entry.hash == remote_id)
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(|range| range.expand()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        remote_lines,
+        vec![2],
+        "recovery must extend the finalized commit's immediate-parent human, not the old ref tip"
+    );
+    assert_eq!(
+        log.metadata
+            .humans
+            .get(&remote_id)
+            .map(|record| &record.author),
+        Some(&remote_identity.to_string())
     );
 }
 

--- a/tests/integration/session_event_attribution.rs
+++ b/tests/integration/session_event_attribution.rs
@@ -139,6 +139,32 @@ fn assert_session_attests_lines(
     );
 }
 
+fn human_attested_lines(authorship_log: &AuthorshipLog, file_path: &str) -> Vec<u32> {
+    let mut lines = authorship_log
+        .attestations
+        .iter()
+        .filter(|attestation| attestation.file_path == file_path)
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| entry.hash.starts_with("h_"))
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
+        .collect::<Vec<_>>();
+    lines.sort_unstable();
+    lines.dedup();
+    lines
+}
+
+fn assert_human_attests_lines(
+    authorship_log: &AuthorshipLog,
+    file_path: &str,
+    expected_lines: &[u32],
+) {
+    assert_eq!(
+        human_attested_lines(authorship_log, file_path),
+        expected_lines,
+        "expected known-human attestation for {file_path} lines {expected_lines:?}"
+    );
+}
+
 fn session_ids_for_tool(authorship_log: &AuthorshipLog, tool: &str) -> Vec<String> {
     let mut session_ids = authorship_log
         .metadata
@@ -389,6 +415,299 @@ fn test_session_event_recovery_does_not_override_known_human_checkpoint() {
             .contains_key(&recovered_session_id),
         "nearby session event must not be used when explicit human attribution exists"
     );
+}
+
+#[test]
+fn test_pure_human_recovery_marks_uncheckpointed_no_ai_commit_known_human() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("manual.txt");
+    fs::write(&file_path, "manual one\nmanual two\n").unwrap();
+
+    let commit = repo
+        .stage_all_and_commit("Manual no-AI edit")
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("manual.txt");
+    file.assert_committed_lines(lines!["manual one".human(), "manual two".human()]);
+    assert_human_attests_lines(&commit.authorship_log, "manual.txt", &[1, 2]);
+}
+
+#[test]
+fn test_pure_human_recovery_marks_legacy_human_checkpoint_no_ai_commit_known_human() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("legacy.txt");
+    fs::write(&file_path, "legacy one\nlegacy two\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "legacy.txt"])
+        .expect("legacy human checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Legacy no-AI edit")
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("legacy.txt");
+    file.assert_committed_lines(lines!["legacy one".human(), "legacy two".human()]);
+    assert_human_attests_lines(&commit.authorship_log, "legacy.txt", &[1, 2]);
+}
+
+#[test]
+fn test_known_human_recovery_does_not_extend_current_checkpoint_in_mixed_ai_commit() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let human_path = repo.path().join("human-side.txt");
+    fs::write(&human_path, "known human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "human-side.txt"])
+        .expect("known-human checkpoint should succeed");
+
+    fs::write(&human_path, "known human\nlegacy untracked\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "human-side.txt"])
+        .expect("legacy human checkpoint should succeed");
+
+    fs::write(repo.path().join("ai-side.txt"), "ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai-side.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Known human plus AI and legacy")
+        .expect("commit should succeed");
+
+    let mut human_file = repo.filename("human-side.txt");
+    human_file.assert_committed_lines(lines![
+        "known human".human(),
+        "legacy untracked".unattributed_human(),
+    ]);
+    let mut ai_file = repo.filename("ai-side.txt");
+    ai_file.assert_committed_lines(lines!["ai line".ai()]);
+    assert_human_attests_lines(&commit.authorship_log, "human-side.txt", &[1]);
+}
+
+#[test]
+fn test_known_human_recovery_does_not_extend_parent_identity_in_mixed_ai_commit() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("same-file.txt");
+    fs::write(&file_path, "known human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "same-file.txt"])
+        .expect("known-human checkpoint should succeed");
+    repo.stage_all_and_commit("Known human baseline")
+        .expect("baseline commit should succeed");
+
+    fs::write(&file_path, "known human\nlegacy untracked\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "same-file.txt"])
+        .expect("legacy human checkpoint should succeed");
+
+    fs::write(repo.path().join("ai-side.txt"), "ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai-side.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Known human file with AI and legacy")
+        .expect("mixed commit should succeed");
+
+    let mut file = repo.filename("same-file.txt");
+    file.assert_committed_lines(lines![
+        "known human".human(),
+        "legacy untracked".unattributed_human(),
+    ]);
+    let mut ai_file = repo.filename("ai-side.txt");
+    ai_file.assert_committed_lines(lines!["ai line".ai()]);
+    assert_human_attests_lines(&commit.authorship_log, "same-file.txt", &[]);
+}
+
+#[test]
+fn test_known_human_recovery_does_not_extend_current_checkpoint_across_nearby_ai_signal() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("inherited-human.txt");
+    fs::write(&file_path, "known human baseline\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "inherited-human.txt"])
+        .expect("known-human checkpoint should succeed");
+
+    fs::write(
+        &file_path,
+        "known human baseline\nuncheckpointed agent edit\n",
+    )
+    .unwrap();
+    insert_session_event(
+        &metrics_db_path,
+        file_mtime_secs(&file_path),
+        "missed-post-edit-session",
+        "missed-post-edit-tool-use",
+        None,
+    );
+
+    let commit = repo
+        .stage_all_and_commit("Missed agent checkpoint")
+        .expect("mixed-signal commit should succeed");
+
+    let mut file = repo.filename("inherited-human.txt");
+    file.assert_committed_lines(lines![
+        "known human baseline".human(),
+        "uncheckpointed agent edit".unattributed_human(),
+    ]);
+    assert_human_attests_lines(&commit.authorship_log, "inherited-human.txt", &[1]);
+}
+
+#[test]
+fn test_known_human_recovery_does_not_inherit_another_contributors_identity() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["config", "user.name", "Alice"]).unwrap();
+    repo.git(&["config", "user.email", "alice@example.com"])
+        .unwrap();
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("shared.txt");
+    fs::write(&file_path, "written by Alice\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "shared.txt"])
+        .expect("Alice's known-human checkpoint should succeed");
+    repo.stage_all_and_commit("Alice baseline")
+        .expect("Alice's commit should succeed");
+
+    repo.git(&["config", "user.name", "Bob"]).unwrap();
+    repo.git(&["config", "user.email", "bob@example.com"])
+        .unwrap();
+    fs::write(&file_path, "written by Alice\nuncheckpointed by Bob\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "shared.txt"])
+        .expect("Bob's untracked checkpoint should succeed");
+    fs::write(repo.path().join("ai-side.txt"), "AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai-side.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Bob and AI")
+        .expect("Bob's commit should succeed");
+
+    let mut shared = repo.filename("shared.txt");
+    shared.assert_committed_lines(lines![
+        "written by Alice".human(),
+        "uncheckpointed by Bob".unattributed_human(),
+    ]);
+    let mut ai = repo.filename("ai-side.txt");
+    ai.assert_committed_lines(lines!["AI line".ai()]);
+    assert_human_attests_lines(&commit.authorship_log, "shared.txt", &[]);
+}
+
+#[test]
+fn test_known_human_recovery_does_not_cover_untracked_unrelated_files() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let human_path = repo.path().join("human-side.txt");
+    fs::write(&human_path, "known human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "human-side.txt"])
+        .expect("known-human checkpoint should succeed");
+
+    fs::write(&human_path, "known human\nlegacy untracked\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "human-side.txt"])
+        .expect("legacy human checkpoint should succeed");
+
+    fs::write(
+        repo.path().join("unrelated.txt"),
+        "uncheckpointed elsewhere\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join("ai-side.txt"), "ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai-side.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Known human plus unrelated untracked")
+        .expect("commit should succeed");
+
+    let mut human_file = repo.filename("human-side.txt");
+    human_file.assert_committed_lines(lines![
+        "known human".human(),
+        "legacy untracked".unattributed_human(),
+    ]);
+    let mut unrelated_file = repo.filename("unrelated.txt");
+    unrelated_file.assert_committed_lines(lines!["uncheckpointed elsewhere".unattributed_human()]);
+    let mut ai_file = repo.filename("ai-side.txt");
+    ai_file.assert_committed_lines(lines!["ai line".ai()]);
+    assert_human_attests_lines(&commit.authorship_log, "human-side.txt", &[1]);
+    assert_human_attests_lines(&commit.authorship_log, "unrelated.txt", &[]);
+}
+
+#[test]
+fn test_pure_human_recovery_skips_unknown_lines_when_commit_contains_ai() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    fs::write(repo.path().join("manual.txt"), "manual line\n").unwrap();
+    fs::write(repo.path().join("ai.txt"), "ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Manual plus AI")
+        .expect("commit should succeed");
+
+    let mut manual = repo.filename("manual.txt");
+    manual.assert_committed_lines(lines!["manual line".unattributed_human()]);
+    let mut ai = repo.filename("ai.txt");
+    ai.assert_committed_lines(lines!["ai line".ai()]);
+    assert_human_attests_lines(&commit.authorship_log, "manual.txt", &[]);
 }
 
 #[test]

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1,10 +1,25 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::attribution_tracker::Attribution;
+use git_ai::authorship::authorship_log::LineRange;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::working_log::{CheckpointKind, WorkingLogEntry};
 use git_ai::config::AuthorConfig;
 use std::fs;
+
+fn human_attested_lines(authorship_log: &AuthorshipLog, file_path: &str) -> Vec<u32> {
+    let mut lines = authorship_log
+        .attestations
+        .iter()
+        .filter(|attestation| attestation.file_path == file_path)
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| entry.hash.starts_with("h_"))
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
+        .collect::<Vec<_>>();
+    lines.sort_unstable();
+    lines.dedup();
+    lines
+}
 
 fn configure_diff_settings(repo: &TestRepo, settings: &[(&str, &str)]) {
     for (key, value) in settings {
@@ -227,8 +242,11 @@ fn test_simple_ai_then_human_deletion() {
 
     let commit = repo.stage_all_and_commit("Human deletes AI line").unwrap();
 
-    // The authorship log should have no attestations since we only deleted lines
-    assert_eq!(commit.authorship_log.attestations.len(), 0);
+    assert_eq!(
+        human_attested_lines(&commit.authorship_log, "test.txt"),
+        vec![5],
+        "known-human deletion checkpoint should preserve the surviving adjacent human line"
+    );
 
     file.assert_lines_and_blame(crate::lines![
         "Line 1".human(),
@@ -993,9 +1011,9 @@ diff --git a/aidanwashere.md b/aidanwashere.md
 
     let first_commit = repo.commit("Commit human top section").unwrap();
     assert_eq!(
-        first_commit.authorship_log.attestations.len(),
-        0,
-        "first commit should only contain human top insertion"
+        human_attested_lines(&first_commit.authorship_log, "aidanwashere.md"),
+        vec![1, 2, 3],
+        "first commit should recover the pure-human top insertion"
     );
 
     repo.git(&["add", "."]).unwrap();

--- a/tests/integration/squash_merge.rs
+++ b/tests/integration/squash_merge.rs
@@ -559,13 +559,10 @@ fn test_prepare_working_log_squash_multiple_sessions_standard_human() {
     );
     assert_eq!(stats.ai_accepted, 3, "3 AI lines accepted without edits");
     assert_eq!(
-        stats.human_additions, 0,
-        "0 KnownHuman-attested lines (unattributed human via checkpoint --)"
+        stats.human_additions, 1,
+        "1 KnownHuman-attested line recovered from the no-AI human addition"
     );
-    assert_eq!(
-        stats.unknown_additions, 1,
-        "1 unattested line (// Human addition)"
-    );
+    assert_eq!(stats.unknown_additions, 0, "0 unattested lines");
 }
 
 crate::reuse_tests_in_worktree!(

--- a/tests/integration/windsurf.rs
+++ b/tests/integration/windsurf.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
 use git_ai::error::GitAiError;
 use git_ai::streams::agent::Agent;
@@ -13,6 +14,22 @@ use std::time::Duration;
 
 fn parse_windsurf(hook_input: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
     resolve_preset("windsurf")?.parse(hook_input, "t_test")
+}
+
+fn assert_no_ai_attestations(log: &AuthorshipLog) {
+    assert!(
+        log.attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "Human checkpoint should not create AI attestations: {:?}",
+        log.attestations
+    );
+    assert!(
+        log.metadata.prompts.is_empty() && log.metadata.sessions.is_empty(),
+        "Human checkpoint should not create AI metadata: {:?}",
+        log.metadata
+    );
 }
 
 // ============================================================================
@@ -321,11 +338,7 @@ fn test_windsurf_e2e_human_checkpoint() {
         "const y = 2;".human(),
     ]);
 
-    assert_eq!(
-        commit.authorship_log.attestations.len(),
-        0,
-        "Human checkpoint should not create AI attestations"
-    );
+    assert_no_ai_attestations(&commit.authorship_log);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add a final attribution recovery fallback for small commits with no AI signals, no AI lines, and fewer than 1000 added lines.
- Attribute those recovered lines to the commit author as known human while preserving existing explicit untracked/human checkpoint behavior.
- Gate the fallback behind empty working-log inputs, current/parent AI-authorship checks, timestamp-nearby AI signal checks, and the strict size threshold.

## Validation

- `task test TEST_FILTER=test_pure_no_signal_small_commit_is_marked_known_human`
- `task test TEST_FILTER=session_event_attribution`
- `task test TEST_FILTER=human_checkpoint`
- `task test TEST_FILTER=fuzzer`
- `task test TEST_FILTER=test_simple_ai_then_human_deletion`
- `task test TEST_FILTER=test_prepare_working_log_squash_multiple_sessions_standard_human`
- `task test TEST_FILTER=test_post_commit_empty_repo_no_checkpoint`
- `task test TEST_FILTER=cold_trace2_repo`
- `task fmt`
- `task lint`
- `task test`