### PR TITLE
fix(install): use explicit date format to avoid extra whitespace for single-digit days

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -358,7 +358,7 @@ while IFS='|' read -r shell_name config_file; do
     # Append if not already present
     if ! grep -qsF "$INSTALL_DIR" "$config_file"; then
         echo "" >> "$config_file"
-        echo "# Added by git-ai installer on $(date)" >> "$config_file"
+        echo "# Added by git-ai installer on $(date '+%a %b %-e %H:%M:%S %Z %Y')" >> "$config_file"
         echo "$path_cmd" >> "$config_file"
         SHELLS_CONFIGURED="${SHELLS_CONFIGURED}${shell_name}|${config_file}\n"
     else


### PR DESCRIPTION
## Description

The default `$(date)` output pads single-digit days with a leading space (e.g., `Tue Jul  7 20:10:13 EEST 2026`) because the POSIX `date` command uses space-padded day numbers.

This results in shell config files containing lines like:

```
# Added by git-ai installer on Tue Jul  7 20:10:13 EEST 2026
```

with an extra space between the month abbreviation and the day number.

## Fix

Use `date '+%a %b %-e %H:%M:%S %Z %Y'` which uses the GNU/BSD `%-e` format specifier to strip the leading space from the day number, producing clean single-space-separated timestamps:

```
# Added by git-ai installer on Tue Jul 7 20:10:13 EEST 2026
```

The `%-e` format is supported on both Linux (GNU date) and macOS (BSD date), so this is fully portable.

## Related

Fixes #1758
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->