### PR TITLE
Fix Windows CI flakes

### DIFF
--- a/src/daemon/git_backend.rs
+++ b/src/daemon/git_backend.rs
@@ -1,8 +1,7 @@
 use crate::daemon::domain::FamilyKey;
 use crate::error::GitAiError;
 use crate::git::cli_parser::parse_git_cli_args;
-use crate::git::find_repository_in_path;
-use crate::git::repo_state::common_dir_for_worktree;
+use crate::git::repo_state::{common_dir_for_repo_path, common_dir_for_worktree};
 use crate::git::repository::discover_repository_in_path_no_git_exec;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -327,12 +326,13 @@ fn is_builtin_primary_command(command: &str) -> bool {
 
 impl GitBackend for SystemGitBackend {
     fn resolve_family(&self, worktree: &Path) -> Result<FamilyKey, GitAiError> {
-        let worktree_str = worktree.to_string_lossy().to_string();
-        let repo = find_repository_in_path(&worktree_str)?;
-        let common = repo
-            .common_dir()
-            .canonicalize()
-            .unwrap_or_else(|_| repo.common_dir().to_path_buf());
+        let common = common_dir_for_repo_path(worktree).ok_or_else(|| {
+            GitAiError::Generic(format!(
+                "Failed to resolve git common dir for repo path {}",
+                worktree.display()
+            ))
+        })?;
+        let common = common.canonicalize().unwrap_or(common);
         Ok(FamilyKey::new(common.to_string_lossy().to_string()))
     }
 
@@ -564,6 +564,7 @@ mod tests {
     use super::{
         GitBackend, SystemGitBackend, clone_init_positionals, default_clone_target_from_source,
     };
+    use std::fs;
     use std::path::PathBuf;
 
     fn argv(args: &[&str]) -> Vec<String> {
@@ -724,6 +725,44 @@ mod tests {
             .expect("builtin commands should not require repository discovery");
 
         assert_eq!(resolved.as_deref(), Some("commit"));
+    }
+
+    #[test]
+    fn resolve_family_uses_worktree_filesystem_without_git_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let git_dir = temp.path().join(".git");
+        fs::create_dir_all(&git_dir).expect("create git dir");
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+
+        let family = SystemGitBackend::new()
+            .resolve_family(temp.path())
+            .expect("resolve family");
+
+        assert_eq!(
+            family.0,
+            git_dir
+                .canonicalize()
+                .expect("canonical git dir")
+                .to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn resolve_family_accepts_bare_repo_path_without_git_spawn() {
+        let bare = tempfile::tempdir().expect("bare tempdir");
+        fs::write(bare.path().join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+
+        let family = SystemGitBackend::new()
+            .resolve_family(bare.path())
+            .expect("resolve family");
+
+        assert_eq!(
+            family.0,
+            bare.path()
+                .canonicalize()
+                .expect("canonical bare dir")
+                .to_string_lossy()
+        );
     }
 
     #[test]

--- a/tests/integration/tls_native_certs.rs
+++ b/tests/integration/tls_native_certs.rs
@@ -12,13 +12,32 @@ fn test_build_agent_default_config() {
 /// native TLS stack and system certificate store are working correctly.
 #[test]
 fn test_https_request_uses_system_certs() {
-    let agent = git_ai::http::build_agent(Some(10));
-    let result = git_ai::http::send(agent.get("https://example.com"));
-    assert!(
-        result.is_ok(),
-        "HTTPS request to example.com failed — native TLS certs not working: {:?}",
-        result.err()
+    const URLS: &[&str] = &[
+        "https://example.com",
+        "https://www.rust-lang.org",
+        "https://github.com",
+    ];
+    const ATTEMPTS_PER_URL: usize = 3;
+
+    let mut failures = Vec::new();
+    for url in URLS {
+        for attempt in 1..=ATTEMPTS_PER_URL {
+            let agent = git_ai::http::build_agent(Some(10));
+            match git_ai::http::send(agent.get(url)) {
+                Ok(response) if (200..400).contains(&response.status_code) => return,
+                Ok(response) => failures.push(format!(
+                    "{} attempt {} returned status {}",
+                    url, attempt, response.status_code
+                )),
+                Err(error) => {
+                    failures.push(format!("{} attempt {} failed: {}", url, attempt, error))
+                }
+            }
+        }
+    }
+
+    panic!(
+        "HTTPS requests to trusted public endpoints failed; native TLS certs may be broken or the network is unavailable:\n{}",
+        failures.join("\n")
     );
-    let response = result.unwrap();
-    assert_eq!(response.status_code, 200);
 }


### PR DESCRIPTION
## Summary

- resolve daemon family keys from filesystem repo-state data instead of spawning Git for `rev-parse --show-toplevel`
- keep that resolver compatible with both worktree paths and bare/common-dir paths used by explicit push destinations
- make the native TLS cert integration test retry across multiple trusted HTTPS endpoints before failing

## Root cause

The linked Windows main failure was not caused by trace2 event nesting. The daemon test sync path spawned Git to resolve a family key after a Graphite command, and Windows intermittently failed that `rev-parse` with a `.git/config` permission error while the repository was still hot from the command. That repo lookup does not need Git, and keeping it filesystem-only also avoids adding process work to the daemon path.

A separate Windows shard failure in the same main run was a single remote reset from `https://example.com/` in the native TLS cert test, so the test now treats that as an endpoint/network flake unless all trusted endpoints fail.

## Validation

- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=resolve_family`
- `task test CARGO_TEST_ARGS="--test notes_sync_regression" TEST_FILTER=test_notes_sync_push_to_explicit_path_pushes_authorship_to_same_destination`
- `task test CARGO_TEST_ARGS="--test notes_sync_regression"`
- `task test CARGO_TEST_ARGS="--test integration" TEST_FILTER=tls_native_certs::test_https_request_uses_system_certs`
- `task test CARGO_TEST_ARGS="--test integration" TEST_FILTER=graphite::test_gt_pop_retains_working_tree`
- `task test TEST_FILTER=graphite`
- `task fmt`
- `task lint`
- `git diff --check`
- `task test` with local `/home/ubuntu/.opencode/bin` removed from `PATH` because this workstation has an unrelated `opencode` binary that makes an opencode detection test fail on `main` too
