### PR TITLE
fix(notes): bound note materialization and cache batches

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -85,6 +85,13 @@ otherwise unbounded map. Index parsing is rejected above 32 MiB, and staged
 content uses the same constant two-process batch path rather than spawning Git
 once per file.
 
+Authorship-note reads and writes use the same 4,096-item and 16 MiB
+materialization limits. The byte budget is applied after note-blob
+deduplication, across cache, HTTP, and Git fallback sources, so one shared note
+blob cannot be cloned once per commit. The notes SQLite cache enforces the
+budget while rows are read and rolls back queue locks if a pending batch is too
+large. HTTP note requests are limited to 100 entries before JSON serialization.
+
 Separation of concerns:
 
 - The **normalizer** parses trace2/argv facts only. It never reads mutable
@@ -260,6 +267,9 @@ Deterministic tests must cover, at minimum:
     traffic, and never deadlocks checkpoints behind unidentified sockets
 12. oversized historical reflogs remain memory-bounded, fail closed for the
     affected boundary, and preserve exact attribution for the next command
+13. repeated large file blobs remain bounded during batched materialization
+14. repeated large note blobs remain bounded during rewrite-note migration,
+    fail closed, and preserve attribution for the next command
 
 Primary suites: `tests/daemon_mode.rs`, `tests/commit_tree_update_ref.rs`,
 `tests/integration/rewrite_ops_attribution.rs`, ref-cursor unit tests in

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -10,6 +10,18 @@ use crate::api::types::{
     ApiErrorResponse, NotesReadResponse, NotesUploadRequest, NotesUploadResponse,
 };
 use crate::error::GitAiError;
