### PR TITLE
fix(streams): bound JSONL transcript memory

### DIFF
--- a/src/streams/agents/claude.rs
+++ b/src/streams/agents/claude.rs
@@ -188,6 +188,8 @@ impl Agent for ClaudeAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
 
         let mut line = String::new();
         loop {
@@ -202,6 +204,12 @@ impl Agent for ClaudeAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -223,10 +231,16 @@ impl Agent for ClaudeAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
 
@@ -279,25 +293,24 @@ impl Agent for ClaudeAgent {
 
     fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
         use std::fs::File;
-        use std::io::{BufRead, BufReader};
+        use std::io::BufReader;
 
         let file = File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
 
         // Check up to 50 lines for a top-level "cwd" field
-        for line in reader.lines().take(50) {
-            let Ok(line) = line else { continue };
+        crate::streams::types::find_in_jsonl_lines(&mut reader, 50, |line| {
             if line.is_empty() {
-                continue;
+                return None;
             }
-            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(&line)
+            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line)
                 && let Some(cwd) = obj.get("cwd").and_then(|v| v.as_str())
                 && !cwd.is_empty()
             {
                 return Some(PathBuf::from(cwd));
             }
-        }
-        None
+            None
+        })
     }
 
     fn streams(&self) -> Vec<StreamDescriptor> {

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -7,7 +7,7 @@ use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -120,8 +120,10 @@ impl CodexAgent {
     /// the parent session UUID.
     pub fn detect_subagent_parent(path: &Path) -> Option<String> {
         let file = File::open(path).ok()?;
-        let reader = BufReader::new(file);
-        let first_line = reader.lines().next()?.ok()?;
+        let mut reader = BufReader::new(file);
+        let first_line = crate::streams::types::find_in_jsonl_lines(&mut reader, 1, |line| {
+            Some(line.to_string())
+        })?;
         if first_line.trim().is_empty() {
             return None;
         }
@@ -240,6 +242,8 @@ impl Agent for CodexAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
         let mut line = String::new();
 
         loop {
@@ -254,6 +258,12 @@ impl Agent for CodexAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -275,10 +285,16 @@ impl Agent for CodexAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
 
@@ -300,18 +316,17 @@ impl Agent for CodexAgent {
 
     fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
         use std::fs::File;
-        use std::io::{BufRead, BufReader};
+        use std::io::BufReader;
 
         let file = File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
 
         // Codex has cwd in session_meta or turn_context payload events
-        for line in reader.lines().take(20) {
-            let Ok(line) = line else { continue };
+        crate::streams::types::find_in_jsonl_lines(&mut reader, 20, |line| {
             if line.is_empty() {
-                continue;
+                return None;
             }
-            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(&line) {
+            if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) {
                 // Check payload.cwd (session_meta and turn_context)
                 if let Some(cwd) = obj
                     .get("payload")
@@ -322,8 +337,8 @@ impl Agent for CodexAgent {
                     return Some(PathBuf::from(cwd));
                 }
             }
-        }
-        None
+            None
+        })
     }
 
     fn streams(&self) -> Vec<StreamDescriptor> {

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -8,7 +8,7 @@ use crate::streams::watermark::{
     ByteOffsetWatermark, RecordIndexWatermark, WatermarkStrategy, WatermarkType,
 };
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -366,11 +366,9 @@ impl Agent for CopilotAgent {
 
         // Fallback: scan first few lines for file paths in tool calls
         let file = fs::File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
-        for line in reader.lines().take(20).map_while(Result::ok) {
-            let Some(json) = serde_json::from_str::<serde_json::Value>(&line).ok() else {
-                continue;
-            };
+        let mut reader = BufReader::new(file);
+        crate::streams::types::find_in_jsonl_lines(&mut reader, 20, |line| {
+            let json = serde_json::from_str::<serde_json::Value>(line).ok()?;
             if json.get("type").and_then(|v| v.as_str()) == Some("tool.execution_start")
                 && let Some(file_path) = json
                     .get("data")
@@ -387,8 +385,8 @@ impl Agent for CopilotAgent {
                     candidate = dir.parent();
                 }
             }
-        }
-        None
+            None
+        })
     }
 }
 
@@ -529,6 +527,8 @@ pub(super) fn read_event_stream(
     let mut events = Vec::with_capacity(batch_limit);
     let mut current_offset = start_offset;
     let mut line_number = 0;
+    let mut batch_bytes = 0usize;
+    let mut read_stats = crate::streams::types::JsonlReadStats::default();
 
     // Read lines from watermark position
     let mut line = String::new();
@@ -544,6 +544,12 @@ pub(super) fn read_event_stream(
             crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                 line_number += 1;
                 current_offset += bytes_read as u64;
+            }
+            crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                line_number += 1;
+                current_offset += bytes_read as u64;
+                read_stats.record_oversized(bytes_read);
+                continue;
             }
         }
 
@@ -565,10 +571,13 @@ pub(super) fn read_event_stream(
         };
 
         events.push(entry);
-        if events.len() >= batch_limit {
+        batch_bytes += line.len();
+        if crate::streams::types::jsonl_batch_limit_reached(events.len(), batch_limit, batch_bytes)
+        {
             break;
         }
     }
+    read_stats.warn_if_oversized(path);
 
     // Create new watermark with updated offset
     let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));

