### PR TITLE
fix(streams): bound discovery and scheduling

### DIFF
--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -27,6 +27,10 @@ use tokio::time::{Duration, interval};
 const TRIGGERED_SWEEP_COOLDOWN: Duration = Duration::from_secs(30);
 const CHECKPOINT_NOTIFICATION_QUEUE_CAPACITY: usize = 1_024;
 const SWEEP_REQUEST_QUEUE_CAPACITY: usize = 32;
+const MAX_BACKGROUND_STREAM_TASKS: usize = 4_096;
+const MAX_SCHEDULED_STREAM_TASKS: usize =
+    MAX_BACKGROUND_STREAM_TASKS + CHECKPOINT_NOTIFICATION_QUEUE_CAPACITY;
+const MAX_RETAINED_TASK_OBJECTS: usize = MAX_SCHEDULED_STREAM_TASKS * 2;
 
 type StreamTaskKey = (String, PathBuf, String);
 type CheckpointNotificationKey = (PathBuf, String, String);
@@ -375,6 +379,8 @@ struct StreamWorker {
     priority_queue: BinaryHeap<ProcessingTask>,
     delayed_tasks: Vec<ProcessingTask>,
     scheduled: HashMap<StreamTaskKey, Priority>,
+    scheduled_background: usize,
+    scheduler_saturated: bool,
     in_flight: HashSet<(PathBuf, String)>,
     telemetry_handle: DaemonTelemetryWorkerHandle,
     shutdown_notify: Arc<Notify>,
@@ -404,6 +410,8 @@ impl StreamWorker {
             priority_queue: BinaryHeap::new(),
             delayed_tasks: Vec::new(),
             scheduled: HashMap::new(),
+            scheduled_background: 0,
+            scheduler_saturated: false,
             in_flight: HashSet::new(),
             telemetry_handle,
             shutdown_notify,
@@ -530,17 +538,65 @@ impl StreamWorker {
         );
         match self.scheduled.get_mut(&key) {
             Some(priority) if task.priority < *priority => {
+                if *priority == Priority::Low {
+                    self.scheduled_background = self.scheduled_background.saturating_sub(1);
+                }
                 *priority = task.priority;
+                self.compact_task_objects_if_needed();
                 self.priority_queue.push(task);
                 true
             }
             Some(_) => false,
             None => {
+                if !self.has_capacity_for(task.priority) {
+                    if !self.scheduler_saturated {
+                        self.scheduler_saturated = true;
+                        tracing::warn!(
+                            priority = ?task.priority,
+                            scheduled = self.scheduled.len(),
+                            background = self.scheduled_background,
+                            "transcript scheduler is full; a later checkpoint or sweep will recover dropped work"
+                        );
+                    }
+                    return false;
+                }
+                if task.priority == Priority::Low {
+                    self.scheduled_background += 1;
+                }
                 self.scheduled.insert(key, task.priority);
+                self.compact_task_objects_if_needed();
                 self.priority_queue.push(task);
                 true
             }
         }
+    }
+
+    fn has_capacity_for(&self, priority: Priority) -> bool {
+        self.scheduled.len() < MAX_SCHEDULED_STREAM_TASKS
+            && (priority == Priority::Immediate
+                || self.scheduled_background < MAX_BACKGROUND_STREAM_TASKS)
+    }
+
+    fn compact_task_objects_if_needed(&mut self) {
+        if self.priority_queue.len() + self.delayed_tasks.len() < MAX_RETAINED_TASK_OBJECTS {
+            return;
+        }
+
+        let scheduled = &self.scheduled;
+        self.priority_queue.retain(|task| {
+            scheduled.get(&(
+                task.session_id.clone(),
+                task.canonical_path.clone(),
+                task.stream_kind.clone(),
+            )) == Some(&task.priority)
+        });
+        self.delayed_tasks.retain(|task| {
+            scheduled.get(&(
+                task.session_id.clone(),
+                task.canonical_path.clone(),
+                task.stream_kind.clone(),
+            )) == Some(&task.priority)
+        });
     }
 
     fn task_is_current(&self, task: &ProcessingTask) -> bool {
@@ -558,7 +614,10 @@ impl StreamWorker {
             task.stream_kind.clone(),
         );
         if self.scheduled.get(&key) == Some(&task.priority) {
-            self.scheduled.remove(&key);
+            if self.scheduled.remove(&key) == Some(Priority::Low) {
+                self.scheduled_background = self.scheduled_background.saturating_sub(1);
+            }
+            self.scheduler_saturated = false;
         }
     }
 
@@ -611,6 +670,9 @@ impl StreamWorker {
         let mut enqueued_this_sweep: HashSet<(PathBuf, String)> = HashSet::new();
 
         for item in items {
+            if priority == Priority::Low && !self.has_capacity_for(priority) {
+                break;
+            }
             match item {
                 SweepItem::Session {
                     session_id,
@@ -746,9 +808,14 @@ impl StreamWorker {
             return;
         }
 
-        let Ok(entries) = std::fs::read_dir(&subagents_dir) else {
+        let remaining = MAX_BACKGROUND_STREAM_TASKS.saturating_sub(self.scheduled_background);
+        if remaining == 0 {
             return;
-        };
+        }
+        let paths =
+            crate::streams::sweep::discover_recent_files([subagents_dir], remaining, |path| {
+                path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+            });
 
         let external_parent_session_id = stream_path
             .file_stem()
@@ -762,12 +829,7 @@ impl StreamWorker {
                     - std::time::Duration::from_secs(u64::from(days) * 24 * 60 * 60)
             });
 
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_file() || path.extension().map(|ext| ext == "jsonl") != Some(true) {
-                continue;
-            }
-
+        for path in paths {
             let Some(external_session_id) = path
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -1708,6 +1770,55 @@ mod scheduling_tests {
         assert!(worker.enqueue_task(first));
         assert!(worker.enqueue_task(second));
         assert_eq!(worker.priority_queue.len(), 2);
+    }
+
+    #[test]
+    fn scheduled_work_is_bounded_with_capacity_reserved_for_checkpoints() {
+        const EXPECTED_BACKGROUND_LIMIT: usize = 4_096;
+        const EXPECTED_CHECKPOINT_RESERVE: usize = 1_024;
+
+        let (_temp, mut worker, _shutdown) = make_worker();
+        for sequence in 0..=EXPECTED_BACKGROUND_LIMIT {
+            let mut background = task(&format!("background-{sequence}"), None);
+            background.priority = Priority::Low;
+            let accepted = worker.enqueue_task(background);
+            assert_eq!(accepted, sequence < EXPECTED_BACKGROUND_LIMIT);
+        }
+        assert_eq!(worker.scheduled.len(), EXPECTED_BACKGROUND_LIMIT);
+
+        for sequence in 0..=EXPECTED_CHECKPOINT_RESERVE {
+            let checkpoint = task(&format!("checkpoint-{sequence}"), None);
+            let accepted = worker.enqueue_task(checkpoint);
+            assert_eq!(accepted, sequence < EXPECTED_CHECKPOINT_RESERVE);
+        }
+        assert_eq!(
+            worker.scheduled.len(),
+            EXPECTED_BACKGROUND_LIMIT + EXPECTED_CHECKPOINT_RESERVE
+        );
+    }
+
+    #[test]
+    fn stale_heap_and_retry_entries_are_compacted_under_key_churn() {
+        let (_temp, mut worker, _shutdown) = make_worker();
+
+        for sequence in 0..(MAX_RETAINED_TASK_OBJECTS * 3) {
+            let session_id = format!("session-{sequence}");
+            let mut background = task(&session_id, None);
+            background.priority = Priority::Low;
+            assert!(worker.enqueue_task(background.clone()));
+
+            let queued_background = worker.priority_queue.pop().unwrap();
+            worker.delayed_tasks.push(queued_background);
+
+            let immediate = task(&session_id, None);
+            assert!(worker.enqueue_task(immediate.clone()));
+            worker.finish_task(&immediate);
+        }
+
+        assert!(worker.scheduled.is_empty());
+        assert!(
+            worker.priority_queue.len() + worker.delayed_tasks.len() <= MAX_RETAINED_TASK_OBJECTS
+        );
     }
 
     #[tokio::test]

--- a/src/daemon/sweep_coordinator.rs
+++ b/src/daemon/sweep_coordinator.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
+pub(crate) const MAX_SWEEP_ITEMS: usize = 4_096;
+
 /// Work items discovered by the sweep.
 #[derive(Debug, Clone)]
 pub enum SweepItem {
@@ -65,7 +67,13 @@ impl SweepCoordinator {
                 continue;
             }
 
-            let discovered = match agent.discover_sessions() {
+            let remaining = MAX_SWEEP_ITEMS.saturating_sub(items.len());
+            if remaining == 0 {
+                break;
+            }
+            let discovery_limit =
+                remaining.min(crate::streams::sweep::MAX_DISCOVERED_SESSIONS_PER_AGENT);
+            let discovered = match agent.discover_sessions(discovery_limit) {
                 Ok(sessions) => sessions,
                 Err(e) => {
                     tracing::error!(
@@ -91,6 +99,9 @@ impl SweepCoordinator {
                         external_session_id: session.external_session_id.clone(),
                         external_parent_session_id: session.external_parent_session_id.clone(),
                     });
+                    if items.len() == MAX_SWEEP_ITEMS {
+                        break;
+                    }
                 }
             }
 
@@ -111,7 +122,7 @@ impl SweepCoordinator {
                     else {
                         continue;
                     };
-                    if seen_shared_paths.insert(p.clone()) {
+                    if items.len() < MAX_SWEEP_ITEMS && seen_shared_paths.insert(p.clone()) {
                         items.push(item);
                     }
                 }
@@ -216,5 +227,92 @@ impl SweepCoordinator {
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
             .map(|d| d.as_secs() as i64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::streams::agent::{PathResolverKind, StreamDescriptor};
+    use crate::streams::sweep::StreamFormat;
+    use crate::streams::types::StreamBatch;
+    use crate::streams::watermark::{WatermarkStrategy, WatermarkType};
+
+    struct ManySessionsAgent {
+        path: PathBuf,
+        count: usize,
+    }
+
+    impl Agent for ManySessionsAgent {
+        fn sweep_strategy(&self) -> SweepStrategy {
+            SweepStrategy::Periodic(std::time::Duration::from_secs(1))
+        }
+
+        fn discover_sessions(&self, _limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+            Ok((0..self.count)
+                .map(|index| DiscoveredSession {
+                    session_id: format!("session-{index}"),
+                    tool: "test".to_string(),
+                    stream_path: self.path.clone(),
+                    external_session_id: format!("external-{index}"),
+                    external_parent_session_id: None,
+                })
+                .collect())
+        }
+
+        fn read_incremental(
+            &self,
+            _path: &Path,
+            _watermark: Box<dyn WatermarkStrategy>,
+            _session_id: &str,
+        ) -> Result<StreamBatch, StreamError> {
+            unreachable!("coordinator discovery does not read transcript contents")
+        }
+
+        fn extract_event_timestamp(
+            &self,
+            _event: &serde_json::Value,
+            _file_meta: &std::fs::Metadata,
+            _is_first_event: bool,
+        ) -> u32 {
+            0
+        }
+
+        fn streams(&self) -> Vec<StreamDescriptor> {
+            vec![StreamDescriptor {
+                stream_kind: "transcript",
+                format: StreamFormat::ClaudeJsonl,
+                watermark_type: WatermarkType::ByteOffset,
+                path_resolver: PathResolverKind::Identity,
+                shared: false,
+                watermark_type_resolver: None,
+                format_resolver: None,
+            }]
+        }
+    }
+
+    #[test]
+    fn sweep_output_is_bounded_when_an_agent_discovers_many_stale_sessions() {
+        const EXPECTED_SWEEP_LIMIT: usize = 4_096;
+
+        let temp = tempfile::tempdir().unwrap();
+        let transcript = temp.path().join("session.jsonl");
+        std::fs::write(&transcript, "{}\n").unwrap();
+        let db = Arc::new(StreamsDatabase::open(temp.path().join("streams.db")).unwrap());
+        let coordinator = SweepCoordinator {
+            streams_db: db,
+            agent_registry: vec![(
+                "test".to_string(),
+                Box::new(ManySessionsAgent {
+                    path: transcript,
+                    count: EXPECTED_SWEEP_LIMIT + 1,
+                }),
+            )],
+            lookback_days: None,
+        };
+
+        let items = coordinator.run_sweep().unwrap();
+
+        assert_eq!(items.len(), EXPECTED_SWEEP_LIMIT);
     }
 }

--- a/src/streams/agent.rs
+++ b/src/streams/agent.rs
@@ -85,11 +85,11 @@ pub trait Agent: Send + Sync {
     /// Returns the sweep strategy for this agent.
     fn sweep_strategy(&self) -> SweepStrategy;
 
-    /// Discover all sessions in the agent's storage.
+    /// Discover the newest sessions in the agent's storage.
     ///
-    /// Returns ALL sessions found, regardless of whether they're in transcripts-db.
-    /// The coordinator will compare against the DB to decide what to process.
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError>;
+    /// Implementations must retain and return no more than `limit` sessions. The
+    /// coordinator compares them against transcripts-db to decide what to process.
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError>;
 
     /// Maximum number of events to return per `read_incremental` call.
     /// Bounds peak memory to batch_size × avg_event_size instead of file_size.

--- a/src/streams/agents/amp.rs
+++ b/src/streams/agents/amp.rs
@@ -2,7 +2,7 @@
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{BoundedPathCollector, DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{RecordIndexWatermark, WatermarkStrategy};
 use std::fs;
@@ -84,7 +84,7 @@ impl Agent for AmpAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
         let threads_dir = match Self::amp_threads_path() {
             Ok(p) => p,
             Err(_) => return Ok(Vec::new()),
@@ -99,14 +99,18 @@ impl Agent for AmpAgent {
             retry_after: Duration::from_secs(30),
         })?;
 
-        let mut sessions = Vec::new();
+        let mut paths = BoundedPathCollector::new(limit);
 
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("json") {
                 continue;
             }
+            paths.push(path);
+        }
 
+        let mut sessions = Vec::new();
+        for path in paths.into_paths_newest_first() {
             let Some(file_stem) = path
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -116,15 +120,13 @@ impl Agent for AmpAgent {
             };
 
             let session_id = generate_session_id(&file_stem, "amp");
-            let session = DiscoveredSession {
+            sessions.push(DiscoveredSession {
                 session_id,
                 tool: "amp".to_string(),
                 stream_path: path,
                 external_session_id: file_stem,
                 external_parent_session_id: None,
-            };
-
-            sessions.push(session);
+            });
         }
 
         Ok(sessions)

--- a/src/streams/agents/claude.rs
+++ b/src/streams/agents/claude.rs
@@ -2,10 +2,11 @@
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{
+    DiscoveredSession, StreamFormat, SweepStrategy, discover_recent_files,
+};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -25,9 +26,7 @@ impl ClaudeAgent {
     }
 
     /// Scan for Claude conversation files in standard locations.
-    fn scan_conversation_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
+    fn scan_conversation_files(limit: usize) -> Vec<PathBuf> {
         // Check CLAUDE_CONFIG_DIR override first
         let base_dir = if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
             Some(PathBuf::from(config_dir))
@@ -43,33 +42,9 @@ impl ClaudeAgent {
             dirs::config_dir().map(|p| p.join("claude/projects")),
         ];
 
-        for dir_opt in search_dirs {
-            if let Some(dir) = dir_opt
-                && dir.exists()
-            {
-                // Recursively scan for *.jsonl files
-                Self::scan_jsonl_recursive(&dir, &mut paths);
-            }
-        }
-
-        paths
-    }
-
-    /// Recursively scan directory for *.jsonl files.
-    fn scan_jsonl_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
-        let Ok(entries) = fs::read_dir(dir) else {
-            return;
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                Self::scan_jsonl_recursive(&path, paths);
-            } else if path.is_file() && path.extension().map(|ext| ext == "jsonl").unwrap_or(false)
-            {
-                paths.push(path);
-            }
-        }
+        discover_recent_files(search_dirs.into_iter().flatten(), limit, |path| {
+            path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+        })
     }
 
     /// Extract session ID from a Claude conversation file path.
@@ -108,8 +83,8 @@ impl Agent for ClaudeAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_conversation_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_conversation_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {
@@ -396,7 +371,9 @@ mod tests {
 
     #[test]
     fn test_scan_discovers_real_claude_files() {
-        let paths = ClaudeAgent::scan_conversation_files();
+        let paths = ClaudeAgent::scan_conversation_files(
+            crate::streams::sweep::MAX_DISCOVERED_SESSIONS_PER_AGENT,
+        );
         // On this machine we have files in ~/.claude/projects/
         if dirs::home_dir()
             .map(|h| h.join(".claude/projects").exists())

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -3,10 +3,12 @@
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::mdm::utils::codex_home_dir;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{
+    DiscoveredSession, StreamFormat, SweepStrategy, discover_recent_files,
+};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -35,7 +37,7 @@ impl CodexAgent {
         session_id: &str,
         codex_home: &Path,
     ) -> Result<Option<PathBuf>, StreamError> {
-        let mut candidates: Vec<PathBuf> = Vec::new();
+        let mut newest: Option<(PathBuf, std::time::SystemTime)> = None;
 
         for subdir in &["sessions", "archived_sessions"] {
             let search_dir = codex_home.join(subdir);
@@ -53,64 +55,41 @@ impl CodexAgent {
                 let path = entry.map_err(|e| StreamError::Fatal {
                     message: format!("Error reading glob entry: {}", e),
                 })?;
-                candidates.push(path);
-            }
-        }
-
-        if candidates.is_empty() {
-            return Ok(None);
-        }
-
-        // Return the newest by modification time
-        let newest = candidates
-            .into_iter()
-            .filter_map(|p| {
-                p.metadata()
+                let Some(modified) = path
+                    .metadata()
                     .ok()
-                    .and_then(|m| m.modified().ok())
-                    .map(|t| (p, t))
-            })
-            .max_by_key(|(_, t)| *t)
-            .map(|(p, _)| p);
+                    .and_then(|metadata| metadata.modified().ok())
+                else {
+                    continue;
+                };
+                if newest
+                    .as_ref()
+                    .is_none_or(|(_, current)| modified > *current)
+                {
+                    newest = Some((path, modified));
+                }
+            }
+        }
 
-        Ok(newest)
+        Ok(newest.map(|(path, _)| path))
     }
 
-    fn scan_session_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
+    fn scan_session_files(limit: usize) -> Vec<PathBuf> {
         let codex_home = codex_home_dir();
-
-        for subdir in &["sessions", "archived_sessions"] {
-            let search_dir = codex_home.join(subdir);
-            if search_dir.exists() {
-                Self::scan_rollout_recursive(&search_dir, &mut paths);
-            }
-        }
-
-        paths
-    }
-
-    fn scan_rollout_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
-        let Ok(entries) = fs::read_dir(dir) else {
-            return;
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                Self::scan_rollout_recursive(&path, paths);
-            } else if path.is_file()
-                && path.extension().map(|ext| ext == "jsonl").unwrap_or(false)
-                && path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with("rollout-"))
-                    .unwrap_or(false)
-            {
-                paths.push(path);
-            }
-        }
+        discover_recent_files(
+            [
+                codex_home.join("sessions"),
+                codex_home.join("archived_sessions"),
+            ],
+            limit,
+            |path| {
+                path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+                    && path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.starts_with("rollout-"))
+            },
+        )
     }
 
     /// Detect if a Codex JSONL file is a subagent transcript by reading its first line.
@@ -162,8 +141,8 @@ impl Agent for CodexAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_session_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_session_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {

--- a/src/streams/agents/continue_cli.rs
+++ b/src/streams/agents/continue_cli.rs
@@ -2,7 +2,9 @@
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{
+    DiscoveredSession, StreamFormat, SweepStrategy, discover_recent_files,
+};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{RecordIndexWatermark, WatermarkStrategy};
 use std::path::{Path, PathBuf};
@@ -28,25 +30,12 @@ impl ContinueAgent {
     }
 
     /// Scan for Continue session files in `~/.continue/sessions/**/*.json`.
-    fn scan_session_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
-        if let Some(home) = dirs::home_dir() {
-            let pattern = home
-                .join(".continue/sessions/**/*.json")
-                .to_string_lossy()
-                .to_string();
-
-            if let Ok(entries) = glob::glob(&pattern) {
-                for entry in entries.flatten() {
-                    if entry.is_file() {
-                        paths.push(entry);
-                    }
-                }
-            }
-        }
-
-        paths
+    fn scan_session_files(limit: usize) -> Vec<PathBuf> {
+        discover_recent_files(
+            dirs::home_dir().map(|path| path.join(".continue/sessions")),
+            limit,
+            |path| path.extension().and_then(|ext| ext.to_str()) == Some("json"),
+        )
     }
 }
 
@@ -65,8 +54,8 @@ impl Agent for ContinueAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_session_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_session_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -2,7 +2,7 @@
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{BoundedPathCollector, DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{
     ByteOffsetWatermark, RecordIndexWatermark, WatermarkStrategy, WatermarkType,
@@ -30,8 +30,8 @@ impl CopilotAgent {
     /// Scan for Copilot transcript files in standard locations.
     ///
     /// Discovers BOTH session.json files and .jsonl event streams.
-    fn scan_transcript_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
+    fn scan_transcript_files(limit: usize) -> Vec<PathBuf> {
+        let mut paths = BoundedPathCollector::new(limit);
 
         // Standard locations for Copilot transcripts (legacy)
         let search_dirs = vec![
@@ -81,7 +81,7 @@ impl CopilotAgent {
             }
         }
 
-        paths
+        paths.into_paths_newest_first()
     }
 
     /// Returns the VS Code workspace storage root directories to scan.
@@ -225,8 +225,8 @@ impl Agent for CopilotAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_transcript_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_transcript_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {

--- a/src/streams/agents/copilot_cli.rs
+++ b/src/streams/agents/copilot_cli.rs
@@ -1,6 +1,6 @@
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{BoundedPathCollector, DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::WatermarkStrategy;
 use std::fs;
@@ -43,7 +43,7 @@ impl Agent for CopilotCliAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
         let Some(base_dir) = Self::session_state_base_dir() else {
             return Ok(Vec::new());
         };
@@ -57,7 +57,7 @@ impl Agent for CopilotCliAgent {
             retry_after: Duration::from_secs(60),
         })?;
 
-        let mut sessions = Vec::new();
+        let mut paths = BoundedPathCollector::new(limit);
 
         for entry in entries.flatten() {
             let dir_path = entry.path();
@@ -69,9 +69,14 @@ impl Agent for CopilotCliAgent {
             if !events_path.exists() {
                 continue;
             }
+            paths.push(events_path);
+        }
 
-            let Some(external_session_id) = dir_path
-                .file_name()
+        let mut sessions = Vec::new();
+        for events_path in paths.into_paths_newest_first() {
+            let Some(external_session_id) = events_path
+                .parent()
+                .and_then(|path| path.file_name())
                 .and_then(|s| s.to_str())
                 .map(|s| s.to_string())
             else {

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -2,10 +2,11 @@
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{
+    DiscoveredSession, StreamFormat, SweepStrategy, discover_recent_files,
+};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -25,42 +26,18 @@ impl CursorAgent {
     }
 
     /// Scan for Cursor conversation files in standard locations.
-    fn scan_conversation_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
+    fn scan_conversation_files(limit: usize) -> Vec<PathBuf> {
         let base_dir = if let Ok(config_dir) = std::env::var("CURSOR_CONFIG_DIR") {
             Some(PathBuf::from(config_dir))
         } else {
             dirs::home_dir().map(|p| p.join(".cursor"))
         };
 
-        let search_dirs = vec![base_dir.as_ref().map(|p| p.join("projects"))];
-
-        for dir_opt in search_dirs {
-            if let Some(dir) = dir_opt
-                && dir.exists()
-            {
-                Self::scan_jsonl_recursive(&dir, &mut paths);
-            }
-        }
-
-        paths
-    }
-
-    fn scan_jsonl_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
-        let Ok(entries) = fs::read_dir(dir) else {
-            return;
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                Self::scan_jsonl_recursive(&path, paths);
-            } else if path.is_file() && path.extension().map(|ext| ext == "jsonl").unwrap_or(false)
-            {
-                paths.push(path);
-            }
-        }
+        discover_recent_files(
+            base_dir.into_iter().map(|path| path.join("projects")),
+            limit,
+            |path| path.extension().and_then(|ext| ext.to_str()) == Some("jsonl"),
+        )
     }
 }
 
@@ -80,8 +57,8 @@ impl Agent for CursorAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_conversation_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_conversation_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {

--- a/src/streams/agents/droid.rs
+++ b/src/streams/agents/droid.rs
@@ -2,10 +2,11 @@
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{
+    DiscoveredSession, StreamFormat, SweepStrategy, discover_recent_files,
+};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{HybridWatermark, WatermarkStrategy};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -25,45 +26,19 @@ impl DroidAgent {
     }
 
     /// Scan for Droid conversation files in standard locations.
-    fn scan_conversation_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
+    fn scan_conversation_files(limit: usize) -> Vec<PathBuf> {
         // Droid transcripts are stored in ~/.factory/sessions/<project-dir>/<uuid>.jsonl
-        let search_dirs = vec![dirs::home_dir().map(|p| p.join(".factory/sessions"))];
-
-        for dir_opt in search_dirs {
-            if let Some(sessions_dir) = dir_opt
-                && sessions_dir.exists()
-            {
-                // Recursively scan all project directories under sessions/
-                Self::scan_jsonl_recursive(&sessions_dir, &mut paths);
-            }
-        }
-
-        paths
-    }
-
-    /// Recursively scan directory for *.jsonl files (excluding .settings.json).
-    fn scan_jsonl_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
-        let Ok(entries) = fs::read_dir(dir) else {
-            return;
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                Self::scan_jsonl_recursive(&path, paths);
-            } else if path.is_file()
-                && path.extension().map(|ext| ext == "jsonl").unwrap_or(false)
-                && !path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.contains(".settings."))
-                    .unwrap_or(false)
-            {
-                paths.push(path);
-            }
-        }
+        discover_recent_files(
+            dirs::home_dir().map(|path| path.join(".factory/sessions")),
+            limit,
+            |path| {
+                path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+                    && !path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.contains(".settings."))
+            },
+        )
     }
 }
 
@@ -83,8 +58,8 @@ impl Agent for DroidAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_conversation_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_conversation_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {

--- a/src/streams/agents/gemini.rs
+++ b/src/streams/agents/gemini.rs
@@ -3,7 +3,7 @@
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::mdm::utils::gemini_config_dir;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
-use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
+use crate::streams::sweep::{BoundedPathCollector, DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
 use std::fs;
@@ -31,13 +31,13 @@ impl GeminiAgent {
     /// Scan for Gemini session files in standard locations.
     ///
     /// Searches `.gemini/tmp/*/chats/session-*.jsonl` under the configured Gemini CLI home.
-    fn scan_session_files() -> Vec<PathBuf> {
-        let mut paths = Vec::new();
+    fn scan_session_files(limit: usize) -> Vec<PathBuf> {
+        let mut paths = BoundedPathCollector::new(limit);
 
         let gemini_tmp = gemini_config_dir().join("tmp");
         if gemini_tmp.exists() {
             let Ok(project_dirs) = fs::read_dir(&gemini_tmp) else {
-                return paths;
+                return Vec::new();
             };
             for project_entry in project_dirs.flatten() {
                 let chats_dir = project_entry.path().join("chats");
@@ -63,7 +63,7 @@ impl GeminiAgent {
             }
         }
 
-        paths
+        paths.into_paths_newest_first()
     }
 }
 
@@ -82,8 +82,8 @@ impl Agent for GeminiAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
-        let paths = Self::scan_session_files();
+    fn discover_sessions(&self, limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
+        let paths = Self::scan_session_files(limit);
         let mut sessions = Vec::new();
 
         for path in paths {
@@ -285,7 +285,9 @@ mod tests {
         unsafe {
             std::env::set_var("GEMINI_CLI_HOME", &gemini_home);
         }
-        let paths = GeminiAgent::scan_session_files();
+        let paths = GeminiAgent::scan_session_files(
+            crate::streams::sweep::MAX_DISCOVERED_SESSIONS_PER_AGENT,
+        );
         // SAFETY: tests are serialized via #[serial], so restoring process env is safe.
         unsafe {
             match prev {

--- a/src/streams/agents/opencode.rs
+++ b/src/streams/agents/opencode.rs
@@ -204,7 +204,7 @@ impl Agent for OpenCodeAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
+    fn discover_sessions(&self, _limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
         // Discovery comes from presets, not sweep.
         Ok(Vec::new())
     }

--- a/src/streams/agents/pi.rs
+++ b/src/streams/agents/pi.rs
@@ -40,7 +40,7 @@ impl Agent for PiAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
+    fn discover_sessions(&self, _limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
         // Discovery happens via presets, not filesystem scanning
         Ok(Vec::new())
     }

--- a/src/streams/agents/windsurf.rs
+++ b/src/streams/agents/windsurf.rs
@@ -40,7 +40,7 @@ impl Agent for WindsurfAgent {
         SweepStrategy::Periodic(Duration::from_secs(30 * 60))
     }
 
-    fn discover_sessions(&self) -> Result<Vec<DiscoveredSession>, StreamError> {
+    fn discover_sessions(&self, _limit: usize) -> Result<Vec<DiscoveredSession>, StreamError> {
         // Sweep not fully implemented for Windsurf yet — discovery comes from presets
         Ok(Vec::new())
     }

--- a/src/streams/sweep.rs
+++ b/src/streams/sweep.rs
@@ -1,7 +1,119 @@
 // src/streams/sweep.rs
 
-use std::path::PathBuf;
-use std::time::Duration;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// A single agent may retain at most this many transcript paths during discovery.
+pub(crate) const MAX_DISCOVERED_SESSIONS_PER_AGENT: usize = 4_096;
+
+/// Caps recursive nesting and simultaneously open directory iterators.
+const MAX_DISCOVERY_DIRECTORY_DEPTH: usize = 128;
+
+#[derive(Debug, Eq, PartialEq)]
+struct RecentPath {
+    modified: SystemTime,
+    path: PathBuf,
+}
+
+impl Ord for RecentPath {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.modified
+            .cmp(&other.modified)
+            .then_with(|| self.path.cmp(&other.path))
+    }
+}
+
+impl PartialOrd for RecentPath {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Retains only the newest `limit` paths while a directory iterator is consumed.
+pub(crate) struct BoundedPathCollector {
+    limit: usize,
+    paths: BTreeSet<RecentPath>,
+}
+
+impl BoundedPathCollector {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            paths: BTreeSet::new(),
+        }
+    }
+
+    pub(crate) fn push(&mut self, path: PathBuf) {
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            return;
+        };
+        self.push_with_modified(path, metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH));
+    }
+
+    fn push_with_modified(&mut self, path: PathBuf, modified: SystemTime) {
+        if self.limit == 0 {
+            return;
+        }
+        self.paths.insert(RecentPath { modified, path });
+        if self.paths.len() > self.limit {
+            self.paths.pop_first();
+        }
+    }
+
+    pub(crate) fn into_paths_newest_first(self) -> Vec<PathBuf> {
+        self.paths
+            .into_iter()
+            .rev()
+            .map(|candidate| candidate.path)
+            .collect()
+    }
+}
+
+/// Iteratively scans roots with lazy directory iterators and bounded nesting depth.
+pub(crate) fn discover_recent_files(
+    roots: impl IntoIterator<Item = PathBuf>,
+    limit: usize,
+    matches: impl Fn(&Path) -> bool,
+) -> Vec<PathBuf> {
+    let mut files = BoundedPathCollector::new(limit);
+    let mut depth_limit_reached = false;
+    for root in roots {
+        let Ok(root_entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        let mut directory_stack = vec![root_entries];
+        while let Some(entries) = directory_stack.last_mut() {
+            let Some(entry) = entries.next() else {
+                directory_stack.pop();
+                continue;
+            };
+            let Ok(entry) = entry else { continue };
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if file_type.is_dir() {
+                if directory_stack.len() >= MAX_DISCOVERY_DIRECTORY_DEPTH {
+                    depth_limit_reached = true;
+                } else if let Ok(entries) = std::fs::read_dir(path) {
+                    directory_stack.push(entries);
+                }
+            } else if file_type.is_file() && matches(&path) {
+                files.push(path);
+            }
+        }
+    }
+
+    if depth_limit_reached {
+        tracing::warn!(
+            depth_limit = MAX_DISCOVERY_DIRECTORY_DEPTH,
+            "transcript discovery depth limit reached; deeply nested paths were skipped"
+        );
+    }
+
+    files.into_paths_newest_first()
+}
 
 /// Strategy for discovering new/updated sessions.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,5 +194,54 @@ impl StreamFormat {
             Self::OpenCodeSqlite => WatermarkType::Timestamp,
             Self::CopilotOtelSqlite => WatermarkType::TimestampCursor,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_path_collector_keeps_newest_paths() {
+        let mut paths = BoundedPathCollector::new(2);
+        for seconds in 1..=4 {
+            paths.push_with_modified(
+                PathBuf::from(format!("session-{seconds}.jsonl")),
+                SystemTime::UNIX_EPOCH + Duration::from_secs(seconds),
+            );
+        }
+
+        assert_eq!(
+            paths.into_paths_newest_first(),
+            [
+                PathBuf::from("session-4.jsonl"),
+                PathBuf::from("session-3.jsonl")
+            ]
+        );
+    }
+
+    #[test]
+    fn recursive_discovery_bounds_results_and_prefers_newest_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let nested = temp.path().join("a/b/c");
+        std::fs::create_dir_all(&nested).unwrap();
+        let now = filetime::FileTime::now();
+        for seconds_old in 1..=4 {
+            let path = nested.join(format!("session-{seconds_old}.jsonl"));
+            std::fs::write(&path, "{}\n").unwrap();
+            filetime::set_file_mtime(
+                &path,
+                filetime::FileTime::from_unix_time(now.unix_seconds() - seconds_old, 0),
+            )
+            .unwrap();
+        }
+
+        let paths = discover_recent_files([temp.path().to_path_buf()], 2, |path| {
+            path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+        });
+
+        assert_eq!(paths.len(), 2);
+        assert!(paths[0].ends_with("session-1.jsonl"));
+        assert!(paths[1].ends_with("session-2.jsonl"));
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -140,6 +140,7 @@ mod sweep_e2e;
 mod telemetry_memory;
 mod test_utils_unit;
 mod tls_native_certs;
+mod transcript_discovery_memory;
 mod transcript_memory;
 mod transcript_queue_memory;
 mod utf8_filenames;

--- a/tests/integration/transcript_discovery_memory.rs
+++ b/tests/integration/transcript_discovery_memory.rs
@@ -1,0 +1,111 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
+use git_ai::metrics::{PosEncoded, SessionEventValues};
+use serde_json::json;
+use std::fs;
+use std::time::{Duration, Instant, SystemTime};
+
+const DISCOVERY_LIMIT_PLUS_ONE: usize = 4_097;
+
+fn wait_for_live_event(metrics_db_path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if let Ok(db) = MetricsDatabase::open_at_path(metrics_db_path)
+            && db
+                .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+                .unwrap_or_default()
+                .iter()
+                .any(|record| {
+                    SessionEventValues::from_sparse(&record.event.values)
+                        .raw_json
+                        .get("uuid")
+                        .and_then(|value| value.as_str())
+                        == Some("live-discovery-event")
+                })
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "newest transcript was not processed after bounded discovery"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn bounded_transcript_discovery_keeps_newest_session_and_daemon_usable() {
+    let fixture = tempfile::tempdir().unwrap();
+    let claude_config = fixture.path().join("claude");
+    let projects = claude_config.join("projects/test-project");
+    fs::create_dir_all(&projects).unwrap();
+
+    let old_mtime = filetime::FileTime::from_system_time(
+        SystemTime::now() - Duration::from_secs(8 * 24 * 60 * 60),
+    );
+    for index in 0..DISCOVERY_LIMIT_PLUS_ONE {
+        let path = projects.join(format!("historical-{index:05}.jsonl"));
+        fs::write(&path, "{}\n").unwrap();
+        filetime::set_file_mtime(path, old_mtime).unwrap();
+    }
+
+    let live_transcript = projects.join("live-discovery-session.jsonl");
+    fs::write(
+        &live_transcript,
+        format!(
+            "{}\n",
+            json!({
+                "uuid": "live-discovery-event",
+                "timestamp": "2026-07-10T00:00:00Z",
+                "cwd": fixture.path(),
+                "message": { "content": "bounded discovery" },
+            })
+        ),
+    )
+    .unwrap();
+
+    let metrics_db_path = fixture.path().join("metrics.db");
+    let claude_config_str = claude_config.to_string_lossy().to_string();
+    let metrics_db_path_str = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("CLAUDE_CONFIG_DIR", claude_config_str.as_str()),
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path_str.as_str()),
+    ]);
+
+    wait_for_live_event(&metrics_db_path);
+
+    #[cfg(target_os = "linux")]
+    assert!(
+        daemon_hwm_kib(&repo) < 128 * 1024,
+        "bounded transcript discovery exceeded 128 MiB daemon HWM"
+    );
+
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after discovery pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}


### PR DESCRIPTION
## Bug
Transcript discovery recursively collected every session and the stream worker could schedule and retain every discovered task. Large agent history directories therefore produced unbounded directory traversal state and task fanout.

## Fix
Limit discovery to 4,096 sessions per agent/sweep, bound traversal depth and pending directories, cap background and retained task objects, and reserve capacity for checkpoint-triggered work so background sweeps cannot starve attribution.

## Verification
Unit tests cover discovery, depth, scheduling, and retained-object limits. `tests/integration/transcript_discovery_memory.rs` creates an oversized session set and verifies bounded daemon processing.