### PR TITLE
Add checkpoint content budgets

### DIFF
--- a/src/checkpoint_content_budget.rs
+++ b/src/checkpoint_content_budget.rs
@@ -1,0 +1,74 @@
+use std::fmt::Display;
+
+use crate::config;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CheckpointContentBudget {
+    max_file_size_bytes: usize,
+    max_total_size_bytes: usize,
+    max_total_lines: usize,
+    used_size_bytes: usize,
+    used_lines: usize,
+}
+
+impl CheckpointContentBudget {
+    pub(crate) fn from_config(config: &config::Config) -> Self {
+        Self {
+            max_file_size_bytes: config.max_checkpoint_file_size_bytes(),
+            max_total_size_bytes: config.max_checkpoint_total_size_bytes(),
+            max_total_lines: config.max_checkpoint_total_lines(),
+            used_size_bytes: 0,
+            used_lines: 0,
+        }
+    }
+
+    pub(crate) fn max_file_size_bytes(&self) -> usize {
+        self.max_file_size_bytes
+    }
+
+    pub(crate) fn reserve(&mut self, path: impl Display, content: &str) -> bool {
+        let size_bytes = content.len();
+        if size_bytes > self.max_file_size_bytes {
+            tracing::warn!(
+                "skipping file larger than max_checkpoint_file_size_bytes: {} ({} bytes)",
+                path,
+                size_bytes,
+            );
+            return false;
+        }
+
+        let line_count = checkpoint_content_line_count(content);
+        if self.used_size_bytes.saturating_add(size_bytes) > self.max_total_size_bytes {
+            tracing::warn!(
+                "skipping file over max_checkpoint_total_size_bytes budget: {} ({} bytes, {} bytes already used, {} bytes max)",
+                path,
+                size_bytes,
+                self.used_size_bytes,
+                self.max_total_size_bytes,
+            );
+            return false;
+        }
+        if self.used_lines.saturating_add(line_count) > self.max_total_lines {
+            tracing::warn!(
+                "skipping file over max_checkpoint_total_lines budget: {} ({} lines, {} lines already used, {} lines max)",
+                path,
+                line_count,
+                self.used_lines,
+                self.max_total_lines,
+            );
+            return false;
+        }
+
+        self.used_size_bytes += size_bytes;
+        self.used_lines += line_count;
+        true
+    }
+}
+
+fn checkpoint_content_line_count(content: &str) -> usize {
+    if content.is_empty() {
+        return 0;
+    }
+    content.as_bytes().iter().filter(|&&b| b == b'\n').count()
+        + usize::from(!content.as_bytes().ends_with(b"\n"))
+}

--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -1,5 +1,6 @@
 use crate::authorship::authorship_log_serialization::generate_trace_id;
 use crate::authorship::working_log::{AgentId, CheckpointKind};
