### PR TITLE
fix(telemetry): bound worker queues and buffers

### DIFF
--- a/src/daemon/daemon_log_layer.rs
+++ b/src/daemon/daemon_log_layer.rs
@@ -11,11 +11,11 @@ use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
-const MAX_MESSAGE_LENGTH: usize = 16_000;
+pub(crate) const MAX_MESSAGE_LENGTH: usize = 16_000;
 const MAX_TARGET_LENGTH: usize = 512;
 const MAX_FIELD_KEY_LENGTH: usize = 256;
-const MAX_FIELD_VALUE_LENGTH: usize = 4096;
-const MAX_FIELDS_PER_EVENT: usize = 64;
+pub(crate) const MAX_FIELD_VALUE_LENGTH: usize = 4096;
+pub(crate) const MAX_FIELDS_PER_EVENT: usize = 64;
 const MAX_SECRET_SCAN_TOKEN_LENGTH: usize = 90;
 const DAEMON_LOG_CAPTURE_ELIGIBILITY_TTL: Duration = Duration::from_secs(30);
 
@@ -200,7 +200,7 @@ fn sanitize_field_value(value: DaemonLogFieldValue) -> DaemonLogFieldValue {
     }
 }
 
-fn sanitize_log_string(value: &str, max_len: usize) -> String {
+pub(crate) fn sanitize_log_string(value: &str, max_len: usize) -> String {
     let (redacted, _) = redact_secrets_in_text(value);
     truncate_string(&redacted, max_len)
 }
@@ -217,17 +217,17 @@ fn bounded_raw_len(max_len: usize) -> usize {
     max_len.saturating_add(MAX_SECRET_SCAN_TOKEN_LENGTH)
 }
 
-fn bounded_copy(value: &str, max_len: usize) -> String {
+pub(crate) fn bounded_copy(value: &str, max_len: usize) -> String {
     truncate_string(value, bounded_raw_len(max_len))
 }
 
-fn bounded_debug_string(value: &dyn std::fmt::Debug, max_len: usize) -> String {
+pub(crate) fn bounded_debug_string(value: &dyn std::fmt::Debug, max_len: usize) -> String {
     let mut writer = BoundedStringWriter::new(bounded_raw_len(max_len));
     let _ = write!(&mut writer, "{value:?}");
     writer.into_string()
 }
 
-fn bounded_display_string(value: &dyn std::fmt::Display, max_len: usize) -> String {
+pub(crate) fn bounded_display_string(value: &dyn std::fmt::Display, max_len: usize) -> String {
     let mut writer = BoundedStringWriter::new(bounded_raw_len(max_len));
     let _ = write!(&mut writer, "{value}");
     writer.into_string()

--- a/src/daemon/sentry_layer.rs
+++ b/src/daemon/sentry_layer.rs
@@ -5,6 +5,11 @@ use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::{Context, Layer};
 
+use crate::daemon::daemon_log_layer::{
+    MAX_FIELD_VALUE_LENGTH, MAX_FIELDS_PER_EVENT, MAX_MESSAGE_LENGTH, bounded_copy,
+    bounded_debug_string, sanitize_log_string,
+};
+
 /// A tracing Layer that intercepts ERROR-level events and routes them
 /// to the daemon's telemetry worker as `TelemetryEnvelope::Error` events,
 /// which get forwarded to both enterprise and OSS Sentry DSNs.
@@ -22,48 +27,66 @@ impl MessageVisitor {
             fields: serde_json::Map::new(),
         }
     }
+
+    fn record_string(&mut self, field: &Field, value: String) {
+        if field.name() == "message" {
+            self.message = sanitize_log_string(&value, MAX_MESSAGE_LENGTH);
+        } else if self.fields.len() < MAX_FIELDS_PER_EVENT || self.fields.contains_key(field.name())
+        {
+            self.fields.insert(
+                field.name().to_string(),
+                serde_json::Value::String(sanitize_log_string(&value, MAX_FIELD_VALUE_LENGTH)),
+            );
+        }
+    }
+
+    fn can_record_field(&self, field: &Field) -> bool {
+        self.fields.len() < MAX_FIELDS_PER_EVENT || self.fields.contains_key(field.name())
+    }
 }
 
 impl Visit for MessageVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "message" {
-            self.message = format!("{:?}", value);
+        let max_len = if field.name() == "message" {
+            MAX_MESSAGE_LENGTH
         } else {
-            self.fields.insert(
-                field.name().to_string(),
-                serde_json::Value::String(format!("{:?}", value)),
-            );
-        }
+            MAX_FIELD_VALUE_LENGTH
+        };
+        self.record_string(field, bounded_debug_string(value, max_len));
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "message" {
-            self.message = value.to_string();
+        let max_len = if field.name() == "message" {
+            MAX_MESSAGE_LENGTH
         } else {
+            MAX_FIELD_VALUE_LENGTH
+        };
+        self.record_string(field, bounded_copy(value, max_len));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        if self.can_record_field(field) {
             self.fields.insert(
                 field.name().to_string(),
-                serde_json::Value::String(value.to_string()),
+                serde_json::Value::Number(value.into()),
             );
         }
     }
 
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        self.fields.insert(
-            field.name().to_string(),
-            serde_json::Value::Number(value.into()),
-        );
-    }
-
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.fields.insert(
-            field.name().to_string(),
-            serde_json::Value::Number(value.into()),
-        );
+        if self.can_record_field(field) {
+            self.fields.insert(
+                field.name().to_string(),
+                serde_json::Value::Number(value.into()),
+            );
+        }
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.fields
-            .insert(field.name().to_string(), serde_json::Value::Bool(value));
+        if self.can_record_field(field) {
+            self.fields
+                .insert(field.name().to_string(), serde_json::Value::Bool(value));
+        }
     }
 }
 

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -24,7 +24,8 @@ use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
 use tokio::sync::Mutex;
 use tokio::time::{Duration, interval};
 