+use crate::git::repository::{BatchMaterializationBudget, ensure_batch_git_item_limit};
+
+const MAX_NOTES_API_ITEMS: usize = 100;
+
+fn ensure_notes_api_item_limit(kind: &str, count: usize) -> Result<(), GitAiError> {
+    if count > MAX_NOTES_API_ITEMS {
+        return Err(GitAiError::Generic(format!(
+            "{kind} count exceeded the {MAX_NOTES_API_ITEMS} item limit ({count})"
+        )));
+    }
+    Ok(())
+}
 
 impl ApiClient {
     /// Upload a batch of authorship notes to the remote backend.
@@ -24,6 +36,11 @@ impl ApiClient {
         &self,
         request: NotesUploadRequest,
     ) -> Result<NotesUploadResponse, GitAiError> {
+        ensure_notes_api_item_limit("note upload", request.entries.len())?;
+        let mut materialization_budget = BatchMaterializationBudget::new();
+        for entry in &request.entries {
+            materialization_budget.reserve("note upload content", entry.content.len())?;
+        }
         let response = self.context().post_json("/worker/notes/upload", &request)?;
         let status_code = response.status_code;
 
@@ -59,6 +76,7 @@ impl ApiClient {
     /// * `Ok(NotesReadResponse)` - Response mapping commit_sha → note content
     /// * `Err(GitAiError)` - On invalid input, network, or server errors
     pub fn read_notes(&self, commit_shas: &[&str]) -> Result<NotesReadResponse, GitAiError> {
+        ensure_notes_api_item_limit("note read", commit_shas.len())?;
         // Validate that all SHAs are hex strings before making the request
         for sha in commit_shas {
             if !sha.chars().all(|c| c.is_ascii_hexdigit()) {
@@ -79,7 +97,17 @@ impl ApiClient {
             .map_err(|e| GitAiError::Generic(format!("Failed to read response body: {}", e)))?;
 
         match status_code {
-            200 => serde_json::from_str(body).map_err(GitAiError::JsonError),
+            200 => {
+                let parsed: NotesReadResponse =
+                    serde_json::from_str(body).map_err(GitAiError::JsonError)?;
+                ensure_notes_api_item_limit("note response", parsed.notes.len())?;
+                ensure_batch_git_item_limit("note response", parsed.notes.len())?;
+                let mut materialization_budget = BatchMaterializationBudget::new();
+                for content in parsed.notes.values() {
+                    materialization_budget.reserve("note response content", content.len())?;
+                }
+                Ok(parsed)
+            }
             404 => Ok(NotesReadResponse {
                 notes: std::collections::HashMap::new(),
             }),
@@ -109,6 +137,46 @@ mod tests {
             err.contains("non-hex"),
             "error should mention non-hex: {}",
             err
+        );
+    }
+
+    #[test]
+    fn test_read_notes_rejects_oversized_batch_before_http() {
+        let ctx = ApiContext::without_auth(Some("https://127.0.0.1:1".to_string()));
+        let client = ApiClient::new(ctx);
+        let shas = (0..=100)
+            .map(|index| format!("{index:040x}"))
+            .collect::<Vec<_>>();
+        let refs = shas.iter().map(String::as_str).collect::<Vec<_>>();
+
+        let error = client
+            .read_notes(&refs)
+            .expect_err("notes reads must enforce the documented API batch size");
+
+        assert!(error.to_string().contains("100 item limit"));
+    }
+
+    #[test]
+    fn test_upload_notes_rejects_oversized_content_before_http() {
+        let ctx = ApiContext::without_auth(Some("https://127.0.0.1:1".to_string()));
+        let client = ApiClient::new(ctx);
+        let content = "x".repeat(1_024 * 1_024);
+        let entries = (0..=crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES
+            / content.len())
+            .map(|index| NoteEntry {
+                commit_sha: format!("{index:040x}"),
+                content: content.clone(),
+            })
+            .collect();
+
+        let error = client
+            .upload_notes(NotesUploadRequest { entries })
+            .expect_err("notes uploads must be bounded before JSON serialization");
+
+        assert!(
+            error
+                .to_string()
+                .contains("materialized note upload content")
         );
     }
 

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -10,7 +10,7 @@
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::config::{Config, NotesBackendKind};
 use crate::error::GitAiError;
-use crate::git::repository::Repository;
+use crate::git::repository::{BatchMaterializationBudget, Repository, ensure_batch_git_item_limit};
 use std::collections::{HashMap, HashSet};
 
 // Re-export CommitAuthorship so callers don't need to import from refs directly.
@@ -32,6 +32,7 @@ pub fn write_notes_batch(
     if entries.is_empty() {
         return Ok(());
     }
+    ensure_batch_git_item_limit("note write", entries.len())?;
     match Config::get().notes_backend_kind() {
         NotesBackendKind::Http => http_write_batch(entries),
         NotesBackendKind::GitNotes => crate::git::refs::notes_add_batch(repo, entries),
@@ -61,10 +62,13 @@ pub fn read_notes_batch(
     if commit_shas.is_empty() {
         return Ok(HashMap::new());
     }
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
 
     match Config::get().notes_backend_kind() {
         NotesBackendKind::Http => {
             let mut notes = http_read_notes(commit_shas);
+            let mut materialization_budget = BatchMaterializationBudget::new();
+            reserve_note_map(&mut materialization_budget, "note content", &notes)?;
 
             let missing_after_cache: Vec<String> = commit_shas
                 .iter()
@@ -72,7 +76,10 @@ pub fn read_notes_batch(
                 .cloned()
                 .collect();
             if !missing_after_cache.is_empty() {
-                notes.extend(http_fetch_and_cache_notes(&missing_after_cache));
+                notes.extend(http_fetch_and_cache_notes(
+                    &missing_after_cache,
+                    &mut materialization_budget,
+                )?);
             }
 
             let missing_after_http: Vec<String> = commit_shas
@@ -84,6 +91,7 @@ pub fn read_notes_batch(
                 && let Ok(git_notes) =
                     crate::git::refs::notes_for_commits(repo, &missing_after_http)
             {
+                reserve_note_map(&mut materialization_budget, "note content", &git_notes)?;
                 notes.extend(git_notes);
             }
 
@@ -152,6 +160,7 @@ pub fn read_note_blob_oids(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, GitAiError> {
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
     match Config::get().notes_backend_kind() {
         // For Http, notes are in notes-db not in git — no blob OIDs exist.
         // Return an empty map; callers handle this as "no notes in git".
@@ -166,6 +175,7 @@ pub fn commits_with_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashSet<String>, GitAiError> {
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
     match Config::get().notes_backend_kind() {
         NotesBackendKind::Http => {
             // Check the cache first; fall through to git notes for misses.
@@ -192,6 +202,7 @@ pub fn filter_commits_with_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<Vec<CommitAuthorship>, GitAiError> {
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
     match Config::get().notes_backend_kind() {
         NotesBackendKind::Http => {
             // `CommitAuthorship` requires a git_author that is only available from
@@ -265,6 +276,8 @@ pub fn materialize_notes_for_display(repo: &Repository, limit: usize) -> Result<
     use crate::git::repository::exec_git;
     use crate::git::repository::exec_git_stdin;
 
+    ensure_batch_git_item_limit("display note commit", limit)?;
+
     // 1. Get recent commits via rev-list.
     let rev_list_args: Vec<String> = repo
         .global_args_for_exec()
@@ -283,6 +296,7 @@ pub fn materialize_notes_for_display(repo: &Repository, limit: usize) -> Result<
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
         .collect();
+    ensure_batch_git_item_limit("display note commit", commit_shas.len())?;
 
     if commit_shas.is_empty() {
         return Ok(0);
@@ -552,20 +566,23 @@ fn http_read_notes(commit_shas: &[String]) -> HashMap<String, String> {
     db_lock.get_notes(&refs).unwrap_or_default()
 }
 
-fn http_fetch_and_cache_notes(commit_shas: &[String]) -> HashMap<String, String> {
+fn http_fetch_and_cache_notes(
+    commit_shas: &[String],
+    materialization_budget: &mut BatchMaterializationBudget,
+) -> Result<HashMap<String, String>, GitAiError> {
     if commit_shas.is_empty() {
-        return HashMap::new();
+        return Ok(HashMap::new());
     }
 
     let cfg = Config::fresh();
     let Some(backend_url) = cfg.notes_backend_url().map(str::to_string) else {
-        return HashMap::new();
+        return Ok(HashMap::new());
     };
 
     let ctx = crate::api::client::ApiContext::new(Some(backend_url));
     let client = crate::api::client::ApiClient::new(ctx);
     if !client.is_logged_in() && !client.has_api_key() {
-        return HashMap::new();
+        return Ok(HashMap::new());
     }
 
     let mut fetched = HashMap::new();
@@ -576,6 +593,7 @@ fn http_fetch_and_cache_notes(commit_shas: &[String]) -> HashMap<String, String>
                 if response.notes.is_empty() {
                     continue;
                 }
+                reserve_note_map(materialization_budget, "note content", &response.notes)?;
                 let entries: Vec<(String, String)> = response.notes.into_iter().collect();
                 if let Ok(db) = crate::notes::db::NotesDatabase::global()
                     && let Ok(mut lock) = db.lock()
@@ -590,11 +608,23 @@ fn http_fetch_and_cache_notes(commit_shas: &[String]) -> HashMap<String, String>
         }
     }
 
-    fetched
+    Ok(fetched)
 }
 
 fn http_check_exists(commit_shas: &[String]) -> HashSet<String> {
     http_read_notes(commit_shas).into_keys().collect()
+}
+
+fn reserve_note_map(
+    budget: &mut BatchMaterializationBudget,
+    kind: &str,
+    notes: &HashMap<String, String>,
+) -> Result<(), GitAiError> {
+    ensure_batch_git_item_limit("materialized note", notes.len())?;
+    for content in notes.values() {
+        budget.reserve(kind, content.len())?;
+    }
+    Ok(())
 }
 
 // --- Tests ---
@@ -602,6 +632,37 @@ fn http_check_exists(commit_shas: &[String]) -> HashSet<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn note_map_budget_is_shared_across_sources() {
+        let content = "x".repeat(1_024 * 1_024);
+        let cached = (0..8)
+            .map(|index| (format!("{index:040x}"), content.clone()))
+            .collect::<HashMap<_, _>>();
+        let fetched = (8..17)
+            .map(|index| (format!("{index:040x}"), content.clone()))
+            .collect::<HashMap<_, _>>();
+        let mut budget = crate::git::repository::BatchMaterializationBudget::new();
+
+        reserve_note_map(&mut budget, "note content", &cached).unwrap();
+        let error = reserve_note_map(&mut budget, "note content", &fetched)
+            .expect_err("all note sources must share one materialization budget");
+
+        assert!(error.to_string().contains("materialized note content"));
+    }
+
+    #[test]
+    fn materialize_notes_for_display_rejects_oversized_limit_before_git() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+
+        let error = materialize_notes_for_display(
+            tmp.gitai_repo(),
+            crate::git::repository::MAX_BATCH_GIT_ITEMS + 1,
+        )
+        .expect_err("display materialization must bound the requested history walk");
+
+        assert!(error.to_string().contains("display note commit count"));
+    }
 
     /// With kind=Http, the http helpers upsert into notes-db (synced=0) and the
     /// read helper returns the cached value. This tests the private http_* helpers

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -1,7 +1,9 @@
 use crate::authorship::authorship_log_serialization::{AUTHORSHIP_LOG_VERSION, AuthorshipLog};
 use crate::authorship::working_log::Checkpoint;
 use crate::error::GitAiError;
-use crate::git::repository::{Repository, exec_git, exec_git_stdin};
+use crate::git::repository::{
+    BatchMaterializationBudget, Repository, ensure_batch_git_item_limit, exec_git, exec_git_stdin,
+};
 use serde_json;
 use std::collections::{HashMap, HashSet};
 
@@ -129,6 +131,7 @@ fn batch_read_blob_contents(
     if blob_oids.is_empty() {
         return Ok(HashMap::new());
     }
+    ensure_batch_git_item_limit("note blob", blob_oids.len())?;
 
     let mut args = repo.global_args_for_exec();
     args.push("cat-file".to_string());
@@ -169,6 +172,7 @@ pub fn notes_for_commits(
     if commit_shas.is_empty() {
         return Ok(HashMap::new());
     }
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
 
     let note_blob_oids = note_blob_oids_for_commits(repo, commit_shas)?;
     if note_blob_oids.is_empty() {
@@ -183,14 +187,24 @@ pub fn notes_for_commits(
         .collect();
     let blob_contents = batch_read_blob_contents(repo, &unique_blob_oids)?;
 
-    Ok(note_blob_oids
-        .into_iter()
-        .filter_map(|(commit_sha, blob_oid)| {
-            blob_contents
-                .get(&blob_oid)
-                .map(|content| (commit_sha, content.clone()))
-        })
-        .collect())
+    materialize_note_contents(note_blob_oids, &blob_contents)
+}
+
+fn materialize_note_contents(
+    note_blob_oids: HashMap<String, String>,
+    blob_contents: &HashMap<String, String>,
+) -> Result<HashMap<String, String>, GitAiError> {
+    ensure_batch_git_item_limit("materialized note", note_blob_oids.len())?;
+    let mut budget = BatchMaterializationBudget::new();
+    let mut notes = HashMap::with_capacity(note_blob_oids.len());
+    for (commit_sha, blob_oid) in note_blob_oids {
+        let Some(content) = blob_contents.get(&blob_oid) else {
+            continue;
+        };
+        budget.reserve("note content", content.len())?;
+        notes.insert(commit_sha, content.clone());
+    }
+    Ok(notes)
 }
 
 /// Resolve authorship note blob OIDs for a set of commits from a specific notes ref.
@@ -205,6 +219,7 @@ pub fn note_blob_oids_for_commits_from_ref(
     if commit_shas.is_empty() {
         return Ok(HashMap::new());
     }
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
 
     let mut path_to_commit = HashMap::new();
     let mut fanout_prefixes = HashSet::new();
@@ -322,6 +337,7 @@ fn parse_ls_tree_note_entries(data: &[u8]) -> Result<Vec<LsTreeNoteEntry>, GitAi
                 "Malformed ls-tree output: missing object id".to_string(),
             ));
         };
+        ensure_batch_git_item_limit("note tree entry", entries.len().saturating_add(1))?;
         entries.push(LsTreeNoteEntry {
             object_type: object_type.to_string(),
             oid: oid.to_string(),
@@ -343,7 +359,11 @@ pub fn copy_missing_notes_for_commits_from_ref(
     source_ref: &str,
     commit_shas: &[String],
 ) -> Result<usize, GitAiError> {
-    if commit_shas.is_empty() || !ref_exists(repo, source_ref) {
+    if commit_shas.is_empty() {
+        return Ok(0);
+    }
+    ensure_batch_git_item_limit("copied note commit", commit_shas.len())?;
+    if !ref_exists(repo, source_ref) {
         return Ok(0);
     }
 
@@ -372,6 +392,7 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
     if entries.is_empty() {
         return Ok(());
     }
+    let deduped_entries = dedupe_note_entries(entries)?;
 
     let mut args = repo.global_args_for_exec();
     args.push("rev-parse".to_string());
@@ -385,15 +406,6 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
         | Err(GitAiError::GitCliError { code: Some(1), .. }) => None,
         Err(e) => return Err(e),
     };
-
-    let mut deduped_entries: Vec<(String, String)> = Vec::new();
-    let mut seen = HashSet::new();
-    for (commit_sha, note_content) in entries.iter().rev() {
-        if seen.insert(commit_sha.as_str()) {
-            deduped_entries.push((commit_sha.clone(), note_content.clone()));
-        }
-    }
-    deduped_entries.reverse();
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -437,6 +449,21 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
     Ok(())
 }
 
+fn dedupe_note_entries(entries: &[(String, String)]) -> Result<Vec<(String, String)>, GitAiError> {
+    ensure_batch_git_item_limit("note write", entries.len())?;
+    let mut budget = BatchMaterializationBudget::new();
+    let mut deduped_entries = Vec::with_capacity(entries.len());
+    let mut seen = HashSet::new();
+    for (commit_sha, note_content) in entries.iter().rev() {
+        if seen.insert(commit_sha.as_str()) {
+            budget.reserve("note write content", note_content.len())?;
+            deduped_entries.push((commit_sha.clone(), note_content.clone()));
+        }
+    }
+    deduped_entries.reverse();
+    Ok(deduped_entries)
+}
+
 /// Batch-attach existing note blobs to commits without rewriting blob contents.
 ///
 /// Each entry is (commit_sha, existing_note_blob_oid).
@@ -448,6 +475,7 @@ pub fn notes_add_blob_batch(
     if entries.is_empty() {
         return Ok(());
     }
+    ensure_batch_git_item_limit("note blob write", entries.len())?;
 
     let mut args = repo.global_args_for_exec();
     args.push("rev-parse".to_string());
@@ -514,14 +542,15 @@ pub fn notes_add_blob_batch(
             unique_blob_oids.sort();
             let blob_contents = batch_read_blob_contents(repo, &unique_blob_oids)?;
 
-            Ok(deduped_entries
-                .iter()
-                .filter_map(|(commit_sha, blob_oid)| {
-                    blob_contents
-                        .get(blob_oid)
-                        .map(|note_content| (commit_sha.clone(), note_content.clone()))
-                })
-                .collect())
+            let mut budget = BatchMaterializationBudget::new();
+            let mut hook_entries = Vec::with_capacity(deduped_entries.len());
+            for (commit_sha, blob_oid) in &deduped_entries {
+                if let Some(note_content) = blob_contents.get(blob_oid) {
+                    budget.reserve("note hook content", note_content.len())?;
+                    hook_entries.push((commit_sha.clone(), note_content.clone()));
+                }
+            }
+            Ok(hook_entries)
         })();
         match hook_entries {
             Ok(entries) if !entries.is_empty() => {
@@ -561,6 +590,7 @@ pub fn get_commits_with_notes_from_list(
     if commit_shas.is_empty() {
         return Ok(Vec::new());
     }
+    ensure_batch_git_item_limit("note commit", commit_shas.len())?;
 
     // Get the git authors for all commits using git rev-list
     // This approach works in both bare and normal repositories
@@ -611,6 +641,7 @@ pub fn get_commits_with_notes_from_list(
 
     // Build the result Vec
     let mut result = Vec::new();
+    let mut materialization_budget = BatchMaterializationBudget::new();
     for sha in commit_shas {
         let git_author = commit_authors
             .get(sha)
@@ -619,14 +650,21 @@ pub fn get_commits_with_notes_from_list(
 
         if let Some(blob_oid) = note_blob_oids.get(sha)
             && let Some(content) = note_blob_contents.get(blob_oid)
-            && let Ok(mut authorship_log) = AuthorshipLog::deserialize_from_string(content)
         {
-            authorship_log.metadata.base_commit_sha = sha.clone();
-            result.push(CommitAuthorship::Log {
-                sha: sha.clone(),
-                git_author,
-                authorship_log,
-            });
+            materialization_budget.reserve("deserialized note content", content.len())?;
+            if let Ok(mut authorship_log) = AuthorshipLog::deserialize_from_string(content) {
+                authorship_log.metadata.base_commit_sha = sha.clone();
+                result.push(CommitAuthorship::Log {
+                    sha: sha.clone(),
+                    git_author,
+                    authorship_log,
+                });
+            } else {
+                result.push(CommitAuthorship::NoLog {
+                    sha: sha.clone(),
+                    git_author,
+                });
+            }
         } else {
             result.push(CommitAuthorship::NoLog {
                 sha: sha.clone(),
@@ -953,6 +991,67 @@ pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn note_materialization_rejects_shared_blob_amplification() {
+        let blob_oid = "a".repeat(40);
+        let content = "x".repeat(1_024 * 1_024);
+        let note_blob_oids = (0..=crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES
+            / content.len())
+            .map(|index| (format!("{index:040x}"), blob_oid.clone()))
+            .collect::<HashMap<_, _>>();
+        let blob_contents = HashMap::from([(blob_oid, content)]);
+
+        let error = materialize_note_contents(note_blob_oids, &blob_contents)
+            .expect_err("shared note clones must respect the materialization budget");
+
+        assert!(error.to_string().contains("materialized note content"));
+    }
+
+    #[test]
+    fn note_write_deduplication_rejects_oversized_content() {
+        let content = "x".repeat(1_024 * 1_024);
+        let entries = (0..=crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES
+            / content.len())
+            .map(|index| (format!("{index:040x}"), content.clone()))
+            .collect::<Vec<_>>();
+
+        let error = dedupe_note_entries(&entries)
+            .expect_err("note writes must be bounded before content is cloned");
+
+        assert!(
+            error
+                .to_string()
+                .contains("materialized note write content")
+        );
+    }
+
+    #[test]
+    fn note_tree_parser_rejects_oversized_entry_set() {
+        let oid = "a".repeat(40);
+        let mut data = Vec::new();
+        for index in 0..=crate::git::repository::MAX_BATCH_GIT_ITEMS {
+            data.extend_from_slice(format!("100644 blob {oid}\t{index:040x}\0").as_bytes());
+        }
+
+        let error =
+            parse_ls_tree_note_entries(&data).expect_err("oversized notes trees must fail closed");
+
+        assert!(error.to_string().contains("note tree entry count"));
+    }
+
+    #[test]
+    fn notes_for_commits_rejects_oversized_request_before_git() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let commits = (0..=crate::git::repository::MAX_BATCH_GIT_ITEMS)
+            .map(|index| format!("{index:040x}"))
+            .collect::<Vec<_>>();
+
+        let error = notes_for_commits(tmp.gitai_repo(), &commits)
+            .expect_err("oversized note requests must fail closed");
+
+        assert!(error.to_string().contains("note commit count"));
+    }
 
     #[test]
     fn test_parse_batch_check_blob_oid_accepts_sha1_and_sha256() {

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -41,7 +41,7 @@ const MAX_INTERNAL_GIT_STDOUT_BYTES: usize = 32 * 1_024 * 1_024;
 const MAX_INTERNAL_GIT_STDERR_BYTES: usize = 1_024 * 1_024;
 const INTERNAL_GIT_READER_STACK_BYTES: usize = 512 * 1_024;
 pub(crate) const MAX_BATCH_GIT_ITEMS: usize = 4_096;
-const MAX_BATCH_MATERIALIZED_CONTENT_BYTES: usize = 16 * 1_024 * 1_024;
+pub(crate) const MAX_BATCH_MATERIALIZED_CONTENT_BYTES: usize = 16 * 1_024 * 1_024;
 const MAX_GIT_INDEX_BYTES: u64 = 32 * 1_024 * 1_024;
 
 pub(crate) fn ensure_batch_git_item_limit(kind: &str, count: usize) -> Result<(), GitAiError> {
@@ -51,6 +51,27 @@ pub(crate) fn ensure_batch_git_item_limit(kind: &str, count: usize) -> Result<()
         )));
     }
     Ok(())
+}
+
+pub(crate) struct BatchMaterializationBudget {
+    used_bytes: usize,
+}
+
+impl BatchMaterializationBudget {
+    pub(crate) fn new() -> Self {
+        Self { used_bytes: 0 }
+    }
+
+    pub(crate) fn reserve(&mut self, kind: &str, bytes: usize) -> Result<(), GitAiError> {
+        self.used_bytes = self.used_bytes.saturating_add(bytes);
+        if self.used_bytes > MAX_BATCH_MATERIALIZED_CONTENT_BYTES {
+            return Err(GitAiError::Generic(format!(
+                "batched materialized {kind} exceeded the {MAX_BATCH_MATERIALIZED_CONTENT_BYTES} byte limit ({})",
+                self.used_bytes
+            )));
+        }
+        Ok(())
+    }
 }
 
 struct InternalGitLimiter {
@@ -2749,6 +2770,15 @@ fn spawn_probe_log(effective_args: &[String]) {
     let Ok(path) = std::env::var("GIT_AI_SPAWN_LOG") else {
         return;
     };
+    if let Some(filter) = std::env::var_os("GIT_AI_SPAWN_LOG_MATCH") {
+        let filter = filter.to_string_lossy();
+        if !effective_args
+            .iter()
+            .any(|arg| arg.contains(filter.as_ref()))
+        {
+            return;
+        }
+    }
     let sub = effective_args
         .iter()
         .find(|a| !a.starts_with('-') && !a.contains('=') && !a.contains('/') && !a.contains('\\'))
@@ -3098,18 +3128,13 @@ fn materialize_path_contents(
     blob_contents: &HashMap<String, String>,
 ) -> Result<HashMap<(String, String), String>, GitAiError> {
     ensure_batch_git_item_limit("materialized path", request_blob_oids.len())?;
-    let mut materialized_bytes = 0usize;
+    let mut budget = BatchMaterializationBudget::new();
     let mut contents = HashMap::with_capacity(request_blob_oids.len());
     for (request, blob_oid) in request_blob_oids {
         let Some(content) = blob_contents.get(&blob_oid) else {
             continue;
         };
-        materialized_bytes = materialized_bytes.saturating_add(content.len());
-        if materialized_bytes > MAX_BATCH_MATERIALIZED_CONTENT_BYTES {
-            return Err(GitAiError::Generic(format!(
-                "batched Git materialized content exceeded the {MAX_BATCH_MATERIALIZED_CONTENT_BYTES} byte limit ({materialized_bytes})"
-            )));
-        }
+        budget.reserve("content", content.len())?;
         contents.insert(request, content.clone());
     }
     Ok(contents)
@@ -3463,6 +3488,7 @@ mod tests {
         let log_dir = tempfile::tempdir().unwrap();
         let log_path = log_dir.path().join("spawns.log");
         let _spawn_log = TestEnvGuard::set("GIT_AI_SPAWN_LOG", log_path.as_os_str());
+        let _spawn_filter = TestEnvGuard::set("GIT_AI_SPAWN_LOG_MATCH", tmp.path().as_os_str());
 
         let contents = tmp
             .gitai_repo()

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -11,6 +11,7 @@
 //! or migrations to `internal_db` for this feature is explicitly not what we do here.
 
 use crate::error::GitAiError;
+use crate::git::repository::{BatchMaterializationBudget, ensure_batch_git_item_limit};
 use rusqlite::{Connection, params};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -233,6 +234,8 @@ impl NotesDatabase {
     /// - If the content changed, `synced` and `attempts` are reset to 0 so the
     ///   updated note is queued for re-upload.
     pub fn upsert_note(&mut self, commit_sha: &str, content: &str) -> Result<(), GitAiError> {
+        let mut budget = BatchMaterializationBudget::new();
+        budget.reserve("note content", content.len())?;
         let now = unix_now();
         self.conn.execute(
             r#"
@@ -255,6 +258,7 @@ impl NotesDatabase {
         if entries.is_empty() {
             return Ok(());
         }
+        validate_note_entries("database note", entries)?;
         let now = unix_now();
         let tx = self.conn.transaction()?;
         {
@@ -286,6 +290,7 @@ impl NotesDatabase {
         if entries.is_empty() {
             return Ok(());
         }
+        validate_note_entries("cached note", entries)?;
         let now = unix_now();
         let tx = self.conn.transaction()?;
         {
@@ -318,11 +323,13 @@ impl NotesDatabase {
     ///
     /// Rows with `attempts >= 6` are skipped (permanent failure backoff).
     pub fn dequeue_pending(&mut self, batch_size: usize) -> Result<Vec<PendingNote>, GitAiError> {
+        ensure_batch_git_item_limit("pending note", batch_size)?;
         let now = unix_now();
         let stale_cutoff = now - 600; // 10 minutes
+        let tx = self.conn.transaction()?;
 
         // Release stale processing locks so they can be retried.
-        self.conn.execute(
+        tx.execute(
             r#"UPDATE notes
                SET processing_started_at = NULL
                WHERE synced = 0
@@ -334,7 +341,7 @@ impl NotesDatabase {
         // Select eligible rows first, then lock them. Two-step approach avoids
         // UPDATE ... RETURNING which requires SQLite 3.35+.
         let shas: Vec<String> = {
-            let mut stmt = self.conn.prepare(
+            let mut stmt = tx.prepare(
                 r#"SELECT commit_sha FROM notes
                    WHERE synced = 0
                      AND processing_started_at IS NULL
@@ -350,6 +357,7 @@ impl NotesDatabase {
         };
 
         if shas.is_empty() {
+            tx.commit()?;
             return Ok(Vec::new());
         }
 
@@ -369,36 +377,42 @@ impl NotesDatabase {
             params_vec.push(Box::new(sha.clone()));
         }
         let param_refs: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|b| b.as_ref()).collect();
-        self.conn.execute(&update_sql, param_refs.as_slice())?;
+        tx.execute(&update_sql, param_refs.as_slice())?;
 
         // Read back the locked rows.
         let select_sql = format!(
-            "SELECT commit_sha, content, attempts FROM notes WHERE commit_sha IN ({})",
+            "SELECT commit_sha, length(CAST(content AS BLOB)), content, attempts \
+             FROM notes WHERE commit_sha IN ({})",
             shas.iter()
                 .enumerate()
                 .map(|(i, _)| format!("?{}", i + 1))
                 .collect::<Vec<_>>()
                 .join(",")
         );
-        let mut stmt = self.conn.prepare(&select_sql)?;
-        let sha_params: Vec<Box<dyn rusqlite::ToSql>> = shas
-            .iter()
-            .map(|s| Box::new(s.clone()) as Box<dyn rusqlite::ToSql>)
-            .collect();
-        let sha_param_refs: Vec<&dyn rusqlite::ToSql> =
-            sha_params.iter().map(|b| b.as_ref()).collect();
-        let rows = stmt.query_map(sha_param_refs.as_slice(), |row| {
-            Ok(PendingNote {
-                commit_sha: row.get(0)?,
-                content: row.get(1)?,
-                attempts: row.get(2)?,
-            })
-        })?;
+        let out = {
+            let mut stmt = tx.prepare(&select_sql)?;
+            let sha_params: Vec<Box<dyn rusqlite::ToSql>> = shas
+                .iter()
+                .map(|s| Box::new(s.clone()) as Box<dyn rusqlite::ToSql>)
+                .collect();
+            let sha_param_refs: Vec<&dyn rusqlite::ToSql> =
+                sha_params.iter().map(|b| b.as_ref()).collect();
+            let mut rows = stmt.query(sha_param_refs.as_slice())?;
 
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
+            let mut budget = BatchMaterializationBudget::new();
+            let mut out = Vec::with_capacity(shas.len());
+            while let Some(row) = rows.next()? {
+                let content_len = note_content_len(row, 1)?;
+                budget.reserve("pending note content", content_len)?;
+                out.push(PendingNote {
+                    commit_sha: row.get(0)?,
+                    content: row.get(2)?,
+                    attempts: row.get(3)?,
+                });
+            }
+            out
+        };
+        tx.commit()?;
         Ok(out)
     }
 
@@ -410,6 +424,7 @@ impl NotesDatabase {
         if commit_shas.is_empty() {
             return Ok(0);
         }
+        ensure_batch_git_item_limit("synced note", commit_shas.len())?;
         let now = unix_now();
 
         // Build a parameterised `IN (...)` clause.
@@ -442,6 +457,7 @@ impl NotesDatabase {
         if commit_shas.is_empty() {
             return Ok(());
         }
+        ensure_batch_git_item_limit("failed note", commit_shas.len())?;
         let now = unix_now();
         let tx = self.conn.transaction()?;
         for sha in commit_shas {
@@ -464,15 +480,17 @@ impl NotesDatabase {
 
     /// Retrieve the note content for a single commit SHA.
     pub fn get_note(&self, commit_sha: &str) -> Result<Option<String>, GitAiError> {
-        match self.conn.query_row(
-            "SELECT content FROM notes WHERE commit_sha = ?1",
-            params![commit_sha],
-            |row| row.get::<_, String>(0),
-        ) {
-            Ok(c) => Ok(Some(c)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        let mut stmt = self.conn.prepare(
+            "SELECT length(CAST(content AS BLOB)), content FROM notes WHERE commit_sha = ?1",
+        )?;
+        let mut rows = stmt.query(params![commit_sha])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        let content_len = note_content_len(row, 0)?;
+        let mut budget = BatchMaterializationBudget::new();
+        budget.reserve("note content", content_len)?;
+        Ok(Some(row.get(1)?))
     }
 
     /// Return the subset of `commit_shas` that exist in the DB with `synced = 1`.
@@ -480,6 +498,7 @@ impl NotesDatabase {
         if commit_shas.is_empty() {
             return Ok(HashSet::new());
         }
+        ensure_batch_git_item_limit("database note", commit_shas.len())?;
         let placeholders: String = commit_shas
             .iter()
             .enumerate()
@@ -511,6 +530,7 @@ impl NotesDatabase {
         if commit_shas.is_empty() {
             return Ok(HashMap::new());
         }
+        ensure_batch_git_item_limit("database note", commit_shas.len())?;
         let placeholders: String = commit_shas
             .iter()
             .enumerate()
@@ -518,7 +538,8 @@ impl NotesDatabase {
             .collect::<Vec<_>>()
             .join(",");
         let sql = format!(
-            "SELECT commit_sha, content FROM notes WHERE commit_sha IN ({})",
+            "SELECT commit_sha, length(CAST(content AS BLOB)), content \
+             FROM notes WHERE commit_sha IN ({})",
             placeholders
         );
         let params_vec: Vec<&dyn rusqlite::ToSql> = commit_shas
@@ -527,14 +548,14 @@ impl NotesDatabase {
             .collect();
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_vec.as_slice(), |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+        let mut rows = stmt.query(params_vec.as_slice())?;
 
-        let mut result = HashMap::new();
-        for row in rows {
-            let (sha, content) = row?;
-            result.insert(sha, content);
+        let mut budget = BatchMaterializationBudget::new();
+        let mut result = HashMap::with_capacity(commit_shas.len());
+        while let Some(row) = rows.next()? {
+            let content_len = note_content_len(row, 1)?;
+            budget.reserve("note content", content_len)?;
+            result.insert(row.get(0)?, row.get(2)?);
         }
         Ok(result)
     }
@@ -561,6 +582,21 @@ impl NotesDatabase {
         )?;
         Ok(deleted)
     }
+}
+
+fn validate_note_entries(kind: &str, entries: &[(String, String)]) -> Result<(), GitAiError> {
+    ensure_batch_git_item_limit(kind, entries.len())?;
+    let mut budget = BatchMaterializationBudget::new();
+    for (_, content) in entries {
+        budget.reserve("note content", content.len())?;
+    }
+    Ok(())
+}
+
+fn note_content_len(row: &rusqlite::Row<'_>, index: usize) -> Result<usize, GitAiError> {
+    let content_len: i64 = row.get(index)?;
+    usize::try_from(content_len)
+        .map_err(|_| GitAiError::Generic(format!("invalid note content length: {content_len}")))
 }
 
 fn unix_now() -> i64 {
@@ -674,6 +710,26 @@ mod tests {
     }
 
     #[test]
+    fn test_get_note_rejects_legacy_oversized_content() {
+        let (db, _tmp) = create_test_db();
+        let content = "x".repeat(crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES + 1);
+        let now = unix_now();
+        db.conn
+            .execute(
+                "INSERT INTO notes (commit_sha, content, synced, created_at, updated_at, next_retry_at) \
+                 VALUES ('oversized', ?1, 1, ?2, ?2, 0)",
+                params![content, now],
+            )
+            .unwrap();
+
+        let error = db
+            .get_note("oversized")
+            .expect_err("legacy oversized notes must fail closed");
+
+        assert!(error.to_string().contains("materialized note content"));
+    }
+
+    #[test]
     fn test_upsert_new_content_resets_synced() {
         let (mut db, _tmp) = create_test_db();
 
@@ -753,6 +809,43 @@ mod tests {
         // Second dequeue should return nothing (row is now synced = 1).
         let batch2 = db.dequeue_pending(10).unwrap();
         assert!(batch2.is_empty(), "no pending rows after mark_synced");
+    }
+
+    #[test]
+    fn test_dequeue_budget_error_does_not_leave_rows_locked() {
+        let (mut db, _tmp) = create_test_db();
+        let content = "x".repeat(1_024 * 1_024);
+        let now = unix_now();
+        let note_count =
+            crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES / content.len() + 1;
+        for index in 0..note_count {
+            db.conn
+                .execute(
+                    "INSERT INTO notes (commit_sha, content, synced, created_at, updated_at, next_retry_at) \
+                     VALUES (?1, ?2, 0, ?3, ?3, 0)",
+                    params![format!("{index:040x}"), content, now],
+                )
+                .unwrap();
+        }
+
+        let error = db
+            .dequeue_pending(note_count)
+            .expect_err("pending note reads must respect the materialization budget");
+        assert!(
+            error
+                .to_string()
+                .contains("materialized pending note content")
+        );
+
+        let locked: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM notes WHERE processing_started_at IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(locked, 0, "a failed dequeue must roll back row locks");
     }
 
     #[test]
@@ -874,6 +967,65 @@ mod tests {
             !results.contains_key("sha_missing"),
             "missing SHA should not be in result"
         );
+    }
+
+    #[test]
+    fn test_get_notes_rejects_oversized_materialized_content() {
+        let (db, _tmp) = create_test_db();
+        let content = "x".repeat(1_024 * 1_024);
+        let now = unix_now();
+        let mut shas = Vec::new();
+        for index in
+            0..=crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES / content.len()
+        {
+            let sha = format!("{index:040x}");
+            db.conn
+                .execute(
+                    "INSERT INTO notes (commit_sha, content, synced, created_at, updated_at, next_retry_at) \
+                     VALUES (?1, ?2, 1, ?3, ?3, 0)",
+                    params![sha, content, now],
+                )
+                .unwrap();
+            shas.push(sha);
+        }
+        let refs = shas.iter().map(String::as_str).collect::<Vec<_>>();
+
+        let error = db
+            .get_notes(&refs)
+            .expect_err("database note reads must respect the materialization budget");
+
+        assert!(error.to_string().contains("materialized note content"));
+    }
+
+    #[test]
+    fn test_get_notes_rejects_oversized_request_before_query() {
+        let (db, _tmp) = create_test_db();
+        let shas = (0..=crate::git::repository::MAX_BATCH_GIT_ITEMS)
+            .map(|index| format!("{index:040x}"))
+            .collect::<Vec<_>>();
+        let refs = shas.iter().map(String::as_str).collect::<Vec<_>>();
+
+        let error = db
+            .get_notes(&refs)
+            .expect_err("oversized database note reads must fail before querying SQLite");
+
+        assert!(error.to_string().contains("database note count"));
+    }
+
+    #[test]
+    fn test_upsert_notes_batch_rejects_oversized_materialized_content() {
+        let (mut db, _tmp) = create_test_db();
+        let content = "x".repeat(1_024 * 1_024);
+        let entries = (0..=crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES
+            / content.len())
+            .map(|index| (format!("{index:040x}"), content.clone()))
+            .collect::<Vec<_>>();
+
+        let error = db
+            .upsert_notes_batch(&entries)
+            .expect_err("database note writes must respect the materialization budget");
+
+        assert!(error.to_string().contains("materialized note content"));
     }
 
     // --- database_path ---

--- a/tests/integration/daemon_note_materialization_memory.rs
+++ b/tests/integration/daemon_note_materialization_memory.rs
@@ -1,0 +1,139 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::git::refs::notes_add_blob_batch;
+use git_ai::git::repository::find_repository_in_path;
+use std::fs;
+
+const SOURCE_COMMIT_COUNT: usize = 17;
+const SHARED_NOTE_BYTES: usize = 4 * 1_024 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+fn assert_base(repo: &TestRepo) {
+    let mut file = repo.filename("base.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+}
+
+fn assert_source_files(repo: &TestRepo, count: usize, expect_ai: bool) {
+    for index in 0..count {
+        let line = format!("source {index}");
+        let expected = if expect_ai {
+            line.ai()
+        } else {
+            line.unattributed_human()
+        };
+        let mut file = repo.filename(&format!("source-{index}.txt"));
+        file.assert_committed_lines(crate::lines![expected]);
+    }
+}
+
+#[test]
+fn shared_note_blob_materialization_keeps_daemon_bounded_and_recovers() {
+    let repo = TestRepo::new_dedicated_daemon();
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.stage_all_and_commit("base commit").unwrap();
+    assert_base(&repo);
+
+    let base_branch = repo.current_branch();
+    repo.git(&["switch", "-c", "large-note-sources"]).unwrap();
+    let mut source_shas = Vec::new();
+    for index in 0..SOURCE_COMMIT_COUNT {
+        let path = format!("source-{index}.txt");
+        fs::write(repo.path().join(&path), format!("source {index}\n")).unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", &path]).unwrap();
+        repo.stage_all_and_commit(&format!("source commit {index}"))
+            .unwrap();
+        source_shas.push(
+            repo.git_og(&["rev-parse", "HEAD"])
+                .unwrap()
+                .trim()
+                .to_string(),
+        );
+        assert_base(&repo);
+        assert_source_files(&repo, index + 1, true);
+    }
+
+    let note_file = tempfile::NamedTempFile::new().unwrap();
+    fs::write(note_file.path(), vec![b'x'; SHARED_NOTE_BYTES]).unwrap();
+    let note_path = note_file.path().to_string_lossy();
+    let note_blob_oid = repo
+        .git_og(&["hash-object", "-w", note_path.as_ref()])
+        .unwrap()
+        .trim()
+        .to_string();
+    let note_entries = source_shas
+        .iter()
+        .map(|sha| (sha.clone(), note_blob_oid.clone()))
+        .collect::<Vec<_>>();
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    notes_add_blob_batch(&gitai_repo, &note_entries).unwrap();
+
+    repo.git(&["switch", &base_branch]).unwrap();
+    assert_base(&repo);
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    let mut cherry_pick_args = vec!["cherry-pick"];
+    cherry_pick_args.extend(source_shas.iter().map(String::as_str));
+    repo.git_without_test_sync_for_test(&cherry_pick_args, &[])
+        .unwrap();
+    repo.sync_daemon();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("shared note materialization HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 48 * 1_024,
+            "shared note materialization grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        let materialized_threads = daemon_thread_count(&repo);
+        eprintln!(
+            "shared note materialization threads: baseline={baseline_threads}, materialized={materialized_threads}"
+        );
+        assert!(
+            materialized_threads <= baseline_threads + 2,
+            "note materialization must not retain worker threads: baseline={baseline_threads}, materialized={materialized_threads}"
+        );
+    }
+    assert_base(&repo);
+    assert_source_files(&repo, SOURCE_COMMIT_COUNT, false);
+
+    fs::write(repo.path().join("recovery.txt"), "AI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "recovery.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit after note pressure")
+        .unwrap();
+    assert_base(&repo);
+    assert_source_files(&repo, SOURCE_COMMIT_COUNT, false);
+    let mut recovery = repo.filename("recovery.txt");
+    recovery.assert_committed_lines(crate::lines!["AI recovery".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -55,6 +55,7 @@ mod daemon_commit_carryover;
 mod daemon_git_output_memory;
 mod daemon_ipc_memory;
 mod daemon_log_memory;
+mod daemon_note_materialization_memory;
 mod daemon_reflog_memory;
 mod daemon_repository_reader_memory;
 mod daemon_retained_state_memory;


### PR DESCRIPTION
## Bug
Notes fetch/upload, Git note parsing, and SQLite note-cache operations could materialize unlimited item counts and aggregate content. Oversized rows could also leave dequeued records locked and block later work.

## Fix
Bound API requests, batch items, and cumulative note content (16 MiB), stream budget accounting through Git and SQLite layers, reject oversized legacy notes before full materialization, and release locked rows on budget errors.

## Verification
Database and Git-note tests cover oversized legacy data, batch limits, and lock recovery. `tests/integration/daemon_note_materialization_memory.rs` validates bounded shared-note processing in `TestRepo`.