### PR TITLE
fix(daemon): bound retained repository state

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -36,7 +36,7 @@ use named_pipe::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -100,6 +100,8 @@ const DAEMON_SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(not(windows))]
 const TRACE_SOCKET_RECV_BUFFER_BYTES: usize = 512 * 1024;
 const TRACE_INGEST_QUEUE_CAPACITY: usize = 16_384;
+const MAX_RETAINED_AUXILIARY_STATE_KEYS: usize = 1_024;
+const MAX_RETAINED_PENDING_OIDS: usize = 4_096;
 #[cfg(not(windows))]
 const TRACE_CONNECTION_BOOTSTRAP_READ_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(windows)]
@@ -111,6 +113,15 @@ const WINDOWS_STDOUT_HANDLE: u32 = (-11i32) as u32;
 #[cfg(windows)]
 const WINDOWS_STDERR_HANDLE: u32 = (-12i32) as u32;
 static DAEMON_PROCESS_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+fn make_room_for_bounded_key<V>(map: &mut HashMap<String, V>, key: &str) {
+    if !map.contains_key(key)
+        && map.len() >= MAX_RETAINED_AUXILIARY_STATE_KEYS
+        && let Some(evicted) = map.keys().next().cloned()
+    {
+        map.remove(&evicted);
+    }
+}
 
 #[cfg(windows)]
 unsafe extern "system" {
@@ -1299,50 +1310,6 @@ fn apply_checkout_switch_working_log_side_effect(
     Ok(())
 }
 
-fn recent_checkout_switch_prerequisite_from_command(
-    cmd: &crate::daemon::domain::NormalizedCommand,
-) -> Option<RecentReplayPrerequisite> {
-    let parsed = parsed_invocation_for_normalized_command(cmd);
-    let (old_head, new_head) = ActorDaemonCoordinator::resolve_heads_for_command(cmd);
-
-    if old_head.is_empty() || new_head.is_empty() || old_head == new_head {
-        return None;
-    }
-
-    if cmd.primary_command.as_deref() == Some("checkout") && !parsed.pathspecs().is_empty() {
-        return None;
-    }
-
-    let is_force = match cmd.primary_command.as_deref() {
-        Some("checkout") => parsed.has_command_flag("--force") || parsed.has_command_flag("-f"),
-        Some("switch") => {
-            parsed.has_command_flag("--discard-changes")
-                || parsed.has_command_flag("--force")
-                || parsed.has_command_flag("-f")
-        }
-        _ => false,
-    };
-    if is_force {
-        return None;
-    }
-
-    let is_merge = parsed.has_command_flag("--merge") || parsed.has_command_flag("-m");
-    if is_merge {
-        return None;
-    }
-
-    Some(RecentReplayPrerequisite::CheckoutSwitchRename {
-        target_head: new_head,
-        old_head,
-    })
-}
-fn family_key_for_repository(repo: &Repository) -> String {
-    repo.common_dir()
-        .canonicalize()
-        .unwrap_or_else(|_| repo.common_dir().to_path_buf())
-        .to_string_lossy()
-        .to_string()
-}
 fn is_valid_oid(oid: &str) -> bool {
     matches!(oid.len(), 40 | 64) && oid.chars().all(|c| c.is_ascii_hexdigit())
 }
@@ -2465,20 +2432,6 @@ struct PendingCherryPickNoCommit {
     head: String,
 }
 
-#[derive(Debug, Clone)]
-#[allow(dead_code)]
-enum RecentReplayPrerequisite {
-    CheckoutSwitchRename {
-        target_head: String,
-        old_head: String,
-    },
-    CheckoutSwitchMerge {
-        target_head: String,
-        old_head: String,
-        final_state: HashMap<String, String>,
-    },
-}
-
 #[derive(Debug, Default, Clone)]
 struct TraceIngressState {
     root_worktrees: HashMap<String, PathBuf>,
@@ -2520,8 +2473,6 @@ pub struct ActorDaemonCoordinator {
     pending_root_slots_by_root: Mutex<HashMap<String, PendingRootSlot>>,
     commit_file_timestamp_snapshots_by_root:
         Mutex<HashMap<String, CommitFileTimestampSnapshotHandles>>,
-    recent_replay_prerequisites_by_family:
-        Mutex<HashMap<String, VecDeque<RecentReplayPrerequisite>>>,
     side_effect_errors_by_family: Mutex<HashMap<String, BTreeMap<u64, String>>>,
     side_effect_exec_locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
     bash_sessions: Mutex<crate::daemon::bash_sessions::BashSessionState>,
@@ -2605,7 +2556,6 @@ impl ActorDaemonCoordinator {
             family_sequencers_by_family: Mutex::new(HashMap::new()),
             pending_root_slots_by_root: Mutex::new(HashMap::new()),
             commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
-            recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
             side_effect_errors_by_family: Mutex::new(HashMap::new()),
             side_effect_exec_locks: Mutex::new(HashMap::new()),
             bash_sessions: Mutex::new(crate::daemon::bash_sessions::BashSessionState::new()),
@@ -2907,9 +2857,6 @@ impl ActorDaemonCoordinator {
         // NOTE: Do NOT call normalizer.sweep_orphans() here — it removes ALL
         // pending/deferred roots unconditionally which destroys in-flight trace
         // state.  sweep_orphans() is only safe at daemon shutdown.
-        if let Ok(mut map) = self.recent_replay_prerequisites_by_family.lock() {
-            map.retain(|_, entries| !entries.is_empty());
-        }
         if let Ok(mut map) = self.side_effect_errors_by_family.lock() {
             map.retain(|_, errors| !errors.is_empty());
         }
@@ -2917,7 +2864,7 @@ impl ActorDaemonCoordinator {
             map.retain(|_, state| !state.entries.is_empty());
         }
         if let Ok(mut map) = self.side_effect_exec_locks.lock() {
-            map.retain(|_, lock| Arc::strong_count(lock) <= 1);
+            map.retain(|_, lock| Arc::strong_count(lock) > 1);
         }
         if let Ok(mut map) = self.pending_rebase_original_head_by_worktree.lock() {
             map.shrink_to_fit();
@@ -2946,6 +2893,9 @@ impl ActorDaemonCoordinator {
                 map.retain(|_, family_map| !family_map.is_empty());
             }
         }
+        if let Ok(mut sessions) = self.bash_sessions.lock() {
+            sessions.prune_stale_sessions();
+        }
     }
 
     fn canonicalize_path(path: &str) -> String {
@@ -2957,8 +2907,9 @@ impl ActorDaemonCoordinator {
     fn register_pending_ai_edits(&self, family: &str, file_paths: &[String]) {
         let now_ns = now_unix_nanos();
         if let Ok(mut map) = self.pending_ai_edits_by_family.lock() {
+            make_room_for_bounded_key(&mut map, family);
             let family_map = map.entry(family.to_string()).or_default();
-            for file in file_paths {
+            for file in file_paths.iter().take(MAX_RETAINED_PENDING_OIDS) {
                 family_map.insert(Self::canonicalize_path(file), now_ns);
             }
         }
@@ -3267,9 +3218,16 @@ impl ActorDaemonCoordinator {
             .side_effect_errors_by_family
             .lock()
             .map_err(|_| GitAiError::Generic("side effect errors map lock poisoned".to_string()))?;
+        make_room_for_bounded_key(&mut map, family);
         let family_errors = map.entry(family.to_string()).or_insert_with(BTreeMap::new);
-        family_errors.insert(seq, error.to_string());
-        while family_errors.len() > 256 {
+        family_errors.insert(
+            seq,
+            crate::daemon::daemon_log_layer::bounded_display_string(
+                error,
+                crate::daemon::daemon_log_layer::MAX_MESSAGE_LENGTH,
+            ),
+        );
+        while family_errors.len() > 1 {
             if let Some(oldest) = family_errors.keys().next().copied() {
                 family_errors.remove(&oldest);
             } else {
@@ -3287,27 +3245,6 @@ impl ActorDaemonCoordinator {
         Ok(map
             .get(family)
             .and_then(|errors| errors.iter().next_back().map(|(_, error)| error.clone())))
-    }
-
-    fn record_recent_replay_prerequisite(
-        &self,
-        family: &str,
-        prerequisite: RecentReplayPrerequisite,
-    ) -> Result<(), GitAiError> {
-        const MAX_RECENT_REPLAY_PREREQUISITES_PER_FAMILY: usize = 256;
-
-        let mut map = self
-            .recent_replay_prerequisites_by_family
-            .lock()
-            .map_err(|_| {
-                GitAiError::Generic("recent replay prerequisites map lock poisoned".to_string())
-            })?;
-        let entries = map.entry(family.to_string()).or_insert_with(VecDeque::new);
-        entries.push_back(prerequisite);
-        while entries.len() > MAX_RECENT_REPLAY_PREREQUISITES_PER_FAMILY {
-            let _ = entries.pop_front();
-        }
-        Ok(())
     }
 
     fn maybe_append_test_completion_log(
@@ -4019,10 +3956,22 @@ impl ActorDaemonCoordinator {
             .side_effect_exec_locks
             .lock()
             .map_err(|_| GitAiError::Generic("side effect lock map lock poisoned".to_string()))?;
-        Ok(map
-            .entry(family.to_string())
-            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-            .clone())
+        if let Some(lock) = map.get(family) {
+            return Ok(lock.clone());
+        }
+        if map.len() >= MAX_RETAINED_AUXILIARY_STATE_KEYS
+            && let Some(idle) = map
+                .iter()
+                .find(|(_, lock)| Arc::strong_count(lock) == 1)
+                .map(|(family, _)| family.clone())
+        {
+            map.remove(&idle);
+        }
+        let lock = Arc::new(AsyncMutex::new(()));
+        if map.len() < MAX_RETAINED_AUXILIARY_STATE_KEYS {
+            map.insert(family.to_string(), lock.clone());
+        }
+        Ok(lock)
     }
 
     async fn append_checkpoint_to_family_sequencer(
@@ -4449,7 +4398,9 @@ impl ActorDaemonCoordinator {
             .map_err(|_| {
                 GitAiError::Generic("pending rebase original-head map lock poisoned".to_string())
             })?;
-        map.insert(Self::worktree_state_key(worktree), (original_head, onto));
+        let key = Self::worktree_state_key(worktree);
+        make_room_for_bounded_key(&mut map, &key);
+        map.insert(key, (original_head, onto));
         Ok(())
     }
 
@@ -4483,7 +4434,7 @@ impl ActorDaemonCoordinator {
     fn set_pending_cherry_pick_sources_for_worktree(
         &self,
         worktree: &Path,
-        sources: Vec<String>,
+        mut sources: Vec<String>,
     ) -> Result<(), GitAiError> {
         let mut map = self
             .pending_cherry_pick_sources_by_worktree
@@ -4495,6 +4446,8 @@ impl ActorDaemonCoordinator {
         if sources.is_empty() {
             map.remove(&key);
         } else {
+            sources.truncate(MAX_RETAINED_PENDING_OIDS);
+            make_room_for_bounded_key(&mut map, &key);
             map.insert(key, sources);
         }
         Ok(())
@@ -4548,7 +4501,7 @@ impl ActorDaemonCoordinator {
     fn set_pending_cherry_pick_no_commit_for_worktree(
         &self,
         worktree: &Path,
-        source_commits: Vec<String>,
+        mut source_commits: Vec<String>,
         head: String,
     ) -> Result<(), GitAiError> {
         let mut map = self
@@ -4561,6 +4514,8 @@ impl ActorDaemonCoordinator {
         if source_commits.is_empty() || head.is_empty() {
             map.remove(&key);
         } else {
+            source_commits.truncate(MAX_RETAINED_PENDING_OIDS);
+            make_room_for_bounded_key(&mut map, &key);
             map.insert(
                 key,
                 PendingCherryPickNoCommit {
@@ -4608,10 +4563,9 @@ impl ActorDaemonCoordinator {
         let mut map = self.pending_squash_merge_by_worktree.lock().map_err(|_| {
             GitAiError::Generic("pending squash merge map lock poisoned".to_string())
         })?;
-        map.insert(
-            Self::worktree_state_key(worktree),
-            PendingSquashMerge { source_head, onto },
-        );
+        let key = Self::worktree_state_key(worktree);
+        make_room_for_bounded_key(&mut map, &key);
+        map.insert(key, PendingSquashMerge { source_head, onto });
         Ok(())
     }
 
@@ -4942,6 +4896,7 @@ impl ActorDaemonCoordinator {
                     "commit file timestamp snapshot cache lock poisoned".to_string(),
                 )
             })?;
+        make_room_for_bounded_key(&mut cache, &command.root_sid);
         cache.insert(command.root_sid.clone(), handles);
         Ok(())
     }
@@ -5247,7 +5202,7 @@ impl ActorDaemonCoordinator {
             // Fix #957: `checkout/switch --merge` exits with code 1 when it produces
             // conflict markers but HEAD still moves to the target branch.  We must not
             // return early here — fall through so apply_checkout_switch_working_log_side_effect
-            // and recent_checkout_switch_prerequisite_from_command can migrate the working log.
+            // can migrate the working log.
             let is_merge_checkout =
                 matches!(cmd.primary_command.as_deref(), Some("checkout" | "switch")) && {
                     let p = parsed_invocation_for_normalized_command(cmd);
@@ -5676,18 +5631,6 @@ impl ActorDaemonCoordinator {
         }
 
         if matches!(cmd.primary_command.as_deref(), Some("checkout" | "switch")) {
-            if let Some(prerequisite) = recent_checkout_switch_prerequisite_from_command(cmd) {
-                let family = family.map(std::borrow::ToOwned::to_owned).or_else(|| {
-                    cmd.worktree.as_ref().and_then(|worktree| {
-                        find_repository_in_path(&worktree.to_string_lossy())
-                            .ok()
-                            .map(|repo| family_key_for_repository(&repo))
-                    })
-                });
-                if let Some(family) = family {
-                    self.record_recent_replay_prerequisite(&family, prerequisite)?;
-                }
-            }
             apply_checkout_switch_working_log_side_effect(cmd)?;
         }
 
@@ -6092,7 +6035,7 @@ impl ActorDaemonCoordinator {
                 }
 
                 let mut state = self.bash_sessions.lock().unwrap();
-                state.start_session(crate::daemon::bash_sessions::BashSessionStart {
+                if !state.start_session(crate::daemon::bash_sessions::BashSessionStart {
                     session_id,
                     tool_use_id,
                     repo_work_dir: worktree_key,
@@ -6102,7 +6045,11 @@ impl ActorDaemonCoordinator {
                     start_trace_id: trace_id,
                     started_at_ns,
                     command,
-                });
+                }) {
+                    tracing::warn!(
+                        "bash session snapshot exceeded daemon retention limits; post-hook will fall back gracefully"
+                    );
+                }
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::BashSessionEnd {
@@ -6239,7 +6186,8 @@ impl ActorDaemonCoordinator {
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::BashSessionQuery { repo_work_dir } => {
-                let state = self.bash_sessions.lock().unwrap();
+                let mut state = self.bash_sessions.lock().unwrap();
+                state.prune_stale_sessions();
                 let repo_work_dir = Self::worktree_state_key(Path::new(&repo_work_dir));
                 let response = match state.query_active_for_repo(&repo_work_dir) {
                     Some((key, session)) => {
@@ -6271,7 +6219,8 @@ impl ActorDaemonCoordinator {
                 session_id,
                 tool_use_id,
             } => {
-                let state = self.bash_sessions.lock().unwrap();
+                let mut state = self.bash_sessions.lock().unwrap();
+                state.prune_stale_sessions();
                 let response = match state.get_snapshot(&session_id, &tool_use_id) {
                     Some(snapshot) => {
                         let data = serde_json::to_value(BashSnapshotQueryResponse {
@@ -8190,6 +8139,62 @@ mod tests {
         // This assertion documents the intent: if symlink and target mtimes differ,
         // the watermark must track the symlink, not the target.
         let _ = target_mtime; // used only as documentation; may equal symlink_mtime on some FS
+    }
+
+    #[tokio::test]
+    async fn stale_family_state_gc_drops_idle_locks_and_preserves_active_locks() {
+        let coordinator = ActorDaemonCoordinator::new();
+        let idle = coordinator.side_effect_exec_lock("idle").unwrap();
+        drop(idle);
+        let active = coordinator.side_effect_exec_lock("active").unwrap();
+
+        coordinator.gc_stale_family_state();
+
+        let locks = coordinator.side_effect_exec_locks.lock().unwrap();
+        assert!(!locks.contains_key("idle"));
+        assert!(locks.contains_key("active"));
+        drop(locks);
+        drop(active);
+    }
+
+    #[tokio::test]
+    async fn retained_family_and_worktree_auxiliary_maps_are_bounded() {
+        const EXPECTED_LIMIT: usize = 1_024;
+
+        let coordinator = ActorDaemonCoordinator::new();
+        for index in 0..=EXPECTED_LIMIT {
+            coordinator
+                .record_side_effect_error(
+                    &format!("family-{index}"),
+                    index as u64,
+                    &GitAiError::Generic(format!("error-{index}")),
+                )
+                .unwrap();
+            coordinator
+                .set_pending_rebase_original_head_for_worktree(
+                    Path::new(&format!("/missing/repo-{index}")),
+                    format!("{index:040x}"),
+                    None,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(
+            coordinator
+                .side_effect_errors_by_family
+                .lock()
+                .unwrap()
+                .len(),
+            EXPECTED_LIMIT
+        );
+        assert_eq!(
+            coordinator
+                .pending_rebase_original_head_by_worktree
+                .lock()
+                .unwrap()
+                .len(),
+            EXPECTED_LIMIT
+        );
     }
 
     #[test]

--- a/src/daemon/bash_sessions.rs
+++ b/src/daemon/bash_sessions.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 const STALE_SESSION_SECS: u64 = 300;
+const MAX_ACTIVE_BASH_SESSIONS: usize = 32;
+const MAX_RETAINED_BASH_SESSION_BYTES: usize = 32 * 1024 * 1024;
 
 pub struct BashSession {
     pub repo_work_dir: String,
@@ -14,6 +16,7 @@ pub struct BashSession {
     pub started_at_ns: u128,
     pub command: Option<String>,
     pub started_at: Instant,
+    retained_bytes: usize,
 }
 
 pub struct BashSessionStart {
@@ -31,6 +34,7 @@ pub struct BashSessionStart {
 #[derive(Default)]
 pub struct BashSessionState {
     sessions: HashMap<(String, String), BashSession>,
+    retained_bytes: usize,
 }
 
 impl BashSessionState {
@@ -38,15 +42,44 @@ impl BashSessionState {
         Self::default()
     }
 
-    fn prune_stale_sessions(&mut self) {
-        self.sessions
-            .retain(|_, s| s.started_at.elapsed() < Duration::from_secs(STALE_SESSION_SECS));
+    pub fn prune_stale_sessions(&mut self) {
+        let mut removed_bytes = 0usize;
+        self.sessions.retain(|_, session| {
+            let keep = session.started_at.elapsed() < Duration::from_secs(STALE_SESSION_SECS);
+            if !keep {
+                removed_bytes = removed_bytes.saturating_add(session.retained_bytes);
+            }
+            keep
+        });
+        self.retained_bytes = self.retained_bytes.saturating_sub(removed_bytes);
     }
 
-    pub fn start_session(&mut self, session: BashSessionStart) {
+    pub fn start_session(&mut self, session: BashSessionStart) -> bool {
         self.prune_stale_sessions();
+        let retained_bytes = retained_session_bytes(&session);
+        if retained_bytes > MAX_RETAINED_BASH_SESSION_BYTES {
+            return false;
+        }
+
+        let key = (session.session_id, session.tool_use_id);
+        self.remove_session(&key);
+        while self.sessions.len() >= MAX_ACTIVE_BASH_SESSIONS
+            || self.retained_bytes.saturating_add(retained_bytes) > MAX_RETAINED_BASH_SESSION_BYTES
+        {
+            let Some(oldest) = self
+                .sessions
+                .iter()
+                .min_by_key(|(_, session)| session.started_at)
+                .map(|(key, _)| key.clone())
+            else {
+                return false;
+            };
+            self.remove_session(&oldest);
+        }
+
+        self.retained_bytes = self.retained_bytes.saturating_add(retained_bytes);
         self.sessions.insert(
-            (session.session_id, session.tool_use_id),
+            key,
             BashSession {
                 repo_work_dir: session.repo_work_dir,
                 agent_id: session.agent_id,
@@ -56,13 +89,14 @@ impl BashSessionState {
                 started_at_ns: session.started_at_ns,
                 command: session.command,
                 started_at: Instant::now(),
+                retained_bytes,
             },
         );
+        true
     }
 
     pub fn end_session(&mut self, session_id: &str, tool_use_id: &str) -> Option<BashSession> {
-        self.sessions
-            .remove(&(session_id.to_string(), tool_use_id.to_string()))
+        self.remove_session(&(session_id.to_string(), tool_use_id.to_string()))
     }
 
     pub fn query_active_for_repo(
@@ -78,5 +112,113 @@ impl BashSessionState {
         self.sessions
             .get(&(session_id.to_string(), tool_use_id.to_string()))
             .map(|s| &s.stat_snapshot)
+    }
+
+    fn remove_session(&mut self, key: &(String, String)) -> Option<BashSession> {
+        let removed = self.sessions.remove(key)?;
+        self.retained_bytes = self.retained_bytes.saturating_sub(removed.retained_bytes);
+        Some(removed)
+    }
+}
+
+fn retained_session_bytes(session: &BashSessionStart) -> usize {
+    let snapshot = &session.stat_snapshot;
+    let mut bytes = std::mem::size_of::<BashSession>()
+        .saturating_add(session.session_id.len())
+        .saturating_add(session.tool_use_id.len())
+        .saturating_add(session.repo_work_dir.len())
+        .saturating_add(session.agent_id.tool.len())
+        .saturating_add(session.agent_id.id.len())
+        .saturating_add(session.agent_id.model.len())
+        .saturating_add(session.start_trace_id.len())
+        .saturating_add(session.command.as_ref().map_or(0, String::len))
+        .saturating_add(snapshot.invocation_key.len())
+        .saturating_add(snapshot.repo_root.to_string_lossy().len());
+    for (key, value) in &session.metadata {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<String>() * 2)
+            .saturating_add(key.len())
+            .saturating_add(value.len());
+    }
+    for path in snapshot.entries.keys() {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<std::path::PathBuf>())
+            .saturating_add(path.to_string_lossy().len())
+            .saturating_add(std::mem::size_of::<
+                crate::commands::checkpoint_agent::bash_tool::StatEntry,
+            >());
+    }
+    for path in snapshot.per_file_wm.keys() {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<String>())
+            .saturating_add(path.len())
+            .saturating_add(std::mem::size_of::<u128>());
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn start(index: usize) -> BashSessionStart {
+        BashSessionStart {
+            session_id: format!("session-{index}"),
+            tool_use_id: format!("tool-{index}"),
+            repo_work_dir: "/repo".to_string(),
+            agent_id: AgentId {
+                tool: "codex".to_string(),
+                id: "test".to_string(),
+                model: "test".to_string(),
+            },
+            metadata: HashMap::new(),
+            stat_snapshot: StatSnapshot {
+                entries: HashMap::new(),
+                taken_at: None,
+                invocation_key: format!("session-{index}:tool-{index}"),
+                repo_root: "/repo".into(),
+                effective_worktree_wm: None,
+                per_file_wm: HashMap::new(),
+            },
+            start_trace_id: format!("trace-{index}"),
+            started_at_ns: index as u128,
+            command: None,
+        }
+    }
+
+    #[test]
+    fn active_bash_sessions_are_bounded() {
+        const EXPECTED_LIMIT: usize = 32;
+
+        let mut state = BashSessionState::new();
+        for index in 0..=EXPECTED_LIMIT {
+            state.start_session(start(index));
+        }
+
+        assert_eq!(state.sessions.len(), EXPECTED_LIMIT);
+        assert!(state.get_snapshot("session-0", "tool-0").is_none());
+        assert!(
+            state
+                .get_snapshot(
+                    &format!("session-{EXPECTED_LIMIT}"),
+                    &format!("tool-{EXPECTED_LIMIT}")
+                )
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn oversized_bash_session_is_not_retained() {
+        let mut state = BashSessionState::new();
+        let mut session = start(1);
+        session.metadata.insert(
+            "oversized".to_string(),
+            "x".repeat(MAX_RETAINED_BASH_SESSION_BYTES + 1),
+        );
+
+        assert!(!state.start_session(session));
+        assert!(state.sessions.is_empty());
+        assert_eq!(state.retained_bytes, 0);
     }
 }

--- a/src/daemon/coordinator.rs
+++ b/src/daemon/coordinator.rs
@@ -6,15 +6,62 @@ use crate::daemon::family_actor::{FamilyActorHandle, spawn_family_actor};
 use crate::daemon::git_backend::GitBackend;
 use crate::daemon::global_actor::{GlobalActorHandle, spawn_global_actor};
 use crate::error::GitAiError;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+const MAX_RETAINED_FAMILY_ACTORS: usize = 1_024;
+
+struct FamilyActorRegistry {
+    actors: HashMap<String, FamilyActorHandle>,
+    insertion_order: VecDeque<String>,
+    saturated: bool,
+}
+
+impl FamilyActorRegistry {
+    fn new() -> Self {
+        Self {
+            actors: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            saturated: false,
+        }
+    }
+
+    fn evict_oldest_idle(&mut self) -> Option<FamilyActorHandle> {
+        for _ in 0..self.insertion_order.len() {
+            let key = self.insertion_order.pop_front()?;
+            let Some(actor) = self.actors.get(&key) else {
+                continue;
+            };
+            if actor.is_closed() || actor.is_idle_for_eviction() {
+                return self.actors.remove(&key);
+            }
+            self.insertion_order.push_back(key);
+        }
+        None
+    }
+}
+
+fn configured_family_actor_capacity() -> usize {
+    let is_test_daemon = std::env::var_os("GIT_AI_TEST_DB_PATH").is_some()
+        || std::env::var_os("GITAI_TEST_DB_PATH").is_some();
+    if is_test_daemon
+        && let Some(capacity) = std::env::var("GIT_AI_TEST_MAX_FAMILY_ACTORS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|capacity| *capacity > 0)
+    {
+        return capacity;
+    }
+    MAX_RETAINED_FAMILY_ACTORS
+}
+
 pub struct Coordinator<B: GitBackend> {
     backend: Arc<B>,
     global: GlobalActorHandle,
-    families: Mutex<HashMap<String, FamilyActorHandle>>,
+    families: Mutex<FamilyActorRegistry>,
+    max_family_actors: usize,
 }
 
 impl<B: GitBackend> Coordinator<B> {
@@ -22,7 +69,8 @@ impl<B: GitBackend> Coordinator<B> {
         Self {
             backend,
             global: spawn_global_actor(),
-            families: Mutex::new(HashMap::new()),
+            families: tokio::sync::Mutex::new(FamilyActorRegistry::new()),
+            max_family_actors: configured_family_actor_capacity(),
         }
     }
 
@@ -72,8 +120,8 @@ impl<B: GitBackend> Coordinator<B> {
 
     pub async fn shutdown(&self) -> Result<(), GitAiError> {
         let actors = {
-            let map = self.families.lock().await;
-            map.values().cloned().collect::<Vec<_>>()
+            let registry = self.families.lock().await;
+            registry.actors.values().cloned().collect::<Vec<_>>()
         };
         for actor in actors {
             let _ = actor.shutdown().await;
@@ -82,12 +130,36 @@ impl<B: GitBackend> Coordinator<B> {
     }
 
     async fn get_or_create_family_actor(&self, family_key: FamilyKey) -> FamilyActorHandle {
-        let mut map = self.families.lock().await;
-        if let Some(existing) = map.get(&family_key.0) {
+        let mut registry = self.families.lock().await;
+        if let Some(existing) = registry.actors.get(&family_key.0) {
             return existing.clone();
         }
+
+        while registry.actors.len() >= self.max_family_actors {
+            let Some(evicted) = registry.evict_oldest_idle() else {
+                if !registry.saturated {
+                    registry.saturated = true;
+                    tracing::warn!(
+                        capacity = self.max_family_actors,
+                        "family actor registry is full; using a transient actor for a new repository"
+                    );
+                }
+                return spawn_family_actor(family_key);
+            };
+            tracing::debug!(
+                family = %evicted.family_key.0,
+                capacity = self.max_family_actors,
+                "evicted idle family actor"
+            );
+            drop(evicted);
+        }
+
+        registry.saturated = false;
         let created = spawn_family_actor(family_key.clone());
-        map.insert(family_key.0.clone(), created.clone());
+        registry.insertion_order.push_back(family_key.0.clone());
+        registry
+            .actors
+            .insert(family_key.0.clone(), created.clone());
         created
     }
 }
@@ -212,5 +284,57 @@ mod tests {
         assert_eq!(f.seq, 1);
 
         coordinator.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn family_actor_registry_is_bounded() {
+        const EXPECTED_FAMILY_ACTOR_LIMIT: usize = 1_024;
+
+        let coordinator = Coordinator::new(Arc::new(MockBackend::default()));
+        for index in 0..=EXPECTED_FAMILY_ACTOR_LIMIT {
+            let actor = coordinator
+                .get_or_create_family_actor(FamilyKey::new(format!("family-{index}")))
+                .await;
+            drop(actor);
+        }
+
+        assert_eq!(
+            coordinator.families.lock().await.actors.len(),
+            EXPECTED_FAMILY_ACTOR_LIMIT
+        );
+    }
+
+    #[tokio::test]
+    async fn family_actor_registry_never_evicts_a_borrowed_actor() {
+        let coordinator = Coordinator {
+            backend: Arc::new(MockBackend::default()),
+            global: spawn_global_actor(),
+            families: tokio::sync::Mutex::new(FamilyActorRegistry::new()),
+            max_family_actors: 1,
+        };
+        let active = coordinator
+            .get_or_create_family_actor(FamilyKey::new("active"))
+            .await;
+
+        let transient = coordinator
+            .get_or_create_family_actor(FamilyKey::new("transient"))
+            .await;
+        {
+            let registry = coordinator.families.lock().await;
+            assert!(registry.actors.contains_key("active"));
+            assert!(!registry.actors.contains_key("transient"));
+        }
+        drop(transient);
+
+        active.apply_checkpoint().await.unwrap();
+        drop(active);
+        let replacement = coordinator
+            .get_or_create_family_actor(FamilyKey::new("replacement"))
+            .await;
+        let registry = coordinator.families.lock().await;
+        assert!(!registry.actors.contains_key("active"));
+        assert!(registry.actors.contains_key("replacement"));
+        drop(registry);
+        replacement.shutdown().await.unwrap();
     }
 }

--- a/src/daemon/family_actor.rs
+++ b/src/daemon/family_actor.rs
@@ -9,6 +9,21 @@ use crate::error::GitAiError;
 use std::collections::HashMap;
 use tokio::sync::{mpsc, oneshot};
 
+const MAX_PER_FILE_WATERMARKS: usize = 4_096;
+const MAX_PER_WORKTREE_WATERMARKS: usize = 256;
+
+fn retain_newest_watermarks(watermarks: &mut HashMap<String, u128>, limit: usize) {
+    if watermarks.len() <= limit {
+        return;
+    }
+    let mut entries = watermarks.drain().collect::<Vec<_>>();
+    entries.select_nth_unstable_by(limit, |left, right| {
+        right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0))
+    });
+    entries.truncate(limit);
+    watermarks.extend(entries);
+}
+
 pub enum FamilyMsg {
     Apply(
         Box<NormalizedCommand>,
@@ -28,6 +43,14 @@ pub struct FamilyActorHandle {
 }
 
 impl FamilyActorHandle {
+    pub(crate) fn is_idle_for_eviction(&self) -> bool {
+        self.tx.strong_count() == 1
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.tx.is_closed()
+    }
+
     pub async fn apply(&self, cmd: NormalizedCommand) -> Result<AppliedCommand, GitAiError> {
         let (tx, rx) = oneshot::channel();
         self.tx
@@ -158,6 +181,14 @@ pub fn spawn_family_actor(family_key: FamilyKey) -> FamilyActorHandle {
                             state.watermarks.per_file.retain(|_, file_ts| *file_ts > ts);
                         }
                     }
+                    retain_newest_watermarks(
+                        &mut state.watermarks.per_file,
+                        MAX_PER_FILE_WATERMARKS,
+                    );
+                    retain_newest_watermarks(
+                        &mut state.watermarks.per_worktree,
+                        MAX_PER_WORKTREE_WATERMARKS,
+                    );
                 }
                 FamilyMsg::Shutdown => break,
             }
@@ -267,6 +298,54 @@ mod tests {
         assert_eq!(wm.per_file.get("src/main.rs"), Some(&3000));
         assert_eq!(wm.per_file.get("src/lib.rs"), Some(&2000));
 
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn per_file_watermarks_keep_only_the_newest_bounded_set() {
+        const EXPECTED_LIMIT: usize = 4_096;
+
+        let handle = spawn_family_actor(FamilyKey::new("bounded-watermarks"));
+        handle
+            .update_watermarks(WatermarkState {
+                per_file: (0..=EXPECTED_LIMIT)
+                    .map(|index| (format!("src/file-{index}.rs"), index as u128))
+                    .collect(),
+                per_worktree: HashMap::new(),
+            })
+            .await
+            .unwrap();
+
+        let watermarks = handle.watermarks().await.unwrap();
+        assert_eq!(watermarks.per_file.len(), EXPECTED_LIMIT);
+        assert!(!watermarks.per_file.contains_key("src/file-0.rs"));
+        assert_eq!(
+            watermarks
+                .per_file
+                .get(&format!("src/file-{EXPECTED_LIMIT}.rs")),
+            Some(&(EXPECTED_LIMIT as u128))
+        );
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn per_worktree_watermarks_keep_only_the_newest_bounded_set() {
+        const EXPECTED_LIMIT: usize = 256;
+
+        let handle = spawn_family_actor(FamilyKey::new("bounded-worktrees"));
+        handle
+            .update_watermarks(WatermarkState {
+                per_file: HashMap::new(),
+                per_worktree: (0..=EXPECTED_LIMIT)
+                    .map(|index| (format!("/repo/worktree-{index}"), index as u128))
+                    .collect(),
+            })
+            .await
+            .unwrap();
+
+        let watermarks = handle.watermarks().await.unwrap();
+        assert_eq!(watermarks.per_worktree.len(), EXPECTED_LIMIT);
+        assert!(!watermarks.per_worktree.contains_key("/repo/worktree-0"));
         handle.shutdown().await.unwrap();
     }
 

--- a/src/daemon/git_backend.rs
+++ b/src/daemon/git_backend.rs
@@ -42,6 +42,9 @@ pub trait GitBackend: Send + Sync + 'static {
 }
 
 const ALIAS_CACHE_TTL_SECS: u64 = 60;
+const MAX_ALIAS_CACHE_FAMILIES: usize = 1_024;
+const MAX_ALIASES_PER_FAMILY: usize = 256;
+const MAX_RETAINED_ALIAS_BYTES_PER_FAMILY: usize = 64 * 1_024;
 
 struct AliasCacheEntry {
     /// Resolved alias name → expansion value (e.g. "ci" → "commit -v")
@@ -230,6 +233,12 @@ fn refresh_alias_cache(
         }
     };
     if let Ok(mut cache) = alias_cache.lock() {
+        if !cache.contains_key(family_key)
+            && cache.len() >= MAX_ALIAS_CACHE_FAMILIES
+            && let Some(evicted) = cache.keys().next().cloned()
+        {
+            cache.remove(&evicted);
+        }
         cache.insert(
             family_key.to_string(),
             AliasCacheEntry {
@@ -243,6 +252,7 @@ fn refresh_alias_cache(
 
 fn read_all_aliases_from_config(config: &gix_config::File<'_>) -> HashMap<String, String> {
     let mut aliases = HashMap::new();
+    let mut retained_bytes = 0usize;
     let Some(sections) = config.sections_by_name("alias") else {
         return aliases;
     };
@@ -254,7 +264,24 @@ fn read_all_aliases_from_config(config: &gix_config::File<'_>) -> HashMap<String
                 continue;
             }
             if let Some(value) = body.value(&key_str) {
-                aliases.insert(key_str.to_ascii_lowercase(), value.to_string());
+                let key = key_str.to_ascii_lowercase();
+                if aliases.len() >= MAX_ALIASES_PER_FAMILY && !aliases.contains_key(&key) {
+                    continue;
+                }
+                let value = value.to_string();
+                let previous_bytes = aliases
+                    .get(&key)
+                    .map(|previous: &String| key.len().saturating_add(previous.len()))
+                    .unwrap_or_default();
+                let entry_bytes = key.len().saturating_add(value.len());
+                let next_retained_bytes = retained_bytes
+                    .saturating_sub(previous_bytes)
+                    .saturating_add(entry_bytes);
+                if next_retained_bytes > MAX_RETAINED_ALIAS_BYTES_PER_FAMILY {
+                    continue;
+                }
+                aliases.insert(key, value);
+                retained_bytes = next_retained_bytes;
             }
         }
     }
@@ -562,10 +589,15 @@ fn parse_alias_tokens(value: &str) -> Option<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        GitBackend, SystemGitBackend, clone_init_positionals, default_clone_target_from_source,
+        AliasCacheEntry, GitBackend, MAX_ALIAS_CACHE_FAMILIES, MAX_ALIASES_PER_FAMILY,
+        MAX_RETAINED_ALIAS_BYTES_PER_FAMILY, SystemGitBackend, clone_init_positionals,
+        default_clone_target_from_source, read_all_aliases_from_config, refresh_alias_cache,
     };
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::Mutex;
+    use std::time::Instant;
 
     fn argv(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
@@ -809,5 +841,59 @@ mod tests {
                 .is_err(),
             "unknown commands should still consult repository alias config"
         );
+    }
+
+    #[test]
+    fn alias_cache_does_not_retain_unbounded_repository_families() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let git_dir = temp.path().join(".git");
+        fs::create_dir_all(&git_dir).expect("create git dir");
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+        fs::write(git_dir.join("config"), "[alias]\n    ci = commit\n").expect("write config");
+
+        let cache = Mutex::new(
+            (0..MAX_ALIAS_CACHE_FAMILIES)
+                .map(|index| {
+                    (
+                        format!("family-{index}"),
+                        AliasCacheEntry {
+                            aliases: HashMap::new(),
+                            refreshed_at: Instant::now(),
+                            refresh_in_progress: false,
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>(),
+        );
+
+        refresh_alias_cache(temp.path(), "new-family", &cache);
+
+        let cache = cache.lock().expect("cache lock");
+        assert_eq!(cache.len(), MAX_ALIAS_CACHE_FAMILIES);
+        assert!(cache.contains_key("new-family"));
+    }
+
+    #[test]
+    fn alias_cache_entry_has_count_and_byte_limits() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config");
+        let mut contents = String::from("[alias]\n");
+        for index in 0..1_025 {
+            contents.push_str(&format!("    alias{index} = commit\n"));
+        }
+        contents.push_str(&format!("    huge = {}\n", "x".repeat(1024 * 1024)));
+        fs::write(&config_path, contents).expect("write config");
+        let config =
+            gix_config::File::from_path_no_includes(config_path, gix_config::Source::Local)
+                .expect("parse config");
+
+        let aliases = read_all_aliases_from_config(&config);
+        let retained_bytes = aliases
+            .iter()
+            .map(|(key, value)| key.len().saturating_add(value.len()))
+            .sum::<usize>();
+
+        assert!(aliases.len() <= MAX_ALIASES_PER_FAMILY);
+        assert!(retained_bytes <= MAX_RETAINED_ALIAS_BYTES_PER_FAMILY);
     }
 }

--- a/src/daemon/reducer.rs
+++ b/src/daemon/reducer.rs
@@ -5,6 +5,9 @@ use crate::daemon::domain::{
 use crate::error::GitAiError;
 use std::path::{Path, PathBuf};
 
+const MAX_RETAINED_REFS_PER_FAMILY: usize = 4_096;
+const MAX_RETAINED_WORKTREES_PER_FAMILY: usize = 256;
+
 pub fn reduce_family_command(
     state: &mut FamilyState,
     cmd: NormalizedCommand,
@@ -84,6 +87,16 @@ fn apply_ref_changes(state: &mut FamilyState, cmd: &NormalizedCommand) {
         if change.new.trim().is_empty() || is_zero_oid(&change.new) {
             state.refs.remove(&change.reference);
         } else {
+            if !state.refs.contains_key(&change.reference)
+                && state.refs.len() >= MAX_RETAINED_REFS_PER_FAMILY
+                && let Some(evicted) = state
+                    .refs
+                    .keys()
+                    .find(|reference| reference.as_str() != "HEAD")
+                    .cloned()
+            {
+                state.refs.remove(&evicted);
+            }
             state
                 .refs
                 .insert(change.reference.clone(), change.new.clone());
@@ -145,6 +158,19 @@ fn apply_worktree_state(state: &mut FamilyState, cmd: &NormalizedCommand) {
             last_updated_ns: cmd.finished_at_ns,
         },
     );
+    if state.worktrees.len() > MAX_RETAINED_WORKTREES_PER_FAMILY
+        && let Some(oldest) = state
+            .worktrees
+            .iter()
+            .min_by(|(left_path, left), (right_path, right)| {
+                left.last_updated_ns
+                    .cmp(&right.last_updated_ns)
+                    .then_with(|| left_path.cmp(right_path))
+            })
+            .map(|(path, _)| path.clone())
+    {
+        state.worktrees.remove(&oldest);
+    }
 }
 
 fn unique_branch_for_head_change(
@@ -369,6 +395,58 @@ mod tests {
         let (_applied, _analysis) = reduce_family_command(&mut state, cmd, &registry).unwrap();
 
         assert!(!state.refs.contains_key("refs/heads/feature"));
+    }
+
+    #[test]
+    fn reducer_bounds_retained_refs_and_preserves_head_and_latest_change() {
+        const EXPECTED_LIMIT: usize = 4_096;
+
+        let mut state = family_state();
+        state.refs.insert("HEAD".to_string(), "head".to_string());
+        let registry = AnalyzerRegistry::new();
+        let mut command = normalized();
+        command.ref_changes = (1..=EXPECTED_LIMIT)
+            .map(|index| RefChange {
+                reference: format!("refs/heads/generated-{index}"),
+                old: String::new(),
+                new: format!("{index:040x}"),
+            })
+            .collect();
+
+        reduce_family_command(&mut state, command, &registry).unwrap();
+
+        assert_eq!(state.refs.len(), EXPECTED_LIMIT);
+        assert!(state.refs.contains_key("HEAD"));
+        assert!(
+            state
+                .refs
+                .contains_key(&format!("refs/heads/generated-{EXPECTED_LIMIT}"))
+        );
+    }
+
+    #[test]
+    fn reducer_bounds_retained_worktrees_and_keeps_most_recent() {
+        const EXPECTED_LIMIT: usize = 256;
+
+        let mut state = family_state();
+        let registry = AnalyzerRegistry::new();
+        for index in 0..=EXPECTED_LIMIT {
+            let mut command = normalized();
+            command.worktree = Some(PathBuf::from(format!("/missing/worktree-{index}")));
+            command.finished_at_ns = index as u128;
+            command.ref_changes.clear();
+            reduce_family_command(&mut state, command, &registry).unwrap();
+        }
+
+        assert_eq!(state.worktrees.len(), EXPECTED_LIMIT);
+        assert!(
+            !state
+                .worktrees
+                .contains_key(&PathBuf::from("/missing/worktree-0"))
+        );
+        assert!(state.worktrees.contains_key(&PathBuf::from(format!(
+            "/missing/worktree-{EXPECTED_LIMIT}"
+        ))));
     }
 
     #[test]

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -6,10 +6,16 @@ use crate::git::cli_parser::{
 };
 use crate::git::find_repository_in_path;
 use crate::git::repo_state::{common_dir_for_worktree, git_dir_for_worktree, is_valid_git_oid};
+use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+
+const MAX_RETAINED_STASH_ENTRIES: usize = 4_096;
+const MAX_RETAINED_CHERRY_PICK_SOURCE_OIDS: usize = 4_096;
+const MAX_RETAINED_REF_CURSOR_KEYS: usize = 4_096;
+const MAX_RETAINED_SPARSE_REFLOG_ENTRIES: usize = 4_096;
 
 #[derive(Debug)]
 pub struct RefCursor {
@@ -18,6 +24,7 @@ pub struct RefCursor {
     anchors: HashMap<String, ReflogAnchor>,
     consumed_offsets: HashMap<String, HashSet<u64>>,
     consumed_anchors: HashMap<String, HashMap<u64, ReflogAnchor>>,
+    retained_sparse_entries: usize,
     /// Per-command soft hints from the daemon-ingress reflog offset capture.
     /// Populated at the start of each command's enrichment and cleared when the
     /// next command's enrichment begins. Unlike `offsets` (the authoritative
@@ -94,7 +101,7 @@ struct ReflogRecord {
 struct ReflogAnchor {
     old: String,
     new: String,
-    message: String,
+    message_hash: [u8; 32],
     end_offset: u64,
 }
 
@@ -127,6 +134,7 @@ impl RefCursor {
             anchors: HashMap::new(),
             consumed_offsets: HashMap::new(),
             consumed_anchors: HashMap::new(),
+            retained_sparse_entries: 0,
             command_start_hints: HashMap::new(),
             stash_stack: Vec::new(),
             pending_cherry_pick_source_oids: Vec::new(),
@@ -1805,6 +1813,7 @@ impl RefCursor {
             }
             _ => {}
         }
+        self.stash_stack.truncate(MAX_RETAINED_STASH_ENTRIES);
     }
 
     fn discover_common_refs(&self) -> Result<Vec<String>, GitAiError> {
@@ -1860,9 +1869,9 @@ impl RefCursor {
     }
 
     fn initialize_reflog_cursor(&mut self, key: &str, offset: u64) -> Result<(), GitAiError> {
+        self.ensure_ref_cursor_key(key);
         self.offsets.insert(key.to_string(), offset);
-        self.consumed_offsets.remove(key);
-        self.consumed_anchors.remove(key);
+        self.clear_sparse_entries_for_key(key);
         if offset == 0 {
             self.anchors.remove(key);
             return Ok(());
@@ -1930,6 +1939,15 @@ impl RefCursor {
     }
 
     fn consume_entry(&mut self, entry: &CursorEntry) -> Result<(), GitAiError> {
+        self.ensure_ref_cursor_key(&entry.key);
+        let already_retained = self
+            .consumed_offsets
+            .get(&entry.key)
+            .is_some_and(|offsets| offsets.contains(&entry.end_offset));
+        if !already_retained && self.retained_sparse_entries >= MAX_RETAINED_SPARSE_REFLOG_ENTRIES {
+            self.advance_cursor_to_entry(entry);
+            return Ok(());
+        }
         self.consumed_offsets
             .entry(entry.key.clone())
             .or_default()
@@ -1938,15 +1956,18 @@ impl RefCursor {
             .entry(entry.key.clone())
             .or_default()
             .insert(entry.end_offset, ReflogAnchor::from(entry));
+        if !already_retained {
+            self.retained_sparse_entries = self.retained_sparse_entries.saturating_add(1);
+        }
         self.compact_consumed_entries(&entry.key, &entry.path, &entry.reference)
     }
 
     fn advance_cursor_to_entry(&mut self, entry: &CursorEntry) {
+        self.ensure_ref_cursor_key(&entry.key);
         self.offsets.insert(entry.key.clone(), entry.end_offset);
         self.anchors
             .insert(entry.key.clone(), ReflogAnchor::from(entry));
-        self.consumed_offsets.remove(&entry.key);
-        self.consumed_anchors.remove(&entry.key);
+        self.clear_sparse_entries_for_key(&entry.key);
     }
 
     fn compact_consumed_entries(
@@ -1974,7 +1995,11 @@ impl RefCursor {
                 self.anchors.insert(key.to_string(), anchor);
             }
             if let Some(consumed) = self.consumed_offsets.get_mut(key) {
+                let before = consumed.len();
                 consumed.retain(|offset| *offset > advanced_to);
+                self.retained_sparse_entries = self
+                    .retained_sparse_entries
+                    .saturating_sub(before.saturating_sub(consumed.len()));
                 if consumed.is_empty() {
                     self.consumed_offsets.remove(key);
                 }
@@ -2025,9 +2050,9 @@ impl RefCursor {
         match fs::metadata(&path) {
             Ok(metadata) => {
                 let len = metadata.len();
+                self.ensure_ref_cursor_key(&key);
                 self.offsets.insert(key.clone(), len);
-                self.consumed_offsets.remove(&key);
-                self.consumed_anchors.remove(&key);
+                self.clear_sparse_entries_for_key(&key);
                 if let Some(record) = read_reflog_record_ending_at(&path, len)? {
                     self.anchors.insert(key, ReflogAnchor::from(&record));
                 } else {
@@ -2125,8 +2150,33 @@ impl RefCursor {
     fn clear_ref_cursor(&mut self, key: &str) {
         self.offsets.remove(key);
         self.anchors.remove(key);
-        self.consumed_offsets.remove(key);
+        self.clear_sparse_entries_for_key(key);
+    }
+
+    fn ensure_ref_cursor_key(&mut self, key: &str) {
+        if self.offsets.contains_key(key) {
+            return;
+        }
+        if self.offsets.len() >= MAX_RETAINED_REF_CURSOR_KEYS
+            && let Some(evicted) = self
+                .offsets
+                .keys()
+                .find(|candidate| candidate.starts_with("common:"))
+                .or_else(|| self.offsets.keys().next())
+                .cloned()
+        {
+            self.clear_ref_cursor(&evicted);
+        }
+        self.offsets.insert(key.to_string(), 0);
+    }
+
+    fn clear_sparse_entries_for_key(&mut self, key: &str) {
+        let removed = self
+            .consumed_offsets
+            .remove(key)
+            .map_or(0, |offsets| offsets.len());
         self.consumed_anchors.remove(key);
+        self.retained_sparse_entries = self.retained_sparse_entries.saturating_sub(removed);
     }
 }
 
@@ -2205,7 +2255,7 @@ impl From<&CursorEntry> for ReflogAnchor {
         Self {
             old: entry.old.clone(),
             new: entry.new.clone(),
-            message: entry.message.clone(),
+            message_hash: Sha256::digest(entry.message.as_bytes()).into(),
             end_offset: entry.end_offset,
         }
     }
@@ -2216,7 +2266,7 @@ impl From<&ReflogRecord> for ReflogAnchor {
         Self {
             old: record.old.clone(),
             new: record.new.clone(),
-            message: record.message.clone(),
+            message_hash: Sha256::digest(record.message.as_bytes()).into(),
             end_offset: record.end_offset,
         }
     }
@@ -2404,6 +2454,9 @@ fn resolve_cherry_pick_source_oids_from_sources(
     state: &FamilyState,
     sources: &[&str],
 ) -> Result<Option<Vec<String>>, GitAiError> {
+    if sources.len() > MAX_RETAINED_CHERRY_PICK_SOURCE_OIDS {
+        return Ok(None);
+    }
     let mut out = Vec::new();
     let mut seen = HashSet::new();
 
@@ -3678,6 +3731,79 @@ mod tests {
             revert_source_args(&["-Smy-key".to_string(), "HEAD~1".to_string()]),
             vec!["HEAD~1"]
         );
+    }
+
+    #[test]
+    fn oversized_cherry_pick_source_list_fails_closed() {
+        let family = FamilyKey::new("/tmp/git-ai-source-cap".to_string());
+        let state = family_state(&family);
+        let cmd = command(&family, &["cherry-pick"]);
+        let source_strings = (1..=4_097)
+            .map(|index| format!("{index:040x}"))
+            .collect::<Vec<_>>();
+        let sources = source_strings
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        let resolved = resolve_cherry_pick_source_oids_from_sources(&cmd, &state, &sources)
+            .expect("resolve sources");
+
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn retained_ref_cursor_keys_are_bounded() {
+        let mut cursor = RefCursor::new(FamilyKey::new("/tmp/git-ai-ref-cursor-cap"));
+        for index in 0..=4_096 {
+            cursor
+                .initialize_reflog_cursor(&format!("common:refs/heads/branch-{index}"), 0)
+                .unwrap();
+        }
+
+        assert_eq!(cursor.offsets.len(), 4_096);
+        assert!(cursor.offsets.contains_key("common:refs/heads/branch-4096"));
+    }
+
+    #[test]
+    fn retained_sparse_reflog_entries_are_bounded() {
+        let mut cursor = RefCursor::new(FamilyKey::new("/tmp/git-ai-sparse-cursor-cap"));
+        let key = "common:refs/heads/main";
+        let missing_log = PathBuf::from("/definitely/missing/git-ai-reflog");
+        for index in 1..=4_097_u64 {
+            cursor
+                .consume_entry(&CursorEntry {
+                    key: key.to_string(),
+                    path: missing_log.clone(),
+                    reference: "refs/heads/main".to_string(),
+                    old: A.to_string(),
+                    new: B.to_string(),
+                    message: format!("commit: {index}"),
+                    timestamp_secs: Some(index as i64),
+                    start_offset: index - 1,
+                    end_offset: index,
+                })
+                .unwrap();
+        }
+
+        assert!(cursor.consumed_offsets.get(key).map_or(0, HashSet::len) <= 4_096);
+    }
+
+    #[test]
+    fn reflog_anchor_does_not_retain_the_full_message() {
+        let anchor = ReflogAnchor::from(&CursorEntry {
+            key: "common:refs/heads/main".to_string(),
+            path: PathBuf::from("/tmp/reflog"),
+            reference: "refs/heads/main".to_string(),
+            old: A.to_string(),
+            new: B.to_string(),
+            message: "x".repeat(16 * 1_024),
+            timestamp_secs: Some(1),
+            start_offset: 0,
+            end_offset: 1,
+        });
+
+        assert!(format!("{anchor:?}").len() < 512);
     }
 
     #[test]
@@ -5775,5 +5901,35 @@ mod tests {
             }]
         );
         assert_eq!(cursor.stash_stack, vec![C.to_string()]);
+    }
+
+    #[test]
+    fn stash_cursor_retains_only_a_bounded_newest_stack() {
+        const EXPECTED_LIMIT: usize = 4_096;
+
+        let mut cursor = RefCursor::new(FamilyKey::new("/tmp/family"));
+        for index in 1..=(EXPECTED_LIMIT + 1) {
+            cursor.apply_stash_ref_entry(
+                "push",
+                &CursorEntry {
+                    key: "common:refs/stash".to_string(),
+                    path: PathBuf::from("/tmp/stash-log"),
+                    reference: "refs/stash".to_string(),
+                    old: zero_oid(),
+                    new: format!("{index:040x}"),
+                    message: "stash push".to_string(),
+                    timestamp_secs: None,
+                    start_offset: index as u64,
+                    end_offset: index as u64 + 1,
+                },
+            );
+        }
+
+        assert_eq!(cursor.stash_stack.len(), EXPECTED_LIMIT);
+        assert_eq!(
+            cursor.stash_stack.first(),
+            Some(&format!("{:040x}", EXPECTED_LIMIT + 1))
+        );
+        assert!(!cursor.stash_stack.contains(&format!("{:040x}", 1)));
     }
 }

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -59,6 +59,7 @@ pub struct TraceNormalizer<B: GitBackend> {
 }
 
 const COMPLETED_ROOT_RETENTION_LIMIT: usize = 16_384;
+const MAX_OBSERVED_CHILD_COMMANDS: usize = 64;
 
 impl<B: GitBackend> TraceNormalizer<B> {
     pub fn new(backend: Arc<B>) -> Self {
@@ -461,7 +462,27 @@ impl<B: GitBackend> TraceNormalizer<B> {
         }
 
         if let Some(pending) = self.state.pending.get_mut(root_sid) {
-            pending.observed_child_commands.push(cmd);
+            let already_retained = pending
+                .observed_child_commands
+                .iter()
+                .any(|retained| retained == &cmd);
+            if !already_retained {
+                if pending.observed_child_commands.len() < MAX_OBSERVED_CHILD_COMMANDS {
+                    pending.observed_child_commands.push(cmd);
+                } else {
+                    let has_primary_child = pending
+                        .observed_child_commands
+                        .iter()
+                        .any(|retained| !is_git_binary(retained));
+                    let preserve_late_signal =
+                        cmd == "rebase" || (!has_primary_child && !is_git_binary(&cmd));
+                    if preserve_late_signal
+                        && let Some(last) = pending.observed_child_commands.last_mut()
+                    {
+                        *last = cmd;
+                    }
+                }
+            }
         }
         self.refresh_pending_mutation_capture(root_sid)?;
         Ok(None)
@@ -1635,6 +1656,51 @@ mod tests {
         let cmd = normalizer.ingest_payload(&atexit).unwrap().unwrap();
         assert_eq!(cmd.observed_child_commands, vec!["status".to_string()]);
         assert_eq!(cmd.primary_command.as_deref(), Some("status"));
+    }
+
+    #[test]
+    fn child_command_retention_is_bounded_and_preserves_rebase_signal() {
+        let backend = Arc::new(MockBackend::default());
+        backend.set_family("/repo", "/repo/.git");
+        let mut normalizer = TraceNormalizer::new(backend);
+        normalizer
+            .ingest_payload(&serde_json::json!({
+                "event":"start",
+                "sid":"many-children",
+                "ts":1,
+                "argv":["git","pull"],
+                "worktree":"/repo"
+            }))
+            .unwrap();
+
+        for index in 0..64 {
+            normalizer
+                .ingest_payload(&serde_json::json!({
+                    "event":"cmd_name",
+                    "sid":format!("many-children/child-{index}"),
+                    "ts":index + 2,
+                    "name":format!("child-{index}")
+                }))
+                .unwrap();
+        }
+        normalizer
+            .ingest_payload(&serde_json::json!({
+                "event":"cmd_name",
+                "sid":"many-children/rebase",
+                "ts":100,
+                "name":"rebase"
+            }))
+            .unwrap();
+
+        let children = &normalizer
+            .state()
+            .pending
+            .get("many-children")
+            .expect("pending root")
+            .observed_child_commands;
+        assert_eq!(children.len(), 64);
+        assert_eq!(children.first().map(String::as_str), Some("child-0"));
+        assert!(children.iter().any(|child| child == "rebase"));
     }
 
     #[test]

--- a/tests/integration/daemon_retained_state_memory.rs
+++ b/tests/integration/daemon_retained_state_memory.rs
@@ -1,0 +1,61 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn family_actor_churn_keeps_daemon_bounded_and_attribution_working() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_MAX_FAMILY_ACTORS", "4")]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+
+    let external = tempfile::tempdir().unwrap();
+    for index in 0..12 {
+        let path = external.path().join(format!("repo-{index}"));
+        fs::create_dir_all(&path).unwrap();
+        let path = path.to_string_lossy();
+        repo.git_without_test_sync_for_test(&["-C", &path, "init"], &[])
+            .unwrap();
+        repo.git_without_test_sync_for_test(
+            &["-C", &path, "checkout", "--orphan", "actor-pressure"],
+            &[],
+        )
+        .unwrap();
+    }
+    repo.sync_daemon();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        assert!(
+            hwm_growth_kib < 24 * 1024,
+            "family actor churn grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after family churn")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -52,6 +52,7 @@ mod cross_repo_cwd_attribution;
 mod cursor;
 mod daemon_commit_carryover;
 mod daemon_log_memory;
+mod daemon_retained_state_memory;
 mod diff;
 mod diff_comprehensive;
 mod diff_ignore_binary;


### PR DESCRIPTION
## Bug
Several long-lived daemon maps had no lifecycle ceiling: family actors, trace/reducer auxiliary keys, ref watermarks, pending OIDs, Git aliases, and shell-session payloads. Users touching many repos/paths or emitting many sessions could grow resident state forever.

## Fix
Add explicit count/byte limits and inactive-entry eviction to each retained structure, including a 1,024-family ceiling, bounded watermarks/pending OIDs, and a 32-session/32 MiB shell-session budget. Active attribution state is preserved; excess auxiliary state fails closed.

## Verification
Structure-level tests cover every eviction/limit path. `tests/integration/daemon_retained_state_memory.rs` stresses retained repo families through `TestRepo`.