### PR TITLE
fix(streams): bound monolithic JSON inputs

### DIFF
--- a/src/streams/agents/amp.rs
+++ b/src/streams/agents/amp.rs
@@ -3,7 +3,7 @@
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{BoundedPathCollector, DiscoveredSession, StreamFormat, SweepStrategy};
-use crate::streams::types::{StreamBatch, StreamError};
+use crate::streams::types::{StreamBatch, StreamError, read_monolithic_transcript_json};
 use crate::streams::watermark::{RecordIndexWatermark, WatermarkStrategy};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -151,29 +151,7 @@ impl Agent for AmpAgent {
 
         let skip_count = record_watermark.0 as usize;
 
-        let file = fs::File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to read transcript file: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let reader = std::io::BufReader::new(file);
-        let mut parsed: serde_json::Value =
-            serde_json::from_reader(reader).map_err(|e| StreamError::Parse {
-                line: 0,
-                message: format!("Invalid JSON in {}: {}", path.display(), e),
-            })?;
+        let mut parsed = read_monolithic_transcript_json(path)?;
 
         let messages = match parsed
             .as_object_mut()

--- a/src/streams/agents/continue_cli.rs
+++ b/src/streams/agents/continue_cli.rs
@@ -5,7 +5,7 @@ use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{
     DiscoveredSession, StreamFormat, SweepStrategy, discover_recent_files,
 };
-use crate::streams::types::{StreamBatch, StreamError};
+use crate::streams::types::{StreamBatch, StreamError, read_monolithic_transcript_json};
 use crate::streams::watermark::{RecordIndexWatermark, WatermarkStrategy};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -102,29 +102,7 @@ impl Agent for ContinueAgent {
 
         let already_processed = record_watermark.0;
 
-        let file = std::fs::File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to read transcript file: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let reader = std::io::BufReader::new(file);
-        let mut parsed: serde_json::Value =
-            serde_json::from_reader(reader).map_err(|e| StreamError::Parse {
-                line: 0,
-                message: format!("Invalid JSON in {}: {}", path.display(), e),
-            })?;
+        let mut parsed = read_monolithic_transcript_json(path)?;
 
         let history = match parsed.as_object_mut().and_then(|obj| obj.remove("history")) {
             Some(serde_json::Value::Array(arr)) => arr,
@@ -372,5 +350,25 @@ mod tests {
         assert_eq!(result.events.len(), 1);
         assert_eq!(result.events[0]["message"]["content"], "Let me check");
         assert!(result.events[0]["contextItems"].is_array());
+    }
+
+    #[test]
+    fn test_oversized_monolithic_transcript_is_rejected_before_parse() {
+        use tempfile::NamedTempFile;
+
+        let file = NamedTempFile::new().unwrap();
+        file.as_file().set_len(32 * 1_024 * 1_024 + 1).unwrap();
+        let agent = ContinueAgent::new();
+        let error = match agent.read_incremental(
+            file.path(),
+            Box::new(RecordIndexWatermark::new(0)),
+            "oversized",
+        ) {
+            Ok(_) => panic!("oversized monolithic transcripts must fail before parsing"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("monolithic transcript"));
+        assert!(error.to_string().contains("33554432 byte limit"));
     }
 }

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -127,8 +127,12 @@ impl CopilotAgent {
         // workspace.json: .../workspaceStorage/{hash}/workspace.json
         let workspace_hash_dir = stream_path.parent()?.parent()?.parent()?;
         let workspace_json = workspace_hash_dir.join("workspace.json");
-        let content = fs::read_to_string(&workspace_json).ok()?;
-        let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+        let json = crate::streams::types::read_bounded_json_file(
+            &workspace_json,
+            "Copilot workspace metadata",
+            crate::streams::types::MAX_JSON_METADATA_BYTES,
+        )
+        .ok()?;
         let folder_uri = json.get("folder")?.as_str()?;
         let path_str = folder_uri.strip_prefix("file://")?;
         let decoded = percent_decode_path(path_str);
@@ -420,29 +424,7 @@ fn read_session_json(
         });
     }
 
-    let file = std::fs::File::open(path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            StreamError::Fatal {
-                message: format!("Transcript file not found: {}", path.display()),
-            }
-        } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StreamError::Fatal {
-                message: format!("Permission denied reading transcript: {}", path.display()),
-            }
-        } else {
-            StreamError::Transient {
-                message: format!("Failed to read transcript file: {}", e),
-                retry_after: std::time::Duration::from_secs(5),
-            }
-        }
-    })?;
-
-    let reader = std::io::BufReader::new(file);
-    let mut session_json: serde_json::Value =
-        serde_json::from_reader(reader).map_err(|e| StreamError::Parse {
-            line: 0,
-            message: format!("Invalid JSON in {}: {}", path.display(), e),
-        })?;
+    let mut session_json = crate::streams::types::read_monolithic_transcript_json(path)?;
 
     let requests = match session_json
         .as_object_mut()

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -25,14 +25,11 @@ pub fn extract_model(
 pub fn extract_model_from_droid_settings(
     settings_path: &Path,
 ) -> Result<Option<String>, StreamError> {
-    let content = match std::fs::read_to_string(settings_path) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => return Ok(None),
-        Err(_) => return Ok(None),
-    };
-
-    let json: serde_json::Value = match serde_json::from_str(&content) {
+    let json = match crate::streams::types::read_bounded_json_file(
+        settings_path,
+        "Droid model metadata",
+        crate::streams::types::MAX_JSON_METADATA_BYTES,
+    ) {
         Ok(v) => v,
         Err(_) => return Ok(None),
     };
@@ -150,14 +147,14 @@ pub fn extract_model_from_copilot_models_json(
         .join(session_id)
         .join("models.json");
 
-    let content = match std::fs::read_to_string(&models_path) {
-        Ok(c) => c,
+    let models = match crate::streams::types::read_bounded_json_file(
+        &models_path,
+        "Copilot model metadata",
+        crate::streams::types::MAX_JSON_METADATA_BYTES,
+    ) {
+        Ok(serde_json::Value::Array(models)) => models,
         Err(_) => return Ok(None),
-    };
-
-    let models: Vec<serde_json::Value> = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
+        Ok(_) => return Ok(None),
     };
 
     let model = models.iter().find_map(|m| {
@@ -260,12 +257,7 @@ fn extract_model_from_copilot_otel_sqlite(
 }
 
 fn extract_model_from_copilot_session_json(path: &Path) -> Result<Option<String>, StreamError> {
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return Ok(None),
-    };
-
-    let json: serde_json::Value = match serde_json::from_str(&content) {
+    let json = match crate::streams::types::read_monolithic_transcript_json(path) {
         Ok(v) => v,
         Err(_) => return Ok(None),
     };
@@ -285,12 +277,7 @@ fn extract_model_from_copilot_session_json(path: &Path) -> Result<Option<String>
 }
 
 fn extract_model_from_amp_thread_json(path: &Path) -> Result<Option<String>, StreamError> {
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return Ok(None),
-    };
-
-    let json: serde_json::Value = match serde_json::from_str(&content) {
+    let json = match crate::streams::types::read_monolithic_transcript_json(path) {
         Ok(v) => v,
         Err(_) => return Ok(None),
     };

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -1,6 +1,6 @@
 //! Core types for transcript processing.
 
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::time::Duration;
 
 /// Maximum retained size of one JSONL transcript record.
@@ -11,6 +11,56 @@ pub const MAX_JSONL_EVENT_BYTES: usize = 1024 * 1024;
 /// The record that crosses this threshold remains in the batch, so the hard
 /// upper bound is this value plus [`MAX_JSONL_EVENT_BYTES`].
 pub const MAX_JSONL_BATCH_BYTES: usize = 8 * 1024 * 1024;
+
+/// Maximum size of vendor transcript formats that require whole-document JSON parsing.
+pub const MAX_MONOLITHIC_JSON_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Maximum size of auxiliary JSON metadata consulted during transcript processing.
+pub const MAX_JSON_METADATA_BYTES: u64 = 1024 * 1024;
+
+pub fn read_bounded_json_file(
+    path: &std::path::Path,
+    kind: &str,
+    max_bytes: u64,
+) -> Result<serde_json::Value, StreamError> {
+    let file = std::fs::File::open(path).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => StreamError::Fatal {
+            message: format!("{kind} file not found: {}", path.display()),
+        },
+        std::io::ErrorKind::PermissionDenied => StreamError::Fatal {
+            message: format!("permission denied reading {kind}: {}", path.display()),
+        },
+        _ => StreamError::Transient {
+            message: format!("failed to open {kind} {}: {error}", path.display()),
+            retry_after: Duration::from_secs(5),
+        },
+    })?;
+    let size_bytes = file.metadata().map_err(|error| StreamError::Transient {
+        message: format!("failed to inspect {kind} {}: {error}", path.display()),
+        retry_after: Duration::from_secs(5),
+    })?;
+    if size_bytes.len() > max_bytes {
+        return Err(StreamError::Fatal {
+            message: format!(
+                "{kind} exceeded the {max_bytes} byte limit ({}): {}",
+                size_bytes.len(),
+                path.display()
+            ),
+        });
+    }
+
+    let reader = std::io::BufReader::new(file.take(max_bytes.saturating_add(1)));
+    serde_json::from_reader(reader).map_err(|error| StreamError::Parse {
+        line: error.line(),
+        message: format!("invalid JSON in {kind} {}: {error}", path.display()),
+    })
+}
+
+pub fn read_monolithic_transcript_json(
+    path: &std::path::Path,
+) -> Result<serde_json::Value, StreamError> {
+    read_bounded_json_file(path, "monolithic transcript", MAX_MONOLITHIC_JSON_BYTES)
+}
 
 #[derive(Default)]
 pub struct JsonlReadStats {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -151,6 +151,7 @@ mod test_utils_unit;
 mod tls_native_certs;
 mod transcript_discovery_memory;
 mod transcript_memory;
+mod transcript_monolithic_memory;
 mod transcript_queue_memory;
 mod utf8_filenames;
 mod virtual_attribution_unit;

--- a/tests/integration/transcript_monolithic_memory.rs
+++ b/tests/integration/transcript_monolithic_memory.rs
@@ -1,0 +1,159 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
+use git_ai::metrics::{PosEncoded, SessionEventValues};
+use serde_json::json;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+const OVERSIZED_PAYLOAD_BYTES: usize = 64 * 1_024 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+fn write_oversized_continue_transcript(path: &Path) {
+    let file = File::create(path).unwrap();
+    let mut writer = BufWriter::new(file);
+    writer
+        .write_all(b"{\"history\":[{\"uuid\":\"oversized-monolithic\",\"message\":{\"content\":\"")
+        .unwrap();
+    let chunk = vec![b'x'; 1_024 * 1_024];
+    for _ in 0..OVERSIZED_PAYLOAD_BYTES / chunk.len() {
+        writer.write_all(&chunk).unwrap();
+    }
+    writer.write_all(b"\"}}]}").unwrap();
+    writer.flush().unwrap();
+}
+
+fn wait_for_recovery_event(metrics_db_path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(db) = MetricsDatabase::open_at_path(metrics_db_path)
+            && db
+                .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+                .unwrap_or_default()
+                .iter()
+                .any(|record| {
+                    SessionEventValues::from_sparse(&record.event.values)
+                        .raw_json
+                        .get("uuid")
+                        .and_then(|value| value.as_str())
+                        == Some("monolithic-recovery")
+                })
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "valid transcript was not processed after oversized input"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn monolithic_transcript_pressure_keeps_daemon_bounded_and_recovers() {
+    let fixture = tempfile::tempdir().unwrap();
+    let metrics_db_path = fixture.path().join("metrics.db");
+    let metrics_db_path_str = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path_str.as_str(),
+    )]);
+
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let transcript_path = fixture.path().join("continue-session.json");
+    write_oversized_continue_transcript(&transcript_path);
+    let hook_input = |hook_event_name: &str| {
+        json!({
+            "cwd": repo.canonical_path().to_string_lossy(),
+            "hook_event_name": hook_event_name,
+            "session_id": "monolithic-memory-session",
+            "tool_name": "edit",
+            "tool_use_id": "monolithic-memory-tool-use",
+            "transcript_path": transcript_path.to_string_lossy(),
+            "tool_input": { "file_path": file_path.to_string_lossy() },
+        })
+        .to_string()
+    };
+
+    let pre_hook = hook_input("PreToolUse");
+    repo.git_ai(&["checkpoint", "continue-cli", "--hook-input", &pre_hook])
+        .unwrap();
+    fs::write(&file_path, "base\nai line\n").unwrap();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    let post_hook = hook_input("PostToolUse");
+    repo.git_ai(&["checkpoint", "continue-cli", "--hook-input", &post_hook])
+        .unwrap();
+    std::thread::sleep(Duration::from_secs(3));
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("monolithic transcript HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 32 * 1_024,
+            "monolithic transcript grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        assert!(
+            daemon_thread_count(&repo) <= baseline_threads + 2,
+            "transcript parsing must not retain worker threads"
+        );
+    }
+
+    fs::write(
+        &transcript_path,
+        json!({
+            "history": [{
+                "uuid": "monolithic-recovery",
+                "message": {"content": "recovered"},
+            }],
+        })
+        .to_string(),
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "continue-cli", "--hook-input", &post_hook])
+        .unwrap();
+    wait_for_recovery_event(&metrics_db_path);
+
+    repo.stage_all_and_commit("AI edit after monolithic transcript pressure")
+        .unwrap();
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "ai line".ai()]);
+}


### PR DESCRIPTION
## Bug
Several agent adapters loaded whole monolithic JSON transcripts and metadata files before checking size. A single oversized transcript could therefore be fully allocated and parsed inside the daemon.

## Fix
Route monolithic transcript reads through a 32 MiB bounded JSON reader and cap auxiliary JSON metadata at 1 MiB. Oversized inputs are rejected before deserialization, while the existing parser behavior remains unchanged for valid files.

## Verification
Parser tests cover pre-parse rejection. `tests/integration/transcript_monolithic_memory.rs` supplies a 64 MiB transcript and confirms the daemon remains bounded.