### PR TITLE
fix(metrics): bound persistence and upload memory

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -14,11 +14,15 @@ use crate::authorship::authorship_log_serialization::GIT_AI_VERSION;
 use crate::config::{Config, get_or_create_distinct_id};
 use crate::daemon::control_api::{CasSyncPayload, TelemetryEnvelope};
 use crate::error::GitAiError;
-use crate::metrics::db::{METADATA_BACKFILL_BATCH_SIZE, MetricRecord, MetricsDatabase};
+use crate::metrics::db::{
+    MAX_METRIC_EVENT_JSON_BYTES, MAX_METRIC_UPLOAD_BATCH_BYTES, METADATA_BACKFILL_BATCH_SIZE,
+    MetricRecord, MetricsDatabase,
+};
 use crate::metrics::{MetricEvent, MetricsBatch};
 use crate::observability::MAX_METRICS_PER_ENVELOPE;
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
+use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
@@ -642,24 +646,118 @@ fn flush_pending_metrics() {
 }
 
 fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
+    let db = MetricsDatabase::global()?;
+    store_metric_events_with(events, |event_jsons| {
+        let mut db_lock = db
+            .lock()
+            .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
+        db_lock.insert_events(event_jsons)
+    })
+}
+
+fn store_metric_events_with<Insert>(
+    events: &[MetricEvent],
+    mut insert_events: Insert,
+) -> Result<Vec<i64>, GitAiError>
+where
+    Insert: FnMut(&[String]) -> Result<Vec<i64>, GitAiError>,
+{
     if events.is_empty() {
         return Ok(Vec::new());
     }
 
-    let event_jsons: Vec<String> = events
-        .iter()
-        .map(serde_json::to_string)
-        .collect::<Result<_, _>>()?;
+    let mut inserted_ids = Vec::new();
+    let mut event_jsons = Vec::new();
+    let mut batch_bytes = 0usize;
+    let mut oversized_events = 0usize;
 
-    if event_jsons.is_empty() {
-        return Ok(Vec::new());
+    for event in events {
+        let Some(event_json) = serialize_metric_event_bounded(event)? else {
+            oversized_events = oversized_events.saturating_add(1);
+            continue;
+        };
+        let event_bytes = event_json.len();
+
+        if !event_jsons.is_empty()
+            && batch_bytes.saturating_add(event_bytes) > MAX_METRIC_UPLOAD_BATCH_BYTES
+        {
+            inserted_ids.extend(insert_events(&event_jsons)?);
+            event_jsons.clear();
+            batch_bytes = 0;
+        }
+
+        batch_bytes = batch_bytes.saturating_add(event_bytes);
+        event_jsons.push(event_json);
     }
 
-    let db = MetricsDatabase::global()?;
-    let mut db_lock = db
-        .lock()
-        .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
-    db_lock.insert_events(&event_jsons)
+    if !event_jsons.is_empty() {
+        inserted_ids.extend(insert_events(&event_jsons)?);
+    }
+
+    if oversized_events > 0 {
+        tracing::debug!(
+            oversized_events,
+            limit_bytes = MAX_METRIC_EVENT_JSON_BYTES,
+            "metrics: skipped oversized events"
+        );
+    }
+
+    Ok(inserted_ids)
+}
+
+struct BoundedMetricJsonWriter {
+    bytes: Vec<u8>,
+    exceeded_limit: bool,
+}
+
+impl BoundedMetricJsonWriter {
+    fn new() -> Self {
+        Self {
+            bytes: Vec::with_capacity(8 * 1024),
+            exceeded_limit: false,
+        }
+    }
+}
+
+impl Write for BoundedMetricJsonWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        let Some(new_len) = self.bytes.len().checked_add(bytes.len()) else {
+            self.exceeded_limit = true;
+            return Err(std::io::Error::other("metric JSON exceeds byte limit"));
+        };
+        if new_len > MAX_METRIC_EVENT_JSON_BYTES {
+            self.exceeded_limit = true;
+            return Err(std::io::Error::other("metric JSON exceeds byte limit"));
+        }
+
+        if new_len > self.bytes.capacity() {
+            let next_capacity = self
+                .bytes
+                .capacity()
+                .saturating_mul(2)
+                .max(new_len)
+                .min(MAX_METRIC_EVENT_JSON_BYTES);
+            self.bytes
+                .reserve_exact(next_capacity.saturating_sub(self.bytes.len()));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialize_metric_event_bounded(event: &MetricEvent) -> Result<Option<String>, GitAiError> {
+    let mut writer = BoundedMetricJsonWriter::new();
+    match serde_json::to_writer(&mut writer, event) {
+        Ok(()) => String::from_utf8(writer.bytes)
+            .map(Some)
+            .map_err(|e| GitAiError::Generic(format!("metric JSON was not UTF-8: {e}"))),
+        Err(_) if writer.exceeded_limit => Ok(None),
+        Err(error) => Err(error.into()),
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -1423,6 +1521,18 @@ mod tests {
         format!(r#"{{"t":{ts},"e":1,"v":{{}},"a":{{}}}}"#)
     }
 
+    fn metric_event_with_payload(payload_bytes: usize) -> MetricEvent {
+        MetricEvent {
+            timestamp: now_ts(),
+            event_id: 1,
+            values: std::collections::HashMap::from([(
+                "0".to_string(),
+                serde_json::Value::String("x".repeat(payload_bytes)),
+            )]),
+            attrs: std::collections::HashMap::new(),
+        }
+    }
+
     fn unix_now() -> u64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1500,6 +1610,72 @@ mod tests {
         assert!(
             handle.buffer.lock().await.daemon_logs.is_empty(),
             "daemon log submission retained an event in a deferred task"
+        );
+    }
+
+    #[test]
+    fn metric_storage_drops_event_over_per_event_byte_limit() {
+        let events = vec![metric_event_with_payload(MAX_METRIC_EVENT_JSON_BYTES + 1)];
+        let mut inserted = 0usize;
+
+        store_metric_events_with(&events, |event_jsons| {
+            inserted += event_jsons.len();
+            Ok(Vec::new())
+        })
+        .unwrap();
+
+        assert_eq!(inserted, 0);
+    }
+
+    #[test]
+    fn metric_json_serialization_stops_at_per_event_byte_limit() {
+        let event = metric_event_with_payload(MAX_METRIC_EVENT_JSON_BYTES + 1);
+        let mut writer = BoundedMetricJsonWriter::new();
+
+        assert!(serde_json::to_writer(&mut writer, &event).is_err());
+        assert!(writer.exceeded_limit);
+        assert!(writer.bytes.len() <= MAX_METRIC_EVENT_JSON_BYTES);
+        assert!(writer.bytes.capacity() <= MAX_METRIC_EVENT_JSON_BYTES);
+    }
+
+    #[test]
+    fn metric_storage_keeps_event_below_per_event_byte_limit() {
+        let events = vec![metric_event_with_payload(1024 * 1024)];
+        let mut inserted = Vec::new();
+
+        store_metric_events_with(&events, |event_jsons| {
+            inserted.extend(event_jsons.iter().cloned());
+            Ok(Vec::new())
+        })
+        .unwrap();
+
+        assert_eq!(inserted.len(), 1);
+        assert_eq!(
+            serde_json::from_str::<MetricEvent>(&inserted[0])
+                .unwrap()
+                .values["0"],
+            events[0].values["0"]
+        );
+    }
+
+    #[test]
+    fn metric_storage_inserts_byte_bounded_chunks() {
+        let events = (0..10)
+            .map(|_| metric_event_with_payload(1024 * 1024))
+            .collect::<Vec<_>>();
+        let mut chunk_bytes = Vec::new();
+
+        store_metric_events_with(&events, |event_jsons| {
+            chunk_bytes.push(event_jsons.iter().map(String::len).sum::<usize>());
+            Ok(Vec::new())
+        })
+        .unwrap();
+
+        assert!(chunk_bytes.len() > 1);
+        assert!(
+            chunk_bytes
+                .iter()
+                .all(|bytes| *bytes <= MAX_METRIC_UPLOAD_BATCH_BYTES)
         );
     }
 

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -20,6 +20,8 @@ const SCHEMA_VERSION: usize = 4;
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
+pub(crate) const MAX_METRIC_EVENT_JSON_BYTES: usize = 2 * 1024 * 1024;
+pub(crate) const MAX_METRIC_UPLOAD_BATCH_BYTES: usize = 8 * 1024 * 1024;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
 /// Database migrations - each migration upgrades the schema by one version
@@ -563,9 +565,9 @@ impl MetricsDatabase {
         self.release_stale_processing_locks(now)?;
 
         let tx = self.conn.transaction()?;
-        let ids = {
+        let (ids, oversized_ids) = {
             let mut stmt = tx.prepare(
-                "SELECT id FROM metrics \
+                "SELECT id, length(CAST(event_json AS BLOB)) FROM metrics \
                  WHERE delivered_ts IS NULL \
                    AND processing_started_at IS NULL \
                    AND next_retry_at <= ?1 \
@@ -575,14 +577,50 @@ impl MetricsDatabase {
             )?;
             let rows = stmt.query_map(
                 params![now as i64, MAX_METRIC_UPLOAD_ATTEMPTS as i64, limit as i64],
-                |row| row.get::<_, i64>(0),
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
             )?;
             let mut ids = Vec::new();
+            let mut oversized_ids = Vec::new();
+            let mut selected_bytes = 0usize;
             for row in rows {
-                ids.push(row?);
+                let (id, event_bytes) = row?;
+                let event_bytes = event_bytes.max(0) as usize;
+                if event_bytes > MAX_METRIC_EVENT_JSON_BYTES {
+                    oversized_ids.push(id);
+                    continue;
+                }
+                if selected_bytes.saturating_add(event_bytes) > MAX_METRIC_UPLOAD_BATCH_BYTES {
+                    break;
+                }
+                selected_bytes = selected_bytes.saturating_add(event_bytes);
+                ids.push(id);
             }
-            ids
+            (ids, oversized_ids)
         };
+
+        if !oversized_ids.is_empty() {
+            let error = format!(
+                "metric event exceeds {}-byte upload limit",
+                MAX_METRIC_EVENT_JSON_BYTES
+            );
+            let mut stmt = tx.prepare_cached(
+                "UPDATE metrics \
+                 SET processing_started_at = NULL, \
+                     attempts = ?1, \
+                     last_sync_error = ?2, \
+                     last_sync_at = ?3, \
+                     next_retry_at = ?3 \
+                 WHERE id = ?4 AND delivered_ts IS NULL",
+            )?;
+            for id in oversized_ids {
+                stmt.execute(params![
+                    MAX_METRIC_UPLOAD_ATTEMPTS as i64,
+                    error,
+                    now as i64,
+                    id,
+                ])?;
+            }
+        }
 
         if ids.is_empty() {
             tx.commit()?;
@@ -1526,6 +1564,13 @@ mod tests {
         format!(r#"{{"t":{ts},"e":1,"v":{{}},"a":{{}}}}"#)
     }
 
+    fn event_json_with_payload(ts: u32, payload_bytes: usize) -> String {
+        format!(
+            r#"{{"t":{ts},"e":1,"v":{{"0":"{}"}},"a":{{}}}}"#,
+            "x".repeat(payload_bytes)
+        )
+    }
+
     fn event_json_with_repo(ts: u32, event_id: u16, repo: &str) -> String {
         format!(r#"{{"t":{ts},"e":{event_id},"v":{{}},"a":{{"1":"{repo}"}}}}"#)
     }
@@ -2436,6 +2481,63 @@ mod tests {
         assert!(batch[0].id > batch[1].id);
         assert!(batch[0].event_json.contains(&format!("\"t\":{newest_ts}")));
         assert!(batch[1].event_json.contains(&format!("\"t\":{middle_ts}")));
+    }
+
+    #[test]
+    fn test_dequeue_pending_batch_is_bounded_by_serialized_bytes() {
+        let (mut db, _temp_dir) = create_test_db();
+        let events = (0..10)
+            .map(|index| event_json_with_payload(days_ago(index + 1), 1024 * 1024))
+            .collect::<Vec<_>>();
+        db.insert_events(&events).unwrap();
+
+        let first_batch = db.dequeue_pending_batch(1000).unwrap();
+        let first_batch_bytes = first_batch
+            .iter()
+            .map(|record| record.event_json.len())
+            .sum::<usize>();
+
+        assert!(!first_batch.is_empty());
+        assert!(first_batch.len() < events.len());
+        assert!(first_batch_bytes <= MAX_METRIC_UPLOAD_BATCH_BYTES);
+
+        let second_batch = db.dequeue_pending_batch(1000).unwrap();
+        let second_batch_bytes = second_batch
+            .iter()
+            .map(|record| record.event_json.len())
+            .sum::<usize>();
+        assert_eq!(first_batch.len() + second_batch.len(), events.len());
+        assert!(second_batch_bytes <= MAX_METRIC_UPLOAD_BATCH_BYTES);
+    }
+
+    #[test]
+    fn test_dequeue_pending_batch_rejects_oversized_legacy_row_without_loading_it() {
+        let (mut db, _temp_dir) = create_test_db();
+        db.insert_events(&[event_json_with_payload(
+            days_ago(1),
+            MAX_METRIC_EVENT_JSON_BYTES + 1,
+        )])
+        .unwrap();
+
+        assert!(db.dequeue_pending_batch(1000).unwrap().is_empty());
+        assert_eq!(db.count_retryable().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_oversized_legacy_row_does_not_block_valid_pending_row() {
+        let (mut db, _temp_dir) = create_test_db();
+        let valid_event = event_json(days_ago(2));
+        db.insert_events(&[
+            valid_event.clone(),
+            event_json_with_payload(days_ago(1), MAX_METRIC_EVENT_JSON_BYTES + 1),
+        ])
+        .unwrap();
+
+        let batch = db.dequeue_pending_batch(1000).unwrap();
+
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].event_json, valid_event);
+        assert_eq!(db.count_retryable().unwrap(), 0);
     }
 
     #[test]

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -2,7 +2,8 @@
 
 use super::pos_encoded::{
     PosEncoded, PosField, sparse_get_string, sparse_get_u32, sparse_get_u64, sparse_get_vec_string,
-    sparse_get_vec_u32, sparse_set, string_to_json, u32_to_json, u64_to_json, vec_string_to_json,
+    sparse_get_vec_u32, sparse_set, string_into_json, string_to_json, u32_into_json, u32_to_json,
+    u64_into_json, u64_to_json, vec_string_into_json, vec_string_to_json, vec_u32_into_json,
     vec_u32_to_json,
 };
 use super::types::{EventValues, MetricEventId, SparseArray};
@@ -323,6 +324,77 @@ impl PosEncoded for CommittedValues {
         map
     }
 
+    fn into_sparse(self) -> SparseArray {
+        let mut map = SparseArray::new();
+        sparse_set(
+            &mut map,
+            committed_pos::HUMAN_ADDITIONS,
+            u32_into_json(self.human_additions),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::GIT_DIFF_DELETED_LINES,
+            u32_into_json(self.git_diff_deleted_lines),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::GIT_DIFF_ADDED_LINES,
+            u32_into_json(self.git_diff_added_lines),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::TOOL_MODEL_PAIRS,
+            vec_string_into_json(self.tool_model_pairs),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::AI_ADDITIONS,
+            vec_u32_into_json(self.ai_additions),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::AI_ACCEPTED,
+            vec_u32_into_json(self.ai_accepted),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::FIRST_CHECKPOINT_TS,
+            u64_into_json(self.first_checkpoint_ts),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::COMMIT_SUBJECT,
+            string_into_json(self.commit_subject),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::COMMIT_BODY,
+            string_into_json(self.commit_body),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::AUTHORSHIP_NOTE,
+            string_into_json(self.authorship_note),
+        );
+        sparse_set(&mut map, committed_pos::HUNKS, string_into_json(self.hunks));
+        sparse_set(
+            &mut map,
+            committed_pos::AUTHOR_TS,
+            u64_into_json(self.author_ts),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::COMMIT_TS,
+            u64_into_json(self.commit_ts),
+        );
+        sparse_set(
+            &mut map,
+            committed_pos::PATCH_ID,
+            string_into_json(self.patch_id),
+        );
+        map
+    }
+
     fn from_sparse(arr: &SparseArray) -> Self {
         Self {
             // Scalar fields
@@ -355,6 +427,10 @@ impl EventValues for CommittedValues {
 
     fn to_sparse(&self) -> SparseArray {
         PosEncoded::to_sparse(self)
+    }
+
+    fn into_sparse(self) -> SparseArray {
+        PosEncoded::into_sparse(self)
     }
 
     fn from_sparse(arr: &SparseArray) -> Self {
@@ -604,6 +680,71 @@ impl PosEncoded for RewriteCommittedValues {
         map
     }
 
+    fn into_sparse(self) -> SparseArray {
+        let mut map = SparseArray::new();
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::HUMAN_ADDITIONS,
+            u32_into_json(self.human_additions),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::GIT_DIFF_DELETED_LINES,
+            u32_into_json(self.git_diff_deleted_lines),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::GIT_DIFF_ADDED_LINES,
+            u32_into_json(self.git_diff_added_lines),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::TOOL_MODEL_PAIRS,
+            vec_string_into_json(self.tool_model_pairs),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::AI_ADDITIONS,
+            vec_u32_into_json(self.ai_additions),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::AI_ACCEPTED,
+            vec_u32_into_json(self.ai_accepted),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::COMMIT_SUBJECT,
+            string_into_json(self.commit_subject),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::COMMIT_BODY,
+            string_into_json(self.commit_body),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::AUTHORSHIP_NOTE,
+            string_into_json(self.authorship_note),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::HUNKS,
+            string_into_json(self.hunks),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::OPERATION_KIND,
+            string_into_json(self.operation_kind),
+        );
+        sparse_set(
+            &mut map,
+            rewrite_committed_pos::ORIGINAL_COMMIT_SHAS,
+            vec_string_into_json(self.original_commit_shas),
+        );
+        map
+    }
+
     fn from_sparse(arr: &SparseArray) -> Self {
         Self {
             human_additions: sparse_get_u32(arr, rewrite_committed_pos::HUMAN_ADDITIONS),
@@ -635,6 +776,10 @@ impl EventValues for RewriteCommittedValues {
 
     fn to_sparse(&self) -> SparseArray {
         PosEncoded::to_sparse(self)
+    }
+
+    fn into_sparse(self) -> SparseArray {
+        PosEncoded::into_sparse(self)
     }
 
     fn from_sparse(arr: &SparseArray) -> Self {
@@ -1106,6 +1251,28 @@ mod tests {
     }
 
     #[test]
+    fn committed_values_owned_encoding_matches_borrowed_encoding() {
+        let values = CommittedValues::new()
+            .human_additions(50)
+            .git_diff_deleted_lines(20)
+            .git_diff_added_lines(150)
+            .tool_model_pairs(vec!["all".to_string(), "codex:gpt-5".to_string()])
+            .ai_additions(vec![100, 70])
+            .ai_accepted(vec![80, 55])
+            .first_checkpoint_ts(1_704_067_200)
+            .commit_subject("subject")
+            .commit_body("body")
+            .authorship_note("note")
+            .hunks("[]")
+            .author_ts(1_704_067_210)
+            .commit_ts(1_704_067_220)
+            .patch_id("patch-id");
+        let borrowed = PosEncoded::to_sparse(&values);
+
+        assert_eq!(PosEncoded::into_sparse(values), borrowed);
+    }
+
+    #[test]
     fn test_committed_values_with_commit_timestamps_and_patch_id() {
         use super::PosEncoded;
 
@@ -1188,6 +1355,7 @@ mod tests {
             .original_commit_shas(vec!["old1".to_string()]);
 
         let sparse = PosEncoded::to_sparse(&original);
+        assert_eq!(PosEncoded::into_sparse(original.clone()), sparse);
 
         assert!(!sparse.contains_key("10"));
         assert_eq!(sparse.get("15"), Some(&Value::String("rebase".to_string())));

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -53,7 +53,7 @@ pub fn record<V: EventValues>(values: V, attrs: EventAttributes) {
     if should_ignore_debug_self_check_event(&attrs) {
         return;
     }
-    let event = MetricEvent::new(&values, attrs.to_sparse());
+    let event = MetricEvent::from_values(values, attrs.to_sparse());
     // Write directly to observability log
     crate::observability::log_metrics(vec![event]);
 }

--- a/src/metrics/pos_encoded.rs
+++ b/src/metrics/pos_encoded.rs
@@ -18,8 +18,58 @@ pub type PosField<T> = Option<Option<T>>;
 /// Trait for types that can be position-encoded.
 pub trait PosEncoded: Sized + Default {
     fn to_sparse(&self) -> SparseArray;
+    fn into_sparse(self) -> SparseArray {
+        self.to_sparse()
+    }
     #[allow(dead_code)]
     fn from_sparse(arr: &SparseArray) -> Self;
+}
+
+pub fn string_into_json(field: PosField<String>) -> Option<Value> {
+    match field {
+        None => None,
+        Some(None) => Some(Value::Null),
+        Some(Some(value)) => Some(Value::String(value)),
+    }
+}
+
+pub fn u32_into_json(field: PosField<u32>) -> Option<Value> {
+    match field {
+        None => None,
+        Some(None) => Some(Value::Null),
+        Some(Some(value)) => Some(Value::Number(value.into())),
+    }
+}
+
+pub fn u64_into_json(field: PosField<u64>) -> Option<Value> {
+    match field {
+        None => None,
+        Some(None) => Some(Value::Null),
+        Some(Some(value)) => Some(Value::Number(value.into())),
+    }
+}
+
+pub fn vec_string_into_json(field: PosField<Vec<String>>) -> Option<Value> {
+    match field {
+        None => None,
+        Some(None) => Some(Value::Null),
+        Some(Some(values)) => Some(Value::Array(
+            values.into_iter().map(Value::String).collect(),
+        )),
+    }
+}
+
+pub fn vec_u32_into_json(field: PosField<Vec<u32>>) -> Option<Value> {
+    match field {
+        None => None,
+        Some(None) => Some(Value::Null),
+        Some(Some(values)) => Some(Value::Array(
+            values
+                .into_iter()
+                .map(|value| Value::Number(value.into()))
+                .collect(),
+        )),
+    }
 }
 
 /// Convert a `PosField<String>` to JSON Value for sparse array.

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -74,11 +74,17 @@ pub fn log_metrics(events: Vec<MetricEvent>) {
         return;
     }
 
-    // Split into chunks of MAX_METRICS_PER_ENVELOPE
-    for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-        let envelope = crate::daemon::TelemetryEnvelope::Metrics {
-            events: chunk.to_vec(),
-        };
+    // Consume owned chunks so large metric payloads are not cloned before submission.
+    let mut events = events.into_iter();
+    loop {
+        let chunk = events
+            .by_ref()
+            .take(MAX_METRICS_PER_ENVELOPE)
+            .collect::<Vec<_>>();
+        if chunk.is_empty() {
+            break;
+        }
+        let envelope = crate::daemon::TelemetryEnvelope::Metrics { events: chunk };
         submit_telemetry_envelope(vec![envelope]);
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -86,6 +86,7 @@ mod jetbrains_download;
 mod jetbrains_ide_types;
 mod log;
 mod merge_rebase;
+mod metrics_memory;
 mod multi_repo_workspace;
 mod non_utf8_files;
 mod notes_merge_mixed_fanout;

--- a/tests/integration/metrics_memory.rs
+++ b/tests/integration/metrics_memory.rs
@@ -1,0 +1,133 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::attrs::attr_pos;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+const MAX_METRIC_EVENT_JSON_BYTES: usize = 2 * 1024 * 1024;
+
+fn codex_checkpoint(repo: &TestRepo, file_path: &Path, hook_event_name: &str, tool_use_id: &str) {
+    let hook_input = json!({
+        "session_id": "metrics-memory-session",
+        "cwd": repo.canonical_path().to_string_lossy(),
+        "hook_event_name": hook_event_name,
+        "tool_name": "apply_patch",
+        "tool_use_id": tool_use_id,
+        "model": "gpt-5",
+        "tool_input": {
+            "patch": format!("*** Update File: {}\n", file_path.to_string_lossy())
+        },
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
+        .expect("codex checkpoint should succeed");
+}
+
+fn commit_sha(event: &git_ai::metrics::MetricEvent) -> Option<&str> {
+    event
+        .attrs
+        .get(&attr_pos::COMMIT_SHA.to_string())
+        .and_then(|value| value.as_str())
+}
+
+#[test]
+fn oversized_commit_metric_is_not_retained_and_following_metric_persists() {
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_db_path = metrics_dir.path().join("metrics.db");
+    let metrics_db_path_str = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path_str.as_str(),
+    )]);
+
+    let file_path = repo.path().join("generated.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("generated.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    codex_checkpoint(&repo, &file_path, "PreToolUse", "oversized-metric-edit");
+    fs::write(&file_path, "base\nfirst ai line\n").unwrap();
+    codex_checkpoint(&repo, &file_path, "PostToolUse", "oversized-metric-edit");
+    repo.git(&["add", "-A"]).unwrap();
+
+    let message_path = metrics_dir.path().join("oversized-commit-message.txt");
+    fs::write(
+        &message_path,
+        format!(
+            "Oversized commit metric\n\n{}\n",
+            "x".repeat(3 * 1024 * 1024)
+        ),
+    )
+    .unwrap();
+    repo.git(&[
+        "commit",
+        "-F",
+        message_path.to_str().expect("message path should be UTF-8"),
+    ])
+    .unwrap();
+    repo.sync_daemon();
+    let oversized_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "first ai line".ai()]);
+
+    codex_checkpoint(&repo, &file_path, "PreToolUse", "normal-metric-edit");
+    fs::write(&file_path, "base\nfirst ai line\nsecond ai line\n").unwrap();
+    codex_checkpoint(&repo, &file_path, "PostToolUse", "normal-metric-edit");
+    let normal_commit = repo.stage_all_and_commit("Normal commit metric").unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "first ai line".ai(),
+        "second ai line".ai(),
+    ]);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let settle_time = Duration::from_secs(1);
+    let mut normal_seen_at = None;
+    loop {
+        let db = MetricsDatabase::open_at_path(&metrics_db_path).unwrap();
+        let events = db
+            .get_metric_history(0, None, &[MetricEventId::Committed as u16])
+            .unwrap()
+            .into_iter()
+            .map(|record| record.event)
+            .collect::<Vec<_>>();
+
+        assert!(
+            events.iter().all(|event| {
+                serde_json::to_vec(event)
+                    .is_ok_and(|json| json.len() <= MAX_METRIC_EVENT_JSON_BYTES)
+            }),
+            "persisted metric exceeded the per-event byte limit"
+        );
+        assert!(
+            events
+                .iter()
+                .all(|event| commit_sha(event) != Some(oversized_commit.as_str())),
+            "oversized committed metric was retained"
+        );
+
+        if events
+            .iter()
+            .any(|event| commit_sha(event) == Some(normal_commit.commit_sha.as_str()))
+        {
+            let seen_at = normal_seen_at.get_or_insert_with(Instant::now);
+            if seen_at.elapsed() >= settle_time {
+                break;
+            }
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "normal metric after oversized metric was not persisted"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    repo.git_ai(&["status", "--json"])
+        .expect("daemon should remain responsive after oversized metric");
+}


### PR DESCRIPTION
## Bug
Metric serialization, SQLite dequeue, metadata backfill, and upload construction could materialize arbitrarily large legacy rows or arbitrarily large batches. One bad metric could also block valid rows behind it indefinitely.

## Fix
Cap serialized events at 2 MiB and upload batches at 8 MiB, select SQLite rows under a byte budget before materializing payloads, reject oversized legacy rows, paginate metadata work, and bound upload attempts. Valid rows continue past rejected legacy data.

## Verification
Focused database/serialization tests cover oversized rows, byte-limited batches, and forward progress. `tests/integration/metrics_memory.rs` validates bounded daemon behavior with large metrics.