### PR TITLE
fix(authorship): bound ignore configuration memory

### DIFF
--- a/src/authorship/ignore.rs
+++ b/src/authorship/ignore.rs
@@ -2,7 +2,12 @@ use crate::git::repository::Repository;
 use glob::Pattern;
 use std::collections::HashSet;
 use std::fs;
+use std::io::Read;
 use std::path::Path;
+
+const MAX_IGNORE_FILE_BYTES: u64 = 256 * 1024;
+const MAX_IGNORE_PATTERNS: usize = 4_096;
+const MAX_IGNORE_PATTERN_BYTES: usize = 4 * 1024;
 
 const DEFAULT_IGNORE_PATTERNS: &[&str] = &[
     "*.lock",
@@ -53,6 +58,8 @@ impl IgnoreMatcher {
     pub fn new(patterns: &[String]) -> Self {
         let patterns = patterns
             .iter()
+            .filter(|pattern| pattern.len() <= MAX_IGNORE_PATTERN_BYTES)
+            .take(MAX_IGNORE_PATTERNS)
             .map(|pattern| match Pattern::new(pattern) {
                 Ok(glob) => CompiledPattern::Glob(glob),
                 Err(_) => CompiledPattern::Exact(pattern.clone()),
@@ -144,8 +151,11 @@ fn parse_linguist_generated_patterns(contents: &str) -> Vec<String> {
             }
         }
 
-        if state == Some(true) {
+        if state == Some(true) && path_pattern.len() <= MAX_IGNORE_PATTERN_BYTES {
             patterns.push(path_pattern.to_string());
+            if patterns.len() >= MAX_IGNORE_PATTERNS {
+                break;
+            }
         }
     }
 
@@ -157,12 +167,12 @@ fn load_root_gitattributes_contents(repo: &Repository) -> Option<String> {
         return repo
             .get_file_content(".gitattributes", "HEAD")
             .ok()
-            .and_then(|bytes| String::from_utf8(bytes).ok());
+            .and_then(|bytes| bounded_ignore_contents(bytes, ".gitattributes", None));
     }
 
     let workdir = repo.workdir().ok()?;
     let gitattributes_path = workdir.join(".gitattributes");
-    fs::read_to_string(gitattributes_path).ok()
+    read_optional_ignore_file(&gitattributes_path, ".gitattributes")
 }
 
 /// Load ignore patterns from a `.git-ai-ignore` file at the repository root.
@@ -180,7 +190,13 @@ pub fn load_git_ai_ignore_patterns(repo: &Repository) -> Vec<String> {
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
+        if line.len() > MAX_IGNORE_PATTERN_BYTES {
+            continue;
+        }
         patterns.push(line.to_string());
+        if patterns.len() >= MAX_IGNORE_PATTERNS {
+            break;
+        }
     }
 
     dedupe_patterns(patterns)
@@ -191,20 +207,21 @@ fn load_root_git_ai_ignore_contents(repo: &Repository) -> Option<String> {
         return repo
             .get_file_content(".git-ai-ignore", "HEAD")
             .ok()
-            .and_then(|bytes| String::from_utf8(bytes).ok());
+            .and_then(|bytes| bounded_ignore_contents(bytes, ".git-ai-ignore", None));
     }
 
     let workdir = repo.workdir().ok()?;
     let ignore_path = workdir.join(".git-ai-ignore");
-    fs::read_to_string(ignore_path).ok()
+    read_optional_ignore_file(&ignore_path, ".git-ai-ignore")
 }
 
 /// Load `.git-ai-ignore` patterns from a repo root path directly (no Repository object needed).
 /// Use this when you have a `&Path` but not a `Repository` (e.g. in snapshot capture code).
 pub fn load_git_ai_ignore_patterns_from_path(repo_root: &Path) -> Vec<String> {
-    let contents = match fs::read_to_string(repo_root.join(".git-ai-ignore")) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
+    let path = repo_root.join(".git-ai-ignore");
+    let contents = match read_optional_ignore_file(&path, ".git-ai-ignore") {
+        Some(contents) => contents,
+        None => return Vec::new(),
     };
     let mut patterns = Vec::new();
     for raw_line in contents.lines() {
@@ -212,7 +229,13 @@ pub fn load_git_ai_ignore_patterns_from_path(repo_root: &Path) -> Vec<String> {
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
+        if line.len() > MAX_IGNORE_PATTERN_BYTES {
+            continue;
+        }
         patterns.push(line.to_string());
+        if patterns.len() >= MAX_IGNORE_PATTERNS {
+            break;
+        }
     }
     dedupe_patterns(patterns)
 }
@@ -221,9 +244,10 @@ pub fn load_git_ai_ignore_patterns_from_path(repo_root: &Path) -> Vec<String> {
 /// Use this when you have a `&Path` but not a `Repository` (e.g. in snapshot capture code).
 /// Uses the same parser as `load_linguist_generated_patterns_from_root_gitattributes`.
 pub fn load_linguist_generated_patterns_from_path(repo_root: &Path) -> Vec<String> {
-    match fs::read_to_string(repo_root.join(".gitattributes")) {
-        Ok(contents) => parse_linguist_generated_patterns(&contents),
-        Err(_) => Vec::new(),
+    let path = repo_root.join(".gitattributes");
+    match read_optional_ignore_file(&path, ".gitattributes") {
+        Some(contents) => parse_linguist_generated_patterns(&contents),
+        None => Vec::new(),
     }
 }
 
@@ -237,8 +261,8 @@ pub fn effective_ignore_patterns(
         repo,
     ));
     patterns.extend(load_git_ai_ignore_patterns(repo));
-    patterns.extend(extra_patterns.iter().cloned());
-    patterns.extend(user_patterns.iter().cloned());
+    patterns.extend(extra_patterns.iter().take(MAX_IGNORE_PATTERNS).cloned());
+    patterns.extend(user_patterns.iter().take(MAX_IGNORE_PATTERNS).cloned());
     dedupe_patterns(patterns)
 }
 
@@ -247,12 +271,39 @@ fn dedupe_patterns(patterns: Vec<String>) -> Vec<String> {
     let mut deduped = Vec::new();
 
     for pattern in patterns {
+        if pattern.len() > MAX_IGNORE_PATTERN_BYTES {
+            continue;
+        }
         if seen.insert(pattern.clone()) {
             deduped.push(pattern);
+            if deduped.len() >= MAX_IGNORE_PATTERNS {
+                break;
+            }
         }
     }
 
     deduped
+}
+
+fn read_optional_ignore_file(path: &Path, kind: &str) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut bytes = Vec::new();
+    file.take(MAX_IGNORE_FILE_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .ok()?;
+    bounded_ignore_contents(bytes, kind, Some(path))
+}
+
+fn bounded_ignore_contents(bytes: Vec<u8>, kind: &str, path: Option<&Path>) -> Option<String> {
+    if bytes.len() as u64 > MAX_IGNORE_FILE_BYTES {
+        tracing::warn!(
+            path = %path.map_or_else(|| "<git object>".to_string(), |path| path.display().to_string()),
+            max_bytes = MAX_IGNORE_FILE_BYTES,
+            "ignoring oversized {kind} file"
+        );
+        return None;
+    }
+    String::from_utf8(bytes).ok()
 }
 
 fn split_gitattributes_tokens(line: &str) -> Vec<String> {
@@ -292,6 +343,23 @@ fn split_gitattributes_tokens(line: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ignore_pattern_count_is_bounded() {
+        let contents = (0..5_000)
+            .map(|index| format!("generated-{index}.txt"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let patterns = contents.lines().map(str::to_owned).collect::<Vec<_>>();
+        let deduped = dedupe_patterns(patterns);
+
+        assert_eq!(deduped.len(), 4_096);
+        assert_eq!(
+            deduped.last().map(String::as_str),
+            Some("generated-4095.txt")
+        );
+    }
 
     #[test]
     fn defaults_include_snapshot_and_lock_patterns() {

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1355,6 +1355,7 @@ fn collect_unstaged_hunks(
     if let Some(paths) = pathspecs
         && let Ok(workdir) = repo.workdir()
     {
+        let mut untracked_content_budget = BatchMaterializationBudget::new();
         for pathspec in paths {
             // Skip if we already found this file in git diff
             if unstaged_hunks.contains_key(pathspec) {
@@ -1371,7 +1372,13 @@ fn collect_unstaged_hunks(
             let file_path = workdir.join(pathspec);
             if file_path.exists() && file_path.is_file() {
                 // Try to read the file
-                if let Ok(content) = std::fs::read_to_string(&file_path) {
+                if let Ok(content) = read_bounded_working_log_file(&file_path) {
+                    if untracked_content_budget
+                        .reserve("untracked worktree content", content.len())
+                        .is_err()
+                    {
+                        break;
+                    }
                     // Count the lines - all lines are "unstaged" since the file is untracked
                     let line_count = content.lines().count() as u32;
                     if line_count > 0 {

--- a/tests/integration/daemon_ignore_memory.rs
+++ b/tests/integration/daemon_ignore_memory.rs
@@ -1,0 +1,88 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+
+const IGNORE_FILE_BYTES: usize = 4 * 1_024 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+fn write_large_ignore_file(repo: &TestRepo) {
+    let file = File::create(repo.path().join(".git-ai-ignore")).unwrap();
+    let mut writer = BufWriter::new(file);
+    let mut written = 0usize;
+    let mut index = 0usize;
+    while written < IGNORE_FILE_BYTES {
+        let line = format!("generated-{index:08}.txt\n");
+        writer.write_all(line.as_bytes()).unwrap();
+        written += line.len();
+        index += 1;
+    }
+    writer.flush().unwrap();
+}
+
+#[test]
+fn oversized_ignore_configuration_keeps_daemon_bounded_and_attribution_working() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    write_large_ignore_file(&repo);
+    fs::write(&file_path, "base\nai line\n").unwrap();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("ignore configuration HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 32 * 1_024,
+            "ignore configuration grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        let checkpoint_threads = daemon_thread_count(&repo);
+        assert!(
+            checkpoint_threads <= baseline_threads + 2,
+            "ignore parsing must not retain worker threads: baseline={baseline_threads}, checkpoint={checkpoint_threads}"
+        );
+    }
+
+    fs::remove_file(repo.path().join(".git-ai-ignore")).unwrap();
+    repo.stage_all_and_commit("AI edit after ignore pressure")
+        .unwrap();
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -54,6 +54,7 @@ mod daemon_batch_materialization_memory;
 mod daemon_commit_carryover;
 mod daemon_git_output_memory;
 mod daemon_http_memory;
+mod daemon_ignore_memory;
 mod daemon_ipc_memory;
 mod daemon_log_memory;
 mod daemon_note_materialization_memory;


### PR DESCRIPTION
## Bug
Ignore files and configured pattern collections had no limits on file bytes, pattern count, or pattern length. Huge ignore inputs were repeatedly cloned and compiled during attribution work.

## Fix
Bound ignore files to 256 KiB, retain at most 4,096 patterns of at most 4 KiB each, deduplicate under the same budget, and apply the limits consistently to repository, user, and generated patterns.

## Verification
Unit tests cover oversized files and collection sanitization. `tests/integration/daemon_ignore_memory.rs` exercises a multi-megabyte ignore file in a real `TestRepo`.