### PR TITLE
[codex] Limit oversized checkpoints jsonl

### DIFF
--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -303,6 +303,7 @@ fn write_path_filtered_checkpoints(
 ) -> Result<(), GitAiError> {
     let source_checkpoints = source_log.dir.join("checkpoints.jsonl");
     let filtered_checkpoints = filtered_log.dir.join("checkpoints.jsonl");
+    source_log.ensure_checkpoints_file_size_limit()?;
     if !source_checkpoints.exists() {
         return filtered_log.write_all_checkpoints(&[]);
     }

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -8,8 +8,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
+
+pub const MAX_CHECKPOINTS_JSONL_BYTES: u64 = 1024 * 1024 * 1024;
+
+#[cfg(feature = "test-support")]
+const TEST_CHECKPOINTS_JSONL_MAX_BYTES_ENV: &str = "GIT_AI_TEST_CHECKPOINTS_JSONL_MAX_BYTES";
 
 /// Initial attributions data structure stored in the INITIAL file
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -329,7 +335,7 @@ impl PersistedWorkingLog {
         }
 
         // Clear checkpoints by truncating the JSONL file
-        let checkpoints_file = self.dir.join("checkpoints.jsonl");
+        let checkpoints_file = self.checkpoints_file();
         fs::write(&checkpoints_file, "")?;
 
         // Clear INITIAL attributions file so stale attributions from a
@@ -339,6 +345,10 @@ impl PersistedWorkingLog {
         }
 
         Ok(())
+    }
+
+    pub fn checkpoints_file(&self) -> PathBuf {
+        self.dir.join("checkpoints.jsonl")
     }
 
     /* blob storage */
