### PR TITLE
fix(git): bound configuration parsing memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,7 @@ dependencies = [
 name = "git-ai"
 version = "1.6.13"
 dependencies = [
+ "bstr",
  "chrono",
  "clap",
  "criterion",
@@ -1031,7 +1032,9 @@ dependencies = [
  "futures",
  "git-ai",
  "gix-config",
+ "gix-glob",
  "gix-index",
+ "gix-path",
  "glob",
  "ignore",
  "imara-diff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde_json_canonicalizer = "0.3"
 sha2 = "0.10"
 imara-diff = "0.2"
 chrono = { version = "0.4.44", default-features = false, features = ["serde", "clock", "std"] }
+bstr = "1.12"
 indicatif = "0.18"
 futures = "0.3"
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time", "macros"] }
@@ -34,7 +35,9 @@ crossterm = "0.29"
 keyring = { version = "3", features = ["sync-secret-service", "apple-native", "windows-native"], optional = true }
 once_cell = "1.21"
 gix-config = "0.53.0"
+gix-glob = "0.24.0"
 gix-index = "0.48.0"
+gix-path = "0.11.1"
 rand = "0.10"
 regex = "1.12"
 toml = "0.9"

--- a/src/commands/git_hook_handlers.rs
+++ b/src/commands/git_hook_handlers.rs
@@ -286,11 +286,7 @@ fn load_config(
     path: &Path,
     source: gix_config::Source,
 ) -> Result<gix_config::File<'static>, GitAiError> {
-    if path.exists() {
-        return gix_config::File::from_path_no_includes(path.to_path_buf(), source)
-            .map_err(|e| GitAiError::GixError(e.to_string()));
-    }
-    Ok(gix_config::File::default())
+    Ok(crate::git::config_reader::load_single_git_config(path, source)?.unwrap_or_default())
 }
 
 fn write_config(path: &Path, cfg: &gix_config::File<'_>) -> Result<(), GitAiError> {
@@ -612,4 +608,20 @@ fn should_forward_repo_state_first(repo: Option<&Repository>) -> Option<PathBuf>
     }
 
     Some(candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_config;
+
+    #[test]
+    fn hook_config_loader_rejects_oversized_file_before_parsing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("config");
+        std::fs::write(&path, vec![b'#'; 512 * 1_024]).unwrap();
+
+        let error = load_config(&path, gix_config::Source::Local)
+            .expect_err("oversized hook config must be rejected");
+        assert!(error.to_string().contains("byte limit"));
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::env;
 use std::fs;
 use std::hash::{Hash, Hasher};
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -13,6 +12,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use crate::feature_flags::FeatureFlags;
 use crate::git::repository::Repository;
 use crate::mdm::utils::home_dir;
+use crate::utils::read_file_with_limit;
 
 #[cfg(any(test, feature = "test-support"))]
 use std::sync::RwLock;
@@ -1456,23 +1456,6 @@ fn parse_file_config_bytes(data: &[u8]) -> Result<FileConfig, serde_json::Error>
     let mut config = serde_json::from_slice::<FileConfig>(data)?;
     bound_file_config_collections(&mut config);
     Ok(config)
-}
-
-fn read_file_with_limit(path: &Path, max_bytes: u64, kind: &str) -> std::io::Result<Vec<u8>> {
-    let file = fs::File::open(path)?;
-    let mut bytes = Vec::new();
-    file.take(max_bytes.saturating_add(1))
-        .read_to_end(&mut bytes)?;
-    if bytes.len() as u64 > max_bytes {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "{kind} exceeded the {max_bytes} byte limit ({})",
-                bytes.len()
-            ),
-        ));
-    }
-    Ok(bytes)
 }
 
 fn bound_file_config_collections(config: &mut FileConfig) {

--- a/src/daemon/git_backend.rs
+++ b/src/daemon/git_backend.rs
@@ -882,10 +882,13 @@ mod tests {
             contents.push_str(&format!("    alias{index} = commit\n"));
         }
         contents.push_str(&format!("    huge = {}\n", "x".repeat(1024 * 1024)));
-        fs::write(&config_path, contents).expect("write config");
-        let config =
-            gix_config::File::from_path_no_includes(config_path, gix_config::Source::Local)
-                .expect("parse config");
+        fs::write(&config_path, &contents).expect("write config");
+        let config = gix_config::File::from_bytes_no_includes(
+            contents.as_bytes(),
+            gix_config::file::Metadata::api(),
+            Default::default(),
+        )
+        .expect("parse config");
 
         let aliases = read_all_aliases_from_config(&config);
         let retained_bytes = aliases

--- a/src/git/config_reader.rs
+++ b/src/git/config_reader.rs
@@ -1,0 +1,488 @@
+use crate::error::GitAiError;
+use crate::utils::read_file_with_limit;
+use bstr::{BStr, BString, ByteSlice, ByteVec};
+use gix_config::file::Metadata;
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const MAX_GIT_CONFIG_FILE_BYTES: u64 = 256 * 1_024;
+const MAX_GIT_CONFIG_TOTAL_BYTES: u64 = 1_024 * 1_024;
+const MAX_GIT_CONFIG_FILES: usize = 32;
+const MAX_GIT_CONFIG_SECTIONS: usize = 4_096;
+const MAX_GIT_CONFIG_VALUES: usize = 16_384;
+const MAX_GIT_CONFIG_ENV_ITEMS: usize = 4_096;
+const MAX_GIT_CONFIG_INCLUDE_DEPTH: u8 = 10;
+
+struct ConfigLimits {
+    bytes: u64,
+    files: usize,
+    sections: usize,
+    values: usize,
+}
+
+impl ConfigLimits {
+    fn new() -> Self {
+        Self {
+            bytes: 0,
+            files: 0,
+            sections: 0,
+            values: 0,
+        }
+    }
+
+    fn reserve_input(&mut self, kind: &str, bytes: usize) -> Result<(), GitAiError> {
+        self.bytes = self.bytes.saturating_add(bytes as u64);
+        if self.bytes > MAX_GIT_CONFIG_TOTAL_BYTES {
+            return Err(GitAiError::Generic(format!(
+                "{kind} exceeded the {MAX_GIT_CONFIG_TOTAL_BYTES} cumulative byte limit ({})",
+                self.bytes
+            )));
+        }
+        Ok(())
+    }
+
+    fn reserve_file(&mut self, path: &Path, bytes: usize) -> Result<(), GitAiError> {
+        self.files = self.files.saturating_add(1);
+        if self.files > MAX_GIT_CONFIG_FILES {
+            return Err(GitAiError::Generic(format!(
+                "Git config exceeded the {MAX_GIT_CONFIG_FILES} file limit while reading {}",
+                path.display()
+            )));
+        }
+        self.reserve_input("Git config", bytes)
+    }
+
+    fn reserve_structure(&mut self, sections: usize, values: usize) -> Result<(), GitAiError> {
+        self.sections = self.sections.saturating_add(sections);
+        if self.sections > MAX_GIT_CONFIG_SECTIONS {
+            return Err(GitAiError::Generic(format!(
+                "Git config exceeded the {MAX_GIT_CONFIG_SECTIONS} section limit ({})",
+                self.sections
+            )));
+        }
+        self.values = self.values.saturating_add(values);
+        if self.values > MAX_GIT_CONFIG_VALUES {
+            return Err(GitAiError::Generic(format!(
+                "Git config exceeded the {MAX_GIT_CONFIG_VALUES} value limit ({})",
+                self.values
+            )));
+        }
+        Ok(())
+    }
+}
+
+struct ConfigLoader<'a> {
+    git_dir: Option<&'a Path>,
+    canonical_git_dir: Option<PathBuf>,
+    home_dir: Option<PathBuf>,
+    limits: ConfigLimits,
+}
+
+impl<'a> ConfigLoader<'a> {
+    fn new(git_dir: Option<&'a Path>) -> Self {
+        Self {
+            git_dir,
+            canonical_git_dir: git_dir.and_then(|path| path.canonicalize().ok()),
+            home_dir: dirs::home_dir(),
+            limits: ConfigLimits::new(),
+        }
+    }
+
+    fn load_globals(&mut self) -> Result<gix_config::File<'static>, GitAiError> {
+        let mut config = gix_config::File::default();
+        let mut seen = HashSet::new();
+        for kind in [
+            gix_config::source::Kind::GitInstallation,
+            gix_config::source::Kind::System,
+            gix_config::source::Kind::Global,
+        ] {
+            for source in kind.sources() {
+                let Some(path) = source
+                    .storage_location(&mut |name| std::env::var_os(name))
+                    .map(Cow::into_owned)
+                else {
+                    continue;
+                };
+                if !path.is_file() || !seen.insert(path.clone()) {
+                    continue;
+                }
+                config.append(self.load_file(&path, *source, 0, Vec::new())?);
+            }
+        }
+        Ok(config)
+    }
+
+    fn load_optional_file(
+        &mut self,
+        path: &Path,
+        source: gix_config::Source,
+    ) -> Result<Option<gix_config::File<'static>>, GitAiError> {
+        match std::fs::metadata(path) {
+            Ok(metadata) if metadata.is_file() => {
+                self.load_file(path, source, 0, Vec::new()).map(Some)
+            }
+            Ok(_) => Ok(None),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn load_file(
+        &mut self,
+        path: &Path,
+        source: gix_config::Source,
+        depth: u8,
+        mut search_remote_urls: Vec<BString>,
+    ) -> Result<gix_config::File<'static>, GitAiError> {
+        let parsed = self.parse_file(path, source, depth, true)?;
+        if depth == 0 {
+            extend_remote_urls(&parsed, &mut search_remote_urls)?;
+        }
+        self.expand_includes(parsed, Some(path), source, depth, &mut search_remote_urls)
+    }
+
+    fn parse_file(
+        &mut self,
+        path: &Path,
+        source: gix_config::Source,
+        depth: u8,
+        lossy: bool,
+    ) -> Result<gix_config::File<'static>, GitAiError> {
+        if depth >= MAX_GIT_CONFIG_INCLUDE_DEPTH {
+            return Err(GitAiError::Generic(format!(
+                "Git config include depth exceeded {MAX_GIT_CONFIG_INCLUDE_DEPTH} while reading {}",
+                path.display()
+            )));
+        }
+        let mut bytes = read_file_with_limit(path, MAX_GIT_CONFIG_FILE_BYTES, "Git config")?;
+        self.limits.reserve_file(path, bytes.len())?;
+        let mut metadata = Metadata::try_from_path(path, source)?;
+        metadata.level = depth;
+        let parsed = gix_config::File::from_bytes_owned(
+            &mut bytes,
+            metadata,
+            gix_config::file::init::Options {
+                includes: gix_config::file::includes::Options::no_follow(),
+                lossy,
+                ..Default::default()
+            },
+        )
+        .map_err(|error| GitAiError::GixError(error.to_string()))?;
+        self.reserve_parsed_structure(&parsed)?;
+        Ok(parsed)
+    }
+
+    fn reserve_parsed_structure(
+        &mut self,
+        config: &gix_config::File<'_>,
+    ) -> Result<(), GitAiError> {
+        let mut sections = 0usize;
+        let mut values = 0usize;
+        for section in config.sections() {
+            sections = sections.saturating_add(1);
+            values = values.saturating_add(section.body().num_values());
+        }
+        self.limits.reserve_structure(sections, values)
+    }
+
+    fn expand_includes(
+        &mut self,
+        mut parsed: gix_config::File<'static>,
+        source_path: Option<&Path>,
+        source: gix_config::Source,
+        depth: u8,
+        search_remote_urls: &mut Vec<BString>,
+    ) -> Result<gix_config::File<'static>, GitAiError> {
+        let section_ids: Vec<_> = parsed.section_ids().collect();
+        let mut expanded = gix_config::File::default();
+
+        for section_id in section_ids {
+            let section = parsed
+                .remove_section_by_id(section_id)
+                .expect("section id came from the same Git config");
+            let include_paths = if self.include_section_matches(
+                &section,
+                source_path,
+                search_remote_urls,
+            )? {
+                let paths = section.body().values("path");
+                if paths.len() > MAX_GIT_CONFIG_FILES {
+                    return Err(GitAiError::Generic(format!(
+                        "Git config include section exceeded the {MAX_GIT_CONFIG_FILES} path limit ({})",
+                        paths.len()
+                    )));
+                }
+                paths
+                    .into_iter()
+                    .map(|path| gix_config::Path::from(Cow::Owned(path.into_owned())))
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
+            expanded.push_section(section);
+
+            for include_path in include_paths {
+                let Some(include_path) = self.resolve_include_path(include_path, source_path)?
+                else {
+                    continue;
+                };
+                if !include_path.is_file() {
+                    continue;
+                }
+                let included = self.load_file(
+                    &include_path,
+                    source,
+                    depth.saturating_add(1),
+                    search_remote_urls.clone(),
+                )?;
+                extend_remote_urls(&included, search_remote_urls)?;
+                expanded.append(included);
+            }
+        }
+        Ok(expanded)
+    }
+
+    fn include_section_matches(
+        &self,
+        section: &gix_config::file::Section<'_>,
+        source_path: Option<&Path>,
+        search_remote_urls: &[BString],
+    ) -> Result<bool, GitAiError> {
+        let name = section.header().name();
+        if name.eq_ignore_ascii_case(b"include") && section.header().subsection_name().is_none() {
+            return Ok(true);
+        }
+        if !name.eq_ignore_ascii_case(b"includeIf") {
+            return Ok(false);
+        }
+        let Some(condition) = section.header().subsection_name() else {
+            return Ok(false);
+        };
+        let Some(separator) = condition.iter().position(|byte| *byte == b':') else {
+            return Ok(false);
+        };
+        let (prefix, condition) = condition.split_at(separator);
+        let condition = &condition[1..];
+        match prefix {
+            b"gitdir" => self.gitdir_matches(condition.as_bstr(), source_path, false),
+            b"gitdir/i" => self.gitdir_matches(condition.as_bstr(), source_path, true),
+            b"onbranch" => Ok(false),
+            b"hasconfig" => Ok(hasconfig_matches(condition, search_remote_urls)),
+            _ => Ok(false),
+        }
+    }
+
+    fn gitdir_matches(
+        &self,
+        condition: &BStr,
+        source_path: Option<&Path>,
+        ignore_case: bool,
+    ) -> Result<bool, GitAiError> {
+        let Some(git_dir) = self.git_dir else {
+            return Ok(false);
+        };
+        let interpolated = match gix_config::Path::from(Cow::Borrowed(condition)).interpolate(
+            gix_config::path::interpolate::Context {
+                home_dir: self.home_dir.as_deref(),
+                home_for_user: Some(gix_config::path::interpolate::home_for_user),
+                ..Default::default()
+            },
+        ) {
+            Ok(path) => path,
+            Err(_) => return Ok(false),
+        };
+        let mut pattern =
+            gix_path::to_unix_separators_on_windows(gix_path::into_bstr(interpolated));
+        if let Some(relative) = pattern.strip_prefix(b"./") {
+            let Some(parent) = source_path.and_then(Path::parent) else {
+                return Ok(false);
+            };
+            let mut joined =
+                gix_path::to_unix_separators_on_windows(gix_path::into_bstr(parent)).into_owned();
+            joined.push(b'/');
+            joined.extend_from_slice(relative);
+            pattern = Cow::Owned(joined);
+        }
+        if !gix_path::from_bstr(pattern.clone()).is_absolute() {
+            let mut prefixed = pattern.into_owned();
+            prefixed.insert_str(0, "**/");
+            pattern = Cow::Owned(prefixed);
+        }
+        if pattern.ends_with(b"/") {
+            let mut suffixed = pattern.into_owned();
+            suffixed.push_str("**");
+            pattern = Cow::Owned(suffixed);
+        }
+
+        let mut mode = gix_glob::wildmatch::Mode::NO_MATCH_SLASH_LITERAL;
+        if ignore_case {
+            mode |= gix_glob::wildmatch::Mode::IGNORE_CASE;
+        }
+        for candidate in
+            std::iter::once(git_dir).chain(self.canonical_git_dir.as_deref().into_iter())
+        {
+            let candidate = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(candidate));
+            if gix_glob::wildmatch(pattern.as_bstr(), candidate.as_bstr(), mode) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn resolve_include_path(
+        &self,
+        path: gix_config::Path<'static>,
+        source_path: Option<&Path>,
+    ) -> Result<Option<PathBuf>, GitAiError> {
+        let path = match path.interpolate(gix_config::path::interpolate::Context {
+            home_dir: self.home_dir.as_deref(),
+            home_for_user: Some(gix_config::path::interpolate::home_for_user),
+            ..Default::default()
+        }) {
+            Ok(path) => path,
+            Err(_) => return Ok(None),
+        };
+        if path.is_absolute() {
+            return Ok(Some(path.into_owned()));
+        }
+        Ok(source_path
+            .and_then(Path::parent)
+            .map(|parent| parent.join(path)))
+    }
+
+    fn load_environment_overrides(&mut self) -> Result<gix_config::File<'static>, GitAiError> {
+        let Some(count) = std::env::var("GIT_CONFIG_COUNT")
+            .ok()
+            .map(|value| value.parse::<usize>())
+            .transpose()
+            .map_err(|error| GitAiError::GixError(error.to_string()))?
+        else {
+            return Ok(gix_config::File::default());
+        };
+        if count > MAX_GIT_CONFIG_ENV_ITEMS {
+            return Err(GitAiError::Generic(format!(
+                "Git environment config exceeded the {MAX_GIT_CONFIG_ENV_ITEMS} item limit ({count})"
+            )));
+        }
+        let mut bytes = 0usize;
+        for index in 0..count {
+            for prefix in ["GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_"] {
+                if let Some(value) = std::env::var_os(format!("{prefix}{index}")) {
+                    bytes = bytes.saturating_add(value.as_encoded_bytes().len());
+                    if bytes as u64 > MAX_GIT_CONFIG_TOTAL_BYTES {
+                        return Err(GitAiError::Generic(format!(
+                            "Git environment config exceeded the {MAX_GIT_CONFIG_TOTAL_BYTES} byte limit ({bytes})"
+                        )));
+                    }
+                }
+            }
+        }
+        self.limits.reserve_input("Git environment config", bytes)?;
+        let Some(parsed) = gix_config::File::from_env(gix_config::file::init::Options {
+            includes: gix_config::file::includes::Options::no_follow(),
+            ..Default::default()
+        })
+        .map_err(|error| GitAiError::GixError(error.to_string()))?
+        else {
+            return Ok(gix_config::File::default());
+        };
+        self.reserve_parsed_structure(&parsed)?;
+        let mut search_remote_urls = Vec::new();
+        extend_remote_urls(&parsed, &mut search_remote_urls)?;
+        self.expand_includes(
+            parsed,
+            None,
+            gix_config::Source::Env,
+            0,
+            &mut search_remote_urls,
+        )
+    }
+}
+
+fn extend_remote_urls(
+    config: &gix_config::File<'_>,
+    urls: &mut Vec<BString>,
+) -> Result<(), GitAiError> {
+    for section in config.sections() {
+        if !section.header().name().eq_ignore_ascii_case(b"remote") {
+            continue;
+        }
+        for url in section.body().values("url") {
+            if urls.len() >= MAX_GIT_CONFIG_SECTIONS {
+                return Err(GitAiError::Generic(format!(
+                    "Git config exceeded the {MAX_GIT_CONFIG_SECTIONS} remote URL limit"
+                )));
+            }
+            urls.push(url.into_owned());
+        }
+    }
+    Ok(())
+}
+
+fn hasconfig_matches(condition: &[u8], remote_urls: &[BString]) -> bool {
+    let Some(separator) = condition.iter().position(|byte| *byte == b':') else {
+        return false;
+    };
+    let (key_glob, value_glob) = condition.split_at(separator);
+    if key_glob != b"remote.*.url" {
+        return false;
+    }
+    let value_glob = &value_glob[1..];
+    remote_urls.iter().any(|url| {
+        gix_glob::wildmatch(
+            value_glob.as_bstr(),
+            url.as_bstr(),
+            gix_glob::wildmatch::Mode::NO_MATCH_SLASH_LITERAL,
+        )
+    })
+}
+
+pub(crate) fn load_global_git_config() -> Result<gix_config::File<'static>, GitAiError> {
+    ConfigLoader::new(None).load_globals()
+}
+
+pub(crate) fn load_single_git_config(
+    path: &Path,
+    source: gix_config::Source,
+) -> Result<Option<gix_config::File<'static>>, GitAiError> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => ConfigLoader::new(None)
+            .parse_file(path, source, 0, false)
+            .map(Some),
+        Ok(_) => Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) fn load_repository_git_config(
+    git_dir: &Path,
+    git_common_dir: &Path,
+) -> Result<gix_config::File<'static>, GitAiError> {
+    let mut loader = ConfigLoader::new(Some(git_dir));
+    let mut config = loader.load_globals()?;
+
+    let local_path = git_common_dir.join("config");
+    let local = loader.load_optional_file(&local_path, gix_config::Source::Local)?;
+    let worktree_config_enabled = local
+        .as_ref()
+        .and_then(|config| config.boolean("extensions.worktreeConfig"))
+        .and_then(Result::ok)
+        .unwrap_or(false);
+    if let Some(local) = local {
+        config.append(local);
+    }
+
+    if worktree_config_enabled {
+        let worktree_path = git_dir.join("config.worktree");
+        if let Some(worktree) =
+            loader.load_optional_file(&worktree_path, gix_config::Source::Worktree)?
+        {
+            config.append(worktree);
+        }
+    }
+
+    config.append(loader.load_environment_overrides()?);
+    Ok(config)
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,5 +1,6 @@
 pub mod cli_parser;
 pub mod command_classification;
