### PR TITLE
fix(working-log): bound persisted state memory

### DIFF
--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -7,7 +7,11 @@ use crate::authorship::hunk_shift::{DiffHunk, apply_hunk_shifts_to_line_attribut
 use crate::authorship::working_log::CheckpointKind;
 use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
 use crate::error::GitAiError;
-use crate::git::repository::{Repository, batch_read_paths_at_treeishes};
+use crate::git::repo_storage::read_bounded_working_log_file;
+use crate::git::repository::{
+    BatchMaterializationBudget, Repository, batch_read_paths_at_treeishes,
+    ensure_batch_git_item_limit,
+};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -394,6 +398,7 @@ impl VirtualAttributions {
         let mut prompts = BTreeMap::new();
         let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         let mut file_contents: HashMap<String, String> = HashMap::new();
+        let mut content_budget = BatchMaterializationBudget::new();
         // Prompt IDs that originate from INITIAL attributions (prior commits).
         // If a checkpoint later references the same prompt_id, it is removed from
         // this set because the prompt was actively used in this commit's session.
@@ -434,10 +439,16 @@ impl VirtualAttributions {
             if let Ok(workdir) = repo.workdir() {
                 let abs_path = workdir.join(file_path);
                 let file_content = if abs_path.exists() {
-                    std::fs::read_to_string(&abs_path).unwrap_or_default()
+                    read_bounded_working_log_file(&abs_path)?
                 } else {
                     String::new()
                 };
+                reserve_working_log_file_content(
+                    &mut content_budget,
+                    &file_contents,
+                    file_path,
+                    file_content.len(),
+                )?;
                 file_contents.insert(file_path.clone(), file_content.clone());
 
                 // Convert line attributions to character attributions
@@ -532,10 +543,16 @@ impl VirtualAttributions {
                 if let Ok(workdir) = repo.workdir() {
                     let abs_path = workdir.join(&entry.file);
                     let file_content = if abs_path.exists() {
-                        std::fs::read_to_string(&abs_path).unwrap_or_default()
+                        read_bounded_working_log_file(&abs_path)?
                     } else {
                         String::new()
                     };
+                    reserve_working_log_file_content(
+                        &mut content_budget,
+                        &file_contents,
+                        &entry.file,
+                        file_content.len(),
+                    )?;
                     file_contents.insert(entry.file.clone(), file_content);
                 }
 
@@ -604,6 +621,7 @@ impl VirtualAttributions {
         let mut prompts = BTreeMap::new();
         let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         let mut file_contents: HashMap<String, String> = HashMap::new();
+        let mut content_budget = BatchMaterializationBudget::new();
         let mut initial_only_prompt_ids: HashSet<String> = HashSet::new();
         let mut sessions: BTreeMap<String, SessionRecord> = BTreeMap::new();
 
@@ -639,6 +657,12 @@ impl VirtualAttributions {
                 .stored_initial_file_content_from(&initial_attributions, file_path)
                 .or_else(|| final_state_snapshot.get(file_path).cloned())
                 .unwrap_or_default();
+            reserve_working_log_file_content(
+                &mut content_budget,
+                &file_contents,
+                file_path,
+                file_content.len(),
+            )?;
             file_contents.insert(file_path.clone(), file_content.clone());
 
             let char_attrs = line_attributions_to_attributions(line_attrs, &file_content, 0);
@@ -718,14 +742,18 @@ impl VirtualAttributions {
                     continue;
                 }
 
-                let file_content = final_state_snapshot
-                    .get(&entry.file)
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        working_log
-                            .get_file_version(&entry.blob_sha)
-                            .unwrap_or_default()
-                    });
+                let file_content = match final_state_snapshot.get(&entry.file) {
+                    Some(content) => content.clone(),
+                    None => working_log
+                        .get_file_version(&entry.blob_sha)
+                        .unwrap_or_default(),
+                };
+                reserve_working_log_file_content(
+                    &mut content_budget,
+                    &file_contents,
+                    &entry.file,
+                    file_content.len(),
+                )?;
                 file_contents.insert(entry.file.clone(), file_content.clone());
 
                 let line_attrs = if entry.line_attributions.is_empty() {
@@ -789,6 +817,7 @@ impl VirtualAttributions {
         let mut prompts = BTreeMap::new();
         let mut humans: BTreeMap<String, HumanRecord> = BTreeMap::new();
         let mut file_contents: HashMap<String, String> = HashMap::new();
+        let mut content_budget = BatchMaterializationBudget::new();
         let mut initial_only_prompt_ids: HashSet<String> = HashSet::new();
         let mut sessions: BTreeMap<String, SessionRecord> = BTreeMap::new();
 
@@ -826,6 +855,12 @@ impl VirtualAttributions {
                         file_path
                     ))
                 })?;
+            reserve_working_log_file_content(
+                &mut content_budget,
+                &file_contents,
+                file_path,
+                file_content.len(),
+            )?;
             file_contents.insert(file_path.clone(), file_content.clone());
             let char_attrs = line_attributions_to_attributions(line_attrs, &file_content, 0);
             attributions.insert(file_path.clone(), (char_attrs, line_attrs.clone()));
@@ -904,7 +939,15 @@ impl VirtualAttributions {
                     continue;
                 }
 
-                let file_content = working_log.get_file_version(&entry.blob_sha)?;
+                let file_content = working_log
+                    .get_file_version(&entry.blob_sha)
+                    .unwrap_or_default();
+                reserve_working_log_file_content(
+                    &mut content_budget,
+                    &file_contents,
+                    &entry.file,
+                    file_content.len(),
+                )?;
                 file_contents.insert(entry.file.clone(), file_content.clone());
 
                 let line_attrs = if entry.line_attributions.is_empty() {
@@ -3564,9 +3607,78 @@ pub fn restore_virtual_attribution_carryover(
     Ok(())
 }
 
+fn reserve_working_log_file_content(
+    budget: &mut BatchMaterializationBudget,
+    file_contents: &HashMap<String, String>,
+    file_path: &str,
+    bytes: usize,
+) -> Result<(), GitAiError> {
+    let previous_bytes = if let Some(content) = file_contents.get(file_path) {
+        content.len()
+    } else {
+        ensure_batch_git_item_limit(
+            "working-log materialized file",
+            file_contents.len().saturating_add(1),
+        )?;
+        0
+    };
+    budget.replace_reservation("working-log file content", previous_bytes, bytes)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn working_log_content_budget_is_shared_across_files() {
+        let mut budget = crate::git::repository::BatchMaterializationBudget::new();
+        let mut file_contents = HashMap::new();
+        for index in 0..16 {
+            let path = format!("file-{index}.txt");
+            reserve_working_log_file_content(&mut budget, &file_contents, &path, 1_024 * 1_024)
+                .unwrap();
+            file_contents.insert(path, String::new());
+        }
+
+        let error = reserve_working_log_file_content(
+            &mut budget,
+            &file_contents,
+            "overflow.txt",
+            1_024 * 1_024,
+        )
+        .expect_err("working-log file contents must share one byte budget");
+
+        assert!(
+            error
+                .to_string()
+                .contains("materialized working-log file content")
+        );
+    }
+
+    #[test]
+    fn working_log_content_budget_tracks_replacement_bytes() {
+        let mut budget = crate::git::repository::BatchMaterializationBudget::new();
+        let mut file_contents = HashMap::new();
+        let path = "repeated.txt".to_string();
+        let content = "x".repeat(1_024 * 1_024);
+
+        reserve_working_log_file_content(&mut budget, &file_contents, &path, content.len())
+            .unwrap();
+        file_contents.insert(path.clone(), content);
+        for _ in 0..32 {
+            reserve_working_log_file_content(&mut budget, &file_contents, &path, 1_024 * 1_024)
+                .unwrap();
+        }
+
+        let error = reserve_working_log_file_content(
+            &mut budget,
+            &file_contents,
+            &path,
+            17 * 1_024 * 1_024,
+        )
+        .expect_err("a replacement must still fit the live content budget");
+        assert!(error.to_string().contains("working-log file content"));
+    }
 
     #[test]
     fn checkout_merge_rebased_content_preserves_clean_local_hunk_on_target_edit() {

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -3,17 +3,20 @@ use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord
 use crate::authorship::authorship_log_serialization::generate_short_hash;
 use crate::authorship::working_log::{CHECKPOINT_API_VERSION, Checkpoint, CheckpointKind};
 use crate::error::GitAiError;
+use crate::git::repository::{BatchMaterializationBudget, ensure_batch_git_item_limit};
 use crate::utils::normalize_to_posix;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-pub const MAX_CHECKPOINTS_JSONL_BYTES: u64 = 1024 * 1024 * 1024;
+pub const MAX_CHECKPOINTS_JSONL_BYTES: u64 = 32 * 1_024 * 1_024;
+const MAX_INITIAL_ATTRIBUTIONS_BYTES: u64 = 64 * 1_024 * 1_024;
+const MAX_WORKING_LOG_BLOB_BYTES: u64 = 16 * 1_024 * 1_024;
 
 #[cfg(feature = "test-support")]
 const TEST_CHECKPOINTS_JSONL_MAX_BYTES_ENV: &str = "GIT_AI_TEST_CHECKPOINTS_JSONL_MAX_BYTES";
@@ -171,12 +174,13 @@ impl RepoStorage {
             }
 
             let marker = dir_path.join(".archived_at");
-            let archived_at = match fs::read_to_string(&marker) {
-                Ok(contents) => contents.trim().parse::<u64>().unwrap_or(0),
-                // No marker means this was created before the retention feature;
-                // treat it as immediately expired so it gets cleaned up.
-                Err(_) => 0,
-            };
+            let archived_at =
+                match read_bounded_utf8_file(&marker, "working-log archive marker", 64) {
+                    Ok(contents) => contents.trim().parse::<u64>().unwrap_or(0),
+                    // No marker means this was created before the retention feature;
+                    // treat it as immediately expired so it gets cleaned up.
+                    Err(_) => 0,
+                };
 
             if now_secs.saturating_sub(archived_at) >= Self::OLD_WORKING_LOG_RETENTION_SECS {
                 tracing::debug!("Pruning expired old working log: {}", name_str);
@@ -355,11 +359,17 @@ impl PersistedWorkingLog {
     /* blob storage */
     pub fn get_file_version(&self, sha: &str) -> Result<String, GitAiError> {
         let blob_path = self.dir.join("blobs").join(sha);
-        Ok(fs::read_to_string(blob_path)?)
+        read_bounded_utf8_file(&blob_path, "working-log blob", MAX_WORKING_LOG_BLOB_BYTES)
     }
 
     #[allow(dead_code)]
     pub fn persist_file_version(&self, content: &str) -> Result<String, GitAiError> {
+        if content.len() as u64 > MAX_WORKING_LOG_BLOB_BYTES {
+            return Err(GitAiError::Generic(format!(
+                "working-log blob exceeded the {MAX_WORKING_LOG_BLOB_BYTES} byte limit ({})",
+                content.len()
+            )));
+        }
         // Create SHA256 hash of the content
         let mut hasher = Sha256::new();
         hasher.update(content.as_bytes());
@@ -523,6 +533,11 @@ impl PersistedWorkingLog {
                 continue;
             }
 
+            validate_checkpoint_collections(&checkpoint)?;
+            ensure_batch_git_item_limit(
+                "working-log checkpoint",
+                checkpoints.len().saturating_add(1),
+            )?;
             checkpoints.push(checkpoint);
         }
 
@@ -663,8 +678,16 @@ impl PersistedWorkingLog {
     /// by post-commit after transcripts have been refetched and need to be preserved
     /// for from_just_working_log() to read them.
     pub fn write_all_checkpoints(&self, checkpoints: &[Checkpoint]) -> Result<(), GitAiError> {
+        ensure_batch_git_item_limit("working-log checkpoint", checkpoints.len())?;
+        for checkpoint in checkpoints {
+            validate_checkpoint_collections(checkpoint)?;
+        }
         let checkpoints_file = self.checkpoints_file();
-        let mut output = BufWriter::new(fs::File::create(&checkpoints_file)?);
+        let mut output = BoundedWriter::new(
+            Vec::new(),
+            Self::checkpoints_file_size_limit_bytes(),
+            "checkpoints.jsonl",
+        );
 
         for checkpoint in checkpoints {
             serde_json::to_writer(&mut output, checkpoint)?;
@@ -672,6 +695,8 @@ impl PersistedWorkingLog {
         }
 
         output.flush()?;
+        let serialized = output.into_inner();
+        fs::write(&checkpoints_file, serialized)?;
         Ok(())
     }
 
@@ -698,25 +723,39 @@ impl PersistedWorkingLog {
 
     pub fn observed_file_snapshot(&self) -> Result<HashMap<String, String>, GitAiError> {
         let initial = self.read_initial_attributions();
-        let mut snapshot = HashMap::new();
+        let mut blob_by_path = HashMap::new();
 
         for file_path in initial.files.keys() {
-            let content = self
-                .stored_initial_file_content_from(&initial, file_path)
-                .ok_or_else(|| {
-                    GitAiError::Generic(format!(
-                        "INITIAL missing persisted file snapshot for {}",
-                        file_path
-                    ))
-                })?;
-            snapshot.insert(file_path.clone(), content);
+            let blob_sha = initial.file_blobs.get(file_path).ok_or_else(|| {
+                GitAiError::Generic(format!(
+                    "INITIAL missing persisted file snapshot for {}",
+                    file_path
+                ))
+            })?;
+            ensure_new_working_log_snapshot_path(&blob_by_path, file_path)?;
+            blob_by_path.insert(file_path.clone(), blob_sha.clone());
         }
 
         for checkpoint in self.read_all_checkpoints()? {
             for entry in checkpoint.entries {
-                let content = self.get_file_version(&entry.blob_sha)?;
-                snapshot.insert(entry.file, content);
+                ensure_new_working_log_snapshot_path(&blob_by_path, &entry.file)?;
+                blob_by_path.insert(entry.file, entry.blob_sha);
             }
+        }
+
+        let mut blob_contents = HashMap::new();
+        let mut snapshot = HashMap::with_capacity(blob_by_path.len());
+        let mut budget = BatchMaterializationBudget::new();
+        for (file_path, blob_sha) in blob_by_path {
+            if !blob_contents.contains_key(&blob_sha) {
+                blob_contents.insert(
+                    blob_sha.clone(),
+                    self.get_file_version(&blob_sha).unwrap_or_default(),
+                );
+            }
+            let content = blob_contents.get(&blob_sha).expect("inserted above");
+            budget.reserve("working-log snapshot content", content.len())?;
+            snapshot.insert(file_path, content.clone());
         }
 
         Ok(snapshot)
@@ -753,10 +792,27 @@ impl PersistedWorkingLog {
         file_contents: HashMap<String, String>,
         sessions: std::collections::BTreeMap<String, SessionRecord>,
     ) -> Result<(), GitAiError> {
+        validate_initial_files(&attributions)?;
+        ensure_batch_git_item_limit("INITIAL prompt", prompts.len())?;
+        ensure_batch_git_item_limit("INITIAL human", humans.len())?;
+        ensure_batch_git_item_limit("INITIAL file content", file_contents.len())?;
+        ensure_batch_git_item_limit("INITIAL session", sessions.len())?;
         let filtered: HashMap<String, Vec<LineAttribution>> = attributions
             .into_iter()
             .filter(|(_, attrs)| !attrs.is_empty())
             .collect();
+
+        let mut content_budget = BatchMaterializationBudget::new();
+        for file_path in filtered.keys() {
+            let content = file_contents.get(file_path).ok_or_else(|| {
+                GitAiError::Generic(format!(
+                    "INITIAL missing file content snapshot for {}",
+                    file_path
+                ))
+            })?;
+            content_budget.reserve("working-log INITIAL content", content.len())?;
+        }
+
         let mut file_blobs = HashMap::new();
         for file_path in filtered.keys() {
             let content = file_contents.get(file_path).ok_or_else(|| {
@@ -780,6 +836,7 @@ impl PersistedWorkingLog {
 
     /// Write a fully-formed INITIAL state, preserving any persisted blob references.
     pub fn write_initial(&self, initial: InitialAttributions) -> Result<(), GitAiError> {
+        validate_initial_attributions(&initial)?;
         let filtered_files: HashMap<String, Vec<LineAttribution>> = initial
             .files
             .into_iter()
@@ -804,8 +861,15 @@ impl PersistedWorkingLog {
             sessions: initial.sessions,
         };
 
-        let json = serde_json::to_string_pretty(&initial_data)?;
-        fs::write(&self.initial_file, json)?;
+        let mut output = BoundedWriter::new(
+            Vec::new(),
+            MAX_INITIAL_ATTRIBUTIONS_BYTES,
+            "working-log INITIAL",
+        );
+        serde_json::to_writer_pretty(&mut output, &initial_data)?;
+        output.flush()?;
+        let serialized = output.into_inner();
+        fs::write(&self.initial_file, serialized)?;
 
         Ok(())
     }
@@ -867,9 +931,19 @@ impl PersistedWorkingLog {
             return InitialAttributions::default();
         }
 
-        match fs::read_to_string(&self.initial_file) {
+        match read_bounded_utf8_file(
+            &self.initial_file,
+            "working-log INITIAL",
+            MAX_INITIAL_ATTRIBUTIONS_BYTES,
+        ) {
             Ok(content) => match serde_json::from_str(&content) {
-                Ok(initial_data) => initial_data,
+                Ok(initial_data) => match validate_initial_attributions(&initial_data) {
+                    Ok(()) => initial_data,
+                    Err(error) => {
+                        tracing::debug!("Invalid INITIAL file: {}. Returning empty.", error);
+                        InitialAttributions::default()
+                    }
+                },
                 Err(e) => {
                     tracing::debug!("Failed to parse INITIAL file: {}. Returning empty.", e);
                     InitialAttributions::default()
@@ -881,6 +955,118 @@ impl PersistedWorkingLog {
             }
         }
     }
+}
+
+fn validate_initial_attributions(initial: &InitialAttributions) -> Result<(), GitAiError> {
+    validate_initial_files(&initial.files)?;
+    ensure_batch_git_item_limit("INITIAL prompt", initial.prompts.len())?;
+    ensure_batch_git_item_limit("INITIAL blob", initial.file_blobs.len())?;
+    ensure_batch_git_item_limit("INITIAL human", initial.humans.len())?;
+    ensure_batch_git_item_limit("INITIAL session", initial.sessions.len())?;
+    Ok(())
+}
+
+fn validate_initial_files(files: &HashMap<String, Vec<LineAttribution>>) -> Result<(), GitAiError> {
+    ensure_batch_git_item_limit("INITIAL file", files.len())?;
+    for line_attributions in files.values() {
+        ensure_batch_git_item_limit("INITIAL line attribution", line_attributions.len())?;
+    }
+    Ok(())
+}
+
+fn ensure_new_working_log_snapshot_path(
+    paths: &HashMap<String, String>,
+    file_path: &str,
+) -> Result<(), GitAiError> {
+    if !paths.contains_key(file_path) {
+        ensure_batch_git_item_limit("working-log snapshot path", paths.len().saturating_add(1))?;
+    }
+    Ok(())
+}
+
+fn validate_checkpoint_collections(checkpoint: &Checkpoint) -> Result<(), GitAiError> {
+    ensure_batch_git_item_limit("working-log entry", checkpoint.entries.len())?;
+    if let Some(metadata) = &checkpoint.agent_metadata {
+        ensure_batch_git_item_limit("working-log agent metadata", metadata.len())?;
+    }
+    for entry in &checkpoint.entries {
+        ensure_batch_git_item_limit("working-log attribution", entry.attributions.len())?;
+        ensure_batch_git_item_limit(
+            "working-log line attribution",
+            entry.line_attributions.len(),
+        )?;
+    }
+    Ok(())
+}
+
+struct BoundedWriter<W> {
+    inner: W,
+    written: u64,
+    max_bytes: u64,
+    kind: &'static str,
+}
+
+impl<W> BoundedWriter<W> {
+    fn new(inner: W, max_bytes: u64, kind: &'static str) -> Self {
+        Self {
+            inner,
+            written: 0,
+            max_bytes,
+            kind,
+        }
+    }
+
+    fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: Write> Write for BoundedWriter<W> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let next_size = self.written.saturating_add(buffer.len() as u64);
+        if next_size > self.max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "{} exceeded the {} byte limit ({next_size})",
+                    self.kind, self.max_bytes
+                ),
+            ));
+        }
+
+        let written = self.inner.write(buffer)?;
+        self.written = self.written.saturating_add(written as u64);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn read_bounded_utf8_file(path: &Path, kind: &str, max_bytes: u64) -> Result<String, GitAiError> {
+    let file = fs::File::open(path)?;
+    let size_bytes = file.metadata()?.len();
+    if size_bytes > max_bytes {
+        return Err(GitAiError::Generic(format!(
+            "{kind} exceeded the {max_bytes} byte limit ({size_bytes})"
+        )));
+    }
+    let mut bytes = Vec::new();
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_bytes {
+        return Err(GitAiError::Generic(format!(
+            "{kind} exceeded the {max_bytes} byte limit ({})",
+            bytes.len()
+        )));
+    }
+    String::from_utf8(bytes)
+        .map_err(|error| GitAiError::Generic(format!("{kind} is not UTF-8: {error}")))
+}
+
+pub(crate) fn read_bounded_working_log_file(path: &Path) -> Result<String, GitAiError> {
+    read_bounded_utf8_file(path, "working-log file", MAX_WORKING_LOG_BLOB_BYTES)
 }
 
 #[cfg(test)]

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -63,13 +63,26 @@ impl BatchMaterializationBudget {
     }
 
     pub(crate) fn reserve(&mut self, kind: &str, bytes: usize) -> Result<(), GitAiError> {
-        self.used_bytes = self.used_bytes.saturating_add(bytes);
-        if self.used_bytes > MAX_BATCH_MATERIALIZED_CONTENT_BYTES {
+        self.replace_reservation(kind, 0, bytes)
+    }
+
+    pub(crate) fn replace_reservation(
+        &mut self,
+        kind: &str,
+        previous_bytes: usize,
+        replacement_bytes: usize,
+    ) -> Result<(), GitAiError> {
+        let next_used_bytes = self
+            .used_bytes
+            .saturating_sub(previous_bytes)
+            .saturating_add(replacement_bytes);
+        if next_used_bytes > MAX_BATCH_MATERIALIZED_CONTENT_BYTES {
             return Err(GitAiError::Generic(format!(
                 "batched materialized {kind} exceeded the {MAX_BATCH_MATERIALIZED_CONTENT_BYTES} byte limit ({})",
-                self.used_bytes
+                next_used_bytes
             )));
         }
+        self.used_bytes = next_used_bytes;
         Ok(())
     }
 }

--- a/tests/integration/daemon_working_log_memory.rs
+++ b/tests/integration/daemon_working_log_memory.rs
@@ -1,0 +1,199 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::attribution_tracker::LineAttribution;
+use git_ai::authorship::working_log::{AgentId, Checkpoint, CheckpointKind, WorkingLogEntry};
+use std::fs;
+
+const PRESSURE_FILE_COUNT: usize = 17;
+const SHARED_BLOB_BYTES: usize = 4 * 1_024 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+fn assert_base(repo: &TestRepo) {
+    let mut file = repo.filename("base.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+}
+
+fn assert_pressure_files(repo: &TestRepo) {
+    for index in 0..PRESSURE_FILE_COUNT {
+        let mut file = repo.filename(&format!("pressure-{index}.txt"));
+        file.assert_committed_lines(crate::lines![
+            format!("pressure {index}").unattributed_human()
+        ]);
+    }
+}
+
+#[test]
+fn shared_working_log_blob_materialization_keeps_daemon_bounded_and_recovers() {
+    let repo = TestRepo::new_dedicated_daemon();
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.stage_all_and_commit("base commit").unwrap();
+    assert_base(&repo);
+
+    let working_log = repo.current_working_logs();
+    let shared_blob = "x".repeat(SHARED_BLOB_BYTES);
+    let blob_sha = working_log.persist_file_version(&shared_blob).unwrap();
+    let mut entries = Vec::new();
+    for index in 0..PRESSURE_FILE_COUNT {
+        let path = format!("pressure-{index}.txt");
+        fs::write(repo.path().join(&path), format!("pressure {index}\n")).unwrap();
+        entries.push(WorkingLogEntry::new(
+            path,
+            blob_sha.clone(),
+            Vec::new(),
+            vec![LineAttribution::new(
+                1,
+                1,
+                "working-log-pressure-ai".to_string(),
+                None,
+            )],
+        ));
+    }
+    let mut checkpoint = Checkpoint::new(
+        CheckpointKind::AiAgent,
+        String::new(),
+        "mock_ai".to_string(),
+        entries,
+    );
+    checkpoint.agent_id = Some(AgentId {
+        tool: "mock_ai".to_string(),
+        id: "working-log-pressure".to_string(),
+        model: "test".to_string(),
+    });
+    working_log.write_all_checkpoints(&[checkpoint]).unwrap();
+    drop(shared_blob);
+
+    repo.git_og(&["add", "-A"]).unwrap();
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    repo.git_without_test_sync_for_test(&["commit", "-m", "working log pressure"], &[])
+        .unwrap();
+    repo.sync_daemon();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("shared working-log blob HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 48 * 1_024,
+            "shared working-log blob grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        let reconstructed_threads = daemon_thread_count(&repo);
+        assert!(
+            reconstructed_threads <= baseline_threads + 2,
+            "working-log reconstruction must not retain worker threads: baseline={baseline_threads}, reconstructed={reconstructed_threads}"
+        );
+    }
+    assert_base(&repo);
+    assert_pressure_files(&repo);
+
+    fs::write(repo.path().join("recovery.txt"), "AI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "recovery.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit after working-log pressure")
+        .unwrap();
+    assert_base(&repo);
+    assert_pressure_files(&repo);
+    let mut recovery = repo.filename("recovery.txt");
+    recovery.assert_committed_lines(crate::lines!["AI recovery".ai()]);
+}
+
+#[test]
+fn repeated_checkpoint_file_replacement_uses_net_materialized_bytes() {
+    let repo = TestRepo::new_dedicated_daemon();
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.stage_all_and_commit("base commit").unwrap();
+    assert_base(&repo);
+
+    let large_line = "x".repeat(2 * 1_024 * 1_024);
+    let pressure_path = repo.path().join("pressure.txt");
+    let mut contents = format!("{large_line}\n");
+    let mut expected = vec![large_line.ai()];
+    for index in 0..9 {
+        if index > 0 {
+            let line = format!("AI checkpoint {index}");
+            contents.push_str(&line);
+            contents.push('\n');
+            expected.push(line.ai());
+        }
+        fs::write(&pressure_path, &contents).unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", "pressure.txt"])
+            .unwrap();
+    }
+
+    repo.stage_all_and_commit("repeated file checkpoints")
+        .unwrap();
+    assert_base(&repo);
+    let mut pressure = repo.filename("pressure.txt");
+    pressure.assert_committed_lines(expected);
+}
+
+#[test]
+fn missing_checkpoint_blob_degrades_without_losing_committed_attribution() {
+    let repo = TestRepo::new_dedicated_daemon();
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.stage_all_and_commit("base commit").unwrap();
+    assert_base(&repo);
+
+    fs::write(repo.path().join("committed.txt"), "AI survives\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "committed.txt"])
+        .unwrap();
+
+    let working_log = repo.current_working_logs();
+    let mut checkpoints = working_log.read_all_checkpoints().unwrap();
+    let ai_checkpoint = checkpoints
+        .iter_mut()
+        .find(|checkpoint| checkpoint.kind == CheckpointKind::AiAgent)
+        .expect("AI checkpoint should exist");
+    let committed_entry = ai_checkpoint
+        .entries
+        .iter()
+        .find(|entry| entry.file == "committed.txt")
+        .expect("committed file checkpoint entry should exist")
+        .clone();
+    let missing_blob_sha = working_log
+        .persist_file_version("missing AI content\n")
+        .unwrap();
+    fs::remove_file(working_log.dir.join("blobs").join(&missing_blob_sha)).unwrap();
+    ai_checkpoint.entries.push(WorkingLogEntry::new(
+        "missing.txt".to_string(),
+        missing_blob_sha,
+        committed_entry.attributions,
+        committed_entry.line_attributions,
+    ));
+    working_log.write_all_checkpoints(&checkpoints).unwrap();
+
+    repo.stage_all_and_commit("commit with missing checkpoint blob")
+        .unwrap();
+    assert_base(&repo);
+    let mut committed = repo.filename("committed.txt");
+    committed.assert_committed_lines(crate::lines!["AI survives".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -60,6 +60,7 @@ mod daemon_note_materialization_memory;
 mod daemon_reflog_memory;
 mod daemon_repository_reader_memory;
 mod daemon_retained_state_memory;
+mod daemon_working_log_memory;
 mod diff;
 mod diff_comprehensive;
 mod diff_ignore_binary;

--- a/tests/integration/repo_storage_unit.rs
+++ b/tests/integration/repo_storage_unit.rs
@@ -1,9 +1,9 @@
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::attribution_tracker::LineAttribution;
 use git_ai::authorship::working_log::{
-    AgentId, CHECKPOINT_API_VERSION, Checkpoint, CheckpointKind,
+    AgentId, CHECKPOINT_API_VERSION, Checkpoint, CheckpointKind, WorkingLogEntry,
 };
-use git_ai::git::repo_storage::{InitialAttributions, RepoStorage};
+use git_ai::git::repo_storage::{InitialAttributions, MAX_CHECKPOINTS_JSONL_BYTES, RepoStorage};
 use std::collections::HashMap;
 use std::fs;
 use std::time::SystemTime;
@@ -235,6 +235,188 @@ fn test_oversized_checkpoints_file_is_truncated_before_read() {
             .len(),
         0,
         "oversized checkpoints file should be truncated to an empty file"
+    );
+}
+
+#[test]
+fn test_default_checkpoints_file_limit_is_memory_bounded() {
+    let configured_limit = std::hint::black_box(MAX_CHECKPOINTS_JSONL_BYTES);
+    assert!(
+        configured_limit <= 32 * 1_024 * 1_024,
+        "checkpoint history must not be parsed up to {configured_limit} bytes"
+    );
+}
+
+#[test]
+fn test_oversized_checkpoint_write_preserves_existing_file() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let checkpoints_file = working_log.checkpoints_file();
+    fs::write(&checkpoints_file, "existing checkpoint data\n").unwrap();
+
+    let checkpoint = Checkpoint::new(
+        CheckpointKind::Human,
+        "x".repeat(MAX_CHECKPOINTS_JSONL_BYTES as usize),
+        "oversized".to_string(),
+        vec![],
+    );
+    let error = working_log
+        .write_all_checkpoints(&[checkpoint])
+        .expect_err("oversized checkpoint serialization must be rejected");
+
+    assert!(error.to_string().contains("checkpoints.jsonl"));
+    assert_eq!(
+        fs::read_to_string(checkpoints_file).unwrap(),
+        "existing checkpoint data\n",
+        "a rejected rewrite must leave the prior checkpoint history intact"
+    );
+}
+
+#[test]
+fn test_checkpoint_write_rejects_nested_collection_amplification() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let entries = (0..=4_096)
+        .map(|index| {
+            WorkingLogEntry::new(
+                format!("file-{index}.txt"),
+                "blob".to_string(),
+                Vec::new(),
+                Vec::new(),
+            )
+        })
+        .collect();
+    let checkpoint = Checkpoint::new(
+        CheckpointKind::Human,
+        String::new(),
+        "nested-amplification".to_string(),
+        entries,
+    );
+
+    let error = working_log
+        .write_all_checkpoints(&[checkpoint])
+        .expect_err("nested checkpoint collections must be bounded");
+
+    assert!(error.to_string().contains("working-log entry count"));
+    assert!(!working_log.checkpoints_file().exists());
+}
+
+#[test]
+fn test_initial_write_rejects_nested_collection_amplification() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let mut initial = InitialAttributions::default();
+    initial.files.insert(
+        "file.txt".to_string(),
+        (0..=4_096)
+            .map(|index| LineAttribution::new(index + 1, index + 1, "ai".to_string(), None))
+            .collect(),
+    );
+    initial
+        .file_blobs
+        .insert("file.txt".to_string(), "blob".to_string());
+
+    let error = working_log
+        .write_initial(initial)
+        .expect_err("nested INITIAL collections must be bounded");
+
+    assert!(error.to_string().contains("INITIAL line attribution count"));
+    assert!(!working_log.initial_file.exists());
+}
+
+#[test]
+fn test_initial_content_snapshot_uses_shared_materialization_budget() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let mut files = HashMap::new();
+    let mut contents = HashMap::new();
+    for index in 0..17 {
+        let path = format!("file-{index}.txt");
+        files.insert(
+            path.clone(),
+            vec![LineAttribution::new(1, 1, "ai".to_string(), None)],
+        );
+        contents.insert(path, "x".repeat(1_024 * 1_024));
+    }
+
+    let error = working_log
+        .write_initial_attributions_with_contents(
+            files,
+            HashMap::new(),
+            Default::default(),
+            contents,
+            Default::default(),
+        )
+        .expect_err("INITIAL file contents must share one materialization budget");
+
+    assert!(
+        error
+            .to_string()
+            .contains("materialized working-log INITIAL content")
+    );
+    assert!(!working_log.initial_file.exists());
+}
+
+#[test]
+fn test_oversized_working_log_blob_is_rejected() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let blobs_dir = working_log.dir.join("blobs");
+    fs::create_dir_all(&blobs_dir).unwrap();
+    let blob_path = blobs_dir.join("oversized");
+    let blob = fs::File::create(&blob_path).unwrap();
+    blob.set_len(16 * 1_024 * 1_024 + 1).unwrap();
+
+    let error = working_log
+        .get_file_version("oversized")
+        .expect_err("oversized working-log blobs must fail before allocation");
+
+    assert!(error.to_string().contains("working-log blob"));
+}
+
+#[test]
+fn test_observed_snapshot_rejects_shared_blob_amplification() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+    let content = "x".repeat(1_024 * 1_024);
+    let blob_sha = working_log.persist_file_version(&content).unwrap();
+    let mut initial = InitialAttributions::default();
+    for index in 0..17 {
+        let path = format!("shared-{index}.txt");
+        initial.files.insert(
+            path.clone(),
+            vec![LineAttribution::new(1, 1, "ai".to_string(), None)],
+        );
+        initial.file_blobs.insert(path, blob_sha.clone());
+    }
+    working_log.write_initial(initial).unwrap();
+
+    let error = working_log
+        .observed_file_snapshot()
+        .expect_err("shared working-log blobs must respect an aggregate byte budget");
+
+    assert!(
+        error
+            .to_string()
+            .contains("materialized working-log snapshot content")
     );
 }
 


### PR DESCRIPTION
## Bug
Working-log checkpoints, initial-attribution files, and per-file blobs were read or serialized without aggregate budgets. Repeated references could amplify allocations; the first bounded implementation also charged every replacement of one path cumulatively instead of tracking live map bytes.

That implementation additionally propagated a bounded blob-read error from one snapshot reconstruction path where the prior behavior degraded a missing blob to empty content. A partially cleaned or corrupt checkpoint blob could therefore abort post-commit processing instead of preserving attribution for the commit's readable files.

## Fix
Add bounded UTF-8 reads and streaming writes, cap checkpoint JSONL at 32 MiB, initial attribution at 64 MiB, and individual blobs at 16 MiB. Shared materialization is accounted once, and replacing a file reservation subtracts the retained version before adding the new size, while still rejecting a live map above 16 MiB.

Missing, unreadable, or oversized checkpoint blobs now degrade to empty content consistently in observed-snapshot materialization and both persisted reconstruction entrypoints. The 16 MiB bounded reader still rejects the content before allocation, so graceful recovery cannot reopen the memory issue. INITIAL snapshots remain strict because their attribution has no later checkpoint version to supersede it.

## TDD and verification
The new dedicated-daemon `TestRepo` regression creates a valid AI checkpoint, injects a second entry whose persisted blob is deleted, commits only the valid file, and requires daemon sync plus exact AI line attribution to succeed. It failed with the original I/O side-effect error and passes only after all live reconstruction stages degrade the missing checkpoint blob consistently.

Existing tests continue to cover oversized writes, collection amplification, shared snapshots, and net replacement accounting. Dedicated `TestRepo` memory regressions verify bounded shared-blob reconstruction and repeated 2 MiB checkpoint replacements. The final stack passes `task fmt`, `task lint`, `task build`, the complete `task test` matrix, and a four-core/four-thread run of all 3,282 executed integration tests.
