### PR TITLE
fix(git): bound internal command resources

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -63,6 +63,13 @@ affected connection and fails closed for attribution; it never delays or wraps
 the Git command. Control connections are independently capped at 16, with a
 36 MiB request limit that accommodates the default 32 MiB checkpoint budget.
 
+Git subprocesses used later by asynchronous side effects are also bounded and
+never run on trace ingress. At most eight buffered internal Git commands run at
+once. Each accepts at most 16,384 arguments / 4 MiB of argument data and 32 MiB
+of stdin, retains at most 32 MiB of stdout and 1 MiB of stderr, and uses bounded
+reader-thread stacks. Overflow is drained, reported as an error, and fails the
+affected attribution side effect closed without retaining the excess output.
+
 Separation of concerns:
 
 - The **normalizer** parses trace2/argv facts only. It never reads mutable

--- a/src/config.rs
+++ b/src/config.rs
@@ -1041,6 +1041,8 @@ fn build_config() -> Config {
         .unwrap_or_default();
 
     let git_path = resolve_git_path(&file_cfg);
+    #[cfg(any(test, feature = "test-support"))]
+    let git_path = env::var("GIT_AI_TEST_GIT_PATH").unwrap_or(git_path);
 
     // Build feature flags from file config
     let feature_flags = build_feature_flags(&file_cfg);

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -15,9 +15,11 @@ use regex::Regex;
 use std::cell::Cell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex, OnceLock};
 
 #[cfg(windows)]
 use crate::utils::CREATE_NO_WINDOW;
@@ -30,6 +32,87 @@ thread_local! {
     static INTERNAL_GIT_HOOKS_DISABLED_DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 static INTERNAL_GIT_HOOKS_DISABLED_DEPTH_GLOBAL: AtomicUsize = AtomicUsize::new(0);
+
+const MAX_INTERNAL_GIT_COMMANDS: usize = 8;
+const MAX_INTERNAL_GIT_ARGS: usize = 16_384;
+const MAX_INTERNAL_GIT_ARG_BYTES: usize = 4 * 1_024 * 1_024;
+const MAX_INTERNAL_GIT_STDIN_BYTES: usize = 32 * 1_024 * 1_024;
+const MAX_INTERNAL_GIT_STDOUT_BYTES: usize = 32 * 1_024 * 1_024;
+const MAX_INTERNAL_GIT_STDERR_BYTES: usize = 1_024 * 1_024;
+const INTERNAL_GIT_READER_STACK_BYTES: usize = 512 * 1_024;
+
+struct InternalGitLimiter {
+    active: Mutex<usize>,
+    available: Condvar,
+}
+
+impl InternalGitLimiter {
+    fn acquire(&self) -> InternalGitPermit<'_> {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while *active >= MAX_INTERNAL_GIT_COMMANDS {
+            active = self
+                .available
+                .wait(active)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        *active += 1;
+        InternalGitPermit { limiter: self }
+    }
+}
+
+struct InternalGitPermit<'a> {
+    limiter: &'a InternalGitLimiter,
+}
+
+impl Drop for InternalGitPermit<'_> {
+    fn drop(&mut self) {
+        let mut active = self
+            .limiter
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *active = active.saturating_sub(1);
+        self.limiter.available.notify_one();
+    }
+}
+
+fn internal_git_limiter() -> &'static InternalGitLimiter {
+    static LIMITER: OnceLock<InternalGitLimiter> = OnceLock::new();
+    LIMITER.get_or_init(|| InternalGitLimiter {
+        active: Mutex::new(0),
+        available: Condvar::new(),
+    })
+}
+
+struct BoundedCommandOutput {
+    bytes: Vec<u8>,
+    exceeded: bool,
+}
+
+fn read_bounded_command_output(
+    mut reader: impl Read,
+    max_bytes: usize,
+) -> std::io::Result<BoundedCommandOutput> {
+    let mut bytes = Vec::with_capacity(max_bytes.min(64 * 1_024));
+    let mut exceeded = false;
+    let mut chunk = [0u8; 16 * 1_024];
+    loop {
+        let read = match reader.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        let remaining = max_bytes.saturating_sub(bytes.len());
+        let retained = remaining.min(read);
+        bytes.extend_from_slice(&chunk[..retained]);
+        exceeded |= retained < read;
+    }
+    Ok(BoundedCommandOutput { bytes, exceeded })
+}
 
 pub struct InternalGitHooksGuard;
 