+pub(crate) mod config_reader;
 pub mod fast_reader;
 pub mod notes_api;
 pub mod refs;

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -43,6 +43,8 @@ const INTERNAL_GIT_READER_STACK_BYTES: usize = 512 * 1_024;
 pub(crate) const MAX_BATCH_GIT_ITEMS: usize = 4_096;
 pub(crate) const MAX_BATCH_MATERIALIZED_CONTENT_BYTES: usize = 16 * 1_024 * 1_024;
 const MAX_GIT_INDEX_BYTES: u64 = 32 * 1_024 * 1_024;
+const MAX_GIT_CONFIG_QUERY_ITEMS: usize = 4_096;
+const MAX_GIT_CONFIG_QUERY_OUTPUT_BYTES: usize = 1_024 * 1_024;
 
 pub(crate) fn ensure_batch_git_item_limit(kind: &str, count: usize) -> Result<(), GitAiError> {
     if count > MAX_BATCH_GIT_ITEMS {
@@ -1138,8 +1140,7 @@ pub fn global_git_config_committer_identity() -> Result<GitAuthorIdentity, GitAi
 }
 
 pub fn global_git_config_identity_resolution() -> Result<GitConfigIdentityResolution, GitAiError> {
-    let config =
-        gix_config::File::from_globals().map_err(|e| GitAiError::GixError(e.to_string()))?;
+    let config = crate::git::config_reader::load_global_git_config()?;
     Ok(git_config_identity_resolution_from_config(&config))
 }
 
@@ -1409,6 +1410,7 @@ impl Repository {
     pub fn remotes_with_urls(&self) -> Result<Vec<(String, String)>, GitAiError> {
         let config = self.get_git_config_file()?;
         let mut remotes = Vec::new();
+        let mut retained_bytes = 0usize;
 
         for section in config.sections() {
             if !section.header().name().eq_ignore_ascii_case(b"remote") {
@@ -1420,22 +1422,22 @@ impl Repository {
             let Some(url) = section.body().value("url") else {
                 continue;
             };
-            remotes.push((name.to_string(), url.to_string()));
+            let name = name.to_string();
+            let url = url.to_string();
+            retained_bytes = retained_bytes
+                .saturating_add(name.len())
+                .saturating_add(url.len());
+            if remotes.len() >= MAX_GIT_CONFIG_QUERY_ITEMS
+                || retained_bytes > MAX_GIT_CONFIG_QUERY_OUTPUT_BYTES
+            {
+                return Err(GitAiError::Generic(
+                    "Git remote config output exceeded its retention limit".to_string(),
+                ));
+            }
+            remotes.push((name, url));
         }
 
         Ok(remotes)
-    }
-
-    fn load_optional_config_file(
-        path: &Path,
-        source: gix_config::Source,
-    ) -> Result<Option<gix_config::File<'static>>, GitAiError> {
-        if !path.exists() {
-            return Ok(None);
-        }
-        gix_config::File::from_path_no_includes(path.to_path_buf(), source)
-            .map(Some)
-            .map_err(|e| GitAiError::GixError(e.to_string()))
     }
 
     pub(crate) fn get_git_config_file(&self) -> Result<gix_config::File<'static>, GitAiError> {
@@ -1521,6 +1523,7 @@ impl Repository {
 
         let config = self.get_git_config_file()?;
         let mut matches: HashMap<String, String> = HashMap::new();
+        let mut retained_bytes = 0usize;
 
         for section in config.sections() {
             let section_name = section.header().name().to_string().to_lowercase();
@@ -1537,7 +1540,24 @@ impl Repository {
                 if re.is_match(&full_key)
                     && let Some(value) = section.body().value(value_name).map(|c| c.to_string())
                 {
+                    let previous_bytes = matches
+                        .get(&full_key)
+                        .map(|previous| full_key.len().saturating_add(previous.len()))
+                        .unwrap_or(0);
+                    let next_retained_bytes = retained_bytes
+                        .saturating_sub(previous_bytes)
+                        .saturating_add(full_key.len())
+                        .saturating_add(value.len());
+                    if (!matches.contains_key(&full_key)
+                        && matches.len() >= MAX_GIT_CONFIG_QUERY_ITEMS)
+                        || next_retained_bytes > MAX_GIT_CONFIG_QUERY_OUTPUT_BYTES
+                    {
+                        return Err(GitAiError::Generic(format!(
+                            "Git config query exceeded the {MAX_GIT_CONFIG_QUERY_OUTPUT_BYTES} output byte limit"
+                        )));
+                    }
                     matches.insert(full_key, value);
+                    retained_bytes = next_retained_bytes;
                 }
             }
         }
@@ -2368,63 +2388,7 @@ fn git_config_file_for_repo_paths(
     git_dir: &Path,
     git_common_dir: &Path,
 ) -> Result<gix_config::File<'static>, GitAiError> {
-    let mut config =
-        gix_config::File::from_globals().map_err(|e| GitAiError::GixError(e.to_string()))?;
-
-    let home = dirs::home_dir();
-    let options = gix_config::file::init::Options {
-        includes: gix_config::file::includes::Options::follow(
-            gix_config::path::interpolate::Context {
-                home_dir: home.as_deref(),
-                ..Default::default()
-            },
-            gix_config::file::includes::conditional::Context {
-                git_dir: Some(git_dir),
-                branch_name: None,
-            },
-        ),
-        ..Default::default()
-    };
-
-    config
-        .resolve_includes(options)
-        .map_err(|e| GitAiError::GixError(e.to_string()))?;
-
-    let local_config_path = git_common_dir.join("config");
-    let local_config =
-        Repository::load_optional_config_file(&local_config_path, gix_config::Source::Local)?;
-    let worktree_config_enabled = local_config
-        .as_ref()
-        .and_then(|cfg| cfg.boolean("extensions.worktreeConfig"))
-        .and_then(Result::ok)
-        .unwrap_or(false);
-
-    if let Some(mut local_config) = local_config {
-        local_config
-            .resolve_includes(options)
-            .map_err(|e| GitAiError::GixError(e.to_string()))?;
-        config.append(local_config);
-    }
-
-    if worktree_config_enabled {
-        let worktree_config_path = git_dir.join("config.worktree");
-        if let Some(mut worktree_config) = Repository::load_optional_config_file(
-            &worktree_config_path,
-            gix_config::Source::Worktree,
-        )? {
-            worktree_config
-                .resolve_includes(options)
-                .map_err(|e| GitAiError::GixError(e.to_string()))?;
-            config.append(worktree_config);
-        }
-    }
-
-    config.append(
-        gix_config::File::from_environment_overrides()
-            .map_err(|e| GitAiError::GixError(e.to_string()))?,
-    );
-
-    Ok(config)
+    crate::git::config_reader::load_repository_git_config(git_dir, git_common_dir)
 }
 
 pub fn config_get_str_for_path_no_git_exec(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::error::GitAiError;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Read};
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -8,6 +9,27 @@ static IS_TERMINAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 #[inline]
 pub fn normalize_to_posix(path: &str) -> String {
     path.replace('\\', "/")
+}
+
+pub(crate) fn read_file_with_limit(
+    path: &Path,
+    max_bytes: u64,
+    kind: &str,
+) -> std::io::Result<Vec<u8>> {
+    let file = std::fs::File::open(path)?;
+    let mut bytes = Vec::new();
+    file.take(max_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > max_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{kind} exceeded the {max_bytes} byte limit ({})",
+                bytes.len()
+            ),
+        ));
+    }
+    Ok(bytes)
 }
 
 fn resolve_git_ai_exe_from_invocation_path(path: PathBuf) -> PathBuf {

--- a/tests/integration/daemon_git_config_memory.rs
+++ b/tests/integration/daemon_git_config_memory.rs
@@ -1,0 +1,101 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+
+const INCLUDED_CONFIG_BYTES: usize = 4 * 1_024 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+fn write_large_git_config(path: &std::path::Path) {
+    let file = File::create(path).unwrap();
+    let mut writer = BufWriter::new(file);
+    let mut written = 0usize;
+    let mut index = 0usize;
+    while written < INCLUDED_CONFIG_BYTES {
+        let section = format!(
+            "[remote \"pressure-{index:08}\"]\n\turl = https://example.com/pressure/{index:08}.git\n"
+        );
+        writer.write_all(section.as_bytes()).unwrap();
+        written += section.len();
+        index += 1;
+    }
+    writer.flush().unwrap();
+}
+
+#[test]
+fn oversized_included_git_config_keeps_daemon_bounded_and_attribution_working() {
+    let repo = TestRepo::new_with_daemon_env(&[]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let git_config_path = repo.path().join(".git/config");
+    let original_config = fs::read(&git_config_path).unwrap();
+    let included_config_path = repo.path().join(".git/pressure.config");
+    write_large_git_config(&included_config_path);
+    let mut config_with_include = original_config.clone();
+    write!(
+        config_with_include,
+        "\n[include]\n\tpath = {}\n",
+        included_config_path.display()
+    )
+    .unwrap();
+    fs::write(&git_config_path, config_with_include).unwrap();
+    fs::write(&file_path, "base\nai line\n").unwrap();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    #[cfg(target_os = "linux")]
+    let baseline_threads = daemon_thread_count(&repo);
+
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("included Git config HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 32 * 1_024,
+            "included Git config grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+        assert!(
+            daemon_thread_count(&repo) <= baseline_threads + 2,
+            "Git config parsing must not retain worker threads"
+        );
+    }
+
+    fs::write(&git_config_path, original_config).unwrap();
+    fs::remove_file(included_config_path).unwrap();
+    repo.stage_all_and_commit("AI edit after Git config pressure")
+        .unwrap();
+    file.assert_committed_lines(crate::lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/gix_config_tests.rs
+++ b/tests/integration/gix_config_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs;
 
 use crate::repos::test_repo::TestRepo;
 use git_ai::git::repository as GitAiRepository;
@@ -22,6 +23,14 @@ fn git_config_cli_regexp(
         }
     }
     Ok(result)
+}
+
+fn git_config_path(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn git_config_path_value(path: &std::path::Path) -> String {
+    serde_json::to_string(&git_config_path(path)).expect("serialize Git config path value")
 }
 
 // ============================================================================
@@ -115,6 +124,135 @@ fn test_config_get_str_special_chars() {
             .unwrap()
             .trim()
     );
+}
+
+#[test]
+fn test_config_get_str_resolves_bounded_include() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let included_path = git_ai_repo.common_dir().join("included.config");
+    fs::write(&included_path, "[included]\n\tvalue = from-include\n").unwrap();
+    fs::write(
+        git_ai_repo.common_dir().join("config"),
+        format!(
+            "[include]\n\tpath = {}\n",
+            git_config_path_value(&included_path)
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(
+        git_ai_repo.config_get_str("included.value").unwrap(),
+        Some("from-include".to_string())
+    );
+}
+
+#[test]
+fn test_config_include_preserves_later_local_precedence() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let included_path = git_ai_repo.common_dir().join("precedence.config");
+    fs::write(&included_path, "[precedence]\n\tvalue = included\n").unwrap();
+    fs::write(
+        git_ai_repo.common_dir().join("config"),
+        format!(
+            "[precedence]\n\tvalue = before\n[include]\n\tpath = {}\n[precedence]\n\tvalue = after\n",
+            git_config_path_value(&included_path)
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(
+        git_ai_repo.config_get_str("precedence.value").unwrap(),
+        Some("after".to_string())
+    );
+}
+
+#[test]
+fn test_config_get_str_resolves_gitdir_conditional_include() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let included_path = git_ai_repo.common_dir().join("gitdir.config");
+    fs::write(&included_path, "[conditional]\n\tvalue = gitdir\n").unwrap();
+    let git_dir = git_config_path(&git_ai_repo.path().canonicalize().unwrap());
+    let included_path = git_config_path_value(&included_path);
+    fs::write(
+        git_ai_repo.common_dir().join("config"),
+        format!("[includeIf \"gitdir:{git_dir}\"]\n\tpath = {included_path}\n"),
+    )
+    .unwrap();
+
+    assert_eq!(
+        git_ai_repo.config_get_str("conditional.value").unwrap(),
+        Some("gitdir".to_string())
+    );
+}
+
+#[test]
+fn test_config_get_str_matches_git_for_exact_gitdir_with_trailing_slash() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let included_path = git_ai_repo.common_dir().join("gitdir-trailing.config");
+    fs::write(&included_path, "[conditional]\n\tvalue = trailing-slash\n").unwrap();
+    let git_dir = git_config_path(&git_ai_repo.path().canonicalize().unwrap());
+    let included_path = git_config_path_value(&included_path);
+    fs::write(
+        git_ai_repo.common_dir().join("config"),
+        format!("[includeIf \"gitdir:{git_dir}/\"]\n\tpath = {included_path}\n"),
+    )
+    .unwrap();
+
+    assert!(
+        repo.git_og(&["config", "--get", "conditional.value"])
+            .is_err(),
+        "Git treats a trailing slash as a directory-prefix pattern, so an exact git dir does not match"
+    );
+    assert_eq!(
+        git_ai_repo.config_get_str("conditional.value").unwrap(),
+        None
+    );
+}
+
+#[test]
+fn test_config_get_str_resolves_hasconfig_conditional_include() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let included_path = git_ai_repo.common_dir().join("hasconfig.config");
+    fs::write(&included_path, "[conditional]\n\tvalue = hasconfig\n").unwrap();
+    fs::write(
+        git_ai_repo.common_dir().join("config"),
+        format!(
+            "[includeIf \"hasconfig:remote.*.url:https://example.com/private/**\"]\n\tpath = {}\n[remote \"origin\"]\n\turl = https://example.com/private/repo.git\n",
+            git_config_path_value(&included_path)
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(
+        git_ai_repo.config_get_str("conditional.value").unwrap(),
+        Some("hasconfig".to_string())
+    );
+}
+
+#[test]
+fn test_oversized_repository_config_is_rejected_before_parsing() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let config_path = git_ai_repo.common_dir().join("config");
+    let mut config = fs::read(&config_path).unwrap();
+    config.extend(std::iter::repeat_n(b'#', 512 * 1_024));
+    fs::write(config_path, config).unwrap();
+
+    let error = git_ai_repo
+        .config_get_str("user.name")
+        .expect_err("oversized Git config must fail before parsing");
+    assert!(error.to_string().contains("byte limit"));
 }
 
 // ============================================================================
@@ -212,6 +350,24 @@ fn test_config_get_regexp_case_insensitive_keys() {
     assert_eq!(result, git_config_result);
 }
 
+#[test]
+fn test_config_get_regexp_rejects_amplified_output() {
+    let repo = TestRepo::new();
+    let git_ai_repo =
+        GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let subsection = "s".repeat(64 * 1_024);
+    let mut config = format!("[amplified \"{subsection}\"]\n");
+    for index in 0..64 {
+        config.push_str(&format!("\tkey{index} = value{index}\n"));
+    }
+    fs::write(git_ai_repo.common_dir().join("config"), config).unwrap();
+
+    let error = git_ai_repo
+        .config_get_regexp(r"^amplified\.")
+        .expect_err("amplified config query output must be rejected");
+    assert!(error.to_string().contains("output byte limit"));
+}
+
 // ============================================================================
 // Global config fallback tests
 // ============================================================================
@@ -306,10 +462,17 @@ crate::reuse_tests_in_worktree!(
     test_config_get_str_subsection,
     test_config_get_str_missing_key_returns_none,
     test_config_get_str_special_chars,
+    test_config_get_str_resolves_bounded_include,
+    test_config_include_preserves_later_local_precedence,
+    test_config_get_str_resolves_gitdir_conditional_include,
+    test_config_get_str_matches_git_for_exact_gitdir_with_trailing_slash,
+    test_config_get_str_resolves_hasconfig_conditional_include,
+    test_oversized_repository_config_is_rejected_before_parsing,
     test_config_get_regexp_subsection,
     test_config_get_regexp_no_matches,
     test_config_get_regexp_with_subsections,
     test_config_get_regexp_case_insensitive_keys,
+    test_config_get_regexp_rejects_amplified_output,
     test_config_local_overrides_global,
     test_config_get_str_bare_repo,
     test_config_get_regexp_bare_repo,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -53,6 +53,7 @@ mod cursor;
 mod daemon_batch_materialization_memory;
 mod daemon_commit_carryover;
 mod daemon_config_memory;
+mod daemon_git_config_memory;
 mod daemon_git_output_memory;
 mod daemon_http_memory;
 mod daemon_ignore_memory;


### PR DESCRIPTION
## Bug
Git configuration lookup could traverse unlimited include files and retain unlimited sections, values, environment entries, and command output. Include chains and huge config files could make routine daemon repository discovery consume unbounded memory.

## Fix
Introduce one bounded config reader with per-file/cumulative byte, file-count, include-depth, section, value, and environment limits. It preserves Git precedence and supported `includeIf` semantics while bounding fallback query output without adding per-item Git spawns.

## Verification
Dedicated tests cover include precedence, `gitdir`/`hasconfig` conditionals, and all limits. A `TestRepo` linked-worktree conformance test compares the bounded reader with the real Git CLI for an exact `gitdir:.../.git/` condition and confirms both intentionally do not match. `tests/integration/daemon_git_config_memory.rs` validates oversized included config.

## Windows CI follow-up
The TestRepo include fixtures now serialize file paths as quoted Git config values while keeping normalized `gitdir:` match patterns separate. This fixes drive-letter and backslash parsing on Windows without changing production parsing or its memory bounds. The bounded include, `gitdir`, `hasconfig`, and later-precedence TestRepo cases all pass locally.
