### PR TITLE
fix(daemon): bound IPC frames and connections

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -43,7 +43,7 @@ daemon-ingress "start" offsets captured after the fact.
 
 ```
 git (trace2 socket target)
-  → socket listener (src/daemon.rs)
+  → bounded socket listener (src/daemon.rs)
       prepare_trace_payload_for_ingest: filters definitely-read-only roots,
       enqueues mutating roots with sequence numbers
   → TraceNormalizer (src/daemon/trace_normalizer.rs)
@@ -55,6 +55,13 @@ git (trace2 socket target)
   → analyzers (src/daemon/analyzers/history.rs)
       classified semantic events → rewrite/post-commit side effects
 ```
+
+The listener rejects trace frames larger than 64 KiB, retains at most 64 root
+SIDs per connection, and admits at most 128 live trace connections. Unix and
+Windows connection handlers use bounded stacks. Exceeding any limit closes the
+affected connection and fails closed for attribution; it never delays or wraps
+the Git command. Control connections are independently capped at 16, with a
+36 MiB request limit that accommodates the default 32 MiB checkpoint budget.
 
 Separation of concerns:
 
@@ -81,8 +88,9 @@ Trust is decided at the cursor, not at ingress (see below).
 Per family, the cursor stores per-ref-key:
 
 - byte offset into the reflog file (always at a line boundary)
-- anchor: the full reflog record ending at that offset (old/new OIDs,
-  message) proving the offset still belongs to the same reflog generation
+- anchor: the old/new OIDs, end offset, and a SHA-256 message fingerprint for
+  the reflog record ending at that offset, proving the offset still belongs to
+  the same reflog generation without retaining an unbounded message
 - consumed offsets/anchors (entries already owned by earlier commands)
 - in-memory stash stack and pending cherry-pick source OIDs
 

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -528,42 +528,32 @@ fn handle_checkpoint(args: &[String]) {
         );
     }
 
-    let t_daemon_config = std::time::Instant::now();
-    let daemon_config =
-        crate::daemon::DaemonConfig::from_env_or_default_paths().map_err(|e| e.to_string());
-
-    let config = match daemon_config {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Background worker unavailable: {}", e);
-            std::process::exit(0);
-        }
-    };
-
-    if perf {
-        eprintln!(
-            "[perf] checkpoint: daemon_config={:.1}ms",
-            t_daemon_config.elapsed().as_secs_f64() * 1000.0
-        );
-    }
-
     let mut sent_count = 0u64;
     for request in requests {
         let t_send = std::time::Instant::now();
         let control_request = ControlRequest::CheckpointRun {
             request: Box::new(request),
         };
-        let send_result =
-            crate::daemon::send_control_request(&config.control_socket_path, &control_request);
+        let send_result = crate::daemon::telemetry_handle::send_via_daemon(&control_request);
         if perf {
             eprintln!(
                 "[perf] checkpoint: ipc_send={:.1}ms",
                 t_send.elapsed().as_secs_f64() * 1000.0,
             );
         }
-        if let Err(e) = send_result {
-            eprintln!("Failed to send checkpoint to background worker: {}", e);
-            std::process::exit(0);
+        match send_result {
+            Ok(response) if response.ok => {}
+            Ok(response) => {
+                eprintln!(
+                    "Background worker rejected checkpoint: {}",
+                    response.error.as_deref().unwrap_or("unknown daemon error")
+                );
+                std::process::exit(0);
+            }
+            Err(e) => {
+                eprintln!("Failed to send checkpoint to background worker: {}", e);
+                std::process::exit(0);
+            }
         }
         sent_count += 1;
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -102,6 +102,13 @@ const TRACE_SOCKET_RECV_BUFFER_BYTES: usize = 512 * 1024;
 const TRACE_INGEST_QUEUE_CAPACITY: usize = 16_384;
 const MAX_RETAINED_AUXILIARY_STATE_KEYS: usize = 1_024;
 const MAX_RETAINED_PENDING_OIDS: usize = 4_096;
+const MAX_TRACE_JSON_LINE_BYTES: usize = 64 * 1024;
+const MAX_CONTROL_JSON_LINE_BYTES: usize = 36 * 1024 * 1024;
+const MAX_TRACE_CONNECTION_ROOTS: usize = 64;
+const MAX_TRACE_SID_BYTES: usize = 1_024;
+const MAX_TRACE_CONNECTIONS: usize = 128;
+const MAX_CONTROL_CONNECTIONS: usize = 16;
+const CONNECTION_HANDLER_STACK_BYTES: usize = 512 * 1024;
 #[cfg(not(windows))]
 const TRACE_CONNECTION_BOOTSTRAP_READ_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(windows)]
@@ -2364,13 +2371,71 @@ fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
-fn read_json_line<R: BufRead>(reader: &mut R) -> Result<Option<String>, GitAiError> {
-    let mut line = String::new();
-    let read = reader.read_line(&mut line)?;
-    if read == 0 {
-        return Ok(None);
+pub(crate) fn read_json_line_with_limit<R: BufRead>(
+    reader: &mut R,
+    max_bytes: usize,
+) -> Result<Option<String>, GitAiError> {
+    let mut line = Vec::with_capacity(max_bytes.min(8 * 1024));
+    loop {
+        let available = loop {
+            match reader.fill_buf() {
+                Ok(available) => break available,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error.into()),
+            }
+        };
+        if available.is_empty() {
+            if line.is_empty() {
+                return Ok(None);
+            }
+            break;
+        }
+        let chunk_len = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |index| index + 1);
+        if line.len().saturating_add(chunk_len) > max_bytes {
+            return Err(GitAiError::Generic(format!(
+                "daemon JSON line exceeds {max_bytes} bytes"
+            )));
+        }
+        line.extend_from_slice(&available[..chunk_len]);
+        reader.consume(chunk_len);
+        if line.last() == Some(&b'\n') {
+            break;
+        }
     }
-    Ok(Some(line))
+    String::from_utf8(line)
+        .map(Some)
+        .map_err(|error| GitAiError::IoError(io::Error::new(io::ErrorKind::InvalidData, error)))
+}
+
+fn try_acquire_connection_slot(counter: &AtomicUsize, limit: usize) -> bool {
+    counter
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+            (active < limit).then_some(active + 1)
+        })
+        .is_ok()
+}
+
+fn release_connection_slot(counter: &AtomicUsize) {
+    let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+        Some(active.saturating_sub(1))
+    });
+}
+
+fn configured_connection_limit(env_name: &str, default: usize) -> usize {
+    let is_test_daemon = std::env::var_os("GIT_AI_TEST_DB_PATH").is_some()
+        || std::env::var_os("GITAI_TEST_DB_PATH").is_some();
+    if is_test_daemon
+        && let Some(limit) = std::env::var(env_name)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|limit| *limit > 0)
+    {
+        return limit;
+    }
+    default
 }
 
 #[derive(Debug)]