@@ -33,6 +34,13 @@ const DAEMON_LOG_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
 const MAX_DAEMON_LOG_EVENTS_PER_UPLOAD: usize = 1000;
 const MAX_DAEMON_LOG_BUFFER_EVENTS: usize = 5000;
 const MAX_DAEMON_LOG_BUFFER_BYTES: usize = 8 * 1024 * 1024;
+const MAX_TELEMETRY_BUFFER_EVENTS: usize = 5000;
+const MAX_TELEMETRY_BUFFER_BYTES: usize = 8 * 1024 * 1024;
+const MAX_TELEMETRY_EVENT_BYTES: usize = 256 * 1024;
+const MAX_CAS_BUFFER_RECORDS: usize = 1000;
+const MAX_CAS_BUFFER_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CAS_RECORD_BYTES: usize = 2 * 1024 * 1024;
+const METRIC_PERSISTENCE_QUEUE_CAPACITY: usize = 32;
 
 static METRICS_UPLOAD_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static METRICS_METADATA_BACKFILL_STARTED: AtomicBool = AtomicBool::new(false);
@@ -44,8 +52,12 @@ struct TelemetryBuffer {
     errors: Vec<ErrorEvent>,
     performances: Vec<PerformanceEvent>,
     messages: Vec<MessageEvent>,
-    metrics: Vec<MetricEvent>,
+    telemetry_event_count: usize,
+    telemetry_bytes: usize,
+    dropped_telemetry_events: u64,
     cas_records: Vec<CasSyncPayload>,
+    cas_bytes: usize,
+    dropped_cas_records: u64,
     daemon_logs: Vec<DaemonLogEvent>,
     daemon_log_bytes: usize,
 }
@@ -77,8 +89,12 @@ impl TelemetryBuffer {
             errors: Vec::new(),
             performances: Vec::new(),
             messages: Vec::new(),
-            metrics: Vec::new(),
+            telemetry_event_count: 0,
+            telemetry_bytes: 0,
+            dropped_telemetry_events: 0,
             cas_records: Vec::new(),
+            cas_bytes: 0,
+            dropped_cas_records: 0,
             daemon_logs: Vec::new(),
             daemon_log_bytes: 0,
         }
@@ -88,13 +104,24 @@ impl TelemetryBuffer {
         self.errors.is_empty()
             && self.performances.is_empty()
             && self.messages.is_empty()
-            && self.metrics.is_empty()
             && self.cas_records.is_empty()
             && self.daemon_logs.is_empty()
+            && self.dropped_telemetry_events == 0
+            && self.dropped_cas_records == 0
     }
 
     fn ingest_envelopes(&mut self, envelopes: Vec<TelemetryEnvelope>) {
         for envelope in envelopes {
+            let event_bytes = telemetry_envelope_approx_bytes(&envelope);
+            if event_bytes > MAX_TELEMETRY_EVENT_BYTES
+                || self.telemetry_event_count >= MAX_TELEMETRY_BUFFER_EVENTS
+                || self.telemetry_bytes.saturating_add(event_bytes) > MAX_TELEMETRY_BUFFER_BYTES
+            {
+                self.dropped_telemetry_events = self.dropped_telemetry_events.saturating_add(1);
+                continue;
+            }
+
+            let mut accepted = true;
             match envelope {
                 TelemetryEnvelope::Error {
                     timestamp,
@@ -136,14 +163,30 @@ impl TelemetryBuffer {
                     });
                 }
                 TelemetryEnvelope::Metrics { events } => {
-                    self.metrics.extend(events);
+                    debug_assert!(events.is_empty(), "metric envelopes must be split first");
+                    accepted = false;
                 }
+            }
+            if accepted {
+                self.telemetry_event_count = self.telemetry_event_count.saturating_add(1);
+                self.telemetry_bytes = self.telemetry_bytes.saturating_add(event_bytes);
             }
         }
     }
 
     fn ingest_cas(&mut self, records: Vec<CasSyncPayload>) {
-        self.cas_records.extend(records);
+        for record in records {
+            let record_bytes = cas_payload_approx_bytes(&record);
+            if record_bytes > MAX_CAS_RECORD_BYTES
+                || self.cas_records.len() >= MAX_CAS_BUFFER_RECORDS
+                || self.cas_bytes.saturating_add(record_bytes) > MAX_CAS_BUFFER_BYTES
+            {
+                self.dropped_cas_records = self.dropped_cas_records.saturating_add(1);
+                continue;
+            }
+            self.cas_bytes = self.cas_bytes.saturating_add(record_bytes);
+            self.cas_records.push(record);
+        }
     }
 
     fn ingest_daemon_logs(&mut self, events: Vec<DaemonLogEvent>) {
@@ -190,12 +233,116 @@ impl TelemetryBuffer {
             errors: std::mem::take(&mut self.errors),
             performances: std::mem::take(&mut self.performances),
             messages: std::mem::take(&mut self.messages),
-            metrics: std::mem::take(&mut self.metrics),
+            telemetry_event_count: std::mem::take(&mut self.telemetry_event_count),
+            telemetry_bytes: std::mem::take(&mut self.telemetry_bytes),
+            dropped_telemetry_events: std::mem::take(&mut self.dropped_telemetry_events),
             cas_records: std::mem::take(&mut self.cas_records),
+            cas_bytes: std::mem::take(&mut self.cas_bytes),
+            dropped_cas_records: std::mem::take(&mut self.dropped_cas_records),
             daemon_logs: std::mem::take(&mut self.daemon_logs),
             daemon_log_bytes: std::mem::take(&mut self.daemon_log_bytes),
         }
     }