@@ -461,22 +471,47 @@ impl PersistedWorkingLog {
     }
 
     pub fn read_all_checkpoints(&self) -> Result<Vec<Checkpoint>, GitAiError> {
-        let checkpoints_file = self.dir.join("checkpoints.jsonl");
+        self.read_all_checkpoints_with_size_limit(Self::checkpoints_file_size_limit_bytes())
+    }
+
+    #[cfg(feature = "test-support")]
+    pub fn read_all_checkpoints_with_size_limit_for_test(
+        &self,
+        max_bytes: u64,
+    ) -> Result<Vec<Checkpoint>, GitAiError> {
+        self.read_all_checkpoints_with_size_limit(max_bytes)
+    }
+
+    pub fn ensure_checkpoints_file_size_limit(&self) -> Result<(), GitAiError> {
+        self.truncate_oversized_checkpoints_file(Self::checkpoints_file_size_limit_bytes())?;
+        Ok(())
+    }
+
+    fn read_all_checkpoints_with_size_limit(
+        &self,
+        max_bytes: u64,
+    ) -> Result<Vec<Checkpoint>, GitAiError> {
+        let checkpoints_file = self.checkpoints_file();
 
         if !checkpoints_file.exists() {
             return Ok(Vec::new());
         }
 
-        let content = fs::read_to_string(&checkpoints_file)?;
+        if self.truncate_oversized_checkpoints_file(max_bytes)? {
+            return Ok(Vec::new());
+        }
+
+        let input = fs::File::open(&checkpoints_file)?;
         let mut checkpoints = Vec::new();
 
         // Parse JSONL file - each line is a separate JSON object
-        for line in content.lines() {
+        for line in BufReader::new(input).lines() {
+            let line = line?;
             if line.trim().is_empty() {
                 continue;
             }
 
-            let checkpoint: Checkpoint = serde_json::from_str(line)
+            let checkpoint: Checkpoint = serde_json::from_str(&line)
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
             if checkpoint.api_version != CHECKPOINT_API_VERSION {
@@ -537,6 +572,63 @@ impl PersistedWorkingLog {
         Ok(migrated_checkpoints)
     }
 
+    fn checkpoints_file_size_limit_bytes() -> u64 {
+        #[cfg(feature = "test-support")]
+        if let Ok(raw) = std::env::var(TEST_CHECKPOINTS_JSONL_MAX_BYTES_ENV)
+            && let Ok(value) = raw.parse::<u64>()
+            && value > 0
+        {
+            return value;
+        }
+
+        MAX_CHECKPOINTS_JSONL_BYTES
+    }
+
+    fn truncate_oversized_checkpoints_file(&self, max_bytes: u64) -> Result<bool, GitAiError> {
+        let checkpoints_file = self.checkpoints_file();
+        let metadata = match fs::metadata(&checkpoints_file) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.into()),
+        };
+        let size_bytes = metadata.len();
+        if size_bytes <= max_bytes {
+            return Ok(false);
+        }
+
+        let message = format!(
+            "checkpoints.jsonl exceeded maximum size: {} bytes > {} bytes; deleting and recreating {}",
+            size_bytes,
+            max_bytes,
+            checkpoints_file.display()
+        );
+        tracing::error!(
+            base_commit = %self.base_commit,
+            path = %checkpoints_file.display(),
+            size_bytes,
+            max_bytes,
+            "checkpoints.jsonl exceeded maximum size; deleting and recreating empty file"
+        );
+        crate::observability::log_error(
+            &GitAiError::Generic(message),
+            Some(serde_json::json!({
+                "event": "checkpoints_jsonl_oversized_reset",
+                "base_commit": self.base_commit,
+                "path": checkpoints_file.to_string_lossy(),
+                "size_bytes": size_bytes,
+                "max_bytes": max_bytes,
+            })),
+        );
+
+        match fs::remove_file(&checkpoints_file) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        fs::File::create(&checkpoints_file)?;
+        Ok(true)
+    }
+
     /// Remove char-level attributions from all but the most recent checkpoint per file.
     /// This reduces storage size while preserving precision for the entries that matter.
     /// Only the most recent checkpoint entry for each file is used when computing new entries.
@@ -570,23 +662,15 @@ impl PersistedWorkingLog {
     /// by post-commit after transcripts have been refetched and need to be preserved
     /// for from_just_working_log() to read them.
     pub fn write_all_checkpoints(&self, checkpoints: &[Checkpoint]) -> Result<(), GitAiError> {
-        let checkpoints_file = self.dir.join("checkpoints.jsonl");
+        let checkpoints_file = self.checkpoints_file();
+        let mut output = BufWriter::new(fs::File::create(&checkpoints_file)?);
 
-        // Serialize all checkpoints to JSONL
-        let mut lines = Vec::new();
         for checkpoint in checkpoints {
-            let json_line = serde_json::to_string(checkpoint)?;
-            lines.push(json_line);
+            serde_json::to_writer(&mut output, checkpoint)?;
+            output.write_all(b"\n")?;
         }
 
-        // Write all lines to file
-        let content = lines.join("\n");
-        if !content.is_empty() {
-            fs::write(&checkpoints_file, format!("{}\n", content))?;
-        } else {
-            fs::write(&checkpoints_file, "")?;
-        }
-
+        output.flush()?;
         Ok(())
     }
 

--- a/tests/integration/repo_storage_unit.rs
+++ b/tests/integration/repo_storage_unit.rs
@@ -209,6 +209,35 @@ fn test_read_all_checkpoints_filters_incompatible_versions() {
     assert_eq!(checkpoints[0].api_version, CHECKPOINT_API_VERSION);
 }
 
+#[test]
+fn test_oversized_checkpoints_file_is_truncated_before_read() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let checkpoints_file = working_log.dir.join("checkpoints.jsonl");
+
+    fs::write(&checkpoints_file, "this is intentionally not valid json\n")
+        .expect("write oversized checkpoints fixture");
+
+    let checkpoints = working_log
+        .read_all_checkpoints_with_size_limit_for_test(8)
+        .expect("oversized checkpoint file should be reset before parsing");
+
+    assert!(
+        checkpoints.is_empty(),
+        "oversized checkpoints file should read back as empty"
+    );
+    assert_eq!(
+        fs::metadata(&checkpoints_file)
+            .expect("empty checkpoints file should remain")
+            .len(),
+        0,
+        "oversized checkpoints file should be truncated to an empty file"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 6. test_persisted_working_log_reset
 // ---------------------------------------------------------------------------

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -1355,6 +1355,74 @@ fn test_repeated_stash_pop_does_not_duplicate_checkpoints() {
 }
 
 #[test]
+fn test_partial_stash_truncates_oversized_live_checkpoints_before_filtering() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_CHECKPOINTS_JSONL_MAX_BYTES", "64")]);
+    fs::write(repo.path().join("a.txt"), "base a\n").unwrap();
+    fs::write(repo.path().join("b.txt"), "base b\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    fs::write(repo.path().join("a.txt"), "base a\nai a\n").unwrap();
+    fs::write(repo.path().join("b.txt"), "base b\nai b\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai"]).unwrap();
+
+    let working_log = repo.current_working_logs();
+    let checkpoints_file = working_log.dir.join("checkpoints.jsonl");
+    let checkpoint_line = fs::read_to_string(&checkpoints_file)
+        .expect("checkpoint file exists")
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .expect("checkpoint fixture should contain one line")
+        .to_string();
+    fs::write(
+        &checkpoints_file,
+        (0..8)
+            .map(|_| checkpoint_line.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n",
+    )
+    .expect("inflate checkpoint file above test limit");
+    assert!(
+        fs::metadata(&checkpoints_file).unwrap().len() > 64,
+        "test setup should exceed the daemon's test checkpoint size limit"
+    );
+
+    repo.git(&["stash", "push", "--", "a.txt"])
+        .expect("partial stash should survive oversized checkpoints.jsonl");
+    repo.sync_daemon_force();
+
+    let reset_size = fs::metadata(&checkpoints_file)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    assert_eq!(
+        reset_size, 0,
+        "oversized live checkpoints file should be reset before path filtering"
+    );
+    assert!(
+        repo.current_working_logs()
+            .read_all_checkpoints()
+            .expect("read reset checkpoints")
+            .is_empty(),
+        "oversized checkpoint history should be discarded"
+    );
+
+    repo.git(&["stash", "pop"])
+        .expect("stash pop after oversized checkpoint recovery should succeed");
+    repo.stage_all_and_commit("commit recovered stash").unwrap();
+
+    let mut a = repo.filename("a.txt");
+    a.assert_committed_lines(crate::lines![
+        "base a".unattributed_human(),
+        "ai a".unattributed_human(),
+    ]);
+    let mut b = repo.filename("b.txt");
+    b.assert_committed_lines(crate::lines![
+        "base b".unattributed_human(),
+        "ai b".unattributed_human(),
+    ]);
+}
+
+#[test]
 fn test_stash_operation_deletes_legacy_stashes_dir() {
     let repo = TestRepo::new();
     fs::write(repo.path().join("example.txt"), "base\n").unwrap();


### PR DESCRIPTION
## Summary
- add a 1 GiB hard cap for `.git/ai/working_logs/*/checkpoints.jsonl` reads
- delete and recreate oversized checkpoint logs as empty before parsing, with tracing and telemetry error context
- route the stash path-filter streaming reader through the same size guard
- add TestRepo regressions for central reads and partial-stash filtering of oversized checkpoint logs

## Root Cause
PR #1719 stopped duplicating stash checkpoint history going forward, but already-bloated `checkpoints.jsonl` files could still be read before self-healing. Most call sites go through `PersistedWorkingLog::read_all_checkpoints`, while the partial-stash filtering path opened `checkpoints.jsonl` directly.

## Verification
- `task test TEST_FILTER=test_oversized_checkpoints_file_is_truncated_before_read`
- `task test TEST_FILTER=test_partial_stash_truncates_oversized_live_checkpoints_before_filtering`
- `task test TEST_FILTER=repo_storage_unit`
- `task test TEST_FILTER=stash_attribution`
- `task fmt`
- `task build`
- `task lint`
- `git diff --check`
- `task test`