@@ -2400,6 +2465,27 @@ struct FamilySequencerState {
 struct PendingRootSlot {
     family: String,
     order: FamilySequencerOrder,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DaemonConnectionKind {
+    Control,
+    Trace,
+}
+
+struct DaemonConnectionPermit {
+    coordinator: Arc<ActorDaemonCoordinator>,
+    kind: DaemonConnectionKind,
+}
+
+impl Drop for DaemonConnectionPermit {
+    fn drop(&mut self) {
+        let counter = match self.kind {
+            DaemonConnectionKind::Control => &self.coordinator.active_control_connections,
+            DaemonConnectionKind::Trace => &self.coordinator.active_trace_connections,
+        };
+        release_connection_slot(counter);
+    }
 }
 
 type CommitFileTimestampSnapshotHandle =
@@ -2491,6 +2577,10 @@ pub struct ActorDaemonCoordinator {
     processed_trace_ingest_seq: AtomicUsize,
     trace_ingest_progress_notify: Notify,
     trace_ingress_state: Mutex<TraceIngressState>,
+    active_control_connections: AtomicUsize,
+    active_trace_connections: AtomicUsize,
+    max_control_connections: usize,
+    max_trace_connections: usize,
     shutting_down: AtomicBool,
     shutdown_action: AtomicU8,
     shutdown_notify: Notify,
@@ -2581,6 +2671,16 @@ impl ActorDaemonCoordinator {
             processed_trace_ingest_seq: AtomicUsize::new(0),
             trace_ingest_progress_notify: Notify::new(),
             trace_ingress_state: Mutex::new(TraceIngressState::default()),
+            active_control_connections: AtomicUsize::new(0),
+            active_trace_connections: AtomicUsize::new(0),
+            max_control_connections: configured_connection_limit(
+                "GIT_AI_TEST_MAX_CONTROL_CONNECTIONS",
+                MAX_CONTROL_CONNECTIONS,
+            ),
+            max_trace_connections: configured_connection_limit(
+                "GIT_AI_TEST_MAX_TRACE_CONNECTIONS",
+                MAX_TRACE_CONNECTIONS,
+            ),
             shutting_down: AtomicBool::new(false),
             shutdown_action: AtomicU8::new(DaemonExitAction::Stop.as_u8()),
             shutdown_notify: Notify::new(),
@@ -2593,6 +2693,58 @@ impl ActorDaemonCoordinator {
         // Acquire pairs with the Release store in request_shutdown so all
         // writes made before shutdown is requested are visible to the caller.
         self.shutting_down.load(Ordering::Acquire)
+    }
+
+    fn try_acquire_connection(
+        self: &Arc<Self>,
+        kind: DaemonConnectionKind,
+    ) -> Option<DaemonConnectionPermit> {
+        let (counter, limit) = match kind {
+            DaemonConnectionKind::Control => (
+                &self.active_control_connections,
+                self.max_control_connections,
+            ),
+            DaemonConnectionKind::Trace => {
+                (&self.active_trace_connections, self.max_trace_connections)
+            }
+        };
+        try_acquire_connection_slot(counter, limit).then(|| DaemonConnectionPermit {
+            coordinator: self.clone(),
+            kind,
+        })
+    }
+
+    fn acquire_connection_with_backpressure(
+        self: &Arc<Self>,
+        kind: DaemonConnectionKind,
+    ) -> Option<DaemonConnectionPermit> {
+        if let Some(permit) = self.try_acquire_connection(kind) {
+            return Some(permit);
+        }
+
+        let limit = match kind {
+            DaemonConnectionKind::Control => self.max_control_connections,
+            DaemonConnectionKind::Trace => self.max_trace_connections,
+        };
+        tracing::debug!(
+            ?kind,
+            limit,
+            "connection capacity exhausted; applying listener backpressure"
+        );
+
+        // The listener already owns one accepted stream. Keep it bounded here
+        // so socket backpressure delays writers instead of discarding data.
+        let mut delay = std::time::Duration::from_micros(100);
+        while !self.is_shutting_down() {
+            std::thread::sleep(delay);
+            if let Some(permit) = self.try_acquire_connection(kind) {
+                return Some(permit);
+            }
+            delay = delay
+                .saturating_mul(2)
+                .min(std::time::Duration::from_millis(5));
+        }
+        None
     }
 
     fn trigger_transcript_sweep(&self, trigger: crate::daemon::stream_worker::SweepTrigger) {
@@ -6271,10 +6423,18 @@ fn control_listener_loop_actor(
             let Ok(stream) = stream else {
                 continue;
             };
+            let Some(permit) =
+                coordinator.acquire_connection_with_backpressure(DaemonConnectionKind::Control)
+            else {
+                break;
+            };
             let coord = coordinator.clone();
             let handle = runtime_handle.clone();
             if std::thread::Builder::new()
+                .name("git-ai-control-connection".to_string())
+                .stack_size(CONNECTION_HANDLER_STACK_BYTES)
                 .spawn(move || {
+                    let _permit = permit;
                     if let Err(e) = handle_control_connection_actor(stream, coord, handle) {
                         tracing::debug!(%e, "control connection error");
                     }
@@ -6416,8 +6576,17 @@ fn windows_control_pipe_worker_loop(
 
         let coord = coordinator.clone();
         let handle = runtime_handle.clone();
+        let Some(permit) =
+            coord.acquire_connection_with_backpressure(DaemonConnectionKind::Control)
+        else {
+            let _ = server.disconnect();
+            break;
+        };
         std::thread::Builder::new()
+            .name("git-ai-control-connection".to_string())
+            .stack_size(CONNECTION_HANDLER_STACK_BYTES)
             .spawn(move || {
+                let _permit = permit;
                 handle_windows_control_pipe_connection(server, coord, handle);
             })
             .map_err(|e| {
@@ -6460,7 +6629,7 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
     coordinator: Arc<ActorDaemonCoordinator>,
     runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), GitAiError> {
-    while let Some(line) = read_json_line(reader)? {
+    while let Some(line) = read_json_line_with_limit(reader, MAX_CONTROL_JSON_LINE_BYTES)? {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -6503,6 +6672,11 @@ fn trace_listener_loop_actor(
             }
             let Ok(stream) = stream else {
                 continue;
+            };
+            let Some(permit) =
+                coordinator.acquire_connection_with_backpressure(DaemonConnectionKind::Trace)
+            else {
+                break;
             };
             // Raise the receive buffer on each accepted connection. Unlike TCP,
             // a Unix-domain listener's SO_RCVBUF is not inherited by accepted
@@ -6576,7 +6750,10 @@ fn trace_listener_loop_actor(
             let coord = coordinator.clone();
             let observed_roots_on_spawn_failure = observed_roots.clone();
             if std::thread::Builder::new()
+                .name("git-ai-trace-connection".to_string())
+                .stack_size(CONNECTION_HANDLER_STACK_BYTES)
                 .spawn(move || {
+                    let _permit = permit;
                     if let Err(e) =
                         handle_trace_connection_actor_reader(reader, coord, observed_roots)
                     {
@@ -6672,8 +6849,16 @@ fn windows_trace_pipe_worker_loop(
         connecting = windows_pipe_connecting_server(&trace_socket_path, false)?;
 
         let coord = coordinator.clone();
+        let Some(permit) = coord.acquire_connection_with_backpressure(DaemonConnectionKind::Trace)
+        else {
+            let _ = server.disconnect();
+            break;
+        };
         std::thread::Builder::new()
+            .name("git-ai-trace-connection".to_string())
+            .stack_size(CONNECTION_HANDLER_STACK_BYTES)
             .spawn(move || {
+                let _permit = permit;
                 handle_windows_trace_pipe_connection(server, coord);
             })
             .map_err(|e| {
@@ -6739,7 +6924,7 @@ fn bootstrap_trace_connection_actor_reader<R: Read>(
     observed_roots: &mut std::collections::BTreeSet<String>,
 ) -> Result<TraceConnectionBootstrap, GitAiError> {
     for _ in 0..TRACE_CONNECTION_BOOTSTRAP_MAX_LINES {
-        let line = match read_json_line(reader) {
+        let line = match read_json_line_with_limit(reader, MAX_TRACE_JSON_LINE_BYTES) {
             Ok(Some(line)) => line,
             Ok(None) => return Ok(TraceConnectionBootstrap::Eof),
             Err(error) if trace_bootstrap_read_timed_out(&error) => {
@@ -6779,7 +6964,7 @@ fn handle_trace_connection_actor_reader<R: Read>(
     coordinator: Arc<ActorDaemonCoordinator>,
     mut observed_roots: std::collections::BTreeSet<String>,
 ) -> Result<(), GitAiError> {
-    while let Some(line) = read_json_line(&mut reader)? {
+    while let Some(line) = read_json_line_with_limit(&mut reader, MAX_TRACE_JSON_LINE_BYTES)? {
         if process_trace_connection_line(&line, coordinator.clone(), &mut observed_roots)?
             .is_some_and(|outcome| !outcome.continue_reading)
         {
@@ -6812,8 +6997,23 @@ fn process_trace_connection_line(
     #[cfg(not(windows))]
     let mut bootstrap_complete = false;
     if let Some(sid) = parsed.get("sid").and_then(Value::as_str) {
+        if sid.len() > MAX_TRACE_SID_BYTES {
+            return Ok(Some(TraceLineOutcome {
+                continue_reading: false,
+                #[cfg(not(windows))]
+                bootstrap_complete: true,
+            }));
+        }
         let was_unidentified = observed_roots.is_empty();
         let root_sid = trace_root_sid(sid).to_string();
+        if !observed_roots.contains(&root_sid) && observed_roots.len() >= MAX_TRACE_CONNECTION_ROOTS
+        {
+            return Ok(Some(TraceLineOutcome {
+                continue_reading: false,
+                #[cfg(not(windows))]
+                bootstrap_complete: true,
+            }));
+        }
         // `start` carries argv but not the worktree. Keep bootstrapping on the
         // listener thread until the root `def_repo` event has been processed;
         // that is the first point where trace augmentation can capture reflog
@@ -7546,8 +7746,8 @@ fn write_all_daemon_client_stream(
     Ok(())
 }
 
-fn read_daemon_client_line(
-    reader: &mut BufReader<DaemonClientStream>,
+fn read_daemon_client_line<R: BufRead>(
+    reader: &mut R,
     socket_path: &Path,
     response_timeout: Duration,
 ) -> Result<String, GitAiError> {
@@ -7562,6 +7762,7 @@ fn read_daemon_client_line(
                 )));
             }
             Ok(_) => return Ok(line),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(error)
                 if matches!(
                     error.kind(),
@@ -7711,7 +7912,165 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::ffi::OsString;
-    use std::io::Write;
+    use std::io::{Read, Write};
+
+    struct InterruptOnceReader<R> {
+        inner: R,
+        interrupted: bool,
+    }
+
+    impl<R> InterruptOnceReader<R> {
+        fn new(inner: R) -> Self {
+            Self {
+                inner,
+                interrupted: false,
+            }
+        }
+    }
+
+    impl<R: Read> Read for InterruptOnceReader<R> {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            if !self.interrupted {
+                self.interrupted = true;
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            self.inner.read(buffer)
+        }
+    }
+
+    struct InterruptingBufRead {
+        state: u8,
+    }
+
+    impl Read for InterruptingBufRead {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            let available = self.fill_buf()?;
+            let len = available.len().min(buffer.len());
+            buffer[..len].copy_from_slice(&available[..len]);
+            self.consume(len);
+            Ok(len)
+        }
+    }
+
+    impl BufRead for InterruptingBufRead {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            match self.state {
+                0 => Ok(b"{\"ok\":"),
+                1 => {
+                    self.state += 1;
+                    Err(io::Error::from(io::ErrorKind::Interrupted))
+                }
+                2 => Ok(b"true}\n"),
+                _ => Ok(&[]),
+            }
+        }
+
+        fn consume(&mut self, amount: usize) {
+            let expected = match self.state {
+                0 => b"{\"ok\":".len(),
+                2 => b"true}\n".len(),
+                _ => 0,
+            };
+            assert_eq!(amount, expected);
+            self.state += 1;
+        }
+    }
+
+    #[test]
+    fn bounded_json_line_reader_rejects_oversized_frames() {
+        let mut reader = BufReader::new(std::io::Cursor::new(b"0123456789abcdefX\n"));
+
+        let error = read_json_line_with_limit(&mut reader, 16).unwrap_err();
+
+        assert!(error.to_string().contains("exceeds 16 bytes"));
+    }
+
+    #[test]
+    fn bounded_json_line_reader_preserves_complete_lines() {
+        let mut reader = BufReader::new(std::io::Cursor::new(b"{\"one\":1}\n{\"two\":2}\n"));
+
+        assert_eq!(
+            read_json_line_with_limit(&mut reader, 64).unwrap(),
+            Some("{\"one\":1}\n".to_string())
+        );
+        assert_eq!(
+            read_json_line_with_limit(&mut reader, 64).unwrap(),
+            Some("{\"two\":2}\n".to_string())
+        );
+        assert_eq!(read_json_line_with_limit(&mut reader, 64).unwrap(), None);
+    }
+
+    #[test]
+    fn bounded_json_line_reader_retries_interrupted_reads() {
+        let source = InterruptOnceReader::new(std::io::Cursor::new(b"{\"one\":1}\n"));
+        let mut reader = BufReader::new(source);
+
+        assert_eq!(
+            read_json_line_with_limit(&mut reader, 64).unwrap(),
+            Some("{\"one\":1}\n".to_string())
+        );
+    }
+
+    #[test]
+    fn daemon_client_line_reader_retries_interrupted_reads() {
+        let mut reader = InterruptingBufRead { state: 0 };
+
+        assert_eq!(
+            read_daemon_client_line(
+                &mut reader,
+                Path::new("test-control.sock"),
+                Duration::from_secs(1)
+            )
+            .unwrap(),
+            "{\"ok\":true}\n"
+        );
+    }
+
+    #[test]
+    fn connection_slot_counter_is_bounded_and_reusable() {
+        let counter = AtomicUsize::new(0);
+
+        assert!(try_acquire_connection_slot(&counter, 2));
+        assert!(try_acquire_connection_slot(&counter, 2));
+        assert!(!try_acquire_connection_slot(&counter, 2));
+        release_connection_slot(&counter);
+        assert!(try_acquire_connection_slot(&counter, 2));
+        assert_eq!(counter.load(Ordering::Acquire), 2);
+    }
+
+    #[tokio::test]
+    async fn trace_connection_tracks_only_a_bounded_number_of_roots() {
+        let coordinator = Arc::new(ActorDaemonCoordinator::new());
+        let mut roots = std::collections::BTreeSet::new();
+        for index in 0..64 {
+            let line = serde_json::json!({
+                "event": "start",
+                "sid": format!("root-{index}"),
+                "argv": ["git", "status"],
+                "time_ns": index,
+            })
+            .to_string();
+            let outcome = process_trace_connection_line(&line, coordinator.clone(), &mut roots)
+                .unwrap()
+                .unwrap();
+            assert!(outcome.continue_reading);
+        }
+
+        let overflow = serde_json::json!({
+            "event": "start",
+            "sid": "root-overflow",
+            "argv": ["git", "status"],
+            "time_ns": 100,
+        })
+        .to_string();
+        let outcome = process_trace_connection_line(&overflow, coordinator.clone(), &mut roots)
+            .unwrap()
+            .unwrap();
+
+        assert!(!outcome.continue_reading);
+        assert_eq!(roots.len(), 64);
+        finalize_trace_connection_roots(coordinator, roots).unwrap();
+    }
 
     struct EnvVarGuard {
         key: &'static str,

--- a/src/daemon/telemetry_handle.rs
+++ b/src/daemon/telemetry_handle.rs
@@ -38,11 +38,24 @@ impl DaemonTelemetryHandle {
     /// blocks indefinitely (which would hold the global mutex and stall the
     /// entire process).
     fn apply_socket_timeouts(stream: &mut DaemonClientStream, socket_path: &std::path::Path) {
-        let _ = crate::daemon::set_daemon_client_stream_timeouts(
-            stream,
-            socket_path,
-            DAEMON_SOCKET_IO_TIMEOUT,
-        );
+        Self::apply_socket_timeout(stream, socket_path, DAEMON_SOCKET_IO_TIMEOUT);
+    }
+
+    fn apply_socket_timeout(
+        stream: &mut DaemonClientStream,
+        socket_path: &std::path::Path,
+        timeout: Duration,
+    ) {
+        let _ = crate::daemon::set_daemon_client_stream_timeouts(stream, socket_path, timeout);
+    }
+
+    fn reconnect(&mut self) -> Result<(), String> {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&self.socket_path, Duration::from_secs(1))
+                .map_err(|error| error.to_string())?;
+        Self::apply_socket_timeouts(&mut stream, &self.socket_path);
+        self.conn = BufReader::new(stream);
+        Ok(())
     }
 
     /// Send a control request over the persistent connection and read the response.
@@ -50,18 +63,23 @@ impl DaemonTelemetryHandle {
     fn send(&mut self, request: &ControlRequest) -> Result<ControlResponse, String> {
         match self.send_inner(request) {
             Ok(resp) => Ok(resp),
+            Err(error) if matches!(request, ControlRequest::CheckpointRun { .. }) => {
+                // The daemon may have accepted the checkpoint before the response
+                // failed, so never replay it. Heal the persistent socket for the
+                // next request without changing this request's error result.
+                match self.reconnect() {
+                    Ok(()) => Err(error),
+                    Err(reconnect_error) => Err(format!(
+                        "send failed ({error}), reconnect also failed ({reconnect_error})"
+                    )),
+                }
+            }
             Err(first_err) => {
                 // Connection may have been dropped by the daemon; try reconnecting once.
-                match open_local_socket_stream_with_timeout(
-                    &self.socket_path,
-                    Duration::from_secs(1),
-                ) {
-                    Ok(mut stream) => {
-                        Self::apply_socket_timeouts(&mut stream, &self.socket_path);
-                        self.conn = BufReader::new(stream);
-                        self.send_inner(request)
-                            .map_err(|e| format!("reconnect ok but send failed: {}", e))
-                    }
+                match self.reconnect() {
+                    Ok(()) => self
+                        .send_inner(request)
+                        .map_err(|e| format!("reconnect ok but send failed: {}", e)),
                     Err(reconnect_err) => Err(format!(
                         "send failed ({}), reconnect also failed ({})",
                         first_err, reconnect_err
@@ -72,6 +90,17 @@ impl DaemonTelemetryHandle {
     }
 
     fn send_inner(&mut self, request: &ControlRequest) -> Result<ControlResponse, String> {
+        Self::apply_socket_timeout(
+            self.conn.get_mut(),
+            &self.socket_path,
+            crate::daemon::control_request_response_timeout(request),
+        );
+        let result = self.exchange(request);
+        Self::apply_socket_timeouts(self.conn.get_mut(), &self.socket_path);
+        result
+    }
+
+    fn exchange(&mut self, request: &ControlRequest) -> Result<ControlResponse, String> {
         let mut body = serde_json::to_vec(request).map_err(|e| e.to_string())?;
         body.push(b'\n');
         self.conn
@@ -250,4 +279,134 @@ pub fn submit_cas(records: Vec<CasSyncPayload>) {
 pub fn submit_notes() {
     let request = ControlRequest::FlushNotes;
     let _ = send_via_daemon(&request);
+}
+
+#[cfg(all(test, not(windows)))]
+mod tests {
+    use super::*;
+    use crate::authorship::working_log::CheckpointKind;
+    use crate::commands::checkpoint_agent::orchestrator::{
+        BaseCommit, CheckpointFile, CheckpointRequest,
+    };
+    use crate::daemon::checkpoint::PreparedPathRole;
+    use interprocess::local_socket::{ListenerOptions, prelude::*};
+    use std::io::{BufRead, BufReader, Write};
+    use std::path::PathBuf;
+    use std::thread;
+
+    fn checkpoint_request(trace_id: &str) -> ControlRequest {
+        ControlRequest::CheckpointRun {
+            request: Box::new(CheckpointRequest {
+                trace_id: trace_id.to_string(),
+                checkpoint_kind: CheckpointKind::Human,
+                agent_id: None,
+                files: vec![CheckpointFile {
+                    path: PathBuf::from("test.txt"),
+                    content: None,
+                    repo_work_dir: PathBuf::from("/tmp/repo"),
+                    base_commit: BaseCommit::Initial,
+                }],
+                path_role: PreparedPathRole::WillEdit,
+                stream_source: None,
+                metadata: Default::default(),
+            }),
+        }
+    }
+
+    fn bind_test_listener(socket_path: &std::path::Path) -> LocalSocketListener {
+        ListenerOptions::new()
+            .name(crate::daemon::local_socket_name(socket_path).unwrap())
+            .create_sync()
+            .unwrap()
+    }
+
+    fn connect_test_handle(socket_path: &std::path::Path) -> DaemonTelemetryHandle {
+        let mut stream =
+            open_local_socket_stream_with_timeout(socket_path, Duration::from_secs(1)).unwrap();
+        DaemonTelemetryHandle::apply_socket_timeouts(&mut stream, socket_path);
+        DaemonTelemetryHandle {
+            socket_path: socket_path.to_path_buf(),
+            conn: BufReader::new(stream),
+        }
+    }
+
+    fn read_request_and_respond(stream: LocalSocketStream, delay: Duration) -> ControlRequest {
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        let request = serde_json::from_str(line.trim()).unwrap();
+        thread::sleep(delay);
+        let response = serde_json::to_string(&ControlResponse::ok(None, None)).unwrap();
+        reader.get_mut().write_all(response.as_bytes()).unwrap();
+        reader.get_mut().write_all(b"\n").unwrap();
+        reader.get_mut().flush().unwrap();
+        request
+    }
+
+    #[test]
+    fn persistent_handle_honors_long_control_request_timeout() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let socket_path = temp_dir.path().join("control.sock");
+        let listener = bind_test_listener(&socket_path);
+        let server = thread::spawn(move || {
+            let stream = listener.incoming().next().unwrap().unwrap();
+            read_request_and_respond(stream, Duration::from_millis(2_100))
+        });
+        let mut handle = connect_test_handle(&socket_path);
+
+        let response = handle.send(&ControlRequest::SyncFamily {
+            repo_working_dir: "/tmp/repo".to_string(),
+        });
+
+        assert!(
+            response.is_ok(),
+            "long control request failed: {response:?}"
+        );
+        assert!(matches!(
+            server.join().unwrap(),
+            ControlRequest::SyncFamily { .. }
+        ));
+    }
+
+    #[test]
+    fn failed_checkpoint_heals_connection_without_replaying_request() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let socket_path = temp_dir.path().join("control.sock");
+        let listener = bind_test_listener(&socket_path);
+        let server = thread::spawn(move || {
+            let first_stream = listener.incoming().next().unwrap().unwrap();
+            let mut first_reader = BufReader::new(first_stream);
+            let mut first_line = String::new();
+            first_reader.read_line(&mut first_line).unwrap();
+            drop(first_reader);
+
+            let second_stream = listener.incoming().next().unwrap().unwrap();
+            let second_request = read_request_and_respond(second_stream, Duration::from_millis(0));
+            (first_line, second_request)
+        });
+        let mut handle = connect_test_handle(&socket_path);
+
+        assert!(handle.send(&checkpoint_request("first")).is_err());
+        let second = handle.send(&checkpoint_request("second"));
+        if second.is_err() {
+            // Unblock the test server on the red path where the failed checkpoint
+            // did not establish a fresh connection.
+            let _ = open_local_socket_stream_with_timeout(&socket_path, Duration::from_secs(1));
+        }
+
+        assert!(
+            second.is_ok(),
+            "healed checkpoint connection failed: {second:?}"
+        );
+        let (first_line, second_request) = server.join().unwrap();
+        let first_request: ControlRequest = serde_json::from_str(first_line.trim()).unwrap();
+        assert!(matches!(
+            first_request,
+            ControlRequest::CheckpointRun { .. }
+        ));
+        let ControlRequest::CheckpointRun { request } = second_request else {
+            panic!("reconnected socket received a replay or non-checkpoint request");
+        };
+        assert_eq!(request.trace_id, "second");
+    }
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -640,13 +640,16 @@ impl WorkdirRaceHarness {
             .env("GIT_AI_DAEMON_CHECKPOINT_DELEGATE", "true")
             .output()
             .expect("failed to execute delegated checkpoint");
+        let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
-            output.status.success(),
+            output.status.success()
+                && !stderr.contains("Background worker rejected checkpoint")
+                && !stderr.contains("Failed to send checkpoint to background worker"),
             "delegated checkpoint failed in {} for {} \nstdout:{}\nstderr:{}",
             workdir.display(),
             file_rel,
             String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
+            stderr
         );
     }
 
@@ -4417,9 +4420,13 @@ fn daemon_memory_does_not_grow_unbounded_under_trace_load() {
     fs::write(repo.path().join("init.txt"), "init\n").expect("write failed");
     repo.git(&["add", "init.txt"]).expect("add failed");
     repo.git(&["commit", "-m", "init"]).expect("commit failed");
+    repo.filename("init.txt")
+        .assert_committed_lines(crate::lines!["init".unattributed_human()]);
 
-    let mut guard = DaemonGuard::start(&repo);
-    let pid = guard.child.id();
+    let pid = repo
+        .daemon_pid()
+        .expect("dedicated daemon should be running");
+    let trace_socket_path = repo.daemon_trace_socket_path();
 
     // Let the daemon settle after startup.
     thread::sleep(Duration::from_millis(500));
@@ -4436,15 +4443,17 @@ fn daemon_memory_does_not_grow_unbounded_under_trace_load() {
 
     // Send 2000 complete git trace lifecycle rounds (start + exit + atexit).
     // Each round simulates a complete `git status` invocation with a unique SID.
-    for batch in 0..20 {
+    // Keep each connection below the per-connection root SID limit while
+    // preserving the full 2,000-command load across sequential connections.
+    for batch in 0..40 {
         let mut frames = Vec::new();
-        for i in 0..100u64 {
+        for i in 0..50u64 {
             let sid = format!("stress-{}-{}", batch, i);
             frames.push(serde_json::json!({
                 "event": "start",
                 "sid": &sid,
                 "argv": ["git", "status"],
-                "time_ns": 1000000000u64 + (batch * 100) as u64 + i,
+                "time_ns": 1000000000u64 + (batch * 50) as u64 + i,
             }));
             frames.push(serde_json::json!({
                 "event": "def_repo",
@@ -4456,15 +4465,15 @@ fn daemon_memory_does_not_grow_unbounded_under_trace_load() {
                 "event": "exit",
                 "sid": &sid,
                 "code": 0,
-                "time_ns": 1000000001u64 + (batch * 100) as u64 + i,
+                "time_ns": 1000000001u64 + (batch * 50) as u64 + i,
             }));
             frames.push(trace_atexit_frame(
                 &sid,
                 0,
-                1000000002u64 + (batch * 100) as u64 + i,
+                1000000002u64 + (batch * 50) as u64 + i,
             ));
         }
-        send_trace_frames(&guard.trace_socket_path, &frames);
+        send_trace_frames(&trace_socket_path, &frames);
         // Small delay to let the daemon process frames.
         thread::sleep(Duration::from_millis(50));
     }
@@ -4491,7 +4500,17 @@ fn daemon_memory_does_not_grow_unbounded_under_trace_load() {
         eprintln!("RSS measurement unavailable, verifying daemon survived load");
     }
 
-    guard.shutdown();
+    let status = send_control_request(
+        &repo.daemon_control_socket_path(),
+        &ControlRequest::StatusFamily {
+            repo_working_dir: repo_workdir_string(&repo),
+        },
+    )
+    .expect("dedicated daemon should survive trace load");
+    assert!(
+        status.ok,
+        "dedicated daemon rejected status after trace load"
+    );
 }
 
 fn bg_command(repo: &TestRepo, subcommand: &str, extra_args: &[&str]) -> Output {

--- a/tests/integration/daemon_ipc_memory.rs
+++ b/tests/integration/daemon_ipc_memory.rs
@@ -1,0 +1,268 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+#[cfg(not(windows))]
+use crate::repos::test_repo::new_daemon_test_sync_session_id;
+use git_ai::daemon::open_local_socket_stream_with_timeout;
+#[cfg(not(windows))]
+use git_ai::daemon::{ControlRequest, send_control_request_with_timeout};
+use std::fs;
+use std::io::Write;
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+#[test]
+fn oversized_trace_frame_keeps_daemon_bounded_and_attribution_working() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+
+    let mut stream = open_local_socket_stream_with_timeout(
+        &repo.daemon_trace_socket_path(),
+        Duration::from_secs(2),
+    )
+    .expect("connect trace socket");
+    let mut frame = Vec::with_capacity(32 * 1024 * 1024);
+    frame.extend_from_slice(br#"{"event":"start","sid":"oversized","padding":""#);
+    frame.resize(32 * 1024 * 1024 - 3, b'x');
+    frame.extend_from_slice(b"\"}\n");
+    let _ = stream.write_all(&frame);
+    let _ = stream.flush();
+    drop(stream);
+    std::thread::sleep(Duration::from_millis(250));
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        assert!(
+            hwm_growth_kib < 24 * 1024,
+            "oversized trace frame grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after oversized frame")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn trace_connection_limit_backpressures_without_losing_commands() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_MAX_TRACE_CONNECTIONS", "4")]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    let trace_socket = repo.daemon_trace_socket_path();
+    let worktree = repo.path().to_string_lossy();
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+    let mut stalled_streams = Vec::new();
+    for index in 0..4 {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&trace_socket, Duration::from_secs(2))
+                .expect("connect stalled trace socket");
+        let sid = format!("stalled-{index}");
+        let frames = format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "event": "start",
+                "sid": sid,
+                "argv": ["git", "status"],
+                "worktree": worktree,
+                "time_ns": index,
+            }),
+            serde_json::json!({
+                "event": "def_repo",
+                "sid": sid,
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": index + 1,
+            })
+        );
+        stream.write_all(frames.as_bytes()).unwrap();
+        stream.flush().unwrap();
+        stalled_streams.push(stream);
+    }
+    std::thread::sleep(Duration::from_millis(500));
+
+    let sessions = (0..8)
+        .map(|_| new_daemon_test_sync_session_id())
+        .collect::<Vec<_>>();
+    for (index, session) in sessions.iter().enumerate() {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&trace_socket, Duration::from_secs(2))
+                .expect("connect backpressured trace socket");
+        let sid = format!("backpressured-{index}");
+        let session_arg = format!("git-ai.testSyncSession={session}");
+        let time_ns = 10_000 + index as u64 * 100;
+        let frames = [
+            serde_json::json!({
+                "event": "start",
+                "sid": sid,
+                "argv": ["git", "-c", session_arg, "commit", "-m", "synthetic"],
+                "time_ns": time_ns,
+            }),
+            serde_json::json!({
+                "event": "def_repo",
+                "sid": sid,
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": time_ns + 1,
+            }),
+            serde_json::json!({
+                "event": "exit",
+                "sid": sid,
+                "code": 0,
+                "time_ns": time_ns + 2,
+            }),
+            serde_json::json!({
+                "event": "atexit",
+                "sid": sid,
+                "code": 0,
+                "time_ns": time_ns + 3,
+            }),
+        ]
+        .into_iter()
+        .map(|frame| serde_json::to_string(&frame).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+        let _ = stream.write_all(format!("{frames}\n").as_bytes());
+        let _ = stream.flush();
+    }
+
+    #[cfg(target_os = "linux")]
+    assert!(
+        daemon_thread_count(&repo) <= baseline_threads + 8,
+        "trace handler thread count exceeded configured capacity"
+    );
+    drop(stalled_streams);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let completed = repo
+            .daemon_completion_entries()
+            .into_iter()
+            .filter_map(|entry| entry.test_sync_session)
+            .collect::<std::collections::HashSet<_>>();
+        let missing = sessions
+            .iter()
+            .filter(|session| !completed.contains(*session))
+            .cloned()
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "trace connection pressure dropped completion sessions: {missing:?}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    repo.sync_daemon_external_completion_sessions(&sessions);
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after connection pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn control_connection_limit_backpressures_without_dropping_requests() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_MAX_CONTROL_CONNECTIONS", "2")]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    let control_socket = repo.daemon_control_socket_path();
+    let stalled_streams = (0..2)
+        .map(|_| {
+            open_local_socket_stream_with_timeout(&control_socket, Duration::from_secs(2))
+                .expect("connect stalled control socket")
+        })
+        .collect::<Vec<_>>();
+    std::thread::sleep(Duration::from_millis(250));
+
+    let request_socket = control_socket.clone();
+    let request = std::thread::spawn(move || {
+        send_control_request_with_timeout(
+            &request_socket,
+            &ControlRequest::Ping,
+            Duration::from_secs(5),
+        )
+    });
+    std::thread::sleep(Duration::from_millis(250));
+    assert!(
+        !request.is_finished(),
+        "control request should remain backpressured while every handler is occupied"
+    );
+
+    #[cfg(target_os = "linux")]
+    assert!(
+        daemon_thread_count(&repo) <= baseline_threads + 4,
+        "control handler thread count exceeded configured capacity"
+    );
+    drop(stalled_streams);
+
+    let response = request
+        .join()
+        .expect("control request thread should not panic")
+        .expect("backpressured control request should complete");
+    assert!(
+        response.ok,
+        "backpressured ping should succeed: {response:?}"
+    );
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after control pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -51,6 +51,7 @@ mod continue_cli;
 mod cross_repo_cwd_attribution;
 mod cursor;
 mod daemon_commit_carryover;
+mod daemon_ipc_memory;
 mod daemon_log_memory;
 mod daemon_retained_state_memory;
 mod diff;


### PR DESCRIPTION
## Bug
The daemon accepted unbounded socket connections, spawned an OS thread per connection, and read unbounded JSON frames/SIDs/root sets. The first connection ceiling fixed the memory bound by accepting and immediately dropping sockets once the cap was full, which silently discarded trace2 commands and control requests under CPU pressure. That broke the attribution contract: whole Graphite/rewrite sessions vanished, and downstream daemon syncs timed out even though the daemon remained alive. Interrupted socket reads could independently close a valid connection.

## Fix
Cap trace/control connections (128/16), handler stacks, frame sizes, SID length, and roots per trace connection without dropping accepted work. Permit acquisition keeps the existing single atomic fast path; only saturated listeners retain the accepted socket and wait with a short bounded exponential delay, allowing the OS/socket queues to apply backpressure until capacity is available or shutdown begins. Unix and Windows trace/control listeners share this behavior, and bounded line readers retry `Interrupted` reads.

Checkpoints reuse the existing persistent control socket, which applies the request-specific response deadline. After ambiguous checkpoint I/O it reconnects to heal future calls but never replays the state-changing request.

## Verification
Strict TestRepo regressions saturate a four-handler trace limit, enqueue eight tracked commit sessions, release capacity, require every session to complete, and then verify exact AI line attribution. A separate two-handler control test proves a third ping waits instead of being disconnected and verifies exact attribution after recovery. Both tests failed against the drop-on-saturation implementation before the backpressure fix. Reader unit tests inject partial input plus `Interrupted` and prove the complete frame is preserved.

A four-core constrained run of the complete integration binary passed 3,281 tests (85 expected ignores) in 479 seconds, including all Graphite, rebase, subdirectory, delayed-response, overload, and exact-attribution workflows that previously exposed lost sessions.
