### PR TITLE
Reduce trace2 event nesting

### DIFF
--- a/scripts/benchmarks/git/benchmark_modes_vs_main.py
+++ b/scripts/benchmarks/git/benchmark_modes_vs_main.py
@@ -271,7 +271,7 @@ class VariantRunner:
             )
             self.base_env["GIT_TRACE2_EVENT_NESTING"] = os.environ.get(
                 "GIT_AI_TEST_TRACE2_NESTING",
-                "10",
+                "0",
             )
             self.base_env["GIT_AI_DAEMON_CHECKPOINT_DELEGATE"] = "true"
             self.base_env["GIT_AI_DAEMON_CONTROL_SOCKET"] = str(

--- a/scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py
+++ b/scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py
@@ -241,7 +241,7 @@ def setup_variant_runtime(
         env["GIT_TRACE2_EVENT"] = f"af_unix:stream:{trace_socket}"
         env["GIT_TRACE2_EVENT_NESTING"] = os.environ.get(
             "GIT_AI_TEST_TRACE2_NESTING",
-            "10",
+            "0",
         )
         env["GIT_AI_DAEMON_CHECKPOINT_DELEGATE"] = "true"
         env["GIT_AI_DAEMON_CONTROL_SOCKET"] = str(control_socket)

--- a/scripts/benchmarks/git/benchmark_nasty_rebases.sh
+++ b/scripts/benchmarks/git/benchmark_nasty_rebases.sh
@@ -114,7 +114,7 @@ if [[ "$HOOK_MODE" == "daemon" ]]; then
     export GIT_TRACE2_EVENT="af_unix:stream:$HOME/.git-ai/internal/daemon/trace2.sock"
   fi
   if [[ -z "${GIT_TRACE2_EVENT_NESTING:-}" ]]; then
-    export GIT_TRACE2_EVENT_NESTING="10"
+    export GIT_TRACE2_EVENT_NESTING="0"
   fi
   export GIT_AI_DAEMON_CHECKPOINT_DELEGATE="true"
 

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -13,7 +13,7 @@ use std::process::{Command, Stdio};
 
 const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
 const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
-const TRACE2_EVENT_NESTING_VALUE: &str = "10";
+const TRACE2_EVENT_NESTING_VALUE: &str = "0";
 const VISUAL_STUDIO_INSTALLER_ID: &str = "visual-studio";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -1484,6 +1484,54 @@ mod tests {
     }
 
     #[test]
+    fn alias_pull_rebase_expands_invoked_args_without_child_cmd_name() {
+        // If a trace stream omits child cmd_name events, alias resolution must
+        // still use the backend fallback instead of leaving the literal alias
+        // token as the normalized command.
+        let backend = Arc::new(MockBackend::default());
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        backend.set_alias(
+            worktree.to_str().expect("utf8 worktree"),
+            "up",
+            "pull --rebase",
+        );
+        let mut normalizer = TraceNormalizer::new(backend);
+
+        let start = serde_json::json!({
+            "event":"start",
+            "sid":"alias-pull-no-child",
+            "ts":1,
+            "argv":["git","up","origin","main"],
+            "worktree":worktree
+        });
+        let exit = serde_json::json!({
+            "event":"exit",
+            "sid":"alias-pull-no-child",
+            "ts":2,
+            "code":0
+        });
+        let atexit = atexit_payload("alias-pull-no-child", 3);
+
+        assert!(normalizer.ingest_payload(&start).unwrap().is_none());
+        assert!(normalizer.ingest_payload(&exit).unwrap().is_none());
+        let cmd = normalizer.ingest_payload(&atexit).unwrap().unwrap();
+
+        assert_eq!(cmd.primary_command.as_deref(), Some("pull"));
+        assert_eq!(cmd.invoked_command.as_deref(), Some("pull"));
+        assert_eq!(
+            cmd.invoked_args,
+            vec![
+                "--rebase".to_string(),
+                "origin".to_string(),
+                "main".to_string()
+            ],
+            "backend fallback must preserve alias-expanded flags without child events"
+        );
+    }
+
+    #[test]
     fn non_alias_pull_invocation_is_unchanged() {
         // A plain (non-alias) invocation must expand to the identical command
         // token, leaving invoked_args byte-identical to the pre-alias behavior.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -18,7 +18,7 @@ const SELF_CHECK_CONTENT_KNOWN_HUMAN: &str = "Untracked line\nKnown human line\n
 const SELF_CHECK_CONTENT_AI: &str = "Untracked line\nKnown human line\nAI line\n";
 const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
 const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
-const TRACE2_EVENT_NESTING_VALUE: &str = "10";
+const TRACE2_EVENT_NESTING_VALUE: &str = "0";
 const SELF_CHECK_TRACE_ENV_REMOVE: &[&str] = &[
     "GIT_TRACE2_PARENT_SID",
     "GIT_TRACE2_PARENT_NAME",

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -253,7 +253,7 @@ fn install_hooks_async_mode_sets_daemon_trace2_global_config() {
     let nesting = read_global_git_config(&repo, "trace2.eventNesting");
 
     assert_eq!(target.as_deref(), Some(expected_target.as_str()));
-    assert_eq!(nesting.as_deref(), Some("10"));
+    assert_eq!(nesting.as_deref(), Some("0"));
 }
 
 #[test]
@@ -373,7 +373,7 @@ fn daemon_status_does_not_self_emit_trace2_events() {
     );
 
     let mut set_nesting_command = Command::new(real_git_executable());
-    set_nesting_command.args(["config", "--global", "trace2.eventNesting", "10"]);
+    set_nesting_command.args(["config", "--global", "trace2.eventNesting", "0"]);
     set_nesting_command.current_dir(repo.path());
     configure_test_home_env(&mut set_nesting_command, &repo);
     let set_nesting = set_nesting_command

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -110,7 +110,7 @@ fn raw_traced_git(repo: &TestRepo, args: &[&str]) -> String {
     );
     command.env(
         "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "10".to_string()),
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
     );
 
     let output = command
@@ -152,7 +152,7 @@ fn raw_traced_git_stdin(repo: &TestRepo, args: &[&str], stdin: &str) -> String {
     );
     command.env(
         "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "10".to_string()),
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
     );
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
@@ -206,7 +206,7 @@ fn raw_traced_git_with_session(repo: &TestRepo, args: &[&str], session: &str) ->
     );
     command.env(
         "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "10".to_string()),
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
     );
 
     let output = command
@@ -257,7 +257,7 @@ fn raw_git_trace_to_file_output(repo: &TestRepo, args: &[&str], trace_path: &Pat
     command.env("GIT_TRACE2_EVENT", trace_path);
     command.env(
         "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "10".to_string()),
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
     );
 
     command

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -543,7 +543,7 @@ fn git_trace_env(trace_socket_path: &Path) -> [(&'static str, String); 2] {
             "GIT_TRACE2_EVENT",
             DaemonConfig::trace2_event_target_for_path(trace_socket_path),
         ),
-        ("GIT_TRACE2_EVENT_NESTING", "10".to_string()),
+        ("GIT_TRACE2_EVENT_NESTING", "0".to_string()),
     ]
 }
 
@@ -609,7 +609,7 @@ impl WorkdirRaceHarness {
                 "GIT_TRACE2_EVENT",
                 DaemonConfig::trace2_event_target_for_path(&self.trace_socket_path),
             )
-            .env("GIT_TRACE2_EVENT_NESTING", "10")
+            .env("GIT_TRACE2_EVENT_NESTING", "0")
             .output()
             .expect("failed to execute traced git command");
         assert!(

--- a/tests/integration/daemon_commit_carryover.rs
+++ b/tests/integration/daemon_commit_carryover.rs
@@ -27,7 +27,7 @@ fn test_daemon_commit_uses_immutable_commit_content_not_next_worktree_edit() {
         &["commit", "-m", "add ai line"],
         &[
             ("GIT_TRACE2_EVENT", trace_target.as_str()),
-            ("GIT_TRACE2_EVENT_NESTING", "10"),
+            ("GIT_TRACE2_EVENT_NESTING", "0"),
         ],
     )
     .unwrap();

--- a/tests/integration/git_alias_resolution.rs
+++ b/tests/integration/git_alias_resolution.rs
@@ -179,6 +179,8 @@ fn alias_with_double_quotes() {
 fn aliased_commit_triggers_authorship_hooks() {
     let repo = TestRepo::new();
 
+    // TestRepo routes real Git trace2 events through the daemon with the
+    // default nesting value, so this covers aliases under nesting=0.
     // Configure alias: ci = commit
     repo.git(&["config", "alias.ci", "commit"]).unwrap();
 

--- a/tests/integration/graphite.rs
+++ b/tests/integration/graphite.rs
@@ -286,7 +286,7 @@ fn gt(repo: &TestRepo, args: &[&str]) -> Result<String, String> {
     apply_deterministic_git_env(&mut command, repo);
 
     let trace_socket = repo.daemon_trace_socket_path();
-    let nesting = std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "10".to_string());
+    let nesting = std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string());
     command.env(
         "GIT_TRACE2_EVENT",
         git_ai::daemon::DaemonConfig::trace2_event_target_for_path(&trace_socket),

--- a/tests/integration/repos/mod.rs
+++ b/tests/integration/repos/mod.rs
@@ -92,7 +92,7 @@ macro_rules! subdir_test_variants {
                         command.env("GIT_CONFIG_NOSYSTEM", "1");
                         let trace_socket = self.inner.daemon_trace_socket_path();
                         let nesting = std::env::var("GIT_AI_TEST_TRACE2_NESTING")
-                            .unwrap_or_else(|_| "10".to_string());
+                            .unwrap_or_else(|_| "0".to_string());
                         command.env(
                             "GIT_TRACE2_EVENT",
                             git_ai::daemon::DaemonConfig::trace2_event_target_for_path(
@@ -203,7 +203,7 @@ macro_rules! subdir_test_variants {
                             command.env("GIT_CONFIG_NOSYSTEM", "1");
                             let trace_socket = self.inner.daemon_trace_socket_path();
                             let nesting = std::env::var("GIT_AI_TEST_TRACE2_NESTING")
-                                .unwrap_or_else(|_| "10".to_string());
+                                .unwrap_or_else(|_| "0".to_string());
                             command.env(
                                 "GIT_TRACE2_EVENT",
                                 git_ai::daemon::DaemonConfig::trace2_event_target_for_path(

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -391,7 +391,7 @@ impl DaemonProcess {
                 "GIT_TRACE2_EVENT",
                 DaemonConfig::trace2_event_target_for_path(&self.trace_socket_path),
             )
-            .env("GIT_TRACE2_EVENT_NESTING", "10");
+            .env("GIT_TRACE2_EVENT_NESTING", "0");
         configure_test_home_env(&mut command, &self.daemon_home);
 
         let output = run_command_output(&mut command, "daemon readiness probe git config")
@@ -1759,7 +1759,7 @@ impl TestRepo {
     }
 
     fn trace2_nesting_value() -> String {
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "10".to_string())
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string())
     }
 
     fn setup_daemon_mode(&mut self) {


### PR DESCRIPTION
## Summary

- lower the installed and diagnosed `trace2.eventNesting` value from `10` to `0`
- update trace2-backed test harness defaults and direct raw Git trace invocations to exercise nesting `0` by default
- keep the override hook `GIT_AI_TEST_TRACE2_NESTING` available for targeted comparisons
- restack this on #1739, which fixes the Windows CI failure already present on `main`

## Validation

- `GIT_AI_TEST_TRACE2_NESTING=0 task test CARGO_TEST_ARGS='--test commit_tree_update_ref'`
- `GIT_AI_TEST_TRACE2_NESTING=0 task test`
- `task fmt`
- `task test CARGO_TEST_ARGS='--test commit_tree_update_ref'`
- `task test CARGO_TEST_ARGS='--test async_mode'`
- `task test TEST_FILTER=graphite`
- `task test CARGO_TEST_ARGS="--test notes_sync_regression"`
- `task test CARGO_TEST_ARGS="--test integration" TEST_FILTER=tls_native_certs::test_https_request_uses_system_certs`
- `task lint`
- `git diff --check`
- `task test` with local `/home/ubuntu/.opencode/bin` removed from `PATH` because this workstation has an unrelated `opencode` binary that makes `mdm::agents::opencode::tests::test_opencode_no_binary_no_config_not_detected` fail on `main` too
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
