### PR TITLE
feat(daemon): ping/sentinel socket health checks (replaces drain-progress watchdog)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -44,7 +44,7 @@ use std::os::fd::{AsFd, AsRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot};
@@ -85,6 +85,10 @@ const TRACE_ROOT_STARTED_AT_NS_FIELD: &str = "git_ai_root_started_at_ns";
 const TRACE_ROOT_WORKTREE_FIELD: &str = "git_ai_root_worktree";
 pub(crate) const TRACE_ROOT_REFLOG_START_OFFSETS_FIELD: &str = "git_ai_root_reflog_start_offsets";
 const TRACE_CONNECTION_CLOSED_EVENT: &str = "git_ai_connection_closed";
+// Sentinel trace2 event the daemon writes to its own trace socket as a liveness
+// ping. The trace reader recognizes it, stamps a received-timestamp, and closes
+// the connection without enqueuing it. See `daemon_socket_health_check_loop`.
+const TRACE_HEALTH_PING_EVENT: &str = "git_ai_health_ping";
 const DAEMON_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 const DAEMON_CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
 const DAEMON_CHECKPOINT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
@@ -2537,6 +2541,10 @@ pub struct ActorDaemonCoordinator {
     shutdown_notify: Notify,
     shutdown_condvar: std::sync::Condvar,
     shutdown_condvar_mutex: Mutex<()>,
+    /// Wall-clock nanoseconds at which the trace reader last observed a health
+    /// ping (sentinel line). The socket health loop watches this watermark to
+    /// confirm the trace read path is still draining. `0` means none seen yet.
+    last_trace_ping_received_ns: AtomicU64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2628,7 +2636,21 @@ impl ActorDaemonCoordinator {
             shutdown_notify: Notify::new(),
             shutdown_condvar: std::sync::Condvar::new(),
             shutdown_condvar_mutex: Mutex::new(()),
+            last_trace_ping_received_ns: AtomicU64::new(0),
         }
+    }
+
+    /// Record that the trace reader observed a health ping (sentinel line),
+    /// stamping the current wall-clock time.
+    fn record_trace_health_ping(&self) {
+        self.last_trace_ping_received_ns
+            .store(now_unix_nanos() as u64, Ordering::Release);
+    }
+
+    /// Wall-clock nanoseconds at which the last trace health ping was observed,
+    /// or 0 if none has been seen yet.
+    fn last_trace_ping_received_ns(&self) -> u64 {
+        self.last_trace_ping_received_ns.load(Ordering::Acquire)
     }
 
     fn is_shutting_down(&self) -> bool {
@@ -6838,6 +6860,18 @@ fn process_trace_connection_line(
         Ok(v) => v,
         Err(_) => return Ok(None),
     };
+    // Liveness sentinel written by the daemon's own health-check loop. Stamp the
+    // received-timestamp so the loop can confirm the trace read path is still
+    // draining, then close the connection without treating it as a trace root
+    // or enqueuing it for ingest.
+    if parsed.get("event").and_then(Value::as_str) == Some(TRACE_HEALTH_PING_EVENT) {
+        coordinator.record_trace_health_ping();
+        return Ok(Some(TraceLineOutcome {
+            continue_reading: false,
+            #[cfg(not(windows))]
+            bootstrap_complete: false,
+        }));
+    }
     #[cfg(not(windows))]
     let event = parsed
         .get("event")
@@ -7016,6 +7050,72 @@ fn daemon_min_uptime_for_self_restart() -> u64 {
         .unwrap_or(DAEMON_MIN_UPTIME_FOR_SELF_RESTART_SECS)
 }
 
+/// Number of seconds a socket may go without acknowledging a liveness ping
+/// before the health loop raises an alert. Deliberately generous: the ping is a
+/// heartbeat, not a latency probe, and we never want a transient hiccup to fire.
+const DAEMON_PING_STALL_SECS: u64 = 120;
+
+fn daemon_ping_stall_secs() -> u64 {
+    std::env::var("GIT_AI_DAEMON_PING_STALL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DAEMON_PING_STALL_SECS)
+}
+
+/// Tracks whether a daemon socket keeps acknowledging liveness pings.
+///
+/// Each health-check tick reports whether the socket acknowledged a ping since
+/// the previous tick (control: a `Ping` request round-tripped; trace: the
+/// daemon stamped a received sentinel). Once a socket stays unacknowledged for
+/// `threshold`, the detector fires exactly once per stall episode so we alert
+/// without spamming, and re-arms only after the socket recovers. A zero
+/// `threshold` disables detection entirely.
+struct SocketPingHealth {
+    threshold: Duration,
+    unacked_since: Option<std::time::Instant>,
+    alerted: bool,
+}
+
+impl SocketPingHealth {
+    fn new(threshold: Duration) -> Self {
+        Self {
+            threshold,
+            unacked_since: None,
+            alerted: false,
+        }
+    }
+
+    /// Feed one observation. Returns `Some(stall_duration)` exactly once, on the
+    /// tick where the socket first crosses `threshold` without acknowledging a
+    /// ping. Acknowledgement resets the detector so a later stall alerts again.
+    fn observe(&mut self, acknowledged: bool, now: std::time::Instant) -> Option<Duration> {
+        if self.threshold.is_zero() || acknowledged {
+            self.unacked_since = None;
+            self.alerted = false;
+            return None;
+        }
+        let since = *self.unacked_since.get_or_insert(now);
+        let elapsed = now.saturating_duration_since(since);
+        if elapsed >= self.threshold && !self.alerted {
+            self.alerted = true;
+            return Some(elapsed);
+        }
+        None
+    }
+}
+
+/// Write a single health-ping sentinel line to the trace socket. The trace
+/// reader recognizes `TRACE_HEALTH_PING_EVENT`, stamps a received-timestamp, and
+/// closes the connection without ingesting it. Best-effort: a failure here is
+/// itself a liveness signal picked up by the stall detector on the next tick.
+fn send_trace_health_ping(trace_socket_path: &Path, timeout: Duration) -> Result<(), GitAiError> {
+    let mut stream = open_local_socket_stream_with_timeout(trace_socket_path, timeout)?;
+    let line = format!("{{\"event\":\"{}\"}}\n", TRACE_HEALTH_PING_EVENT);
+    stream.write_all(line.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
 /// Background loop that verifies the daemon's sockets are reachable by
 /// actually connecting to them.  A successful connect proves the socket file
 /// exists, points to this daemon's listener, and that the listener thread is
@@ -7028,6 +7128,15 @@ fn daemon_min_uptime_for_self_restart() -> u64 {
 /// it has been up for at least 60 seconds.  If sockets fail before that,
 /// it shuts down without restart — the next wrapper invocation will attempt
 /// to start a fresh daemon.
+///
+/// Alongside the connect probes, the loop sends a liveness ping over each
+/// socket every tick — a `Ping` control request and a sentinel line on the
+/// trace socket — and tracks when each was last acknowledged. A connect probe
+/// only proves the listener calls `accept()`; the pings additionally prove the
+/// control handler and the trace read path keep draining, catching a wedge on
+/// an already-established connection. A ping stall only *alerts* (it does not
+/// restart) so we avoid the memory spikes and restart loops that aggressive
+/// drain-based restarts risked.
 fn daemon_socket_health_check_loop(
     coordinator: Arc<ActorDaemonCoordinator>,
     control_socket_path: PathBuf,
@@ -7035,14 +7144,40 @@ fn daemon_socket_health_check_loop(
 ) {
     let started = std::time::Instant::now();
     let interval = daemon_socket_health_check_interval().max(1);
+    let ping_stall = Duration::from_secs(daemon_ping_stall_secs());
+    let mut control_health = SocketPingHealth::new(ping_stall);
+    let mut trace_health = SocketPingHealth::new(ping_stall);
+    // Baseline the trace watermark before the first ping so the first
+    // evaluation only fires if the sentinel we send below is never stamped.
+    let mut prev_trace_ping_ns = coordinator.last_trace_ping_received_ns();
     tracing::info!(
         interval,
+        ping_stall_secs = ping_stall.as_secs(),
         control = %control_socket_path.display(),
         trace = %trace_socket_path.display(),
         "socket health check started"
     );
 
     loop {
+        if coordinator.is_shutting_down() {
+            return;
+        }
+
+        // Send a liveness ping over each socket, then sleep so the trace
+        // sentinel has time to be read before we evaluate acknowledgement. The
+        // control `Ping` round-trips synchronously, so its result already
+        // reflects control-path liveness for this tick.
+        let control_ping_ok = send_control_request_with_timeout(
+            &control_socket_path,
+            &ControlRequest::Ping,
+            DAEMON_SOCKET_PROBE_TIMEOUT,
+        )
+        .is_ok();
+        if let Err(error) = send_trace_health_ping(&trace_socket_path, DAEMON_SOCKET_PROBE_TIMEOUT)
+        {
+            tracing::debug!(%error, "trace health ping send failed");
+        }
+
         {
             let guard = coordinator
                 .shutdown_condvar_mutex
@@ -7058,6 +7193,27 @@ fn daemon_socket_health_check_loop(
 
         if coordinator.is_shutting_down() {
             return;
+        }
+
+        // Evaluate ping acknowledgement. The trace socket is one-way, so we
+        // confirm the sentinel was read by watching the daemon-side watermark
+        // advance rather than expecting a response.
+        let now = std::time::Instant::now();
+        let cur_trace_ping_ns = coordinator.last_trace_ping_received_ns();
+        let trace_ping_acked = cur_trace_ping_ns > prev_trace_ping_ns;
+        prev_trace_ping_ns = cur_trace_ping_ns;
+
+        if let Some(stall) = control_health.observe(control_ping_ok, now) {
+            tracing::warn!(
+                stall_secs = stall.as_secs(),
+                "daemon control socket stopped acknowledging health pings"
+            );
+        }
+        if let Some(stall) = trace_health.observe(trace_ping_acked, now) {
+            tracing::warn!(
+                stall_secs = stall.as_secs(),
+                "daemon trace socket stopped acknowledging health pings"
+            );
         }
 
         let control_ok =
@@ -9053,6 +9209,95 @@ mod tests {
             }
             tokio::task::yield_now().await;
         }
+        coord.request_shutdown();
+    }
+
+    /// A socket that keeps acknowledging pings never alerts; once it goes silent
+    /// past the threshold it alerts exactly once, then re-arms after recovery.
+    #[test]
+    fn socket_ping_health_alerts_once_per_stall_then_rearms() {
+        let threshold = Duration::from_secs(120);
+        let mut health = SocketPingHealth::new(threshold);
+        let t0 = std::time::Instant::now();
+
+        // Acknowledged pings never alert.
+        assert_eq!(health.observe(true, t0), None);
+
+        // A stall stays quiet until the threshold elapses.
+        assert_eq!(health.observe(false, t0 + Duration::from_secs(1)), None);
+        assert_eq!(health.observe(false, t0 + Duration::from_secs(119)), None);
+
+        // Crossing the threshold alerts exactly once for this episode.
+        let fired = health.observe(false, t0 + Duration::from_secs(121));
+        assert!(
+            fired.is_some_and(|elapsed| elapsed >= threshold),
+            "should alert once the unacknowledged span exceeds the threshold"
+        );
+        assert_eq!(
+            health.observe(false, t0 + Duration::from_secs(300)),
+            None,
+            "must not re-alert within the same stall episode"
+        );
+
+        // Recovery re-arms the detector so a later stall alerts again.
+        assert_eq!(health.observe(true, t0 + Duration::from_secs(310)), None);
+        assert_eq!(health.observe(false, t0 + Duration::from_secs(311)), None);
+        assert!(
+            health
+                .observe(false, t0 + Duration::from_secs(440))
+                .is_some(),
+            "a fresh stall after recovery must alert again"
+        );
+    }
+
+    /// A zero threshold disables ping-stall detection entirely.
+    #[test]
+    fn socket_ping_health_zero_threshold_never_alerts() {
+        let mut health = SocketPingHealth::new(Duration::from_secs(0));
+        let t0 = std::time::Instant::now();
+        for secs in [0u64, 1, 1_000, 1_000_000] {
+            assert_eq!(
+                health.observe(false, t0 + Duration::from_secs(secs)),
+                None,
+                "a zero threshold must never alert"
+            );
+        }
+    }
+
+    /// The trace health-ping sentinel must stamp the received watermark, close
+    /// the connection, and never register a root or enter the ingest queue.
+    #[tokio::test]
+    async fn trace_health_ping_sentinel_is_recorded_and_not_ingested() {
+        let coord = Arc::new(ActorDaemonCoordinator::new());
+        assert_eq!(
+            coord.last_trace_ping_received_ns(),
+            0,
+            "watermark starts unset"
+        );
+
+        let mut observed_roots = std::collections::BTreeSet::new();
+        let line = format!("{{\"event\":\"{}\"}}", TRACE_HEALTH_PING_EVENT);
+        let outcome = process_trace_connection_line(&line, coord.clone(), &mut observed_roots)
+            .expect("processing the sentinel must not error")
+            .expect("sentinel line must yield an outcome");
+
+        assert!(
+            !outcome.continue_reading,
+            "sentinel must close its connection after being observed"
+        );
+        assert!(
+            coord.last_trace_ping_received_ns() > 0,
+            "sentinel must stamp the trace health-ping watermark"
+        );
+        assert!(
+            observed_roots.is_empty(),
+            "sentinel must not be treated as a trace root"
+        );
+        assert_eq!(
+            coord.queued_trace_payloads.load(Ordering::Acquire),
+            0,
+            "sentinel must not be enqueued for ingest"
+        );
         coord.request_shutdown();
     }
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1507,6 +1507,78 @@ fn daemon_trace_listener_stalled_connection_does_not_block_later_trace_connectio
     );
 }
 
+/// The daemon's own liveness sentinel (written to the trace socket by the socket
+/// health-check loop) must be accepted by the real trace listener without being
+/// treated as a trace command: it must not produce a completion entry, must not
+/// wedge the listener, and must leave the daemon responsive to both a real trace
+/// command and a control `Ping` afterwards.
+#[test]
+#[cfg(not(windows))]
+fn daemon_trace_health_ping_sentinel_is_accepted_without_disrupting_ingest() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let control_socket = daemon_control_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    // Send the liveness sentinel exactly as the health-check loop does.
+    send_trace_frames(&trace_socket, &[json!({ "event": "git_ai_health_ping" })]);
+
+    // The daemon must still process a subsequent real trace command, proving the
+    // sentinel neither wedged the listener nor corrupted connection accounting.
+    let session = repos::test_repo::new_daemon_test_sync_session_id();
+    let session_arg = format!("git-ai.testSyncSession={session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "health-ping-followup",
+                "argv": ["git", "-c", session_arg, "commit", "-m", "synthetic"],
+                "time_ns": 20_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "health-ping-followup",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 20_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "health-ping-followup",
+                "code": 0,
+                "time_ns": 20_100u64,
+            }),
+            trace_atexit_frame("health-ping-followup", 0, 20_101u64),
+        ],
+    );
+
+    let start = std::time::Instant::now();
+    let mut processed = false;
+    while start.elapsed() < Duration::from_secs(2) {
+        if repo
+            .daemon_completion_entries()
+            .iter()
+            .any(|entry| entry.test_sync_session.as_deref() == Some(session.as_str()))
+        {
+            processed = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        processed,
+        "daemon did not process a real trace command after receiving a health-ping sentinel"
+    );
+
+    // The daemon remains responsive on the control socket.
+    assert!(
+        send_control_request(&control_socket, &ControlRequest::Ping).is_ok(),
+        "daemon should answer a control Ping after handling a health-ping sentinel"
+    );
+}
+
 #[test]
 #[cfg(not(windows))]
 fn daemon_stalled_unidentified_trace_connection_does_not_block_checkpoint_control_request() {


### PR DESCRIPTION
## Summary

Reworks the daemon socket health check from a trace-ingest **drain watchdog** (which self-restarted the daemon when ingest appeared stalled) into a **liveness ping/sentinel** mechanism that *alerts* instead of restarting. The watchdog's aggressive restarts risked memory spikes and restart loops; a heartbeat that surfaces the problem is simpler and less edge-case-prone.

Each health-check tick (every `DAEMON_SOCKET_HEALTH_CHECK_SECS`, default 30s) the loop now sends a liveness ping over **both** sockets and tracks when each was last acknowledged:

- **Control socket:** send `ControlRequest::Ping` and observe the synchronous round-trip result.
- **Trace socket:** write a one-way sentinel line `{"event":"git_ai_health_ping"}`. The trace reader recognizes it in `process_trace_connection_line`, stamps `last_trace_ping_received_ns`, and closes the connection **without** registering a root or enqueuing it for ingest. The loop confirms the watermark advanced.

A small `SocketPingHealth` detector decides when to alert:

```rust
// per socket, once per stall episode; re-arms after recovery
fn observe(&mut self, acknowledged: bool, now: Instant) -> Option<Duration> {
    if threshold.is_zero() || acknowledged { reset(); return None; }
    let since = *self.unacked_since.get_or_insert(now);
    (now - since >= threshold && !self.alerted).then(|| { self.alerted = true; now - since })
}
```

If a socket goes unacknowledged for `DAEMON_PING_STALL_SECS` (default 120s, override `GIT_AI_DAEMON_PING_STALL_SECS`, `0` disables) the loop emits a single `tracing::warn!` for that episode. It does **not** restart.

The pre-existing connect-probe restart safety net (dead/stale listener → `spawn_self_restart`) is retained unchanged — the pings are strictly additive and catch a wedge on an already-established connection that a bare `accept()` probe cannot.

Because the ping is on the health-check loop, nothing is added to the latency-sensitive trace ingestion path.

## Scope note
Socket receive-buffer tuning (raising `SO_RCVBUF` to absorb trace2 bursts) is split into its own small PR (#1762) so it can land independently of this change.

## Tests (TDD)
- `socket_ping_health_alerts_once_per_stall_then_rearms` — threshold, single alert per episode, re-arm after recovery.
- `socket_ping_health_zero_threshold_never_alerts` — disable switch.
- `trace_health_ping_sentinel_is_recorded_and_not_ingested` — sentinel stamps the watermark, closes the connection, registers no root, and never enters the ingest queue (real `ActorDaemonCoordinator`).
- `daemon_trace_health_ping_sentinel_is_accepted_without_disrupting_ingest` — end-to-end: after a sentinel, the real daemon still ingests a trace command and answers a control `Ping`.


Link to Devin session: https://app.devin.ai/sessions/a9931f84ae914fcc82663a2e52106bd5
Requested by: @Siddhant-K-code