### PR TITLE
fix(rewrites): bound history expansion and source resolution

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -70,6 +70,14 @@ of stdin, retains at most 32 MiB of stdout and 1 MiB of stderr, and uses bounded
 reader-thread stacks. Overflow is drained, reported as an error, and fails the
 affected attribution side effect closed without retaining the excess output.
 
+Rewrite side effects additionally cap parsed work at 4,096 commits, mappings,
+or diff pairs. Revision walks request at most one extra record so overflow is
+detected before note maps and diff structures are built. Ordinary
+cherry-pick/revert source expressions share one `cat-file` batch; at most one
+range walk is allowed alongside that batch because combining independent
+ranges changes Git's exclusion semantics. Multiple range arguments fail the
+attribution side effect closed instead of spawning Git once per range.
+
 Separation of concerns:
 
 - The **normalizer** parses trace2/argv facts only. It never reads mutable

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -9,6 +9,22 @@ use crate::git::repo_state::is_valid_git_oid;
 use crate::git::repository::{Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin};
 
 const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+pub(crate) const MAX_REWRITE_COMMITS: usize = 4_096;
+
+pub(crate) fn ensure_rewrite_work_limit(kind: &str, count: usize) -> Result<(), GitAiError> {
+    if count > MAX_REWRITE_COMMITS {
+        return Err(GitAiError::Generic(format!(
+            "rewrite work exceeded the {MAX_REWRITE_COMMITS} {kind} limit ({count})"
+        )));
+    }
+    Ok(())
+}
+
+fn push_bounded_rewrite_item<T>(items: &mut Vec<T>, item: T, kind: &str) -> Result<(), GitAiError> {
+    ensure_rewrite_work_limit(kind, items.len().saturating_add(1))?;
+    items.push(item);
+    Ok(())
+}
 
 #[derive(Debug)]
 pub enum RewriteEvent {
@@ -413,6 +429,8 @@ pub(crate) fn handle_rewrite_event_with_metrics(
             sources,
             new_commits,
         } => {
+            ensure_rewrite_work_limit("source commits", sources.len())?;
+            ensure_rewrite_work_limit("destination commits", new_commits.len())?;
             let mappings: Vec<(String, String)> = sources.into_iter().zip(new_commits).collect();
             if mappings.is_empty() {
                 return Ok(RewriteOutcome::empty());
@@ -487,7 +505,7 @@ fn handle_squash_merge(
         .filter(|log| !log.attestations.is_empty());
 
     let base = find_merge_base(repo, source_head, onto).unwrap_or_else(|| onto.to_string());
-    let source_commits = list_commits_in_range(repo, &base, source_head);
+    let source_commits = list_commits_in_range(repo, &base, source_head)?;
     let sources = if source_commits.is_empty() {
         vec![source_head.to_string()]
     } else {
@@ -736,6 +754,7 @@ fn shift_authorship_notes_with_existing_mode(
     if mappings.is_empty() {
         return Ok(Vec::new());
     }
+    ensure_rewrite_work_limit("note mappings", mappings.len())?;
 
     // Batch-read all notes for source and target commits in O(1) git calls
     let all_shas: Vec<String> = mappings
@@ -938,9 +957,13 @@ fn derive_mappings_from_range_diff(
         _ => &base,
     };
     let range_diff_output = run_range_diff(repo, &base, old_tip, onto, new_tip)?;
-    let mut mappings = parse_range_diff_output(&range_diff_output);
+    let mut mappings = parse_range_diff_output(&range_diff_output)?;
 
     let merge_mappings = derive_merge_commit_mappings(repo, &base, old_tip, new_tip, &mappings)?;
+    ensure_rewrite_work_limit(
+        "combined range-diff mappings",
+        mappings.len().saturating_add(merge_mappings.len()),
+    )?;
     mappings.extend(merge_mappings);
 
     Ok(mappings)
@@ -971,24 +994,25 @@ fn find_merge_base(repo: &Repository, a: &str, b: &str) -> Option<String> {
     if base.is_empty() { None } else { Some(base) }
 }
 
-pub(crate) fn list_commits_in_range(repo: &Repository, base: &str, tip: &str) -> Vec<String> {
+pub(crate) fn list_commits_in_range(
+    repo: &Repository,
+    base: &str,
+    tip: &str,
+) -> Result<Vec<String>, GitAiError> {
     let mut args = repo.global_args_for_exec();
     args.extend([
         "rev-list".to_string(),
         "--reverse".to_string(),
+        format!("--max-count={}", MAX_REWRITE_COMMITS + 1),
         format!("{}..{}", base, tip),
     ]);
-    exec_git_allow_nonzero(&args)
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| {
-            String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .map(|l| l.trim().to_string())
-                .filter(|l| !l.is_empty())
-                .collect()
-        })
-        .unwrap_or_default()
+    let Ok(output) = exec_git_allow_nonzero(&args) else {
+        return Ok(Vec::new());
+    };
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+    parse_bounded_rewrite_oids(&output.stdout, "commits")
 }
 
 fn run_range_diff(
@@ -1009,10 +1033,10 @@ fn run_range_diff(
         format!("{}..{}", new_base, new_tip),
     ]);
     let output = exec_git(&args)?;
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
+fn parse_range_diff_output(output: &str) -> Result<Vec<(String, String)>, GitAiError> {
     let mut mappings = Vec::new();
     let mut pending_dropped: Vec<String> = Vec::new();
     let mut previous_new_sha: Option<String> = None;
@@ -1039,9 +1063,17 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
                 // Dropped commit (squashed into a later commit)
                 if !old_sha.chars().all(|c| c == '0') {
                     if let Some(new_sha) = previous_new_sha.as_ref() {
-                        mappings.push((old_sha, new_sha.clone()));
+                        push_bounded_rewrite_item(
+                            &mut mappings,
+                            (old_sha, new_sha.clone()),
+                            "range-diff mappings",
+                        )?;
                     } else {
-                        pending_dropped.push(old_sha);
+                        push_bounded_rewrite_item(
+                            &mut pending_dropped,
+                            old_sha,
+                            "pending range-diff commits",
+                        )?;
                     }
                 }
             }
@@ -1056,10 +1088,18 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
                 }
                 // Map any preceding dropped commits to this new commit (squash)
                 for dropped in pending_dropped.drain(..) {
-                    mappings.push((dropped, new_sha.clone()));
+                    push_bounded_rewrite_item(
+                        &mut mappings,
+                        (dropped, new_sha.clone()),
+                        "range-diff mappings",
+                    )?;
                 }
                 previous_new_sha = Some(new_sha.clone());
-                mappings.push((old_sha, new_sha));
+                push_bounded_rewrite_item(
+                    &mut mappings,
+                    (old_sha, new_sha),
+                    "range-diff mappings",
+                )?;
             }
             _ => {
                 // '>' (new commit) or other — skip
@@ -1068,7 +1108,19 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
         }
     }
 
-    mappings
+    Ok(mappings)
+}
+
+fn parse_bounded_rewrite_oids(data: &[u8], kind: &str) -> Result<Vec<String>, GitAiError> {
+    let mut oids = Vec::new();
+    for line in String::from_utf8_lossy(data).lines() {
+        let oid = line.trim();
+        if oid.is_empty() {
+            continue;
+        }
+        push_bounded_rewrite_item(&mut oids, oid.to_string(), kind)?;
+    }
+    Ok(oids)
 }
 
 /// Find the first maximal ASCII-hex run in `s` whose length is a valid git OID
@@ -1185,6 +1237,7 @@ fn list_merge_commits(repo: &Repository, base: &str, tip: &str) -> Result<Vec<St
         "--merges".to_string(),
         "--topo-order".to_string(),
         "--reverse".to_string(),
+        format!("--max-count={}", MAX_REWRITE_COMMITS + 1),
         format!("{}..{}", base, tip),
     ]);
 