--- a/src/streams/agents/copilot_cli.rs
+++ b/src/streams/agents/copilot_cli.rs
@@ -124,19 +124,17 @@ impl Agent for CopilotCliAgent {
     }
 
     fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
-        use std::io::{BufRead, BufReader};
+        use std::io::BufReader;
 
         let file = fs::File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
 
-        for line in reader.lines().map_while(Result::ok).take(5) {
+        crate::streams::types::find_in_jsonl_lines(&mut reader, 5, |line| {
             let trimmed = line.trim();
             if trimmed.is_empty() {
-                continue;
+                return None;
             }
-            let Some(json) = serde_json::from_str::<serde_json::Value>(trimmed).ok() else {
-                continue;
-            };
+            let json = serde_json::from_str::<serde_json::Value>(trimmed).ok()?;
             if json.get("type").and_then(|v| v.as_str()) == Some("session.start") {
                 return json
                     .get("data")
@@ -145,8 +143,8 @@ impl Agent for CopilotCliAgent {
                     .and_then(|v| v.as_str())
                     .map(PathBuf::from);
             }
-        }
-        None
+            None
+        })
     }
 
     fn streams(&self) -> Vec<StreamDescriptor> {

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -160,6 +160,8 @@ impl Agent for CursorAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
 
         let mut line = String::new();
         loop {
@@ -174,6 +176,12 @@ impl Agent for CursorAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -195,10 +203,16 @@ impl Agent for CursorAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
 

--- a/src/streams/agents/droid.rs
+++ b/src/streams/agents/droid.rs
@@ -167,6 +167,8 @@ impl Agent for DroidAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
         let mut latest_timestamp: Option<chrono::DateTime<chrono::Utc>> =
             hybrid_watermark.timestamp;
 
@@ -184,6 +186,12 @@ impl Agent for DroidAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -226,10 +234,16 @@ impl Agent for DroidAgent {
 
             // Push raw JSON entry
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         // Create new hybrid watermark with updated offset, record count, and timestamp
         let new_watermark = Box::new(HybridWatermark::new(

--- a/src/streams/agents/gemini.rs
+++ b/src/streams/agents/gemini.rs
@@ -162,6 +162,8 @@ impl Agent for GeminiAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
 
         let mut line = String::new();
         loop {
@@ -176,6 +178,12 @@ impl Agent for GeminiAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -197,10 +205,16 @@ impl Agent for GeminiAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
 

--- a/src/streams/agents/pi.rs
+++ b/src/streams/agents/pi.rs
@@ -93,6 +93,8 @@ impl Agent for PiAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
 
         let mut line = String::new();
         loop {
@@ -107,6 +109,12 @@ impl Agent for PiAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -128,10 +136,16 @@ impl Agent for PiAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
 

--- a/src/streams/agents/windsurf.rs
+++ b/src/streams/agents/windsurf.rs
@@ -93,6 +93,8 @@ impl Agent for WindsurfAgent {
         let mut events = Vec::with_capacity(batch_limit);
         let mut current_offset = start_offset;
         let mut line_number = 0;
+        let mut batch_bytes = 0usize;
+        let mut read_stats = crate::streams::types::JsonlReadStats::default();
 
         let mut line = String::new();
         loop {
@@ -107,6 +109,12 @@ impl Agent for WindsurfAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    read_stats.record_oversized(bytes_read);
+                    continue;
                 }
             }
 
@@ -128,10 +136,16 @@ impl Agent for WindsurfAgent {
             };
 
             events.push(entry);
-            if events.len() >= batch_limit {
+            batch_bytes += line.len();
+            if crate::streams::types::jsonl_batch_limit_reached(
+                events.len(),
+                batch_limit,
+                batch_bytes,
+            ) {
                 break;
             }
         }
+        read_stats.warn_if_oversized(path);
 
         let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
 

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -117,13 +117,8 @@ fn extract_model_from_jsonl_line(line: &str) -> Option<String> {
 
 fn extract_model_from_jsonl_head(path: &Path) -> Option<String> {
     let file = File::open(path).ok()?;
-    let reader = BufReader::new(file);
-    for line in reader.lines().map_while(Result::ok).take(20) {
-        if let Some(model) = extract_model_from_jsonl_line(&line) {
-            return Some(model);
-        }
-    }
-    None
+    let mut reader = BufReader::new(file);
+    crate::streams::types::find_in_jsonl_lines(&mut reader, 20, extract_model_from_jsonl_line)
 }
 
 /// Extracts the model from VS Code Copilot's `models.json` debug log.

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -3,6 +3,40 @@
 use std::io::BufRead;
 use std::time::Duration;
 
+/// Maximum retained size of one JSONL transcript record.
+pub const MAX_JSONL_EVENT_BYTES: usize = 1024 * 1024;
+
+/// Target maximum raw size of events retained in one transcript batch.
+///
+/// The record that crosses this threshold remains in the batch, so the hard
+/// upper bound is this value plus [`MAX_JSONL_EVENT_BYTES`].
+pub const MAX_JSONL_BATCH_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Default)]
+pub struct JsonlReadStats {
+    oversized_records: usize,
+    oversized_bytes: usize,
+}
+
+impl JsonlReadStats {
+    pub fn record_oversized(&mut self, bytes: usize) {
+        self.oversized_records = self.oversized_records.saturating_add(1);
+        self.oversized_bytes = self.oversized_bytes.saturating_add(bytes);
+    }
+
+    pub fn warn_if_oversized(&self, path: &std::path::Path) {
+        if self.oversized_records > 0 {
+            tracing::warn!(
+                path = %path.display(),
+                records = self.oversized_records,
+                bytes = self.oversized_bytes,
+                per_record_limit = MAX_JSONL_EVENT_BYTES,
+                "skipped oversized JSONL records"
+            );
+        }
+    }
+}
+
 /// Result of reading a single line from a JSONL reader.
 pub enum JsonlLineState {
     /// End of file reached.
@@ -11,25 +45,104 @@ pub enum JsonlLineState {
     Partial,
     /// Complete line ready for processing. Contains bytes read.
     Complete(usize),
+    /// Complete line that exceeded [`MAX_JSONL_EVENT_BYTES`] and was discarded.
+    Oversized(usize),
 }
 
 /// Read a line from a BufReader, detecting partial writes from concurrent writers.
 ///
 /// Returns `Eof` if no more data, `Partial` if the line lacks a trailing newline,
-/// or `Complete(bytes)` on success.
+/// `Complete(bytes)` on success, or `Oversized(bytes)` after consuming and
+/// discarding a complete record that exceeds [`MAX_JSONL_EVENT_BYTES`].
 pub fn read_jsonl_line(
     reader: &mut impl BufRead,
     line: &mut String,
 ) -> std::io::Result<JsonlLineState> {
-    line.clear();
-    let bytes_read = reader.read_line(line)?;
+    let mut bytes = std::mem::take(line).into_bytes();
+    bytes.clear();
+    let mut bytes_read = 0usize;
+    let mut complete = false;
+    let mut oversized = false;
+
+    loop {
+        let consumed = {
+            let available = reader.fill_buf()?;
+            if available.is_empty() {
+                break;
+            }
+
+            let consumed = available
+                .iter()
+                .position(|byte| *byte == b'\n')
+                .map_or(available.len(), |index| index + 1);
+            complete = available[consumed - 1] == b'\n';
+            bytes_read = bytes_read.saturating_add(consumed);
+
+            if !oversized && bytes_read <= MAX_JSONL_EVENT_BYTES {
+                bytes.extend_from_slice(&available[..consumed]);
+            } else {
+                oversized = true;
+            }
+            consumed
+        };
+        reader.consume(consumed);
+
+        if complete {
+            break;
+        }
+    }
+
     if bytes_read == 0 {
+        *line = String::from_utf8(bytes).expect("empty byte buffer is valid UTF-8");
         return Ok(JsonlLineState::Eof);
     }
-    if !line.ends_with('\n') {
+
+    if oversized {
+        *line = String::new();
+        return Ok(if complete {
+            JsonlLineState::Oversized(bytes_read)
+        } else {
+            JsonlLineState::Partial
+        });
+    }
+
+    *line = String::from_utf8(bytes)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+    if !complete {
         return Ok(JsonlLineState::Partial);
     }
     Ok(JsonlLineState::Complete(bytes_read))
+}
+
+/// Whether a JSONL reader should return its current batch.
+pub fn jsonl_batch_limit_reached(
+    event_count: usize,
+    event_limit: usize,
+    batch_bytes: usize,
+) -> bool {
+    event_count >= event_limit || batch_bytes >= MAX_JSONL_BATCH_BYTES
+}
+
+/// Search a bounded number of complete JSONL records without retaining an
+/// oversized record.
+pub fn find_in_jsonl_lines<T>(
+    reader: &mut impl BufRead,
+    max_lines: usize,
+    mut find: impl FnMut(&str) -> Option<T>,
+) -> Option<T> {
+    let mut line = String::new();
+    for _ in 0..max_lines {
+        match read_jsonl_line(reader, &mut line).ok()? {
+            JsonlLineState::Complete(_) => {
+                if let Some(value) = find(&line) {
+                    return Some(value);
+                }
+            }
+            JsonlLineState::Oversized(_) => continue,
+            JsonlLineState::Eof | JsonlLineState::Partial => break,
+        }
+    }
+    None
 }
 
 /// Errors that can occur during transcript processing.
@@ -194,5 +307,56 @@ mod tests {
 
         let r2 = read_jsonl_line(&mut reader, &mut line).unwrap();
         assert!(matches!(r2, JsonlLineState::Partial));
+    }
+
+    #[test]
+    fn test_read_jsonl_line_discards_oversized_record_and_reads_next_line() {
+        let oversized_bytes = MAX_JSONL_EVENT_BYTES + 1;
+        let mut data = vec![b'x'; oversized_bytes];
+        data.push(b'\n');
+        data.extend_from_slice(b"{\"kept\":true}\n");
+        let mut reader = std::io::BufReader::with_capacity(31, data.as_slice());
+        let mut line = String::new();
+
+        let first = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(
+            first,
+            JsonlLineState::Oversized(bytes) if bytes == oversized_bytes + 1
+        ));
+        assert!(line.is_empty());
+        assert!(line.capacity() <= MAX_JSONL_EVENT_BYTES);
+
+        let second = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(second, JsonlLineState::Complete(14)));
+        assert_eq!(line, "{\"kept\":true}\n");
+    }
+
+    #[test]
+    fn test_read_jsonl_line_does_not_advance_incomplete_oversized_record() {
+        let data = vec![b'x'; MAX_JSONL_EVENT_BYTES + 1];
+        let mut reader = std::io::BufReader::with_capacity(31, data.as_slice());
+        let mut line = String::new();
+
+        let result = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(result, JsonlLineState::Partial));
+        assert!(line.is_empty());
+        assert!(line.capacity() <= MAX_JSONL_EVENT_BYTES);
+    }
+
+    #[test]
+    fn test_find_in_jsonl_lines_skips_oversized_record() {
+        let mut data = vec![b'x'; MAX_JSONL_EVENT_BYTES + 1];
+        data.extend_from_slice(b"\n{\"cwd\":\"/repo\"}\n");
+        let mut reader = std::io::BufReader::with_capacity(31, data.as_slice());
+
+        let cwd = find_in_jsonl_lines(&mut reader, 2, |line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .ok()?
+                .get("cwd")?
+                .as_str()
+                .map(str::to_owned)
+        });
+
+        assert_eq!(cwd.as_deref(), Some("/repo"));
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -137,6 +137,7 @@ mod superuser_guard;
 mod sweep_e2e;
 mod test_utils_unit;
 mod tls_native_certs;
+mod transcript_memory;
 mod utf8_filenames;
 mod virtual_attribution_unit;
 mod windsurf;

--- a/tests/integration/transcript_memory.rs
+++ b/tests/integration/transcript_memory.rs
@@ -1,0 +1,149 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
+use git_ai::metrics::{PosEncoded, SessionEventValues};
+use git_ai::streams::agent::Agent;
+use git_ai::streams::agents::ClaudeAgent;
+use git_ai::streams::watermark::ByteOffsetWatermark;
+use serde_json::json;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+const EVENT_PAYLOAD_BYTES: usize = 512 * 1024;
+
+fn write_jsonl_event(writer: &mut impl Write, uuid: &str, payload_bytes: usize) {
+    serde_json::to_writer(
+        &mut *writer,
+        &json!({
+            "uuid": uuid,
+            "timestamp": "2026-07-10T00:00:00Z",
+            "message": { "content": "x".repeat(payload_bytes) },
+        }),
+    )
+    .unwrap();
+    writer.write_all(b"\n").unwrap();
+}
+
+fn wait_for_test_session_events(db_path: &Path) -> Vec<String> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let db = MetricsDatabase::open_at_path(db_path).expect("metrics database should open");
+        let events = db
+            .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+            .expect("session metrics should load")
+            .into_iter()
+            .filter_map(|record| {
+                SessionEventValues::from_sparse(&record.event.values)
+                    .raw_json
+                    .get("uuid")
+                    .and_then(|uuid| uuid.as_str())
+                    .filter(|uuid| matches!(*uuid, "oversized" | "kept"))
+                    .map(str::to_owned)
+            })
+            .collect::<Vec<_>>();
+
+        if events.iter().any(|uuid| uuid == "kept") {
+            return events;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "valid event after oversized record was not persisted"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn transcript_daemon_skips_oversized_record_and_keeps_following_event() {
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_db_path = metrics_dir.path().join("metrics.db");
+    let metrics_db_path_str = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path_str.as_str(),
+    )]);
+
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let transcript_path = metrics_dir.path().join("session.jsonl");
+    fs::write(&transcript_path, "").unwrap();
+    let hook_input = |hook_event_name: &str| {
+        json!({
+            "cwd": repo.canonical_path().to_string_lossy(),
+            "hook_event_name": hook_event_name,
+            "session_id": "transcript-memory-session",
+            "tool_name": "Write",
+            "tool_use_id": "transcript-memory-tool-use",
+            "transcript_path": transcript_path.to_string_lossy(),
+            "tool_input": { "file_path": file_path.to_string_lossy() },
+        })
+        .to_string()
+    };
+
+    let pre_hook = hook_input("PreToolUse");
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &pre_hook])
+        .unwrap();
+    fs::write(&file_path, "base\nai line\n").unwrap();
+
+    let transcript = File::create(&transcript_path).unwrap();
+    let mut transcript = BufWriter::new(transcript);
+    write_jsonl_event(&mut transcript, "oversized", 2 * 1024 * 1024);
+    write_jsonl_event(&mut transcript, "kept", 16);
+    transcript.flush().unwrap();
+
+    let post_hook = hook_input("PostToolUse");
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &post_hook])
+        .unwrap();
+
+    assert_eq!(wait_for_test_session_events(&metrics_db_path), ["kept"]);
+
+    repo.stage_all_and_commit("AI edit").unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}
+
+#[test]
+fn transcript_reader_limits_batch_by_bytes_not_only_event_count() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let transcript_path = temp_dir.path().join("session.jsonl");
+    let transcript = File::create(&transcript_path).unwrap();
+    let mut transcript = BufWriter::new(transcript);
+    for index in 0..24 {
+        write_jsonl_event(
+            &mut transcript,
+            &format!("event-{index}"),
+            EVENT_PAYLOAD_BYTES,
+        );
+    }
+    transcript.flush().unwrap();
+
+    let agent = ClaudeAgent::new();
+    let first = agent
+        .read_incremental(
+            &transcript_path,
+            Box::new(ByteOffsetWatermark::new(0)),
+            "transcript-memory-session",
+        )
+        .unwrap();
+    assert!(
+        first.events.len() < 24,
+        "the reader loaded the entire 12 MiB transcript into one batch"
+    );
+    assert!(!first.events.is_empty());
+
+    let second = agent
+        .read_incremental(
+            &transcript_path,
+            first.new_watermark,
+            "transcript-memory-session",
+        )
+        .unwrap();
+    assert!(!second.events.is_empty());
+    assert_eq!(first.events.len() + second.events.len(), 24);
+}


### PR DESCRIPTION
## Bug
JSONL transcript readers accepted an arbitrarily large line and accumulated arbitrarily large event batches. A malformed or merely huge agent transcript could therefore make the daemon allocate in proportion to the file before parsing or checkpointing it.

## Fix
Use the shared bounded JSONL reader across every agent parser. Individual records are capped at 1 MiB and batches at 8 MiB; complete oversized records are skipped, while incomplete records do not advance the cursor so streaming semantics remain correct.

## Verification
Unit tests cover oversized complete and partial records. `tests/integration/transcript_memory.rs` exercises large transcripts through `TestRepo` and verifies bounded processing and attribution behavior.