### PR TITLE
fix(ci) - Agent v1 shell command CI break

### DIFF
--- a/scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py
+++ b/scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py
@@ -592,7 +592,14 @@ def main() -> int:
             prepare_main_worktree(repo_root, args.main_ref, main_worktree)
             created_main_worktree = True
             print("Building main branch binary...")
-            main_bin = build_release_binary(main_worktree, targets_dir / "main")
+            try:
+                main_bin = build_release_binary(main_worktree, targets_dir / "main")
+            except BenchmarkError as err:
+                print(
+                    "::warning::Skipping nasty benchmark because the main baseline failed to build."
+                )
+                print(f"Baseline build error: {err}")
+                return 0
             main_sha = git_output(main_worktree, ["rev-parse", "HEAD"])
 
         print("Cloning seed repo snapshot...")

--- a/src/commands/checkpoint_agent/presets/agent_v1.rs
+++ b/src/commands/checkpoint_agent/presets/agent_v1.rs
@@ -167,9 +167,10 @@ impl AgentPreset for AgentV1Preset {
                     model,
                     conversation_id,
                     trace_id,
-                    command,
+                    command.clone(),
                 ),
                 tool_use_id: tool_use_id.unwrap_or_else(|| "shell".to_string()),
+                command,
             }),
             AgentV1Payload::PostShellCommand {
                 repo_working_dir,
@@ -185,9 +186,10 @@ impl AgentPreset for AgentV1Preset {
                     model,
                     conversation_id,
                     trace_id,
-                    command,
+                    command.clone(),
                 ),
                 tool_use_id: tool_use_id.unwrap_or_else(|| "shell".to_string()),
+                command,
                 stream_source: None,
             }),
         };
@@ -308,6 +310,10 @@ mod tests {
                     e.context.metadata.get("command").map(String::as_str),
                     Some("printf 'generated\\n' > output.txt")
                 );
+                assert_eq!(
+                    e.command.as_deref(),
+                    Some("printf 'generated\\n' > output.txt")
+                );
             }
             _ => panic!("Expected PreBashCall"),
         }
@@ -339,6 +345,10 @@ mod tests {
                     e.context.metadata.get("command").map(String::as_str),
                     Some("printf 'generated\\n' > output.txt")
                 );
+                assert_eq!(
+                    e.command.as_deref(),
+                    Some("printf 'generated\\n' > output.txt")
+                );
                 assert!(e.stream_source.is_none());
             }
             _ => panic!("Expected PostBashCall"),
@@ -360,6 +370,7 @@ mod tests {
             ParsedHookEvent::PreBashCall(e) => {
                 assert_eq!(e.tool_use_id, "shell");
                 assert!(e.context.metadata.is_empty());
+                assert!(e.command.is_none());
             }
             _ => panic!("Expected PreBashCall"),
         }

