### PR TITLE
fix(checkpoint): normalize Codex namespaced tool names for PD-86

### DIFF
--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -304,8 +304,15 @@ pub enum ToolClass {
 // Tool classification per agent (Section 8.2 of PRD)
 // ---------------------------------------------------------------------------
 
+/// Strip the `functions.` namespace prefix that Codex/OpenAI function-call
+/// tools add to hook tool names (e.g. `functions.apply_patch` -> `apply_patch`).
+fn normalize_tool_name(tool_name: &str) -> &str {
+    tool_name.strip_prefix("functions.").unwrap_or(tool_name)
+}
+
 /// Classify a tool name for a given agent.
 pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
+    let tool_name = normalize_tool_name(tool_name);
     match agent {
         Agent::Claude => match tool_name {
             "Write" | "Edit" | "MultiEdit" => ToolClass::FileEdit,
@@ -345,6 +352,7 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
         Agent::Codex => match tool_name {
             "apply_patch" => ToolClass::FileEdit,
             "Bash" | "exec_command" | "shell" | "shell_command" => ToolClass::Bash,
+            "multi_tool_use.parallel" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
         Agent::Pi => match tool_name {
@@ -1507,6 +1515,49 @@ mod tests {
         );
         assert_eq!(classify_tool(Agent::Cursor, "Shell"), ToolClass::Bash);
         assert_eq!(classify_tool(Agent::Cursor, "Read"), ToolClass::Skip);
+    }
+
+    #[test]
+    fn test_tool_classification_codex_namespaced() {
+        // Codex Desktop/OpenAI function calls namespace tools with "functions." prefix.
+        assert_eq!(
+            classify_tool(Agent::Codex, "functions.apply_patch"),
+            ToolClass::FileEdit
+        );
+        assert_eq!(
+            classify_tool(Agent::Codex, "functions.Bash"),
+            ToolClass::Bash
+        );
+        assert_eq!(
+            classify_tool(Agent::Codex, "functions.exec_command"),
+            ToolClass::Bash
+        );
+        assert_eq!(
+            classify_tool(Agent::Codex, "functions.shell"),
+            ToolClass::Bash
+        );
+        assert_eq!(
+            classify_tool(Agent::Codex, "functions.shell_command"),
+            ToolClass::Bash
+        );
+        // Unqualified names still work as before.
+        assert_eq!(
+            classify_tool(Agent::Codex, "apply_patch"),
+            ToolClass::FileEdit
+        );
+        assert_eq!(classify_tool(Agent::Codex, "Bash"), ToolClass::Bash);
+        assert_eq!(classify_tool(Agent::Codex, "exec_command"), ToolClass::Bash);
+        // The parallel tool wrapper must be routed through the bash/stat-diff path.
+        assert_eq!(
+            classify_tool(Agent::Codex, "multi_tool_use.parallel"),
+            ToolClass::Bash
+        );
+        // Unknown names are still skipped.
+        assert_eq!(
+            classify_tool(Agent::Codex, "functions.Read"),
+            ToolClass::Skip
+        );
+        assert_eq!(classify_tool(Agent::Codex, "Read"), ToolClass::Skip);
     }
 
     #[test]

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -312,7 +312,6 @@ fn normalize_tool_name(tool_name: &str) -> &str {
 
 /// Classify a tool name for a given agent.
 pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
-    let tool_name = normalize_tool_name(tool_name);
     match agent {
         Agent::Claude => match tool_name {
             "Write" | "Edit" | "MultiEdit" => ToolClass::FileEdit,
@@ -349,12 +348,17 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             "Bash" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
-        Agent::Codex => match tool_name {
-            "apply_patch" => ToolClass::FileEdit,
-            "Bash" | "exec_command" | "shell" | "shell_command" => ToolClass::Bash,
-            "multi_tool_use.parallel" => ToolClass::Bash,
-            _ => ToolClass::Skip,
-        },
+        Agent::Codex => {
+            // Codex Desktop (OpenAI function-calling) prefixes tool names with
+            // "functions."; strip it before matching the bare tool name.
+            let tool_name = normalize_tool_name(tool_name);
+            match tool_name {
+                "apply_patch" => ToolClass::FileEdit,
+                "Bash" | "exec_command" | "shell" | "shell_command" => ToolClass::Bash,
+                "multi_tool_use.parallel" => ToolClass::Bash,
+                _ => ToolClass::Skip,
+            }
+        }
         Agent::Pi => match tool_name {
             "edit" | "write" | "replace" | "rename" => ToolClass::FileEdit,
             "bash" => ToolClass::Bash,

--- a/src/commands/checkpoint_agent/presets/codex.rs
+++ b/src/commands/checkpoint_agent/presets/codex.rs
@@ -310,6 +310,92 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_namespaced_tools_are_classified() {
+        for tool_name in &[
+            "functions.apply_patch",
+            "functions.exec_command",
+            "functions.Bash",
+            "multi_tool_use.parallel",
+        ] {
+            let input = json!({
+                "cwd": "/home/user/project",
+                "hook_event_name": "PostToolUse",
+                "tool_name": tool_name,
+                "session_id": "codex-sess-1",
+                "tool_use_id": "tu-1"
+            })
+            .to_string();
+            let events = CodexPreset.parse(&input, "t_test123456789a").unwrap();
+            assert_eq!(events.len(), 1, "{} should parse to one event", tool_name);
+            match &events[0] {
+                ParsedHookEvent::PostBashCall(_) => {
+                    assert!(
+                        tool_name.ends_with("exec_command")
+                            || tool_name.ends_with("Bash")
+                            || *tool_name == "multi_tool_use.parallel",
+                        "{} should be bash",
+                        tool_name
+                    );
+                }
+                ParsedHookEvent::PostFileEdit(_) => {
+                    assert_eq!(
+                        *tool_name, "functions.apply_patch",
+                        "only apply_patch is a file edit"
+                    );
+                }
+                _ => panic!("Expected PostBashCall or PostFileEdit for {}", tool_name),
+            }
+        }
+    }
+
+    #[test]
+    fn test_codex_extracts_patch_file_paths_from_patch_and_command_keys() {
+        let input = json!({
+            "cwd": "/home/user/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "apply_patch",
+            "session_id": "codex-sess-1",
+            "tool_use_id": "patch-1",
+            "tool_input": {
+                "patch": "*** Update File: /home/user/project/src/main.rs\n@@ old\n+new\n"
+            }
+        })
+        .to_string();
+        let events = CodexPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/main.rs")]
+                );
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+
+        let input = json!({
+            "cwd": "/home/user/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "functions.apply_patch",
+            "session_id": "codex-sess-1",
+            "tool_use_id": "patch-2",
+            "tool_input": {
+                "command": "*** Update File: /home/user/project/src/main.rs\n@@ old\n+new\n"
+            }
+        })
+        .to_string();
+        let events = CodexPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/main.rs")]
+                );
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
     fn test_codex_rejects_non_bash_tool() {
         let input = json!({
             "cwd": "/home/user/project",

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -481,6 +481,27 @@ mod tests {
     }
 
     #[test]
+    fn test_opencode_extracts_file_paths_from_patch_key() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "sess-1",
+            "cwd": "/project",
+            "tool_name": "edit",
+            "tool_input": {
+                "patch": "*** Update File: /project/src/main.rs\n@@ old\n+new\n"
+            }
+        })
+        .to_string();
+        let events = OpenCodePreset.parse(&input, "t_test").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.file_paths, vec![PathBuf::from("/project/src/main.rs")]);
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
     fn test_opencode_default_tool_use_id() {
         let input = json!({
             "hook_event_name": "PreToolUse",

--- a/tests/integration/codex.rs
+++ b/tests/integration/codex.rs
@@ -1197,6 +1197,243 @@ fn test_codex_e2e_apply_patch_preserves_human_lines() {
     ]);
 }
 
+#[test]
+fn test_codex_e2e_namespaced_apply_patch_file_edit_full_cycle() {
+    use crate::repos::test_repo::TestRepo;
+
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("lib.rs");
+    fs::write(&file_path, "fn old() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-apply-patch-namespaced.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "codex-apply-patch-namespaced-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "functions.apply_patch",
+        "tool_use_id": "patch-namespaced-1",
+        "tool_input": {
+            "command": format!("*** Update File: {}\n@@ fn old() {{}}\n+fn new_func() {{}}\n", file_path.to_string_lossy())
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("namespaced apply_patch pre-hook should succeed");
+
+    fs::write(&file_path, "fn new_func() {}\nfn helper() {}\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "codex-apply-patch-namespaced-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "functions.apply_patch",
+        "tool_use_id": "patch-namespaced-1",
+        "tool_input": {
+            "command": format!("*** Update File: {}\n@@ fn old() {{}}\n+fn new_func() {{}}\n+fn helper() {{}}\n", file_path.to_string_lossy())
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("namespaced apply_patch post-hook should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Codex namespaced apply_patch edit")
+        .expect("commit should succeed");
+
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("session record should exist");
+
+    assert_eq!(session.agent_id.tool, "codex");
+    assert_eq!(session.agent_id.id, "codex-apply-patch-namespaced-session");
+
+    let mut tracked_file = repo.filename("lib.rs");
+    tracked_file.assert_lines_and_blame(crate::lines![
+        "fn new_func() {}".ai(),
+        "fn helper() {}".ai(),
+    ]);
+}
+
+#[test]
+fn test_codex_e2e_namespaced_exec_command_bash_full_cycle() {
+    use crate::repos::test_repo::TestRepo;
+
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("app.py");
+    fs::write(&file_path, "print('hello')\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-exec-command-namespaced.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "codex-exec-command-namespaced-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "functions.exec_command",
+        "tool_use_id": "exec-namespaced-1",
+        "tool_input": {
+            "command": "sed -i '' 's/hello/world/' app.py"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("namespaced exec_command pre-hook should succeed");
+
+    fs::write(&file_path, "print('world')\nprint('from codex')\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "codex-exec-command-namespaced-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "functions.exec_command",
+        "tool_use_id": "exec-namespaced-1",
+        "tool_input": {
+            "command": "sed -i '' 's/hello/world/' app.py"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("namespaced exec_command post-hook should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Codex namespaced exec_command edit")
+        .expect("commit should succeed");
+
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("session record should exist");
+
+    assert_eq!(session.agent_id.tool, "codex");
+    assert_eq!(session.agent_id.id, "codex-exec-command-namespaced-session");
+
+    let mut tracked_file = repo.filename("app.py");
+    tracked_file.assert_lines_and_blame(crate::lines![
+        "print('world')".ai(),
+        "print('from codex')".ai(),
+    ]);
+}
+
+#[test]
+fn test_codex_e2e_multi_tool_use_parallel_wrapper() {
+    use crate::repos::test_repo::TestRepo;
+
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("main.rs");
+    fs::write(&file_path, "fn old() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-parallel-wrapper.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "codex-parallel-wrapper-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "multi_tool_use.parallel",
+        "tool_use_id": "parallel-1",
+        "tool_input": {
+            "tool_uses": [
+                {
+                    "name": "functions.apply_patch",
+                    "arguments": {"command": format!("*** Update File: {}\n@@ fn old() {{}}\n+fn new_func() {{}}\n", file_path.to_string_lossy())}
+                },
+                {
+                    "name": "functions.exec_command",
+                    "arguments": {"command": "echo 'parallel'"}
+                }
+            ]
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("multi_tool_use.parallel pre-hook should succeed");
+
+    fs::write(&file_path, "fn new_func() {}\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "codex-parallel-wrapper-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "multi_tool_use.parallel",
+        "tool_use_id": "parallel-1",
+        "tool_input": {
+            "tool_uses": [
+                {
+                    "name": "functions.apply_patch",
+                    "arguments": {"command": format!("*** Update File: {}\n@@ fn old() {{}}\n+fn new_func() {{}}\n", file_path.to_string_lossy())}
+                },
+                {
+                    "name": "functions.exec_command",
+                    "arguments": {"command": "echo 'parallel'"}
+                }
+            ]
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("multi_tool_use.parallel post-hook should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Codex multi_tool_use.parallel edit")
+        .expect("commit should succeed");
+
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("session record should exist");
+
+    assert_eq!(session.agent_id.tool, "codex");
+    assert_eq!(session.agent_id.id, "codex-parallel-wrapper-session");
+
+    let mut tracked_file = repo.filename("main.rs");
+    tracked_file.assert_lines_and_blame(crate::lines!["fn new_func() {}".ai(),]);
+}
+
 crate::reuse_tests_in_worktree!(
     test_codex_raw_event_fidelity,
     test_codex_preset_structured_hook_input,
@@ -1216,4 +1453,7 @@ crate::reuse_tests_in_worktree!(
     test_codex_e2e_bash_then_apply_patch_in_same_session,
     test_codex_e2e_bash_modifies_multiple_files_all_attributed,
     test_codex_e2e_apply_patch_preserves_human_lines,
+    test_codex_e2e_namespaced_apply_patch_file_edit_full_cycle,
+    test_codex_e2e_namespaced_exec_command_bash_full_cycle,
+    test_codex_e2e_multi_tool_use_parallel_wrapper,
 );


### PR DESCRIPTION
## Summary

Codex Desktop sends namespaced tool names in `PreToolUse`/`PostToolUse` hook events:

- `functions.apply_patch`
- `functions.exec_command`
- `functions.Bash`

`classify_tool()` in `bash_tool.rs` only matched the bare names, so the Codex preset treated these as `ToolClass::Skip` and left AI-authored edits unattributed (the "untracked changes" in PD-86).

### What changed

- Added `normalize_tool_name()` to strip the `functions.` prefix before classification.
- Scoped the normalization to `Agent::Codex` so other agents' classification is unaffected.
- Updated `classify_tool(Agent::Codex, ...)` so namespaced variants map to the same classes as their bare equivalents:
  - `functions.apply_patch` → `ToolClass::FileEdit`
  - `functions.exec_command` / `functions.Bash` / `shell` / `shell_command` → `ToolClass::Bash`
  - `multi_tool_use.parallel` → `ToolClass::Bash`
- Added unit tests for `classify_tool` with namespaced names.
- Added `TestRepo`-based integration tests for:
  - `functions.apply_patch` file-edit full cycle
  - `functions.exec_command` bash full cycle
  - `multi_tool_use.parallel` wrapper dispatch

### Validation

```bash
# Build
cargo build

# Unit tests
cargo test --lib

# Codex integration tests
cargo test --test integration -- codex --skip _in_worktree
```

The `_in_worktree` variants require `git worktree add --orphan` (Git 2.38+). The remaining tests are not affected by the worktree limitation.

Link to Devin session: https://app.devin.ai/sessions/8e39a47986744c188da41511d0f64470
Requested by: @Siddhant-K-code