### PR TITLE
Limit Bash checkpoint processing to 10 seconds

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -89,6 +89,7 @@ const TRACE_CONNECTION_CLOSED_EVENT: &str = "git_ai_connection_closed";
 const DAEMON_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 const DAEMON_CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
 const DAEMON_CHECKPOINT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
+const BASH_CHECKPOINT_PROCESSING_TIMEOUT: Duration = Duration::from_secs(10);
 const DAEMON_SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 // Trace2 frames are written synchronously by Git to the daemon's Unix socket.
 // With small kernel socket buffers (macOS defaults to ~8 KiB), a bursty trace2
@@ -848,9 +849,38 @@ fn rfc3339_to_unix_nanos(value: &str) -> Option<u128> {
         .and_then(|timestamp| u128::try_from(timestamp.timestamp_nanos_opt()?).ok())
 }
 
-fn apply_checkpoint_side_effect(mut request: CheckpointRequest) -> Result<(), GitAiError> {
+fn bash_checkpoint_processing_timeout() -> Duration {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Ok(timeout_ms) = std::env::var("GIT_AI_TEST_BASH_CHECKPOINT_PROCESSING_TIMEOUT_MS")
+        && let Ok(timeout_ms) = timeout_ms.parse::<u64>()
+    {
+        return Duration::from_millis(timeout_ms);
+    }
+
+    BASH_CHECKPOINT_PROCESSING_TIMEOUT
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn delay_checkpoint_processing_for_test() {
+    if let Ok(delay_ms) = std::env::var("GIT_AI_TEST_CHECKPOINT_PROCESSING_DELAY_MS")
+        && let Ok(delay_ms) = delay_ms.parse::<u64>()
+    {
+        std::thread::sleep(Duration::from_millis(delay_ms));
+    }
+}
+
+fn apply_checkpoint_side_effect(
+    mut request: CheckpointRequest,
+    processing_deadline: Option<crate::daemon::checkpoint::CheckpointProcessingDeadline>,
+) -> Result<(), GitAiError> {
     if request.files.is_empty() {
         return Ok(());
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    delay_checkpoint_processing_for_test();
+    if let Some(deadline) = processing_deadline {
+        deadline.check("checkpoint side-effect setup")?;
     }
 
     let repo_work_dir = &request.files[0].repo_work_dir;
@@ -884,12 +914,13 @@ fn apply_checkpoint_side_effect(mut request: CheckpointRequest) -> Result<(), Gi
         return Ok(());
     };
 
-    crate::daemon::checkpoint::execute_resolved_checkpoint_from_daemon(
+    crate::daemon::checkpoint::execute_resolved_checkpoint_from_daemon_with_deadline(
         &repo,
         &author,
         request.checkpoint_kind,
         request,
         resolved,
+        processing_deadline,
     )
 }
 
@@ -4268,6 +4299,12 @@ impl ActorDaemonCoordinator {
                     let should_log_completion = true; // Always log for test sync
                     tracing::info!(kind = %checkpoint_kind_str, repo = %repo_wd, "checkpoint start");
                     let checkpoint_start = std::time::Instant::now();
+                    let processing_deadline = request.is_bash().then(|| {
+                        crate::daemon::checkpoint::CheckpointProcessingDeadline::new(
+                            checkpoint_start,
+                            bash_checkpoint_processing_timeout(),
+                        )
+                    });
                     let checkpoint_request = {
                         let future = async {
                             if !repo_wd.is_empty() {
@@ -4275,12 +4312,14 @@ impl ActorDaemonCoordinator {
                                     self.coordinator.apply_checkpoint(Path::new(&repo_wd)).await;
                                 match ack {
                                     Ok(ack) => {
-                                        apply_checkpoint_side_effect(*request).map(|_| ack.seq)
+                                        apply_checkpoint_side_effect(*request, processing_deadline)
+                                            .map(|_| ack.seq)
                                     }
                                     Err(error) => Err(error),
                                 }
                             } else {
-                                apply_checkpoint_side_effect(*request).map(|_| 0)
+                                apply_checkpoint_side_effect(*request, processing_deadline)
+                                    .map(|_| 0)
                             }
                         };
                         let caught = std::panic::AssertUnwindSafe(future);
@@ -7968,6 +8007,11 @@ mod tests {
             checkpoint_control_response_timeout(&sample_checkpoint_request(), false),
             DAEMON_CONTROL_RESPONSE_TIMEOUT
         );
+    }
+
+    #[test]
+    fn bash_checkpoint_processing_budget_is_ten_seconds() {
+        assert_eq!(BASH_CHECKPOINT_PROCESSING_TIMEOUT, Duration::from_secs(10));
     }
 
     #[test]

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 #[cfg(not(any(test, feature = "test-support")))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -85,6 +85,46 @@ pub struct ResolvedCheckpointExecution {
     pub ts: u128,
     pub files: Vec<String>,
     pub dirty_files: HashMap<String, Arc<str>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CheckpointProcessingDeadline {
+    started_at: Instant,
+    timeout: Duration,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CheckpointExecutionContext {
+    started_at: Instant,
+    processing_deadline: Option<CheckpointProcessingDeadline>,
+}
+
+impl CheckpointProcessingDeadline {
+    pub fn new(started_at: Instant, timeout: Duration) -> Self {
+        Self {
+            started_at,
+            timeout,
+        }
+    }
+
+    pub(crate) fn check(self, phase: &str) -> Result<(), GitAiError> {
+        if self.started_at.elapsed() < self.timeout {
+            return Ok(());
+        }
+
+        Err(GitAiError::Generic(format!(
+            "Bash checkpoint processing timed out after {}ms during {}",
+            self.timeout.as_millis(),
+            phase,
+        )))
+    }
+}
+
+fn check_processing_deadline(
+    deadline: Option<CheckpointProcessingDeadline>,
+    phase: &str,
+) -> Result<(), GitAiError> {
+    deadline.map_or(Ok(()), |deadline| deadline.check(phase))
 }
 
 /// Build EventAttributes for AgentUsage events.
@@ -168,6 +208,24 @@ pub fn execute_resolved_checkpoint_from_daemon(
     checkpoint_request: CheckpointRequest,
     resolved: ResolvedCheckpointExecution,
 ) -> Result<(), GitAiError> {
+    execute_resolved_checkpoint_from_daemon_with_deadline(
+        repo,
+        author,
+        kind,
+        checkpoint_request,
+        resolved,
+        None,
+    )
+}
+
+pub fn execute_resolved_checkpoint_from_daemon_with_deadline(
+    repo: &Repository,
+    author: &str,
+    kind: CheckpointKind,
+    checkpoint_request: CheckpointRequest,
+    resolved: ResolvedCheckpointExecution,
+    processing_deadline: Option<CheckpointProcessingDeadline>,
+) -> Result<(), GitAiError> {
     let checkpoint_start = Instant::now();
     tracing::debug!("[BENCHMARK] Starting daemon replay checkpoint");
     execute_resolved_checkpoint(
@@ -177,7 +235,10 @@ pub fn execute_resolved_checkpoint_from_daemon(
         true,
         checkpoint_request,
         resolved,
-        checkpoint_start,
+        CheckpointExecutionContext {
+            started_at: checkpoint_start,
+            processing_deadline,
+        },
     )
     .map(|_| ())
 }
@@ -189,8 +250,13 @@ fn execute_resolved_checkpoint(
     quiet: bool,
     checkpoint_request: CheckpointRequest,
     mut resolved: ResolvedCheckpointExecution,
-    checkpoint_start: Instant,
+    context: CheckpointExecutionContext,
 ) -> Result<(usize, usize, usize), GitAiError> {
+    let CheckpointExecutionContext {
+        started_at: checkpoint_start,
+        processing_deadline,
+    } = context;
+    check_processing_deadline(processing_deadline, "checkpoint setup")?;
     if kind.is_ai() && checkpoint_request.agent_id.is_none() {
         return Err(GitAiError::Generic(
             "AI checkpoint is missing agent_id".to_string(),
@@ -207,6 +273,7 @@ fn execute_resolved_checkpoint(
 
     let read_checkpoints_start = Instant::now();
     let mut checkpoints = working_log.read_all_checkpoints()?;
+    check_processing_deadline(processing_deadline, "working log read")?;
     tracing::debug!(
         "[BENCHMARK] Reading {} checkpoints took {:?}",
         checkpoints.len(),
@@ -239,7 +306,8 @@ fn execute_resolved_checkpoint(
     }
 
     let save_states_start = Instant::now();
-    let file_content_hashes = save_current_file_states(&working_log, &resolved.files)?;
+    let file_content_hashes =
+        save_current_file_states(&working_log, &resolved.files, processing_deadline)?;
     tracing::debug!(
         "[BENCHMARK] save_current_file_states for {} files took {:?}",
         resolved.files.len(),
@@ -252,6 +320,7 @@ fn execute_resolved_checkpoint(
 
     let mut combined_hasher = Sha256::new();
     for (file_path, hash) in ordered_hashes {
+        check_processing_deadline(processing_deadline, "content hash aggregation")?;
         combined_hasher.update(file_path.as_bytes());
         combined_hasher.update(hash.as_bytes());
     }
@@ -276,7 +345,9 @@ fn execute_resolved_checkpoint(
         resolved.ts,
         Some(resolved.base_commit.as_str()),
         trace_id.clone(),
+        processing_deadline,
     ))?;
+    check_processing_deadline(processing_deadline, "checkpoint entry generation")?;
     tracing::debug!(
         "[BENCHMARK] get_checkpoint_entries generated {} entries, took {:?}",
         entries.len(),
@@ -333,6 +404,7 @@ fn execute_resolved_checkpoint(
         );
 
         let append_start = Instant::now();
+        check_processing_deadline(processing_deadline, "checkpoint append")?;
         working_log.append_checkpoint(&checkpoint)?;
         tracing::debug!(
             "[BENCHMARK] Appending checkpoint to working log took {:?}",
@@ -434,6 +506,7 @@ fn execute_resolved_checkpoint(
 fn save_current_file_states(
     working_log: &PersistedWorkingLog,
     files: &[String],
+    processing_deadline: Option<CheckpointProcessingDeadline>,
 ) -> Result<HashMap<String, String>, GitAiError> {
     let _read_start = Instant::now();
 
@@ -457,6 +530,7 @@ fn save_current_file_states(
                     .acquire_owned()
                     .await
                     .expect("file state semaphore was closed");
+                check_processing_deadline(processing_deadline, "file state capture")?;
 
                 // Read file content - check dirty_files first, then filesystem
                 let content = if let Some(ref dirty_map) = *dirty_files {
@@ -471,7 +545,7 @@ fn save_current_file_states(
                     ))
                 })?;
 
-                crate::tokio_runtime::spawn_blocking_result(move || {
+                let result = crate::tokio_runtime::spawn_blocking_result(move || {
                     // Create SHA256 hash of the content
                     let mut hasher = Sha256::new();
                     hasher.update(content.as_bytes());
@@ -486,7 +560,9 @@ fn save_current_file_states(
 
                     Ok::<(String, String), GitAiError>((file_path, sha))
                 })
-                .await
+                .await;
+                check_processing_deadline(processing_deadline, "file state capture")?;
+                result
             });
         }
 
@@ -590,7 +666,9 @@ fn get_checkpoint_entry_for_file(
     initial_snapshot_contents: Arc<HashMap<String, Arc<str>>>,
     parent_note_attributions: Arc<HashMap<String, Vec<LineAttribution>>>,
     ts: u128,
+    processing_deadline: Option<CheckpointProcessingDeadline>,
 ) -> Result<Option<(WorkingLogEntry, FileLineStats)>, GitAiError> {
+    check_processing_deadline(processing_deadline, "file attribution")?;
     let file_start = Instant::now();
     let initial_attrs_for_file = initial_attributions
         .get(&file_path)
@@ -627,6 +705,7 @@ fn get_checkpoint_entry_for_file(
 
         let stats = compute_file_line_stats(&previous_content, &current_content);
         let entry = WorkingLogEntry::new(file_path, file_content_hash, Vec::new(), Vec::new());
+        check_processing_deadline(processing_deadline, "file attribution")?;
         return Ok(Some((entry, stats)));
     }
 
@@ -771,6 +850,7 @@ fn get_checkpoint_entry_for_file(
             remapped_attributions,
             line_attributions,
         );
+        check_processing_deadline(processing_deadline, "file attribution")?;
         return Ok(Some((entry, FileLineStats::default())));
     }
 
@@ -784,6 +864,7 @@ fn get_checkpoint_entry_for_file(
         content: &current_content,
         ts,
     })?;
+    check_processing_deadline(processing_deadline, "file attribution")?;
 
     tracing::debug!(
         "[BENCHMARK] Processing file {} took {:?}",
@@ -806,7 +887,9 @@ async fn get_checkpoint_entries(
     ts: u128,
     head_commit_override: Option<&str>,
     trace_id: String,
+    processing_deadline: Option<CheckpointProcessingDeadline>,
 ) -> Result<(Vec<WorkingLogEntry>, Vec<FileLineStats>), GitAiError> {
+    check_processing_deadline(processing_deadline, "checkpoint entry setup")?;
     let entries_fn_start = Instant::now();
 
     // Read INITIAL attributions from working log (empty if file doesn't exist)
@@ -930,6 +1013,7 @@ async fn get_checkpoint_entries(
                     initial_snapshot_contents.clone(),
                     parent_note_attributions.clone(),
                     ts,
+                    processing_deadline,
                 )
             })
             .await
@@ -946,6 +1030,7 @@ async fn get_checkpoint_entries(
     // Await all tasks concurrently
     let await_start = Instant::now();
     let results = futures::future::join_all(tasks).await;
+    check_processing_deadline(processing_deadline, "checkpoint entry generation")?;
     tracing::debug!(
         "[BENCHMARK] Awaiting {} tasks took {:?}",
         results.len(),

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -4300,6 +4300,93 @@ fn daemon_pure_trace_socket_concurrent_checkpoint_requests_preserve_exact_line_a
 
 #[test]
 #[serial]
+#[cfg(not(windows))]
+fn daemon_times_out_bash_checkpoint_processing_without_affecting_other_checkpoints() {
+    use git_ai::commands::checkpoint_agent::orchestrator::{
+        BaseCommit, CheckpointFile, CheckpointRequest,
+    };
+    use git_ai::daemon::checkpoint::PreparedPathRole;
+
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_BASH_CHECKPOINT_PROCESSING_TIMEOUT_MS", "50"),
+            ("GIT_AI_TEST_CHECKPOINT_PROCESSING_DELAY_MS", "100"),
+        ],
+    );
+    let file_path = repo.path().join("timeout.txt");
+    fs::write(&file_path, "checkpoint content\n").expect("failed to write checkpoint file");
+
+    let request = |trace_id: &str, metadata: std::collections::HashMap<String, String>| {
+        ControlRequest::CheckpointRun {
+            request: Box::new(CheckpointRequest {
+                trace_id: trace_id.to_string(),
+                checkpoint_kind: CheckpointKind::Human,
+                agent_id: None,
+                files: vec![CheckpointFile {
+                    path: file_path.clone(),
+                    content: Some("checkpoint content\n".to_string()),
+                    repo_work_dir: repo.path().to_path_buf(),
+                    base_commit: BaseCommit::Initial,
+                }],
+                path_role: PreparedPathRole::WillEdit,
+                stream_source: None,
+                metadata,
+            }),
+        }
+    };
+
+    let bash_response = send_control_request_with_timeout(
+        &daemon.control_socket_path,
+        &request(
+            "bash-timeout",
+            std::collections::HashMap::from([(
+                "checkpoint_origin".to_string(),
+                "bash".to_string(),
+            )]),
+        ),
+        Duration::from_secs(2),
+    )
+    .expect("daemon should return a structured Bash checkpoint timeout response");
+    assert!(!bash_response.ok, "delayed Bash checkpoint should time out");
+    assert!(
+        bash_response
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("Bash checkpoint processing timed out")),
+        "unexpected timeout response: {bash_response:?}"
+    );
+    assert!(
+        repo.current_working_logs()
+            .read_all_checkpoints()
+            .expect("failed to read checkpoints after timeout")
+            .is_empty(),
+        "timed-out Bash checkpoint must not be appended"
+    );
+
+    let non_bash_response = send_control_request_with_timeout(
+        &daemon.control_socket_path,
+        &request("non-bash", std::collections::HashMap::new()),
+        Duration::from_secs(2),
+    )
+    .expect("non-Bash checkpoint request should receive a response");
+    assert!(
+        non_bash_response.ok,
+        "non-Bash checkpoint should not use the Bash deadline: {non_bash_response:?}"
+    );
+    assert_eq!(
+        repo.current_working_logs()
+            .read_all_checkpoints()
+            .expect("failed to read checkpoints after non-Bash request")
+            .len(),
+        1,
+        "non-Bash checkpoint should still be appended"
+    );
+}
+
+#[test]
+#[serial]
 fn daemon_pure_trace_socket_parallel_worktree_streams_preserve_exact_line_attribution() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
     let _daemon = DaemonGuard::start(&repo);


### PR DESCRIPTION
## Summary\n- enforce a 10-second daemon processing budget only for explicitly marked Bash checkpoints\n- check the deadline cooperatively around working-log reads, file-state capture, hashing, attribution, and append\n- leave the existing 2-second product response timeout unchanged; it limits caller wait, not daemon processing\n\n## Tests\n- TDD integration coverage verifies a delayed Bash checkpoint times out without appending state while the same delayed non-Bash checkpoint completes\n- existing concurrent same-worktree checkpoint attribution test passes\n- \n- full 
running 2048 tests
test api::client::tests::test_api_client_is_logged_in_false ... ok
test api::client::tests::test_api_context_with_timeout ... ok
test api::client::tests::test_api_client_is_logged_in_true ... ok
test api::client::tests::test_api_context_without_auth ... ok
test api::client::tests::test_api_client_context_access ... ok
test api::client::tests::test_api_context_default_timeout ... ok
test api::client::tests::test_api_context_with_auth ... ok
test api::client::tests::test_encode_for_header_ascii_passthrough ... ok
test api::client::tests::test_encode_for_header_non_ascii ... ok
test api::client::tests::test_build_url_invalid_base ... ok
test api::client::tests::test_encode_for_header_percent_encoded_for_reversibility ... ok
test api::client::tests::test_encode_for_header_special_ascii_chars_passthrough ... ok
test api::client::tests::test_encode_for_header_all_bytes_valid_for_ureq ... ok
test api::client::tests::test_mutex_is_accessible ... ok
test api::client::tests::test_build_url_preserves_path_prefix ... ok
test api::client::tests::test_build_url_preserves_path_prefix_with_trailing_slash ... ok
test api::metrics::tests::test_validate_error_indices_rejects_out_of_bounds_index ... ok
test api::metrics::tests::metrics_upload_rate_limiter_enforces_half_second_spacing ... ok
test api::notes::tests::test_notes_upload_response_deserialization ... ok
test api::notes::tests::test_notes_upload_request_serialization ... ok
test api::metrics::tests::test_successful_indices_all_errors ... ok
test api::metrics::tests::test_successful_indices_empty_errors ... ok
test api::metrics::tests::test_successful_indices ... ok
test api::types::tests::test_api_error_response_serialization ... ok
test api::types::tests::test_api_error_response_without_details ... ok
test api::types::tests::daemon_logs_upload_response_accepts_null_error_index ... ok
test api::types::tests::test_api_file_record_clone ... ok
test api::types::tests::test_api_file_record_from_file_diff_empty ... ok
test api::notes::tests::test_notes_read_response_deserialization ... ok
test api::client::tests::test_concurrent_access_to_mutex ... ok
test api::types::tests::test_api_file_record_from_file_diff_ranges ... ok
test api::types::tests::test_api_file_record_from_file_diff_single_lines ... ok
test api::types::tests::test_api_file_record_from_file_diff_mixed ... ok
test api::types::tests::daemon_logs_upload_request_serializes_contract_fields ... ok
test api::types::tests::test_cas_object_empty_metadata ... ok
test api::types::tests::test_cas_object_serialization ... ok
test api::types::tests::test_cas_upload_result ... ok
test api::types::tests::test_cas_upload_result_with_error ... ok
test api::types::tests::test_cas_upload_response ... ok
test api::types::tests::test_cas_upload_request ... ok
test api::types::tests::test_create_bundle_response_deserialization ... ok
test auth::client::tests::test_parse_oauth_error_with_description ... ok
test auth::client::tests::test_parse_device_auth_response_valid ... ok
test auth::client::tests::test_credentials_expiry_calculation ... ok
test auth::client::tests::test_parse_oauth_error_without_description ... ok
test auth::client::tests::test_parse_device_auth_response_without_optional_uri ... ok
test api::types::tests::test_cas_messages_object ... ok
test auth::client::tests::test_parse_token_response_valid ... ok
test auth::client::tests::test_parse_token_response_wrong_types ... ok
test auth::client::tests::test_parse_token_response_missing_field ... ok
test auth::client::tests::test_validate_https_url_valid ... ok
test auth::client::tests::test_validate_https_url_invalid_scheme ... ok
test auth::client::tests::test_validate_https_url_no_scheme ... ok
test auth::client::tests::test_validate_https_url_http_allowed_in_debug ... ok
test auth::client::tests::test_validate_https_url_empty ... ok
test auth::client::tests::test_validate_https_url_with_path ... ok
test auth::client::tests::test_validate_https_url_with_port ... ok
test auth::credential_backend::tests::test_mock_backend_fail_clear ... ok
test auth::credential_backend::tests::test_mock_backend_fail_load ... ok
test auth::credential_backend::tests::test_mock_backend_fail_store ... ok
test auth::credential_backend::tests::test_mock_backend_overwrite ... ok
test auth::credential_backend::tests::test_mock_backend_store_load_clear ... ok
test auth::credentials::tests::test_clear_error_handling ... ok
test auth::credential_backend::tests::test_file_backend_clear_nonexistent ... ok
test auth::credentials::tests::test_corrupted_credentials_empty_json_object ... ok
test auth::credentials::tests::test_corrupted_credentials_json_array ... ok
test auth::credentials::tests::test_corrupted_credentials_truncated_json ... ok
test auth::credentials::tests::test_corrupted_credentials_wrong_schema ... ok
test auth::credentials::tests::test_corrupted_credentials_null_json ... ok
test auth::credentials::tests::test_backend_name ... ok
test auth::credentials::tests::test_empty_credentials_file_fails_parse ... ok
test auth::credentials::tests::test_fallback_path_contains_credentials ... ok
test auth::credentials::tests::test_fallback_path_contains_git_ai_test_dir ... ok
test auth::credentials::tests::test_fallback_path_is_deterministic ... ok
test auth::credential_backend::tests::test_file_backend_roundtrip ... ok
test api::client::tests::test_build_url_simple ... ok
test api::client::tests::test_build_url_with_trailing_slash ... ok
test api::client::tests::test_build_url_preserves_query_string ... ok
test auth::credentials::tests::test_has_credentials_returns_false_on_load_error ... ok
test auth::credentials::tests::test_has_credentials_with_mock ... ok
test auth::credentials::tests::test_load_error_handling ... ok
test auth::credentials::tests::test_load_nonexistent_with_mock ... ok
test auth::credentials::tests::test_roundtrip_store_load_credentials ... ok
test auth::credentials::tests::test_overwrite_credentials_with_mock ... ok
test auth::credentials::tests::test_store_error_handling ... ok
test auth::credentials::tests::test_store_load_clear_with_mock ... ok
test auth::credentials::tests::test_file_backend_store_load_clear ... ok
test auth::credentials::tests::test_file_backend_creates_directory ... ok
test auth::credentials::tests::test_file_backend_sets_unix_permissions ... ok
test auth::types::tests::test_access_token_negative_buffer ... ok
test auth::types::tests::test_access_token_exactly_at_boundary ... ok
test auth::types::tests::test_access_token_expired ... ok
test auth::types::tests::test_access_token_large_buffer ... ok
test auth::types::tests::test_access_token_expires_within_buffer ... ok
test auth::types::tests::test_access_token_not_expired ... ok
test auth::identity::tests::test_extract_identity_handles_non_jwt_token ... ok
test auth::identity::tests::test_extract_identity_from_access_token ... ok
test auth::types::tests::test_access_token_one_second_after_boundary ... ok
test auth::types::tests::test_access_token_zero_buffer ... ok
test auth::types::tests::test_debug_redacts_access_token ... ok
test auth::types::tests::test_debug_redacts_refresh_token ... ok
test auth::types::tests::test_debug_shows_timestamps ... ok
test auth::types::tests::test_refresh_token_exactly_at_boundary ... ok
test auth::types::tests::test_refresh_token_expired ... ok
test auth::types::tests::test_refresh_token_not_expired ... ok
test auth::types::tests::test_refresh_token_one_second_before_expiry ... ok
test authorship::agent_detection::tests::test_match_email_codex ... ok
test authorship::agent_detection::tests::test_match_email_case_insensitive ... ok
test authorship::agent_detection::tests::test_match_email_cursor ... ok
test authorship::agent_detection::tests::test_match_email_devin ... ok
test authorship::agent_detection::tests::test_match_username_case_insensitive ... ok
test authorship::agent_detection::tests::test_match_email_no_match ... ok
test authorship::agent_detection::tests::test_match_email_claude ... ok
test authorship::agent_detection::tests::test_match_email_copilot ... ok
test api::notes::tests::test_read_notes_rejects_non_hex_sha ... ok
test authorship::agent_detection::tests::test_match_username_copilot ... ok
test authorship::agent_detection::tests::test_match_username_cursor ... ok
test authorship::agent_detection::tests::test_match_username_devin ... ok
test authorship::agent_detection::tests::test_match_username_no_match ... ok
test api::notes::tests::test_read_notes_accepts_valid_hex_sha ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_allows_coarse_timestamp_rounded_before_start ... ok
test authorship::agent_detection::tests::test_simulate_agent_authorship_basic ... ok
test authorship::agent_detection::tests::test_simulate_agent_authorship_single_line ... ok
test authorship::agent_detection::tests::test_simulate_agent_authorship_uses_commit_sha_as_id ... ok
test authorship::agent_detection::tests::test_simulate_agent_authorship_deterministic_hash ... ok
test authorship::agent_detection::tests::test_simulate_agent_authorship_different_tools_different_hash ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_prefers_cwd_ancestor_over_time_only ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_falls_back_to_closest_time ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_prefers_workdir_ancestor_over_cwd_ancestor ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_prefers_workdir_ancestor_when_no_session_matches ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_requires_matching_time_range ... ok
test authorship::attribution_recovery::tests::session_event_candidate_ranking_rejects_time_only_sessions ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_prefers_session_already_in_commit ... ok
test authorship::attribution_recovery::tests::bash_candidate_ranking_uses_time_within_existing_commit_sessions ... ok
test authorship::attribution_recovery::tests::session_event_candidate_distance_uses_event_second_bucket ... ok
test authorship::attribution_recovery::tests::session_event_candidate_ranking_prefers_matching_repo_url ... ok
test authorship::attribution_recovery::tests::edge_recovery_keeps_human_and_different_session_guardrails ... ok
test authorship::attribution_tracker::tests::collect_line_metadata_strips_cr_from_text ... ok
test authorship::attribution_recovery::tests::edge_recovery_extends_one_sided_runs_and_bridges_matching_ai_neighbors ... ok
test authorship::attribution_tracker::tests::line_attributions_follow_dominant_tokens ... ok
test authorship::attribution_tracker::tests::line_attribution_handles_split_multibyte_ranges ... ok
test authorship::attribution_recovery::tests::unknown_lines_exclude_existing_attestations ... ok
test authorship::attribution_tracker::tests::crlf_to_lf_same_content_preserves_attributions ... ok
test authorship::attribution_tracker::tests::deletions_remove_attribution ... ok
test authorship::attribution_tracker::tests::lf_to_crlf_same_content_preserves_attributions ... ok
test authorship::attribution_tracker::tests::adding_semicolon_is_substantive ... ok
test authorship::attribution_tracker::tests::line_reflow_without_token_change_is_non_substantive ... ok
test authorship::attribution_tracker::tests::line_reflow_without_token_change_is_non_substantive_with_semicolon ... ok
test authorship::attribution_tracker::tests::crlf_to_lf_with_real_edit_attributes_correctly ... ok
test authorship::attribution_tracker::tests::multibyte_tokens_are_preserved_and_added ... ok
test authorship::attribution_tracker::tests::ai_inserted_blank_line_counts_for_ai ... ok
test authorship::attribution_tracker::tests::unattributed_ranges_are_filled ... ok
test authorship::attribution_tracker::tests::substantive_token_change_switches_author ... ok
test authorship::attribution_tracker::tests::whitespace_only_indent_change_preserves_tokens ... ok
test authorship::attribution_tracker::tests::move_block_preserves_original_authors_one_line_threshold ... ok
test authorship::attribution_tracker::tests::unsorted_ranges_preserve_existing_lines_across_insertions ... ok
test authorship::attribution_tracker::tests::move_block_preserves_original_authors_default_threshold ... ok
test authorship::authorship_log::tests::test_shift_range_zero_offset_identity ... ok
test authorship::authorship_log::tests::test_shift_range_partial_underflow ... ok
test authorship::authorship_log::tests::test_shift_range_collapses_to_single ... ok
test authorship::authorship_log::tests::test_shift_single_below_insertion_unchanged ... ok
test authorship::authorship_log::tests::test_shift_single_large_value_i64_arithmetic ... ok
test authorship::authorship_log::tests::test_shift_single_underflow_returns_none ... ok
test authorship::attribution_tracker::tests::reflow_complex_if_statement_is_non_substantive ... ok
test authorship::authorship_log_serialization::tests::test_generate_session_id ... ok
test authorship::authorship_log_serialization::tests::test_generate_human_short_hash ... ok
test authorship::authorship_log_serialization::tests::test_generate_trace_id ... ok
test authorship::authorship_log_serialization::tests::test_remove_line_ranges_complete_removal ... ok
test authorship::authorship_log_serialization::tests::test_remove_line_ranges_partial_removal ... ok
test authorship::authorship_log_serialization::tests::test_session_id_uses_same_hash_base_as_prompt_id ... ok
test authorship::diff_ai_accepted::tests::test_diff_ai_accepted_stats_debug ... ok
test authorship::diff_ai_accepted::tests::test_diff_ai_accepted_stats_default ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_consecutive ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_empty ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_large_numbers ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_mixed ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_non_consecutive ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_single ... ok
test authorship::diff_ai_accepted::tests::test_lines_to_ranges_two_groups ... ok
test authorship::hunk_shift::tests::test_entry_fully_inside_hunk_removed ... ok
test authorship::hunk_shift::tests::test_file_attestation_returns_none_when_all_emptied ... ok
test authorship::hunk_shift::tests::test_file_attestation_returns_some_when_entries_survive ... ok
test authorship::hunk_shift::tests::test_line_attributions_no_hunks_unchanged ... ok
test authorship::hunk_shift::tests::test_line_attributions_shift ... ok
test authorship::hunk_shift::tests::test_multiple_hunks_accumulate_offsets ... ok
test authorship::hunk_shift::tests::test_no_hunks_entries_unchanged ... ok
test authorship::hunk_shift::tests::test_parse_hunk_header_basic ... ok
test authorship::hunk_shift::tests::test_parse_hunk_header_insertion_only ... ok
test authorship::hunk_shift::tests::test_parse_hunk_header_invalid ... ok
test authorship::hunk_shift::tests::test_parse_hunk_header_single_line ... ok
test authorship::hunk_shift::tests::test_parse_range_spec_invalid ... ok
test authorship::hunk_shift::tests::test_parse_range_spec_with_count ... ok
test authorship::hunk_shift::tests::test_parse_range_spec_without_count ... ok
test authorship::hunk_shift::tests::test_pure_deletion_removes_and_shifts ... ok
test authorship::hunk_shift::tests::test_pure_insertion_shifts_lines_after ... ok
test authorship::hunk_shift::tests::test_replacement_drops_replaced_lines ... ok
test authorship::hunk_shift::tests::test_single_line_range_handling ... ok
test authorship::ignore::tests::defaults_do_not_ignore_generic_snapshots_directories ... ok
test authorship::ignore::tests::defaults_ignore_drizzle_meta_files ... ok
test authorship::ignore::tests::defaults_ignore_nested_named_lockfiles ... ok
test authorship::attribution_tracker::tests::large_file_small_edit_preserves_unchanged_tokens ... ok
test authorship::ignore::tests::defaults_include_protobuf_generated_patterns ... ok
test authorship::ignore::tests::defaults_include_snapshot_and_lock_patterns ... ok
test authorship::ignore::tests::defaults_ignore_protobuf_generated_files ... ok
test authorship::ignore::tests::invalid_patterns_fallback_to_exact_path_or_filename ... ok
test authorship::ignore::tests::should_ignore_file_matches_path_and_filename ... ok
test authorship::imara_diff_utils::tests::test_capture_diff_slices_delete ... ok
test authorship::imara_diff_utils::tests::test_capture_diff_slices_insert ... ok
test authorship::imara_diff_utils::tests::test_capture_diff_slices_simple ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes_crlf_old_with_real_addition ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes_crlf_to_lf_identical_content ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes_insert_only ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes_lf_to_crlf_identical_content ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes_crlf_large_file_few_additions ... ok
test authorship::imara_diff_utils::tests::test_compute_line_changes_mixed_crlf_with_modification ... ok
test authorship::imara_diff_utils::tests::test_split_lines_with_terminators ... ok
test authorship::imara_diff_utils::tests::test_split_lines_with_terminators_crlf ... ok
test authorship::internal_db::tests::test_cas_cache_get_miss ... ok
test authorship::internal_db::tests::test_cas_cache_overwrite ... ok
test authorship::authorship_log_serialization::tests::test_format_line_ranges ... ok
test authorship::internal_db::tests::test_database_path ... ok
test authorship::authorship_log_serialization::tests::test_line_range_sorting ... ok
test authorship::authorship_log_serialization::tests::test_expected_format ... ok
test authorship::authorship_log_serialization::tests::test_hash_always_maps_to_prompt ... ok
test authorship::authorship_log_serialization::tests::test_parse_line_ranges ... ok
test authorship::authorship_log_serialization::tests::test_serialize_deserialize_roundtrip ... ok
test authorship::authorship_log_serialization::tests::test_serialize_deserialize_no_attestations ... ok
test authorship::authorship_log_serialization::tests::test_file_names_with_spaces ... ok
test authorship::internal_db::tests::test_exponential_backoff ... ok
test authorship::internal_db::tests::test_cas_cache_set_and_get ... ok
test authorship::internal_db::tests::test_cas_sync_queue_schema ... ok
test authorship::internal_db::tests::test_initialize_schema_handles_preexisting_cas_cache_table ... ok
test authorship::internal_db::tests::test_enqueue_cas_object ... ok
test authorship::internal_db::tests::test_initialize_schema ... ok
test authorship::move_detection::tests::allows_single_line_moves_with_threshold_one ... ok
test authorship::move_detection::tests::detects_basic_move ... ok
test authorship::move_detection::tests::detects_multiple_groups ... ok
test authorship::move_detection::tests::drops_whitespace_only_lines ... ok
test authorship::move_detection::tests::filters_groups_below_threshold ... ok
test authorship::move_detection::tests::handles_duplicate_candidates ... ok
test authorship::move_detection::tests::matches_when_whitespace_differs ... ok
test authorship::move_detection::tests::no_matches_when_normalized_content_differs ... ok
test authorship::move_detection::tests::works_with_unsorted_input ... ok
test authorship::post_commit::tests::parse_commit_metric_metadata_output_reads_subject_body_and_timestamps ... ok
test authorship::post_commit::tests::parse_commit_metric_metadata_output_uses_null_body_for_empty_body ... ok
test authorship::post_commit::tests::test_count_line_ranges_all_contiguous ... ok
test authorship::post_commit::tests::test_count_line_ranges_all_scattered ... ok
test authorship::post_commit::tests::test_count_line_ranges_duplicates ... ok
test authorship::post_commit::tests::test_count_line_ranges_handles_scattered_and_contiguous_lines ... ok
test authorship::post_commit::tests::test_count_line_ranges_single_element ... ok
test authorship::post_commit::tests::test_count_line_ranges_two_ranges ... ok
test authorship::post_commit::tests::test_count_line_ranges_unsorted ... ok
test authorship::post_commit::tests::test_metric_tool_model_breakdown_filters_mock_ai ... ok
test authorship::post_commit::tests::test_metric_tool_model_breakdown_skips_mock_only ... ok
test authorship::post_commit::tests::test_should_skip_expensive_post_commit_stats_thresholds ... ok
test authorship::post_commit::tests::test_should_skip_stats_exactly_at_thresholds ... ok
test authorship::rewrite::tests::branch_name_from_ref_only_accepts_local_branch_refs ... ok
test authorship::internal_db::tests::test_delete_cas_sync_record ... ok
test authorship::rewrite::tests::rewrite_metric_operation_strings_are_stable ... ok
test authorship::rewrite::tests::test_extract_b_path_rename ... ok
test authorship::rewrite::tests::test_extract_b_path_simple ... ok
test authorship::rewrite::tests::metric_commits_from_mappings_groups_squashed_sources ... ok
test authorship::rewrite::tests::test_find_next_sha_does_not_panic_on_multibyte_subject ... ok
test authorship::rewrite::tests::test_extract_b_path_with_spaces ... ok
test authorship::rewrite::tests::test_find_next_sha_rejects_non_oid_length_runs ... ok
test authorship::rewrite::tests::test_find_next_sha_returns_full_sha256_oid ... ok
test authorship::rewrite::tests::test_is_tree_pair_separator_accepts_sha256_pair ... ok
test authorship::rewrite::tests::test_is_tree_pair_separator_invalid ... ok
test authorship::rewrite::tests::test_is_tree_pair_separator_valid ... ok
test authorship::rewrite::tests::test_parse_batched_diff_tree_output_empty ... ok
test authorship::rewrite::tests::test_parse_batched_diff_tree_output_identical_trees ... ok
test authorship::rewrite::tests::test_parse_batched_diff_tree_output_mixed_identical_and_changed ... ok
test authorship::rewrite::tests::test_parse_batched_diff_tree_output_multiple_pairs ... ok
test authorship::rewrite::tests::test_parse_diff_tree_empty_output ... ok
test authorship::rewrite::tests::test_parse_batched_diff_tree_output_single_pair ... ok
test authorship::internal_db::tests::test_dequeue_respects_next_retry ... ok
test authorship::rewrite::tests::test_parse_diff_tree_output_binary ... ok
test authorship::internal_db::tests::test_enqueue_cas_object_with_metadata ... ok
test authorship::rewrite::tests::test_parse_diff_tree_output_multiple_files ... ok
test authorship::rewrite::tests::test_parse_diff_tree_output_simple ... ok
test authorship::rewrite::tests::test_parse_diff_tree_output_with_rename ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_dropped_and_new ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_dropped_then_matched_maps_both_to_destination ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_empty ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_matched_bang ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_matched_equal ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_matched_then_dropped_maps_all_to_destination ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_multiple_lines ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_null_shas_skipped ... ok
test authorship::rewrite::tests::test_parse_range_diff_output_sha256 ... ok
test authorship::rewrite_cherry_pick::tests::match_cherry_pick_pairs_empty_new_commits ... ok
test authorship::internal_db::tests::test_enqueue_duplicate_hash ... ok
test authorship::rewrite_cherry_pick::tests::match_cherry_pick_pairs_empty_sources ... ok
test authorship::internal_db::tests::test_dequeue_locks_records ... ok
test authorship::internal_db::tests::test_dequeue_cas_batch ... ok
test authorship::rewrite_revert::tests::legacy_revert_metric_original_sha_uses_reverted_commit ... ok
test authorship::rewrite_stash::tests::test_path_matches_any_directory_prefix ... ok
test authorship::rewrite_stash::tests::test_path_matches_any_directory_without_slash ... ok
test authorship::rewrite_stash::tests::test_path_matches_any_empty_specs ... ok
test authorship::rewrite_stash::tests::test_path_matches_any_exact ... ok
test authorship::rewrite_stash::tests::test_path_matches_any_trailing_glob ... ok
test authorship::rewrite_stash::tests::test_path_matches_any_trailing_slash_normalized ... ok
test authorship::rewrite_stash::tests::test_stash_metadata_empty_pathspecs_default ... ok
test authorship::rewrite_stash::tests::test_stash_metadata_serialization_roundtrip ... ok
test authorship::secrets::tests::test_extract_tokens ... ok
test authorship::internal_db::tests::test_max_attempts_limit ... ok
test authorship::rewrite_reset::tests::test_enclosed_range_preserves_head_and_tail ... ok
test authorship::secrets::tests::test_distinct_values ... ok
test authorship::secrets::tests::test_no_redaction_for_normal_text ... ok
test authorship::rewrite_cherry_pick::tests::positional_pairing_more_sources_than_new ... ok
test authorship::rewrite_cherry_pick::tests::positional_pairing_more_new_than_sources ... ok
test authorship::rewrite_cherry_pick::tests::positional_pairing_equal_lengths ... ok
test authorship::secrets::tests::test_p_random_random_strings ... ok
test authorship::secrets::tests::test_p_random_non_random_strings ... ok
test authorship::secrets::tests::test_no_false_positives_in_normal_code ... ok
test authorship::secrets::tests::test_is_random ... ok
test authorship::secrets::tests::test_redact_secret ... ok
test authorship::secrets::tests::test_redact_multiple_secrets_in_code ... ok
test authorship::secrets::tests::test_redact_secret_in_json_config ... ok
test authorship::secrets::tests::test_redact_secret_in_lorem_ipsum ... ok
test authorship::secrets::tests::test_redact_secrets_in_text ... ok
test authorship::transcript::tests::test_ai_transcript_add_message ... ok
test authorship::transcript::tests::test_ai_transcript_default ... ok
test authorship::transcript::tests::test_ai_transcript_equality ... ok
test authorship::transcript::tests::test_ai_transcript_deserialization ... ok
test authorship::transcript::tests::test_ai_transcript_first_message_timestamp_unix ... ok
test authorship::transcript::tests::test_ai_transcript_last_message_timestamp_unix ... ok
test authorship::internal_db::tests::test_stale_lock_recovery ... ok
test authorship::transcript::tests::test_ai_transcript_messages ... ok
test authorship::transcript::tests::test_ai_transcript_new ... ok
test authorship::transcript::tests::test_ai_transcript_serialization ... ok
test authorship::transcript::tests::test_ai_transcript_timestamp_unix_invalid_format ... ok
test authorship::transcript::tests::test_ai_transcript_timestamp_unix_no_messages ... ok
test authorship::transcript::tests::test_ai_transcript_timestamp_unix_no_timestamps ... ok
test authorship::transcript::tests::test_ai_transcript_without_tool_use ... ok
test authorship::transcript::tests::test_message_assistant ... ok
test authorship::transcript::tests::test_message_deserialization ... ok
test authorship::secrets::tests::test_redact_secret_in_env_file ... ok
test authorship::transcript::tests::test_message_equality ... ok
test authorship::transcript::tests::test_message_is_tool_use ... ok
test authorship::transcript::tests::test_message_plan ... ok
test authorship::transcript::tests::test_message_skip_none_timestamp ... ok
test authorship::transcript::tests::test_message_serialization ... ok
test authorship::transcript::tests::test_message_text ... ok
test authorship::transcript::tests::test_message_thinking ... ok
test authorship::transcript::tests::test_message_timestamp ... ok
test authorship::transcript::tests::test_message_user ... ok
test authorship::transcript::tests::test_message_tool_use ... ok
test authorship::internal_db::tests::test_update_cas_sync_failure ... ok
test authorship::virtual_attribution::tests::carryover_merge_committed_only_change_keeps_committed ... ok
test authorship::virtual_attribution::tests::carryover_merge_observed_only_change_keeps_observed ... ok
test authorship::virtual_attribution::tests::carryover_merge_overlapping_conflict_favors_observed ... ok
test authorship::virtual_attribution::tests::checkout_merge_rebased_content_maps_eof_newline_only_target_line ... ok
test authorship::virtual_attribution::tests::checkout_merge_rebased_content_preserves_clean_local_hunk_on_target_edit ... ok
test authorship::virtual_attribution::tests::carryover_merge_non_overlapping_changes_combines_both_sides ... ok
test authorship::virtual_attribution::tests::checkout_merge_rebased_content_preserves_local_side_for_overlapping_conflict ... ok
test authorship::virtual_attribution::tests::checkout_merge_rebased_content_uses_observed_when_target_unchanged ... ok
test authorship::working_log::tests::test_is_ai_returns_false_for_human_kinds ... ok
test authorship::working_log::tests::test_is_ai_returns_true_for_ai_kinds ... ok
test authorship::working_log::tests::test_checkpoint_kind_known_human_roundtrip ... ok
test authorship::working_log::tests::test_checkpoint_trace_id_backwards_compat ... ok
test authorship::working_log::tests::test_checkpoint_with_known_human_metadata_roundtrip ... ok
test authorship::working_log::tests::test_checkpoint_serialization ... ok
test authorship::working_log::tests::test_log_array_serialization ... ok
test ci::ci_context::tests::test_ci_run_result_debug ... ok
test ci::ci_context::tests::test_ci_event_debug ... ok
test ci::github::tests::test_authenticate_clone_url_supports_enterprise_hosts ... ok
test ci::github::tests::test_authenticate_clone_url_supports_github_dot_com ... ok
test authorship::virtual_attribution::tests::test_build_attestations_is_deterministically_sorted ... ok
test ci::github::tests::test_github_synchronize_payload_deserializes_before_after ... ok
test ci::gitlab::tests::test_diff_refs_deserialization_missing_diff_refs ... ok
test ci::gitlab::tests::test_diff_refs_deserialization_happy ... ok
test ci::gitlab::tests::test_diff_refs_deserialization_null_shas ... ok
test authorship::stats::tests::test_markdown_stats_display ... ok
test authorship::stats::tests::test_terminal_stats_display ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_404_returns_none ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_malformed_body_returns_none ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_missing_diff_refs_returns_none ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_falls_back_to_base_sha_when_start_sha_missing ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_prefers_start_sha_over_base_sha ... ok
test ci::gitlab::tests::test_gitlab_ci_template_yaml_not_empty ... ok
test ci::gitlab::tests::test_gitlab_merge_request_deserialization ... ok
test ci::gitlab::tests::test_gitlab_merge_request_deserialization_minimal ... ok
test ci::gitlab::tests::test_gitlab_merge_request_deserialization_with_squash ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_with_job_token_header ... ok
test ci::gitlab::tests::test_lookback_minutes_falls_back_on_invalid_value ... ok
test ci::gitlab::tests::test_lookback_minutes_reads_env_var ... ok
test ci::gitlab::tests::test_fetch_mr_base_sha_returns_none_when_both_shas_missing ... ok
test ci::gitlab::tests::test_lookback_minutes_defaults_to_15 ... ok
test commands::analyze::cube::tests::builds_basic_measure_query ... ok
test commands::analyze::cube::tests::builds_time_dimension_with_range_and_granularity ... ok
test commands::analyze::cube::tests::explicit_date_range_pair_becomes_array ... ok
test commands::analyze::cube::tests::date_range_without_time_dimension_errors ... ok
test commands::analyze::cube::tests::invalid_filters_json_errors ... ok
test commands::analyze::cube::tests::order_and_limit_and_filters ... ok
test commands::analyze::cube::tests::tsv_uses_union_of_columns ... ok
test commands::analyze::sessions::tests::equals_filters_skips_unset ... ok
test commands::analyze::sessions::tests::cursor_serves_each_row_exactly_once ... ok
test commands::analyze::sessions::tests::derived_funnel_gaps_compute_from_stage_columns ... ok
test commands::analyze::sessions::tests::merge_filters_combines_convenience_and_raw ... ok
test commands::analyze::sessions::tests::merge_filters_rejects_non_array_raw ... ok
test commands::analyze::sessions::tests::cursor_tracks_fetch_progress ... ok
test commands::analyze::sessions::tests::insert_sessions_dedupes_by_session_id ... ok
test commands::analyze::sessions::tests::events_persist_idempotently_and_round_trip ... ok
test commands::analyze::sessions::tests::session_numbers_and_time_parse ... ok
test commands::analyze::tests::parses_order_with_and_without_direction ... ok
test commands::analyze::tests::render_json_extracts_data_array ... ok
test commands::analyze::tests::splits_csv_and_trims ... ok
test commands::analyze::sessions::tests::pull_does_not_rewind_analysis_cursor ... ok
test commands::analyze::sessions::tests::recompute_models_denormalizes_distinct_models ... ok
test commands::analyze::sessions::tests::recompute_pr_counts_counts_distinct_prs ... ok
test commands::checkpoint_agent::bash_tool::tests::test_diff_detects_creation ... ok
test commands::checkpoint_agent::bash_tool::tests::test_diff_detects_modification ... ok
test commands::analyze::sessions::tests::reset_rewinds_cursor_to_reserve_from_start ... ok
test commands::checkpoint_agent::bash_tool::tests::test_git_status_fallback_disables_optional_index_locks ... ok
test commands::checkpoint_agent::bash_tool::tests::test_normalize_path_consistency ... ok
test commands::checkpoint_agent::bash_tool::tests::test_stat_diff_result_all_changed_paths ... ok
test commands::checkpoint_agent::bash_tool::tests::test_diff_empty_snapshots ... ok
test commands::checkpoint_agent::bash_tool::tests::test_stat_entry_equality ... ok
test commands::checkpoint_agent::bash_tool::tests::test_stat_entry_from_metadata ... ok
test commands::checkpoint_agent::bash_tool::tests::test_system_time_to_nanos ... ok
test commands::checkpoint_agent::bash_tool::tests::test_system_time_to_nanos_epoch ... ok
test commands::checkpoint_agent::bash_tool::tests::test_tool_classification_all_agents ... ok
test commands::checkpoint_agent::bash_tool::tests::test_tool_classification_claude ... ok
test commands::checkpoint_agent::bash_tool::tests::test_tool_classification_codex_namespaced ... ok
test commands::checkpoint_agent::orchestrator::tests::checkpoint_request_detects_bash_origin ... ok
test commands::checkpoint_agent::orchestrator::tests::checkpoint_request_does_not_treat_edit_kind_as_origin ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_ai_agent_type ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_human_no_filepaths ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_human_type ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_invalid_json ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_post_shell_command_type ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_pre_shell_command_type ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_shell_command_defaults_tool_use_id ... ok
test commands::checkpoint_agent::presets::agent_v1::tests::test_agent_v1_unknown_type ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_after_edit ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_before_edit ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_defaults_cwd_to_dot ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_generates_session_id_without_completion_id ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_rejects_empty_model ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_rejects_empty_tool ... ok
test commands::checkpoint_agent::presets::ai_tab::tests::test_ai_tab_rejects_invalid_event ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_edited_filepaths_takes_priority ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_file_paths_from_tool_input_multiple_keys ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_post_bash_call ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_post_file_edit ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_pre_bash_call ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_pre_file_edit ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_session_id_falls_back_to_tool_use_id ... ok
test commands::checkpoint_agent::presets::amp::tests::test_amp_session_id_from_thread_id ... ok
test ci::ci_context::tests::sync_fetch_uses_blobless_only_for_named_promisor_remote ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_post_bash_call ... ok
test commands::checkpoint_agent::bash_tool::tests::test_build_gitignore_reads_git_ai_ignore ... ok
test commands::checkpoint_agent::bash_tool::tests::test_build_gitignore_reads_linguist_generated_from_gitattributes ... ok
test commands::checkpoint_agent::bash_tool::tests::test_build_gitignore_applies_default_patterns ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_skips_cursor_payload ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_skips_vscode_copilot_payload ... ok
test commands::checkpoint_agent::bash_tool::tests::test_stat_entry_modification_detected ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_missing_session_and_thread_id ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_post_file_edit ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_post_bash_call ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_pre_bash_call ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_pre_file_edit ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_pre_bash_call ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_extracts_patch_file_paths_from_patch_and_command_keys ... ok
test commands::checkpoint_agent::presets::claude::tests::test_claude_session_id_from_filename ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_rejects_non_bash_tool ... ok
test commands::checkpoint_agent::presets::continue_cli::tests::test_continue_default_model ... ok
test commands::checkpoint_agent::presets::continue_cli::tests::test_continue_post_bash_call ... ok
test commands::checkpoint_agent::presets::continue_cli::tests::test_continue_post_file_edit ... ok
test commands::checkpoint_agent::presets::continue_cli::tests::test_continue_pre_bash_call ... ok
test commands::checkpoint_agent::presets::continue_cli::tests::test_continue_pre_file_edit ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_absolute_file_path ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_apply_patch_pre_file_edit ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_apply_patch_post_file_edit ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_apply_patch_with_absolute_path_in_patch ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_delete_tool ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_file_edit_accepts_path_field ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_file_edit_prefers_file_path_over_path ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_multiple_workspace_roots ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_no_transcript_path ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_post_file_edit ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_post_shell_tool ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_pre_file_edit ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_requires_conversation_id ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_pre_shell_tool ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_shell_falls_back_to_default_tool_use_id ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_skips_legacy_events ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_cursor_skips_non_edit_tools ... ok
test commands::checkpoint_agent::presets::cursor::tests::test_matching_workspace_root ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_rejects_unknown_event ... ok
test ci::ci_context::tests::commit_is_ancestor_errors_for_invalid_descendant ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_derived_session_paths ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_thread_id_fallback ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_apply_patch_from_patch_field ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_apply_patch_extracts_paths ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_camel_case_keys ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_metadata_includes_transcript_and_settings ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_shell_tool_variants_treated_as_bash ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_requires_cwd ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_requires_hook_event_name ... ok
test commands::checkpoint_agent::presets::codex::tests::test_codex_namespaced_tools_are_classified ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_session_paths_helper ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_dirty_files ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_extract_file_paths_from_object ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_extract_file_paths_from_string_patch ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_extract_patch_paths ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_normalize_hook_path ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_post_apply_patch_fallback_to_tool_response ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_post_bash_call ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_post_file_edit ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_pre_bash_call ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_pre_file_edit ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_rejects_invalid_event ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_propagates_tool_use_id ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_skips_legacy_events ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_skips_unsupported_tool ... ok
test commands::checkpoint_agent::presets::firebender::tests::test_firebender_uses_workspace_roots_fallback ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_post_bash_call ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_post_file_edit ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_pre_bash_call ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_pre_file_edit ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::classify_cli_tool_matrix ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_bash_post ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_bash_pre ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_claude_format_bash_pre ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_claude_format_edit_pre_post ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_claude_format_powershell_pre ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_create_post ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_create_pre_synthesizes_empty_dirty_files ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_create_with_no_path_errors ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_relative_path_resolved_against_cwd ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_skips_claude_format_read ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_skips_read_bash_write_bash_stop_bash ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_skips_report_intent ... ok
test commands::checkpoint_agent::presets::droid::tests::test_droid_session_id_fallback ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_write_pre_synthesizes_empty_dirty_files ... ok
test commands::checkpoint_agent::presets::github_copilot::cli::tests::cli_str_replace_pre_post ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_classify_copilot_tool_bash ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_classify_copilot_tool_file_edit ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_classify_copilot_tool_heuristic ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_classify_copilot_tool_skip ... ok
test commands::checkpoint_agent::presets::gemini::tests::test_gemini_also_accepts_pre_tool_use ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_collect_apply_patch_paths ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_camel_case_keys ... ok
test commands::checkpoint_agent::presets::gemini::tests::test_gemini_post_bash_call ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_dirty_files_camel_case ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_legacy_before_edit ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_legacy_before_edit_empty_filepaths ... ok
test commands::checkpoint_agent::presets::gemini::tests::test_gemini_post_file_edit ... ok
test authorship::rewrite_cherry_pick::tests::stable_patch_ids_for_commits_batches_multiple_commits ... ok
test commands::checkpoint_agent::presets::gemini::tests::test_gemini_pre_file_edit ... ok
test commands::checkpoint_agent::presets::gemini::tests::test_gemini_pre_bash_call ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_legacy_after_edit ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_default_after_edit_when_no_hook_event_name ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_session_id_fallback ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_skips_claude_transcript ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_skips_non_edit_tools ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_is_supported_vscode_edit_tool_name ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_looks_like_copilot_transcript_path ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_create_file_pre_empty_dirty ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::dispatches_cli_when_tool_name_is_cli_shape ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::dispatches_ide_legacy_for_before_edit ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_post_bash_call ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_collect_tool_paths_basic ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_collect_tool_paths_file_uri ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_collect_tool_paths_nested ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_normalize_hook_path_absolute ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_normalize_hook_path_empty ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_normalize_hook_path_file_uri ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::test_normalize_hook_path_relative ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_collect_apply_patch_paths ... ok
test ci::ci_context::tests::commit_is_ancestor_returns_false_for_unrelated_histories ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_pre_file_edit ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_default_tool_use_id ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_normalize_hook_path_absolute ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_normalize_hook_path_empty ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_pre_bash_call ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_normalize_hook_path_file_uri ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_normalize_hook_path_relative ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_extracts_file_paths_from_tool_input ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_post_bash_call ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_extracts_file_paths_from_patch_key ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_post_file_edit ... ok
test commands::checkpoint_agent::presets::parse::tests::test_bash_command_from_tool_input_cmd_camel_case ... ok
test commands::checkpoint_agent::presets::parse::tests::test_bash_command_from_tool_input_command ... ok
test commands::checkpoint_agent::presets::parse::tests::test_bash_command_from_top_level_command ... ok
test commands::checkpoint_agent::presets::parse::tests::test_bash_command_missing_or_empty ... ok
test commands::checkpoint_agent::presets::parse::tests::test_collect_apply_patch_paths_dedupes_and_trims_quotes ... ok
test commands::checkpoint_agent::presets::parse::tests::test_collect_apply_patch_paths_from_text ... ok
test commands::checkpoint_agent::presets::parse::tests::test_dirty_files_from_hook_data ... ok
test commands::checkpoint_agent::presets::parse::tests::test_file_paths_from_tool_input_missing ... ok
test commands::checkpoint_agent::presets::parse::tests::test_file_paths_from_tool_input_single ... ok
test commands::checkpoint_agent::presets::parse::tests::test_optional_str_missing ... ok
test commands::checkpoint_agent::presets::parse::tests::test_optional_str_multi_key ... ok
test commands::checkpoint_agent::presets::parse::tests::test_optional_str_multi_key_missing ... ok
test commands::checkpoint_agent::presets::parse::tests::test_optional_str_present ... ok
test commands::checkpoint_agent::presets::parse::tests::test_required_file_stem ... ok
test commands::checkpoint_agent::presets::parse::tests::test_required_str_missing ... ok
test commands::checkpoint_agent::presets::parse::tests::test_required_str_present ... ok
test commands::checkpoint_agent::presets::parse::tests::test_resolve_absolute_already_absolute ... ok
test commands::checkpoint_agent::presets::parse::tests::test_resolve_absolute_relative ... ok
test commands::checkpoint_agent::presets::parse::tests::test_str_or_default_missing ... ok
test commands::checkpoint_agent::presets::parse::tests::test_str_or_default_present ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_after_command ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_after_edit ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_after_edit_requires_filepaths ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_before_command ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_before_edit ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_before_edit_requires_filepaths ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_default_tool_use_id ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_rejects_bash_with_edit_event ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_rejects_edit_with_command_event ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_rejects_unknown_tool ... ok
test commands::checkpoint_agent::presets::pi::tests::test_pi_strips_provider_prefix ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_escape_control_chars_in_json_strings_fixes_raw_newlines ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_escape_control_chars_preserves_escaped_quotes_and_utf8 ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_bash_fallback_tool_use_id ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_cwd_fallback_to_top_level ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_default_transcript_path ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_cwd_from_tool_info ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_post_bash_call ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_missing_cwd_falls_back ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_pre_bash_call ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_post_file_edit ... ok
test commands::checkpoint_agent::presets::windsurf::tests::test_windsurf_pre_write_code ... ok
test commands::config::tests::test_codex_hooks_format_invalid_value ... ok
test commands::config::tests::test_codex_hooks_format_valid_values ... ok
test commands::config::tests::test_detect_pattern_type_bracket_pattern ... ok
test commands::config::tests::test_detect_pattern_type_double_dot ... ok
test commands::config::tests::test_detect_pattern_type_file_path_absolute ... ok
test commands::config::tests::test_detect_pattern_type_file_path_home ... ok
test commands::config::tests::test_detect_pattern_type_file_path_relative ... ok
test commands::config::tests::test_detect_pattern_type_git_protocol ... ok
test commands::config::tests::test_detect_pattern_type_git_ssh ... ok
test commands::config::tests::test_detect_pattern_type_global_wildcard ... ok
test commands::config::tests::test_detect_pattern_type_http_url ... ok
test commands::config::tests::test_detect_pattern_type_question_mark_pattern ... ok
test commands::config::tests::test_detect_pattern_type_single_dot ... ok
test commands::config::tests::test_detect_pattern_type_ssh_url ... ok
test commands::config::tests::test_detect_pattern_type_wildcard_in_url ... ok
test commands::config::tests::test_log_array_changes_add_mode ... ok
test commands::config::tests::test_log_array_changes_empty ... ok
test commands::config::tests::test_log_array_changes_set_mode ... ok
test commands::config::tests::test_log_array_removals ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_pre_bash_call ... ok
test commands::config::tests::test_log_array_removals_empty ... ok
test commands::config::tests::test_mask_api_key_exactly_eight ... ok
test commands::config::tests::test_mask_api_key_long ... ok
test commands::config::tests::test_mask_api_key_nine_chars ... ok
test commands::config::tests::test_mask_api_key_short ... ok
test commands::config::tests::test_parse_author_config_object_rejects_non_object ... ok
test commands::config::tests::test_parse_bool_case_insensitive ... ok
test commands::config::tests::test_parse_bool_empty_string ... ok
test commands::config::tests::test_parse_bool_invalid_number ... ok
test commands::config::tests::test_parse_bool_invalid_value ... ok
test commands::config::tests::test_parse_bool_numeric ... ok
test commands::config::tests::test_parse_author_config_object ... ok
test commands::config::tests::test_parse_bool_valid_false_values ... ok
test commands::config::tests::test_parse_bool_valid_true_values ... ok
test commands::config::tests::test_parse_bool_whitespace ... ok
test commands::config::tests::test_parse_bool_word_forms ... ok
test commands::config::tests::test_parse_custom_attributes_object_rejects_empty_name ... ok
test commands::config::tests::test_parse_custom_attributes_object_coerces_number_and_bool ... ok
test commands::config::tests::test_parse_custom_attributes_object_rejects_nested_value ... ok
test commands::checkpoint_agent::presets::opencode::tests::test_opencode_pre_file_edit ... ok
test commands::config::tests::test_parse_custom_attributes_object_rejects_non_object ... ok
test commands::config::tests::test_parse_custom_attributes_object_string_values ... ok
test commands::config::tests::test_parse_git_ai_hooks_object ... ok
test commands::config::tests::test_parse_hook_command_values_json_primitive_falls_back_to_string ... ok
test commands::config::tests::test_parse_hook_command_values_supports_json_array ... ok
test commands::config::tests::test_parse_hook_command_values_supports_plain_string ... ok
test commands::config::tests::test_parse_key_path_deeply_nested ... ok
test commands::config::tests::test_parse_key_path_empty ... ok
test commands::config::tests::test_parse_key_path_nested ... ok
test commands::config::tests::test_parse_key_path_single ... ok
test commands::config::tests::test_parse_value_json_array ... ok
test commands::config::tests::test_parse_value_json_boolean ... ok
test commands::config::tests::test_parse_value_json_number ... ok
test commands::config::tests::test_parse_value_json_object ... ok
test commands::config::tests::test_parse_value_json_string ... ok
test commands::config::tests::test_parse_value_plain_string ... ok
test commands::config::tests::test_pattern_type_combinations ... ok
test commands::config::tests::test_pattern_type_custom_protocols ... ok
test commands::config::tests::test_prompt_storage_invalid_value ... ok
test commands::config::tests::test_prompt_storage_invalid_value_error_message ... ok
test commands::config::tests::test_prompt_storage_valid_values ... ok
test commands::config::tests::test_resolve_repository_value_git_ssh ... ok
test commands::config::tests::test_resolve_repository_value_url ... ok
test commands::config::tests::test_resolve_repository_value_wildcard ... ok
test commands::debug::tests::test_append_git_committer_identity_includes_effective_author ... ok
test commands::debug::tests::test_collect_git_environment_entries_sorts_and_redacts ... ok
test commands::debug::tests::test_command_output_to_result_formats_diagnostics_without_stderr ... ok
test commands::debug::tests::test_format_bytes ... ok
test commands::debug::tests::test_is_debug_git_env_key_matches_git_prefixes ... ok
test commands::debug::tests::test_parse_debug_options_accepts_skip_trace2_checks ... ok
test commands::debug::tests::test_parse_debug_options_rejects_unknown_arg ... ok
test commands::debug::tests::test_parse_git_version_accepts_minimum_version ... ok
test commands::debug::tests::test_parse_git_version_handles_platform_suffixes ... ok
test commands::debug::tests::test_redact_git_config_line_keeps_non_sensitive_key ... ok
test commands::debug::tests::test_redact_git_config_line_redacts_sensitive_key ... ok
test commands::debug::tests::test_redact_git_config_line_two_field_format_keeps_non_sensitive ... ok
test commands::debug::tests::test_redact_git_config_line_two_field_format_redacts_sensitive ... ok
test commands::debug::tests::test_realpath_for_display_canonicalizes_existing_path ... ok
test commands::debug::tests::test_select_lookup_path_falls_back_to_first_non_empty_line ... ok
test commands::debug::tests::test_select_lookup_path_prefers_existing_path ... ok
test commands::diff::tests::test_calculate_diff_commit_stats_tracks_unknown_added_lines ... ok
test commands::diff::tests::test_format_attribution_ai ... ok
test commands::diff::tests::test_diff_line_key_equality ... ok
test commands::diff::tests::test_format_attribution_human ... ok
test commands::diff::tests::test_format_attribution_no_data ... ok
test commands::diff::tests::test_format_git_ident_handles_missing_parts ... ok
test commands::diff::tests::test_format_git_ident_prefers_full_ident ... ok
test commands::diff::tests::test_is_binary_diff_section_allows_text ... ok
test commands::diff::tests::test_is_binary_diff_section_detects_binary ... ok
test commands::diff::tests::test_is_diff_header_line_respects_hunk_state ... ok
test commands::diff::tests::test_parse_diff_args_all_prompts_rejects_ranges ... ok
test commands::diff::tests::test_parse_diff_args_all_prompts_requires_json ... ok
test commands::diff::tests::test_parse_diff_args_all_prompts_single_commit_json ... ok
test commands::diff::tests::test_parse_diff_args_blame_deletions_flags ... ok
test commands::diff::tests::test_parse_diff_args_blame_deletions_since_requires_blame_deletions ... ok
test commands::diff::tests::test_parse_diff_args_commit_range ... ok
test commands::diff::tests::test_parse_diff_args_include_stats_rejects_ranges ... ok
test commands::diff::tests::test_parse_diff_args_include_stats_requires_json ... ok
test commands::diff::tests::test_parse_diff_args_include_stats_single_commit_json ... ok
test commands::diff::tests::test_parse_diff_args_invalid_range ... ok
test commands::diff::tests::test_parse_diff_args_only_json_flag ... ok
test commands::diff::tests::test_parse_diff_args_single_commit ... ok
test commands::diff::tests::test_parse_diff_args_too_many_positional_args ... ok
test commands::diff::tests::test_parse_diff_args_two_positional_commits ... ok
test commands::diff::tests::test_parse_diff_args_two_positional_commits_with_json ... ok
test commands::diff::tests::test_parse_diff_git_header_paths_standard_and_quoted ... ok
test commands::diff::tests::test_parse_diff_hunks_empty ... ok
test commands::diff::tests::test_parse_diff_hunks_custom_prefix_paths ... ok
test commands::diff::tests::test_parse_diff_hunks_no_prefix_paths ... ok
test commands::diff::tests::test_parse_diff_hunks_multiple_files ... ok
test commands::diff::tests::test_parse_diff_hunks_preserves_header_like_content_inside_hunk ... ok
test commands::diff::tests::test_parse_diff_hunks_preserves_plus_plus_plus_content_inside_hunk ... ok
test commands::diff::tests::test_parse_hunk_header_for_line_nums ... ok
test commands::diff::tests::test_parse_diff_hunks_rename_tracks_old_file_path ... ok
test commands::diff::tests::test_parse_hunk_header_for_line_nums_invalid ... ok
test commands::diff::tests::test_parse_hunk_header_for_line_nums_single_line ... ok
test commands::diff::tests::test_parse_hunk_line_basic ... ok
test commands::diff::tests::test_parse_hunk_line_pure_addition ... ok
test commands::diff::tests::test_parse_hunk_line_pure_deletion ... ok
test commands::diff::tests::test_parse_hunk_line_single_line_addition ... ok
test commands::diff::tests::test_parse_hunk_line_single_line_deletion ... ok
test commands::install_hooks::tests::parse_git_version_apple_suffix ... ok
test commands::install_hooks::tests::parse_git_version_at_minimum ... ok
test commands::install_hooks::tests::parse_git_version_invalid ... ok
test commands::install_hooks::tests::parse_git_version_no_patch ... ok
test commands::install_hooks::tests::parse_git_version_old ... ok
test commands::install_hooks::tests::parse_git_version_standard ... ok
test commands::install_hooks::tests::parse_install_options_defaults_visual_studio_extension_to_disabled ... ok
test commands::install_hooks::tests::parse_install_options_enables_visual_studio_extension_flag ... ok
test commands::install_hooks::tests::persist_install_config_persists_api_key ... ok
test commands::install_hooks::tests::persist_install_config_skips_without_env_or_in_dry_run ... ok
test commands::install_hooks::tests::persist_install_config_preserves_existing_git_path ... ok
test commands::log::tests::bare_flag_extracted ... ok
test commands::log::tests::dash_c_followed_by_log_option ... ok
test commands::log::tests::dash_c_with_valid_config_key ... ok
test commands::log::tests::dash_c_without_dot_is_not_extracted ... ok
test commands::log::tests::dash_capital_c_not_extracted ... ok
test commands::log::tests::dash_capital_p_not_extracted ... ok
test commands::log::tests::dash_p_not_extracted ... ok
test commands::log::tests::double_dash_after_global_arg ... ok
test commands::log::tests::double_dash_alone ... ok
test commands::log::tests::double_dash_as_last_after_log_args ... ok
test commands::log::tests::double_dash_stops_extraction ... ok
test commands::log::tests::empty_args ... ok
test commands::log::tests::exec_path_equals_form ... ok
test commands::log::tests::exec_path_standalone ... ok
test commands::log::tests::git_dir_equals_form ... ok
test commands::log::tests::git_dir_spaced_form ... ok
test commands::log::tests::global_args_then_double_dash_then_pathspecs ... ok
test commands::log::tests::log_notes_flag_is_consumed ... ok
test commands::install_hooks::tests::persist_install_config_persists_both_api_base_and_api_key ... ok
test commands::log::tests::log_raw_flag_is_consumed ... ok
test commands::log::tests::log_show_notes_alias_is_consumed ... ok
test commands::log::tests::multiple_global_args_with_log_args ... ok
test commands::log::tests::no_value_global_flags_extracted ... ok
test commands::log::tests::oneline_is_consumed ... ok
test commands::log::tests::pager_globals_are_not_kept_for_repository_commands ... ok
test commands::log::tests::pathspec_after_double_dash_is_not_interpreted ... ok
test commands::log::tests::plain_mode_allows_git_render_flags ... ok
test commands::log::tests::plain_mode_consumes_only_plain_flag ... ok
test commands::log::tests::plain_pathspec_after_double_dash_is_not_interpreted ... ok
test commands::log::tests::sticky_c_with_valid_config_key ... ok
test commands::log::tests::sticky_c_without_dot_is_not_extracted ... ok
test commands::log::tests::takes_value_option_at_end_without_value ... ok
test commands::log::tests::truncate_for_width_does_not_cut_incomplete_ansi_reset ... ok
test commands::log::tests::truncate_for_width_preserves_ansi_escape_sequences ... ok
test commands::log::tests::unsupported_render_flag_errors ... ok
test commands::install_hooks::tests::persist_install_config_updates_api_base_and_backfills_git_path ... ok
test commands::checkpoint_agent::presets::github_copilot::tests::dispatches_ide_when_tool_name_is_ide_shape ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_model_prefers_otel_selected_model_over_models_json_default ... ok
test commands::upgrade::tests::check_for_update_available_returns_no_update_when_auto_updates_disabled ... ok
test commands::upgrade::tests::check_for_update_available_returns_no_update_when_cache_has_no_pending_update ... ok
test commands::upgrade::tests::check_for_update_available_returns_update_ready_when_cache_has_pending_update ... ok
test commands::upgrade::tests::test_check_for_update_available_no_cache_newer_version ... ok
test commands::upgrade::tests::test_check_for_update_available_same_version ... ok
test commands::upgrade::tests::test_daemon_update_check_result_debug ... ok
test commands::upgrade::tests::test_determine_action_already_latest ... ok
test commands::upgrade::tests::test_determine_action_force ... ok
test commands::upgrade::tests::test_determine_action_running_newer ... ok
test commands::upgrade::tests::test_determine_action_upgrade_available ... ok
test commands::upgrade::tests::test_is_newer_version ... ok
test commands::upgrade::tests::test_is_newer_version_empty_parts ... ok
test commands::upgrade::tests::test_is_newer_version_equal ... ok
test commands::upgrade::tests::test_is_newer_version_major ... ok
test commands::upgrade::tests::test_is_newer_version_minor ... ok
test commands::upgrade::tests::test_is_newer_version_patch ... ok
test commands::upgrade::tests::test_parse_checksums_empty_input ... ok
test commands::upgrade::tests::test_parse_checksums_ignores_invalid_lines ... ok
test commands::upgrade::tests::test_parse_checksums_multiple_spaces ... ok
test commands::upgrade::tests::test_parse_checksums_valid_format ... ok
test commands::upgrade::tests::test_parse_checksums_whitespace_lines ... ok
test commands::upgrade::tests::test_parse_checksums_with_extensions ... ok
test commands::upgrade::tests::test_persist_update_state_creates_cache_object ... ok
test commands::upgrade::tests::test_persist_update_state_no_release_structure ... ok
test commands::upgrade::tests::test_release_from_response_empty_checksum ... ok
test commands::upgrade::tests::test_release_from_response_empty_tag ... ok
test commands::upgrade::tests::test_release_from_response_invalid_semver ... ok
test commands::upgrade::tests::test_release_from_response_missing_channel ... ok
test commands::upgrade::tests::test_release_from_response_success ... ok
test commands::upgrade::tests::test_run_impl_with_url ... ok
test commands::upgrade::tests::test_run_impl_with_url_enterprise_channels ... ok
test commands::upgrade::tests::test_semver_from_tag_empty ... ok
test commands::upgrade::tests::test_semver_from_tag_enterprise_prefix ... ok
test commands::upgrade::tests::test_semver_from_tag_strips_prefix_and_suffix ... ok
test commands::upgrade::tests::test_semver_from_tag_with_build_metadata ... ok
test commands::upgrade::tests::test_should_check_for_updates_channel_mismatch ... ok
test commands::upgrade::tests::test_should_check_for_updates_no_cache ... ok
test commands::upgrade::tests::test_should_check_for_updates_respects_interval ... ok
test commands::upgrade::tests::test_should_check_for_updates_skips_when_recently_checked ... ok
test commands::upgrade::tests::test_should_check_for_updates_verifies_channel ... ok
test commands::upgrade::tests::test_should_check_for_updates_zero_last_checked ... ok
test commands::upgrade::tests::test_update_cache_matches_channel_enterprise ... ok
test commands::upgrade::tests::test_update_cache_new ... ok
test commands::upgrade::tests::test_update_cache_serialization ... ok
test commands::upgrade::tests::test_update_cache_update_available ... ok
test commands::upgrade::tests::test_upgrade_action_to_string ... ok
test commands::upgrade::tests::test_verify_sha256_case_insensitive ... ok
test commands::upgrade::tests::test_verify_sha256_empty_content ... ok
test commands::upgrade::tests::test_verify_sha256_mismatch ... ok
test commands::upgrade::tests::test_verify_sha256_success ... ok
test commands::upgrade::tests::test_verify_sha256_with_binary_content ... ok
test commands::whoami::tests::render_whoami_distinguishes_login_credentials_from_usable_token ... ok
test commands::whoami::tests::render_whoami_shows_login_identity_and_metrics_summary ... ok
test commands::whoami::tests::render_whoami_shows_unset_api_key_and_not_logged_in ... ok
test commands::whoami::tests::render_whoami_treats_api_key_only_as_connected ... ok
test commands::whoami::tests::should_exit_failure_preserves_stored_login_success ... ok
test config::tests::test_allow_without_exclude ... ok
test config::tests::test_allowed_repo_not_excluded_with_remotes ... ok
test config::tests::test_allowlist_denies_unmatched_remotes ... ok
test config::tests::test_allowlist_matches_ssh_url_remote_with_scp_pattern ... ok
test config::tests::test_allowlist_with_remotes ... ok
test config::tests::test_author_config_empty_when_all_fields_blank ... ok
test config::tests::test_author_config_file_fingerprint_detects_same_length_edits ... ok
test config::tests::test_author_config_normalizes_empty_fields ... ok
test config::tests::test_complex_glob_patterns ... ok
test config::tests::test_debug_self_check_remote_bypasses_prompt_exclusion_wildcard ... ok
test config::tests::test_effective_prompt_storage_exclude_always_wins ... ok
test config::tests::test_effective_prompt_storage_include_pattern_matching ... ok
test config::tests::test_effective_prompt_storage_no_fallback_defaults_to_local ... ok
test config::tests::test_effective_prompt_storage_no_include_list_uses_global ... ok
test config::tests::test_effective_prompt_storage_non_wildcard_include_no_match_uses_fallback ... ok
test config::tests::test_effective_prompt_storage_wildcard_include_matches_no_repo ... ok
test config::tests::test_empty_allowlist_allows_everything ... ok
test config::tests::test_empty_remotes_treated_as_no_match_for_exclusion ... ok
test config::tests::test_exact_match_still_works ... ok
test config::tests::test_exclude_prompt_patterns_match_ssh_equivalent_remotes ... ok
test config::tests::test_exclude_without_allow ... ok
test config::tests::test_excluded_repo_with_remotes ... ok
test config::tests::test_exclusion_matches_scp_remote_with_ssh_url_pattern ... ok
test config::tests::test_exclusion_takes_precedence_over_allow ... ok
test config::tests::test_exclusion_takes_precedence_with_remotes ... ok
test config::tests::test_glob_pattern_wildcard_in_allow ... ok
test config::tests::test_glob_pattern_wildcard_in_exclude ... ok
test config::tests::test_include_prompt_patterns_match_ssh_equivalent_remotes ... ok
test config::tests::test_multiple_remotes_one_excluded ... ok
test config::tests::test_no_remotes_allowed_when_only_excludes ... ok
test config::tests::test_no_remotes_denied_when_allowlist_active ... ok
test config::tests::test_notes_backend_config_default_is_git_notes ... ok
test config::tests::test_notes_backend_enabled_false_for_git_notes ... ok
test config::tests::test_notes_backend_env_var_overrides_file_config_via_fresh ... ok
test config::tests::test_notes_backend_kind_as_str ... ok
test config::tests::test_notes_backend_kind_display ... ok
test config::tests::test_notes_backend_kind_env_var_parsing ... ok
test config::tests::test_notes_backend_kind_roundtrip ... ok
test config::tests::test_notes_backend_nested_file_config_roundtrip ... ok
test config::tests::test_notes_backend_url_unset_returns_none ... ok
test config::tests::test_parse_file_config_bytes_accepts_utf8_bom ... ok
test config::tests::test_parse_file_config_bytes_without_bom_still_parses ... ok
test config::tests::test_path_is_git_ai_binary_hardlink ... ok
test config::tests::test_path_is_git_ai_binary_real_git_with_sibling_symlink ... ok
test config::tests::test_path_is_git_ai_binary_symlink_to_git_ai ... ok
test config::tests::test_prompt_storage_mode_as_str ... ok
test config::tests::test_prompt_storage_mode_from_str ... ok
test config::tests::test_quiet_can_be_enabled ... ok
test config::tests::test_quiet_default_is_false ... ok
test config::tests::test_remote_pattern_matching_allows_hostless_repository_patterns ... ok
test config::tests::test_remote_pattern_matching_handles_azure_https_and_ssh_shape_difference ... ok
test config::tests::test_remote_pattern_matching_normalizes_common_git_url_forms ... ok
test config::tests::test_should_exclude_prompts_empty_patterns_returns_false ... ok
test config::tests::test_should_exclude_prompts_local_repo_not_excluded_without_wildcard ... ok
test config::tests::test_should_exclude_prompts_no_repository_returns_false ... ok
test config::tests::test_should_exclude_prompts_pattern_matching ... ok
test config::tests::test_should_exclude_prompts_respects_patterns_when_remotes_exist ... ok
test config::tests::test_should_exclude_prompts_wildcard_all ... ok
test config::tests::test_transcript_streaming_lookback_days_default ... ok
test config::tests::test_transcript_streaming_lookback_days_env_override ... ok
test config::tests::test_transcript_streaming_lookback_days_zero_means_unlimited ... ok
test config::tests::test_update_channel_default_is_latest ... ok
test config::tests::test_update_channel_enterprise_latest_maps_to_enterprise_latest ... ok
test config::tests::test_update_channel_enterprise_latest_parses ... ok
test config::tests::test_update_channel_enterprise_next_maps_to_enterprise_next ... ok
test config::tests::test_update_channel_enterprise_next_parses ... ok
test daemon::analyzers::generic::tests::generic_never_returns_empty_events ... ok
test daemon::analyzers::generic::tests::generic_ref_mutation_when_ref_changes_exist ... ok
test daemon::analyzers::history::tests::amend_prefers_head_transition_over_contaminated_branch_hint ... ok
test daemon::analyzers::history::tests::amend_prefers_head_transition_over_zero_old_branch_change ... ok
test daemon::analyzers::history::tests::amend_uses_first_head_transition_when_later_head_moves_are_captured ... ok
test daemon::analyzers::history::tests::cherry_pick_uses_full_head_ref_change_span ... ok
test daemon::analyzers::history::tests::cherry_pick_without_ref_transition_is_opaque ... ok
test daemon::analyzers::history::tests::commit_prefers_head_transition_over_other_branch_ref_changes ... ok
test daemon::analyzers::history::tests::commit_without_amend_emits_commit_created ... ok
test daemon::analyzers::history::tests::commit_without_ref_transition_does_not_read_head_reflog ... ok
test daemon::analyzers::history::tests::commit_without_ref_transition_ignores_family_head ... ok
test daemon::analyzers::history::tests::commit_without_ref_transition_ignores_family_refs ... ok
test daemon::analyzers::history::tests::commit_without_ref_transition_is_opaque ... ok
test daemon::analyzers::history::tests::head_change_prefers_head_transition_over_branch_ref_change ... ok
test daemon::analyzers::history::tests::rebase_continue_prefers_branch_ref_change_over_head_span ... ok
test daemon::analyzers::history::tests::reset_emits_reset_kind ... ok
test daemon::analyzers::history::tests::squash_merge_resolves_branch_from_ref_state ... ok
test daemon::analyzers::history::tests::squash_merge_with_unresolved_source_is_opaque ... ok
test daemon::analyzers::history::tests::update_ref_reports_cursor_ref_changes ... ok
test daemon::analyzers::history::tests::update_ref_without_cursor_ref_change_is_opaque ... ok
test daemon::analyzers::transport::tests::pull_with_rebase_maps_strategy ... ok
test daemon::analyzers::workspace::tests::stash_apply_maps_to_stash_operation ... ok
test daemon::bash_history_db::tests::candidate_query_filters_by_window ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_vscode_apply_patch_real_payload ... ok
test daemon::bash_history_db::tests::end_without_start_upserts_best_effort_row ... ok
test daemon::bash_history_db::tests::fallback_database_returns_error_when_file_path_fails ... ok
test daemon::bash_history_db::tests::fallback_database_at_file_has_schema ... ok
test commands::notes_migrate::tests::cat_file_batch_empty_input ... ok
test daemon::bash_history_db::tests::retention_prunes_rows_older_than_thirty_days ... ok
test daemon::bash_history_db::tests::start_and_end_lifecycle_persists_fields ... ok
test daemon::daemon_log_layer::tests::bounded_debug_string_stops_formatting_after_cap ... ok
test daemon::daemon_log_layer::tests::bounded_string_fields_are_redacted_and_truncated ... ok
test daemon::daemon_log_layer::tests::daemon_log_capture_skips_default_api_without_auth_or_key ... ok
test daemon::coordinator::tests::routes_global_and_family_commands ... ok
test daemon::daemon_log_layer::tests::sanitize_log_string_redacts_and_truncates ... ok
test daemon::daemon_log_layer::tests::visitor_collects_primitive_fields ... ok
test daemon::daemon_log_layer::tests::visitor_caps_field_count ... ok
test daemon::family_actor::tests::actor_applies_commands ... ok
test daemon::family_actor::tests::actor_status_reports_applied_seq ... ok
test daemon::family_actor::tests::test_watermarks_initially_empty ... ok
test daemon::family_actor::tests::test_watermarks_update_and_retrieve ... ok
test daemon::family_actor::tests::test_worktree_watermark_prunes_stale_per_file_entries ... ok
test daemon::git_backend::tests::builtin_primary_command_skips_repository_lookup ... ok
test daemon::family_actor::tests::test_worktree_watermark_update_and_retrieve ... ok
test daemon::git_backend::tests::clone_positionals_skips_value_for_config_short_flag ... ok
test daemon::git_backend::tests::clone_positionals_skips_value_for_depth_flag ... ok
test daemon::git_backend::tests::clone_positionals_skips_value_for_jobs_long_flag ... ok
test daemon::git_backend::tests::clone_positionals_skips_value_for_jobs_short_flag ... ok
test daemon::git_backend::tests::clone_positionals_treats_dissociate_as_boolean_not_value_taking ... ok
test daemon::git_backend::tests::clone_target_derives_name_from_url_with_depth_flag ... ok
test daemon::git_backend::tests::clone_target_returns_none_for_explicit_dot_without_cwd_hint ... ok
test daemon::git_backend::tests::default_clone_target_from_url ... ok
test daemon::git_backend::tests::default_clone_target_from_windows_path ... ok
test daemon::git_backend::tests::init_target_resolves_dot_when_cwd_hint_is_provided ... ok
test daemon::git_backend::tests::init_target_returns_none_for_implicit_dot_without_cwd_hint ... ok
test daemon::bash_history_db::tests::unresolved_cwd_call_is_available_as_candidate ... ok
test daemon::git_backend::tests::unknown_primary_command_still_requires_repository_lookup ... ok
test daemon::git_backend::tests::resolve_family_accepts_bare_repo_path_without_git_spawn ... ok
test daemon::reducer::tests::global_reducer_never_drops_commands ... ok
test daemon::global_actor::tests::global_actor_applies_commands ... ok
test daemon::reducer::tests::reducer_applies_ref_changes_and_produces_applied_command ... ok
test daemon::reducer::tests::reducer_does_not_update_refs_without_ref_transition_for_head_moving_commands ... ok
test daemon::reducer::tests::reducer_marks_head_only_transition_as_detached_or_unknown_branch ... ok
test daemon::reducer::tests::reducer_preserves_refs_for_stash_without_ref_transition ... ok
test daemon::reducer::tests::reducer_preserves_worktree_branch_when_command_does_not_move_head ... ok
test daemon::reducer::tests::reducer_records_worktree_branch_from_unique_head_branch_transition ... ok
test daemon::git_backend::tests::resolve_family_uses_worktree_filesystem_without_git_config ... ok
test daemon::reducer::tests::reducer_removes_refs_deleted_with_zero_oid ... ok
test daemon::reducer::tests::reducer_updates_branch_for_checkout_new_branch_without_head_oid_move ... ok
test daemon::ref_cursor::tests::cherry_pick_source_args_do_not_treat_bare_gpg_sign_as_value_option ... ok
test daemon::ref_cursor::tests::amend_without_message_does_not_match_plain_commit_reflog_entry ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_workspace_storage_format ... ok
test commands::checkpoint_agent::presets::github_copilot::ide::tests::test_copilot_native_post_file_edit ... ok
test daemon::ref_cursor::tests::cherry_pick_span_starts_at_first_pick_when_expected_state_matches_second_pick ... ok
test daemon::ref_cursor::tests::cold_pull_rebase_late_ingress_offset_still_recovers_start_and_branch_finish ... ok
test daemon::ref_cursor::tests::cold_start_late_ingress_offset_does_not_skip_commit_on_uninitialized_head_cursor ... ok
test daemon::ref_cursor::tests::cold_pull_rebase_true_boundary_does_not_replay_older_pull_span ... ok
test daemon::ref_cursor::tests::cold_start_late_ingress_offset_does_not_skip_commit_on_uninitialized_common_ref ... ok
test daemon::ref_cursor::tests::cold_rebase_true_boundary_does_not_replay_older_rebase_span ... ok
test daemon::ref_cursor::tests::cold_rebase_late_ingress_offset_still_recovers_start_and_branch_finish ... ok
test daemon::ref_cursor::tests::commit_subject_matches_git_reflog_trailing_whitespace_cleanup ... ok
test daemon::ref_cursor::tests::cold_stash_push_uses_message_to_skip_raw_stash_history ... ok
test daemon::ref_cursor::tests::cold_stash_save_uses_message_to_skip_raw_stash_history ... ok
test daemon::ref_cursor::tests::cold_stash_push_uses_command_reflog_boundary_without_message ... ok
test daemon::ref_cursor::tests::common_ref_discovery_excludes_worktree_head_log ... ok
test daemon::ref_cursor::tests::direct_branch_update_ref_does_not_attach_head_when_state_names_different_branch ... ok
test daemon::ref_cursor::tests::direct_branch_update_ref_consumes_head_mirror_before_later_unstructured_update_ref ... ok
test daemon::ref_cursor::tests::direct_branch_update_ref_does_not_treat_stale_head_reflog_match_as_current_head_move ... ok
test daemon::ref_cursor::tests::direct_branch_update_ref_uses_argv_transition_when_reflog_cursor_starts_too_late ... ok
test daemon::ref_cursor::tests::commit_reflog_boundary_skips_untraced_duplicate_message ... ok
test daemon::ref_cursor::tests::commit_with_exact_reflog_message_ignores_stale_daemon_head ... ok
test daemon::ref_cursor::tests::direct_head_update_ref_uses_argv_and_late_cursor_branch_mirror_once ... ok
test daemon::ref_cursor::tests::direct_update_ref_consumes_matching_reflog_entry_before_later_unstructured_update_ref ... ok
test daemon::ref_cursor::tests::direct_head_update_ref_uses_known_worktree_branch_when_other_branch_matches_same_second ... ok
test daemon::ref_cursor::tests::first_observed_common_boundary_skips_prior_update_ref_history ... ok
test daemon::ref_cursor::tests::direct_head_update_ref_without_known_branch_does_not_guess_ambiguous_branch_mirror ... ok
test daemon::ref_cursor::tests::first_observed_head_boundary_skips_prior_reset_history ... ok
test daemon::ref_cursor::tests::failed_explicit_branch_rebase_consumes_noop_start_marker_before_continue ... ok
test daemon::ref_cursor::tests::pull_reflog_action_uses_expanded_command_for_zero_arg_alias ... ok
test daemon::ref_cursor::tests::ingress_offset_hint_skips_untraced_duplicate_message_commit ... ok
test daemon::ref_cursor::tests::late_ingress_offset_does_not_advance_in_order_cursor_past_own_commit ... ok
test daemon::ref_cursor::tests::late_ingress_offset_skips_untraced_duplicate_message_commit ... ok
test commands::notes_migrate::tests::list_notes_returns_empty_for_repo_without_notes ... ok
test daemon::ref_cursor::tests::rebase_does_not_consume_adjacent_checkout_head_entry ... ok
test daemon::ref_cursor::tests::rebase_prefers_start_entry_when_expected_state_matches_pick ... ok
test daemon::ref_cursor::tests::pull_rebase_span_starts_at_start_entry_when_expected_state_matches_pick ... ok
test daemon::ref_cursor::tests::rebase_does_not_attach_unrelated_branch_with_same_new_tip ... ok
test daemon::ref_cursor::tests::reflog_anchor_rejects_non_newline_end_offset ... ok
test daemon::ref_cursor::tests::reflog_reader_ignores_trailing_unterminated_record ... ok
test daemon::ref_cursor::tests::revert_source_args_do_not_treat_bare_gpg_sign_as_value_option ... ok
test daemon::ref_cursor::tests::reflog_generation_reset_with_same_byte_length_clears_sparse_consumption ... ok
test daemon::ref_cursor::tests::skipped_reflog_entry_remains_available_for_later_sequenced_command ... ok
test daemon::ref_cursor::tests::rebase_span_stops_at_new_rebase_start_before_finish ... ok
test daemon::rewrite_metrics::tests::dedupe_metric_commits_keeps_distinct_original_sets ... ok
test daemon::rewrite_metrics::tests::rewrite_event_schema_does_not_emit_position_10 ... ok
test daemon::rewrite_metrics::tests::rewrite_metric_branch_overrides_head_branch_attr ... ok
test daemon::rewrite_metrics::tests::rewrite_metric_custom_attributes_match_map_builder_wire_format ... ok
test daemon::ref_cursor::tests::update_ref_stdin_is_reconstructed_from_reflog_delta ... ok
test daemon::ref_cursor::tests::rebase_span_stops_before_later_rebase_after_checkout ... ok
test daemon::ref_cursor::tests::reset_late_reflog_offset_uses_command_message_not_stale_state ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_empty_string ... ok
test daemon::ref_cursor::tests::revert_span_starts_at_first_revert_when_expected_state_matches_second_revert ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_invalid_string ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_missing_field ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_null_value ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_numeric_millis ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_rfc3339 ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_rfc3339_subsecond_discarded ... ok
test daemon::stream_worker::extract_event_timestamp_tests::test_rfc3339_without_millis ... ok
test daemon::ref_cursor::tests::rebase_span_continuation_skips_stale_abort_before_selected_start ... ok
test daemon::stream_worker::scheduling_tests::next_delayed_task_at_returns_earliest_retry_deadline ... ok
test daemon::stream_worker::scheduling_tests::promotes_only_ready_delayed_tasks ... ok
test daemon::stream_worker::scheduling_tests::shutdown_wakes_idle_worker ... ok
test daemon::stream_worker::subagent_sweep_tests::recovery_sweep_bypasses_cooldown_and_suppresses_followup_trigger ... ok
test daemon::stream_worker::scheduling_tests::transient_errors_are_stored_as_delayed_retries_not_ready_work ... ok
test daemon::stream_worker::scheduling_tests::shutdown_wakes_worker_sleeping_until_future_retry ... ok
test daemon::stream_worker::subagent_sweep_tests::test_copilot_checkpoint_enqueues_shared_otel_stream_immediately ... ok
test daemon::stream_worker::subagent_sweep_tests::test_handle_checkpoint_skips_subagent_sweep_for_non_claude ... ok
test daemon::stream_worker::subagent_sweep_tests::test_sweep_subagents_deduplicates_in_flight ... ok
test daemon::stream_worker::subagent_sweep_tests::triggered_sweeps_share_thirty_second_cooldown ... ok
test daemon::stream_worker_tests::test_priority_queue_ordering_immediate_first ... ok
test daemon::stream_worker_tests::test_priority_queue_ordering_multiple_same_priority ... ok
test daemon::stream_worker_tests::test_retry_delay_allows_processing_after_delay ... ok
test daemon::stream_worker_tests::test_retry_delay_prevents_immediate_reprocessing ... ok
test daemon::telemetry_worker::tests::daemon_heartbeat_event_uses_upload_contract_shape ... ok
test daemon::telemetry_worker::tests::daemon_log_dispatch_does_not_wait_for_upload_task ... ok
test daemon::telemetry_worker::tests::daemon_log_dispatch_requeues_when_upload_is_already_in_flight ... ok
test daemon::stream_worker::subagent_sweep_tests::test_sweep_subagents_no_dir_is_noop ... ok
test daemon::stream_worker::subagent_sweep_tests::test_sweep_subagents_discovers_subagent_files ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_keeps_rows_pending_after_upload_failure ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_marks_all_server_errors_undeliverable ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_marks_invalid_rows_delivered ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_marks_partial_server_errors_undeliverable ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_retries_batch_for_invalid_server_error_index ... ok
test daemon::telemetry_worker::tests::submit_daemon_internal_telemetry_spawns_when_runtime_exists ... ok
test daemon::telemetry_worker::tests::submit_daemon_internal_telemetry_waits_without_runtime ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_uploads_from_db_and_marks_delivered ... ok
test daemon::telemetry_worker::tests::flush_pending_metric_records_uploads_new_rows_after_old_failure ... ok
test commands::notes_migrate::tests::force_flag_bypasses_synced_cache_filter ... ok
test daemon::telemetry_worker::tests::upload_daemon_log_chunk_counts_events_past_per_upload_cap ... ok
test daemon::rewrite_metrics::tests::rewrite_metric_event_uses_supplied_note_and_parent_diff ... ok
test daemon::telemetry_worker::tests::telemetry_buffer_caps_daemon_logs_to_latest_events ... ok
test daemon::telemetry_worker::tests::telemetry_buffer_requeues_failed_daemon_logs_without_dropping_newer_events ... ok
test daemon::tests::bash_checkpoint_processing_budget_is_ten_seconds ... ok
test daemon::tests::cat_file_start_event_is_not_enqueued ... ok
test daemon::tests::branch_show_current_start_event_is_not_enqueued ... ok
test daemon::tests::checkpoint_control_timeout_false_when_no_ci_or_test_vars ... ok
test daemon::tests::checkpoint_control_timeout_uses_ci_env_var ... ok
test daemon::tests::checkpoint_control_timeout_uses_test_db_env_var ... ok
test daemon::tests::checkpoint_fence_does_not_wait_for_open_branch_readonly_root ... ok
Initialized empty Git repository in /private/var/folders/6w/760cbpln2cs16fxprwshynb80000gn/T/.tmpU0TZYf/.git/
test daemon::tests::checkpoint_fence_does_not_wait_for_unidentified_trace_connection ... ok
Initialized empty Git repository in /private/var/folders/6w/760cbpln2cs16fxprwshynb80000gn/T/.tmpYGFy0G/.git/
test daemon::test_sync::tests::tracked_invocation_does_not_create_ai_dir_for_untracked_commands ... ok
Initialized empty Git repository in /private/var/folders/6w/760cbpln2cs16fxprwshynb80000gn/T/.tmpshqoLH/.git/
test daemon::test_sync::tests::tracked_invocation_keeps_branch_show_current_alias_untracked ... ok
test daemon::tests::checkpoint_requests_use_long_timeout_in_ci_or_test_env ... ok
test daemon::tests::checkpoint_requests_use_short_timeout_in_product_env ... ok
test daemon::tests::checkpoint_trace_ingest_drain_returns_on_shutdown ... ok
test daemon::tests::cherry_pick_source_args_do_not_treat_bare_gpg_sign_as_value_option ... ok
test daemon::tests::compute_watermarks_uses_symlink_metadata_not_target_mtime ... ok
test daemon::test_sync::tests::tracked_invocation_resolves_commit_alias_without_git_exec ... ok
test daemon::tests::concurrent_mutating_enqueues_do_not_deadlock ... ok
test daemon::tests::diff_numstat_start_event_is_not_enqueued ... ok
test daemon::tests::enqueue_accounting_error_does_not_allocate_ingest_sequence ... ok
test daemon::tests::enqueue_before_worker_start_returns_error ... ok
test daemon::tests::exit_is_not_a_root_completion_boundary ... ok
test daemon::tests::explicit_branch_rebase_original_head_prefers_branch_ref_over_head ... ok
test daemon::tests::explicit_stop_overrides_prior_restart_intent ... ok
test daemon::tests::for_each_ref_start_event_is_not_enqueued ... ok
test daemon::tests::mutating_commit_start_event_is_enqueued ... ok
test daemon::tests::checkpoint_fence_waits_for_open_branch_mutation_root ... ok
test daemon::tests::mutating_stash_pop_start_event_is_enqueued ... ok
test daemon::tests::mutating_trace_payload_captures_repo_reflog_start_offsets ... ok
test daemon::tests::mutating_worktree_add_start_event_is_enqueued ... ok
test daemon::tests::pending_rebase_new_tip_prefers_matching_branch_ref_over_later_head_noise ... ok
test daemon::tests::readonly_atexit_event_is_not_enqueued_after_readonly_start ... ok
test daemon::tests::checkpoint_fence_waits_for_open_mutating_trace_root ... ok
test daemon::tests::readonly_start_event_is_not_enqueued ... ok
test daemon::tests::readonly_trace_connection_close_without_atexit_clears_tracking ... ok
test daemon::tests::request_shutdown_is_idempotent_and_consistent ... ok
test daemon::tests::revert_source_args_do_not_treat_bare_gpg_sign_as_value_option ... ok
test daemon::tests::show_commit_start_event_is_not_enqueued ... ok
test daemon::tests::mutating_pending_root_is_created_when_repo_and_argv_arrive_on_different_events ... ok
test commands::debug::tests::test_run_command_capture_with_timeout_reports_partial_output ... ok
test daemon::tests::stash_list_start_event_is_not_enqueued ... ok
test daemon::tests::trace_socket_recv_buffer_helper_raises_socket_capacity ... ok
test daemon::tests::trace_connection_close_without_atexit_cancels_pending_root ... ok
test daemon::tests::trace_socket_recv_buffer_helper_zero_is_noop ... ok
test daemon::tests::transcript_sweep_triggers_for_commit_amend_and_push_events ... ok
test daemon::tests::worktree_list_start_event_is_not_enqueued ... ok
test daemon::trace_normalizer::tests::alias_commit_resolves_primary_command ... ok
test daemon::trace_normalizer::tests::alias_pull_rebase_expands_invoked_args_with_flags ... ok
test daemon::trace_normalizer::tests::alias_pull_rebase_expands_invoked_args_without_child_cmd_name ... ok
test daemon::trace_normalizer::tests::child_cmd_name_enriches_root ... ok
test daemon::trace_normalizer::tests::child_exit_before_root_exec_is_ignored_until_root_exit ... ok
test daemon::trace_normalizer::tests::child_exit_does_not_finalize_without_root_exit ... ok
test daemon::rewrite_metrics::tests::rewrite_metric_worker_hydrates_initial_parent_diff ... ok
test daemon::trace_normalizer::tests::clone_child_def_repo_does_not_overwrite_root_worktree ... ok
test daemon::trace_normalizer::tests::clone_relative_target_falls_back_to_argv_target_when_def_repo_candidate_fails ... ok
test daemon::trace_normalizer::tests::clone_prefers_target_family_over_source_cwd_family ... ok
test daemon::trace_normalizer::tests::completed_root_retention_does_not_clear_all_recent_roots ... ok
test daemon::trace_normalizer::tests::clone_with_late_family_resolution_does_not_need_ref_metadata ... ok
test daemon::trace_normalizer::tests::destructive_stash_can_normalize_without_pre_command_target_oid ... ok
test daemon::tests::readonly_flood_1000_events_processed_in_under_200ms ... ok
test daemon::trace_normalizer::tests::ignores_non_supported_trace_events ... ok
test daemon::trace_normalizer::tests::no_repo_routes_to_global_scope ... ok
test daemon::trace_normalizer::tests::interleaved_roots_with_out_of_order_exits_finalize_independently ... ok
test daemon::trace_normalizer::tests::non_alias_pull_invocation_is_unchanged ... ok
test daemon::trace_normalizer::tests::normalizer_defers_exit_seen_before_start_until_atexit ... ok
test daemon::trace_normalizer::tests::normalizer_defers_root_completion_until_atexit ... ok
test daemon::trace_normalizer::tests::normalizer_emits_one_command_for_start_exit_atexit ... ok
test daemon::trace_normalizer::tests::normalizer_preserves_reflog_start_offsets_from_def_repo ... ok
test daemon::trace_normalizer::tests::payload_timestamp_prefers_stock_trace2_rfc3339_time_over_relative_t_abs ... ok
test daemon::trace_normalizer::tests::normalizer_uses_atexit_when_exit_is_missing ... ok
test daemon::transcript_redaction::tests::test_array_elements_are_redacted ... ok
test daemon::transcript_redaction::tests::test_deeply_nested_redaction ... ok
test daemon::transcript_redaction::tests::test_denied_key_skips_entire_subtree ... ok
test daemon::tests::stash_list_flood_leaves_queue_empty ... ok
test daemon::transcript_redaction::tests::test_depth_limit_stops_recursion ... ok
test daemon::transcript_redaction::tests::test_does_not_redact_denied_key_camel_case ... ok
test daemon::transcript_redaction::tests::test_does_not_redact_denied_key_session_id ... ok
test daemon::transcript_redaction::tests::test_is_denied_key_patterns ... ok
test daemon::transcript_redaction::tests::test_does_not_redact_type_role_model_version ... ok
test daemon::transcript_redaction::tests::test_no_secrets_returns_unchanged ... ok
test daemon::trace_normalizer::tests::start_ignores_repo_gitdir_hint_and_uses_cwd_for_worktree_resolution ... ok
test daemon::transcript_redaction::tests::test_redacts_high_entropy_string_in_content_field ... ok
test diagnostic_sentinels::tests::test_is_debug_self_check_remote_url_matches_raw_and_normalized ... ok
test diagnostics::tests::test_trace2_config_failure_details_explains_missing_config ... ok
test diagnostics::tests::test_validate_trace2_command_events_accepts_expected_events ... ok
test diagnostics::tests::test_validate_trace2_command_events_rejects_missing_cmd_name ... ok
test error::tests::test_error_clone_git_cli_error ... ok
test daemon::tests::worktree_list_flood_leaves_queue_empty ... ok
test error::tests::test_error_clone_generic ... ok
test error::tests::test_error_clone_from_utf8_error ... ok
test error::tests::test_error_clone_gix_converts_to_generic ... ok
test error::tests::test_error_clone_io_error ... ok
test error::tests::test_error_clone_preset_error ... ok
test error::tests::test_error_clone_json_converts_to_generic ... ok
test error::tests::test_error_clone_utf8_error ... ok
test error::tests::test_error_debug_trait ... ok
test error::tests::test_error_display_from_utf8_error ... ok
test error::tests::test_error_display_generic ... ok
test error::tests::test_error_display_git_cli_error_with_code ... ok
test error::tests::test_error_display_git_cli_error_without_code ... ok
test error::tests::test_error_display_gix_error ... ok
test error::tests::test_error_display_io_error ... ok
test error::tests::test_error_display_json_error ... ok
test error::tests::test_error_display_preset_error ... ok
test error::tests::test_error_display_utf8_error ... ok
test error::tests::test_error_is_std_error ... ok
test feature_flags::tests::test_clone_trait ... ok
test feature_flags::tests::test_debug_trait ... ok
test feature_flags::tests::test_default_feature_flags ... ok
test error::tests::test_error_clone_sqlite_converts_to_generic ... ok
test feature_flags::tests::test_from_deserializable ... ok
test error::tests::test_error_display_sqlite_error ... ok
test feature_flags::tests::test_rewrite_metrics_events_file_override ... ok
test feature_flags::tests::test_serialization ... ok
test feature_flags::tests::test_from_env_and_file_defaults_only ... ok
test feature_flags::tests::test_from_env_and_file_file_overrides ... ok
test feature_flags::tests::test_rewrite_metrics_events_env_overrides_file ... ok
test git::authorship_traversal::tests::test_extract_file_paths_from_note_empty ... ok
test git::authorship_traversal::tests::test_extract_file_paths_from_note_invalid_format ... ok
test git::authorship_traversal::tests::test_extract_file_paths_from_note_no_divider ... ok
test git::authorship_traversal::tests::test_batch_read_blobs_with_oids_empty ... ok
test daemon::rewrite_metrics::tests::rewrite_metric_worker_hydrates_missing_parent_and_diff ... ok
test git::authorship_traversal::tests::test_load_ai_touched_files_empty_commits ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_empty ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_invalid_size ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_malformed_header ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_missing ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_multiple_blobs ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_single_blob ... ok
test git::authorship_traversal::tests::test_parse_cat_file_batch_output_truncated ... ok
test git::cli_parser::tests::test_derive_directory_from_url ... ok
test git::cli_parser::tests::test_explicit_rebase_branch_arg_control_mode_returns_none ... ok
test git::cli_parser::tests::test_explicit_rebase_branch_arg_root_mode ... ok
test git::cli_parser::tests::test_explicit_rebase_branch_arg_skips_exec_and_empty_values ... ok
test git::cli_parser::tests::test_explicit_rebase_branch_arg_standard_mode ... ok
test git::cli_parser::tests::test_extract_clone_target_directory ... ok
test git::authorship_traversal::tests::test_commits_have_authorship_notes_empty ... ok
test git::cli_parser::tests::test_pos_command_basic ... ok
test git::cli_parser::tests::test_pos_command_flags_before ... ok
test git::cli_parser::tests::test_pos_command_inline_flag_value ... ok
test git::cli_parser::tests::test_pos_command_multiple_positional ... ok
test git::cli_parser::tests::test_pos_command_with_flag_value ... ok
test git::cli_parser::tests::test_rebase_summary_abort_is_control_mode ... ok
test git::cli_parser::tests::test_rebase_summary_continue_is_control_mode ... ok
test git::cli_parser::tests::test_rebase_summary_interactive_with_upstream ... ok
test git::cli_parser::tests::test_rebase_summary_onto_equals_form ... ok
test git::cli_parser::tests::test_rebase_summary_root_flag ... ok
test git::cli_parser::tests::test_rebase_summary_skip_is_control_mode ... ok
test git::cli_parser::tests::test_rebase_summary_strategy_consumes_value ... ok
test git::cli_parser::tests::test_rebase_summary_tracks_onto_with_c_path ... ok
test git::cli_parser::tests::test_rebase_summary_upstream_only ... ok
test git::cli_parser::tests::test_rebase_summary_treats_show_current_patch_as_control_mode ... ok
test git::command_classification::tests::branch_invocation_classification_distinguishes_read_only_queries_from_ref_updates ... ok
test git::command_classification::tests::clone_and_init_mutate_but_do_not_join_existing_family_sequencer ... ok
test git::command_classification::tests::mutating_commands_are_not_read_only_invocations ... ok
test git::command_classification::tests::mutating_commands_not_read_only ... ok
test git::command_classification::tests::mutating_trace_commands_are_centrally_classified ... ok
test git::command_classification::tests::notes_mutating_subcommands_are_not_read_only_invocations ... ok
test git::command_classification::tests::notes_read_only_subcommands_are_read_only_invocations ... ok
test git::command_classification::tests::read_only_commands_detected ... ok
test git::command_classification::tests::remote_and_tag_invocation_classification_distinguishes_queries_from_mutations ... ok
test git::command_classification::tests::standard_read_only_commands_are_read_only_invocations_regardless_of_args ... ok
test git::command_classification::tests::stash_list_is_read_only_invocation ... ok
test git::command_classification::tests::stash_mutating_subcommands_are_not_read_only ... ok
test git::command_classification::tests::stash_show_is_read_only_invocation ... ok
test git::command_classification::tests::unknown_commands_not_read_only ... ok
test git::command_classification::tests::worktree_list_is_read_only_invocation ... ok
test git::command_classification::tests::worktree_mutating_subcommands_are_not_read_only ... ok
test git::fast_reader::tests::test_invalid_oid_returns_none ... ok
test git::fast_reader::tests::test_alternates_causes_fallback ... ok
test git::fast_reader::tests::test_read_commit_as_blob_returns_none ... ok
test git::fast_reader::tests::test_read_commit_tree_oid ... ok
test git::fast_reader::tests::test_read_head_detached ... ok
test git::fast_reader::tests::test_read_head_missing_returns_none ... ok
test git::fast_reader::tests::test_read_head_symbolic_ref ... ok
test git::fast_reader::tests::test_read_head_invalid_format_returns_none ... ok
test git::fast_reader::tests::test_read_nonexistent_blob ... ok
test git::fast_reader::tests::test_read_loose_blob ... ok
test daemon::tests::checkpoint_control_request_waits_while_blocked_behind_pending_root ... ok
test git::fast_reader::tests::test_read_object_type ... ok
test git::fast_reader::tests::test_resolve_loose_ref ... ok
test git::fast_reader::tests::test_resolve_head_resolves_through_symbolic ... ok
test git::fast_reader::tests::test_resolve_packed_ref ... ok
test git::fast_reader::tests::test_resolve_ref_not_found ... ok
test git::fast_reader::tests::test_resolve_ref_loose_in_git_dir_over_packed ... ok
test git::fast_reader::tests::test_resolve_ref_worktree_common_dir_priority ... ok
test git::fast_reader::tests::test_resolve_symbolic_ref_indirection ... ok
test git::authorship_traversal::tests::test_commits_have_authorship_notes_nonexistent ... ok
test git::fast_reader::tests::test_tree_entry_for_path_not_found ... ok
test git::fast_reader::tests::test_tree_entry_for_path_nested ... ok
test git::fast_reader::tests::test_tree_entry_for_path_single_level ... ok
test git::authorship_traversal::tests::test_load_ai_touched_files_for_nonexistent_commit ... ok
test git::notes_api::tests::http_backend_read_note_blob_oids_returns_empty_map ... ok
test git::notes_api::tests::git_notes_backend_read_note_blob_oids_delegates_to_git ... ok
test git::notes_api::tests::push_pre_command_hook_http_guard_is_in_place ... ok
test daemon::tests::conflict_resolution_note_read_errors_are_not_silently_ignored ... ok
test commands::notes_migrate::tests::migration_uploads_notes_and_caches_with_synced_1 ... ok
test git::refs::tests::test_fanout_note_pathspec_for_commit ... ok
test git::refs::tests::test_flat_note_pathspec_for_commit ... ok
test git::refs::tests::test_notes_path_for_object ... ok
test git::refs::tests::test_parse_batch_check_blob_oid_accepts_sha1_and_sha256 ... ok
test git::refs::tests::test_sanitize_remote_name ... ok
test git::refs::tests::test_tracking_ref_for_remote ... ok
test git::notes_api::tests::http_read_notes_returns_multiple ... ok
test git::notes_api::tests::http_write_then_read_uses_cache ... ok
test git::repo_state::tests::worktree_root_for_path_walks_parent_directories ... ok
test git::repository::tests::author_config_overlays_full_identity ... ok
test git::repository::tests::author_config_supports_partial_overrides ... ok
test git::repository::tests::disable_internal_git_hooks_guard_applies_to_spawned_threads ... ok
test git::repository::tests::general_profile_is_noop ... ok
test git::repository::tests::internal_git_env_disables_trace2_targets ... ok
test git::repository::tests::numstat_profile_disables_renames_and_external_renderers ... ok
test git::repository::tests::numstat_profile_strips_short_rename_and_copy_flags ... ok
test git::repository::tests::patch_profile_applies_canonical_machine_parse_flags ... ok
test git::repository::tests::patch_profile_strips_conflicting_ext_diff_and_color_flags ... ok
test git::repository::tests::patch_profile_strips_split_prefix_args ... ok
test git::repository::tests::profile_rewrite_does_not_strip_pathspec_tokens_after_double_dash ... ok
test git::repository::tests::raw_diff_profile_keeps_rename_flags_untouched ... ok
test git::repository::tests::test_parse_git_version_apple_git ... ok
test git::repository::tests::test_parse_git_version_invalid ... ok
test git::repo_state::tests::read_head_state_for_nested_path_uses_worktree_root ... ok
test git::repository::tests::test_parse_git_version_no_patch ... ok
test git::repository::tests::test_parse_git_version_standard ... ok
test git::repository::tests::test_parse_git_version_windows ... ok
test git::repository::tests::test_parse_git_version_with_newline ... ok
test git::sync_authorship::tests::authorship_fetch_args_always_disable_hooks ... ok
test git::sync_authorship::tests::authorship_push_args_always_disable_hooks ... ok
test git::sync_authorship::tests::missing_remote_notes_ref_error_ignores_unrelated_git_errors ... ok
test git::sync_authorship::tests::missing_remote_notes_ref_error_is_detected ... ok
test git::sync_authorship::tests::repository_arg_extractor_recognizes_explicit_paths_and_urls ... ok
test git::status::tests::parse_varied_porcelain_v2_records ... ok
test mdm::agents::amp::tests::test_amp_plugin_content_is_valid_typescript ... ok
test mdm::agents::amp::tests::test_amp_install_plugin_creates_file_from_scratch ... ok
test mdm::agents::amp::tests::test_amp_plugin_placeholder_substitution ... ok
test mdm::agents::amp::tests::test_amp_plugin_windows_path_escaping ... ok
test mdm::agents::claude_code::tests::c1_no_hooks_returns_not_installed ... ok
test mdm::agents::claude_code::tests::c2_git_ai_in_catch_all_returns_up_to_date ... ok
test git::repo_storage::tests::test_merge_working_log_dirs_old_base_wins_on_conflict ... ok
test mdm::agents::claude_code::tests::c3_git_ai_only_in_old_matcher_returns_installed_but_not_up_to_date ... ok
test mdm::agents::amp::tests::test_amp_plugin_handles_empty_directory ... ok
test mdm::agents::claude_code::tests::s10_stale_command_upgraded_in_catch_all ... ok
test mdm::agents::claude_code::tests::s12_git_ai_spread_across_multiple_old_blocks ... ok
test mdm::agents::claude_code::tests::s11_git_ai_in_arbitrary_old_matcher_migrated ... ok
test mdm::agents::claude_code::tests::s1_fresh_install_creates_catch_all_block ... ok
test mdm::agents::claude_code::tests::s2_idempotent_already_on_catch_all ... ok
test mdm::agents::claude_code::tests::s13_hook_types_handled_independently ... ok
test mdm::agents::claude_code::tests::s3_migration_old_matcher_no_user_hooks ... ok
test mdm::agents::claude_code::tests::s4_migration_old_matcher_user_hook_preserved ... ok
test mdm::agents::claude_code::tests::s5_fresh_install_user_has_old_matcher_hook ... ok
test mdm::agents::claude_code::tests::s7_idempotent_user_catch_all_plus_git_ai ... ok
test mdm::agents::claude_code::tests::s6_fresh_install_user_has_catch_all_hook ... ok
test mdm::agents::claude_code::tests::test_claude_hook_commands_no_windows_extended_path_prefix ... ok
test mdm::agents::claude_code::tests::test_claude_hook_commands_preserve_unix_path ... ok
test mdm::agents::claude_code::tests::test_claude_hook_commands_use_forward_slash_path_on_windows ... ok
test mdm::agents::claude_code::tests::s8_deduplication_git_ai_in_both_catch_all_and_old_matcher ... ok
test mdm::agents::claude_code::tests::s9_deduplication_two_git_ai_in_catch_all_block ... ok
test mdm::agents::claude_code::tests::test_install_hooks_creates_missing_parent_dir ... ok
test mdm::agents::claude_code::tests::u1_uninstall_from_catch_all ... ok
test mdm::agents::claude_code::tests::u2_uninstall_from_old_matcher_preserves_user_hook ... ok
test mdm::agents::codex::tests::test_canonical_json_sorts_keys ... ok
test mdm::agents::claude_code::tests::u4_noop_uninstall_when_no_git_ai ... ok
test mdm::agents::claude_code::tests::u3_uninstall_from_multiple_blocks_preserves_user_hooks ... ok
test mdm::agents::codex::tests::test_compute_trust_hash_deterministic ... ok
test mdm::agents::codex::tests::test_compute_trust_hash_differs_by_command ... ok
test mdm::agents::codex::tests::test_compute_trust_hash_differs_by_event ... ok
test mdm::agents::codex::tests::test_config_hooks_feature_enabled_detects_legacy_flag ... ok
test mdm::agents::codex::tests::test_config_hooks_feature_enabled_detects_new_flag ... ok
test mdm::agents::codex::tests::test_config_with_installed_hooks_adds_inline_hooks_for_all_events ... ok
test mdm::agents::codex::tests::test_config_with_installed_hooks_migrates_legacy_codex_hooks_flag ... ok
test mdm::agents::codex::tests::test_config_with_installed_hooks_preserves_existing_matched_hooks ... ok
test mdm::agents::codex::tests::test_config_with_installed_hooks_sets_new_feature_flag_and_inline_hooks ... ok
test mdm::agents::codex::tests::test_check_hooks_detects_legacy_hooks_json_installation ... ok
test mdm::agents::codex::tests::test_install_hooks_creates_missing_codex_dir ... ok
test mdm::agents::codex::tests::test_install_hooks_dry_run ... ok
test mdm::agents::codex::tests::test_install_hooks_idempotent ... ok
test diagnostics::tests::test_run_logged_command_with_timeout_reports_partial_output ... ok
test mdm::agents::codex::tests::test_install_hooks_migrates_hooks_json_preserves_non_git_ai_entries ... ok
test mdm::agents::codex::tests::test_install_hooks_migrates_hooks_json_to_inline_toml ... ok
test mdm::agents::codex::tests::test_install_hooks_migrates_legacy_via_codex_notify ... ok
test mdm::agents::codex::tests::test_install_hooks_migrates_notify_and_sets_new_feature_flag ... ok
test mdm::agents::codex::tests::test_install_hooks_prefers_hooks_json_removes_existing_inline_git_ai_hooks ... ok
test mdm::agents::codex::tests::test_install_hooks_prefers_hooks_json_when_configured ... ok
test mdm::agents::codex::tests::test_install_hooks_preserves_custom_notify ... ok
test mdm::agents::codex::tests::test_install_hooks_respects_codex_home ... ok
test mdm::agents::codex::tests::test_install_hooks_trust_state_idempotent ... ok
test mdm::agents::codex::tests::test_is_git_ai_codex_notify_args_false_for_non_git_ai_command ... ok
test mdm::agents::codex::tests::test_is_git_ai_codex_notify_args_true_for_absolute_binary ... ok
test mdm::agents::codex::tests::test_is_git_ai_codex_notify_args_true_for_legacy_via_codex_notify_args ... ok
test mdm::agents::codex::tests::test_parse_config_toml_malformed ... ok
test mdm::agents::codex::tests::test_parse_config_toml_non_table_root ... ok
test mdm::agents::codex::tests::test_remove_codex_hooks_from_json_removes_only_git_ai_entries ... ok
test mdm::agents::codex::tests::test_remove_feature_flags_removes_both_old_and_new ... ok
test mdm::agents::codex::tests::test_remove_inline_hooks_from_config ... ok
test mdm::agents::codex::tests::test_remove_inline_hooks_preserves_non_git_ai_hooks ... ok
test mdm::agents::codex::tests::test_remove_notify_if_git_ai_preserves_custom_notify ... ok
test mdm::agents::codex::tests::test_remove_notify_if_git_ai_removes_legacy_via_codex_notify_args ... ok
test mdm::agents::codex::tests::test_remove_notify_if_git_ai_removes_only_git_ai_notify ... ok
test mdm::agents::codex::tests::test_install_hooks_writes_inline_toml_and_check_reports_up_to_date ... ok
test mdm::agents::codex::tests::test_install_hooks_writes_trust_state ... ok
test mdm::agents::codex::tests::test_install_preserves_existing_state_entries ... ok
test mdm::agents::cursor::tests::test_cursor_hook_commands_no_windows_extended_path_prefix ... ok
test mdm::agents::cursor::tests::test_cursor_settings_targets_returns_candidates ... ok
test mdm::agents::codex::tests::test_uninstall_hooks_removes_inline_hooks_and_feature_flags ... ok
test mdm::agents::cursor::tests::test_install_hooks_creates_file_from_scratch ... ok
test mdm::agents::cursor::tests::test_install_hooks_preserves_existing_hooks ... ok
test mdm::agents::codex::tests::test_uninstall_hooks_removes_legacy_hooks_json ... ok
test mdm::agents::droid::tests::c1_no_hooks_returns_not_installed ... ok
test mdm::agents::droid::tests::c2_git_ai_in_catch_all_returns_up_to_date ... ok
test git::notes_api::tests::integration_http_write_note_goes_to_db_not_git ... ok
test mdm::agents::droid::tests::c3_git_ai_only_in_old_matcher_not_up_to_date ... ok
test mdm::agents::cursor::tests::test_install_hooks_updates_outdated_command ... ok
test git::authorship_traversal::tests::test_load_ai_touched_files_for_specific_commits ... ok
test mdm::agents::codex::tests::test_uninstall_hooks_removes_trust_state ... ok
test mdm::agents::droid::tests::jsonc_parse_empty_returns_empty_object ... ok
test mdm::agents::droid::tests::jsonc_parse_with_block_comments ... ok
test mdm::agents::droid::tests::jsonc_parse_with_line_comments ... ok
test mdm::agents::droid::tests::jsonc_parse_with_trailing_commas ... ok
test mdm::agents::droid::tests::c4_binary_on_path_without_dotfiles_detects_tool ... ok
test mdm::agents::droid::tests::c5_no_binary_no_dotfiles_not_detected ... FAILED
test mdm::agents::droid::tests::s10_stale_command_upgraded ... ok
test mdm::agents::droid::tests::c6_dotfiles_without_binary_detects_tool ... ok
test mdm::agents::droid::tests::s11_install_into_jsonc_settings_with_comments ... ok
test mdm::agents::droid::tests::s12_install_into_jsonc_settings_with_trailing_commas ... ok
test mdm::agents::droid::tests::s2_idempotent_already_on_catch_all ... ok
test mdm::agents::droid::tests::s1_fresh_install_creates_catch_all_block ... ok
test mdm::agents::droid::tests::s3_migration_old_matcher_no_user_hooks ... ok
test mdm::agents::droid::tests::c7_binary_on_path_install_creates_settings ... ok
test mdm::agents::droid::tests::s4_migration_old_matcher_user_hook_preserved ... ok
test mdm::agents::droid::tests::s5_fresh_install_user_has_old_matcher_hook ... ok
test mdm::agents::droid::tests::s6_fresh_install_user_has_catch_all_hook ... ok
test mdm::agents::droid::tests::s7_idempotent_user_catch_all_plus_git_ai ... ok
test mdm::agents::droid::tests::s9_deduplication_two_git_ai_in_catch_all ... ok
test mdm::agents::droid::tests::s8_deduplication_git_ai_in_both_blocks ... ok
test mdm::agents::droid::tests::u2_uninstall_from_old_matcher_preserves_user_hook ... ok
test mdm::agents::droid::tests::u1_uninstall_from_catch_all ... ok
test mdm::agents::firebender::tests::test_firebender_command_detection ... ok
test mdm::agents::droid::tests::u3_uninstall_from_multiple_blocks ... ok
test mdm::agents::droid::tests::u4_noop_uninstall_when_no_git_ai ... ok
test mdm::agents::firebender::tests::test_check_hooks_not_up_to_date_when_matcher_present ... ok
test mdm::agents::droid::tests::u5_uninstall_from_jsonc_settings_with_comments ... ok
test mdm::agents::gemini::tests::c1_no_hooks_returns_not_installed ... ok
test mdm::agents::gemini::tests::c2_git_ai_in_catch_all_returns_up_to_date ... ok
test mdm::agents::gemini::tests::c3_git_ai_only_in_old_matcher_not_up_to_date ... ok
test mdm::agents::firebender::tests::test_install_hooks_creates_expected_entries ... ok
test mdm::agents::gemini::tests::s10_stale_command_upgraded ... ok
test mdm::agents::gemini::tests::s11_enables_hooks_when_missing ... ok
test mdm::agents::firebender::tests::test_install_hooks_removes_matcher_from_existing_entry ... ok
test mdm::agents::gemini::tests::s1_fresh_install_creates_catch_all_block ... ok
test mdm::agents::gemini::tests::s2_idempotent_already_on_catch_all ... ok
test mdm::agents::firebender::tests::test_install_hooks_updates_existing_firebender_command ... ok
test mdm::agents::gemini::tests::s3_migration_old_matcher_no_user_hooks ... ok
test mdm::agents::gemini::tests::s5_fresh_install_user_has_old_matcher_hook ... ok
test mdm::agents::gemini::tests::s4_migration_old_matcher_user_hook_preserved ... ok
test mdm::agents::gemini::tests::s7_idempotent_user_catch_all_plus_git_ai ... ok
test mdm::agents::gemini::tests::s6_fresh_install_user_has_catch_all_hook ... ok
test mdm::agents::firebender::tests::test_uninstall_hooks_removes_only_firebender_entries ... ok
test mdm::agents::gemini::tests::s8_deduplication_git_ai_in_both_blocks ... ok
test mdm::agents::gemini::tests::s9_deduplication_two_git_ai_in_catch_all ... ok
test mdm::agents::gemini::tests::u1_uninstall_from_catch_all ... ok
test mdm::agents::gemini::tests::u2_uninstall_from_old_matcher_preserves_user_hook ... ok
test mdm::agents::gemini::tests::test_install_hooks_respects_gemini_cli_home ... ok
test mdm::agents::gemini::tests::u4_noop_uninstall_when_no_git_ai ... ok
test mdm::agents::github_copilot::tests::test_github_copilot_installer_id ... ok
test mdm::agents::github_copilot::tests::test_github_copilot_installer_name ... ok
test mdm::agents::gemini::tests::u3_uninstall_from_multiple_blocks ... ok
test git::notes_api::tests::integration_materialize_notes_for_display ... ok
test mdm::agents::github_copilot::tests::test_check_hooks_detects_legacy_path_as_installed ... ok
test mdm::agents::cursor::tests::test_install_extras_does_not_nag_when_cli_absent ... ok
test git::notes_api::tests::warm_cache_for_remote_populates_db_with_synced_1 ... ok
test git::notes_api::tests::warm_cache_for_remote_skips_already_cached_shas ... ok
test mdm::agents::github_copilot::tests::test_check_hooks_partial_post_tool_use_counts_as_installed ... ok
test mdm::agents::github_copilot::tests::test_check_hooks_partial_pre_tool_use_counts_as_installed ... ok
test mdm::agents::github_copilot::tests::test_install_hooks_creates_expected_file ... ok
test mdm::agents::github_copilot::tests::test_install_hooks_deletes_legacy_hooks_file ... ok
test mdm::agents::github_copilot::tests::test_install_hooks_dry_run_does_not_create_files ... ok
test mdm::agents::opencode::tests::test_opencode_install_plugin_creates_file_from_scratch ... ok
test mdm::agents::opencode::tests::test_opencode_plugin_content_is_valid_typescript ... ok
test mdm::agents::github_copilot::tests::test_install_hooks_idempotent ... ok
test mdm::agents::opencode::tests::test_opencode_plugin_placeholder_substitution ... ok
test mdm::agents::opencode::tests::test_opencode_plugin_handles_empty_directory ... ok
test mdm::agents::opencode::tests::test_opencode_plugin_skips_if_already_exists ... ok
test mdm::agents::opencode::tests::test_opencode_plugin_windows_path_escaping ... ok
test mdm::agents::opencode::tests::test_opencode_process_names_includes_opencode2 ... ok
test mdm::agents::pi::tests::test_pi_extension_content_contains_checkpoint_command ... ok
test mdm::agents::pi::tests::test_pi_extension_content_contains_tool_normalization_table ... ok
test mdm::agents::pi::tests::test_pi_extension_output_path ... ok
test mdm::agents::github_copilot::tests::test_install_hooks_repairs_non_object_hooks_field ... ok
test mdm::agents::vscode::tests::test_vscode_install_hooks_returns_none ... ok
test mdm::agents::opencode::tests::test_opencode_plugin_updates_outdated_content ... ok
test mdm::agents::vscode::tests::test_vscode_installer_id ... ok
test mdm::agents::vscode::tests::test_vscode_installer_name ... ok
test mdm::agents::vscode::tests::test_vscode_settings_targets ... ok
test mdm::agents::vscode::tests::test_vscode_settings_targets_returns_candidates ... ok
test mdm::agents::vscode::tests::test_vscode_uninstall_extras_returns_manual_message ... ok
test mdm::agents::vscode::tests::test_vscode_uninstall_hooks_returns_none ... ok
test mdm::jetbrains::detection::tests::test_is_plugin_installed_detects_legacy_extracted_directory ... ok
test mdm::jetbrains::detection::tests::test_is_plugin_installed_detects_marketplace_directory_name ... ok
test mdm::jetbrains::detection::tests::test_plugin_version_suffix_falls_back_to_product_code_when_data_directory_name_missing ... ok
test mdm::jetbrains::detection::tests::test_plugin_version_suffix_prefers_product_info_data_directory_name ... ok
test mdm::jetbrains::detection::tests::test_plugins_dir_for_linux_keeps_documented_jetbrains_plugins_root ... ok
test mdm::jetbrains::detection::tests::test_plugins_dir_for_linux_uses_google_parent_for_android_studio_without_plugins_suffix ... ok
test mdm::jetbrains::detection::tests::test_plugins_dir_for_macos_uses_google_parent_for_android_studio ... ok
test mdm::jetbrains::detection::tests::test_plugins_dir_for_windows_keeps_jetbrains_parent_for_regular_ides ... ok
test mdm::jetbrains::detection::tests::test_plugins_dir_for_windows_uses_google_parent_for_android_studio ... ok
test mdm::skills_installer::tests::test_embedded_skills_are_loaded ... ok
test mdm::agents::github_copilot::tests::test_install_hooks_repairs_non_object_root ... ok
test mdm::skills_installer::tests::test_link_skill_dir_creates_link_and_content_is_accessible ... ok
test mdm::agents::github_copilot::tests::test_uninstall_hooks_deletes_legacy_hooks_file ... ok
test mdm::skills_installer::tests::test_link_skill_dir_creates_symlink_on_unix ... ok
test mdm::skills_installer::tests::test_link_skill_dir_creates_parent_directories ... ok
test mdm::agents::github_copilot::tests::test_uninstall_hooks_removes_only_git_ai_entries ... ok
test mdm::skills_installer::tests::test_remove_skill_link_noop_on_nonexistent_path ... ok
test mdm::skills_installer::tests::test_link_skill_dir_replaces_existing_directory ... ok
test mdm::skills_installer::tests::test_link_skill_dir_replaces_existing_file ... ok
test mdm::skills_installer::tests::test_skills_dir_path_is_under_git_ai ... ok
test mdm::spinner::tests::test_print_diff_additions ... ok
test mdm::spinner::tests::test_print_diff_complete ... ok
test mdm::spinner::tests::test_print_diff_context_lines ... ok
test mdm::spinner::tests::test_print_diff_deletions ... ok
test mdm::spinner::tests::test_print_diff_empty ... ok
test mdm::spinner::tests::test_print_diff_file_headers ... ok
test mdm::spinner::tests::test_print_diff_hunk_headers ... ok
test mdm::skills_installer::tests::test_remove_skill_link_removes_directory ... ok
test mdm::spinner::tests::test_print_diff_multiline ... ok
test mdm::agents::opencode::tests::test_opencode2_binary_detected_as_tool_installed ... ok
test mdm::spinner::tests::test_spinner_creation ... ok
test mdm::spinner::tests::test_spinner_error_output ... ok
test mdm::spinner::tests::test_spinner_pending_output ... ok
test mdm::skills_installer::tests::test_remove_skill_link_removes_symlink ... ok
test mdm::spinner::tests::test_spinner_skipped_output ... ok
test mdm::spinner::tests::test_spinner_success_output ... ok
test mdm::spinner::tests::test_spinner_update_message ... ok
test mdm::utils::tests::test_clean_path_preserves_normal_windows_path ... ok
test mdm::utils::tests::test_clean_path_preserves_unix_path ... ok
test mdm::utils::tests::test_clean_path_strips_windows_prefix ... ok
test mdm::agents::opencode::tests::test_opencode2_binary_install_creates_plugin ... ok
test mdm::agents::opencode::tests::test_opencode_no_binary_no_config_not_detected ... ok
test mdm::skills_installer::tests::test_install_and_uninstall_skills_lifecycle ... ok
test mdm::utils::tests::test_claude_config_dir_defaults_to_home_dot_claude ... ok
test mdm::utils::tests::test_claude_config_dir_ignores_empty_env_var ... ok
test mdm::utils::tests::test_claude_config_dir_respects_env_var ... ok
test mdm::utils::tests::test_codex_home_dir_defaults_to_home_dot_codex ... ok
test mdm::utils::tests::test_codex_home_dir_ignores_empty_env_var ... ok
test mdm::utils::tests::test_editor_cli_command_builds_command_with_args ... ok
test mdm::utils::tests::test_codex_home_dir_respects_env_var ... ok
test mdm::utils::tests::test_editor_cli_command_from_cli_js ... ok
test mdm::utils::tests::test_editor_cli_command_from_cli_js_builds_command_with_env ... ok
test mdm::utils::tests::test_editor_cli_command_from_path ... ok
test mdm::utils::tests::test_ensure_parent_dir_no_parent ... ok
test mdm::utils::tests::test_gemini_config_dir_defaults_to_home_dot_gemini ... ok
test mdm::utils::tests::test_gemini_config_dir_ignores_empty_env_var ... ok
test mdm::utils::tests::test_gemini_config_dir_respects_env_var ... ok
test mdm::utils::tests::test_get_editor_cli_candidates_returns_expected_paths ... ok
test mdm::utils::tests::test_is_git_ai_checkpoint_command ... ok
test mdm::utils::tests::test_is_github_codespaces ... ok
test mdm::utils::tests::test_normalize_windows_path_for_shell_converts_different_drive_letter ... ok
test mdm::utils::tests::test_normalize_windows_path_for_shell_converts_windows_path ... ok
test mdm::utils::tests::test_normalize_windows_path_for_shell_handles_drive_relative_path ... ok
test mdm::utils::tests::test_normalize_windows_path_for_shell_handles_extended_prefix_after_clean ... ok
test mdm::utils::tests::test_normalize_windows_path_for_shell_preserves_unix_path ... ok
test mdm::utils::tests::test_parse_version ... ok
test mdm::utils::tests::test_version_meets_requirement ... ok
test mdm::utils::tests::test_version_requirements ... ok
test mdm::utils::tests::test_resolve_editor_cli_returns_none_for_unknown ... ok
test mdm::utils::tests::test_ensure_parent_dir_creates_nested ... ok
test mdm::utils::tests::test_update_vscode_chat_hook_settings_detects_no_change ... ok
test mdm::utils::tests::test_write_atomic_creates_parent_dirs ... ok
test metrics::attrs::tests::test_event_attributes_all_fields ... ok
test mdm::utils::tests::test_update_vscode_chat_hook_settings_enables_use_hooks ... ok
test metrics::attrs::tests::test_event_attributes_all_nulls ... ok
test metrics::attrs::tests::test_event_attributes_builder ... ok
test metrics::attrs::tests::test_event_attributes_default ... ok
test metrics::attrs::tests::test_event_attributes_external_session_id_opt ... ok
test metrics::attrs::tests::test_event_attributes_external_session_ids ... ok
test metrics::attrs::tests::test_event_attributes_from_sparse ... ok
test metrics::attrs::tests::test_event_attributes_git_ai_version_builder ... ok
test metrics::attrs::tests::test_event_attributes_from_sparse_with_session_fields ... ok
test metrics::attrs::tests::test_event_attributes_prompt_id_backward_compat ... ok
test metrics::attrs::tests::test_event_attributes_partial_sparse ... ok
test metrics::attrs::tests::test_event_attributes_roundtrip ... ok
test metrics::attrs::tests::test_event_attributes_roundtrip_with_session_fields ... ok
test metrics::attrs::tests::test_event_attributes_session_id_builder ... ok
test metrics::attrs::tests::test_event_attributes_session_id_null ... ok
test metrics::attrs::tests::test_event_attributes_sparse_positions ... ok
test metrics::attrs::tests::test_event_attributes_to_sparse ... ok
test metrics::attrs::tests::test_event_attributes_to_sparse_all_fields ... ok
test metrics::attrs::tests::test_event_attributes_to_sparse_with_session_fields ... ok
test mdm::utils::tests::test_write_atomic_regular_file ... ok
test mdm::utils::tests::test_update_vscode_chat_hook_settings_adds_use_hooks_to_empty ... ok
test metrics::db::tests::test_database_path ... ok
test mdm::utils::tests::test_write_atomic_preserves_relative_symlink ... ok
test mdm::utils::tests::test_resolve_editor_cli_finds_cli_js_fallback ... ok
test mdm::utils::tests::test_write_atomic_preserves_symlink ... ok
test metrics::db::tests::test_empty_operations ... ok
test metrics::db::tests::test_backfill_event_metadata_batch_after_advances_cursor ... ok
test metrics::db::tests::test_dequeue_pending_batch_prefers_newest_retryable_rows ... ok
test metrics::db::tests::test_backfill_event_metadata_batch_updates_valid_legacy_rows_only ... ok
test metrics::db::tests::test_dequeue_pending_batch_locks_rows ... ok
test metrics::db::tests::test_dequeue_releases_stale_processing_locks ... ok
test metrics::db::tests::test_failed_records_do_not_block_unfailed_retryable_rows ... ok
test metrics::db::tests::test_fallback_database_initializes_schema ... ok
test metrics::db::tests::test_get_metric_history_reads_authoritative_metrics_table ... ok
test metrics::db::tests::test_get_metric_history_reads_legacy_rows_before_and_after_metadata_backfill ... ok
test metrics::db::tests::test_initialize_schema ... ok
test metrics::db::tests::test_insert_events_leaves_event_metadata_null_for_invalid_json ... ok
test metrics::db::tests::test_insert_events ... ok
test metrics::db::tests::test_initialize_schema_handles_preexisting_agent_usage_table ... ok
test metrics::db::tests::test_insert_events_populates_event_specific_external_ids ... ok
test metrics::db::tests::test_insert_events_populates_existing_common_metadata_from_attrs ... ok
test metrics::db::tests::test_insert_events_with_delivered_ts_populates_event_metadata ... ok
test metrics::db::tests::test_insert_events_with_delivered_ts_skips_batch ... ok
test metrics::db::tests::test_mark_records_undeliverable_keeps_history_without_retrying ... ok
test metrics::db::tests::test_max_attempts_are_not_retryable ... ok
test metrics::db::tests::test_mark_records_delivered ... ok
test metrics::db::tests::test_migrates_version_2_to_row_level_retry_schema ... ok
test metrics::db::tests::test_migrates_version_3_to_event_metadata_schema_without_sync_backfill ... ok
test metrics::db::tests::test_migrates_version_2_with_preexisting_retry_columns ... ok
test metrics::db::tests::test_prunes_metric_rows_older_than_retention_by_event_timestamp ... ok
test metrics::db::tests::test_prunes_malformed_delivered_rows_by_delivered_timestamp ... ok
test metrics::db::tests::test_prunes_metric_rows_older_than_retention_by_cached_event_timestamp ... ok
test metrics::db::tests::test_prunes_old_pending_metric_rows ... ok
test metrics::events::session_event_tests::test_otel_trace_values_event_id ... ok
test metrics::events::session_event_tests::test_otel_trace_values_into_sparse_with_ids ... ok
test metrics::events::session_event_tests::test_otel_trace_values_new ... ok
test metrics::events::session_event_tests::test_otel_trace_values_sparse_none_ids_omitted ... ok
test metrics::events::session_event_tests::test_otel_trace_values_sparse_roundtrip_with_ids ... ok
test metrics::events::session_event_tests::test_otel_trace_values_with_ids ... ok
test metrics::events::session_event_tests::test_session_event_values_into_sparse_with_ids ... ok
test metrics::events::session_event_tests::test_session_event_values_new ... ok
test metrics::events::session_event_tests::test_session_event_values_sparse_none_ids_omitted ... ok
test metrics::events::session_event_tests::test_session_event_values_sparse_roundtrip_with_ids ... ok
test metrics::events::session_event_tests::test_session_event_values_with_ids ... ok
test metrics::events::tests::test_agent_usage_values ... ok
test metrics::events::tests::test_agent_usage_values_roundtrip ... ok
test metrics::events::tests::test_checkpoint_event_id ... ok
test metrics::events::tests::test_checkpoint_values_builder ... ok
test metrics::events::tests::test_checkpoint_values_edit_kind_not_set ... ok
test metrics::events::tests::test_checkpoint_values_edit_kind_null ... ok
test metrics::events::tests::test_checkpoint_values_external_tool_use_id_not_set ... ok
test metrics::events::tests::test_checkpoint_values_external_tool_use_id_null ... ok
test metrics::events::tests::test_checkpoint_values_from_sparse ... ok
test metrics::events::tests::test_checkpoint_values_from_sparse_with_edit_kind ... ok
test metrics::events::tests::test_checkpoint_values_from_sparse_with_external_tool_use_id ... ok
test metrics::events::tests::test_checkpoint_values_roundtrip_with_edit_kind ... ok
test metrics::events::tests::test_checkpoint_values_roundtrip_with_external_tool_use_id ... ok
test metrics::events::tests::test_checkpoint_values_to_sparse ... ok
test metrics::events::tests::test_checkpoint_values_to_sparse_with_edit_kind ... ok
test metrics::events::tests::test_checkpoint_values_to_sparse_with_external_tool_use_id ... ok
test metrics::events::tests::test_checkpoint_values_with_edit_kind ... ok
test metrics::events::tests::test_checkpoint_values_with_external_tool_use_id ... ok
test metrics::events::tests::test_checkpoint_values_with_nulls ... ok
test metrics::events::tests::test_checkpoint_values_with_recovery_metadata ... ok
test metrics::events::tests::test_committed_values_array_nulls ... ok
test metrics::events::tests::test_committed_values_builder ... ok
test metrics::events::tests::test_committed_values_event_id ... ok
test metrics::events::tests::test_committed_values_from_sparse ... ok
test metrics::events::tests::test_committed_values_hunks_null ... ok
test metrics::events::tests::test_committed_values_hunks_roundtrip ... ok
test metrics::events::tests::test_committed_values_null_fields ... ok
test metrics::events::tests::test_committed_values_roundtrip_with_new_fields ... ok
test metrics::events::tests::test_committed_values_to_sparse ... ok
test metrics::events::tests::test_committed_values_with_all_arrays ... ok
test metrics::events::tests::test_committed_values_with_commit_info ... ok
test metrics::events::tests::test_committed_values_with_commit_timestamps_and_patch_id ... ok
test metrics::events::tests::test_committed_values_with_hunks ... ok
test metrics::events::tests::test_install_hooks_event_id ... ok
test metrics::events::tests::test_install_hooks_values_builder ... ok
test metrics::events::tests::test_install_hooks_values_from_sparse ... ok
test metrics::events::tests::test_install_hooks_values_to_sparse ... ok
test metrics::events::tests::test_install_hooks_values_with_null_message ... ok
test metrics::events::tests::test_rewrite_committed_values_event_id ... ok
test metrics::events::tests::test_rewrite_committed_values_sparse_roundtrip ... ok
test metrics::local_stats::tests::compute_activity_aggregates_commits_checkpoints_sessions_and_tokens ... ok
test metrics::local_stats::tests::derived_summary_from_records ... ok
test metrics::local_stats::tests::repo_summaries_group_records_by_repo_and_skip_unknown_repo ... ok
test metrics::local_stats::tests::streaks_current_counts_with_yesterday_grace ... ok
test metrics::local_stats::tests::streaks_current_zero_when_trailing_run_is_stale ... ok
test metrics::local_stats::tests::streaks_empty_is_zero ... ok
test metrics::local_stats::tests::streaks_longest_breaks_on_gap_and_current_requires_recency ... ok
test metrics::pos_encoded::tests::test_sparse_get_string ... ok
test metrics::pos_encoded::tests::test_sparse_get_string_wrong_type ... ok
test metrics::pos_encoded::tests::test_sparse_get_u32 ... ok
test metrics::pos_encoded::tests::test_sparse_get_u32_overflow ... ok
test metrics::pos_encoded::tests::test_sparse_get_u32_wrong_type ... ok
test metrics::pos_encoded::tests::test_sparse_get_u64 ... ok
test metrics::pos_encoded::tests::test_sparse_get_vec_string ... ok
test metrics::pos_encoded::tests::test_sparse_get_vec_u32 ... ok
test metrics::pos_encoded::tests::test_sparse_get_vec_u64 ... ok
test metrics::pos_encoded::tests::test_sparse_get_vec_wrong_types ... ok
test metrics::pos_encoded::tests::test_sparse_set ... ok
test metrics::pos_encoded::tests::test_string_to_json ... ok
test metrics::pos_encoded::tests::test_u32_to_json ... ok
test metrics::pos_encoded::tests::test_u64_to_json ... ok
test metrics::pos_encoded::tests::test_vec_string_to_json ... ok
test metrics::pos_encoded::tests::test_vec_u32_to_json ... ok
test metrics::pos_encoded::tests::test_vec_u64_to_json ... ok
test metrics::tests::test_committed_with_mock_ai_tool_model_pair_bypasses_attrs_guard ... ok
test metrics::tests::test_debug_self_check_repo_url_is_ignored ... ok
test metrics::tests::test_mock_ai_is_blocked_by_record_guard ... ok
test metrics::tests::test_record_creates_event ... ok
test metrics::types::tests::test_metric_event_deserialization ... ok
test metrics::types::tests::test_metric_event_id_clone ... ok
test metrics::types::tests::test_metric_event_id_debug ... ok
test metrics::types::tests::test_metric_event_id_equality ... ok
test metrics::types::tests::test_metric_event_id_values ... ok
test metrics::types::tests::test_metric_event_new_creates_current_timestamp ... ok
test metrics::types::tests::test_metric_event_serialization ... ok
test metrics::types::tests::test_metric_event_with_timestamp ... ok
test metrics::types::tests::test_metrics_api_version ... ok
test metrics::types::tests::test_metrics_batch_deserialization ... ok
test metrics::types::tests::test_metrics_batch_serialization ... ok
test metrics::types::tests::test_metrics_batch_with_events ... ok
test metrics::types::tests::test_sparse_array_type ... ok
test notes::db::tests::test_cache_synced_notes_inserts_with_synced_1 ... ok
test notes::db::tests::test_database_path_contains_expected_segments ... ok
test metrics::db::tests::test_prunes_pending_rows_with_timestamp_even_when_kind_is_missing ... ok
test notes::db::tests::test_dequeue_does_not_return_synced_rows ... ok
test metrics::db::tests::test_session_event_candidates_near_timestamps_filters_kind_and_window ... ok
test metrics::db::tests::test_session_event_candidates_parse_required_and_optional_metadata ... ok
test notes::db::tests::test_dequeue_mark_synced_roundtrip ... ok
test notes::db::tests::test_dequeue_returns_pending_notes ... ok
test notes::db::tests::test_fresh_db_creates_notes_table ... ok
test notes::db::tests::test_mark_failed_increments_attempts_and_schedules_retry ... ok
test notes::db::tests::test_get_notes_batch ... ok
test notes::db::tests::test_mark_failed_processing_started_cleared ... ok
test notes::db::tests::test_notes_table_has_expected_columns ... ok
test metrics::db::tests::test_session_event_candidates_treat_event_ts_as_second_bucket ... ok
test metrics::db::tests::test_should_emit_agent_usage_rate_limit ... ok
test notes::reference_server::tests::read_unknown_sha_returns_empty ... ok
test notes::reference_server::tests::store_is_shared_across_connections ... ok
test notes::reference_server::tests::upload_rejects_malformed_body ... ok
test observability::performance_targets::tests::test_log_performance_checkpoint_many_files ... ok
test notes::db::tests::test_upsert_and_get_note_roundtrip ... ok
test observability::performance_targets::tests::test_log_performance_checkpoint_violated ... ok
test observability::performance_targets::tests::test_log_performance_checkpoint_within_target ... ok
test observability::performance_targets::tests::test_log_performance_checkpoint_zero_files ... ok
test observability::tests::test_log_error_no_panic ... ok
test observability::tests::test_log_error_with_context ... ok
test observability::tests::test_log_message_warning ... ok
test observability::tests::test_log_message_basic ... ok
test observability::tests::test_log_metrics_empty ... ok
test observability::tests::test_log_message_with_context ... ok
test notes::db::tests::test_upsert_missing_sha_returns_none ... ok
test observability::tests::test_log_performance_basic ... ok
test observability::tests::test_log_performance_with_context ... ok
test observability::tests::test_log_performance_with_tags ... ok
test observability::tests::test_max_metrics_per_envelope ... ok
test notes::reference_server::tests::upload_then_read_round_trip ... ok
test repo_url::tests::test_normalize_repo_url_git_protocol ... ok
test repo_url::tests::test_normalize_repo_url_empty_or_invalid_ssh ... ok
test repo_url::tests::test_normalize_repo_url_complex_paths ... ok
test repo_url::tests::test_normalize_repo_url_http_upgrade ... ok
test metrics::db::tests::test_status_counts_delivery_buckets ... ok
test repo_url::tests::test_normalize_repo_url_https ... ok
test repo_url::tests::test_normalize_repo_url_no_path ... ok
test repo_url::tests::test_normalize_repo_url_invalid ... ok
test repo_url::tests::test_normalize_repo_url_ssh_scp_edge_cases ... ok
test repo_url::tests::test_normalize_repo_url_whitespace_handling ... ok
test repo_url::tests::test_normalize_repo_url_ssh ... ok
test repo_url::tests::test_normalize_repo_url_unsupported_schemes ... ok
test repo_url::tests::test_normalize_repo_url_with_port ... ok
test repo_url::tests::test_normalize_repo_url_with_credentials ... ok
test repo_url::tests::test_normalize_ssh_url_edge_cases ... ok
test repo_url::tests::test_validate_normalized_url ... ok
test notes::db::tests::test_upsert_new_content_resets_synced ... ok
test notes::db::tests::test_upsert_same_content_preserves_synced ... ok
test streams::agents::amp::tests::test_append_one_record_after_full_read ... ok
test streams::agents::amp::tests::test_batch_resume_no_loss_or_repeat ... ok
test sqlite::tests::open_with_memory_limits_sets_cache_size ... ok
test streams::agents::amp::tests::test_sweep_strategy ... ok
test streams::agents::amp::tests::test_append_several_records_after_full_read ... ok
test sqlite::tests::open_with_flags_and_memory_limits_sets_cache_size ... ok
test streams::agents::claude::tests::test_detect_subagent_parent ... ok
test streams::agents::claude::tests::test_extract_event_ids_assistant_with_tool_use ... ok
test streams::agents::claude::tests::test_extract_event_ids_summary_event ... ok
test streams::agents::claude::tests::test_extract_event_ids_text_only ... ok
test streams::agents::claude::tests::test_extract_event_ids_user_with_tool_result ... ok
test streams::agents::claude::tests::test_append_one_record_after_full_read ... ok
test streams::agents::claude::tests::test_read_incremental_basic ... ok
test streams::agents::claude::tests::test_scan_discovers_real_claude_files ... ok
test streams::agents::claude::tests::test_sweep_strategy ... ok
test streams::agents::claude::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::claude::tests::test_append_several_records_after_full_read ... ok
test streams::agents::claude::tests::test_read_incremental_with_token_usage ... ok
test streams::agents::amp::tests::test_read_incremental_skips_processed ... ok
test streams::agents::amp::tests::test_read_incremental_basic ... ok
test streams::agents::codex::tests::test_append_one_record_after_full_read ... ok
test streams::agents::codex::tests::test_detect_subagent_parent_empty_file ... ok
test streams::agents::codex::tests::test_detect_subagent_parent_nonexistent_file ... ok
test streams::agents::codex::tests::test_append_several_records_after_full_read ... ok
test streams::agents::codex::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::codex::tests::test_sweep_strategy ... ok
test streams::agents::amp::tests::test_read_incremental_thinking_and_tool_use ... ok
test streams::agents::codex::tests::test_detect_subagent_parent_found ... ok
test streams::agents::codex::tests::test_detect_subagent_parent_user_session ... ok
test streams::agents::codex::tests::test_detect_subagent_parent_no_session_meta ... ok
test streams::agents::codex::tests::test_read_incremental_basic ... ok
test streams::agents::codex::tests::test_read_incremental_legacy_format ... ok
test streams::agents::continue_cli::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::continue_cli::tests::test_sweep_strategy ... ok
test streams::agents::continue_cli::tests::test_append_one_record_after_full_read ... ok
test streams::agents::copilot::tests::test_determine_format ... ok
test streams::agents::continue_cli::tests::test_append_several_records_after_full_read ... ok
test streams::agents::copilot::tests::test_event_stream_append_one_after_full_read ... ok
test streams::agents::continue_cli::tests::test_read_incremental_basic ... ok
test streams::agents::copilot::tests::test_event_stream_batch_resume_no_loss_or_repeat ... ok
test streams::agents::copilot::tests::test_extract_event_ids ... ok
test streams::agents::copilot::tests::test_extract_event_ids_null_parent ... ok
test streams::agents::copilot::tests::test_infer_cwd_from_workspace_json ... ok
test streams::agents::copilot::tests::test_percent_decode_path ... ok
test streams::agents::copilot::tests::test_infer_cwd_trait_method ... ok
test streams::agents::copilot::tests::test_event_stream_append_several_after_full_read ... ok
test streams::agents::copilot::tests::test_read_vscode_event_stream_fixture ... ok
test streams::agents::continue_cli::tests::test_read_incremental_with_context_items ... ok
test streams::agents::copilot::tests::test_sweep_strategy ... ok
test streams::agents::continue_cli::tests::test_read_incremental_skips_already_processed ... ok
test streams::agents::copilot::tests::test_read_event_stream_basic ... ok
test streams::agents::copilot_cli::tests::test_extract_event_ids ... ok
test streams::agents::copilot_cli::tests::test_extract_event_ids_null_parent ... ok
test streams::agents::copilot::tests::test_read_session_json_basic ... ok
test streams::agents::copilot::tests::test_session_json_batch_resume_no_loss_or_repeat ... ok
test streams::agents::copilot_cli::tests::test_append_after_full_read ... ok
test streams::agents::copilot::tests::test_session_json_append_one_after_full_read ... ok
test streams::agents::copilot_cli::tests::test_infer_cwd ... ok
test streams::agents::copilot_cli::tests::test_sweep_strategy ... ok
test streams::agents::copilot_cli::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::copilot_otel::tests::test_extract_event_ids ... ok
test streams::agents::copilot_otel::tests::test_extract_event_ids_empty_tool_call_id ... ok
test streams::agents::copilot_otel::tests::test_extract_event_session_id_chat_session_id ... ok
test streams::agents::copilot_otel::tests::test_extract_event_session_id_empty_chat_falls_to_conversation ... ok
test streams::agents::copilot_otel::tests::test_extract_event_session_id_empty_strings_return_none ... ok
test streams::agents::copilot_otel::tests::test_extract_event_session_id_fallback_to_conversation_id ... ok
test streams::agents::copilot_otel::tests::test_extract_event_session_id_missing_both_fields ... ok
test streams::agents::copilot_otel::tests::test_extract_event_session_id_no_span_key ... ok
test streams::agents::copilot_otel::tests::test_extract_event_timestamp ... ok
test streams::agents::copilot::tests::test_session_json_append_several_after_full_read ... ok
test streams::agents::copilot_otel::tests::test_empty_db_returns_empty_batch ... ok
test streams::agents::copilot_otel::tests::test_map_sqlite_error_busy_is_transient ... ok
test streams::agents::copilot_otel::tests::test_map_sqlite_error_other_is_fatal ... ok
test streams::agents::copilot_otel::tests::test_fractional_real_watermark_roundtrip_prevents_reread ... ok
test streams::agents::copilot_otel::tests::test_fractional_real_end_time_ms_no_infinite_loop ... ok
test streams::agents::copilot_otel::tests::test_initial_watermark_uses_simple_greater_than ... ok
test streams::agents::copilot_otel::tests::test_attributes_denormalized ... ok
test streams::agents::copilot_otel::tests::test_batch_size_limits_results ... ok
test mdm::agents::vscode::tests::test_install_extras_does_not_nag_when_cli_absent ... ok
test streams::agents::copilot_otel::tests::test_reads_from_real_fixture ... ok
test streams::agents::copilot_otel::tests::test_batch_resume_no_loss_no_repeats ... ok
test streams::agents::cursor::tests::test_append_one_record_after_full_read ... ok
test streams::agents::copilot_otel::tests::test_otel_json_structure_has_all_span_fields ... ok
test streams::agents::cursor::tests::test_append_several_records_after_full_read ... ok
test streams::agents::cursor::tests::test_read_incremental_basic ... ok
test streams::agents::cursor::tests::test_sweep_strategy ... ok
test streams::agents::cursor::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::droid::tests::test_append_one_record_after_full_read ... ok
test streams::agents::droid::tests::test_append_several_records_after_full_read ... ok
test streams::agents::droid::tests::test_sweep_strategy ... ok
test streams::agents::droid::tests::test_read_incremental_basic ... ok
test streams::agents::droid::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::gemini::tests::test_append_one_record_after_full_read ... ok
test streams::agents::gemini::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::gemini::tests::test_append_several_records_after_full_read ... ok
test streams::agents::gemini::tests::test_read_incremental_basic ... ok
test streams::agents::gemini::tests::test_read_incremental_skips_empty_lines ... ok
test streams::agents::gemini::tests::test_read_incremental_resumes_from_offset ... ok
test streams::agents::gemini::tests::test_sweep_strategy ... ok
test streams::agents::copilot_otel::tests::test_span_events_denormalized ... ok
test streams::agents::gemini::tests::test_scan_session_files_respects_gemini_cli_home ... ok
test streams::agents::opencode::tests::test_extract_event_ids_no_parts ... ok
test streams::agents::opencode::tests::test_extract_event_ids_with_parent_no_tool ... ok
test streams::agents::opencode::tests::test_extract_event_ids_with_tool_call ... ok
test streams::agents::copilot_otel::tests::test_reads_spans_after_watermark ... ok
test streams::agents::copilot_otel::tests::test_watermark_advances_correctly_after_batch ... ok
test streams::agents::copilot_otel::tests::test_no_data_loss_with_duplicate_end_time_ms ... ok
test streams::agents::opencode::tests::test_parts_are_batch_loaded_not_per_message ... ok
test streams::agents::opencode::tests::test_sweep_strategy ... ok
test streams::agents::copilot_otel::tests::test_spans_without_session_ids_are_filtered ... ok
test streams::agents::opencode::tests::test_sqlite_open_sets_cache_size_pragma ... ok
test streams::agents::pi::tests::test_append_one_record_after_full_read ... ok
test streams::agents::pi::tests::test_append_several_records_after_full_read ... ok
test streams::agents::pi::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::pi::tests::test_read_incremental_basic ... ok
test streams::agents::pi::tests::test_sweep_strategy ... ok
test streams::agents::pi::tests::test_read_incremental_resumes_from_offset ... ok
test streams::agents::pi::tests::test_read_incremental_thinking_and_tool_call ... ok
test streams::agents::windsurf::tests::test_append_one_record_after_full_read ... ok
test mdm::agents::windsurf::tests::test_install_extras_does_not_nag_when_cli_absent ... ok
test streams::agents::windsurf::tests::test_read_incremental_basic ... ok
test streams::agents::windsurf::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::agents::windsurf::tests::test_sweep_strategy ... ok
test streams::agents::windsurf::tests::test_append_several_records_after_full_read ... ok
test streams::agents::windsurf::tests::test_read_incremental_resumes_from_offset ... ok
test streams::agents::windsurf::tests::test_read_incremental_tool_actions ... ok
test streams::agents::opencode::tests::test_append_one_record_after_full_read ... ok
test streams::agents::opencode::tests::test_batch_resume_no_loss_or_repeat ... ok
test streams::db::tests::test_all_streams_empty ... ok
test streams::db::tests::test_composite_pk_allows_same_session_id_different_paths ... ok
test streams::agents::opencode::tests::test_append_several_records_after_full_read ... ok
test streams::agents::opencode::tests::test_limit_returns_at_most_batch_size_per_call ... ok
test streams::db::tests::test_all_streams_multiple ... ok
test streams::db::tests::test_composite_pk_allows_same_session_id_different_streams ... ok
test streams::db::tests::test_database_open_creates_schema ... ok
test streams::db::tests::test_database_wal_mode_enabled ... ok
test streams::db::tests::test_database_reopens_correctly ... ok
test streams::db::tests::test_get_nonexistent_stream ... ok
test streams::db::tests::test_delete_nonexistent_stream ... ok
test streams::db::tests::test_delete_stream ... ok
test streams::agents::opencode::tests::test_limit_caps_memory_and_watermark_still_drains_all ... ok
test streams::db::tests::test_indexes_created ... ok
test streams::db::tests::test_insert_and_get_stream ... ok
test streams::db::tests::test_insert_stream_duplicate_fails ... ok
test streams::db::tests::test_mutex_poison_recovery ... ok
test streams::db::tests::test_performance_pragmas_set ... ok
test streams::db::tests::test_record_error ... ok
test streams::db::tests::test_record_error_nonexistent_stream ... ok
test streams::model_extraction::tests::test_extract_model_amp ... ok
test streams::model_extraction::tests::test_extract_model_claude ... ok
test streams::model_extraction::tests::test_extract_model_claude_model_not_on_last_line ... ok
test streams::model_extraction::tests::test_extract_model_copilot_cli ... ok
test streams::db::tests::test_migration_v3_to_v4_preserves_data ... ok
test streams::model_extraction::tests::test_extract_model_copilot_cli_no_model ... ok
test streams::model_extraction::tests::test_extract_model_copilot_event_stream ... ok
test streams::db::tests::test_stream_with_nulls ... ok
test streams::db::tests::test_update_file_metadata ... ok
test streams::db::tests::test_schema_version_tracking ... ok
test streams::model_extraction::tests::test_extract_model_copilot_vscode_models_json_missing ... ok
test streams::model_extraction::tests::test_extract_model_copilot_vscode_models_json ... ok
test streams::model_extraction::tests::test_extract_model_copilot_session ... ok
test streams::model_extraction::tests::test_extract_model_droid_settings ... ok
test streams::model_extraction::tests::test_extract_model_droid_settings_missing_file ... ok
test streams::model_extraction::tests::test_extract_model_empty_file ... ok
test streams::model_extraction::tests::test_extract_model_gemini ... ok
test streams::db::tests::test_migration_v3_to_v4_multiple_sessions_no_conflict ... ok
test streams::model_extraction::tests::test_extract_model_missing_file ... ok
test streams::model_extraction::tests::test_extract_model_copilot_otel_falls_back_to_response_model ... ok
test streams::model_extraction::tests::test_extract_model_opencode ... ok
test streams::model_extraction::tests::test_extract_model_skips_synthetic_model ... ok
test streams::model_extraction::tests::test_extract_model_unsupported_format_returns_none ... ok
test streams::types::tests::test_error_clone ... ok
test streams::types::tests::test_error_is_std_error ... ok
test streams::types::tests::test_fatal_error_display ... ok
test streams::types::tests::test_parse_error_display ... ok
test streams::types::tests::test_read_jsonl_line_complete ... ok
test streams::types::tests::test_read_jsonl_line_complete_then_partial ... ok
test streams::types::tests::test_read_jsonl_line_eof ... ok
test streams::types::tests::test_read_jsonl_line_multiple_lines ... ok
test streams::types::tests::test_read_jsonl_line_partial ... ok
test streams::types::tests::test_transient_error_display ... ok
test streams::watermark::tests::test_byte_offset_watermark_advance ... ok
test streams::watermark::tests::test_byte_offset_watermark_deserialize ... ok
test streams::watermark::tests::test_byte_offset_watermark_invalid ... ok
test streams::watermark::tests::test_byte_offset_watermark_roundtrip ... ok
test streams::watermark::tests::test_byte_offset_watermark_serialize ... ok
test streams::model_extraction::tests::test_extract_model_copilot_vscode_transcript_falls_back_to_models_json ... ok
test streams::watermark::tests::test_hybrid_watermark_advance ... ok
test streams::watermark::tests::test_hybrid_watermark_deserialize_with_timestamp ... ok
test streams::watermark::tests::test_hybrid_watermark_deserialize_without_timestamp ... ok
test streams::watermark::tests::test_hybrid_watermark_invalid_format ... ok
test streams::watermark::tests::test_hybrid_watermark_invalid_offset ... ok
test streams::watermark::tests::test_hybrid_watermark_invalid_record ... ok
test streams::watermark::tests::test_hybrid_watermark_roundtrip_with_timestamp ... ok
test streams::watermark::tests::test_hybrid_watermark_roundtrip_without_timestamp ... ok
test streams::watermark::tests::test_hybrid_watermark_serialize_with_timestamp ... ok
test streams::watermark::tests::test_hybrid_watermark_serialize_without_timestamp ... ok
test streams::watermark::tests::test_record_index_watermark_advance ... ok
test streams::watermark::tests::test_record_index_watermark_deserialize ... ok
test streams::watermark::tests::test_record_index_watermark_roundtrip ... ok
test streams::watermark::tests::test_record_index_watermark_serialize ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_deserialize ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_initial ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_deserialize_fractional ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_invalid_format ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_invalid_millis ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_roundtrip ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_serialize ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_serialize_fractional ... ok
test streams::watermark::tests::test_timestamp_cursor_watermark_roundtrip_fractional ... ok
test streams::watermark::tests::test_timestamp_watermark_advance_noop ... ok
test streams::db::tests::test_update_file_metadata_nonexistent_stream ... ok
test streams::watermark::tests::test_timestamp_watermark_deserialize ... ok
test streams::watermark::tests::test_timestamp_watermark_roundtrip ... ok
test streams::watermark::tests::test_timestamp_watermark_serialize ... ok
test streams::watermark::tests::test_watermark_type_deserialize_byte_offset ... ok
test streams::watermark::tests::test_watermark_type_deserialize_hybrid ... ok
test streams::watermark::tests::test_watermark_type_deserialize_invalid ... ok
test streams::model_extraction::tests::test_extract_model_copilot_otel_newest_request_model_wins ... ok
test streams::watermark::tests::test_watermark_type_deserialize_record_index ... ok
test streams::watermark::tests::test_watermark_type_deserialize_timestamp ... ok
test streams::watermark::tests::test_watermark_type_deserialize_timestamp_cursor ... ok
test streams::watermark::tests::test_watermark_type_display ... ok
test streams::watermark::tests::test_watermark_type_from_str ... ok
test streams::watermark::tests::test_watermark_type_from_str_invalid ... ok
test streams::watermark::tests::test_watermark_type_roundtrip ... ok
test utils::tests::test_internal_git_ai_command_sets_skip_all_hooks_env ... ok
test utils::tests::test_is_interactive_terminal ... ok
test utils::tests::test_current_git_ai_exe_returns_path ... ok
test utils::tests::test_is_running_as_superuser_reports_correctly ... ok
test utils::tests::test_is_superuser_expected_environment_ci ... ok
test utils::tests::test_lockfile_nonexistent_parent_returns_none ... ok
test utils::tests::test_normalize_to_posix_empty ... ok
test utils::tests::test_normalize_to_posix_mixed ... ok
test utils::tests::test_normalize_to_posix_no_change ... ok
test utils::tests::test_normalize_to_posix_windows ... ok
test utils::tests::test_lockfile_acquire_succeeds ... ok
test utils::tests::test_lockfile_second_acquire_blocked ... ok
test utils::tests::test_lockfile_released_on_drop ... ok
test utils::tests::test_spawn_internal_git_ai_subcommand_requires_non_empty_guard_env ... ok
test streams::model_extraction::tests::test_extract_model_opencode_assistant_message_format ... ok
test utils::tests::test_spawn_internal_git_ai_subcommand_respects_guard_env ... ok
test utils::tests::test_superuser_is_allowed_env_var ... ok
test utils::tests::test_unescape_angstrom ... ok
test utils::tests::test_unescape_arabic ... ok
test utils::tests::test_unescape_backslash_only ... ok
test utils::tests::test_unescape_bengali ... ok
test utils::tests::test_unescape_box_drawing ... ok
test utils::tests::test_unescape_combining_diaeresis ... ok
test utils::tests::test_unescape_currency_symbols ... ok
test utils::tests::test_unescape_dingbats ... ok
test utils::tests::test_unescape_emoji_flag ... ok
test utils::tests::test_unescape_emoji_skin_tone ... ok
test utils::tests::test_unescape_emoji_zwj_sequence ... ok
test utils::tests::test_unescape_empty_quoted ... ok
test utils::tests::test_unescape_git_path_chinese_characters ... ok
test utils::tests::test_unescape_git_path_emoji ... ok
test utils::tests::test_unescape_git_path_escaped_characters ... ok
test utils::tests::test_unescape_git_path_mixed_content ... ok
test utils::tests::test_unescape_git_path_quoted_with_spaces ... ok
test utils::tests::test_unescape_git_path_simple ... ok
test utils::tests::test_unescape_greek ... ok
test utils::tests::test_unescape_greek_polytonic ... ok
test utils::tests::test_unescape_gujarati ... ok
test utils::tests::test_unescape_hebrew ... ok
test utils::tests::test_unescape_hindi_devanagari ... ok
test utils::tests::test_unescape_incomplete_octal ... ok
test utils::tests::test_unescape_invalid_octal ... ok
test utils::tests::test_unescape_japanese_hiragana ... ok
test utils::tests::test_unescape_japanese_katakana ... ok
test streams::db::tests::test_update_watermark_nonexistent_stream ... ok
test utils::tests::test_unescape_khmer ... ok
test utils::tests::test_unescape_korean_hangul ... ok
test utils::tests::test_unescape_lao ... ok
test utils::tests::test_unescape_math_symbols ... ok
test utils::tests::test_unescape_mixed_cjk ... ok
test utils::tests::test_unescape_mixed_escapes ... ok
test utils::tests::test_unescape_mixed_rtl_ltr ... ok
test utils::tests::test_unescape_multiple_emoji ... ok
test utils::tests::test_unescape_nfc_precomposed ... ok
test utils::tests::test_unescape_nfd_decomposed ... ok
test utils::tests::test_resolve_git_ai_exe_from_hook_without_target_falls_back_to_git_ai_name ... ok
test utils::tests::test_unescape_persian ... ok
test utils::tests::test_unescape_russian_cyrillic ... ok
test utils::tests::test_unescape_tamil ... ok
test utils::tests::test_unescape_telugu ... ok
test utils::tests::test_unescape_thai ... ok
test utils::tests::test_unescape_traditional_chinese ... ok
test utils::tests::test_unescape_ukrainian_cyrillic ... ok
test utils::tests::test_resolve_git_ai_exe_from_git_sibling_prefers_git_ai ... ok
test utils::tests::test_unescape_unmatched_quotes ... ok
test utils::tests::test_unescape_urdu ... ok
test utils::tests::test_unescape_vietnamese ... ok
test uuid::tests::test_generate_v4_format ... ok
test uuid::tests::test_generate_v4_lowercase ... ok
test utils::tests::test_resolve_git_ai_exe_from_hook_symlink_uses_canonical_git_ai ... ok
test streams::db::tests::test_update_watermark ... ok
test streams::model_extraction::tests::test_extract_model_copilot_vscode_transcript_prefers_otel_over_models_json ... ok
test uuid::tests::test_generate_v4_uniqueness ... ok
test streams::model_extraction::tests::test_extract_model_head_fallback_for_large_file ... ok
test authorship::virtual_attribution::tests::carryover_merge_matches_git_merge_file_on_random_clean_merges ... ok

failures:

---- mdm::agents::droid::tests::c5_no_binary_no_dotfiles_not_detected stdout ----

thread 'mdm::agents::droid::tests::c5_no_binary_no_dotfiles_not_detected' (69241315) panicked at src/mdm/agents/droid.rs:1197:13:
no binary and no ~/.factory should mean tool_installed=false


failures:
    mdm::agents::droid::tests::c5_no_binary_no_dotfiles_not_detected

test result: FAILED. 2047 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.96s passes with only the pre-existing local Droid detector failure skipped