--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -637,7 +637,7 @@ mod tests {
             .join("github.copilot-chat")
             .join("agent-traces.db");
         std::fs::create_dir_all(otel_db_path.parent().unwrap()).unwrap();
-        let conn = rusqlite::Connection::open(&otel_db_path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(&otel_db_path).unwrap();
         conn.execute_batch(
             "CREATE TABLE spans (
                 span_id TEXT PRIMARY KEY,

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -151,17 +151,13 @@ impl MetricsDatabase {
 
     /// Get or initialize the global database
     pub fn global() -> Result<&'static Mutex<MetricsDatabase>, GitAiError> {
-        let db_mutex = METRICS_DB.get_or_init(|| {
-            match Self::new() {
-                Ok(db) => Mutex::new(db),
-                Err(e) => {
-                    eprintln!("[Error] Failed to initialize metrics database: {}", e);
-                    // Create a dummy connection that will fail on any operation
-                    let temp_path = std::env::temp_dir().join("git-ai-metrics-db-failed");
-                    let conn = crate::sqlite::open_with_memory_limits(&temp_path)
-                        .expect("Failed to create temp DB");
-                    Mutex::new(MetricsDatabase { conn })
-                }
+        let db_mutex = METRICS_DB.get_or_init(|| match Self::new() {
+            Ok(db) => Mutex::new(db),
+            Err(e) => {
+                eprintln!("[Error] Failed to initialize metrics database: {}", e);
+                Mutex::new(
+                    Self::new_fallback().expect("Failed to create fallback metrics database"),
+                )
             }
         });
 
@@ -190,6 +186,26 @@ impl MetricsDatabase {
         let mut db = Self { conn };
         db.initialize_schema()?;
 
+        Ok(db)
+    }
+
+    fn new_fallback() -> Result<Self, GitAiError> {
+        let temp_path = std::env::temp_dir().join("git-ai-metrics-db-failed");
+        Self::new_fallback_at_path(&temp_path)
+    }
+
+    fn new_fallback_at_path(path: &std::path::Path) -> Result<Self, GitAiError> {
+        let conn = crate::sqlite::open_with_memory_limits(path)?;
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=NORMAL;
+            PRAGMA temp_store=MEMORY;
+            "#,
+        )?;
+
+        let mut db = Self { conn };
+        db.initialize_schema()?;
         Ok(db)
     }
 
@@ -1668,6 +1684,21 @@ mod tests {
         ] {
             assert_metric_index_exists(&db, index);
         }
+    }
+
+    #[test]
+    fn test_fallback_database_initializes_schema() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("fallback-metrics.db");
+        let mut db = MetricsDatabase::new_fallback_at_path(&db_path).unwrap();
+
+        db.insert_events(&[event_json(days_ago(1))]).unwrap();
+
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -378,7 +378,7 @@ mod tests {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).unwrap();
         }
-        let conn = rusqlite::Connection::open(path).unwrap();
+        let conn = crate::sqlite::open_with_memory_limits(path).unwrap();
         conn.execute_batch(
             "CREATE TABLE spans (
                 span_id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary

Fixes the current CI break caused by Agent v1 shell hook parsing, plus the follow-on CI failures exposed after that compile fix.

`PreBashCall` and `PostBashCall` require a `command` field, but the Agent v1 preset only stored shell commands in context metadata. That made `main` fail to build before tests could run.

## Main CI context

Recent main merges around the break:

- #1725: fix: resolve nightly agent test failures for droid and opencode — green baseline before the break.
- #1636: Add agent-v1 shell command attribution — first merge where main CI started failing.
- #1637: Fix Cursor hook stdin decoding for CJK content — merged after main was already red.
- #1638: Fix Copilot VS Code selected model extraction — merged after main was already red; also introduced test-only SQLite opens that failed the connection policy check once builds were fixed.

## Related PRs checked

- #1514: feat(agent-v1): add pre_bash_call/post_bash_call types — historical Agent v1 shell-event context.
- #1560: fix(copilot): VS Code Copilot always reports the account default model instead of the user-selected mode — related public-contributor Copilot context, not the compile break.
- #1604: feat: HTTP notes backend migration — by `Siddhant-K-code`; had a “Tests started to fail after rebase” comment, but appears separate from this Agent v1 compile failure.
- #1515 / #1721 / #1724: Windows test break was called out as caused by #1515; the latest Windows failure on this PR was `SQLite error: no such table: metrics`, fixed here by making metrics fallback DBs schema-initialized.

## Changes

- Populate `PreBashCall.command` and `PostBashCall.command` from Agent v1 shell hook payloads.
- Keep the existing metadata value for compatibility.
- Add parser assertions so the typed command field cannot be omitted again.
- Use the SQLite memory-limited helper in Copilot OTEL/model-extraction test DB setup.
- Initialize the metrics fallback database schema so Windows test daemons cannot poison the metrics singleton with an empty SQLite DB after fallback initialization.
- Skip the PR smoke benchmark with a GitHub warning when the current branch builds but the `main` comparison baseline does not build.

## Validation

- `task test TEST_FILTER=test_fallback_database_initializes_schema`
- `task test TEST_FILTER=test_reset_hard_with_c_flag`
- `task test TEST_FILTER=sqlite_connections_go_through_memory_limited_helpers`
- `task test TEST_FILTER=copilot_otel`
- `task test TEST_FILTER=agent_v1`
- `task lint`
- `task build`
- `task fmt`
- `python3 -m py_compile scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py`
- Benchmark skip-path sanity run against current broken `origin/main`