@@ -1193,12 +1246,7 @@ fn list_merge_commits(repo: &Repository, base: &str, tip: &str) -> Result<Vec<St
         return Ok(Vec::new());
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(stdout
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
-        .collect())
+    parse_bounded_rewrite_oids(&output.stdout, "merge commits")
 }
 
 fn get_commit_parents_batch(repo: &Repository, shas: &[String]) -> HashMap<String, Vec<String>> {
@@ -1242,6 +1290,7 @@ pub(crate) fn compute_diff_trees_batch(
     if pairs.is_empty() {
         return Ok(Vec::new());
     }
+    ensure_rewrite_work_limit("diff pairs", pairs.len())?;
 
     let unique_shas = unique_pair_shas(pairs);
     let sha_to_tree = resolve_tree_shas(repo, &unique_shas)?;
@@ -1556,7 +1605,7 @@ Binary files a/image.png and b/image.png differ
     #[test]
     fn test_parse_range_diff_output_matched_equal() {
         let output = " 1:  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = 1:  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb Some commit subject\n";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert_eq!(mappings.len(), 1);
         assert_eq!(mappings[0].0, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         assert_eq!(mappings[0].1, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
@@ -1565,7 +1614,7 @@ Binary files a/image.png and b/image.png differ
     #[test]
     fn test_parse_range_diff_output_matched_bang() {
         let output = " 2:  1111111111111111111111111111111111111111 ! 3:  2222222222222222222222222222222222222222 Modified commit\n";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert_eq!(mappings.len(), 1);
         assert_eq!(mappings[0].0, "1111111111111111111111111111111111111111");
         assert_eq!(mappings[0].1, "2222222222222222222222222222222222222222");
@@ -1577,7 +1626,7 @@ Binary files a/image.png and b/image.png differ
  1:  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa < -:  0000000000000000000000000000000000000000 Dropped commit
  -:  0000000000000000000000000000000000000000 > 1:  cccccccccccccccccccccccccccccccccccccccc New commit
 ";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert!(mappings.is_empty());
     }
 
@@ -1587,7 +1636,7 @@ Binary files a/image.png and b/image.png differ
 1:  1111111111111111111111111111111111111111 < -:  ---------------------------------------- Add Python joke
 2:  2222222222222222222222222222222222222222 ! 1:  3333333333333333333333333333333333333333 Add Rust joke
 ";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert_eq!(
             mappings,
             vec![
@@ -1610,7 +1659,7 @@ Binary files a/image.png and b/image.png differ
 2:  2222222222222222222222222222222222222222 < -:  ---------------------------------------- AI commit 2
 3:  3333333333333333333333333333333333333333 < -:  ---------------------------------------- AI commit 3
 ";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert_eq!(
             mappings,
             vec![
@@ -1633,7 +1682,7 @@ Binary files a/image.png and b/image.png differ
     #[test]
     fn test_parse_range_diff_output_null_shas_skipped() {
         let output = " 1:  0000000000000000000000000000000000000000 = 1:  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb Subject\n";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert!(mappings.is_empty());
     }
 
@@ -1644,7 +1693,7 @@ Binary files a/image.png and b/image.png differ
  2:  cccccccccccccccccccccccccccccccccccccccc ! 2:  dddddddddddddddddddddddddddddddddddddddd Second commit
  3:  eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee = 3:  ffffffffffffffffffffffffffffffffffffffff Third commit
 ";
-        let mappings = parse_range_diff_output(output);
+        let mappings = parse_range_diff_output(output).unwrap();
         assert_eq!(mappings.len(), 3);
         assert_eq!(
             mappings[0],
@@ -1671,8 +1720,35 @@ Binary files a/image.png and b/image.png differ
 
     #[test]
     fn test_parse_range_diff_output_empty() {
-        let mappings = parse_range_diff_output("");
+        let mappings = parse_range_diff_output("").unwrap();
         assert!(mappings.is_empty());
+    }
+
+    #[test]
+    fn parse_range_diff_output_rejects_oversized_mapping_set() {
+        let output = (1..=MAX_REWRITE_COMMITS + 1)
+            .map(|index| {
+                let old = format!("{index:040x}");
+                let new = format!("{:040x}", index + MAX_REWRITE_COMMITS + 1);
+                format!(" {index}:  {old} = {index}:  {new} subject\n")
+            })
+            .collect::<String>();
+
+        let error = parse_range_diff_output(&output)
+            .expect_err("oversized range-diff mappings must fail closed");
+
+        assert!(error.to_string().contains("rewrite work exceeded"));
+    }
+
+    #[test]
+    fn compute_diff_trees_batch_rejects_oversized_pair_set_before_git() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let pairs = vec![("a".repeat(40), "b".repeat(40)); MAX_REWRITE_COMMITS + 1];
+
+        let error = compute_diff_trees_batch(tmp.gitai_repo(), &pairs)
+            .expect_err("oversized diff batch must fail closed");
+
+        assert!(error.to_string().contains("rewrite work exceeded"));
     }
 
     #[test]
@@ -1738,7 +1814,7 @@ Binary files a/image.png and b/image.png differ
         let old = "1111111111111111111111111111111111111111111111111111111111111111";
         let new = "2222222222222222222222222222222222222222222222222222222222222222";
         let output = format!(" 1:  {} = 1:  {} Some subject\n", old, new);
-        let mappings = parse_range_diff_output(&output);
+        let mappings = parse_range_diff_output(&output).unwrap();
         assert_eq!(mappings.len(), 1);
         assert_eq!(mappings[0].0, old);
         assert_eq!(mappings[0].1, new);

--- a/src/authorship/rewrite_cherry_pick.rs
+++ b/src/authorship/rewrite_cherry_pick.rs
@@ -12,6 +12,11 @@ pub fn match_cherry_pick_pairs(
     sources: &[String],
     new_commits: &[String],
 ) -> Result<Vec<(String, String)>, crate::error::GitAiError> {
+    crate::authorship::rewrite::ensure_rewrite_work_limit("source commits", sources.len())?;
+    crate::authorship::rewrite::ensure_rewrite_work_limit(
+        "destination commits",
+        new_commits.len(),
+    )?;
     if sources.is_empty() || new_commits.is_empty() {
         return Ok(Vec::new());
     }
@@ -103,6 +108,7 @@ pub(crate) fn stable_patch_ids_for_commits(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, crate::error::GitAiError> {
+    crate::authorship::rewrite::ensure_rewrite_work_limit("patch-id commits", commit_shas.len())?;
     let mut commits = Vec::new();
     let mut seen = HashSet::new();
     for sha in commit_shas {
@@ -236,6 +242,19 @@ mod tests {
         assert!(looks_like_hex_id(first_patch_id));
         assert!(looks_like_hex_id(second_patch_id));
         assert_ne!(first_patch_id, second_patch_id);
+    }
+
+    #[test]
+    fn stable_patch_ids_reject_oversized_commit_set_before_git() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let commits = (0..=crate::authorship::rewrite::MAX_REWRITE_COMMITS)
+            .map(|index| format!("{index:040x}"))
+            .collect::<Vec<_>>();
+
+        let error = stable_patch_ids_for_commits(tmp.gitai_repo(), &commits)
+            .expect_err("oversized patch-id batch must fail closed");
+
+        assert!(error.to_string().contains("rewrite work exceeded"));
     }
 
     /// Helper that simulates pass-2 positional pairing without patch-id (for unit testing).

--- a/src/authorship/rewrite_reset.rs
+++ b/src/authorship/rewrite_reset.rs
@@ -19,7 +19,7 @@ pub fn reconstruct_working_log_after_backward_reset(
     new_tip: &str,
 ) -> Result<(), GitAiError> {
     // List all commits being "un-done" (between new_tip exclusive and old_tip inclusive)
-    let commits = list_commits_in_range(repo, new_tip, old_tip);
+    let commits = list_commits_in_range(repo, new_tip, old_tip)?;
     if commits.is_empty() {
         return Ok(());
     }
@@ -241,7 +241,11 @@ fn extract_attributions_from_log_shifted(
     }
 }
 
-fn list_commits_in_range(repo: &Repository, base: &str, tip: &str) -> Vec<String> {
+fn list_commits_in_range(
+    repo: &Repository,
+    base: &str,
+    tip: &str,
+) -> Result<Vec<String>, GitAiError> {
     crate::authorship::rewrite::list_commits_in_range(repo, base, tip)
 }
 

--- a/src/authorship/rewrite_revert.rs
+++ b/src/authorship/rewrite_revert.rs
@@ -35,6 +35,10 @@ pub(crate) fn handle_revert_commits_with_metrics(
     if specs.is_empty() {
         return Ok(Vec::new());
     }
+    crate::authorship::rewrite::ensure_rewrite_work_limit(
+        "revert diff pairs",
+        specs.len().saturating_mul(2),
+    )?;
     let collect_metrics = crate::authorship::rewrite::rewrite_metrics_enabled();
 
     // Resolve every spec's parent_sha (only those missing need a lookup) and the
@@ -353,6 +357,23 @@ fn clip_file_attestation_to_lines(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn revert_batch_rejects_oversized_spec_set_before_git() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let specs = (0..crate::authorship::rewrite::MAX_REWRITE_COMMITS)
+            .map(|index| RevertSpec {
+                revert_commit: format!("{index:040x}"),
+                parent: Some("a".repeat(40)),
+                reverted_commit: Some("b".repeat(40)),
+            })
+            .collect::<Vec<_>>();
+
+        let error = handle_revert_commits_with_metrics(tmp.gitai_repo(), &specs)
+            .expect_err("two diff pairs per revert must fit the rewrite work limit");
+
+        assert!(error.to_string().contains("rewrite work exceeded"));
+    }
 
     #[test]
     fn legacy_revert_metric_original_sha_uses_reverted_commit() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -713,6 +713,22 @@ struct RewriteMetricContext {
     parent_diff_by_commit: HashMap<String, crate::authorship::rewrite::DiffTreeResult>,
 }
 
+fn parse_rewrite_commit_parent_pairs(data: &[u8]) -> Result<Vec<(String, String)>, GitAiError> {
+    let mut pairs = Vec::new();
+    for line in String::from_utf8_lossy(data).lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(commit_sha), Some(parent_sha)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        crate::authorship::rewrite::ensure_rewrite_work_limit(
+            "conflict-resolution commits",
+            pairs.len().saturating_add(1),
+        )?;
+        pairs.push((commit_sha.to_string(), parent_sha.to_string()));
+    }
+    Ok(pairs)
+}
+
 fn process_conflict_resolution_working_logs(
     repo: &Repository,
     new_tip: &str,
@@ -728,18 +744,14 @@ fn process_conflict_resolution_working_logs(
     args.extend([
         "log".to_string(),
         "--format=%H %P".to_string(),
+        format!(
+            "--max-count={}",
+            crate::authorship::rewrite::MAX_REWRITE_COMMITS + 1
+        ),
         format!("{}..{}", onto_sha, new_tip),
     ]);
     let output = crate::git::repository::exec_git(&args)?;
-    let log_output = String::from_utf8_lossy(&output.stdout);
-
-    let commit_parent_pairs = log_output
-        .lines()
-        .filter_map(|line| {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            (parts.len() >= 2).then(|| (parts[0].to_string(), parts[1].to_string()))
-        })
-        .collect::<Vec<_>>();
+    let commit_parent_pairs = parse_rewrite_commit_parent_pairs(&output.stdout)?;
     let commit_shas = commit_parent_pairs
         .iter()
         .map(|(commit_sha, _)| commit_sha.clone())
@@ -1624,30 +1636,83 @@ fn resolve_cherry_pick_source_args_with_git_in_head_context(
     source_args: &[String],
     head_context: Option<&str>,
 ) -> Result<Vec<String>, GitAiError> {
-    let mut resolved = Vec::new();
-    let mut seen = HashSet::new();
-
-    for source in source_args {
-        let source = head_context
-            .map(|head| rewrite_head_source_arg_for_side_effect(source, head))
-            .unwrap_or_else(|| source.clone());
-        let oids = if cherry_pick_source_is_range(&source) {
-            if cherry_pick_range_has_omitted_side(&source) {
-                Vec::new()
-            } else {
-                resolve_cherry_pick_range_source_with_git(repo, &source)?
-            }
-        } else {
-            resolve_cherry_pick_single_source_with_git(repo, &source)?
-        };
-
-        for oid in oids {
-            if seen.insert(oid.clone()) {
-                resolved.push(oid);
-            }
-        }
+    crate::authorship::rewrite::ensure_rewrite_work_limit("source arguments", source_args.len())?;
+    let sources = source_args
+        .iter()
+        .map(|source| {
+            head_context
+                .map(|head| rewrite_head_source_arg_for_side_effect(source, head))
+                .unwrap_or_else(|| source.clone())
+        })
+        .filter(|source| {
+            !cherry_pick_source_is_range(source) || !cherry_pick_range_has_omitted_side(source)
+        })
+        .collect::<Vec<_>>();
+    if sources.is_empty() {
+        return Ok(Vec::new());
     }
 
+    let range_count = sources
+        .iter()
+        .filter(|source| cherry_pick_source_is_range(source))
+        .count();
+    if range_count > 1 {
+        return Err(GitAiError::Generic(
+            "rewrite source resolution does not support multiple range arguments".to_string(),
+        ));
+    }
+
+    let single_sources = sources
+        .iter()
+        .filter(|source| !cherry_pick_source_is_range(source))
+        .cloned()
+        .collect::<Vec<_>>();
+    let single_oids = resolve_cherry_pick_single_sources_with_git(repo, &single_sources)?;
+    let range_oids = match sources
+        .iter()
+        .find(|source| cherry_pick_source_is_range(source))
+    {
+        Some(source) => resolve_cherry_pick_range_source_with_git(repo, source)?,
+        None => Vec::new(),
+    };
+
+    let mut resolved = Vec::new();
+    let mut seen = HashSet::new();
+    for source in &sources {
+        if cherry_pick_source_is_range(source) {
+            for oid in &range_oids {
+                push_resolved_cherry_pick_oid(&mut resolved, &mut seen, oid)?;
+            }
+        } else if let Some(oid) = single_oids.get(source) {
+            push_resolved_cherry_pick_oid(&mut resolved, &mut seen, oid)?;
+        }
+    }
+    Ok(resolved)
+}
+
+fn push_resolved_cherry_pick_oid(
+    resolved: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+    oid: &str,
+) -> Result<(), GitAiError> {
+    if seen.insert(oid.to_string()) {
+        crate::authorship::rewrite::ensure_rewrite_work_limit(
+            "resolved commits",
+            resolved.len().saturating_add(1),
+        )?;
+        resolved.push(oid.to_string());
+    }
+    Ok(())
+}
+
+fn collect_resolved_cherry_pick_oids<'a>(
+    lines: impl Iterator<Item = &'a str>,
+) -> Result<Vec<String>, GitAiError> {
+    let mut resolved = Vec::new();
+    let mut seen = HashSet::new();
+    for oid in lines.map(str::trim).filter(|oid| is_valid_oid(oid)) {
+        push_resolved_cherry_pick_oid(&mut resolved, &mut seen, oid)?;
+    }
     Ok(resolved)
 }
 
@@ -1689,25 +1754,49 @@ fn rewrite_head_source_term_for_side_effect(term: &str, head_context: &str) -> S
     term.to_string()
 }
 
-fn resolve_cherry_pick_single_source_with_git(
+fn resolve_cherry_pick_single_sources_with_git(
     repo: &Repository,
-    source: &str,
-) -> Result<Vec<String>, GitAiError> {
+    sources: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    if sources.is_empty() {
+        return Ok(HashMap::new());
+    }
     let mut args = repo.global_args_for_exec();
     args.extend([
         "cat-file".to_string(),
         "--batch-check=%(objectname) %(objecttype)".to_string(),
     ]);
-    let stdin_data = format!("{source}^{{commit}}\n");
+    let mut stdin_data = String::new();
+    for source in sources {
+        stdin_data.push_str(source);
+        stdin_data.push_str("^{commit}\n");
+    }
     let output = exec_git_stdin(&args, stdin_data.as_bytes())?;
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let mut parts = line.split_whitespace();
-            let oid = parts.next()?;
-            (parts.next() == Some("commit") && is_valid_oid(oid)).then(|| oid.to_string())
-        })
-        .collect())
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let mut resolved = HashMap::new();
+    for source in sources {
+        let Some(line) = lines.next() else {
+            return Err(GitAiError::Generic(format!(
+                "git cat-file returned fewer records than the {} source requests",
+                sources.len()
+            )));
+        };
+        let mut parts = line.split_whitespace();
+        if let Some(oid) = parts.next()
+            && parts.next() == Some("commit")
+            && is_valid_oid(oid)
+        {
+            resolved.insert(source.clone(), oid.to_string());
+        }
+    }
+    if lines.next().is_some() {
+        return Err(GitAiError::Generic(format!(
+            "git cat-file returned more records than the {} source requests",
+            sources.len()
+        )));
+    }
+    Ok(resolved)
 }
 
 fn resolve_cherry_pick_range_source_with_git(
@@ -1718,15 +1807,14 @@ fn resolve_cherry_pick_range_source_with_git(
     args.extend([
         "rev-list".to_string(),
         "--reverse".to_string(),
+        format!(
+            "--max-count={}",
+            crate::authorship::rewrite::MAX_REWRITE_COMMITS + 1
+        ),
         source.to_string(),
     ]);
     let output = exec_git(&args)?;
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|line| is_valid_oid(line))
-        .map(ToOwned::to_owned)
-        .collect())
+    collect_resolved_cherry_pick_oids(String::from_utf8_lossy(&output.stdout).lines())
 }
 
 fn resolve_explicit_cherry_pick_sources_for_side_effect(
@@ -1872,6 +1960,11 @@ fn apply_cherry_pick_complete_rewrite(
     sources: &[String],
     new_commits: &[String],
 ) -> Result<(), GitAiError> {
+    crate::authorship::rewrite::ensure_rewrite_work_limit("source commits", sources.len())?;
+    crate::authorship::rewrite::ensure_rewrite_work_limit(
+        "destination commits",
+        new_commits.len(),
+    )?;
     let pairs = crate::authorship::rewrite_cherry_pick::match_cherry_pick_pairs(
         repo,
         sources,
@@ -1971,6 +2064,7 @@ fn apply_cherry_pick_no_commit_rewrite(
     if sources.is_empty() || new_head.is_empty() {
         return Ok(());
     }
+    crate::authorship::rewrite::ensure_rewrite_work_limit("source commits", sources.len())?;
     let mappings = sources
         .iter()
         .map(|source| (source.clone(), new_head.to_string()))
@@ -8243,6 +8337,23 @@ mod tests {
     }
 
     #[test]
+    fn conflict_resolution_commit_parser_rejects_oversized_history() {
+        let log = (1..=crate::authorship::rewrite::MAX_REWRITE_COMMITS + 1)
+            .map(|index| {
+                format!(
+                    "{index:040x} {:040x}\n",
+                    index + crate::authorship::rewrite::MAX_REWRITE_COMMITS + 1
+                )
+            })
+            .collect::<String>();
+
+        let error = parse_rewrite_commit_parent_pairs(log.as_bytes())
+            .expect_err("oversized rewrite history must fail closed");
+
+        assert!(error.to_string().contains("rewrite work exceeded"));
+    }
+
+    #[test]
     fn revert_source_args_do_not_treat_bare_gpg_sign_as_value_option() {
         assert_eq!(
             revert_source_args_from_command_args(&["--gpg-sign".to_string(), "HEAD~1".to_string()]),
@@ -8278,6 +8389,114 @@ mod tests {
             ]),
             vec!["HEAD~1"]
         );
+    }
+
+    #[test]
+    #[serial]
+    fn cherry_pick_single_source_resolution_uses_one_git_spawn() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        tmp.write_file("one.txt", "one\n", false)
+            .expect("write source file");
+        let commit = tmp.commit_all("source").expect("source commit");
+        let log_dir = tempfile::tempdir().expect("spawn log directory");
+        let log_path = log_dir.path().join("spawns.log");
+        let _spawn_log = EnvVarGuard::set("GIT_AI_SPAWN_LOG", &log_path.to_string_lossy());
+        let _spawn_filter = EnvVarGuard::set(
+            "GIT_AI_SPAWN_LOG_MATCH",
+            tmp.path().to_str().expect("temporary repo path is UTF-8"),
+        );
+        let sources = vec![commit.clone(); 128];
+
+        let resolved = resolve_cherry_pick_source_args_with_git_in_head_context(
+            tmp.gitai_repo(),
+            &sources,
+            None,
+        )
+        .expect("resolve sources");
+
+        assert_eq!(resolved, vec![commit]);
+        let spawns = std::fs::read_to_string(log_path).expect("read spawn log");
+        assert_eq!(
+            spawns.lines().filter(|line| *line == "cat-file").count(),
+            1,
+            "ordinary cherry-pick sources must share one cat-file batch"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn cherry_pick_mixed_source_resolution_uses_constant_git_spawns() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        tmp.write_file("history.txt", "one\n", false)
+            .expect("write first source");
+        let first = tmp.commit_all("first").expect("first commit");
+        tmp.write_file("history.txt", "one\ntwo\n", false)
+            .expect("write second source");
+        let second = tmp.commit_all("second").expect("second commit");
+        tmp.write_file("history.txt", "one\ntwo\nthree\n", false)
+            .expect("write third source");
+        let third = tmp.commit_all("third").expect("third commit");
+        tmp.write_file("history.txt", "one\ntwo\nthree\nfour\n", false)
+            .expect("write fourth source");
+        let fourth = tmp.commit_all("fourth").expect("fourth commit");
+        let log_dir = tempfile::tempdir().expect("spawn log directory");
+        let log_path = log_dir.path().join("spawns.log");
+        let _spawn_log = EnvVarGuard::set("GIT_AI_SPAWN_LOG", &log_path.to_string_lossy());
+        let _spawn_filter = EnvVarGuard::set(
+            "GIT_AI_SPAWN_LOG_MATCH",
+            tmp.path().to_str().expect("temporary repo path is UTF-8"),
+        );
+        let sources = vec![format!("{first}..{third}"), fourth.clone()];
+
+        let resolved = resolve_cherry_pick_source_args_with_git_in_head_context(
+            tmp.gitai_repo(),
+            &sources,
+            None,
+        )
+        .expect("resolve ranges");
+
+        assert_eq!(resolved, vec![second, third, fourth]);
+        let spawns = std::fs::read_to_string(log_path).expect("read spawn log");
+        assert_eq!(
+            spawns.lines().filter(|line| *line == "rev-list").count(),
+            1,
+            "the one supported cherry-pick range must use one revision walk"
+        );
+        assert_eq!(
+            spawns.lines().filter(|line| *line == "cat-file").count(),
+            1,
+            "all ordinary sources beside a range must share one cat-file batch"
+        );
+    }
+
+    #[test]
+    fn cherry_pick_multiple_ranges_fail_closed_instead_of_spawning_per_range() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let sources = vec!["HEAD~3..HEAD~2".to_string(), "HEAD~1..HEAD".to_string()];
+
+        let error = resolve_cherry_pick_source_args_with_git_in_head_context(
+            tmp.gitai_repo(),
+            &sources,
+            None,
+        )
+        .expect_err("multiple independent ranges must fail closed");
+
+        assert!(error.to_string().contains("multiple range arguments"));
+    }
+
+    #[test]
+    fn cherry_pick_source_resolution_rejects_oversized_work_before_git() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let sources = vec!["HEAD".to_string(); MAX_RETAINED_PENDING_OIDS + 1];
+
+        let error = resolve_cherry_pick_source_args_with_git_in_head_context(
+            tmp.gitai_repo(),
+            &sources,
+            None,
+        )
+        .expect_err("oversized source list must fail closed");
+
+        assert!(error.to_string().contains("rewrite work exceeded"));
     }
 
     #[test]

--- a/tests/integration/rewrite_ops_attribution.rs
+++ b/tests/integration/rewrite_ops_attribution.rs
@@ -2318,6 +2318,123 @@ fn test_rebase_conflict_theirs_preserves_attribution() {
     ]);
 }
 
+#[test]
+fn rebase_with_non_utf8_subject_preserves_attribution() {
+    let repo = TestRepo::new();
+    repo.git(&["config", "i18n.commitEncoding", "ISO-8859-1"])
+        .unwrap();
+    repo.git(&["config", "i18n.logOutputEncoding", "ISO-8859-1"])
+        .unwrap();
+
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "base.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut base_file = repo.filename("base.txt");
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let feature_path = repo.path().join("feature.txt");
+    fs::write(&feature_path, "feature ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+        .unwrap();
+    repo.git(&["add", "feature.txt"]).unwrap();
+    let message_dir = tempfile::tempdir().unwrap();
+    let message_path = message_dir.path().join("message.txt");
+    fs::write(&message_path, b"feature caf\xe9 subject\n").unwrap();
+    repo.git(&["commit", "-F", message_path.to_str().unwrap()])
+        .unwrap();
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.assert_committed_lines(crate::lines!["feature ai".ai()]);
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    let main_path = repo.path().join("main.txt");
+    fs::write(&main_path, "main human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "main.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("main advance").unwrap();
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    let mut main_file = repo.filename("main.txt");
+    main_file.assert_committed_lines(crate::lines!["main human".human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &main_branch]).unwrap();
+
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    feature_file.assert_committed_lines(crate::lines!["feature ai".ai()]);
+    main_file.assert_committed_lines(crate::lines!["main human".human()]);
+}
+
+#[test]
+fn cherry_pick_named_sources_batches_resolution_and_preserves_attribution() {
+    const SOURCE_COUNT: usize = 6;
+
+    let log_dir = tempfile::tempdir().unwrap();
+    let log_path = log_dir.path().join("spawns.log");
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_SPAWN_LOG", log_path.to_str().unwrap())]);
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "base.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut base_file = repo.filename("base.txt");
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    let main_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "named-sources"]).unwrap();
+    let mut source_names = Vec::new();
+    for index in 0..SOURCE_COUNT {
+        let name = format!("source-{index}.txt");
+        fs::write(repo.path().join(&name), format!("AI source {index}\n")).unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", &name]).unwrap();
+        repo.stage_all_and_commit(&format!("source {index}"))
+            .unwrap();
+        let tag = format!("pick-source-{index}");
+        repo.git(&["tag", &tag]).unwrap();
+        source_names.push(tag);
+
+        base_file.assert_committed_lines(crate::lines!["base".human()]);
+        for committed_index in 0..=index {
+            let mut source_file = repo.filename(&format!("source-{committed_index}.txt"));
+            source_file
+                .assert_committed_lines(crate::lines![format!("AI source {committed_index}").ai()]);
+        }
+    }
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    repo.sync_daemon();
+    let before = fs::read_to_string(&log_path)
+        .map(|contents| contents.lines().count())
+        .unwrap_or_default();
+
+    let mut args = vec!["cherry-pick".to_string()];
+    args.extend(source_names);
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    repo.git(&arg_refs).unwrap();
+    repo.sync_daemon();
+
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    for index in 0..SOURCE_COUNT {
+        let mut source_file = repo.filename(&format!("source-{index}.txt"));
+        source_file.assert_committed_lines(crate::lines![format!("AI source {index}").ai()]);
+    }
+
+    let after_log = fs::read_to_string(&log_path).unwrap_or_default();
+    let side_effect_spawns = after_log.lines().skip(before).collect::<Vec<_>>();
+    let cat_file_spawns = side_effect_spawns
+        .iter()
+        .filter(|command| **command == "cat-file")
+        .count();
+    assert!(
+        cat_file_spawns <= 4,
+        "named-source resolution must stay batched; saw {cat_file_spawns} cat-file spawns: {side_effect_spawns:?}"
+    );
+}
+
 /// Spawn-scaling guard: a multi-commit `git revert` must trigger a CONSTANT
 /// number of daemon git spawns regardless of how many commits are reverted.
 /// Reverting N commits in one command and 3*N commits in another must produce


### PR DESCRIPTION
## Bug
Rewrite handling could expand and retain an arbitrary number of commits/source specifications for reset, revert, cherry-pick, and related history operations. Huge ranges could exhaust memory before attribution migration completed.

## Fix
Enforce a 4,096-commit rewrite ceiling, validate counts before materialization, and use bounded batched history/source resolution through existing Git helpers. Operations beyond the bound fail closed for attribution rather than issuing per-commit Git work.

## Verification
Unit tests cover oversized mappings, logs, and source lists. Spawn-count probes use the existing repository filter so unrelated parallel tests cannot contaminate constant-spawn assertions. `tests/integration/rewrite_ops_attribution.rs` verifies real rewrite operations still preserve line attribution; the focused tests and full suite pass on the final stack tip.

## Review follow-up
Range-diff output is decoded lossily because only the ASCII commit IDs are semantically parsed; arbitrary subject bytes must not abort rewrite handling. A new TestRepo regression creates an ISO-8859-1 commit subject, proves the strict decoder fails daemon post-processing, rebases it, and checks exact human/AI attribution after every commit and after note migration.