+}
+
+fn telemetry_envelope_approx_bytes(envelope: &TelemetryEnvelope) -> usize {
+    const FIXED_FIELDS_BYTES: usize = 128;
+
+    let bytes = match envelope {
+        TelemetryEnvelope::Error {
+            timestamp,
+            message,
+            context,
+        } => timestamp
+            .len()
+            .saturating_add(message.len())
+            .saturating_add(optional_json_approx_bytes(context)),
+        TelemetryEnvelope::Performance {
+            timestamp,
+            operation,
+            context,
+            tags,
+            ..
+        } => {
+            let mut bytes = timestamp
+                .len()
+                .saturating_add(operation.len())
+                .saturating_add(optional_json_approx_bytes(context));
+            if let Some(tags) = tags {
+                for (key, value) in tags {
+                    bytes = bytes
+                        .saturating_add(16)
+                        .saturating_add(key.len())
+                        .saturating_add(value.len());
+                    if bytes > MAX_TELEMETRY_EVENT_BYTES {
+                        break;
+                    }
+                }
+            }
+            bytes
+        }
+        TelemetryEnvelope::Message {
+            timestamp,
+            message,
+            level,
+            context,
+        } => timestamp
+            .len()
+            .saturating_add(message.len())
+            .saturating_add(level.len())
+            .saturating_add(optional_json_approx_bytes(context)),
+        TelemetryEnvelope::Metrics { .. } => MAX_TELEMETRY_EVENT_BYTES.saturating_add(1),
+    };
+
+    FIXED_FIELDS_BYTES.saturating_add(bytes)
+}
+
+fn optional_json_approx_bytes(value: &Option<Value>) -> usize {
+    value.as_ref().map_or(0, |value| {
+        json_value_approx_bytes(value, MAX_TELEMETRY_EVENT_BYTES)
+    })
+}
+
+fn json_value_approx_bytes(value: &Value, limit: usize) -> usize {
+    fn add_bounded(total: usize, bytes: usize, limit: usize) -> usize {
+        total.saturating_add(bytes).min(limit.saturating_add(1))
+    }
+
+    match value {
+        Value::Null | Value::Bool(_) => 8,
+        Value::Number(_) => 32,
+        Value::String(value) => value.len().saturating_add(16),
+        Value::Array(values) => {
+            let mut total = 16usize;
+            for value in values {
+                total = add_bounded(total, json_value_approx_bytes(value, limit), limit);
+                if total > limit {
+                    break;
+                }
+            }
+            total
+        }
+        Value::Object(values) => {
+            let mut total = 16usize;
+            for (key, value) in values {
+                total = add_bounded(total, key.len().saturating_add(16), limit);
+                total = add_bounded(total, json_value_approx_bytes(value, limit), limit);
+                if total > limit {
+                    break;
+                }
+            }
+            total
+        }
+    }
+}
+
+fn cas_payload_approx_bytes(record: &CasSyncPayload) -> usize {
+    const FIXED_FIELDS_BYTES: usize = 128;
+
+    FIXED_FIELDS_BYTES
+        .saturating_add(record.hash.len())
+        .saturating_add(record.data.len())
+        .saturating_add(record.metadata.as_ref().map_or(0, String::len))
 }
 
 fn daemon_log_event_approx_bytes(event: &DaemonLogEvent) -> usize {
@@ -231,13 +378,29 @@ fn daemon_log_field_value_approx_bytes(value: &DaemonLogFieldValue) -> usize {
 #[derive(Clone)]
 pub struct DaemonTelemetryWorkerHandle {
     buffer: Arc<Mutex<TelemetryBuffer>>,
+    metric_tx: SyncSender<Vec<MetricEvent>>,
+    pending_metric_events: Arc<AtomicUsize>,
+    dropped_metric_events: Arc<AtomicU64>,
 }
 
 impl DaemonTelemetryWorkerHandle {
     #[cfg(test)]
     pub fn new_noop() -> Self {
+        Self::new_with_metric_persister(|_| {})
+    }
+
+    #[cfg(test)]
+    fn new_with_metric_persister<Persist>(persist: Persist) -> Self
+    where
+        Persist: Fn(Vec<MetricEvent>) + Send + 'static,
+    {
+        let (metric_tx, pending_metric_events, dropped_metric_events) =
+            spawn_metric_persistence_worker(persist);
         Self {
             buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
+            metric_tx,
+            pending_metric_events,
+            dropped_metric_events,
         }
     }
 
@@ -250,19 +413,14 @@ impl DaemonTelemetryWorkerHandle {
                 .await
                 .ingest_envelopes(buffered_envelopes);
         }
-
-        if !metric_events.is_empty() {
-            std::mem::drop(tokio::task::spawn_blocking(move || {
-                if let Err(e) = store_metrics_in_db(&metric_events) {
-                    tracing::warn!(%e, "telemetry: failed to persist metrics locally");
-                }
-            }));
-        }
+        self.enqueue_metrics(metric_events);
     }
 
     /// Submit CAS records for batched upload.
     pub async fn submit_cas(&self, records: Vec<CasSyncPayload>) {
-        self.buffer.lock().await.ingest_cas(records);
+        if !records.is_empty() {
+            self.buffer.lock().await.ingest_cas(records);
+        }
     }
 
     /// Submit daemon diagnostic events for batched upload.
@@ -276,18 +434,11 @@ impl DaemonTelemetryWorkerHandle {
     /// Returns the current number of metrics waiting for upload.
     ///
     /// Used by the transcript worker for backpressure: if SQLite pending rows
-    /// or the legacy in-memory buffer are above a threshold, the worker yields
-    /// to let the flush loop drain them. Returns `usize::MAX` when the buffer
-    /// lock is contended, so callers default to "wait" rather than "push more".
+    /// or the bounded persistence queue are above a threshold, the worker yields
+    /// to let the flush loop drain them. Returns `usize::MAX` when SQLite is
+    /// contended, so callers default to "wait" rather than "push more".
     pub fn metrics_buffer_len(&self) -> usize {
-        let buffered = self
-            .buffer
-            .try_lock()
-            .map(|buf| buf.metrics.len())
-            .unwrap_or(usize::MAX);
-        if buffered == usize::MAX {
-            return usize::MAX;
-        }
+        let buffered = self.pending_metric_events.load(Ordering::Relaxed);
 
         if !METRICS_UPLOAD_AVAILABLE.load(Ordering::Relaxed) {
             return buffered;
@@ -305,11 +456,9 @@ impl DaemonTelemetryWorkerHandle {
 
     /// Persist metrics directly from an existing blocking worker.
     ///
-    /// Transcript sweeps can emit many batches in a tight loop. Routing those
-    /// through the async telemetry entrypoint creates one fire-and-forget
-    /// `spawn_blocking` task per batch, so a fast producer can retain many raw
-    /// transcript events while SQLite writes catch up. This path keeps the
-    /// producer coupled to the metrics DB write and bounds peak memory.
+    /// Transcript sweeps can emit many batches in a tight loop. This path keeps
+    /// the producer coupled to the metrics DB write, so its watermark advances
+    /// only after persistence and it cannot overflow the best-effort queue.
     pub fn persist_metrics_blocking(&self, events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
         store_metrics_in_db(events)
     }
@@ -327,11 +476,7 @@ impl DaemonTelemetryWorkerHandle {
             buf.ingest_envelopes(buffered_envelopes);
         }
 
-        if !metric_events.is_empty()
-            && let Err(e) = store_metrics_in_db(&metric_events)
-        {
-            tracing::warn!(%e, "telemetry: failed to persist daemon metrics locally");
-        }
+        self.enqueue_metrics(metric_events);
     }
 
     /// Submit CAS records synchronously (best-effort, non-blocking).
@@ -353,6 +498,69 @@ impl DaemonTelemetryWorkerHandle {
             buf.ingest_daemon_logs(events);
         }
     }
+
+    fn enqueue_metrics(&self, events: Vec<MetricEvent>) {
+        if events.is_empty() {
+            return;
+        }
+
+        let event_count = events.len();
+        atomic_saturating_add(&self.pending_metric_events, event_count);
+        match self.metric_tx.try_send(events) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {
+                atomic_saturating_sub(&self.pending_metric_events, event_count);
+                atomic_u64_saturating_add(&self.dropped_metric_events, event_count as u64);
+            }
+        }
+    }
+}
+
+fn spawn_metric_persistence_worker<Persist>(
+    persist: Persist,
+) -> (
+    SyncSender<Vec<MetricEvent>>,
+    Arc<AtomicUsize>,
+    Arc<AtomicU64>,
+)
+where
+    Persist: Fn(Vec<MetricEvent>) + Send + 'static,
+{
+    let (tx, rx) = sync_channel::<Vec<MetricEvent>>(METRIC_PERSISTENCE_QUEUE_CAPACITY);
+    let pending_events = Arc::new(AtomicUsize::new(0));
+    let dropped_events = Arc::new(AtomicU64::new(0));
+    let worker_pending_events = Arc::clone(&pending_events);
+
+    std::thread::Builder::new()
+        .name("git-ai-metrics-persistence".to_string())
+        .spawn(move || {
+            while let Ok(events) = rx.recv() {
+                let event_count = events.len();
+                persist(events);
+                atomic_saturating_sub(&worker_pending_events, event_count);
+            }
+        })
+        .expect("failed to spawn metrics persistence worker");
+
+    (tx, pending_events, dropped_events)
+}
+
+fn atomic_saturating_add(value: &AtomicUsize, amount: usize) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(amount))
+    });
+}
+
+fn atomic_saturating_sub(value: &AtomicUsize, amount: usize) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(amount))
+    });
+}
+
+fn atomic_u64_saturating_add(value: &AtomicU64, amount: u64) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_add(amount))
+    });
 }
 
 /// Global handle for the daemon's in-process telemetry worker.