+use crate::checkpoint_content_budget::CheckpointContentBudget;
 use crate::commands::checkpoint_agent::presets::{
     KnownHumanEdit, ParsedHookEvent, PostBashCall, PostFileEdit, PreBashCall, PreFileEdit,
     StreamSource, UntrackedEdit,
@@ -57,6 +58,30 @@ struct RepoContext {
 
 const MAX_CHECKPOINT_FILES: usize = 1000;
 
+fn apply_checkpoint_content_budget(files: &mut [CheckpointFile]) {
+    let mut budget = CheckpointContentBudget::from_config(config::Config::get());
+    for file in files {
+        let Some(content) = file.content.as_ref() else {
+            continue;
+        };
+        if !budget.reserve(file.path.display(), content) {
+            file.content = None;
+        }
+    }
+}
+
+fn apply_dirty_file_overrides(
+    files: &mut [CheckpointFile],
+    dirty_files: &HashMap<PathBuf, String>,
+) {
+    for file in &mut *files {
+        if let Some(override_content) = dirty_files.get(&file.path) {
+            file.content = Some(override_content.clone());
+        }
+    }
+    apply_checkpoint_content_budget(files);
+}
+
 fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>, GitAiError> {
     let perf = std::env::var("GIT_AI_DEBUG_PERFORMANCE").is_ok_and(|v| !v.is_empty() && v != "0");
 
@@ -71,7 +96,8 @@ fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>,
 
     let mut repo_cache: HashMap<PathBuf, RepoContext> = HashMap::new();
     let mut files = Vec::new();
-    let max_size = config::Config::get().max_checkpoint_file_size_bytes();
+    let mut content_budget = CheckpointContentBudget::from_config(config::Config::get());
+    let max_size = content_budget.max_file_size_bytes();
 
     for path in capped_paths {
         if !path.is_absolute() {
@@ -143,6 +169,8 @@ fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>,
                 content.as_ref().map(|c| c.len()).unwrap_or(0),
             );
         }
+
+        let content = content.filter(|content| content_budget.reserve(path.display(), content));
 
         files.push(CheckpointFile {
             path: path.clone(),
@@ -317,23 +345,9 @@ fn split_files_into_requests(
 }
 
 fn execute_pre_file_edit(e: PreFileEdit) -> Result<Vec<CheckpointRequest>, GitAiError> {
-    let max_size = config::Config::get().max_checkpoint_file_size_bytes();
     let mut files = build_checkpoint_files(&e.file_paths)?;
     if let Some(ref dirty) = e.dirty_files {
-        for f in &mut files {
-            if let Some(override_content) = dirty.get(&f.path) {
-                if override_content.len() > max_size {
-                    tracing::warn!(
-                        "skipping dirty file override larger than max_checkpoint_file_size_bytes: {} ({} bytes)",
-                        f.path.display(),
-                        override_content.len(),
-                    );
-                    f.content = None;
-                } else {
-                    f.content = Some(override_content.clone());
-                }
-            }
-        }
+        apply_dirty_file_overrides(&mut files, dirty);
     }
     let mut metadata = e.context.metadata;
     if let Some(tuid) = e.tool_use_id {
@@ -354,23 +368,9 @@ fn execute_post_file_edit(
     e: PostFileEdit,
     preset_name: &str,
 ) -> Result<Vec<CheckpointRequest>, GitAiError> {
-    let max_size = config::Config::get().max_checkpoint_file_size_bytes();
     let mut files = build_checkpoint_files(&e.file_paths)?;
     if let Some(ref dirty) = e.dirty_files {
-        for f in &mut files {
-            if let Some(override_content) = dirty.get(&f.path) {
-                if override_content.len() > max_size {
-                    tracing::warn!(
-                        "skipping dirty file override larger than max_checkpoint_file_size_bytes: {} ({} bytes)",
-                        f.path.display(),
-                        override_content.len(),
-                    );
-                    f.content = None;
-                } else {
-                    f.content = Some(override_content.clone());
-                }
-            }
-        }
+        apply_dirty_file_overrides(&mut files, dirty);
     }
     let checkpoint_kind = match preset_name {
         "ai_tab" => CheckpointKind::AiTab,
@@ -395,23 +395,9 @@ fn execute_post_file_edit(
 }
 
 fn execute_known_human_edit(e: KnownHumanEdit) -> Result<Vec<CheckpointRequest>, GitAiError> {
-    let max_size = config::Config::get().max_checkpoint_file_size_bytes();
     let mut files = build_checkpoint_files(&e.file_paths)?;
     if let Some(ref dirty) = e.dirty_files {
-        for f in &mut files {
-            if let Some(override_content) = dirty.get(&f.path) {
-                if override_content.len() > max_size {
-                    tracing::warn!(
-                        "skipping dirty file override larger than max_checkpoint_file_size_bytes: {} ({} bytes)",
-                        f.path.display(),
-                        override_content.len(),
-                    );
-                    f.content = None;
-                } else {
-                    f.content = Some(override_content.clone());
-                }
-            }
-        }
+        apply_dirty_file_overrides(&mut files, dirty);
     }
     Ok(split_files_into_requests(
         files,

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -119,6 +119,9 @@ fn print_config_help() {
     println!(
         "  transcript_streaming_lookback_days  Days to look back when sweeping transcripts (0 = unlimited)"
     );
+    println!("  max_checkpoint_file_size_bytes      Per-file checkpoint content limit in bytes");
+    println!("  max_checkpoint_total_size_bytes     Per-checkpoint content limit in bytes");
+    println!("  max_checkpoint_total_lines          Per-checkpoint content limit in lines");
     println!("  custom_attributes            Custom telemetry attributes, string->string (object)");
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
     println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
@@ -375,6 +378,19 @@ fn show_all_config() -> Result<(), String> {
     );
 
     effective_config.insert(
+        "max_checkpoint_file_size_bytes".to_string(),
+        Value::Number(runtime_config.max_checkpoint_file_size_bytes().into()),
+    );
+    effective_config.insert(
+        "max_checkpoint_total_size_bytes".to_string(),
+        Value::Number(runtime_config.max_checkpoint_total_size_bytes().into()),
+    );
+    effective_config.insert(
+        "max_checkpoint_total_lines".to_string(),
+        Value::Number(runtime_config.max_checkpoint_total_lines().into()),
+    );
+
+    effective_config.insert(
         "custom_attributes".to_string(),
         serde_json::to_value(runtime_config.custom_attributes())
             .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
@@ -505,6 +521,12 @@ fn get_config_value(key: &str) -> Result<(), String> {
             ),
             "max_checkpoint_file_size_bytes" => {
                 Value::Number(runtime_config.max_checkpoint_file_size_bytes().into())
+            }
+            "max_checkpoint_total_size_bytes" => {
+                Value::Number(runtime_config.max_checkpoint_total_size_bytes().into())
+            }
+            "max_checkpoint_total_lines" => {
+                Value::Number(runtime_config.max_checkpoint_total_lines().into())
             }
             "custom_attributes" => serde_json::to_value(runtime_config.custom_attributes())
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
@@ -820,6 +842,28 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.max_checkpoint_file_size_bytes = Some(bytes);
                 crate::config::save_file_config(&file_config)?;
                 println!("[max_checkpoint_file_size_bytes]: {}", bytes);
+            }
+            "max_checkpoint_total_size_bytes" => {
+                let bytes = value.trim().parse::<usize>().map_err(|_| {
+                    format!(
+                        "Invalid max_checkpoint_total_size_bytes value '{}'. Expected a non-negative integer in bytes",
+                        value
+                    )
+                })?;
+                file_config.max_checkpoint_total_size_bytes = Some(bytes);
+                crate::config::save_file_config(&file_config)?;
+                println!("[max_checkpoint_total_size_bytes]: {}", bytes);
+            }
+            "max_checkpoint_total_lines" => {
+                let lines = value.trim().parse::<usize>().map_err(|_| {
+                    format!(
+                        "Invalid max_checkpoint_total_lines value '{}'. Expected a non-negative integer in lines",
+                        value
+                    )
+                })?;
+                file_config.max_checkpoint_total_lines = Some(lines);
+                crate::config::save_file_config(&file_config)?;
+                println!("[max_checkpoint_total_lines]: {}", lines);
             }
             "custom_attributes" => {
                 if add_mode {
@@ -1165,6 +1209,20 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [max_checkpoint_file_size_bytes]: {}", v);
+                }
+            }
+            "max_checkpoint_total_size_bytes" => {
+                let old_value = file_config.max_checkpoint_total_size_bytes.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [max_checkpoint_total_size_bytes]: {}", v);
+                }
+            }
+            "max_checkpoint_total_lines" => {
+                let old_value = file_config.max_checkpoint_total_lines.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [max_checkpoint_total_lines]: {}", v);
                 }
             }
             "custom_attributes" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,9 @@ use std::sync::RwLock;
 
 /// Default API base URL for comparison
 pub const DEFAULT_API_BASE_URL: &str = "https://usegitai.com";
+pub const DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES: usize = 3 * 1024 * 1024;
+pub const DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES: usize = 32 * 1024 * 1024;
+pub const DEFAULT_MAX_CHECKPOINT_TOTAL_LINES: usize = 500_000;
 
 /// Which backend to use for storing authorship notes.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -182,6 +185,8 @@ pub struct Config {
     notes_backend: NotesBackendConfig,
     transcript_streaming_lookback_days: Option<u32>,
     max_checkpoint_file_size_bytes: usize,
+    max_checkpoint_total_size_bytes: usize,
+    max_checkpoint_total_lines: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
@@ -265,6 +270,10 @@ pub struct FileConfig {
     pub transcript_streaming_lookback_days: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_checkpoint_file_size_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_checkpoint_total_size_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_checkpoint_total_lines: Option<usize>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -326,6 +335,10 @@ pub struct ConfigPatch {
     pub transcript_streaming_lookback_days: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_checkpoint_file_size_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_checkpoint_total_size_bytes: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_checkpoint_total_lines: Option<usize>,
 }
 
 impl Config {
@@ -635,6 +648,16 @@ impl Config {
     /// Returns the per-file size limit for checkpoint content reads.
     pub fn max_checkpoint_file_size_bytes(&self) -> usize {
         self.max_checkpoint_file_size_bytes
+    }
+
+    /// Returns the total byte budget for content in one checkpoint request.
+    pub fn max_checkpoint_total_size_bytes(&self) -> usize {
+        self.max_checkpoint_total_size_bytes
+    }
+
+    /// Returns the total line budget for content in one checkpoint request.
+    pub fn max_checkpoint_total_lines(&self) -> usize {
+        self.max_checkpoint_total_lines
     }
 
     /// Returns true if quiet mode is enabled (suppresses chart output after commits)
@@ -1161,7 +1184,7 @@ fn build_config() -> Config {
         .or(Some(7))
         .and_then(|v| if v == 0 { None } else { Some(v) });
 
-    // Per-file checkpoint content limit: env > file > default (3 MiB).
+    // Checkpoint content limits: env > file > defaults.
     let max_checkpoint_file_size_bytes = env::var("GIT_AI_MAX_CHECKPOINT_FILE_SIZE_BYTES")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
@@ -1170,7 +1193,23 @@ fn build_config() -> Config {
                 .as_ref()
                 .and_then(|c| c.max_checkpoint_file_size_bytes)
         })
-        .unwrap_or(3 * 1024 * 1024);
+        .unwrap_or(DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES);
+
+    let max_checkpoint_total_size_bytes = env::var("GIT_AI_MAX_CHECKPOINT_TOTAL_SIZE_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .or_else(|| {
+            file_cfg
+                .as_ref()
+                .and_then(|c| c.max_checkpoint_total_size_bytes)
+        })
+        .unwrap_or(DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES);
+
+    let max_checkpoint_total_lines = env::var("GIT_AI_MAX_CHECKPOINT_TOTAL_LINES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .or_else(|| file_cfg.as_ref().and_then(|c| c.max_checkpoint_total_lines))
+        .unwrap_or(DEFAULT_MAX_CHECKPOINT_TOTAL_LINES);
 
     #[cfg(any(test, feature = "test-support"))]
     {
@@ -1199,6 +1238,8 @@ fn build_config() -> Config {
             notes_backend,
             transcript_streaming_lookback_days,
             max_checkpoint_file_size_bytes,
+            max_checkpoint_total_size_bytes,
+            max_checkpoint_total_lines,
         };
         apply_test_config_patch(&mut config);
         config
@@ -1230,6 +1271,8 @@ fn build_config() -> Config {
         notes_backend,
         transcript_streaming_lookback_days,
         max_checkpoint_file_size_bytes,
+        max_checkpoint_total_size_bytes,
+        max_checkpoint_total_lines,
     }
 }
 
@@ -1679,6 +1722,12 @@ fn apply_test_config_patch(config: &mut Config) {
         if let Some(max_bytes) = patch.max_checkpoint_file_size_bytes {
             config.max_checkpoint_file_size_bytes = max_bytes;
         }
+        if let Some(max_bytes) = patch.max_checkpoint_total_size_bytes {
+            config.max_checkpoint_total_size_bytes = max_bytes;
+        }
+        if let Some(max_lines) = patch.max_checkpoint_total_lines {
+            config.max_checkpoint_total_lines = max_lines;
+        }
     }
 }
 
@@ -1720,7 +1769,9 @@ mod tests {
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
-            max_checkpoint_file_size_bytes: 3 * 1024 * 1024,
+            max_checkpoint_file_size_bytes: DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES,
+            max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
+            max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
         }
     }
 
@@ -1963,7 +2014,9 @@ mod tests {
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
-            max_checkpoint_file_size_bytes: 3 * 1024 * 1024,
+            max_checkpoint_file_size_bytes: DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES,
+            max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
+            max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
         }
     }
 
@@ -2109,7 +2162,9 @@ mod tests {
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
-            max_checkpoint_file_size_bytes: 3 * 1024 * 1024,
+            max_checkpoint_file_size_bytes: DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES,
+            max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
+            max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,5 @@
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::checkpoint_content_budget::CheckpointContentBudget;
 use crate::config;
 use crate::daemon::git_backend::GitBackend;
 use crate::error::GitAiError;
@@ -918,7 +919,8 @@ fn resolve_checkpoint_request(
     let mut files = Vec::new();
     let mut dirty_files: HashMap<String, Arc<str>> = HashMap::new();
     let mut seen = std::collections::HashSet::new();
-    let max_size = config::Config::fresh().max_checkpoint_file_size_bytes();
+    let config = config::Config::fresh();
+    let mut content_budget = CheckpointContentBudget::from_config(&config);
 
     for file in &mut request.files {
         let path_str = file.path.to_string_lossy();
@@ -955,10 +957,13 @@ fn resolve_checkpoint_request(
             continue;
         }
 
-        if let Some(content) = std::mem::take(&mut file.content)
-            && !content.chars().any(|c| c == '\0')
-            && content.len() <= max_size
-        {
+        if let Some(content) = std::mem::take(&mut file.content) {
+            if content.as_bytes().contains(&0) {
+                continue;
+            }
+            if !content_budget.reserve(&relative_path, &content) {
+                continue;
+            }
             dirty_files.insert(relative_path.clone(), Arc::from(content));
             files.push(relative_path);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod auth;
 pub mod authorship;
+pub(crate) mod checkpoint_content_budget;
 pub mod ci;
 pub mod commands;
 pub mod config;

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1555,6 +1555,72 @@ fn daemon_stalled_unidentified_trace_connection_does_not_block_checkpoint_contro
 
 #[test]
 #[cfg(not(windows))]
+fn daemon_checkpoint_resolution_applies_total_content_budget() {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    repo.patch_git_ai_config(|p| {
+        p.max_checkpoint_file_size_bytes = Some(1024);
+        p.max_checkpoint_total_size_bytes = Some(96);
+        p.max_checkpoint_total_lines = Some(1000);
+    });
+
+    let control_socket = daemon_control_socket_path(&repo);
+    fs::write(repo.path().join("a_kept.txt"), "a".repeat(48)).unwrap();
+    fs::write(repo.path().join("z_skipped.txt"), "z".repeat(64)).unwrap();
+
+    let request = CheckpointRequest {
+        trace_id: "daemon-checkpoint-budget".to_string(),
+        checkpoint_kind: CheckpointKind::Human,
+        agent_id: None,
+        files: vec![
+            CheckpointFile {
+                path: PathBuf::from("a_kept.txt"),
+                content: Some("a".repeat(48)),
+                repo_work_dir: repo.path().to_path_buf(),
+                base_commit: BaseCommit::Initial,
+            },
+            CheckpointFile {
+                path: PathBuf::from("z_skipped.txt"),
+                content: Some("z".repeat(64)),
+                repo_work_dir: repo.path().to_path_buf(),
+                base_commit: BaseCommit::Initial,
+            },
+        ],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+
+    let response = send_control_request_with_timeout(
+        &control_socket,
+        &ControlRequest::CheckpointRun {
+            request: Box::new(request),
+        },
+        Duration::from_secs(5),
+    )
+    .expect("checkpoint control request should succeed");
+
+    assert!(
+        response.ok,
+        "checkpoint control request should succeed: {:?}",
+        response
+    );
+
+    let checkpoints = repo
+        .current_working_logs()
+        .read_all_checkpoints()
+        .expect("checkpoints should be readable");
+    assert_eq!(checkpoints.len(), 1, "expected exactly one checkpoint");
+    let checkpoint = checkpoints.last().unwrap();
+    assert_eq!(
+        checkpoint.entries.len(),
+        1,
+        "expected daemon resolver to apply aggregate content budget"
+    );
+    assert_eq!(checkpoint.entries[0].file, "a_kept.txt");
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_stalled_unidentified_trace_connection_does_not_block_sync_control_request() {
     let repo = TestRepo::new_dedicated_daemon();
     let trace_socket = daemon_trace_socket_path(&repo);

--- a/tests/integration/checkpoint_size.rs
+++ b/tests/integration/checkpoint_size.rs
@@ -1,6 +1,8 @@
 use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::working_log::CheckpointKind;
 use git_ai::git::repository::find_repository_in_path;
 use rand::{RngExt, distr::Alphanumeric};
+use serde_json::json;
 use std::{fs, time::Instant};
 
 #[test]
@@ -142,6 +144,130 @@ fn test_checkpoint_saves_normal_files_under_limit() {
         "expected one entry for normal file"
     );
     assert_eq!(latest.entries[0].file, "normal.txt");
+}
+
+#[test]
+fn test_checkpoint_skips_files_over_total_size_budget() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|p| {
+        p.max_checkpoint_file_size_bytes = Some(1024);
+        p.max_checkpoint_total_size_bytes = Some(96);
+        p.max_checkpoint_total_lines = Some(1000);
+    });
+
+    let kept_path = repo.path().join("a_kept.txt");
+    let skipped_path = repo.path().join("z_skipped.txt");
+    fs::write(&kept_path, "a".repeat(48)).expect("write kept file");
+    fs::write(&skipped_path, "z".repeat(64)).expect("write skipped file");
+
+    repo.git_ai(&["checkpoint", "mock_ai", "a_kept.txt", "z_skipped.txt"])
+        .expect("git-ai checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    assert_eq!(checkpoints.len(), 1, "expected exactly one checkpoint");
+    let latest = checkpoints.last().unwrap();
+    assert_eq!(
+        latest.entries.len(),
+        1,
+        "expected aggregate byte budget to skip the second file"
+    );
+    assert_eq!(latest.entries[0].file, "a_kept.txt");
+}
+
+#[test]
+fn test_checkpoint_skips_files_over_total_line_budget() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|p| {
+        p.max_checkpoint_file_size_bytes = Some(1024);
+        p.max_checkpoint_total_size_bytes = Some(1024);
+        p.max_checkpoint_total_lines = Some(3);
+    });
+
+    let kept_path = repo.path().join("a_kept.txt");
+    let skipped_path = repo.path().join("z_skipped.txt");
+    fs::write(&kept_path, "one\ntwo\n").expect("write kept file");
+    fs::write(&skipped_path, "three\nfour\n").expect("write skipped file");
+
+    repo.git_ai(&["checkpoint", "mock_ai", "a_kept.txt", "z_skipped.txt"])
+        .expect("git-ai checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    assert_eq!(checkpoints.len(), 1, "expected exactly one checkpoint");
+    let latest = checkpoints.last().unwrap();
+    assert_eq!(
+        latest.entries.len(),
+        1,
+        "expected aggregate line budget to skip the second file"
+    );
+    assert_eq!(latest.entries[0].file, "a_kept.txt");
+}
+
+#[test]
+fn test_checkpoint_total_size_budget_applies_to_bash_checkpoints() {
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|p| {
+        p.max_checkpoint_file_size_bytes = Some(1024);
+        p.max_checkpoint_total_size_bytes = Some(96);
+        p.max_checkpoint_total_lines = Some(1000);
+    });
+
+    let repo_root = repo.canonical_path();
+    let kept_path = repo_root.join("a_kept.txt");
+    let skipped_path = repo_root.join("z_skipped.txt");
+    fs::write(&kept_path, "base\n").expect("write kept base");
+    fs::write(&skipped_path, "base\n").expect("write skipped base");
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let transcript_path = repo_root.join("codex-session.jsonl");
+    fs::write(&transcript_path, "{}\n").expect("write transcript");
+
+    let pre_hook = json!({
+        "session_id": "checkpoint-budget-session",
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "checkpoint-budget-bash",
+        "tool_input": {
+            "command": "echo hello"
+        },
+        "transcript_path": transcript_path.to_string_lossy()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook])
+        .expect("pre bash checkpoint should succeed");
+
+    fs::write(&kept_path, "a".repeat(48)).expect("write kept edit");
+    fs::write(&skipped_path, "z".repeat(64)).expect("write skipped edit");
+
+    let post_hook = json!({
+        "session_id": "checkpoint-budget-session",
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "checkpoint-budget-bash",
+        "tool_input": {
+            "command": "echo hello"
+        },
+        "transcript_path": transcript_path.to_string_lossy()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook])
+        .expect("post bash checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    let latest_ai = checkpoints
+        .iter()
+        .rev()
+        .find(|checkpoint| checkpoint.kind == CheckpointKind::AiAgent)
+        .expect("expected bash AI checkpoint");
+    assert_eq!(
+        latest_ai.entries.len(),
+        1,
+        "expected aggregate budget to apply to bash checkpoint payload"
+    );
+    assert_eq!(latest_ai.entries[0].file, "a_kept.txt");
 }
 
 crate::reuse_tests_in_worktree!(test_checkpoint_size_logging_large_ai_rewrites,);

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -75,6 +75,44 @@ fn test_config_transcript_streaming_lookback_days_set_get_unset() {
 }
 
 #[test]
+fn test_config_checkpoint_budget_set_get_unset() {
+    let repo = TestRepo::new();
+
+    repo.git_ai(&[
+        "config",
+        "set",
+        "max_checkpoint_total_size_bytes",
+        "1048576",
+    ])
+    .expect("set max_checkpoint_total_size_bytes");
+    assert_eq!(
+        get_json(&repo, "max_checkpoint_total_size_bytes"),
+        Value::Number(1_048_576.into())
+    );
+
+    repo.git_ai(&["config", "set", "max_checkpoint_total_lines", "4096"])
+        .expect("set max_checkpoint_total_lines");
+    assert_eq!(
+        get_json(&repo, "max_checkpoint_total_lines"),
+        Value::Number(4096.into())
+    );
+
+    repo.git_ai(&["config", "unset", "max_checkpoint_total_size_bytes"])
+        .expect("unset max_checkpoint_total_size_bytes");
+    assert_eq!(
+        get_json(&repo, "max_checkpoint_total_size_bytes"),
+        Value::Number((32 * 1024 * 1024).into())
+    );
+
+    repo.git_ai(&["config", "unset", "max_checkpoint_total_lines"])
+        .expect("unset max_checkpoint_total_lines");
+    assert_eq!(
+        get_json(&repo, "max_checkpoint_total_lines"),
+        Value::Number(500_000.into())
+    );
+}
+
+#[test]
 fn test_config_custom_attributes_object_set_get_unset() {
     let repo = TestRepo::new();
 
@@ -197,6 +235,8 @@ fn test_config_show_all_includes_new_keys() {
 
     assert!(value.get("allow_superuser").is_some());
     assert!(value.get("transcript_streaming_lookback_days").is_some());
+    assert!(value.get("max_checkpoint_total_size_bytes").is_some());
+    assert!(value.get("max_checkpoint_total_lines").is_some());
     assert!(value.get("custom_attributes").is_some());
 }
 
@@ -261,6 +301,8 @@ fn fully_populated_file_config() -> FileConfig {
         notes_backend: Some(NotesBackendConfig::default()),
         transcript_streaming_lookback_days: Some(7),
         max_checkpoint_file_size_bytes: Some(3 * 1024 * 1024),
+        max_checkpoint_total_size_bytes: Some(32 * 1024 * 1024),
+        max_checkpoint_total_lines: Some(500_000),
     }
 }
 

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1245,6 +1245,18 @@ impl TestRepo {
                 serde_json::Value::Number(serde_json::Number::from(max_bytes as u64)),
             );
         }
+        if let Some(max_bytes) = patch.max_checkpoint_total_size_bytes {
+            config.insert(
+                "max_checkpoint_total_size_bytes".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(max_bytes as u64)),
+            );
+        }
+        if let Some(max_lines) = patch.max_checkpoint_total_lines {
+            config.insert(
+                "max_checkpoint_total_lines".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(max_lines as u64)),
+            );
+        }
 
         let config_dir = home.join(".git-ai");
         fs::create_dir_all(&config_dir).expect("failed to create test HOME config directory");


### PR DESCRIPTION
Limit checkpoint payloads by aggregate bytes and lines in the checkpoint builder and daemon resolver. Expose the limits through config and cover standard, Bash, and direct daemon checkpoint paths.