### PR TITLE
fix(http): bound request and response bodies

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -92,6 +92,12 @@ blob cannot be cloned once per commit. The notes SQLite cache enforces the
 budget while rows are read and rolls back queue locks if a pending batch is too
 large. HTTP note requests are limited to 100 entries before JSON serialization.
 
+Shared HTTP transport rejects response bodies above 32 MiB, using both an
+early `Content-Length` check and a one-byte-over streaming read for chunked or
+misreported responses. Outbound JSON serialization writes through a 64 MiB
+bounded buffer shared by the API and Cube clients, so request construction
+cannot create an unbounded second copy of an in-memory payload.
+
 Separation of concerns:
 
 - The **normalizer** parses trace2/argv facts only. It never reads mutable
@@ -270,6 +276,8 @@ Deterministic tests must cover, at minimum:
 13. repeated large file blobs remain bounded during batched materialization
 14. repeated large note blobs remain bounded during rewrite-note migration,
     fail closed, and preserve attribution for the next command
+15. oversized HTTP responses remain bounded and preserve attribution for the
+    next command
 
 Primary suites: `tests/daemon_mode.rs`, `tests/commit_tree_update_ref.rs`,
 `tests/integration/rewrite_ops_attribution.rs`, ref-cursor unit tests in

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -310,7 +310,7 @@ impl ApiContext {
         body: &T,
     ) -> Result<http::Response, GitAiError> {
         let url = self.build_url(endpoint)?;
-        let body_json = serde_json::to_string(body).map_err(GitAiError::JsonError)?;
+        let body_json = http::serialize_json_body(body).map_err(GitAiError::JsonError)?;
 
         let (_agent, mut request) = Self::http_post(&url, self.timeout_secs);
         request = request.set("Content-Type", "application/json");

--- a/src/commands/analyze/cube.rs
+++ b/src/commands/analyze/cube.rs
@@ -89,7 +89,8 @@ impl CubeClient {
             .post(&self.url(path))
             .set("x-api-key", &self.api_key)
             .set("Content-Type", "application/json");
-        let body_str = serde_json::to_string(body).map_err(|e| CubeError::Json(e.to_string()))?;
+        let body_str =
+            http::serialize_json_body(body).map_err(|e| CubeError::Json(e.to_string()))?;
         let response = http::send_with_body(request, &body_str).map_err(CubeError::Transport)?;
         Self::parse(response)
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,9 @@
-use std::io::Read;
+use std::io::{Read, Write};
 use std::sync::Arc;
 use std::time::Duration;
+
+const MAX_HTTP_RESPONSE_BODY_BYTES: usize = 32 * 1_024 * 1_024;
+const MAX_HTTP_REQUEST_BODY_BYTES: usize = 64 * 1_024 * 1_024;
 
 /// Build a ureq Agent that uses the platform's native TLS library.
 ///
@@ -43,12 +46,75 @@ impl Response {
 
 fn read_ureq_response(response: ureq::Response) -> Result<Response, String> {
     let status_code = response.status();
-    let mut body = Vec::new();
-    response
-        .into_reader()
-        .read_to_end(&mut body)
-        .map_err(|e| format!("Failed to read response body: {}", e))?;
+    if response
+        .header("Content-Length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .is_some_and(|length| length > MAX_HTTP_RESPONSE_BODY_BYTES)
+    {
+        return Err(format!(
+            "HTTP response body exceeded the {MAX_HTTP_RESPONSE_BODY_BYTES} byte limit"
+        ));
+    }
+    let body = read_body_with_limit(response.into_reader(), MAX_HTTP_RESPONSE_BODY_BYTES)?;
     Ok(Response { status_code, body })
+}
+
+fn read_body_with_limit(reader: impl Read, limit: usize) -> Result<Vec<u8>, String> {
+    let read_limit = u64::try_from(limit).unwrap_or(u64::MAX).saturating_add(1);
+    let mut limited = reader.take(read_limit);
+    let mut body = Vec::new();
+    limited
+        .read_to_end(&mut body)
+        .map_err(|e| format!("Failed to read response body: {e}"))?;
+    if body.len() > limit {
+        return Err(format!(
+            "HTTP response body exceeded the {limit} byte limit"
+        ));
+    }
+    Ok(body)
+}
+
+struct BoundedJsonWriter {
+    bytes: Vec<u8>,
+    limit: usize,
+}
+
+impl Write for BoundedJsonWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let remaining = self.limit.saturating_sub(self.bytes.len());
+        if buf.len() > remaining {
+            return Err(std::io::Error::other(format!(
+                "HTTP JSON request body exceeded the {} byte limit",
+                self.limit
+            )));
+        }
+        self.bytes.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) fn serialize_json_body<T: serde::Serialize + ?Sized>(
+    body: &T,
+) -> Result<String, serde_json::Error> {
+    serialize_json_with_limit(body, MAX_HTTP_REQUEST_BODY_BYTES)
+}
+
+fn serialize_json_with_limit<T: serde::Serialize + ?Sized>(
+    body: &T,
+    limit: usize,
+) -> Result<String, serde_json::Error> {
+    let mut writer = BoundedJsonWriter {
+        bytes: Vec::new(),
+        limit,
+    };
+    serde_json::to_writer(&mut writer, body)?;
+    String::from_utf8(writer.bytes).map_err(|error| {
+        serde_json::Error::io(std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+    })
 }
 
 /// Execute a ureq request, normalizing errors so that HTTP error status codes
@@ -67,5 +133,42 @@ pub fn send_with_body(request: ureq::Request, body: &str) -> Result<Response, St
         Ok(response) => read_ureq_response(response),
         Err(ureq::Error::Status(_code, response)) => read_ureq_response(response),
         Err(ureq::Error::Transport(err)) => Err(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn response_body_accepts_exact_byte_limit() {
+        let body = read_body_with_limit(Cursor::new(b"12345678"), 8).unwrap();
+
+        assert_eq!(body, b"12345678");
+    }
+
+    #[test]
+    fn response_body_rejects_one_byte_over_limit() {
+        let error = read_body_with_limit(Cursor::new(b"123456789"), 8)
+            .expect_err("HTTP bodies must be rejected after the first excess byte");
+
+        assert!(error.contains("8 byte limit"));
+    }
+
+    #[test]
+    fn bounded_json_serialization_accepts_exact_limit() {
+        let value = "123456";
+        let serialized = serialize_json_with_limit(&value, 8).unwrap();
+
+        assert_eq!(serialized, "\"123456\"");
+    }
+
+    #[test]
+    fn bounded_json_serialization_rejects_first_excess_write() {
+        let error = serialize_json_with_limit(&"1234567", 8)
+            .expect_err("JSON serialization must stop at the configured byte limit");
+
+        assert!(error.to_string().contains("8 byte limit"));
     }
 }

--- a/tests/integration/daemon_http_memory.rs
+++ b/tests/integration/daemon_http_memory.rs
@@ -1,0 +1,213 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::config::{NotesBackendConfig, NotesBackendKind};
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const OVERSIZED_RESPONSE_BYTES: usize = 64 * 1_024 * 1_024;
+
+struct OversizedResponseServer {
+    addr: SocketAddr,
+    requested: Arc<AtomicBool>,
+    response_finished: Arc<AtomicBool>,
+    shutdown: Arc<AtomicBool>,
+    join: Option<JoinHandle<()>>,
+}
+
+impl OversizedResponseServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requested = Arc::new(AtomicBool::new(false));
+        let response_finished = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let requested_for_thread = Arc::clone(&requested);
+        let response_finished_for_thread = Arc::clone(&response_finished);
+        let shutdown_for_thread = Arc::clone(&shutdown);
+        let join = std::thread::spawn(move || {
+            while !shutdown_for_thread.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = [0u8; 16 * 1_024];
+                        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+                        let _ = stream.read(&mut request);
+                        requested_for_thread.store(true, Ordering::Release);
+                        let header = format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                             Content-Length: {OVERSIZED_RESPONSE_BYTES}\r\nConnection: close\r\n\r\n"
+                        );
+                        if stream.write_all(header.as_bytes()).is_ok() {
+                            let chunk = [b'x'; 64 * 1_024];
+                            for _ in 0..OVERSIZED_RESPONSE_BYTES / chunk.len() {
+                                if stream.write_all(&chunk).is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        response_finished_for_thread.store(true, Ordering::Release);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Self {
+            addr,
+            requested,
+            response_finished,
+            shutdown,
+            join: Some(join),
+        }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    fn wait_for_response_completion(&self) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !self.response_finished.load(Ordering::Acquire) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            self.requested.load(Ordering::Acquire),
+            "daemon never requested the oversized HTTP response"
+        );
+        assert!(
+            self.response_finished.load(Ordering::Acquire),
+            "oversized HTTP response did not finish before the deadline"
+        );
+    }
+}
+
+impl Drop for OversizedResponseServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(self.addr);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_daemon_thread_bound(repo: &TestRepo, maximum: u64) -> u64 {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let current = daemon_thread_count(repo);
+        if current <= maximum || Instant::now() >= deadline {
+            return current;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn oversized_http_response_keeps_daemon_bounded_and_recovers() {
+    let server = OversizedResponseServer::start();
+    let backend_url = server.base_url();
+    let mut repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+        ("GIT_AI_NOTES_BACKEND_URL", backend_url.as_str()),
+        ("GIT_AI_API_KEY", "oversized-response-test-key"),
+    ]);
+    repo.patch_git_ai_config(|patch| {
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: Some(backend_url.clone()),
+        });
+    });
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.git_og(&["add", "base.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "base commit"]).unwrap();
+    let mut base = repo.filename("base.txt");
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let base_branch = repo.current_branch();
+    repo.git_og(&["switch", "-c", "http-source"]).unwrap();
+    fs::write(repo.path().join("source.txt"), "source\n").unwrap();
+    repo.git_og(&["add", "source.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "source commit"]).unwrap();
+    let source_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    let mut source = repo.filename("source.txt");
+    source.assert_committed_lines(crate::lines!["source".unattributed_human()]);
+    repo.git_og(&["switch", &base_branch]).unwrap();
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    repo.git_without_test_sync_for_test(&["cherry-pick", source_sha.trim()], &[])
+        .unwrap();
+    repo.sync_daemon();
+    server.wait_for_response_completion();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("oversized HTTP response HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 40 * 1_024,
+            "oversized HTTP response grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        let rejected_threads = wait_for_daemon_thread_bound(&repo, baseline_threads + 2);
+        eprintln!(
+            "oversized HTTP response threads: baseline={baseline_threads}, rejected={rejected_threads}"
+        );
+        assert!(
+            rejected_threads <= baseline_threads + 2,
+            "HTTP response rejection must not retain worker threads: baseline={baseline_threads}, rejected={rejected_threads}"
+        );
+    }
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    source.assert_committed_lines(crate::lines!["source".unattributed_human()]);
+
+    fs::write(repo.path().join("recovery.txt"), "AI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "recovery.txt"])
+        .unwrap();
+    repo.git(&["add", "recovery.txt"]).unwrap();
+    repo.git(&["commit", "-m", "AI commit after oversized HTTP response"])
+        .unwrap();
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    source.assert_committed_lines(crate::lines!["source".unattributed_human()]);
+    let mut recovery = repo.filename("recovery.txt");
+    recovery.assert_committed_lines(crate::lines!["AI recovery".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -53,6 +53,7 @@ mod cursor;
 mod daemon_batch_materialization_memory;
 mod daemon_commit_carryover;
 mod daemon_git_output_memory;
+mod daemon_http_memory;
 mod daemon_ipc_memory;
 mod daemon_log_memory;
 mod daemon_note_materialization_memory;


### PR DESCRIPTION
## Bug
HTTP helpers buffered request JSON and response bodies without hard ceilings. A large server response, misleading `Content-Length`, or oversized local payload could allocate tens of gigabytes in a daemon worker.

## Fix
Reject request bodies above 64 MiB, preflight responses above 32 MiB when length is known, and stream unknown-length responses through a bounded reader. API and analysis callers use the shared limited serializer/reader.

## Verification
Unit tests cover declared and streaming oversize cases. `tests/integration/daemon_http_memory.rs` serves a large response to a `TestRepo` daemon and verifies bounded rejection.