### PR TITLE
Recover committed AI insertion attributions

### DIFF
--- a/src/authorship/imara_diff_utils.rs
+++ b/src/authorship/imara_diff_utils.rs
@@ -264,6 +264,19 @@ pub(crate) fn normalize_line_endings(s: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(s.replace("\r\n", "\n"))
 }
 
+/// Compare two strings while treating CRLF and LF line endings as equivalent.
+pub(crate) fn content_eq_ignoring_line_endings(a: &str, b: &str) -> bool {
+    a == b || normalize_line_endings(a) == normalize_line_endings(b)
+}
+
+/// Split content into terminator-preserving lines normalized for CRLF/LF comparisons.
+pub(crate) fn split_lines_normalized_terminators(s: &str) -> Vec<std::borrow::Cow<'_, str>> {
+    split_lines_with_terminators(s)
+        .into_iter()
+        .map(normalize_line_endings)
+        .collect()
+}
+
 /// Splits a string into lines, preserving line terminators.
 fn split_lines_with_terminators(s: &str) -> Vec<&str> {
     let mut lines = Vec::new();

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1651,7 +1651,9 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
             // Resolve pending region: if both sides inserted differing content,
             // favor observed; else take whichever inserted.
             if !c_pending.is_empty() && !o_pending.is_empty() {
-                if c_pending == o_pending {
+                if committed_cmp_lines[committed_i..c_anchor]
+                    == observed_cmp_lines[observed_i..o_anchor]
+                {
                     result.extend(c_pending);
                 } else {
                     result.extend(o_pending);
@@ -1696,8 +1698,11 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
                 .iter()
                 .map(|s| (*s).to_string())
                 .collect();
-            let committed_changed = committed_chunk != base_chunk;
-            let observed_changed = observed_chunk != base_chunk;
+            let base_cmp_chunk = &base_cmp_lines[chunk_base_start..base_i];
+            let committed_cmp_chunk = &committed_cmp_lines[committed_i..c_anchor];
+            let observed_cmp_chunk = &observed_cmp_lines[observed_i..o_anchor];
+            let committed_changed = committed_cmp_chunk != base_cmp_chunk;
+            let observed_changed = observed_cmp_chunk != base_cmp_chunk;
 
             match (committed_changed, observed_changed) {
                 (true, false) => result.extend(committed_chunk),
@@ -1705,7 +1710,7 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
                 (true, true) => {
                     // Two-sided change → favor observed (matches --theirs),
                     // unless both produced identical content.
-                    if committed_chunk == observed_chunk {
+                    if committed_cmp_chunk == observed_cmp_chunk {
                         result.extend(committed_chunk);
                     } else {
                         result.extend(observed_chunk);
@@ -1729,7 +1734,7 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
         .map(|s| (*s).to_string())
         .collect();
     if !c_tail.is_empty() && !o_tail.is_empty() {
-        if c_tail == o_tail {
+        if committed_cmp_lines[committed_i..] == observed_cmp_lines[observed_i..] {
             result.extend(c_tail);
         } else {
             result.extend(o_tail);
@@ -3681,6 +3686,18 @@ mod tests {
             committed
         );
         assert!(diff_hunks_between_contents(observed, committed).is_empty());
+    }
+
+    #[test]
+    fn carryover_merge_does_not_treat_crlf_only_observed_chunk_as_change() {
+        let parent = "a\nb\nc\n";
+        let committed = "A\nb\nC\n";
+        let observed = "a\r\nb\r\nD\r\n";
+
+        assert_eq!(
+            carryover_merge_content(parent, committed, observed),
+            "A\nb\nD\r\n"
+        );
     }
 
     /// Differential test: the in-memory carryover merge must agree with real

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -4,6 +4,9 @@ use crate::authorship::attribution_tracker::{
 };
 use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord, SessionRecord};
 use crate::authorship::hunk_shift::{DiffHunk, apply_hunk_shifts_to_line_attributions};
+use crate::authorship::imara_diff_utils::{
+    content_eq_ignoring_line_endings, split_lines_normalized_terminators,
+};
 use crate::authorship::working_log::CheckpointKind;
 use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
 use crate::error::GitAiError;
@@ -1385,12 +1388,12 @@ fn collect_unstaged_hunks_from_snapshot(
             .cloned()
             .unwrap_or_else(|| committed_content.clone());
 
-        if committed_content == final_content {
+        if content_eq_ignoring_line_endings(&committed_content, &final_content) {
             continue;
         }
 
-        let committed_lines = split_lines_preserving_terminators(&committed_content);
-        let final_lines = split_lines_preserving_terminators(&final_content);
+        let committed_lines = split_lines_normalized_terminators(&committed_content);
+        let final_lines = split_lines_normalized_terminators(&final_content);
         let diff_ops = crate::authorship::imara_diff_utils::capture_diff_slices(
             &committed_lines,
             &final_lines,
@@ -1459,8 +1462,8 @@ fn split_lines_preserving_terminators(s: &str) -> Vec<&str> {
 }
 
 fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
-    let old_lines = split_lines_preserving_terminators(old_content);
-    let new_lines = split_lines_preserving_terminators(new_content);
+    let old_lines = split_lines_normalized_terminators(old_content);
+    let new_lines = split_lines_normalized_terminators(new_content);
     crate::authorship::imara_diff_utils::capture_diff_slices(&old_lines, &new_lines)
         .into_iter()
         .filter_map(|op| match op {
@@ -1501,13 +1504,13 @@ fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<Diff
 }
 
 fn line_sequence_contains(needle: &str, haystack: &str) -> bool {
-    let needle_lines = split_lines_preserving_terminators(needle);
+    let needle_lines = split_lines_normalized_terminators(needle);
     if needle_lines.is_empty() {
         return true;
     }
 
     let mut next_needle = 0;
-    for haystack_line in split_lines_preserving_terminators(haystack) {
+    for haystack_line in split_lines_normalized_terminators(haystack) {
         if haystack_line == needle_lines[next_needle] {
             next_needle += 1;
             if next_needle == needle_lines.len() {
@@ -1528,16 +1531,19 @@ fn merged_carryover_content_pure(
     if committed_content == observed_content {
         return observed_content.to_string();
     }
+    if content_eq_ignoring_line_endings(committed_content, observed_content) {
+        return committed_content.to_string();
+    }
     if line_sequence_contains(committed_content, observed_content) {
         return observed_content.to_string();
     }
     if line_sequence_contains(observed_content, committed_content) {
         return committed_content.to_string();
     }
-    if committed_content == parent_content {
+    if content_eq_ignoring_line_endings(committed_content, parent_content) {
         return observed_content.to_string();
     }
-    if observed_content == parent_content {
+    if content_eq_ignoring_line_endings(observed_content, parent_content) {
         return committed_content.to_string();
     }
     carryover_merge_content(parent_content, committed_content, observed_content)
@@ -1558,21 +1564,31 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
     if committed == observed {
         return observed.to_string();
     }
-    if parent == committed {
+    if content_eq_ignoring_line_endings(committed, observed) {
+        return committed.to_string();
+    }
+    if content_eq_ignoring_line_endings(parent, committed) {
         return observed.to_string();
     }
-    if parent == observed {
+    if content_eq_ignoring_line_endings(parent, observed) {
         return committed.to_string();
     }
 
     let base_lines = split_lines_preserving_terminators(parent);
     let committed_lines = split_lines_preserving_terminators(committed);
     let observed_lines = split_lines_preserving_terminators(observed);
+    let base_cmp_lines = split_lines_normalized_terminators(parent);
+    let committed_cmp_lines = split_lines_normalized_terminators(committed);
+    let observed_cmp_lines = split_lines_normalized_terminators(observed);
 
     // For each side, map every base line index to its aligned index on that
     // side (None if the base line was changed/deleted on that side). Also record
     // each side's content so we can emit it for changed chunks.
-    fn align_to_base(base_len: usize, base: &[&str], side: &[&str]) -> Vec<Option<usize>> {
+    fn align_to_base<T: std::hash::Hash + Eq + Clone>(
+        base: &[T],
+        side: &[T],
+    ) -> Vec<Option<usize>> {
+        let base_len = base.len();
         let mut map = vec![None; base_len];
         for op in capture_diff_slices(base, side) {
             if let DiffOp::Equal {
@@ -1589,8 +1605,8 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
         map
     }
 
-    let committed_map = align_to_base(base_lines.len(), &base_lines, &committed_lines);
-    let observed_map = align_to_base(base_lines.len(), &base_lines, &observed_lines);
+    let committed_map = align_to_base(&base_cmp_lines, &committed_cmp_lines);
+    let observed_map = align_to_base(&base_cmp_lines, &observed_cmp_lines);
 
     // A base line is "stable" when both sides keep it aligned (unchanged on
     // both). We walk base lines; runs of stable lines are emitted verbatim,
@@ -3652,6 +3668,19 @@ mod tests {
             carryover_merge_content(parent, committed, observed),
             "a\nB\n"
         );
+    }
+
+    #[test]
+    fn carryover_merge_ignores_mixed_eol_when_content_matches_committed() {
+        let parent = "base one\nbase two\n";
+        let committed = "base one\nbase two\nai line\n";
+        let observed = "base one\r\nbase two\r\nai line\n";
+
+        assert_eq!(
+            merged_carryover_content_pure(parent, committed, observed),
+            committed
+        );
+        assert!(diff_hunks_between_contents(observed, committed).is_empty());
     }
 
     /// Differential test: the in-memory carryover merge must agree with real

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1461,6 +1461,16 @@ fn split_lines_preserving_terminators(s: &str) -> Vec<&str> {
     lines
 }
 
+fn normalized_line_at(content: &str, line_num: u32) -> Option<std::borrow::Cow<'_, str>> {
+    if line_num == 0 {
+        return None;
+    }
+
+    split_lines_normalized_terminators(content)
+        .into_iter()
+        .nth((line_num - 1) as usize)
+}
+
 fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
     let old_lines = split_lines_normalized_terminators(old_content);
     let new_lines = split_lines_normalized_terminators(new_content);
@@ -2261,6 +2271,30 @@ impl VirtualAttributions {
         // Remove files with no unstaged hunks
         unstaged_hunks.retain(|_, ranges| !ranges.is_empty());
 
+        let mut committed_content_requests: Vec<(String, String)> = Vec::new();
+        for (file_path, (_, line_attrs)) in &self.attributions {
+            if line_attrs.is_empty() {
+                continue;
+            }
+
+            let nfc_file_path: String = file_path.nfc().collect();
+            let has_unstaged_lines = unstaged_hunks
+                .get(&nfc_file_path)
+                .or_else(|| {
+                    rename_map
+                        .get(&nfc_file_path)
+                        .and_then(|np| unstaged_hunks.get(np))
+                })
+                .is_some_and(|ranges| !ranges.is_empty());
+            if has_unstaged_lines {
+                let attestation_path = rename_map.get(&nfc_file_path).unwrap_or(&nfc_file_path);
+                committed_content_requests.push((commit_sha.to_string(), attestation_path.clone()));
+            }
+        }
+        committed_content_requests.sort();
+        committed_content_requests.dedup();
+        let committed_contents_for_unstaged = batch_file_contents(repo, &committed_content_requests)?;
+
         // Process each file
         for (file_path, (_, line_attrs)) in &self.attributions {
             if line_attrs.is_empty() {
@@ -2313,12 +2347,22 @@ impl VirtualAttributions {
                 }
                 unstaged_lines.sort_unstable();
             }
+            let pure_insertion_lines: std::collections::HashSet<u32> = pure_insertion_hunks
+                .get(&nfc_file_path)
+                .or_else(|| {
+                    rename_map
+                        .get(&nfc_file_path)
+                        .and_then(|np| pure_insertion_hunks.get(np))
+                })
+                .map(|ranges| ranges.iter().flat_map(|r| r.expand()).collect())
+                .unwrap_or_default();
 
             // Split line attributions into committed and uncommitted
             // VirtualAttributions has line numbers in working directory coordinates,
             // so we need to convert to commit coordinates before comparing with committed hunks
             let mut committed_lines_map: StdHashMap<String, Vec<u32>> = StdHashMap::new();
             let mut uncommitted_lines_map: StdHashMap<String, Vec<u32>> = StdHashMap::new();
+            let mut pending_unstaged_lines: Vec<(String, u32, u32)> = Vec::new();
 
             // Get the committed hunks for this file (if any) - these are in commit coordinates.
             // If the file was renamed, committed_hunks is keyed by the new path.
@@ -2327,6 +2371,16 @@ impl VirtualAttributions {
                     .get(&nfc_file_path)
                     .and_then(|np| committed_hunks.get(np))
             });
+            let attestation_path = rename_map.get(&nfc_file_path).unwrap_or(&nfc_file_path);
+            let line_content_source = if let Some(snapshot) = &carryover_snapshot {
+                snapshot
+                    .get(&nfc_file_path)
+                    .or_else(|| snapshot.get(file_path))
+            } else {
+                self.file_contents
+                    .get(file_path)
+                    .or_else(|| self.file_contents.get(&nfc_file_path))
+            };
 
             for line_attr in line_attrs {
                 // Check each line individually
@@ -2335,18 +2389,28 @@ impl VirtualAttributions {
                     let is_unstaged = unstaged_lines.binary_search(&workdir_line_num).is_ok();
 
                     if is_unstaged {
-                        // Line is unstaged, mark as uncommitted
-                        uncommitted_lines_map
-                            .entry(line_attr.author_id.clone())
-                            .or_default()
-                            .push(workdir_line_num);
-                        referenced_prompts.insert(line_attr.author_id.clone());
+                        // Defer bucketing until we can check whether this is a
+                        // committed line that only overlaps an unstaged pure insertion.
+                        let adjustment = unstaged_lines
+                            .iter()
+                            .filter(|&&l| {
+                                l < workdir_line_num && pure_insertion_lines.contains(&l)
+                            })
+                            .count() as u32;
+                        let commit_line_num = workdir_line_num.saturating_sub(adjustment);
+                        pending_unstaged_lines.push((
+                            line_attr.author_id.clone(),
+                            workdir_line_num,
+                            commit_line_num,
+                        ));
                     } else {
                         // Convert working directory line number to commit line number
                         // by subtracting the count of unstaged lines before this line
                         let adjustment = unstaged_lines
                             .iter()
-                            .filter(|&&l| l < workdir_line_num)
+                            .filter(|&&l| {
+                                l < workdir_line_num && pure_insertion_lines.contains(&l)
+                            })
                             .count() as u32;
                         let commit_line_num = workdir_line_num - adjustment;
 
@@ -2378,6 +2442,42 @@ impl VirtualAttributions {
                                 .or_default()
                                 .push(commit_line_num);
                         }
+                    }
+                }
+            }
+
+            if !pending_unstaged_lines.is_empty() {
+                let committed_path = attestation_path.to_string();
+                let committed_content = committed_contents_for_unstaged
+                    .get(&(commit_sha.to_string(), committed_path))
+                    .map(String::as_str)
+                    .unwrap_or_default();
+
+                for (author_id, workdir_line_num, commit_line_num) in pending_unstaged_lines {
+                    let is_ai_author = author_id != CheckpointKind::Human.to_str()
+                        && !author_id.starts_with("h_");
+                    let is_committed = file_committed_hunks
+                        .map(|hunks| hunks.iter().any(|hunk| hunk.contains(commit_line_num)))
+                        .unwrap_or(false);
+                    let content_matches = match line_content_source {
+                        Some(content) => normalized_line_at(content, workdir_line_num)
+                            .zip(normalized_line_at(committed_content, commit_line_num))
+                            .map(|(left, right)| left == right)
+                            .unwrap_or(false),
+                        None => false,
+                    };
+
+                    if is_ai_author && is_committed && content_matches {
+                        committed_lines_map
+                            .entry(author_id)
+                            .or_default()
+                            .push(commit_line_num);
+                    } else {
+                        uncommitted_lines_map
+                            .entry(author_id.clone())
+                            .or_default()
+                            .push(workdir_line_num);
+                        referenced_prompts.insert(author_id);
                     }
                 }
             }

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -5,7 +5,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 #[cfg(not(any(test, feature = "test-support")))]
 use crate::authorship::authorship_log_serialization::generate_short_hash;
 use crate::authorship::imara_diff_utils::{
-    LineChangeTag, compute_line_changes, normalize_line_endings,
+    LineChangeTag, compute_line_changes, content_eq_ignoring_line_endings,
 };
 use crate::authorship::working_log::CheckpointKind;
 use crate::authorship::working_log::{Checkpoint, WorkingLogEntry};
@@ -521,14 +521,6 @@ fn get_previous_content_from_head(
     }
 }
 
-/// Compare file contents ignoring CRLF/LF differences.
-fn content_eq_normalized(a: &str, b: &str) -> bool {
-    if a == b {
-        return true;
-    }
-    normalize_line_endings(a) == normalize_line_endings(b)
-}
-
 #[doc(hidden)]
 pub fn is_ai_author_id(author_id: &str) -> bool {
     author_id != "human" && !author_id.starts_with("h_")
@@ -616,7 +608,7 @@ fn get_checkpoint_entry_for_file(
             get_previous_content_from_head(&repo, &file_path, head_tree_id.as_ref())
         };
 
-        if content_eq_normalized(&current_content, &previous_content) {
+        if content_eq_ignoring_line_endings(&current_content, &previous_content) {
             return Ok(None);
         }
 
@@ -644,7 +636,7 @@ fn get_checkpoint_entry_for_file(
 
         // Skip if no changes, UNLESS we have INITIAL attributions for this file
         // (in which case we need to create an entry to record those attributions)
-        if content_eq_normalized(&current_content, &previous_content)
+        if content_eq_ignoring_line_endings(&current_content, &previous_content)
             && initial_attrs_for_file.is_empty()
         {
             return Ok(None);
@@ -675,7 +667,7 @@ fn get_checkpoint_entry_for_file(
             let snapshot = initial_snapshot_content
                 .as_deref()
                 .unwrap_or(&previous_content);
-            if content_eq_normalized(snapshot, &current_content) {
+            if content_eq_ignoring_line_endings(snapshot, &current_content) {
                 &previous_content
             } else {
                 snapshot
@@ -736,7 +728,7 @@ fn get_checkpoint_entry_for_file(
 
     // Skip if no changes (but we already checked this earlier, accounting for INITIAL attributions)
     // For files from previous checkpoints, check if content has changed
-    if is_from_checkpoint && content_eq_normalized(&current_content, &previous_content) {
+    if is_from_checkpoint && content_eq_ignoring_line_endings(&current_content, &previous_content) {
         if current_content == previous_content {
             // Byte-identical — truly no change.
             return Ok(None);

--- a/tests/integration/post_commit_unit.rs
+++ b/tests/integration/post_commit_unit.rs
@@ -1,3 +1,4 @@
+use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 
@@ -35,6 +36,49 @@ fn test_post_commit_empty_repo_with_checkpoint() {
         note_result.is_some(),
         "post_commit should handle empty repo without errors"
     );
+}
+
+#[test]
+fn test_post_commit_preserves_ai_attribution_for_mixed_eol_worktree() {
+    let repo = TestRepo::new();
+    repo.git(&["config", "core.autocrlf", "true"]).unwrap();
+
+    let file_path = repo.path().join("eol.txt");
+    std::fs::write(&file_path, b"base one\r\nbase two\r\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    repo.git_ai(&["checkpoint", "human", "eol.txt"]).unwrap();
+
+    // Reproduce the Windows failure mode: existing checkout lines are CRLF, but
+    // the AI append writes LF, so the working tree becomes mixed while Git stores
+    // the committed blob as LF.
+    std::fs::write(&file_path, b"base one\r\nbase two\r\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "eol.txt"])
+        .unwrap();
+
+    let commit = repo.stage_all_and_commit("AI mixed eol edit").unwrap();
+
+    let mut file = repo.filename("eol.txt");
+    file.assert_committed_lines(lines![
+        "base one".unattributed_human(),
+        "base two".unattributed_human(),
+        "ai line".ai(),
+    ]);
+
+    let initial_path = repo
+        .path()
+        .join(".git")
+        .join("ai")
+        .join("working_logs")
+        .join(commit.commit_sha)
+        .join("INITIAL");
+    if initial_path.exists() {
+        let initial = std::fs::read_to_string(initial_path).unwrap();
+        assert!(
+            !initial.contains("eol.txt"),
+            "mixed EOL normalization should not carry committed lines into INITIAL: {initial}"
+        );
+    }
 }
 
 #[test]

--- a/tests/integration/stats_unit.rs
+++ b/tests/integration/stats_unit.rs
@@ -61,6 +61,35 @@ fn test_stats_for_simple_ai_commit() {
 }
 
 #[test]
+fn test_stats_for_ai_insertions_across_multiple_hunks() {
+    let repo = TestRepo::new();
+
+    let initial = "package com.example;\n\n/**\n * @author test\n * @date 2021/7/22\n */\npublic class Content {\n    public static final String LOCAL_DATA_EXAMPLE = \"2021-07-22\";\n\n    public static final String SUNDAY = \"sunday\";\n    public static final String MONDAY = \"monday\";\n    public static final String TUESDAY = \"tuesday\";\n    public static final String WEDNESDAY = \"wednesday\";\n    public static final String THURSDAY = \"thursday\";\n    public static final String FRIDAY = \"friday\";\n    public static final String SATURDAY = \"saturday\";\n}\n";
+    let updated = "package com.example;\n\n/**\n * Common content constants used by BTM models.\n *\n * @author test\n * @date 2021/7/22\n */\npublic class Content {\n    /** Example date value in local data format. */\n    public static final String LOCAL_DATA_EXAMPLE = \"2021-07-22\";\n\n    /** Day name constant for Sunday. */\n    public static final String SUNDAY = \"sunday\";\n    /** Day name constant for Monday. */\n    public static final String MONDAY = \"monday\";\n    /** Day name constant for Tuesday. */\n    public static final String TUESDAY = \"tuesday\";\n    /** Day name constant for Wednesday. */\n    public static final String WEDNESDAY = \"wednesday\";\n    /** Day name constant for Thursday. */\n    public static final String THURSDAY = \"thursday\";\n    /** Day name constant for Friday. */\n    public static final String FRIDAY = \"friday\";\n    /** Day name constant for Saturday. */\n    public static final String SATURDAY = \"saturday\";\n}\n";
+
+    std::fs::write(repo.path().join("Content.java"), initial).unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    std::fs::write(repo.path().join("Content.java"), updated).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "Content.java"])
+        .unwrap();
+    repo.stage_all_and_commit("AI adds comments").unwrap();
+
+    let head_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let stats = stats_for_commit_stats(&gitai_repo, &head_sha, &[]).unwrap();
+
+    assert_eq!(stats.git_diff_added_lines, 10);
+    assert_eq!(stats.ai_accepted, 10);
+    assert_eq!(stats.ai_additions, 10);
+    assert_eq!(stats.unknown_additions, 0);
+}
+
+#[test]
 fn test_stats_for_mixed_commit() {
     let repo = TestRepo::new();
 


### PR DESCRIPTION
## Summary
- Recover AI-attributed lines that overlap unstaged pure insertions but are also present in committed hunks
- Verify recovered lines still match the committed content while ignoring only CRLF/LF differences
- Add a regression test for AI insertions across multiple separate hunks

## Notes
- Stacked on / depends on #1665 for shared line-ending comparison helpers.
- This fixes #1770.

## Tests
- Not run locally: `cargo` is not available in this environment.
- Ran `git diff --check`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->