@@ -2693,7 +2776,6 @@ fn spawn_probe_log(effective_args: &[String]) {
         .append(true)
         .open(&path)
     {
-        use std::io::Write;
         let _ = writeln!(f, "{}", sub);
     }
 }
@@ -2702,16 +2784,50 @@ fn spawn_probe_log(effective_args: &[String]) {
 #[inline]
 fn spawn_probe_log(_effective_args: &[String]) {}
 
-fn exec_git_allow_nonzero_with_profile_and_env(
+fn validate_internal_git_command(
     args: &[String],
-    profile: InternalGitProfile,
+    stdin_data: Option<&[u8]>,
+) -> Result<(), GitAiError> {
+    if args.len() > MAX_INTERNAL_GIT_ARGS
+        || args
+            .iter()
+            .try_fold(0usize, |total, arg| total.checked_add(arg.len() + 1))
+            .is_none_or(|total| total > MAX_INTERNAL_GIT_ARG_BYTES)
+    {
+        return Err(GitAiError::Generic(
+            "internal Git command arguments exceeded the 4 MiB limit".to_string(),
+        ));
+    }
+    if stdin_data.is_some_and(|data| data.len() > MAX_INTERNAL_GIT_STDIN_BYTES) {
+        return Err(GitAiError::Generic(
+            "internal Git command stdin exceeded the 32 MiB limit".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn kill_and_wait(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn run_internal_git_command(
+    effective_args: &[String],
     envs: &[(&str, &OsStr)],
+    stdin_data: Option<&[u8]>,
 ) -> Result<Output, GitAiError> {
-    let effective_args =
-        args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
-    spawn_probe_log(&effective_args);
+    validate_internal_git_command(effective_args, stdin_data)?;
+    let _permit = internal_git_limiter().acquire();
+
     let mut cmd = Command::new(config::Config::get().git_cmd());
-    cmd.args(&effective_args);
+    cmd.args(effective_args)
+        .stdin(if stdin_data.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
     apply_internal_git_env(&mut cmd);
     for (key, value) in envs {
         cmd.env(key, value);
@@ -2724,7 +2840,125 @@ fn exec_git_allow_nonzero_with_profile_and_env(
         }
     }
 
-    cmd.output().map_err(GitAiError::IoError)
+    let mut child = cmd.spawn().map_err(GitAiError::IoError)?;
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            kill_and_wait(&mut child);
+            return Err(GitAiError::IoError(std::io::Error::other(
+                "internal Git command stdout was not piped",
+            )));
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            kill_and_wait(&mut child);
+            return Err(GitAiError::IoError(std::io::Error::other(
+                "internal Git command stderr was not piped",
+            )));
+        }
+    };
+    let stdin = child.stdin.take();
+
+    let (status, stdout, stderr) = std::thread::scope(|scope| {
+        let stdout_handle = match std::thread::Builder::new()
+            .name("git-ai-git-stdout".to_string())
+            .stack_size(INTERNAL_GIT_READER_STACK_BYTES)
+            .spawn_scoped(scope, move || {
+                read_bounded_command_output(stdout, MAX_INTERNAL_GIT_STDOUT_BYTES)
+            }) {
+            Ok(handle) => handle,
+            Err(error) => {
+                kill_and_wait(&mut child);
+                return Err(GitAiError::IoError(error));
+            }
+        };
+        let stderr_handle = match std::thread::Builder::new()
+            .name("git-ai-git-stderr".to_string())
+            .stack_size(INTERNAL_GIT_READER_STACK_BYTES)
+            .spawn_scoped(scope, move || {
+                read_bounded_command_output(stderr, MAX_INTERNAL_GIT_STDERR_BYTES)
+            }) {
+            Ok(handle) => handle,
+            Err(error) => {
+                kill_and_wait(&mut child);
+                return Err(GitAiError::IoError(error));
+            }
+        };
+        let stdin_handle = if let (Some(mut stdin), Some(data)) = (stdin, stdin_data) {
+            match std::thread::Builder::new()
+                .name("git-ai-git-stdin".to_string())
+                .stack_size(INTERNAL_GIT_READER_STACK_BYTES)
+                .spawn_scoped(scope, move || stdin.write_all(data))
+            {
+                Ok(handle) => Some(handle),
+                Err(error) => {
+                    kill_and_wait(&mut child);
+                    return Err(GitAiError::IoError(error));
+                }
+            }
+        } else {
+            None
+        };
+
+        let status = match child.wait() {
+            Ok(status) => status,
+            Err(error) => {
+                kill_and_wait(&mut child);
+                return Err(GitAiError::IoError(error));
+            }
+        };
+        let stdout = stdout_handle
+            .join()
+            .map_err(|_| std::io::Error::other("internal Git stdout reader panicked"))??;
+        let stderr = stderr_handle
+            .join()
+            .map_err(|_| std::io::Error::other("internal Git stderr reader panicked"))??;
+        if let Some(handle) = stdin_handle {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) if error.kind() == std::io::ErrorKind::BrokenPipe => {}
+                Ok(Err(error)) => return Err(GitAiError::IoError(error)),
+                Err(_) => {
+                    return Err(GitAiError::IoError(std::io::Error::other(
+                        "internal Git stdin writer panicked",
+                    )));
+                }
+            }
+        }
+        Ok((status, stdout, stderr))
+    })?;
+
+    if stdout.exceeded || stderr.exceeded {
+        let stream = if stdout.exceeded && stderr.exceeded {
+            "stdout and stderr"
+        } else if stdout.exceeded {
+            "stdout"
+        } else {
+            "stderr"
+        };
+        return Err(GitAiError::Generic(format!(
+            "internal Git command {stream} exceeded its memory limit"
+        )));
+    }
+
+    Ok(Output {
+        status,
+        stdout: stdout.bytes,
+        stderr: stderr.bytes,
+    })
+}
+
+fn exec_git_allow_nonzero_with_profile_and_env(
+    args: &[String],
+    profile: InternalGitProfile,
+    envs: &[(&str, &OsStr)],
+) -> Result<Output, GitAiError> {
+    let effective_args =
+        args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
+    spawn_probe_log(&effective_args);
+    run_internal_git_command(&effective_args, envs, None)
 }
 
 /// Spawn a git command with stdout piped and stderr inherited.
@@ -2843,42 +3077,7 @@ pub fn exec_git_stdin_with_profile(
     let effective_args =
         args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
     spawn_probe_log(&effective_args);
-    let mut cmd = Command::new(config::Config::get().git_cmd());
-    cmd.args(&effective_args)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
-    apply_internal_git_env(&mut cmd);
-
-    #[cfg(windows)]
-    {
-        if !is_interactive_terminal() {
-            cmd.creation_flags(CREATE_NO_WINDOW);
-        }
-    }
-
-    let mut child = cmd.spawn().map_err(GitAiError::IoError)?;
-
-    // Write stdin in a separate thread to avoid deadlock: if we write all stdin
-    // before reading stdout, the child's stdout pipe buffer can fill up, causing
-    // the child to block on write, which prevents it from consuming more stdin,
-    // which blocks our write_all. Writing concurrently avoids this.
-    let stdin_handle = child.stdin.take().map(|mut stdin| {
-        let data = stdin_data.to_vec();
-        std::thread::spawn(move || {
-            use std::io::Write;
-            stdin.write_all(&data)
-        })
-    });
-
-    let output = child.wait_with_output().map_err(GitAiError::IoError)?;
-
-    if let Some(handle) = stdin_handle
-        && let Err(e) = handle.join().expect("stdin writer thread panicked")
-        && e.kind() != std::io::ErrorKind::BrokenPipe
-    {
-        return Err(GitAiError::IoError(e));
-    }
+    let output = run_internal_git_command(&effective_args, &[], Some(stdin_data))?;
 
     if !output.status.success() {
         let code = output.status.code();
@@ -3191,6 +3390,56 @@ mod tests {
                 Some(Some((*value).to_string()))
             );
         }
+    }
+
+    #[test]
+    fn bounded_command_output_retains_prefix_and_reports_overflow() {
+        let output = read_bounded_command_output(std::io::Cursor::new(b"abcdef"), 3).unwrap();
+
+        assert_eq!(output.bytes, b"abc");
+        assert!(output.exceeded);
+
+        let exact = read_bounded_command_output(std::io::Cursor::new(b"abc"), 3).unwrap();
+        assert_eq!(exact.bytes, b"abc");
+        assert!(!exact.exceeded);
+    }
+
+    #[test]
+    fn internal_git_command_rejects_unbounded_argument_count() {
+        let args = vec![String::new(); MAX_INTERNAL_GIT_ARGS + 1];
+
+        let error = validate_internal_git_command(&args, None).unwrap_err();
+
+        assert!(error.to_string().contains("arguments exceeded"));
+    }
+
+    #[test]
+    fn internal_git_limiter_blocks_past_capacity_and_reuses_permits() {
+        let limiter = std::sync::Arc::new(InternalGitLimiter {
+            active: Mutex::new(0),
+            available: Condvar::new(),
+        });
+        let mut held = (0..MAX_INTERNAL_GIT_COMMANDS)
+            .map(|_| limiter.acquire())
+            .collect::<Vec<_>>();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let waiting_limiter = limiter.clone();
+        let waiter = std::thread::spawn(move || {
+            let _permit = waiting_limiter.acquire();
+            tx.send(()).unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "a ninth internal Git command must wait for capacity"
+        );
+        held.pop();
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("released capacity should wake a waiting command");
+
+        drop(held);
+        waiter.join().unwrap();
     }
 
     #[test]

--- a/tests/integration/checkpoint_size.rs
+++ b/tests/integration/checkpoint_size.rs
@@ -321,12 +321,23 @@ fn test_repeated_checkpoints_plateau_after_runtime_warmup() {
     }
 
     #[cfg(target_os = "linux")]
+    let first_window_vm_size_kib = daemon_vm_size_kib(&repo);
+
+    for iteration in 33..=52 {
+        checkpoint_and_commit(iteration);
+    }
+
+    #[cfg(target_os = "linux")]
     {
-        let growth_kib = daemon_vm_size_kib(&repo).saturating_sub(warmed_vm_size_kib);
-        eprintln!("post-warmup checkpoint daemon VmSize growth: {growth_kib} KiB");
+        let first_window_growth_kib = first_window_vm_size_kib.saturating_sub(warmed_vm_size_kib);
+        let late_window_growth_kib =
+            daemon_vm_size_kib(&repo).saturating_sub(first_window_vm_size_kib);
+        eprintln!(
+            "checkpoint daemon VmSize growth: first window {first_window_growth_kib} KiB, late window {late_window_growth_kib} KiB"
+        );
         assert!(
-            growth_kib < 256 * 1024,
-            "post-warmup checkpoints grew daemon VmSize by {growth_kib} KiB"
+            late_window_growth_kib < 256 * 1024,
+            "late checkpoint window grew daemon VmSize by {late_window_growth_kib} KiB"
         );
     }
 }

--- a/tests/integration/daemon_git_output_memory.rs
+++ b/tests/integration/daemon_git_output_memory.rs
@@ -1,0 +1,130 @@
+#![cfg(unix)]
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::{TestRepo, real_git_executable};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+#[cfg(target_os = "linux")]
+use std::time::{Duration, Instant};
+
+// The reader retains 32 MiB; leave room for Vec growth and its two bounded reader stacks.
+#[cfg(target_os = "linux")]
+const MAX_DAEMON_HWM_GROWTH_KIB: u64 = 48 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_internal_git_threads_to_exit(repo: &TestRepo) -> usize {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let active = fs::read_dir(format!("/proc/{pid}/task"))
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                fs::read_to_string(entry.path().join("comm"))
+                    .is_ok_and(|name| name.trim().starts_with("git-ai-git-"))
+            })
+            .count();
+        if active == 0 || Instant::now() >= deadline {
+            return active;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn oversized_internal_git_stdout_keeps_daemon_bounded_and_attribution_working() {
+    let wrapper_dir = tempfile::tempdir().unwrap();
+    let wrapper_path = wrapper_dir.path().join("pressure-git");
+    let pressure_flag = wrapper_dir.path().join("emit-oversized-output");
+    let pressure_marker = wrapper_dir.path().join("oversized-output-emitted");
+    fs::write(
+        &wrapper_path,
+        format!(
+            "#!/bin/sh\n\
+             if [ -f '{}' ]; then\n\
+               case \"$*\" in\n\
+                 *--abbrev-ref*)\n\
+                   printf hit > '{}'\n\
+                   dd if=/dev/zero bs=1048576 count=64 2>/dev/null | tr '\\000' x\n\
+                   printf '\\n'\n\
+                   exit 0\n\
+                   ;;\n\
+               esac\n\
+             fi\n\
+             exec '{}' \"$@\"\n",
+            pressure_flag.display(),
+            pressure_marker.display(),
+            real_git_executable(),
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&wrapper_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&wrapper_path, permissions).unwrap();
+
+    let wrapper = wrapper_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_GIT_PATH", wrapper.as_str())]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    assert_eq!(wait_for_internal_git_threads_to_exit(&repo), 0);
+
+    fs::write(&pressure_flag, b"enabled").unwrap();
+    fs::write(&file_path, "base\nuntracked line\n").unwrap();
+    repo.git_ai(&["checkpoint", "human", "tracked.txt"])
+        .unwrap();
+    repo.sync_daemon_force();
+    assert!(
+        pressure_marker.exists(),
+        "daemon should execute the oversized-output Git wrapper branch"
+    );
+    fs::remove_file(&pressure_flag).unwrap();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        assert!(
+            hwm_growth_kib < MAX_DAEMON_HWM_GROWTH_KIB,
+            "oversized internal Git stdout grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        assert_eq!(
+            wait_for_internal_git_threads_to_exit(&repo),
+            0,
+            "internal Git I/O threads must exit after command completion"
+        );
+    }
+
+    fs::write(&file_path, "base\nknown human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "tracked.txt"])
+        .unwrap();
+    fs::write(&file_path, "base\nknown human line\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after oversized Git output")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "known human line".human(),
+        "ai line".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -51,6 +51,7 @@ mod continue_cli;
 mod cross_repo_cwd_attribution;
 mod cursor;
 mod daemon_commit_carryover;
+mod daemon_git_output_memory;
 mod daemon_ipc_memory;
 mod daemon_log_memory;
 mod daemon_reflog_memory;


### PR DESCRIPTION
## Bug
Internal Git helpers had unbounded concurrent spawns and used output collection that could retain unlimited stdout/stderr, arguments, or stdin. Parallel daemon work could multiply those allocations and thread stacks.

## Fix
Reuse the central Git helper with an eight-command concurrency limiter, bounded args/stdin, concurrent bounded stream drains (32 MiB stdout and 1 MiB stderr), and 512 KiB reader stacks. This adds no Git work and preserves constant-spawn batched operations.

## Verification
Unit tests cover input limits, stream truncation, and concurrency. `tests/integration/daemon_git_output_memory.rs` emits 64 MiB from a real `TestRepo` Git wrapper and verifies daemon HWM remains below 48 MiB, allowing allocator and bounded reader-stack overhead above the 32 MiB retained-output ceiling. The fixture disables pressure before HWM assertions so any failure cannot affect later tests, and its Unix-only imports are gated at module scope for Windows all-target lint. All memory regressions, the complete local suite (2,213 library, 58 daemon, 3,282 integration, 20 notes-sync, and active doctests), `task lint`, `task fmt`, and `task build` pass on the final stack tip.

## Ubuntu CI follow-up
The pressure checkpoint is asynchronous, so the test calls `TestRepo::sync_daemon_force()` before sampling `/proc`. This waits for the bounded internal Git command and its scoped reader-thread joins rather than racing legitimate in-flight readers under CI load.

The first follow-up still compared total daemon thread counts. Eleven upper-layer Ubuntu runs showed why that signal was too broad: bounded Tokio blocking workers can initialize between samples even after the Git I/O threads have exited. The regression now polls `/proc/<pid>/task/*/comm` specifically for the scoped `git-ai-git-*` readers/writer and requires all of those named threads to exit. Four focused runs pass after the correction, including three simultaneous copies under scheduler pressure.

One Ubuntu run also recorded 265,240 KiB of one-time allocator growth in the plateau regression's first 20-commit window, 3,096 KiB above its threshold. The test now records that initialization window and applies the unchanged 256 MiB ceiling to a second 20-commit window, so sustained per-checkpoint growth still fails without misclassifying bounded pool initialization. Three simultaneous runs recorded first-window growth of 67,668 KiB, 0 KiB, and 67,668 KiB and late-window growth of 0 KiB in all three.
