### PR TITLE
ci(nightly): skip live agent test when API key secret is unconfigured

### DIFF
--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -315,7 +315,25 @@ jobs:
           source "$GITHUB_WORKSPACE/scripts/nightly/start-async-daemon.sh" \
             "$GITHUB_WORKSPACE/target/release/git-ai"
 
+      # A live agent CLI needs a real API key to do anything. When the matching
+      # secret is not configured (e.g. on forks, or when a key was rotated out),
+      # the agent makes no changes and the live test fails — a false positive
+      # that has nothing to do with git-ai. Detect that case and skip the live
+      # steps instead of failing the whole nightly and opening a triage issue.
+      - name: Check API key availability
+        id: api_key
+        env:
+          AGENT_API_KEY: ${{ secrets[matrix.api_key_var] }}
+        run: |
+          if [ -z "$AGENT_API_KEY" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Live test skipped::Secret ${{ matrix.api_key_var }} is not configured; skipping live ${{ matrix.agent }} (${{ matrix.channel }}) test."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run live agent test (with retry)
+        if: steps.api_key.outputs.available == 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
           timeout_minutes: 20
@@ -332,6 +350,7 @@ jobs:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
 
       - name: Verify attribution pipeline
+        if: steps.api_key.outputs.available == 'true'
         run: |
           export PATH="$GITHUB_WORKSPACE/target/release:$PATH"
           bash "$GITHUB_WORKSPACE/scripts/nightly/verify-attribution.sh" "${{ matrix.agent }}"

--- a/.github/workflows/nightly-agent-integration.yml
+++ b/.github/workflows/nightly-agent-integration.yml
@@ -323,16 +323,24 @@ jobs:
       - name: Check API key availability
         id: api_key
         env:
-          AGENT_API_KEY: ${{ secrets[matrix.api_key_var] }}
+          # Map each secret explicitly (no dynamic secrets[...] indexing, which
+          # CodeQL flags as excessive secret exposure), then pick the agent's
+          # key by name via bash indirect expansion.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+          API_KEY_VAR: ${{ matrix.api_key_var }}
         run: |
-          if [ -z "$AGENT_API_KEY" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=Live test skipped::Secret ${{ matrix.api_key_var }} is not configured; skipping live ${{ matrix.agent }} (${{ matrix.channel }}) test."
-          else
+          if [ -n "${!API_KEY_VAR:-}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Live test skipped::Secret ${API_KEY_VAR} is not configured; skipping live ${{ matrix.agent }} (${{ matrix.channel }}) test."
           fi
 
       - name: Run live agent test (with retry)
+        id: live_test
         if: steps.api_key.outputs.available == 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
         with:
@@ -340,7 +348,6 @@ jobs:
           max_attempts: 2
           command: |
             export PATH="$GITHUB_WORKSPACE/target/release:$PATH"
-            export ${{ matrix.api_key_var }}="${{ secrets[matrix.api_key_var] }}"
             bash "$GITHUB_WORKSPACE/scripts/nightly/test-live-agent.sh" "${{ matrix.agent }}" "${{ matrix.binary_name }}"
         continue-on-error: ${{ matrix.channel == 'latest' }}
         env:
@@ -350,7 +357,7 @@ jobs:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
 
       - name: Verify attribution pipeline
-        if: steps.api_key.outputs.available == 'true'
+        if: steps.api_key.outputs.available == 'true' && steps.live_test.outcome == 'success'
         run: |
           export PATH="$GITHUB_WORKSPACE/target/release:$PATH"
           bash "$GITHUB_WORKSPACE/scripts/nightly/verify-attribution.sh" "${{ matrix.agent }}"


### PR DESCRIPTION
The nightly agent integration test fails and opens a triage issue whenever an agent's API key secret is empty (e.g. `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` not configured, or a fork without secrets). In that case the agent CLI can do nothing, makes no changes, and the harness reports 'Agent made no changes', a false positive unrelated to git-ai attribution.

Add a 'Check API key availability' guard that reads the matrix agent's key secret and skips the live test + attribution verification steps (with a warning annotation) when it is absent. Agents that DO have a configured key still run and surface real regressions.


Fixes #1741
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->