### PR TITLE
fix(daemon): bound reflog processing memory

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -105,6 +105,11 @@ Robustness requirements (all implemented and tested):
 - offset beyond file length (pruned/truncated reflog) clears the cursor
 - branch delete/recreate clears the stale cursor
 - expiry/`reflog expire` invalidates via anchor mismatch
+- one cursor read covers at most 4 MiB and one reflog record at most 64 KiB;
+  exceeding either limit fails closed, seeds the cursor at the current EOF,
+  and lets the next command recover without rescanning oversized history
+- common-ref discovery is iterative and bounded to 8,192 filesystem entries,
+  4,096 reflogs, 4,096 pending directories, and 64 directory levels
 
 ### Consumption
 
@@ -128,7 +133,11 @@ Cursors come into existence at trusted observation points:
 
 1. **Trace ingress capture** (best-effort): when the daemon sees a *live*,
    non-terminal trace2 frame for a mutating command, it captures current
-   reflog ends and attaches them to the root as claimed start offsets. Because
+   reflog ends and attaches them to the root as claimed start offsets. This
+   latency-sensitive capture never inventories the ref tree: it performs
+   constant work for the worktree `HEAD`, its current symbolic ref, and one
+   auxiliary ref: `refs/stash` normally, or the explicit local source ref for
+   `merge --squash`. The symbolic `HEAD` read is capped at 4 KiB. Because
    delivery is asynchronous, these claims may already be post-append;
    `command_start_offset_is_authoritative` only accepts a claimed offset if
    records exist after it and it does not move an existing cursor backward.
@@ -227,6 +236,8 @@ Deterministic tests must cover, at minimum:
 10. no hidden sync before `show`/`blame`
 11. daemon survives partial trace roots, socket close ordering, child trace
     traffic, and never deadlocks checkpoints behind unidentified sockets
+12. oversized historical reflogs remain memory-bounded, fail closed for the
+    affected boundary, and preserve exact attribution for the next command
 
 Primary suites: `tests/daemon_mode.rs`, `tests/commit_tree_update_ref.rs`,
 `tests/integration/rewrite_ops_attribution.rs`, ref-cursor unit tests in

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -631,12 +631,12 @@ fn trace_invocation_is_definitely_read_only(
     }
 }
 
