### PR TITLE
feat(daemon): add beta await command for daemon drain and telemetry flush

### DIFF
--- a/src/commands/await.rs
+++ b/src/commands/await.rs
@@ -1,4 +1,4 @@
-//! Handle the `pre-exit` command.
+//! Handle the `await` command.
 //!
 //! Waits for the git-ai daemon to finish all in-flight work and telemetry
 //! flushing before the process exits. This is useful in cloud sandboxes where
@@ -6,8 +6,6 @@
 
 use crate::daemon::{ControlRequest, send_control_request};
 use serde::Deserialize;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -15,19 +13,19 @@ const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
 const LOG_INTERVAL_SECONDS: u64 = 5;
 
 #[derive(Debug, Deserialize)]
-struct PreExitResponse {
+struct AwaitResponse {
     done: bool,
     timed_out: bool,
     metrics_remaining: usize,
     notes_remaining: usize,
 }
 
-/// Handle `git-ai pre-exit [--timeout <seconds>]`.
+/// Handle `git-ai await [--timeout <seconds>]`.
 ///
-/// Blocks until the daemon reports it has drained all work and flushed
+/// Beta command. Blocks until the daemon reports it has drained all work and flushed
 /// telemetry, or until the configured timeout elapses. Prints a progress
 /// message every few seconds while waiting.
-pub(crate) fn handle_pre_exit(args: &[String]) {
+pub(crate) fn handle_await(args: &[String]) {
     let mut timeout_secs = DEFAULT_TIMEOUT_SECONDS;
 
     let mut iter = args.iter();
@@ -35,11 +33,11 @@ pub(crate) fn handle_pre_exit(args: &[String]) {
         match arg.as_str() {
             "--timeout" => {
                 let value = iter.next().unwrap_or_else(|| {
-                    eprintln!("pre-exit: --timeout requires a value");
+                    eprintln!("await: --timeout requires a value");
                     std::process::exit(1);
                 });
                 timeout_secs = value.parse::<u64>().unwrap_or_else(|_| {
-                    eprintln!("pre-exit: --timeout must be a positive integer");
+                    eprintln!("await: --timeout must be a positive integer");
                     std::process::exit(1);
                 });
             }
@@ -48,7 +46,7 @@ pub(crate) fn handle_pre_exit(args: &[String]) {
                 std::process::exit(0);
             }
             _ => {
-                eprintln!("pre-exit: unknown argument: {}", arg);
+                eprintln!("await: unknown argument: {}", arg);
                 print_usage();
                 std::process::exit(1);
             }
@@ -58,38 +56,35 @@ pub(crate) fn handle_pre_exit(args: &[String]) {
     let config = match crate::commands::daemon::ensure_daemon_running(Duration::from_secs(5)) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("pre-exit: failed to reach git-ai background service: {}", e);
+            eprintln!("await: failed to reach git-ai background service: {}", e);
             std::process::exit(1);
         }
     };
 
-    let request = ControlRequest::PreExit { timeout_secs };
+    let request = ControlRequest::Await { timeout_secs };
 
-    eprintln!("pre-exit: waiting for background service to finish work...");
+    eprintln!("await: waiting for background service to finish work...");
 
-    let running = Arc::new(AtomicBool::new(true));
-    let running_for_thread = Arc::clone(&running);
-
+    let (stop_progress_tx, stop_progress_rx) = std::sync::mpsc::channel();
     let progress_handle = thread::spawn(move || {
-        while running_for_thread.load(Ordering::Relaxed) {
-            thread::sleep(Duration::from_secs(LOG_INTERVAL_SECONDS));
-            if running_for_thread.load(Ordering::Relaxed) {
-                eprintln!("pre-exit: still waiting for background service...");
+        loop {
+            match stop_progress_rx.recv_timeout(Duration::from_secs(LOG_INTERVAL_SECONDS)) {
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    eprintln!("await: still waiting for background service...");
+                }
             }
         }
     });
 
     let response = send_control_request(&config.control_socket_path, &request);
-    running.store(false, Ordering::Relaxed);
+    let _ = stop_progress_tx.send(());
     let _ = progress_handle.join();
 
     let response = match response {
         Ok(r) => r,
         Err(e) => {
-            eprintln!(
-                "pre-exit: failed to send request to background service: {}",
-                e
-            );
+            eprintln!("await: failed to send request to background service: {}", e);
             std::process::exit(1);
         }
     };
@@ -103,43 +98,45 @@ pub(crate) fn handle_pre_exit(args: &[String]) {
                     .map(|s| s.to_string())
             })
             .unwrap_or_else(|| "background service returned an error".to_string());
-        eprintln!("pre-exit: {}", message);
+        eprintln!("await: {}", message);
         std::process::exit(1);
     }
 
     let data = match response.data {
-        Some(value) => match serde_json::from_value::<PreExitResponse>(value) {
+        Some(value) => match serde_json::from_value::<AwaitResponse>(value) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("pre-exit: failed to parse response: {}", e);
+                eprintln!("await: failed to parse response: {}", e);
                 std::process::exit(1);
             }
         },
         None => {
-            eprintln!("pre-exit: background service returned an empty response");
+            eprintln!("await: background service returned an empty response");
             std::process::exit(1);
         }
     };
 
     if data.timed_out {
-        eprintln!("pre-exit: timed out after {}s", timeout_secs);
+        eprintln!("await: timed out after {}s", timeout_secs);
         std::process::exit(1);
     }
 
     if !data.done {
         eprintln!(
-            "pre-exit: background service could not finish ({} metrics, {} notes remaining)",
+            "await: background service could not finish ({} metrics, {} notes remaining)",
             data.metrics_remaining, data.notes_remaining
         );
         std::process::exit(1);
     }
 
-    eprintln!("pre-exit: background service finished");
+    eprintln!("await: background service finished");
 }
 
 fn print_usage() {
-    eprintln!("Usage: git-ai pre-exit [--timeout <seconds>]");
-    eprintln!("  Wait for the background service to finish all work and telemetry flushing.");
+    eprintln!("Usage: git-ai await [--timeout <seconds>]");
+    eprintln!(
+        "  [beta] Wait for the background service to finish all work and telemetry flushing."
+    );
     eprintln!();
     eprintln!("Options:");
     eprintln!(

--- a/src/commands/await.rs
+++ b/src/commands/await.rs
@@ -36,10 +36,13 @@ pub(crate) fn handle_await(args: &[String]) {
                     eprintln!("await: --timeout requires a value");
                     std::process::exit(1);
                 });
-                timeout_secs = value.parse::<u64>().unwrap_or_else(|_| {
-                    eprintln!("await: --timeout must be a positive integer");
-                    std::process::exit(1);
-                });
+                timeout_secs = match value.parse::<u64>() {
+                    Ok(value) if value > 0 => value,
+                    _ => {
+                        eprintln!("await: --timeout must be a positive integer");
+                        std::process::exit(1);
+                    }
+                };
             }
             "--help" | "-h" | "help" => {
                 print_usage();

--- a/src/commands/await.rs
+++ b/src/commands/await.rs
@@ -4,7 +4,7 @@
 //! flushing before the process exits. This is useful in cloud sandboxes where
 //! the container may be torn down immediately after a build step.
 
-use crate::daemon::{ControlRequest, send_control_request};
+use crate::daemon::{ControlRequest, ControlResponse, send_control_request};
 use serde::Deserialize;
 use std::thread;
 use std::time::Duration;
@@ -93,14 +93,7 @@ pub(crate) fn handle_await(args: &[String]) {
     };
 
     if !response.ok {
-        let message = response
-            .data
-            .and_then(|v| {
-                v.get("message")
-                    .and_then(|m| m.as_str())
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| "background service returned an error".to_string());
+        let message = response_error_message(&response);
         eprintln!("await: {}", message);
         std::process::exit(1);
     }
@@ -135,6 +128,13 @@ pub(crate) fn handle_await(args: &[String]) {
     eprintln!("await: background service finished");
 }
 
+fn response_error_message(response: &ControlResponse) -> &str {
+    response
+        .error
+        .as_deref()
+        .unwrap_or("background service returned an error")
+}
+
 fn print_usage() {
     eprintln!("Usage: git-ai await [--timeout <seconds>]");
     eprintln!(
@@ -147,4 +147,16 @@ fn print_usage() {
         DEFAULT_TIMEOUT_SECONDS
     );
     eprintln!("  -h, --help           Show this help");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn await_reports_daemon_error_message() {
+        let response = ControlResponse::err("telemetry flush failed");
+
+        assert_eq!(response_error_message(&response), "telemetry flush failed");
+    }
 }

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -191,8 +191,8 @@ pub fn handle_git_ai(args: &[String]) {
         "flush-metrics-db" => {
             commands::flush_metrics_db::handle_flush_metrics_db(&args[1..]);
         }
-        "pre-exit" => {
-            commands::pre_exit::handle_pre_exit(&args[1..]);
+        "await" => {
+            commands::r#await::handle_await(&args[1..]);
         }
         "login" => {
             commands::login::handle_login(&args[1..]);
@@ -374,7 +374,7 @@ fn print_help() {
     eprintln!("  ci                 Continuous integration utilities");
     eprintln!("    github                 GitHub CI helpers");
     eprintln!("  git-path           Print the path to the underlying git executable");
-    eprintln!("  pre-exit           Wait for the background service to finish all work");
+    eprintln!("  await [beta]       Wait for the background service to finish all work");
     eprintln!("    --timeout <seconds>    Maximum time to wait (default: 30)");
     eprintln!("  upgrade            Check for updates and install if available");
     eprintln!("    --force               Reinstall latest version even if already up to date");

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -191,6 +191,9 @@ pub fn handle_git_ai(args: &[String]) {
         "flush-metrics-db" => {
             commands::flush_metrics_db::handle_flush_metrics_db(&args[1..]);
         }
+        "pre-exit" => {
+            commands::pre_exit::handle_pre_exit(&args[1..]);
+        }
         "login" => {
             commands::login::handle_login(&args[1..]);
         }
@@ -371,6 +374,8 @@ fn print_help() {
     eprintln!("  ci                 Continuous integration utilities");
     eprintln!("    github                 GitHub CI helpers");
     eprintln!("  git-path           Print the path to the underlying git executable");
+    eprintln!("  pre-exit           Wait for the background service to finish all work");
+    eprintln!("    --timeout <seconds>    Maximum time to wait (default: 30)");
     eprintln!("  upgrade            Check for updates and install if available");
     eprintln!("    --force               Reinstall latest version even if already up to date");
     eprintln!("  fetch-notes [remote] Synchronously fetch AI authorship notes");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod r#await;
 pub mod blame;
 pub mod checkpoint_agent;
 pub mod ci_handlers;
@@ -18,7 +19,6 @@ pub mod login;
 pub mod logout;
 pub mod notes_migrate;
 pub mod personal_dashboard;
-pub mod pre_exit;
 pub mod show;
 pub mod show_prompt;
 pub mod status;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod login;
 pub mod logout;
 pub mod notes_migrate;
 pub mod personal_dashboard;
+pub mod pre_exit;
 pub mod show;
 pub mod show_prompt;
 pub mod status;

--- a/src/commands/pre_exit.rs
+++ b/src/commands/pre_exit.rs
@@ -1,0 +1,150 @@
+//! Handle the `pre-exit` command.
+//!
+//! Waits for the git-ai daemon to finish all in-flight work and telemetry
+//! flushing before the process exits. This is useful in cloud sandboxes where
+//! the container may be torn down immediately after a build step.
+
+use crate::daemon::{ControlRequest, send_control_request};
+use serde::Deserialize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+const DEFAULT_TIMEOUT_SECONDS: u64 = 30;
+const LOG_INTERVAL_SECONDS: u64 = 5;
+
+#[derive(Debug, Deserialize)]
+struct PreExitResponse {
+    done: bool,
+    timed_out: bool,
+    metrics_remaining: usize,
+    notes_remaining: usize,
+}
+
+/// Handle `git-ai pre-exit [--timeout <seconds>]`.
+///
+/// Blocks until the daemon reports it has drained all work and flushed
+/// telemetry, or until the configured timeout elapses. Prints a progress
+/// message every few seconds while waiting.
+pub(crate) fn handle_pre_exit(args: &[String]) {
+    let mut timeout_secs = DEFAULT_TIMEOUT_SECONDS;
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--timeout" => {
+                let value = iter.next().unwrap_or_else(|| {
+                    eprintln!("pre-exit: --timeout requires a value");
+                    std::process::exit(1);
+                });
+                timeout_secs = value.parse::<u64>().unwrap_or_else(|_| {
+                    eprintln!("pre-exit: --timeout must be a positive integer");
+                    std::process::exit(1);
+                });
+            }
+            "--help" | "-h" | "help" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            _ => {
+                eprintln!("pre-exit: unknown argument: {}", arg);
+                print_usage();
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let config = match crate::commands::daemon::ensure_daemon_running(Duration::from_secs(5)) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("pre-exit: failed to reach git-ai background service: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let request = ControlRequest::PreExit { timeout_secs };
+
+    eprintln!("pre-exit: waiting for background service to finish work...");
+
+    let running = Arc::new(AtomicBool::new(true));
+    let running_for_thread = Arc::clone(&running);
+
+    let progress_handle = thread::spawn(move || {
+        while running_for_thread.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_secs(LOG_INTERVAL_SECONDS));
+            if running_for_thread.load(Ordering::Relaxed) {
+                eprintln!("pre-exit: still waiting for background service...");
+            }
+        }
+    });
+
+    let response = send_control_request(&config.control_socket_path, &request);
+    running.store(false, Ordering::Relaxed);
+    let _ = progress_handle.join();
+
+    let response = match response {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "pre-exit: failed to send request to background service: {}",
+                e
+            );
+            std::process::exit(1);
+        }
+    };
+
+    if !response.ok {
+        let message = response
+            .data
+            .and_then(|v| {
+                v.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or_else(|| "background service returned an error".to_string());
+        eprintln!("pre-exit: {}", message);
+        std::process::exit(1);
+    }
+
+    let data = match response.data {
+        Some(value) => match serde_json::from_value::<PreExitResponse>(value) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("pre-exit: failed to parse response: {}", e);
+                std::process::exit(1);
+            }
+        },
+        None => {
+            eprintln!("pre-exit: background service returned an empty response");
+            std::process::exit(1);
+        }
+    };
+
+    if data.timed_out {
+        eprintln!("pre-exit: timed out after {}s", timeout_secs);
+        std::process::exit(1);
+    }
+
+    if !data.done {
+        eprintln!(
+            "pre-exit: background service could not finish ({} metrics, {} notes remaining)",
+            data.metrics_remaining, data.notes_remaining
+        );
+        std::process::exit(1);
+    }
+
+    eprintln!("pre-exit: background service finished");
+}
+
+fn print_usage() {
+    eprintln!("Usage: git-ai pre-exit [--timeout <seconds>]");
+    eprintln!("  Wait for the background service to finish all work and telemetry flushing.");
+    eprintln!();
+    eprintln!("Options:");
+    eprintln!(
+        "  --timeout <seconds>  Maximum time to wait (default: {})",
+        DEFAULT_TIMEOUT_SECONDS
+    );
+    eprintln!("  -h, --help           Show this help");
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6210,7 +6210,7 @@ impl ActorDaemonCoordinator {
                 // Trigger an immediate notes flush in a blocking task.
                 // Fire-and-forget: the periodic flush loop is the safety net.
                 tokio::task::spawn_blocking(|| {
-                    crate::daemon::telemetry_worker::flush_notes(false);
+                    crate::daemon::telemetry_worker::flush_notes();
                 });
                 Ok(ControlResponse::ok(None, None))
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -153,9 +153,9 @@ pub fn daemon_process_active() -> bool {
     DAEMON_PROCESS_ACTIVE.load(Ordering::SeqCst)
 }
 
-/// Result returned by the `pre-exit` control request.
+/// Result returned by the `await` control request.
 #[derive(Debug, Serialize, Deserialize)]
-struct PreExitResult {
+struct AwaitResult {
     done: bool,
     timed_out: bool,
     metrics_remaining: usize,
@@ -5978,10 +5978,10 @@ impl ActorDaemonCoordinator {
 
     /// Wait for the daemon to finish all in-flight work and telemetry flushing.
     ///
-    /// Progress is logged every few seconds. Returns a `PreExitResult` describing
+    /// Progress is logged every few seconds. Returns an `AwaitResult` describing
     /// whether the daemon was idle before the timeout and how much telemetry
     /// (if any) is still pending.
-    async fn pre_exit(&self, timeout_secs: u64) -> PreExitResult {
+    async fn await_completion(&self, timeout_secs: u64) -> AwaitResult {
         use tokio::time::{Duration, Instant, timeout};
 
         let start = Instant::now();
@@ -5989,7 +5989,7 @@ impl ActorDaemonCoordinator {
         let log_interval = Duration::from_secs(3);
         let mut last_log = start;
 
-        let mut result = PreExitResult {
+        let mut result = AwaitResult {
             done: false,
             timed_out: false,
             metrics_remaining: 0,
@@ -5999,8 +5999,8 @@ impl ActorDaemonCoordinator {
         let mut maybe_log = |phase: &str| {
             let now = Instant::now();
             if now - last_log >= log_interval {
-                tracing::info!(phase, "pre-exit: still waiting");
-                eprintln!("pre-exit: still waiting for {}...", phase);
+                tracing::info!(phase, "await: still waiting");
+                eprintln!("await: still waiting for {}...", phase);
                 last_log = now;
             }
         };
@@ -6064,7 +6064,7 @@ impl ActorDaemonCoordinator {
                 match timeout(remaining, worker.drain()).await {
                     Ok(Ok(())) => {}
                     Ok(Err(e)) => {
-                        tracing::warn!(error = %e, "pre-exit: transcript drain failed");
+                        tracing::warn!(error = %e, "await: transcript drain failed");
                     }
                     Err(_) => {
                         result.timed_out = true;
@@ -6089,7 +6089,7 @@ impl ActorDaemonCoordinator {
                         result.notes_remaining = status.notes_remaining;
                     }
                     Ok(Err(e)) => {
-                        tracing::warn!(error = %e, "pre-exit: telemetry flush failed");
+                        tracing::warn!(error = %e, "await: telemetry flush failed");
                     }
                     Err(_) => {
                         result.timed_out = true;
@@ -6214,8 +6214,8 @@ impl ActorDaemonCoordinator {
                 });
                 Ok(ControlResponse::ok(None, None))
             }
-            ControlRequest::PreExit { timeout_secs } => {
-                let result = self.pre_exit(timeout_secs).await;
+            ControlRequest::Await { timeout_secs } => {
+                let result = self.await_completion(timeout_secs).await;
                 serde_json::to_value(result)
                     .map(|v| ControlResponse::ok(None, Some(v)))
                     .map_err(GitAiError::from)
@@ -7571,10 +7571,10 @@ fn checkpoint_control_response_timeout(
         }
         ControlRequest::SyncFamily { .. } => DAEMON_CHECKPOINT_RESPONSE_TIMEOUT,
         ControlRequest::SnapshotWatermarks { .. } => Duration::from_millis(500),
-        // Pre-exit blocks until the requested timeout is reached; give the daemon
+        // Await blocks until the requested timeout is reached; give the daemon
         // a small grace period over the requested limit so the caller sees a
         // response rather than a client-side socket timeout.
-        ControlRequest::PreExit { timeout_secs } => {
+        ControlRequest::Await { timeout_secs } => {
             Duration::from_secs(timeout_secs.saturating_add(5))
         }
         _ => DAEMON_CONTROL_RESPONSE_TIMEOUT,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -153,6 +153,15 @@ pub fn daemon_process_active() -> bool {
     DAEMON_PROCESS_ACTIVE.load(Ordering::SeqCst)
 }
 
+/// Result returned by the `pre-exit` control request.
+#[derive(Debug, Serialize, Deserialize)]
+struct PreExitResult {
+    done: bool,
+    timed_out: bool,
+    metrics_remaining: usize,
+    notes_remaining: usize,
+}
+
 struct DaemonProcessActiveGuard;
 
 impl DaemonProcessActiveGuard {
@@ -5967,6 +5976,164 @@ impl ActorDaemonCoordinator {
         self.status_for_family(repo_working_dir).await
     }
 
+    /// Wait for the daemon to finish all in-flight work and telemetry flushing.
+    ///
+    /// Progress is logged every few seconds. Returns a `PreExitResult` describing
+    /// whether the daemon was idle before the timeout and how much telemetry
+    /// (if any) is still pending.
+    async fn pre_exit(&self, timeout_secs: u64) -> PreExitResult {
+        use tokio::time::{Duration, Instant, timeout};
+
+        let start = Instant::now();
+        let deadline = start + Duration::from_secs(timeout_secs);
+        let log_interval = Duration::from_secs(3);
+        let mut last_log = start;
+
+        let mut result = PreExitResult {
+            done: false,
+            timed_out: false,
+            metrics_remaining: 0,
+            notes_remaining: 0,
+        };
+
+        let mut maybe_log = |phase: &str| {
+            let now = Instant::now();
+            if now - last_log >= log_interval {
+                tracing::info!(phase, "pre-exit: still waiting");
+                eprintln!("pre-exit: still waiting for {}...", phase);
+                last_log = now;
+            }
+        };
+
+        // Phase 1: wait for the trace-ingest and family-sequencer work side.
+        while !self.is_shutting_down() {
+            let now = Instant::now();
+            if now >= deadline {
+                result.timed_out = true;
+                break;
+            }
+            let remaining = deadline - now;
+
+            maybe_log("daemon work");
+            if timeout(remaining, self.wait_for_trace_ingest_processed_through())
+                .await
+                .is_err()
+            {
+                result.timed_out = true;
+                break;
+            }
+
+            if self.is_shutting_down() {
+                break;
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                result.timed_out = true;
+                break;
+            }
+            let remaining = deadline - now;
+
+            if timeout(remaining, self.drain_all_ready_family_sequencers())
+                .await
+                .is_err()
+            {
+                result.timed_out = true;
+                break;
+            }
+
+            if !self.has_pending_daemon_work() {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        if self.is_shutting_down() {
+            result.timed_out = true;
+        }
+
+        // Phase 2: drain the transcript/stream worker.
+        if !result.timed_out
+            && let Some(worker) = &self.stream_worker
+        {
+            let now = Instant::now();
+            if now < deadline {
+                let remaining = deadline - now;
+                maybe_log("transcript processing");
+                match timeout(remaining, worker.drain()).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, "pre-exit: transcript drain failed");
+                    }
+                    Err(_) => {
+                        result.timed_out = true;
+                    }
+                }
+            } else {
+                result.timed_out = true;
+            }
+        }
+
+        // Phase 3: flush telemetry and wait for the worker to finish.
+        if !result.timed_out
+            && let Some(worker) = &self.telemetry_worker
+        {
+            let now = Instant::now();
+            if now < deadline {
+                let remaining = deadline - now;
+                maybe_log("telemetry flush");
+                match timeout(remaining, worker.flush_and_wait()).await {
+                    Ok(Ok(status)) => {
+                        result.metrics_remaining = status.metrics_remaining;
+                        result.notes_remaining = status.notes_remaining;
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, "pre-exit: telemetry flush failed");
+                    }
+                    Err(_) => {
+                        result.timed_out = true;
+                    }
+                }
+            } else {
+                result.timed_out = true;
+            }
+        }
+
+        result.done = !result.timed_out
+            && result.metrics_remaining == 0
+            && result.notes_remaining == 0
+            && !self.has_pending_daemon_work();
+        result
+    }
+
+    fn has_pending_daemon_work(&self) -> bool {
+        if self.queued_trace_payloads.load(Ordering::Acquire) > 0 {
+            return true;
+        }
+        if self.next_trace_ingest_seq.load(Ordering::Acquire)
+            > self.processed_trace_ingest_seq.load(Ordering::Acquire)
+        {
+            return true;
+        }
+        if self.has_open_trace_roots_that_may_mutate_refs() {
+            return true;
+        }
+        if let Ok(map) = self.inflight_effects_by_family.lock()
+            && !map.is_empty()
+        {
+            return true;
+        }
+        if let Ok(map) = self.family_sequencers_by_family.lock() {
+            for state in map.values() {
+                if !state.entries.is_empty() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     async fn handle_control_request(&self, request: ControlRequest) -> ControlResponse {
         let result = match request {
             ControlRequest::Ping => Ok(ControlResponse::ok(None, None)),
@@ -6043,9 +6210,15 @@ impl ActorDaemonCoordinator {
                 // Trigger an immediate notes flush in a blocking task.
                 // Fire-and-forget: the periodic flush loop is the safety net.
                 tokio::task::spawn_blocking(|| {
-                    crate::daemon::telemetry_worker::flush_notes();
+                    crate::daemon::telemetry_worker::flush_notes(false);
                 });
                 Ok(ControlResponse::ok(None, None))
+            }
+            ControlRequest::PreExit { timeout_secs } => {
+                let result = self.pre_exit(timeout_secs).await;
+                serde_json::to_value(result)
+                    .map(|v| ControlResponse::ok(None, Some(v)))
+                    .map_err(GitAiError::from)
             }
             ControlRequest::BashSessionStart {
                 repo_work_dir,
@@ -7398,6 +7571,12 @@ fn checkpoint_control_response_timeout(
         }
         ControlRequest::SyncFamily { .. } => DAEMON_CHECKPOINT_RESPONSE_TIMEOUT,
         ControlRequest::SnapshotWatermarks { .. } => Duration::from_millis(500),
+        // Pre-exit blocks until the requested timeout is reached; give the daemon
+        // a small grace period over the requested limit so the caller sees a
+        // response rather than a client-side socket timeout.
+        ControlRequest::PreExit { timeout_secs } => {
+            Duration::from_secs(timeout_secs.saturating_add(5))
+        }
         _ => DAEMON_CONTROL_RESPONSE_TIMEOUT,
     }
 }

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -85,8 +85,8 @@ pub enum ControlRequest {
         command: Option<String>,
     },
     /// Wait for the daemon to finish all in-flight work and flush telemetry.
-    #[serde(rename = "pre-exit")]
-    PreExit { timeout_secs: u64 },
+    #[serde(rename = "await")]
+    Await { timeout_secs: u64 },
     #[serde(rename = "shutdown")]
     Shutdown,
 }

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -84,6 +84,9 @@ pub enum ControlRequest {
         ended_at_ns: u128,
         command: Option<String>,
     },
+    /// Wait for the daemon to finish all in-flight work and flush telemetry.
+    #[serde(rename = "pre-exit")]
+    PreExit { timeout_secs: u64 },
     #[serde(rename = "shutdown")]
     Shutdown,
 }

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -1297,22 +1297,7 @@ impl StreamWorker {
 
     /// Drain immediate priority tasks before shutdown.
     async fn drain_immediate_tasks(&mut self) {
-        let mut immediate_tasks = Vec::new();
-
-        // Collect all immediate tasks from priority queue and delayed tasks
-        while let Some(task) = self.priority_queue.pop() {
-            if task.priority == Priority::Immediate {
-                immediate_tasks.push(task);
-            }
-        }
-        let mut i = 0;
-        while i < self.delayed_tasks.len() {
-            if self.delayed_tasks[i].priority == Priority::Immediate {
-                immediate_tasks.push(self.delayed_tasks.swap_remove(i));
-            } else {
-                i += 1;
-            }
-        }
+        let immediate_tasks = self.take_immediate_tasks();
 
         tracing::info!(tasks = immediate_tasks.len(), "draining immediate tasks");
 
@@ -1343,6 +1328,32 @@ impl StreamWorker {
                 Ok(Ok(())) => {}
             }
         }
+    }
+
+    /// Removes immediate tasks while preserving lower-priority work.
+    fn take_immediate_tasks(&mut self) -> Vec<ProcessingTask> {
+        let mut immediate_tasks = Vec::new();
+        let mut retained_tasks = Vec::new();
+
+        while let Some(task) = self.priority_queue.pop() {
+            if task.priority == Priority::Immediate {
+                immediate_tasks.push(task);
+            } else {
+                retained_tasks.push(task);
+            }
+        }
+        self.priority_queue.extend(retained_tasks);
+
+        let mut i = 0;
+        while i < self.delayed_tasks.len() {
+            if self.delayed_tasks[i].priority == Priority::Immediate {
+                immediate_tasks.push(self.delayed_tasks.swap_remove(i));
+            } else {
+                i += 1;
+            }
+        }
+
+        immediate_tasks
     }
 }
 
@@ -1505,6 +1516,24 @@ mod scheduling_tests {
         worker.delayed_tasks.push(task("earlier", Some(earlier)));
 
         assert_eq!(worker.next_delayed_task_at(), Some(earlier));
+    }
+
+    #[test]
+    fn take_immediate_tasks_preserves_low_priority_tasks() {
+        let (_temp, mut worker, _shutdown) = make_worker();
+        let immediate = task("immediate", None);
+        let mut queued_low = task("queued-low", None);
+        queued_low.priority = Priority::Low;
+        let mut delayed_low = task("delayed-low", None);
+        delayed_low.priority = Priority::Low;
+
+        worker.priority_queue.push(immediate.clone());
+        worker.priority_queue.push(queued_low.clone());
+        worker.delayed_tasks.push(delayed_low.clone());
+
+        assert_eq!(worker.take_immediate_tasks(), vec![immediate]);
+        assert_eq!(worker.priority_queue.into_vec(), vec![queued_low]);
+        assert_eq!(worker.delayed_tasks, vec![delayed_low]);
     }
 
     #[tokio::test]

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -408,29 +408,10 @@ impl StreamWorker {
                     self.handle_checkpoint_notification(notification).await;
                 }
                 Some(request) = self.sweep_rx.recv() => {
-                    if sweep_enabled {
-                        tracing::info!(trigger = %request.trigger, "triggered transcript sweep requested");
-                        let result = self.run_sweep(request.priority).await;
-                        if let Err(e) = &result {
-                            tracing::error!(trigger = %request.trigger, error = %e, "triggered sweep failed");
-                        }
-                        if let Some(completion) = request.completion {
-                            let _ = completion.send(result.map(|_| ()));
-                        }
-                    } else {
-                        tracing::debug!(
-                            trigger = %request.trigger,
-                            "triggered transcript sweep skipped because transcript_sweep is disabled"
-                        );
-                        if let Some(completion) = request.completion {
-                            let _ = completion.send(Err(
-                                "transcript_sweep feature is disabled".to_string(),
-                            ));
-                        }
-                    }
+                    self.handle_sweep_request(request, sweep_enabled).await;
                 }
                 Some(request) = self.drain_rx.recv() => {
-                    self.handle_drain_request(request).await;
+                    self.handle_drain_request(request, sweep_enabled).await;
                 }
             }
         }
@@ -450,7 +431,38 @@ impl StreamWorker {
         }
     }
 
-    async fn handle_drain_request(&mut self, request: DrainRequest) {
+    async fn handle_sweep_request(&mut self, request: SweepRequest, sweep_enabled: bool) {
+        if sweep_enabled {
+            tracing::info!(trigger = %request.trigger, "triggered transcript sweep requested");
+            let result = self.run_sweep(request.priority).await;
+            if let Err(e) = &result {
+                tracing::error!(trigger = %request.trigger, error = %e, "triggered sweep failed");
+            }
+            if let Some(completion) = request.completion {
+                let _ = completion.send(result.map(|_| ()));
+            }
+        } else {
+            tracing::debug!(
+                trigger = %request.trigger,
+                "triggered transcript sweep skipped because transcript_sweep is disabled"
+            );
+            if let Some(completion) = request.completion {
+                let _ = completion.send(Err("transcript_sweep feature is disabled".to_string()));
+            }
+        }
+    }
+
+    async fn handle_drain_request(&mut self, request: DrainRequest, sweep_enabled: bool) {
+        // Checkpoint and sweep requests use separate channels from the drain
+        // barrier, so consume ingress that was already queued before the barrier.
+        while let Ok(notification) = self.checkpoint_rx.try_recv() {
+            self.handle_checkpoint_notification(notification).await;
+        }
+        while let Ok(sweep_request) = self.sweep_rx.try_recv() {
+            self.handle_sweep_request(sweep_request, sweep_enabled)
+                .await;
+        }
+
         // Process immediate priority tasks that are already queued.
         self.drain_immediate_tasks().await;
 
@@ -1450,10 +1462,15 @@ mod scheduling_tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_worker() -> (TempDir, StreamWorker, Arc<Notify>) {
+    fn make_worker() -> (
+        TempDir,
+        StreamWorker,
+        Arc<Notify>,
+        tokio::sync::mpsc::UnboundedSender<CheckpointNotification>,
+    ) {
         let temp = TempDir::new().unwrap();
         let db = Arc::new(StreamsDatabase::open(temp.path().join("streams.db")).unwrap());
-        let (_checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
         let (_sweep_tx, sweep_rx) = tokio::sync::mpsc::unbounded_channel();
         let (_drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
         let shutdown = Arc::new(Notify::new());
@@ -1471,7 +1488,7 @@ mod scheduling_tests {
             drain_rx,
             sweep_trigger_gate,
         );
-        (temp, worker, shutdown)
+        (temp, worker, shutdown, checkpoint_tx)
     }
 
     fn task(session_id: &str, next_retry_at: Option<std::time::Instant>) -> ProcessingTask {
@@ -1491,7 +1508,7 @@ mod scheduling_tests {
 
     #[test]
     fn promotes_only_ready_delayed_tasks() {
-        let (_temp, mut worker, _shutdown) = make_worker();
+        let (_temp, mut worker, _shutdown, _checkpoint_tx) = make_worker();
         let now = std::time::Instant::now();
         worker.delayed_tasks.push(task("ready", Some(now)));
         worker
@@ -1508,7 +1525,7 @@ mod scheduling_tests {
 
     #[test]
     fn next_delayed_task_at_returns_earliest_retry_deadline() {
-        let (_temp, mut worker, _shutdown) = make_worker();
+        let (_temp, mut worker, _shutdown, _checkpoint_tx) = make_worker();
         let now = std::time::Instant::now();
         let later = now + Duration::from_secs(30);
         let earlier = now + Duration::from_secs(5);
@@ -1520,7 +1537,7 @@ mod scheduling_tests {
 
     #[test]
     fn take_immediate_tasks_preserves_low_priority_tasks() {
-        let (_temp, mut worker, _shutdown) = make_worker();
+        let (_temp, mut worker, _shutdown, _checkpoint_tx) = make_worker();
         let immediate = task("immediate", None);
         let mut queued_low = task("queued-low", None);
         queued_low.priority = Priority::Low;
@@ -1538,7 +1555,7 @@ mod scheduling_tests {
 
     #[tokio::test]
     async fn transient_errors_are_stored_as_delayed_retries_not_ready_work() {
-        let (_temp, mut worker, _shutdown) = make_worker();
+        let (_temp, mut worker, _shutdown, _checkpoint_tx) = make_worker();
 
         worker
             .handle_processing_error(
@@ -1559,7 +1576,7 @@ mod scheduling_tests {
 
     #[tokio::test]
     async fn shutdown_wakes_idle_worker() {
-        let (_temp, worker, shutdown) = make_worker();
+        let (_temp, worker, shutdown, _checkpoint_tx) = make_worker();
         let handle = tokio::spawn(worker.run());
         tokio::task::yield_now().await;
 
@@ -1573,7 +1590,7 @@ mod scheduling_tests {
 
     #[tokio::test]
     async fn shutdown_wakes_worker_sleeping_until_future_retry() {
-        let (_temp, mut worker, shutdown) = make_worker();
+        let (_temp, mut worker, shutdown, _checkpoint_tx) = make_worker();
         worker.delayed_tasks.push(task(
             "future-retry",
             Some(std::time::Instant::now() + Duration::from_secs(60 * 60)),
@@ -1587,6 +1604,39 @@ mod scheduling_tests {
             .await
             .expect("retry-sleeping worker should exit promptly after shutdown notification")
             .expect("worker task should not panic");
+    }
+
+    #[tokio::test]
+    async fn drain_processes_queued_checkpoint_notifications_before_completing() {
+        let (temp, mut worker, _shutdown, checkpoint_tx) = make_worker();
+        checkpoint_tx
+            .send(CheckpointNotification {
+                session_id: "session".to_string(),
+                tool: "unknown".to_string(),
+                trace_id: "trace".to_string(),
+                tool_use_id: None,
+                stream_path: temp.path().join("transcript.jsonl"),
+                repo_work_dir: Some(temp.path().to_path_buf()),
+                external_session_id: "external".to_string(),
+                external_parent_session_id: None,
+            })
+            .unwrap();
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+
+        worker
+            .handle_drain_request(
+                DrainRequest {
+                    completion: completion_tx,
+                },
+                false,
+            )
+            .await;
+
+        completion_rx.await.unwrap();
+        assert!(
+            worker.checkpoint_rx.is_empty(),
+            "drain must process checkpoint notifications queued before the barrier"
+        );
     }
 }
 

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -105,6 +105,10 @@ struct SweepRequest {
     completion: Option<std::sync::mpsc::Sender<Result<(), String>>>,
 }
 
+struct DrainRequest {
+    completion: tokio::sync::oneshot::Sender<()>,
+}
+
 impl SweepRequest {
     fn normal(trigger: SweepTrigger) -> Self {
         Self {
@@ -182,6 +186,7 @@ impl SweepTriggerGate {
 pub struct StreamWorkerHandle {
     checkpoint_tx: tokio::sync::mpsc::UnboundedSender<CheckpointNotification>,
     sweep_tx: tokio::sync::mpsc::UnboundedSender<SweepRequest>,
+    drain_tx: tokio::sync::mpsc::UnboundedSender<DrainRequest>,
     sweep_trigger_gate: SweepTriggerGate,
 }
 
@@ -252,12 +257,30 @@ impl StreamWorkerHandle {
         })
     }
 
+    /// Request that the worker drain all immediate processing tasks.
+    ///
+    /// Returns after the worker has finished processing all currently-enqueued
+    /// immediate-priority tasks and any that are already in flight.
+    pub async fn drain(&self) -> Result<(), String> {
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        self.drain_tx
+            .send(DrainRequest {
+                completion: completion_tx,
+            })
+            .map_err(|_| "stream worker has stopped".to_string())?;
+        completion_rx
+            .await
+            .map_err(|_| "stream worker drain was cancelled".to_string())
+    }
+
     #[cfg(test)]
     fn for_test_sweep_triggers(sweep_tx: tokio::sync::mpsc::UnboundedSender<SweepRequest>) -> Self {
         let (checkpoint_tx, _checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (drain_tx, _drain_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             checkpoint_tx,
             sweep_tx,
+            drain_tx,
             sweep_trigger_gate: SweepTriggerGate::new(),
         }
     }
@@ -287,11 +310,13 @@ struct StreamWorker {
     shutdown_flag: Arc<AtomicBool>,
     checkpoint_rx: tokio::sync::mpsc::UnboundedReceiver<CheckpointNotification>,
     sweep_rx: tokio::sync::mpsc::UnboundedReceiver<SweepRequest>,
+    drain_rx: tokio::sync::mpsc::UnboundedReceiver<DrainRequest>,
     sweep_trigger_gate: SweepTriggerGate,
 }
 
 impl StreamWorker {
     /// Create a new transcript worker.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         streams_db: Arc<StreamsDatabase>,
         telemetry_handle: DaemonTelemetryWorkerHandle,
@@ -299,6 +324,7 @@ impl StreamWorker {
         shutdown_flag: Arc<AtomicBool>,
         checkpoint_rx: tokio::sync::mpsc::UnboundedReceiver<CheckpointNotification>,
         sweep_rx: tokio::sync::mpsc::UnboundedReceiver<SweepRequest>,
+        drain_rx: tokio::sync::mpsc::UnboundedReceiver<DrainRequest>,
         sweep_trigger_gate: SweepTriggerGate,
     ) -> Self {
         let sweep_coordinator =
@@ -315,6 +341,7 @@ impl StreamWorker {
             shutdown_flag,
             checkpoint_rx,
             sweep_rx,
+            drain_rx,
             sweep_trigger_gate,
         }
     }
@@ -402,6 +429,9 @@ impl StreamWorker {
                         }
                     }
                 }
+                Some(request) = self.drain_rx.recv() => {
+                    self.handle_drain_request(request).await;
+                }
             }
         }
 
@@ -418,6 +448,19 @@ impl StreamWorker {
                 i += 1;
             }
         }
+    }
+
+    async fn handle_drain_request(&mut self, request: DrainRequest) {
+        // Process immediate priority tasks that are already queued.
+        self.drain_immediate_tasks().await;
+
+        // Continue processing newly promoted tasks until there is no ready
+        // work and no in-flight processing.
+        while !self.priority_queue.is_empty() || !self.in_flight.is_empty() {
+            self.process_next_task().await;
+        }
+
+        let _ = request.completion.send(());
     }
 
     fn next_delayed_task_at(&self) -> Option<std::time::Instant> {
@@ -1311,6 +1354,7 @@ pub fn spawn_stream_worker(
 ) -> StreamWorkerHandle {
     let (checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
     let (sweep_tx, sweep_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
     let shutdown_flag = Arc::new(AtomicBool::new(false));
     let sweep_trigger_gate = SweepTriggerGate::new();
 
@@ -1321,6 +1365,7 @@ pub fn spawn_stream_worker(
         shutdown_flag,
         checkpoint_rx,
         sweep_rx,
+        drain_rx,
         sweep_trigger_gate.clone(),
     );
 
@@ -1331,6 +1376,7 @@ pub fn spawn_stream_worker(
     StreamWorkerHandle {
         checkpoint_tx,
         sweep_tx,
+        drain_tx,
         sweep_trigger_gate,
     }
 }
@@ -1398,6 +1444,7 @@ mod scheduling_tests {
         let db = Arc::new(StreamsDatabase::open(temp.path().join("streams.db")).unwrap());
         let (_checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
         let (_sweep_tx, sweep_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
         let shutdown = Arc::new(Notify::new());
         let shutdown_flag = Arc::new(AtomicBool::new(false));
         let telemetry = DaemonTelemetryWorkerHandle::new_noop();
@@ -1410,6 +1457,7 @@ mod scheduling_tests {
             shutdown_flag,
             checkpoint_rx,
             sweep_rx,
+            drain_rx,
             sweep_trigger_gate,
         );
         (temp, worker, shutdown)
@@ -1524,6 +1572,7 @@ mod subagent_sweep_tests {
     fn make_worker(db: Arc<StreamsDatabase>) -> StreamWorker {
         let (_checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
         let (_sweep_tx, sweep_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
         let shutdown = Arc::new(Notify::new());
         let shutdown_flag = Arc::new(AtomicBool::new(false));
         let telemetry = DaemonTelemetryWorkerHandle::new_noop();
@@ -1534,6 +1583,7 @@ mod subagent_sweep_tests {
             shutdown_flag,
             checkpoint_rx,
             sweep_rx,
+            drain_rx,
             SweepTriggerGate::new(),
         )
     }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -90,6 +90,15 @@ impl TelemetryBuffer {
         }
     }
 
+    fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+            && self.performances.is_empty()
+            && self.messages.is_empty()
+            && self.metrics.is_empty()
+            && self.cas_records.is_empty()
+            && self.daemon_logs.is_empty()
+    }
+
     fn ingest_envelopes(&mut self, envelopes: Vec<TelemetryEnvelope>) {
         for envelope in envelopes {
             match envelope {
@@ -496,20 +505,25 @@ async fn telemetry_flush_loop(
             None
         };
 
+        let flush_all = !flush_requests.is_empty();
         let snapshot = {
             let mut buf = buffer.lock().await;
             if let Some(event) = heartbeat {
                 buf.ingest_daemon_logs(vec![event]);
             }
-            buf.take()
+            take_telemetry_flush_snapshot(&mut buf, flush_all)
         };
 
-        let flush_all = !flush_requests.is_empty();
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
         let daemon_id_for_flush = daemon_id.clone();
         let flush_started_at = std::time::Instant::now();
         let flush_result = tokio::task::spawn_blocking(move || {
-            flush_telemetry_batch(snapshot, &daemon_id_for_flush, flush_all)
+            if let Some(snapshot) = snapshot {
+                flush_telemetry_batch(snapshot, &daemon_id_for_flush, flush_all)
+            } else {
+                flush_pending_metrics();
+                (Vec::new(), FlushStatus::default())
+            }
         })
         .await
         .unwrap_or_else(|e| {
@@ -537,6 +551,17 @@ async fn telemetry_flush_loop(
                 .await
                 .requeue_failed_daemon_logs(requeue_daemon_logs);
         }
+    }
+}
+
+fn take_telemetry_flush_snapshot(
+    buffer: &mut TelemetryBuffer,
+    flush_all: bool,
+) -> Option<TelemetryBuffer> {
+    if !flush_all && buffer.is_empty() {
+        None
+    } else {
+        Some(buffer.take())
     }
 }
 
@@ -1487,6 +1512,20 @@ mod tests {
             next_telemetry_flush_at(completed_at),
             completed_at + FLUSH_INTERVAL
         );
+    }
+
+    #[test]
+    fn empty_periodic_flush_preserves_pending_metrics_only_fast_path() {
+        let mut buffer = TelemetryBuffer::new();
+
+        assert!(take_telemetry_flush_snapshot(&mut buffer, false).is_none());
+    }
+
+    #[test]
+    fn explicit_flush_uses_full_metrics_notes_and_status_path() {
+        let mut buffer = TelemetryBuffer::new();
+
+        assert!(take_telemetry_flush_snapshot(&mut buffer, true).is_some());
     }
 
     fn now_ts() -> u32 {

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -35,7 +35,7 @@ static DAEMON_LOG_UPLOAD_IN_FLIGHT: std::sync::OnceLock<Arc<AtomicBool>> =
     std::sync::OnceLock::new();
 
 /// Result of a telemetry flush cycle.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct FlushStatus {
     /// Approximate buffered + pending metrics still awaiting upload.
     pub metrics_remaining: usize,
@@ -45,6 +45,12 @@ pub struct FlushStatus {
 
 struct FlushRequest {
     completion: tokio::sync::oneshot::Sender<FlushStatus>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FlushMode {
+    Periodic,
+    Await,
 }
 
 /// Accumulated telemetry events waiting to be flushed.
@@ -505,30 +511,36 @@ async fn telemetry_flush_loop(
             None
         };
 
-        let flush_all = !flush_requests.is_empty();
+        let flush_mode = if flush_requests.is_empty() {
+            FlushMode::Periodic
+        } else {
+            FlushMode::Await
+        };
         let snapshot = {
             let mut buf = buffer.lock().await;
             if let Some(event) = heartbeat {
                 buf.ingest_daemon_logs(vec![event]);
             }
-            take_telemetry_flush_snapshot(&mut buf, flush_all)
+            take_telemetry_flush_snapshot(&mut buf, flush_mode)
         };
 
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
         let daemon_id_for_flush = daemon_id.clone();
         let flush_started_at = std::time::Instant::now();
         let flush_result = tokio::task::spawn_blocking(move || {
-            if let Some(snapshot) = snapshot {
-                flush_telemetry_batch(snapshot, &daemon_id_for_flush, flush_all)
+            let requeue_daemon_logs = if let Some(snapshot) = snapshot {
+                flush_telemetry_batch(snapshot, &daemon_id_for_flush)
             } else {
                 flush_pending_metrics();
-                (Vec::new(), FlushStatus::default())
-            }
+                Vec::new()
+            };
+            let await_status = collect_await_flush_status(flush_mode);
+            (requeue_daemon_logs, await_status)
         })
         .await
         .unwrap_or_else(|e| {
             tracing::error!(%e, "telemetry flush task panicked");
-            (Vec::new(), FlushStatus::default())
+            (Vec::new(), None)
         });
         let flush_elapsed = flush_started_at.elapsed();
         if flush_elapsed > FLUSH_INTERVAL {
@@ -539,10 +551,10 @@ async fn telemetry_flush_loop(
             );
         }
 
-        let (requeue_daemon_logs, flush_status) = flush_result;
+        let (requeue_daemon_logs, await_status) = flush_result;
 
         for request in flush_requests.drain(..) {
-            let _ = request.completion.send(flush_status);
+            let _ = request.completion.send(await_status.unwrap_or_default());
         }
 
         if !requeue_daemon_logs.is_empty() {
@@ -556,9 +568,9 @@ async fn telemetry_flush_loop(
 
 fn take_telemetry_flush_snapshot(
     buffer: &mut TelemetryBuffer,
-    flush_all: bool,
+    flush_mode: FlushMode,
 ) -> Option<TelemetryBuffer> {
-    if !flush_all && buffer.is_empty() {
+    if flush_mode == FlushMode::Periodic && buffer.is_empty() {
         None
     } else {
         Some(buffer.take())
@@ -569,11 +581,7 @@ fn next_telemetry_flush_at(completed_at: Instant) -> Instant {
     completed_at + FLUSH_INTERVAL
 }
 
-fn flush_telemetry_batch(
-    batch: TelemetryBuffer,
-    daemon_id: &str,
-    flush_all: bool,
-) -> (Vec<DaemonLogEvent>, FlushStatus) {
+fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
     let config = Config::get();
     let distinct_id = get_or_create_distinct_id();
 
@@ -602,47 +610,56 @@ fn flush_telemetry_batch(
     }
 
     // Flush pending notes (reads directly from notes-db; no-op when kind != Http).
-    let notes_done = flush_notes(flush_all);
+    flush_notes();
 
     flush_pending_metrics();
 
-    let requeue_daemon_logs = if batch.daemon_logs.is_empty() {
+    if batch.daemon_logs.is_empty() {
         Vec::new()
     } else {
         dispatch_daemon_log_upload(batch.daemon_logs, daemon_id, &distinct_id)
-    };
+    }
+}
 
-    let metrics_remaining = if METRICS_UPLOAD_AVAILABLE.load(Ordering::Relaxed) {
-        MetricsDatabase::global()
-            .and_then(|db| {
-                db.lock()
-                    .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))
-            })
-            .and_then(|db| db.count_retryable())
-            .unwrap_or(0)
-    } else {
-        0
-    };
-
-    let notes_remaining = if notes_done {
-        0
-    } else {
-        crate::notes::db::NotesDatabase::global()
-            .and_then(|db| {
-                db.lock()
-                    .map_err(|_| GitAiError::Generic("notes DB lock poisoned".to_string()))
-            })
-            .and_then(|db| db.count_pending_syncable())
-            .unwrap_or(0)
-    };
-
-    (
-        requeue_daemon_logs,
-        FlushStatus {
-            metrics_remaining,
-            notes_remaining,
-        },
+fn collect_await_flush_status(flush_mode: FlushMode) -> Option<FlushStatus> {
+    collect_await_flush_status_with(
+        flush_mode,
+        flush_notes_for_await,
+        count_pending_metrics_for_await,
     )
+}
+
+fn collect_await_flush_status_with<Notes, Metrics>(
+    flush_mode: FlushMode,
+    flush_notes: Notes,
+    count_metrics: Metrics,
+) -> Option<FlushStatus>
+where
+    Notes: FnOnce() -> usize,
+    Metrics: FnOnce() -> usize,
+{
+    if flush_mode == FlushMode::Periodic {
+        return None;
+    }
+
+    Some(FlushStatus {
+        metrics_remaining: count_metrics(),
+        notes_remaining: flush_notes(),
+    })
+}
+
+fn count_pending_metrics_for_await() -> usize {
+    if !METRICS_UPLOAD_AVAILABLE.load(Ordering::Relaxed) {
+        return 0;
+    }
+
+    MetricsDatabase::global()
+        .and_then(|db| {
+            db.lock()
+                .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))
+        })
+        .and_then(|db| db.count_retryable())
+        .unwrap_or(0)
 }
 
 fn flush_metrics(events: &[MetricEvent]) {
@@ -1243,27 +1260,22 @@ fn flush_sentry_and_posthog(
 ///
 /// Skips silently when:
 /// - `notes_backend.kind != Http`
-/// - `notes_backend.backend_url` is not configured
 /// - Not authenticated (no API key and not logged in)
-///
-/// If `flush_all` is true, the function repeatedly dequeues and uploads until no
-/// pending notes remain. Returns `true` if no pending notes are left after the
-/// flush, `false` otherwise (e.g. upload failures that left retryable rows).
-pub fn flush_notes(flush_all: bool) -> bool {
+pub fn flush_notes() {
     use crate::api::types::{NoteEntry, NotesUploadRequest};
     use crate::config::NotesBackendKind;
 
     let cfg = Config::fresh();
     if cfg.notes_backend_kind() != NotesBackendKind::Http {
         tracing::debug!("notes: skipping flush, backend is not Http");
-        return true;
+        return;
     }
 
     let backend_url = match cfg.notes_backend_url() {
         Some(url) => url.to_string(),
         None => {
             tracing::debug!("notes: skipping flush, notes_backend.backend_url is not configured");
-            return true;
+            return;
         }
     };
     let context = ApiContext::new(Some(backend_url));
@@ -1271,90 +1283,79 @@ pub fn flush_notes(flush_all: bool) -> bool {
 
     if !client.is_logged_in() && !client.has_api_key() {
         tracing::debug!("notes: skipping flush, not authenticated");
-        return true;
+        return;
     }
 
-    let mut loop_count = 0;
-    let max_loops = if flush_all { 1_000 } else { 1 };
-
-    loop {
-        if loop_count >= max_loops {
-            break;
-        }
-        loop_count += 1;
-
-        // Dequeue up to 50 pending notes.
-        let pending = match crate::notes::db::NotesDatabase::global() {
-            Ok(db) => match db.lock() {
-                Ok(mut lock) => match lock.dequeue_pending(50) {
-                    Ok(rows) => rows,
-                    Err(e) => {
-                        tracing::warn!(%e, "notes: failed to dequeue pending rows");
-                        break;
-                    }
-                },
+    // Dequeue up to 50 pending notes.
+    let pending = match crate::notes::db::NotesDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(mut lock) => match lock.dequeue_pending(50) {
+                Ok(rows) => rows,
                 Err(e) => {
-                    tracing::warn!("notes: DB lock poisoned: {}", e);
-                    break;
+                    tracing::warn!(%e, "notes: failed to dequeue pending rows");
+                    return;
                 }
             },
             Err(e) => {
-                tracing::warn!(%e, "notes: failed to get notes DB");
-                break;
+                tracing::warn!("notes: DB lock poisoned: {}", e);
+                return;
             }
-        };
-
-        if pending.is_empty() {
-            break;
+        },
+        Err(e) => {
+            tracing::warn!(%e, "notes: failed to get notes DB");
+            return;
         }
+    };
 
-        let commit_shas: Vec<String> = pending.iter().map(|p| p.commit_sha.clone()).collect();
+    if pending.is_empty() {
+        return;
+    }
 
-        let entries: Vec<NoteEntry> = pending
-            .iter()
-            .map(|p| NoteEntry {
-                commit_sha: p.commit_sha.clone(),
-                content: p.content.clone(),
-            })
-            .collect();
+    let commit_shas: Vec<String> = pending.iter().map(|p| p.commit_sha.clone()).collect();
 
-        let request = NotesUploadRequest { entries };
+    let entries: Vec<NoteEntry> = pending
+        .iter()
+        .map(|p| NoteEntry {
+            commit_sha: p.commit_sha.clone(),
+            content: p.content.clone(),
+        })
+        .collect();
 
-        match client.upload_notes(request) {
-            Ok(resp) => {
-                tracing::debug!(
-                    success = resp.success_count,
-                    failure = resp.failure_count,
-                    "notes: uploaded batch"
-                );
-                if let Ok(db) = crate::notes::db::NotesDatabase::global()
-                    && let Ok(mut lock) = db.lock()
-                {
-                    if resp.failure_count == 0 {
-                        let _ = lock.mark_synced(&commit_shas);
-                    } else {
-                        // Server reported partial failures but doesn't identify which
-                        // entries failed. Mark the entire batch as failed so all entries
-                        // are retried on the next flush cycle.
-                        let _ = lock.mark_failed(
-                            &commit_shas,
-                            &format!(
-                                "partial failure: {}/{} entries failed",
-                                resp.failure_count,
-                                commit_shas.len()
-                            ),
-                        );
-                    }
+    let request = NotesUploadRequest { entries };
+
+    match client.upload_notes(request) {
+        Ok(resp) => {
+            tracing::debug!(
+                success = resp.success_count,
+                failure = resp.failure_count,
+                "notes: uploaded batch"
+            );
+            if let Ok(db) = crate::notes::db::NotesDatabase::global()
+                && let Ok(mut lock) = db.lock()
+            {
+                if resp.failure_count == 0 {
+                    let _ = lock.mark_synced(&commit_shas);
+                } else {
+                    // Server reported partial failures but doesn't identify which
+                    // entries failed. Mark the entire batch as failed so all entries
+                    // are retried on the next flush cycle.
+                    let _ = lock.mark_failed(
+                        &commit_shas,
+                        &format!(
+                            "partial failure: {}/{} entries failed",
+                            resp.failure_count,
+                            commit_shas.len()
+                        ),
+                    );
                 }
             }
-            Err(e) => {
-                tracing::warn!(%e, "notes: upload error");
-                if let Ok(db) = crate::notes::db::NotesDatabase::global()
-                    && let Ok(mut lock) = db.lock()
-                {
-                    let _ = lock.mark_failed(&commit_shas, &e.to_string());
-                }
-                break;
+        }
+        Err(e) => {
+            tracing::warn!(%e, "notes: upload error");
+            if let Ok(db) = crate::notes::db::NotesDatabase::global()
+                && let Ok(mut lock) = db.lock()
+            {
+                let _ = lock.mark_failed(&commit_shas, &e.to_string());
             }
         }
     }
@@ -1370,13 +1371,39 @@ pub fn flush_notes(flush_all: bool) -> bool {
     {
         let _ = lock.evict_stale_cache(10_000, 90 * 24 * 3600);
     }
+}
 
+fn flush_notes_for_await() -> usize {
+    use crate::config::NotesBackendKind;
+
+    let cfg = Config::fresh();
+    if cfg.notes_backend_kind() != NotesBackendKind::Http || cfg.notes_backend_url().is_none() {
+        return 0;
+    }
+
+    let client = ApiClient::new(ApiContext::new(cfg.notes_backend_url().map(str::to_string)));
+    if !client.is_logged_in() && !client.has_api_key() {
+        return 0;
+    }
+
+    for _ in 0..1_000 {
+        let remaining = count_pending_notes_for_await();
+        if remaining == 0 {
+            return 0;
+        }
+        flush_notes();
+    }
+
+    count_pending_notes_for_await()
+}
+
+fn count_pending_notes_for_await() -> usize {
     match crate::notes::db::NotesDatabase::global() {
         Ok(db) => match db.lock() {
-            Ok(lock) => lock.count_pending_syncable().unwrap_or(0) == 0,
-            Err(_) => false,
+            Ok(lock) => lock.count_pending_uploadable().unwrap_or(0),
+            Err(_) => 0,
         },
-        Err(_) => false,
+        Err(_) => 0,
     }
 }
 
@@ -1518,14 +1545,38 @@ mod tests {
     fn empty_periodic_flush_preserves_pending_metrics_only_fast_path() {
         let mut buffer = TelemetryBuffer::new();
 
-        assert!(take_telemetry_flush_snapshot(&mut buffer, false).is_none());
+        assert!(take_telemetry_flush_snapshot(&mut buffer, FlushMode::Periodic).is_none());
     }
 
     #[test]
-    fn explicit_flush_uses_full_metrics_notes_and_status_path() {
+    fn await_flush_forces_a_snapshot_even_when_the_buffer_is_empty() {
         let mut buffer = TelemetryBuffer::new();
 
-        assert!(take_telemetry_flush_snapshot(&mut buffer, true).is_some());
+        assert!(take_telemetry_flush_snapshot(&mut buffer, FlushMode::Await).is_some());
+    }
+
+    #[test]
+    fn periodic_flush_skips_await_only_notes_and_metrics_status_work() {
+        let status = collect_await_flush_status_with(
+            FlushMode::Periodic,
+            || panic!("periodic flush must not fully flush or count notes"),
+            || panic!("periodic flush must not count metrics"),
+        );
+
+        assert!(status.is_none());
+    }
+
+    #[test]
+    fn await_flush_collects_notes_and_metrics_status() {
+        let status = collect_await_flush_status_with(FlushMode::Await, || 7, || 11);
+
+        assert_eq!(
+            status,
+            Some(FlushStatus {
+                metrics_remaining: 11,
+                notes_remaining: 7,
+            })
+        );
     }
 
     fn now_ts() -> u32 {

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -34,6 +34,19 @@ static METRICS_METADATA_BACKFILL_STARTED: AtomicBool = AtomicBool::new(false);
 static DAEMON_LOG_UPLOAD_IN_FLIGHT: std::sync::OnceLock<Arc<AtomicBool>> =
     std::sync::OnceLock::new();
 
+/// Result of a telemetry flush cycle.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FlushStatus {
+    /// Approximate buffered + pending metrics still awaiting upload.
+    pub metrics_remaining: usize,
+    /// Approximate number of notes still eligible for upload.
+    pub notes_remaining: usize,
+}
+
+struct FlushRequest {
+    completion: tokio::sync::oneshot::Sender<FlushStatus>,
+}
+
 /// Accumulated telemetry events waiting to be flushed.
 struct TelemetryBuffer {
     errors: Vec<ErrorEvent>,
@@ -75,15 +88,6 @@ impl TelemetryBuffer {
             cas_records: Vec::new(),
             daemon_logs: Vec::new(),
         }
-    }
-
-    fn is_empty(&self) -> bool {
-        self.errors.is_empty()
-            && self.performances.is_empty()
-            && self.messages.is_empty()
-            && self.metrics.is_empty()
-            && self.cas_records.is_empty()
-            && self.daemon_logs.is_empty()
     }
 
     fn ingest_envelopes(&mut self, envelopes: Vec<TelemetryEnvelope>) {
@@ -176,13 +180,16 @@ impl TelemetryBuffer {
 #[derive(Clone)]
 pub struct DaemonTelemetryWorkerHandle {
     buffer: Arc<Mutex<TelemetryBuffer>>,
+    flush_tx: tokio::sync::mpsc::UnboundedSender<FlushRequest>,
 }
 
 impl DaemonTelemetryWorkerHandle {
     #[cfg(test)]
     pub fn new_noop() -> Self {
+        let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
+            flush_tx,
         }
     }
 
@@ -216,6 +223,19 @@ impl DaemonTelemetryWorkerHandle {
             return;
         }
         self.buffer.lock().await.ingest_daemon_logs(events);
+    }
+
+    /// Request an immediate telemetry flush and wait for the worker to complete.
+    pub async fn flush_and_wait(&self) -> Result<FlushStatus, GitAiError> {
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        self.flush_tx
+            .send(FlushRequest {
+                completion: completion_tx,
+            })
+            .map_err(|_| GitAiError::Generic("telemetry worker has stopped".to_string()))?;
+        completion_rx
+            .await
+            .map_err(|_| GitAiError::Generic("telemetry flush was cancelled".to_string()))
     }
 
     /// Returns the current number of metrics waiting for upload.
@@ -396,15 +416,17 @@ pub fn submit_daemon_internal_daemon_logs(events: Vec<DaemonLogEvent>) -> bool {
 /// to their respective destinations (Sentry, PostHog, metrics API, CAS API).
 pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
     let buffer = Arc::new(Mutex::new(TelemetryBuffer::new()));
+    let (flush_tx, flush_rx) = tokio::sync::mpsc::unbounded_channel();
     let handle = DaemonTelemetryWorkerHandle {
         buffer: buffer.clone(),
+        flush_tx,
     };
     let daemon_id = crate::uuid::generate_v4();
 
     spawn_metrics_metadata_backfill();
 
     tokio::spawn(async move {
-        telemetry_flush_loop(buffer, daemon_id).await;
+        telemetry_flush_loop(buffer, daemon_id, flush_rx).await;
     });
 
     handle
@@ -447,12 +469,22 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
     Ok(())
 }
 
-async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: String) {
+async fn telemetry_flush_loop(
+    buffer: Arc<Mutex<TelemetryBuffer>>,
+    daemon_id: String,
+    mut flush_rx: tokio::sync::mpsc::UnboundedReceiver<FlushRequest>,
+) {
     let started_at = std::time::Instant::now();
     let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
+    let mut flush_requests: Vec<FlushRequest> = Vec::new();
 
     loop {
-        sleep_until(next_telemetry_flush_at(Instant::now())).await;
+        tokio::select! {
+            _ = sleep_until(next_telemetry_flush_at(Instant::now())) => {}
+            Some(request) = flush_rx.recv() => {
+                flush_requests.push(request);
+            }
+        }
 
         let now = std::time::Instant::now();
         let heartbeat = if now >= next_heartbeat_at && daemon_log_upload_enabled() {
@@ -469,28 +501,20 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
             if let Some(event) = heartbeat {
                 buf.ingest_daemon_logs(vec![event]);
             }
-            if buf.is_empty() {
-                None
-            } else {
-                Some(buf.take())
-            }
+            buf.take()
         };
 
+        let flush_all = !flush_requests.is_empty();
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
         let daemon_id_for_flush = daemon_id.clone();
         let flush_started_at = std::time::Instant::now();
-        let requeue_daemon_logs = tokio::task::spawn_blocking(move || {
-            if let Some(snapshot) = snapshot {
-                flush_telemetry_batch(snapshot, &daemon_id_for_flush)
-            } else {
-                flush_pending_metrics();
-                Vec::new()
-            }
+        let flush_result = tokio::task::spawn_blocking(move || {
+            flush_telemetry_batch(snapshot, &daemon_id_for_flush, flush_all)
         })
         .await
         .unwrap_or_else(|e| {
             tracing::error!(%e, "telemetry flush task panicked");
-            Vec::new()
+            (Vec::new(), FlushStatus::default())
         });
         let flush_elapsed = flush_started_at.elapsed();
         if flush_elapsed > FLUSH_INTERVAL {
@@ -499,6 +523,12 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
                 interval_ms = FLUSH_INTERVAL.as_millis(),
                 "telemetry flush exceeded its scheduling interval"
             );
+        }
+
+        let (requeue_daemon_logs, flush_status) = flush_result;
+
+        for request in flush_requests.drain(..) {
+            let _ = request.completion.send(flush_status);
         }
 
         if !requeue_daemon_logs.is_empty() {
@@ -514,7 +544,11 @@ fn next_telemetry_flush_at(completed_at: Instant) -> Instant {
     completed_at + FLUSH_INTERVAL
 }
 
-fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
+fn flush_telemetry_batch(
+    batch: TelemetryBuffer,
+    daemon_id: &str,
+    flush_all: bool,
+) -> (Vec<DaemonLogEvent>, FlushStatus) {
     let config = Config::get();
     let distinct_id = get_or_create_distinct_id();
 
@@ -543,15 +577,47 @@ fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonL
     }
 
     // Flush pending notes (reads directly from notes-db; no-op when kind != Http).
-    flush_notes();
+    let notes_done = flush_notes(flush_all);
 
     flush_pending_metrics();
 
-    if batch.daemon_logs.is_empty() {
+    let requeue_daemon_logs = if batch.daemon_logs.is_empty() {
         Vec::new()
     } else {
         dispatch_daemon_log_upload(batch.daemon_logs, daemon_id, &distinct_id)
-    }
+    };
+
+    let metrics_remaining = if METRICS_UPLOAD_AVAILABLE.load(Ordering::Relaxed) {
+        MetricsDatabase::global()
+            .and_then(|db| {
+                db.lock()
+                    .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))
+            })
+            .and_then(|db| db.count_retryable())
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    let notes_remaining = if notes_done {
+        0
+    } else {
+        crate::notes::db::NotesDatabase::global()
+            .and_then(|db| {
+                db.lock()
+                    .map_err(|_| GitAiError::Generic("notes DB lock poisoned".to_string()))
+            })
+            .and_then(|db| db.count_pending_syncable())
+            .unwrap_or(0)
+    };
+
+    (
+        requeue_daemon_logs,
+        FlushStatus {
+            metrics_remaining,
+            notes_remaining,
+        },
+    )
 }
 
 fn flush_metrics(events: &[MetricEvent]) {
@@ -1152,22 +1218,27 @@ fn flush_sentry_and_posthog(
 ///
 /// Skips silently when:
 /// - `notes_backend.kind != Http`
+/// - `notes_backend.backend_url` is not configured
 /// - Not authenticated (no API key and not logged in)
-pub fn flush_notes() {
+///
+/// If `flush_all` is true, the function repeatedly dequeues and uploads until no
+/// pending notes remain. Returns `true` if no pending notes are left after the
+/// flush, `false` otherwise (e.g. upload failures that left retryable rows).
+pub fn flush_notes(flush_all: bool) -> bool {
     use crate::api::types::{NoteEntry, NotesUploadRequest};
     use crate::config::NotesBackendKind;
 
     let cfg = Config::fresh();
     if cfg.notes_backend_kind() != NotesBackendKind::Http {
         tracing::debug!("notes: skipping flush, backend is not Http");
-        return;
+        return true;
     }
 
     let backend_url = match cfg.notes_backend_url() {
         Some(url) => url.to_string(),
         None => {
             tracing::debug!("notes: skipping flush, notes_backend.backend_url is not configured");
-            return;
+            return true;
         }
     };
     let context = ApiContext::new(Some(backend_url));
@@ -1175,79 +1246,90 @@ pub fn flush_notes() {
 
     if !client.is_logged_in() && !client.has_api_key() {
         tracing::debug!("notes: skipping flush, not authenticated");
-        return;
+        return true;
     }
 
-    // Dequeue up to 50 pending notes.
-    let pending = match crate::notes::db::NotesDatabase::global() {
-        Ok(db) => match db.lock() {
-            Ok(mut lock) => match lock.dequeue_pending(50) {
-                Ok(rows) => rows,
+    let mut loop_count = 0;
+    let max_loops = if flush_all { 1_000 } else { 1 };
+
+    loop {
+        if loop_count >= max_loops {
+            break;
+        }
+        loop_count += 1;
+
+        // Dequeue up to 50 pending notes.
+        let pending = match crate::notes::db::NotesDatabase::global() {
+            Ok(db) => match db.lock() {
+                Ok(mut lock) => match lock.dequeue_pending(50) {
+                    Ok(rows) => rows,
+                    Err(e) => {
+                        tracing::warn!(%e, "notes: failed to dequeue pending rows");
+                        break;
+                    }
+                },
                 Err(e) => {
-                    tracing::warn!(%e, "notes: failed to dequeue pending rows");
-                    return;
+                    tracing::warn!("notes: DB lock poisoned: {}", e);
+                    break;
                 }
             },
             Err(e) => {
-                tracing::warn!("notes: DB lock poisoned: {}", e);
-                return;
+                tracing::warn!(%e, "notes: failed to get notes DB");
+                break;
             }
-        },
-        Err(e) => {
-            tracing::warn!(%e, "notes: failed to get notes DB");
-            return;
+        };
+
+        if pending.is_empty() {
+            break;
         }
-    };
 
-    if pending.is_empty() {
-        return;
-    }
+        let commit_shas: Vec<String> = pending.iter().map(|p| p.commit_sha.clone()).collect();
 
-    let commit_shas: Vec<String> = pending.iter().map(|p| p.commit_sha.clone()).collect();
+        let entries: Vec<NoteEntry> = pending
+            .iter()
+            .map(|p| NoteEntry {
+                commit_sha: p.commit_sha.clone(),
+                content: p.content.clone(),
+            })
+            .collect();
 
-    let entries: Vec<NoteEntry> = pending
-        .iter()
-        .map(|p| NoteEntry {
-            commit_sha: p.commit_sha.clone(),
-            content: p.content.clone(),
-        })
-        .collect();
+        let request = NotesUploadRequest { entries };
 
-    let request = NotesUploadRequest { entries };
-
-    match client.upload_notes(request) {
-        Ok(resp) => {
-            tracing::debug!(
-                success = resp.success_count,
-                failure = resp.failure_count,
-                "notes: uploaded batch"
-            );
-            if let Ok(db) = crate::notes::db::NotesDatabase::global()
-                && let Ok(mut lock) = db.lock()
-            {
-                if resp.failure_count == 0 {
-                    let _ = lock.mark_synced(&commit_shas);
-                } else {
-                    // Server reported partial failures but doesn't identify which
-                    // entries failed. Mark the entire batch as failed so all entries
-                    // are retried on the next flush cycle.
-                    let _ = lock.mark_failed(
-                        &commit_shas,
-                        &format!(
-                            "partial failure: {}/{} entries failed",
-                            resp.failure_count,
-                            commit_shas.len()
-                        ),
-                    );
+        match client.upload_notes(request) {
+            Ok(resp) => {
+                tracing::debug!(
+                    success = resp.success_count,
+                    failure = resp.failure_count,
+                    "notes: uploaded batch"
+                );
+                if let Ok(db) = crate::notes::db::NotesDatabase::global()
+                    && let Ok(mut lock) = db.lock()
+                {
+                    if resp.failure_count == 0 {
+                        let _ = lock.mark_synced(&commit_shas);
+                    } else {
+                        // Server reported partial failures but doesn't identify which
+                        // entries failed. Mark the entire batch as failed so all entries
+                        // are retried on the next flush cycle.
+                        let _ = lock.mark_failed(
+                            &commit_shas,
+                            &format!(
+                                "partial failure: {}/{} entries failed",
+                                resp.failure_count,
+                                commit_shas.len()
+                            ),
+                        );
+                    }
                 }
             }
-        }
-        Err(e) => {
-            tracing::warn!(%e, "notes: upload error");
-            if let Ok(db) = crate::notes::db::NotesDatabase::global()
-                && let Ok(mut lock) = db.lock()
-            {
-                let _ = lock.mark_failed(&commit_shas, &e.to_string());
+            Err(e) => {
+                tracing::warn!(%e, "notes: upload error");
+                if let Ok(db) = crate::notes::db::NotesDatabase::global()
+                    && let Ok(mut lock) = db.lock()
+                {
+                    let _ = lock.mark_failed(&commit_shas, &e.to_string());
+                }
+                break;
             }
         }
     }
@@ -1262,6 +1344,14 @@ pub fn flush_notes() {
         && let Ok(mut lock) = db.lock()
     {
         let _ = lock.evict_stale_cache(10_000, 90 * 24 * 3600);
+    }
+
+    match crate::notes::db::NotesDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(lock) => lock.count_pending_syncable().unwrap_or(0) == 0,
+            Err(_) => false,
+        },
+        Err(_) => false,
     }
 }
 

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -462,11 +462,16 @@ impl NotesDatabase {
 
     // ----- Read operations -----
 
-    /// Count unsynced notes that have not exhausted their upload attempts.
-    pub fn count_pending_syncable(&self) -> Result<usize, GitAiError> {
+    /// Count unsynced notes that can be dequeued for upload right now.
+    pub fn count_pending_uploadable(&self) -> Result<usize, GitAiError> {
+        let now = unix_now();
         let count: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM notes WHERE synced = 0 AND attempts < 6",
-            [],
+            r#"SELECT COUNT(*) FROM notes
+               WHERE synced = 0
+                 AND processing_started_at IS NULL
+                 AND next_retry_at <= ?1
+                 AND attempts < 6"#,
+            params![now],
             |row| row.get(0),
         )?;
         Ok(count as usize)
@@ -780,7 +785,7 @@ mod tests {
     }
 
     #[test]
-    fn test_count_pending_syncable_excludes_only_permanent_failures() {
+    fn test_count_pending_uploadable_excludes_deferred_and_processing_rows() {
         let (mut db, _tmp) = create_test_db();
 
         for sha in ["ready", "backoff", "processing", "permanent"] {
@@ -805,7 +810,7 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(db.count_pending_syncable().unwrap(), 3);
+        assert_eq!(db.count_pending_uploadable().unwrap(), 1);
     }
 
     // --- cache_synced_notes ---

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -462,6 +462,16 @@ impl NotesDatabase {
 
     // ----- Read operations -----
 
+    /// Count notes that have not been synced to the remote backend.
+    pub fn count_pending_syncable(&self) -> Result<usize, GitAiError> {
+        let count: i64 =
+            self.conn
+                .query_row("SELECT COUNT(*) FROM notes WHERE synced = 0", [], |row| {
+                    row.get(0)
+                })?;
+        Ok(count as usize)
+    }
+
     /// Retrieve the note content for a single commit SHA.
     pub fn get_note(&self, commit_sha: &str) -> Result<Option<String>, GitAiError> {
         match self.conn.query_row(

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -462,13 +462,13 @@ impl NotesDatabase {
 
     // ----- Read operations -----
 
-    /// Count notes that have not been synced to the remote backend.
+    /// Count unsynced notes that have not exhausted their upload attempts.
     pub fn count_pending_syncable(&self) -> Result<usize, GitAiError> {
-        let count: i64 =
-            self.conn
-                .query_row("SELECT COUNT(*) FROM notes WHERE synced = 0", [], |row| {
-                    row.get(0)
-                })?;
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM notes WHERE synced = 0 AND attempts < 6",
+            [],
+            |row| row.get(0),
+        )?;
         Ok(count as usize)
     }
 
@@ -777,6 +777,35 @@ mod tests {
             batch.is_empty(),
             "cache_synced_notes rows must not appear in dequeue_pending"
         );
+    }
+
+    #[test]
+    fn test_count_pending_syncable_excludes_only_permanent_failures() {
+        let (mut db, _tmp) = create_test_db();
+
+        for sha in ["ready", "backoff", "processing", "permanent"] {
+            db.upsert_note(sha, "content").unwrap();
+        }
+        db.conn
+            .execute(
+                "UPDATE notes SET attempts = 1, next_retry_at = ?1 WHERE commit_sha = 'backoff'",
+                params![unix_now() + 3_600],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE notes SET processing_started_at = ?1 WHERE commit_sha = 'processing'",
+                params![unix_now()],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE notes SET attempts = 6 WHERE commit_sha = 'permanent'",
+                [],
+            )
+            .unwrap();
+
+        assert_eq!(db.count_pending_syncable().unwrap(), 3);
     }
 
     // --- cache_synced_notes ---

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -5048,7 +5048,7 @@ fn daemon_self_heals_after_socket_deletion() {
 
 #[test]
 #[serial]
-fn pre_exit_waits_for_metrics_and_notes_flush() {
+fn await_waits_for_metrics_and_notes_flush() {
     let mut mock_api = MockApiServer::start();
     let _api_base_url = ScopedEnvVar::set("GIT_AI_API_BASE_URL", mock_api.base_url());
     let _api_key = ScopedEnvVar::set("GIT_AI_API_KEY", "test-api-key");
@@ -5103,11 +5103,11 @@ fn pre_exit_waits_for_metrics_and_notes_flush() {
 
     // Wait for the daemon to finish and flush telemetry.
     let output = repo
-        .git_ai(&["pre-exit", "--timeout", "30"])
-        .expect("pre-exit should succeed");
+        .git_ai(&["await", "--timeout", "30"])
+        .expect("await should succeed");
     assert!(
         output.contains("finished"),
-        "pre-exit should report finished: {}",
+        "await should report finished: {}",
         output
     );
 
@@ -5129,5 +5129,36 @@ fn pre_exit_waits_for_metrics_and_notes_flush() {
         notes_requests > 0,
         "expected at least one notes upload, got {}",
         notes_requests
+    );
+}
+
+#[test]
+fn await_is_marked_beta_and_returns_promptly_when_idle() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);
+
+    let top_level_help = repo
+        .git_ai(&["--help"])
+        .expect("top-level help should succeed");
+    assert!(
+        top_level_help.contains("await [beta]"),
+        "top-level help should mark await as beta: {}",
+        top_level_help
+    );
+
+    let await_help = repo
+        .git_ai(&["await", "--help"])
+        .expect("await help should succeed");
+    assert!(
+        await_help.contains("beta"),
+        "await help should mark the command as beta: {}",
+        await_help
+    );
+
+    let started_at = std::time::Instant::now();
+    repo.git_ai(&["await", "--timeout", "10"])
+        .expect("await should succeed when the daemon is idle");
+    assert!(
+        started_at.elapsed() < Duration::from_secs(4),
+        "await should return promptly instead of waiting for the progress interval"
     );
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7,6 +7,7 @@ use git_ai::authorship::working_log::CheckpointKind;
 use git_ai::commands::checkpoint_agent::orchestrator::{
     BaseCommit, CheckpointFile, CheckpointRequest,
 };
+use git_ai::config::{NotesBackendConfig, NotesBackendKind};
 #[cfg(not(windows))]
 use git_ai::daemon::checkpoint::PreparedPathRole;
 #[cfg(not(windows))]
@@ -183,6 +184,7 @@ impl Drop for ScopedEnvVar {
 struct MockApiServer {
     base_url: String,
     stop: Arc<AtomicBool>,
+    rx: mpsc::Receiver<Value>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
@@ -193,7 +195,7 @@ impl MockApiServer {
             .set_nonblocking(true)
             .expect("failed to set nonblocking listener");
         let addr = listener.local_addr().expect("failed to read listener addr");
-        let (tx, _rx) = mpsc::channel();
+        let (tx, rx) = mpsc::channel();
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);
 
@@ -214,12 +216,22 @@ impl MockApiServer {
         Self {
             base_url: format!("http://{}", addr),
             stop,
+            rx,
             thread: Some(thread),
         }
     }
 
     fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// Collect all requests captured by the mock so far.
+    fn collect_requests(&mut self) -> Vec<Value> {
+        let mut requests = Vec::new();
+        while let Ok(request) = self.rx.try_recv() {
+            requests.push(request);
+        }
+        requests
     }
 }
 
@@ -238,11 +250,11 @@ fn handle_http_connection(mut stream: TcpStream, tx: &mpsc::Sender<Value>) {
         return;
     };
 
+    let request_json: Value = serde_json::from_slice(&body).unwrap_or_else(|_| json!({}));
+
     let response_body = match path.as_str() {
         "/worker/cas/upload" => {
-            let request_json: Value =
-                serde_json::from_slice(&body).expect("CAS upload should contain JSON");
-            let _ = tx.send(request_json.clone());
+            let _ = tx.send(json!({ "path": path, "body": request_json }));
             let hashes = request_json["objects"]
                 .as_array()
                 .cloned()
@@ -262,7 +274,22 @@ fn handle_http_connection(mut stream: TcpStream, tx: &mpsc::Sender<Value>) {
             })
             .to_string()
         }
-        "/worker/metrics/upload" => json!({ "errors": [] }).to_string(),
+        "/worker/metrics/upload" => {
+            let _ = tx.send(json!({ "path": path, "body": request_json }));
+            json!({ "errors": [] }).to_string()
+        }
+        "/worker/notes/upload" => {
+            let _ = tx.send(json!({ "path": path, "body": request_json }));
+            let success_count = request_json["entries"]
+                .as_array()
+                .map(|entries| entries.len())
+                .unwrap_or(0);
+            json!({
+                "success_count": success_count,
+                "failure_count": 0
+            })
+            .to_string()
+        }
         _ => "{}".to_string(),
     };
 
@@ -5017,4 +5044,90 @@ fn daemon_self_heals_after_socket_deletion() {
         }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+#[test]
+#[serial]
+fn pre_exit_waits_for_metrics_and_notes_flush() {
+    let mut mock_api = MockApiServer::start();
+    let _api_base_url = ScopedEnvVar::set("GIT_AI_API_BASE_URL", mock_api.base_url());
+    let _api_key = ScopedEnvVar::set("GIT_AI_API_KEY", "test-api-key");
+    let _notes_backend_kind = ScopedEnvVar::set("GIT_AI_NOTES_BACKEND_KIND", "http");
+    let _notes_backend_url = ScopedEnvVar::set("GIT_AI_NOTES_BACKEND_URL", mock_api.base_url());
+
+    // Metrics recording is gated in test builds; point it at an isolated DB so
+    // post-commit metric events actually get stored and flushed.
+    let metrics_db_path =
+        std::env::temp_dir().join(format!("git-ai-test-metrics-{}.db", std::process::id()));
+    let _metrics_db_path = ScopedEnvVar::set(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path.to_str().unwrap(),
+    );
+
+    let mut repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+        patch.prompt_storage = Some("default".to_string());
+        patch.telemetry_oss_disabled = Some(true);
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: Some(mock_api.base_url().to_string()),
+        });
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("test.ts");
+
+    // First commit: known-human baseline, then an AI-style edit to produce metrics.
+    fs::write(&file_path, "const x = 1;\n").expect("failed to write initial file");
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.ts"])
+        .expect("known-human checkpoint should succeed");
+    fs::write(&file_path, "const x = 2;\n").expect("failed to write update");
+    repo.git_ai(&["checkpoint", "mock_ai", "test.ts"])
+        .expect("ai checkpoint should succeed");
+    repo.git(&["add", "-A"])
+        .expect("initial add should succeed");
+    repo.git(&["commit", "-m", "Initial commit"])
+        .expect("initial commit should succeed");
+
+    // Second commit: repeat the same pattern to queue more metrics and notes.
+    fs::write(&file_path, "const x = 3;\n").expect("failed to write update");
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.ts"])
+        .expect("known-human checkpoint should succeed");
+    fs::write(&file_path, "const x = 4;\n").expect("failed to write update");
+    repo.git_ai(&["checkpoint", "mock_ai", "test.ts"])
+        .expect("ai checkpoint should succeed");
+    repo.git(&["add", "-A"]).expect("second add should succeed");
+    repo.git(&["commit", "-m", "Second commit"])
+        .expect("second commit should succeed");
+
+    // Wait for the daemon to finish and flush telemetry.
+    let output = repo
+        .git_ai(&["pre-exit", "--timeout", "30"])
+        .expect("pre-exit should succeed");
+    assert!(
+        output.contains("finished"),
+        "pre-exit should report finished: {}",
+        output
+    );
+
+    let requests = mock_api.collect_requests();
+    let metrics_requests = requests
+        .iter()
+        .filter(|r| r["path"].as_str() == Some("/worker/metrics/upload"))
+        .count();
+    let notes_requests = requests
+        .iter()
+        .filter(|r| r["path"].as_str() == Some("/worker/notes/upload"))
+        .count();
+    assert!(
+        metrics_requests > 0,
+        "expected at least one metrics upload, got {}",
+        metrics_requests
+    );
+    assert!(
+        notes_requests > 0,
+        "expected at least one notes upload, got {}",
+        notes_requests
+    );
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -5047,24 +5047,23 @@ fn daemon_self_heals_after_socket_deletion() {
 }
 
 #[test]
-#[serial]
 fn await_waits_for_metrics_and_notes_flush() {
     let mut mock_api = MockApiServer::start();
-    let _api_base_url = ScopedEnvVar::set("GIT_AI_API_BASE_URL", mock_api.base_url());
-    let _api_key = ScopedEnvVar::set("GIT_AI_API_KEY", "test-api-key");
-    let _notes_backend_kind = ScopedEnvVar::set("GIT_AI_NOTES_BACKEND_KIND", "http");
-    let _notes_backend_url = ScopedEnvVar::set("GIT_AI_NOTES_BACKEND_URL", mock_api.base_url());
 
     // Metrics recording is gated in test builds; point it at an isolated DB so
     // post-commit metric events actually get stored and flushed.
     let metrics_db_path =
         std::env::temp_dir().join(format!("git-ai-test-metrics-{}.db", std::process::id()));
-    let _metrics_db_path = ScopedEnvVar::set(
-        "GIT_AI_TEST_METRICS_DB_PATH",
-        metrics_db_path.to_str().unwrap(),
-    );
-
-    let mut repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);
+    let mut repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+        ("GIT_AI_NOTES_BACKEND_URL", mock_api.base_url()),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+    ]);
     repo.patch_git_ai_config(|patch| {
         patch.exclude_prompts_in_repositories = Some(vec![]);
         patch.prompt_storage = Some("default".to_string());

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -5162,3 +5162,17 @@ fn await_is_marked_beta_and_returns_promptly_when_idle() {
         "await should return promptly instead of waiting for the progress interval"
     );
 }
+
+#[test]
+fn await_rejects_zero_timeout() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);
+
+    let error = repo
+        .git_ai(&["await", "--timeout", "0"])
+        .expect_err("zero timeout should be rejected");
+
+    assert!(
+        error.contains("--timeout must be a positive integer"),
+        "await should report an input validation error: {error}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the beta `git-ai await [--timeout <seconds>]` command so CI and container teardown can block until the daemon has finished in-flight trace work, family-sequencer side effects, transcript processing, and metrics/notes flushing.

> [!NOTE]
> `git-ai await` is currently beta and is labeled as such in both the top-level CLI help and command-specific help.

### How it works

- `ControlRequest::Await { timeout_secs }` is handled by `ActorDaemonCoordinator::await_completion()`.
- The coordinator waits for:
  - trace ingestion to catch up via `wait_for_trace_ingest_processed_through`,
  - ready family sequencers to drain via `drain_all_ready_family_sequencers`,
  - queued checkpoint/sweep ingress and ready transcript tasks to drain via `StreamWorkerHandle::drain`,
  - the telemetry worker to flush and report remaining metrics/notes via `DaemonTelemetryWorkerHandle::flush_and_wait`.
- Telemetry flush is a request/response between the coordinator and worker, and `flush_notes` supports draining the full notes queue.
- The CLI defaults to a 30-second timeout, prints periodic progress, and exits with an error if the timeout is exceeded.

### Reliability fixes

- The stream-worker barrier consumes checkpoint and sweep requests that were already queued on their separate ingress channels before reporting completion.
- The CLI progress reporter uses an interruptible wait, so an idle daemon returns promptly instead of waiting up to five seconds for the reporter thread to wake.
- Lower-priority transcript work remains queued while immediate drain work is processed.

### Validation

- `task fmt`
- `task lint`
- `task test` — full local suite passed:
  - 2,053 library tests
  - 59 daemon-mode tests
  - 3,211 integration tests (85 ignored)
  - notes regression tests and doctests
- Focused TDD coverage:
  - `await_waits_for_metrics_and_notes_flush`
  - `await_is_marked_beta_and_returns_promptly_when_idle`
  - `drain_processes_queued_checkpoint_notifications_before_completing`
  - `take_immediate_tasks_preserves_low_priority_tasks`

Link to Devin session: https://app.devin.ai/sessions/4dfa215bb15a4ba7bf981124a1a816ac

Requested by: @Siddhant-K-code