@@ -373,7 +581,7 @@ pub fn set_daemon_internal_telemetry(handle: DaemonTelemetryWorkerHandle) {
 /// Returns true if the handle was available and envelopes were submitted.
 pub fn submit_daemon_internal_telemetry(envelopes: Vec<TelemetryEnvelope>) -> bool {
     if let Some(handle) = DAEMON_INTERNAL_TELEMETRY.get() {
-        submit_daemon_internal_telemetry_with_handle(handle.clone(), envelopes);
+        submit_daemon_internal_telemetry_with_handle(handle, envelopes);
         true
     } else {
         false
@@ -381,16 +589,10 @@ pub fn submit_daemon_internal_telemetry(envelopes: Vec<TelemetryEnvelope>) -> bo
 }
 
 fn submit_daemon_internal_telemetry_with_handle(
-    handle: DaemonTelemetryWorkerHandle,
+    handle: &DaemonTelemetryWorkerHandle,
     envelopes: Vec<TelemetryEnvelope>,
 ) {
-    if let Ok(runtime) = tokio::runtime::Handle::try_current() {
-        runtime.spawn(async move {
-            handle.submit_telemetry(envelopes).await;
-        });
-    } else {
-        handle.submit_telemetry_sync(envelopes);
-    }
+    handle.submit_telemetry_sync(envelopes);
 }
 
 fn split_metric_envelopes(
@@ -413,18 +615,18 @@ fn split_metric_envelopes(
 /// Returns true if the handle was available and records were submitted.
 pub fn submit_daemon_internal_cas(records: Vec<CasSyncPayload>) -> bool {
     if let Some(handle) = DAEMON_INTERNAL_TELEMETRY.get() {
-        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
-            let handle = handle.clone();
-            runtime.spawn(async move {
-                handle.submit_cas(records).await;
-            });
-        } else {
-            handle.submit_cas_sync(records);
-        }
-        true
+        submit_daemon_internal_cas_with_handle(handle, records)
     } else {
         false
     }
+}
+
+fn submit_daemon_internal_cas_with_handle(
+    handle: &DaemonTelemetryWorkerHandle,
+    records: Vec<CasSyncPayload>,
+) -> bool {
+    handle.submit_cas_sync(records);
+    true
 }
 
 /// Submit daemon diagnostic events from within the daemon process.
@@ -451,15 +653,25 @@ fn submit_daemon_internal_daemon_logs_with_handle(
 /// to their respective destinations (Sentry, PostHog, metrics API, CAS API).
 pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
     let buffer = Arc::new(Mutex::new(TelemetryBuffer::new()));
+    let (metric_tx, pending_metric_events, dropped_metric_events) =
+        spawn_metric_persistence_worker(|events| {
+            if let Err(e) = store_metrics_in_db(&events) {
+                tracing::warn!(%e, "telemetry: failed to persist metrics locally");
+            }
+        });
     let handle = DaemonTelemetryWorkerHandle {
         buffer: buffer.clone(),
+        metric_tx,
+        pending_metric_events,
+        dropped_metric_events,
     };
     let daemon_id = crate::uuid::generate_v4();
+    let flush_dropped_metric_events = Arc::clone(&handle.dropped_metric_events);
 
     spawn_metrics_metadata_backfill();
 
     tokio::spawn(async move {
-        telemetry_flush_loop(buffer, daemon_id).await;
+        telemetry_flush_loop(buffer, daemon_id, flush_dropped_metric_events).await;
     });
 
     handle
@@ -502,7 +714,11 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
     Ok(())
 }
 
-async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: String) {
+async fn telemetry_flush_loop(
+    buffer: Arc<Mutex<TelemetryBuffer>>,
+    daemon_id: String,
+    dropped_metric_events: Arc<AtomicU64>,
+) {
     let mut ticker = interval(FLUSH_INTERVAL);
     let started_at = std::time::Instant::now();
     let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
@@ -511,6 +727,15 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
 
     loop {
         ticker.tick().await;
+
+        let dropped_metrics = dropped_metric_events.swap(0, Ordering::Relaxed);
+        if dropped_metrics > 0 {
+            tracing::warn!(
+                dropped_metrics,
+                queue_capacity = METRIC_PERSISTENCE_QUEUE_CAPACITY,
+                "telemetry: metric persistence queue was full"
+            );
+        }
 
         let now = std::time::Instant::now();
         let heartbeat = if now >= next_heartbeat_at && daemon_log_upload_enabled() {
@@ -560,13 +785,16 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
 }
 
 fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
+    if batch.dropped_telemetry_events > 0 || batch.dropped_cas_records > 0 {
+        tracing::warn!(
+            dropped_telemetry_events = batch.dropped_telemetry_events,
+            dropped_cas_records = batch.dropped_cas_records,
+            "telemetry: bounded buffer dropped oversized or excess events"
+        );
+    }
+
     let config = Config::get();
     let distinct_id = get_or_create_distinct_id();
-
-    // Flush metrics (always processed — uploaded or stored in SQLite)
-    if !batch.metrics.is_empty() {
-        flush_metrics(&batch.metrics);
-    }
 
     // Flush Sentry events (errors, performance, messages)
     let has_sentry_or_posthog =
@@ -596,35 +824,6 @@ fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonL
         Vec::new()
     } else {
         dispatch_daemon_log_upload(batch.daemon_logs, daemon_id, &distinct_id)
-    }
-}
-
-fn flush_metrics(events: &[MetricEvent]) {
-    let context = ApiContext::new(None);
-    let api_base_url = context.base_url.clone();
-    let client = ApiClient::new(context);
-
-    let should_upload = metrics_upload_allowed(&api_base_url, &client);
-    METRICS_UPLOAD_AVAILABLE.store(should_upload, Ordering::Relaxed);
-
-    let mut upload_failed = false;
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-
-    for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-        if let Err(e) = store_metrics_in_db(chunk) {
-            tracing::warn!(%e, "telemetry: failed to persist metrics before upload");
-            continue;
-        }
-
-        if should_upload && !upload_failed && std::time::Instant::now() < deadline {
-            match flush_pending_metrics_from_db(&client, deadline) {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(%e, "telemetry: failed to upload pending metrics");
-                    upload_failed = true;
-                }
-            }
-        }
     }
 }
 
@@ -1554,41 +1753,188 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_daemon_internal_telemetry_spawns_when_runtime_exists() {
+    async fn external_telemetry_submission_waits_for_contended_buffer() {
+        let handle = DaemonTelemetryWorkerHandle::new_noop();
+        let guard = handle.buffer.lock().await;
+        let submitter = handle.clone();
+        let mut submission = tokio::spawn(async move {
+            submitter
+                .submit_telemetry(vec![test_message_envelope("external")])
+                .await;
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut submission)
+                .await
+                .is_err(),
+            "external telemetry submission returned while its payload was not buffered"
+        );
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), submission)
+            .await
+            .expect("external telemetry submission should resume after contention")
+            .expect("external telemetry submission task should not panic");
+
+        let buffer = handle.buffer.lock().await;
+        assert_eq!(buffer.messages.len(), 1);
+        assert_eq!(buffer.messages[0].message, "external");
+    }
+
+    #[tokio::test]
+    async fn external_cas_submission_waits_for_contended_buffer() {
+        let handle = DaemonTelemetryWorkerHandle::new_noop();
+        let guard = handle.buffer.lock().await;
+        let submitter = handle.clone();
+        let mut submission = tokio::spawn(async move {
+            submitter
+                .submit_cas(vec![CasSyncPayload {
+                    hash: "external-hash".to_string(),
+                    data: "external-data".to_string(),
+                    metadata: None,
+                }])
+                .await;
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut submission)
+                .await
+                .is_err(),
+            "external CAS submission returned while its payload was not buffered"
+        );
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), submission)
+            .await
+            .expect("external CAS submission should resume after contention")
+            .expect("external CAS submission task should not panic");
+
+        let buffer = handle.buffer.lock().await;
+        assert_eq!(buffer.cas_records.len(), 1);
+        assert_eq!(buffer.cas_records[0].hash, "external-hash");
+    }
+
+    #[tokio::test]
+    async fn async_daemon_log_submission_waits_for_contended_buffer() {
+        let handle = DaemonTelemetryWorkerHandle::new_noop();
+        let guard = handle.buffer.lock().await;
+        let submitter = handle.clone();
+        let mut submission = tokio::spawn(async move {
+            submitter
+                .submit_daemon_logs(vec![sample_daemon_log_event("async")])
+                .await;
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut submission)
+                .await
+                .is_err(),
+            "async daemon-log submission returned while its payload was not buffered"
+        );
+        drop(guard);
+        tokio::time::timeout(Duration::from_secs(1), submission)
+            .await
+            .expect("async daemon-log submission should resume after contention")
+            .expect("async daemon-log submission task should not panic");
+
+        let buffer = handle.buffer.lock().await;
+        assert_eq!(buffer.daemon_logs.len(), 1);
+        assert_eq!(buffer.daemon_logs[0].message, "async");
+    }
+
+    #[tokio::test]
+    async fn daemon_internal_telemetry_does_not_defer_when_buffer_is_busy() {
         let handle = DaemonTelemetryWorkerHandle::new_noop();
         let guard = handle.buffer.lock().await;
 
         submit_daemon_internal_telemetry_with_handle(
-            handle.clone(),
+            &handle,
             vec![test_message_envelope("runtime")],
         );
 
         assert!(guard.messages.is_empty());
         drop(guard);
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
 
-        tokio::time::timeout(std::time::Duration::from_secs(1), async {
-            loop {
-                if handle.buffer.lock().await.messages.len() == 1 {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .unwrap();
+        assert!(
+            handle.buffer.lock().await.messages.is_empty(),
+            "contended telemetry was retained in a deferred task"
+        );
     }
 
     #[test]
-    fn submit_daemon_internal_telemetry_waits_without_runtime() {
+    fn daemon_internal_telemetry_submits_immediately_when_buffer_is_available() {
         let handle = DaemonTelemetryWorkerHandle::new_noop();
 
-        submit_daemon_internal_telemetry_with_handle(
-            handle.clone(),
-            vec![test_message_envelope("sync")],
-        );
+        submit_daemon_internal_telemetry_with_handle(&handle, vec![test_message_envelope("sync")]);
 
         let guard = handle.buffer.try_lock().unwrap();
         assert_eq!(guard.messages.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn daemon_internal_cas_does_not_defer_when_buffer_is_busy() {
+        let handle = DaemonTelemetryWorkerHandle::new_noop();
+        let guard = handle.buffer.lock().await;
+
+        let submitted = submit_daemon_internal_cas_with_handle(
+            &handle,
+            vec![CasSyncPayload {
+                hash: "hash".to_string(),
+                data: "data".to_string(),
+                metadata: None,
+            }],
+        );
+
+        assert!(submitted);
+        assert!(guard.cas_records.is_empty());
+        drop(guard);
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            handle.buffer.lock().await.cas_records.is_empty(),
+            "contended CAS payload was retained in a deferred task"
+        );
+    }
+
+    #[test]
+    fn metric_persistence_queue_is_bounded_while_database_is_busy() {
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let block_first = Arc::new(AtomicBool::new(true));
+        let worker_block_first = Arc::clone(&block_first);
+        let handle = DaemonTelemetryWorkerHandle::new_with_metric_persister(move |_| {
+            if worker_block_first.swap(false, Ordering::Relaxed) {
+                let _ = started_tx.try_send(());
+                let _ = release_rx.recv_timeout(Duration::from_secs(2));
+            }
+        });
+
+        handle.enqueue_metrics(vec![metric_event_with_payload(16)]);
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("persistence worker should receive first metric");
+
+        for _ in 0..(METRIC_PERSISTENCE_QUEUE_CAPACITY + 10) {
+            handle.enqueue_metrics(vec![metric_event_with_payload(16)]);
+        }
+
+        assert_eq!(
+            handle.pending_metric_events.load(Ordering::Relaxed),
+            METRIC_PERSISTENCE_QUEUE_CAPACITY + 1
+        );
+        assert_eq!(handle.dropped_metric_events.load(Ordering::Relaxed), 10);
+
+        release_tx.send(()).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while handle.pending_metric_events.load(Ordering::Relaxed) > 0
+            && std::time::Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(handle.pending_metric_events.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]
@@ -2272,6 +2618,65 @@ mod tests {
         assert_eq!(buffer.daemon_logs.len(), 1);
         assert!(buffer.daemon_log_bytes <= MAX_DAEMON_LOG_BUFFER_BYTES);
         assert!(buffer.daemon_logs[0].message.starts_with("new-"));
+    }
+
+    #[test]
+    fn telemetry_buffer_caps_generic_event_count() {
+        let mut buffer = TelemetryBuffer::new();
+        let envelopes = (0..5002)
+            .map(|index| test_message_envelope(&index.to_string()))
+            .collect();
+
+        buffer.ingest_envelopes(envelopes);
+
+        assert!(buffer.messages.len() <= 5000);
+        assert_eq!(buffer.dropped_telemetry_events, 2);
+    }
+
+    #[test]
+    fn telemetry_buffer_caps_generic_event_bytes() {
+        let mut buffer = TelemetryBuffer::new();
+        let large_message = "x".repeat(4 * 1024 * 1024);
+        let envelopes = (0..3)
+            .map(|_| test_message_envelope(&large_message))
+            .collect();
+
+        buffer.ingest_envelopes(envelopes);
+
+        let retained_bytes = buffer
+            .messages
+            .iter()
+            .map(|event| event.timestamp.len() + event.message.len() + event.level.len())
+            .sum::<usize>();
+        assert!(retained_bytes <= 8 * 1024 * 1024);
+        assert_eq!(buffer.dropped_telemetry_events, 3);
+    }
+
+    #[test]
+    fn telemetry_buffer_caps_cas_count_and_bytes() {
+        let mut buffer = TelemetryBuffer::new();
+        let records = (0..1002)
+            .map(|index| CasSyncPayload {
+                hash: index.to_string(),
+                data: "x".repeat(16 * 1024),
+                metadata: None,
+            })
+            .collect();
+
+        buffer.ingest_cas(records);
+
+        let retained_bytes = buffer
+            .cas_records
+            .iter()
+            .map(|record| {
+                record.hash.len()
+                    + record.data.len()
+                    + record.metadata.as_ref().map_or(0, String::len)
+            })
+            .sum::<usize>();
+        assert!(buffer.cas_records.len() <= 1000);
+        assert!(retained_bytes <= 8 * 1024 * 1024);
+        assert!(buffer.dropped_cas_records > 0);
     }
 
     #[test]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use crate::daemon::daemon_log_layer::{
+    MAX_MESSAGE_LENGTH, bounded_copy, bounded_display_string, sanitize_log_string,
+};
 use crate::metrics::MetricEvent;
 
 pub mod performance_targets;
@@ -20,11 +23,21 @@ fn submit_telemetry_envelope(envelopes: Vec<crate::daemon::TelemetryEnvelope>) {
     }
 }
 
+fn telemetry_error_message(error: &dyn std::error::Error) -> String {
+    let bounded = bounded_display_string(error, MAX_MESSAGE_LENGTH);
+    sanitize_log_string(&bounded, MAX_MESSAGE_LENGTH)
+}
+
+fn telemetry_log_message(message: &str) -> String {
+    let bounded = bounded_copy(message, MAX_MESSAGE_LENGTH);
+    sanitize_log_string(&bounded, MAX_MESSAGE_LENGTH)
+}
+
 /// Log an error to Sentry (via daemon telemetry worker)
 pub fn log_error(error: &dyn std::error::Error, context: Option<serde_json::Value>) {
     let envelope = crate::daemon::TelemetryEnvelope::Error {
         timestamp: chrono::Utc::now().to_rfc3339(),
-        message: error.to_string(),
+        message: telemetry_error_message(error),
         context,
     };
     submit_telemetry_envelope(vec![envelope]);
@@ -52,7 +65,7 @@ pub fn log_performance(
 pub fn log_message(message: &str, level: &str, context: Option<serde_json::Value>) {
     let envelope = crate::daemon::TelemetryEnvelope::Message {
         timestamp: chrono::Utc::now().to_rfc3339(),
-        message: message.to_string(),
+        message: telemetry_log_message(message),
         level: level.to_string(),
         context,
     };
@@ -93,7 +106,52 @@ pub fn log_metrics(events: Vec<MetricEvent>) {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::fmt;
     use std::time::Duration;
+
+    struct SecretError(String);
+
+    impl fmt::Display for SecretError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(&self.0)
+        }
+    }
+
+    impl fmt::Debug for SecretError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.debug_tuple("SecretError").field(&self.0).finish()
+        }
+    }
+
+    impl std::error::Error for SecretError {}
+
+    #[test]
+    fn telemetry_error_message_is_redacted_and_hard_bounded() {
+        let secret = "sk_test_4eC39HqLyjWDarjtT1zdp7dc";
+        let error = SecretError(format!(
+            "{} token={secret} trailing data",
+            "x".repeat(MAX_MESSAGE_LENGTH)
+        ));
+
+        let message = telemetry_error_message(&error);
+
+        assert_eq!(message.chars().count(), MAX_MESSAGE_LENGTH);
+        assert!(!message.contains(secret));
+    }
+
+    #[test]
+    fn telemetry_log_message_is_redacted_and_hard_bounded() {
+        let secret = "sk_test_4eC39HqLyjWDarjtT1zdp7dc";
+        let raw = format!(
+            "{} token={secret} trailing data",
+            "x".repeat(MAX_MESSAGE_LENGTH)
+        );
+
+        let message = telemetry_log_message(&raw);
+
+        assert_eq!(message.chars().count(), MAX_MESSAGE_LENGTH);
+        assert!(!message.contains(secret));
+    }
 
     // Test error logging
     #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -137,6 +137,7 @@ mod streams_e2e;
 mod subdirs;
 mod superuser_guard;
 mod sweep_e2e;
+mod telemetry_memory;
 mod test_utils_unit;
 mod tls_native_certs;
 mod transcript_memory;

--- a/tests/integration/telemetry_memory.rs
+++ b/tests/integration/telemetry_memory.rs
@@ -1,0 +1,101 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::daemon::control_api::{
+    CasSyncPayload, ControlRequest, ControlResponse, TelemetryEnvelope,
+};
+use git_ai::daemon::{DaemonClientStream, open_local_socket_stream_with_timeout};
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::time::Duration;
+
+struct ControlConnection {
+    stream: BufReader<DaemonClientStream>,
+}
+
+impl ControlConnection {
+    fn connect(repo: &TestRepo) -> Self {
+        let stream = open_local_socket_stream_with_timeout(
+            &repo.daemon_control_socket_path(),
+            Duration::from_secs(2),
+        )
+        .expect("test daemon control socket should connect");
+        Self {
+            stream: BufReader::new(stream),
+        }
+    }
+
+    fn send(&mut self, request: &ControlRequest) {
+        serde_json::to_writer(self.stream.get_mut(), request).unwrap();
+        self.stream.get_mut().write_all(b"\n").unwrap();
+        self.stream.get_mut().flush().unwrap();
+
+        let mut response = String::new();
+        self.stream.read_line(&mut response).unwrap();
+        let response: ControlResponse = serde_json::from_str(response.trim()).unwrap();
+        assert!(response.ok, "control request failed: {:?}", response.error);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn telemetry_burst_keeps_daemon_memory_bounded_and_attribution_working() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+
+    let large_payload = "x".repeat(1024 * 1024);
+    let mut control = ControlConnection::connect(&repo);
+    for index in 0..16 {
+        control.send(&ControlRequest::SubmitTelemetry {
+            envelopes: vec![TelemetryEnvelope::Message {
+                timestamp: "2026-07-10T00:00:00Z".to_string(),
+                message: large_payload.clone(),
+                level: "warning".to_string(),
+                context: None,
+            }],
+        });
+        control.send(&ControlRequest::SubmitCas {
+            records: vec![CasSyncPayload {
+                hash: format!("hash-{index}"),
+                data: large_payload.clone(),
+                metadata: None,
+            }],
+        });
+    }
+    control.send(&ControlRequest::Ping);
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        assert!(
+            hwm_growth_kib < 24 * 1024,
+            "telemetry burst grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after telemetry burst")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}


### PR DESCRIPTION
## Bug
Telemetry and CAS buffers, the metric persistence handoff, and Sentry/log field capture all admitted unbounded data. Large values or a producer faster than persistence could grow both queues and individual events without limit.

The first bounded implementation also changed async telemetry, CAS, and daemon-log submissions from awaited delivery to `try_lock()`. A control-socket request could then return success while silently dropping its bounded payload during a brief flush-lock collision.

## Fix
Bound message/field lengths and field count, cap telemetry and CAS records plus total retained bytes, and replace the persistence handoff with a 32-entry bounded channel. Overflow is rejected or dropped with diagnostics instead of being retained.

Async submissions now await the bounded buffer mutex, preserving delivery for external callers. Daemon-internal synchronous entrypoints remain explicitly best-effort and non-blocking. The existing connection and frame caps bound the number and size of async payloads that can wait for the mutex.

The telemetry entrypoints also pass bounded intermediate strings through the shared secret sanitizer before envelope submission. This preserves the scan window needed for boundary-adjacent tokens, redacts secrets, and enforces the final 16,000-character limit.

## TDD and verification
Three async unit regressions hold the buffer lock, submit telemetry/CAS/daemon logs, require the request to remain pending rather than lose data, release the lock, and assert exact delivery. All three failed against `try_lock()` and pass with awaited ingestion. Existing unit coverage still verifies per-event, aggregate-byte, and queue saturation limits, while `tests/integration/telemetry_memory.rs` drives oversized/burst traffic through a `TestRepo` daemon and asserts exact post-burst attribution.

The final stack passes `task fmt`, `task lint`, `task build`, the complete `task test` matrix, and a four-core/four-thread run of all 3,282 executed integration tests.