-fn trace_invocation_may_mutate_refs(primary_command: Option<&str>, argv: &[String]) -> bool {
+fn trace_invocation_may_mutate_refs(
+    primary_command: Option<&str>,
+    command_args: &[String],
+) -> bool {
     primary_command.is_some_and(|cmd| {
-        crate::git::command_classification::git_invocation_may_mutate_repo_state(
-            cmd,
-            &trace_invocation_command_args(Some(cmd), argv),
-        )
+        crate::git::command_classification::git_invocation_may_mutate_repo_state(cmd, command_args)
     })
 }
 
@@ -4013,8 +4013,12 @@ impl ActorDaemonCoordinator {
         };
         let effective_primary =
             early_primary.or_else(|| trace_argv_primary_command(&effective_argv));
+        let effective_command_args = effective_primary
+            .as_deref()
+            .map(|primary| trace_invocation_command_args(Some(primary), &effective_argv))
+            .unwrap_or_default();
         let command_mutates_refs =
-            trace_invocation_may_mutate_refs(effective_primary.as_deref(), &effective_argv);
+            trace_invocation_may_mutate_refs(effective_primary.as_deref(), &effective_command_args);
         if let Some(primary) = effective_primary.as_deref() {
             ingress
                 .root_mutating
@@ -4035,8 +4039,11 @@ impl ActorDaemonCoordinator {
                 .clone()
                 .or_else(|| ingress.root_worktrees.get(&root).cloned())
         {
-            let offsets =
-                crate::daemon::ref_cursor::capture_reflog_start_offsets_for_worktree(&worktree);
+            let offsets = crate::daemon::ref_cursor::capture_reflog_start_offsets_for_worktree(
+                &worktree,
+                effective_primary.as_deref(),
+                &effective_command_args,
+            );
             ingress
                 .root_reflog_start_offsets
                 .insert(root.clone(), offsets);
@@ -8920,6 +8927,7 @@ mod tests {
         std::fs::create_dir_all(head_log.parent().unwrap()).unwrap();
         std::fs::create_dir_all(stash_log.parent().unwrap()).unwrap();
         std::fs::create_dir_all(branch_log.parent().unwrap()).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
         let old_head_reflog = b"old HEAD reflog entry\n";
         let old_reflog = b"old stash reflog entry\n";
         let old_branch_reflog = b"old branch reflog entry\n";

--- a/src/daemon/analyzers/history.rs
+++ b/src/daemon/analyzers/history.rs
@@ -140,7 +140,7 @@ fn squash_source_head(
     resolve_revision_from_ref_state(source, refs)
 }
 
-fn merge_source_args(args: &[String]) -> Vec<&str> {
+pub(crate) fn merge_source_args(args: &[String]) -> Vec<&str> {
     let mut sources = Vec::new();
     let mut iter = args.iter().map(String::as_str).peekable();
     while let Some(arg) = iter.next() {

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -16,6 +16,13 @@ const MAX_RETAINED_STASH_ENTRIES: usize = 4_096;
 const MAX_RETAINED_CHERRY_PICK_SOURCE_OIDS: usize = 4_096;
 const MAX_RETAINED_REF_CURSOR_KEYS: usize = 4_096;
 const MAX_RETAINED_SPARSE_REFLOG_ENTRIES: usize = 4_096;
+const MAX_REFLOG_READ_BYTES: u64 = 4 * 1_024 * 1_024;
+const MAX_REFLOG_RECORD_BYTES: usize = 64 * 1_024;
+const MAX_SYMBOLIC_HEAD_BYTES: u64 = 4 * 1_024;
+const MAX_DISCOVERED_REFLOGS: usize = 4_096;
+const MAX_REFLOG_DISCOVERY_ENTRIES: usize = 8_192;
+const MAX_REFLOG_DISCOVERY_DEPTH: usize = 64;
+const MAX_PENDING_REFLOG_DIRECTORIES: usize = 4_096;
 
 #[derive(Debug)]
 pub struct RefCursor {
@@ -1837,13 +1844,6 @@ impl RefCursor {
     }
 
     fn reflog_start_offset(&mut self, key: &str, path: &Path) -> Result<Option<u64>, GitAiError> {
-        let Some(offset) = self.offsets.get(key).copied() else {
-            return Ok(None);
-        };
-        if offset == 0 {
-            return Ok(Some(0));
-        }
-
         let len = match fs::metadata(path) {
             Ok(metadata) => metadata.len(),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -1852,9 +1852,23 @@ impl RefCursor {
             }
             Err(error) => return Err(GitAiError::IoError(error)),
         };
+        let Some(offset) = self.offsets.get(key).copied() else {
+            if len > MAX_REFLOG_READ_BYTES {
+                self.initialize_reflog_cursor(key, len)?;
+                return Ok(Some(len));
+            }
+            return Ok(None);
+        };
         if offset > len {
             self.clear_ref_cursor(key);
             return Ok(None);
+        }
+        if len.saturating_sub(offset) > MAX_REFLOG_READ_BYTES {
+            self.initialize_reflog_cursor(key, len)?;
+            return Ok(Some(len));
+        }
+        if offset == 0 {
+            return Ok(Some(0));
         }
 
         if let Some(anchor) = self.anchors.get(key) {
@@ -2180,33 +2194,89 @@ impl RefCursor {
     }
 }
 
-pub(crate) fn capture_reflog_start_offsets_for_worktree(worktree: &Path) -> HashMap<String, u64> {
+pub(crate) fn capture_reflog_start_offsets_for_worktree(
+    worktree: &Path,
+    primary_command: Option<&str>,
+    command_args: &[String],
+) -> HashMap<String, u64> {
     let mut offsets = HashMap::new();
 
-    if let Some(git_dir) = git_dir_for_worktree(worktree) {
-        let path = git_dir.join("logs").join("HEAD");
-        if let Ok(metadata) = fs::metadata(&path) {
-            offsets.insert(head_key(&git_dir), metadata.len());
-        }
+    let Some(git_dir) = git_dir_for_worktree(worktree) else {
+        return offsets;
+    };
+    let head_log = git_dir.join("logs").join("HEAD");
+    if let Ok(metadata) = fs::metadata(&head_log) {
+        offsets.insert(head_key(&git_dir), metadata.len());
     }
 
     let Some(common_dir) = common_dir_for_worktree(worktree) else {
         return offsets;
     };
-    let logs = common_dir.join("logs");
-    let mut refs = Vec::new();
-    if discover_reflog_refs(&logs, &logs, &mut refs).is_ok() {
-        for reference in refs {
-            if reference == "HEAD" {
-                continue;
-            }
-            let path = logs.join(&reference);
-            if let Ok(metadata) = fs::metadata(&path) {
-                offsets.insert(common_key(&reference), metadata.len());
-            }
+    let common_logs = common_dir.join("logs");
+    let auxiliary_reference = squash_merge_source_reference(primary_command, command_args)
+        .unwrap_or_else(|| "refs/stash".to_string());
+    let auxiliary_log = common_logs.join(&auxiliary_reference);
+    if let Ok(metadata) = fs::metadata(&auxiliary_log) {
+        offsets.insert(common_key(&auxiliary_reference), metadata.len());
+    }
+    if let Some(reference) = read_symbolic_head_reference(&git_dir) {
+        let branch_log = common_logs.join(&reference);
+        if let Ok(metadata) = fs::metadata(&branch_log) {
+            offsets.insert(common_key(&reference), metadata.len());
         }
     }
     offsets
+}
+
+fn squash_merge_source_reference(
+    primary_command: Option<&str>,
+    command_args: &[String],
+) -> Option<String> {
+    if primary_command != Some("merge") || !command_args.iter().any(|arg| arg == "--squash") {
+        return None;
+    }
+    let source = crate::daemon::analyzers::history::merge_source_args(command_args)
+        .into_iter()
+        .next()?;
+    if source == "HEAD" || is_valid_git_oid(source) {
+        return None;
+    }
+    let reference = if source.starts_with("refs/") {
+        source.to_string()
+    } else {
+        format!("refs/heads/{source}")
+    };
+    safe_reflog_reference(&reference).then_some(reference)
+}
+
+fn read_symbolic_head_reference(git_dir: &Path) -> Option<String> {
+    let file = fs::File::open(git_dir.join("HEAD")).ok()?;
+    if file.metadata().ok()?.len() > MAX_SYMBOLIC_HEAD_BYTES {
+        return None;
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_SYMBOLIC_HEAD_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    if bytes.len() as u64 > MAX_SYMBOLIC_HEAD_BYTES {
+        return None;
+    }
+    let contents = std::str::from_utf8(&bytes).ok()?;
+    let reference = contents.strip_prefix("ref:")?.trim();
+    if !safe_reflog_reference(reference) {
+        return None;
+    }
+    Some(reference.to_string())
+}
+
+fn safe_reflog_reference(reference: &str) -> bool {
+    reference.starts_with("refs/")
+        && reference.len() <= 1_024
+        && !reference.contains('\\')
+        && !reference.chars().any(char::is_control)
+        && reference
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..")
 }
 
 pub(crate) fn refs_at_reflog_start_offsets(
@@ -2986,14 +3056,26 @@ fn read_reflog_records(
         Some(offset) => offset,
         None => 0,
     };
+    let remaining = byte_len.saturating_sub(start);
+    if remaining > MAX_REFLOG_READ_BYTES {
+        return Ok(Vec::new());
+    }
     file.seek(SeekFrom::Start(start))
         .map_err(GitAiError::IoError)?;
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).map_err(GitAiError::IoError)?;
+    let mut bytes = Vec::with_capacity(remaining as usize);
+    file.take(MAX_REFLOG_READ_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(GitAiError::IoError)?;
+    if bytes.len() as u64 > MAX_REFLOG_READ_BYTES {
+        return Ok(Vec::new());
+    }
 
     let mut entries = Vec::new();
     let mut offset = start;
     for raw_line in bytes.split_inclusive(|byte| *byte == b'\n') {
+        if raw_line.len() > MAX_REFLOG_RECORD_BYTES {
+            return Ok(Vec::new());
+        }
         let line_start = offset;
         offset = offset.saturating_add(raw_line.len() as u64);
         if !raw_line.ends_with(b"\n") {
@@ -3054,6 +3136,9 @@ fn read_reflog_record_ending_at(
         };
         if let Some(index) = chunk[..search_end].iter().rposition(|byte| *byte == b'\n') {
             let line_start = chunk_start + index as u64 + 1;
+            if chunk.len() - index - 1 + suffix.len() > MAX_REFLOG_RECORD_BYTES {
+                return Ok(None);
+            }
             let mut line = chunk[index + 1..].to_vec();
             line.extend_from_slice(&suffix);
             let line = String::from_utf8_lossy(&line);
@@ -3062,6 +3147,9 @@ fn read_reflog_record_ending_at(
                 .filter(|record| record.end_offset > line_start));
         }
 
+        if chunk.len() + suffix.len() > MAX_REFLOG_RECORD_BYTES {
+            return Ok(None);
+        }
         let mut line = chunk;
         line.extend_from_slice(&suffix);
         suffix = line;
@@ -3105,26 +3193,45 @@ fn discover_reflog_refs(
     current: &Path,
     out: &mut Vec<String>,
 ) -> Result<(), GitAiError> {
-    if !current.exists() {
+    if out.len() >= MAX_DISCOVERED_REFLOGS {
         return Ok(());
     }
-    for entry in fs::read_dir(current)? {
-        let entry = entry?;
-        let path = entry.path();
-        let file_type = entry.file_type()?;
-        if file_type.is_dir() {
-            discover_reflog_refs(root, &path, out)?;
-            continue;
-        }
-        if !file_type.is_file() {
-            continue;
-        }
-        let Ok(relative) = path.strip_prefix(root) else {
-            continue;
+    let mut pending = VecDeque::from([(current.to_path_buf(), 0usize)]);
+    let mut visited_entries = 0usize;
+    while let Some((directory, depth)) = pending.pop_front() {
+        let entries = match fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(GitAiError::IoError(error)),
         };
-        let reference = relative.to_string_lossy().replace('\\', "/");
-        if reference == "ORIG_HEAD" || reference.starts_with("refs/") {
-            out.push(reference);
+        for entry in entries {
+            if visited_entries >= MAX_REFLOG_DISCOVERY_ENTRIES
+                || out.len() >= MAX_DISCOVERED_REFLOGS
+            {
+                return Ok(());
+            }
+            visited_entries += 1;
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                if depth < MAX_REFLOG_DISCOVERY_DEPTH
+                    && pending.len() < MAX_PENDING_REFLOG_DIRECTORIES
+                {
+                    pending.push_back((path, depth + 1));
+                }
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let Ok(relative) = path.strip_prefix(root) else {
+                continue;
+            };
+            let reference = relative.to_string_lossy().replace('\\', "/");
+            if reference == "ORIG_HEAD" || reference.starts_with("refs/") {
+                out.push(reference);
+            }
         }
     }
     Ok(())
@@ -4711,6 +4818,79 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reflog_start_capture_reads_only_fixed_relevant_refs() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        append_reflog(&git_dir, "HEAD", &[(A, B, "commit: current")]);
+        append_reflog(&git_dir, "refs/heads/main", &[(A, B, "commit: current")]);
+        append_reflog(&git_dir, "refs/stash", &[(A, B, "stash: current")]);
+        for index in 0..128 {
+            append_reflog(
+                &git_dir,
+                &format!("refs/heads/unrelated-{index}"),
+                &[(A, B, "commit: unrelated")],
+            );
+        }
+
+        let offsets = capture_reflog_start_offsets_for_worktree(
+            &worktree,
+            Some("reset"),
+            &["--hard".to_string(), "HEAD~1".to_string()],
+        );
+
+        assert_eq!(offsets.len(), 3);
+        assert!(offsets.contains_key(&head_key(&git_dir)));
+        assert!(offsets.contains_key(&common_key("refs/heads/main")));
+        assert!(offsets.contains_key(&common_key("refs/stash")));
+    }
+
+    #[test]
+    fn squash_merge_start_capture_substitutes_explicit_source_for_stash() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        append_reflog(&git_dir, "HEAD", &[(A, B, "commit: current")]);
+        append_reflog(&git_dir, "refs/heads/main", &[(A, B, "commit: current")]);
+        append_reflog(&git_dir, "refs/heads/feature", &[(A, C, "commit: source")]);
+        append_reflog(&git_dir, "refs/stash", &[(A, B, "stash: current")]);
+
+        let offsets = capture_reflog_start_offsets_for_worktree(
+            &worktree,
+            Some("merge"),
+            &["--squash".to_string(), "feature".to_string()],
+        );
+
+        assert_eq!(offsets.len(), 3);
+        assert!(offsets.contains_key(&head_key(&git_dir)));
+        assert!(offsets.contains_key(&common_key("refs/heads/main")));
+        assert!(offsets.contains_key(&common_key("refs/heads/feature")));
+        assert!(!offsets.contains_key(&common_key("refs/stash")));
+    }
+
+    #[test]
+    fn reflog_discovery_has_bounded_entry_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let logs = temp.path().join("logs");
+        for index in 0..4_100 {
+            append_reflog(
+                temp.path(),
+                &format!("refs/heads/branch-{index}"),
+                &[(A, B, "commit: test")],
+            );
+        }
+        let mut refs = Vec::new();
+
+        discover_reflog_refs(&logs, &logs, &mut refs).unwrap();
+
+        assert!(refs.len() <= 4_096, "discovered {} reflogs", refs.len());
+    }
+
     fn append_reflog(common_dir: &Path, reference: &str, entries: &[(&str, &str, &str)]) {
         let path = common_dir.join("logs").join(reference);
         fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -4749,6 +4929,48 @@ mod tests {
     }
 
     #[test]
+    fn reflog_reader_rejects_oversized_delta() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("HEAD");
+        let line = format!("{}\n", reflog_line(A, B, "commit: historical"));
+        let count = (4 * 1_024 * 1_024 / line.len()) + 2;
+        fs::write(&path, line.repeat(count)).unwrap();
+
+        let records = read_reflog_records(&path, None).unwrap();
+
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn oversized_cold_reflog_seeds_cursor_at_eof_for_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let reference = "refs/heads/main";
+        let path = temp.path().join("logs").join(reference);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let line = format!("{}\n", reflog_line(A, B, "commit: historical"));
+        let count = (4 * 1_024 * 1_024 / line.len()) + 2;
+        fs::write(&path, line.repeat(count)).unwrap();
+        let historical_end = fs::metadata(&path).unwrap().len();
+        let key = common_key(reference);
+        let mut cursor = RefCursor::new(FamilyKey::new(temp.path().to_string_lossy()));
+
+        let first_start = cursor.reflog_start_offset(&key, &path).unwrap();
+
+        assert_eq!(first_start, Some(historical_end));
+        assert_eq!(cursor.offsets.get(&key), Some(&historical_end));
+
+        let next = format!("{}\n", reflog_line(B, C, "commit: next"));
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        use std::io::Write;
+        file.write_all(next.as_bytes()).unwrap();
+
+        assert_eq!(
+            cursor.reflog_start_offset(&key, &path).unwrap(),
+            Some(historical_end)
+        );
+    }
+
+    #[test]
     fn reflog_anchor_rejects_non_newline_end_offset() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("HEAD");
@@ -4769,6 +4991,18 @@ mod tests {
                 .is_none(),
             "an offset inside an unterminated reflog record must not become an anchor"
         );
+    }
+
+    #[test]
+    fn reflog_anchor_rejects_oversized_record() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("HEAD");
+        let line = format!("{}\n", reflog_line(A, B, &"x".repeat(64 * 1_024)));
+        fs::write(&path, &line).unwrap();
+
+        let record = read_reflog_record_ending_at(&path, line.len() as u64).unwrap();
+
+        assert!(record.is_none());
     }
 
     #[test]

--- a/tests/integration/daemon_reflog_memory.rs
+++ b/tests/integration/daemon_reflog_memory.rs
@@ -1,0 +1,77 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn oversized_historical_reflog_keeps_daemon_bounded_and_next_commit_attributed() {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.filename("tracked.txt")
+        .assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let head_log = repo.path().join(".git/logs/HEAD");
+    let existing = fs::read(&head_log).unwrap();
+    let seed_line = existing
+        .split_inclusive(|byte| *byte == b'\n')
+        .next_back()
+        .expect("initial commit should create a HEAD reflog row");
+    assert!(seed_line.ends_with(b"\n"));
+    let mut block = Vec::with_capacity(seed_line.len() * 1_024);
+    for _ in 0..1_024 {
+        block.extend_from_slice(seed_line);
+    }
+    let mut reflog = OpenOptions::new().append(true).open(&head_log).unwrap();
+    while reflog.metadata().unwrap().len() < 64 * 1_024 * 1_024 {
+        reflog.write_all(&block).unwrap();
+    }
+    reflog.flush().unwrap();
+    drop(reflog);
+
+    repo.restart_dedicated_daemon_for_test();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+
+    repo.git(&[
+        "commit",
+        "--allow-empty",
+        "-m",
+        "Seed cursor after oversized reflog",
+    ])
+    .unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        assert!(
+            hwm_growth_kib < 32 * 1_024,
+            "oversized historical reflog grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after oversized reflog")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -53,6 +53,7 @@ mod cursor;
 mod daemon_commit_carryover;
 mod daemon_ipc_memory;
 mod daemon_log_memory;
+mod daemon_reflog_memory;
 mod daemon_retained_state_memory;
 mod diff;
 mod diff_comprehensive;


### PR DESCRIPTION
## Bug
Reflog enrichment read arbitrarily large files and recursively discovered arbitrarily many reflogs/records. A large or corrupt reflog tree could dominate daemon memory during asynchronous trace processing.

## Fix
Bound reflog reads to 4 MiB, records to 64 KiB, symbolic HEAD to 4 KiB, and discovery count/depth/work queues. Ingress still performs only three fixed metadata probes; for `merge --squash <local-ref>`, the explicit source reflog replaces the irrelevant stash probe so cold replay retains source attribution.

## Verification
Unit tests cover file, record, discovery, and fixed-probe limits. `tests/integration/daemon_reflog_memory.rs` and cold squash replay tests verify bounded reads and exact source attribution.