### PR TITLE
fix(daemon): normalize commit subjects for reflog matching

### DIFF
--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -2324,7 +2324,10 @@ fn commit_subject(message: &str) -> Option<String> {
     message
         .lines()
         .find(|line| !line.trim().is_empty())
-        .map(|line| line.to_string())
+        .map(|line| {
+            line.trim_end_matches(|character: char| character.is_ascii_whitespace())
+                .to_string()
+        })
 }
 
 fn resolve_cherry_pick_source_oids_from_sources(
@@ -3526,6 +3529,27 @@ mod tests {
     const E: &str = "5555555555555555555555555555555555555555";
     const F: &str = "6666666666666666666666666666666666666666";
     const G: &str = "7777777777777777777777777777777777777777";
+
+    #[test]
+    fn commit_subject_matches_git_reflog_trailing_whitespace_cleanup() {
+        assert_eq!(commit_subject("subject \t"), Some("subject".to_string()));
+        assert_eq!(
+            commit_subject("\nsubject \t\nbody"),
+            Some("subject".to_string())
+        );
+        assert_eq!(
+            commit_subject("subject\u{00a0}"),
+            Some("subject\u{00a0}".to_string())
+        );
+
+        let args = vec![
+            "commit".to_string(),
+            "-m".to_string(),
+            "subject \t".to_string(),
+        ];
+        assert!(commit_reflog_messages(&args, false).contains("commit: subject"));
+        assert!(commit_reflog_messages(&args, true).contains("commit (amend): subject"));
+    }
 
     #[test]
     fn revert_source_args_do_not_treat_bare_gpg_sign_as_value_option() {

--- a/tests/integration/cold_trace2_repo.rs
+++ b/tests/integration/cold_trace2_repo.rs
@@ -164,6 +164,25 @@ fn test_cold_repo_first_traced_commit_is_processed() {
     assert_no_ai_authorship_for_commit(&repo, &head);
 }
 
+#[test]
+fn test_cold_repo_commit_message_trailing_whitespace_preserves_ai_authorship() {
+    let mut repo = cold_repo();
+    raw_commit_file(&repo, "tracked.txt", "base\n", "raw base");
+
+    start_cold_daemon(&mut repo);
+    write_file(&repo, "tracked.txt", "base\nAI line\n");
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .expect("mock_ai checkpoint should succeed");
+    repo.git(&["add", "tracked.txt"])
+        .expect("staging AI change should succeed");
+    run_traced_git(&repo, &["commit", "-m", "AI change "]);
+
+    assert_ai_authorship_note(&repo, &raw_head(&repo));
+    let stats = repo.stats().expect("commit stats should be available");
+    assert_eq!(stats.ai_additions, 1);
+    assert_eq!(stats.unknown_additions, 0);
+}
+
 fn run_cold_repo_first_traced_pull_rebase_preserves_rebased_ai_authorship() {
     let upstream = TestRepo::new_bare_with_daemon_scope(DaemonTestScope::NoDaemon);
     raw_git(&upstream, &["symbolic-ref", "HEAD", "refs/heads/main"]);
@@ -678,6 +697,7 @@ fn test_cold_repo_traced_stash_after_raw_stash_history_preserves_current_ai_attr
 
 crate::reuse_tests_in_worktree!(
     test_cold_repo_first_traced_commit_is_processed,
+    test_cold_repo_commit_message_trailing_whitespace_preserves_ai_authorship,
     test_traced_commit_after_untraced_head_move_creates_authorship_note,
     test_traced_commit_after_untraced_duplicate_message_head_move_notes_traced_commit,
     test_cold_repo_first_traced_amend_is_processed,


### PR DESCRIPTION
## Summary
- normalize commit subjects to Git's reflog trailing-whitespace behavior
- preserve non-ASCII trailing characters
- add real trace2 regression coverage for regular and linked-worktree repositories

## Problem
A command such as `git commit -m "AI change "` succeeds, but Git removes trailing ASCII whitespace from the subject it records in the reflog. The ref cursor previously derived its expected reflog message from the raw argv value, so exact matching could miss the ref transition. That prevented the semantic `CommitCreated` event and skipped post-commit authorship processing.

## Fix
Trim trailing ASCII whitespace when deriving a commit subject from `-m` / `--message`. This stays on the existing constant-time string-processing path and adds no I/O or Git subprocesses.

## Testing
- `task test TEST_FILTER=commit_subject_matches_git_reflog_trailing_whitespace_cleanup`
- `task test TEST_FILTER=test_cold_repo_commit_message_trailing_whitespace_preserves_ai_authorship` (regular and linked-worktree variants)
- `task test TEST_FILTER=daemon::ref_cursor::tests`
- `task build`
- `task lint`
- `cargo fmt --check`
