### PR TITLE
fix(daemon): bound control metadata reads

### DIFF
--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -15,6 +15,8 @@ use crate::git::repository::{
     exec_git_allow_nonzero_with_env,
 };
 
+const MAX_STASH_METADATA_BYTES: u64 = 1024 * 1024;
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StashMetadata {
     pub base_commit: String,
@@ -148,6 +150,13 @@ pub fn handle_stash_create(
 
     let metadata_path = stash_metadata_path(repo, stash_sha);
     let json = serde_json::to_string_pretty(&metadata)?;
+    if json.len() as u64 > MAX_STASH_METADATA_BYTES {
+        return Err(GitAiError::Generic(format!(
+            "stash metadata exceeded the {} byte limit ({})",
+            MAX_STASH_METADATA_BYTES,
+            json.len()
+        )));
+    }
     fs::write(&metadata_path, json)?;
 
     // Save compact stashed file attributions before cleaning them from the working log.
@@ -172,7 +181,11 @@ pub fn handle_stash_pop_or_apply_with_head(
         return Ok(());
     }
 
-    let content = fs::read_to_string(&metadata_path)?;
+    let content = crate::utils::read_text_file_with_limit(
+        &metadata_path,
+        MAX_STASH_METADATA_BYTES,
+        "stash metadata",
+    )?;
     let metadata: StashMetadata = serde_json::from_str(&content)?;
 
     let Some(current_head) = target_head.filter(|h| !h.is_empty()) else {

--- a/src/commands/git_hook_handlers.rs
+++ b/src/commands/git_hook_handlers.rs
@@ -8,6 +8,7 @@
 //!   during the transition period.
 
 use crate::error::GitAiError;
+use crate::git::repo_state::read_git_control_file;
 use crate::git::repository::Repository;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -23,6 +24,7 @@ const REPO_HOOK_ENABLEMENT_FILE: &str = "git_hooks_enabled";
 const REBASE_HOOK_MASK_STATE_FILE: &str = "rebase_hook_mask_state.json";
 const GIT_HOOKS_DIR_NAME: &str = "hooks";
 const REPO_HOOK_STATE_SCHEMA_VERSION: &str = "repo_hooks/2";
+const MAX_REPO_HOOK_STATE_BYTES: u64 = 256 * 1_024;
 
 pub const ENV_SKIP_ALL_HOOKS: &str = "GIT_AI_SKIP_ALL_HOOKS";
 // Intentionally avoid a GIT_* prefix so git alias shell-command tests don't
@@ -353,7 +355,11 @@ fn read_repo_hook_state(path: &Path) -> Result<Option<RepoHookState>, GitAiError
     if !path.exists() {
         return Ok(None);
     }
-    let content = fs::read_to_string(path)?;
+    let content = crate::utils::read_text_file_with_limit(
+        path,
+        MAX_REPO_HOOK_STATE_BYTES,
+        "repo hook state",
+    )?;
     match serde_json::from_str::<RepoHookState>(&content) {
         Ok(state) => Ok(Some(state)),
         Err(err) => {
@@ -485,7 +491,7 @@ fn git_dir_from_context() -> Option<PathBuf> {
 
 fn worktree_root_from_git_dir(git_dir: &Path) -> Option<PathBuf> {
     let gitdir_file = git_dir.join("gitdir");
-    let gitdir_target = fs::read_to_string(gitdir_file).ok()?;
+    let gitdir_target = read_git_control_file(&gitdir_file)?;
     let gitdir_target = gitdir_target.trim();
     if gitdir_target.is_empty() {
         return None;
@@ -612,7 +618,7 @@ fn should_forward_repo_state_first(repo: Option<&Repository>) -> Option<PathBuf>
 
 #[cfg(test)]
 mod tests {
-    use super::load_config;
+    use super::{load_config, read_repo_hook_state};
 
     #[test]
     fn hook_config_loader_rejects_oversized_file_before_parsing() {
@@ -622,6 +628,17 @@ mod tests {
 
         let error = load_config(&path, gix_config::Source::Local)
             .expect_err("oversized hook config must be rejected");
+        assert!(error.to_string().contains("byte limit"));
+    }
+
+    #[test]
+    fn repo_hook_state_rejects_oversized_file_before_parsing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("git_hooks_state.json");
+        std::fs::write(&path, vec![b' '; 512 * 1_024]).unwrap();
+
+        let error =
+            read_repo_hook_state(&path).expect_err("oversized repo hook state must be rejected");
         assert!(error.to_string().contains("byte limit"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8,7 +8,7 @@ use crate::git::cli_parser::{
 };
 use crate::git::find_repository_in_path;
 use crate::git::repo_state::{
-    common_dir_for_worktree, git_dir_for_worktree, worktree_root_for_path,
+    common_dir_for_worktree, git_dir_for_worktree, read_git_control_file, worktree_root_for_path,
 };
 use crate::git::repository::{
     Repository, discover_repository_in_path_no_git_exec, exec_git, exec_git_stdin,
@@ -371,7 +371,7 @@ fn daemon_worktree_from_repo_path(repo_path: &Path) -> Option<PathBuf> {
 
     let linked_gitdir_file = repo_path.join("gitdir");
     if linked_gitdir_file.is_file() {
-        let content = fs::read_to_string(&linked_gitdir_file).ok()?;
+        let content = read_git_control_file(&linked_gitdir_file)?;
         let linked = PathBuf::from(content.trim());
         if linked.file_name().and_then(|name| name.to_str()) == Some(".git") {
             return linked.parent().map(PathBuf::from);
@@ -2191,18 +2191,29 @@ fn pid_metadata_path(config: &DaemonConfig) -> PathBuf {
         .join(PID_META_FILE)
 }
 
-/// Returns the log file path for the currently running daemon, if any.
-/// Reads the PID from daemon.pid.json and constructs the log path.
-pub fn daemon_log_file_path(config: &DaemonConfig) -> Result<PathBuf, GitAiError> {
+const MAX_PID_METADATA_BYTES: u64 = 4 * 1_024;
+
+fn read_pid_metadata(config: &DaemonConfig) -> Result<DaemonPidMeta, GitAiError> {
     let meta_path = pid_metadata_path(config);
-    let contents = fs::read_to_string(&meta_path).map_err(|e| {
+    let contents = crate::utils::read_text_file_with_limit(
+        &meta_path,
+        MAX_PID_METADATA_BYTES,
+        "daemon PID metadata",
+    )
+    .map_err(|e| {
         GitAiError::Generic(format!(
             "failed to read daemon pid metadata at {}: {}",
             meta_path.display(),
             e
         ))
     })?;
-    let meta: DaemonPidMeta = serde_json::from_str(&contents)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+/// Returns the log file path for the currently running daemon, if any.
+/// Reads the PID from daemon.pid.json and constructs the log path.
+pub fn daemon_log_file_path(config: &DaemonConfig) -> Result<PathBuf, GitAiError> {
+    let meta = read_pid_metadata(config)?;
     let log_dir = config.internal_dir.join("daemon").join("logs");
     Ok(log_dir.join(format!("{}.log", meta.pid)))
 }
@@ -2219,16 +2230,7 @@ fn write_pid_metadata(config: &DaemonConfig) -> Result<(), GitAiError> {
 
 /// Read the PID of the currently running daemon from the pid metadata file.
 pub fn read_daemon_pid(config: &DaemonConfig) -> Result<u32, GitAiError> {
-    let meta_path = pid_metadata_path(config);
-    let contents = fs::read_to_string(&meta_path).map_err(|e| {
-        GitAiError::Generic(format!(
-            "failed to read daemon pid metadata at {}: {}",
-            meta_path.display(),
-            e
-        ))
-    })?;
-    let meta: DaemonPidMeta = serde_json::from_str(&contents)?;
-    Ok(meta.pid)
+    Ok(read_pid_metadata(config)?.pid)
 }
 
 fn remove_pid_metadata(config: &DaemonConfig) -> Result<(), GitAiError> {

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -3,11 +3,13 @@ use crate::daemon::git_backend::GitBackend;
 use crate::error::GitAiError;
 use crate::git::cli_parser::parse_git_cli_args;
 use crate::git::repo_state::{
-    common_dir_for_repo_path, common_dir_for_worktree, worktree_root_for_path,
+    common_dir_for_repo_path, common_dir_for_worktree, read_git_control_file,
+    worktree_root_for_path,
 };
 use crate::observability;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet, VecDeque};
+#[cfg(test)]
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -850,7 +852,7 @@ fn worktree_from_def_repo_repo(repo: &Path) -> Option<PathBuf> {
 
     let linked_gitdir = repo.join("gitdir");
     if linked_gitdir.is_file() {
-        let content = fs::read_to_string(&linked_gitdir).ok()?;
+        let content = read_git_control_file(&linked_gitdir)?;
         let path = PathBuf::from(content.trim());
         if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
             return path.parent().map(PathBuf::from);

--- a/src/git/repo_state.rs
+++ b/src/git/repo_state.rs
@@ -1,5 +1,13 @@
+#[cfg(test)]
 use std::fs;
 use std::path::{Path, PathBuf};
+
+const MAX_GIT_CONTROL_FILE_BYTES: u64 = 64 * 1_024;
+
+pub(crate) fn read_git_control_file(path: &Path) -> Option<String> {
+    crate::utils::read_text_file_with_limit(path, MAX_GIT_CONTROL_FILE_BYTES, "Git control file")
+        .ok()
+}
 
 pub fn is_valid_git_oid(value: &str) -> bool {
     matches!(value.len(), 40 | 64) && value.chars().all(|c| c.is_ascii_hexdigit())
@@ -30,7 +38,7 @@ pub fn git_dir_for_worktree(worktree: &Path) -> Option<PathBuf> {
     if dot_git.is_dir() {
         return Some(dot_git);
     }
-    let contents = fs::read_to_string(&dot_git).ok()?;
+    let contents = read_git_control_file(&dot_git)?;
     let pointer = contents.strip_prefix("gitdir:")?.trim();
     let candidate = PathBuf::from(pointer);
     if candidate.is_absolute() {
@@ -62,7 +70,7 @@ pub fn common_dir_for_repo_path(path: &Path) -> Option<PathBuf> {
     }
 
     if path.file_name().and_then(|name| name.to_str()) == Some(".git") && path.is_file() {
-        let contents = fs::read_to_string(path).ok()?;
+        let contents = read_git_control_file(path)?;
         let pointer = contents.strip_prefix("gitdir:")?.trim();
         let candidate = PathBuf::from(pointer);
         let git_dir = if candidate.is_absolute() {
@@ -142,5 +150,15 @@ mod tests {
         );
         assert_eq!(state.branch.as_deref(), Some("main"));
         assert!(!state.detached);
+    }
+
+    #[test]
+    fn git_dir_for_worktree_rejects_oversized_pointer_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut pointer = String::from("gitdir: ");
+        pointer.push_str(&"x".repeat(128 * 1_024));
+        fs::write(temp.path().join(".git"), pointer).unwrap();
+
+        assert_eq!(git_dir_for_worktree(temp.path()), None);
     }
 }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use crate::error::GitAiError;
 use crate::git::repo_state::{
-    common_dir_for_git_dir, git_dir_for_worktree, worktree_root_for_path,
+    common_dir_for_git_dir, git_dir_for_worktree, read_git_control_file, worktree_root_for_path,
 };
 use crate::git::repo_storage::RepoStorage;
 use crate::git::status::MAX_PATHSPEC_ARGS;
@@ -2565,7 +2565,7 @@ fn has_intervening_git_dir(file_path: &Path, workdir: &Path) -> bool {
 /// Returns `true` if `git_file` is a `.git` file that points to a linked
 /// worktree (i.e., the `gitdir:` target path contains `/worktrees/`).
 fn is_linked_worktree_git_file(git_file: &Path) -> bool {
-    let Ok(contents) = std::fs::read_to_string(git_file) else {
+    let Some(contents) = read_git_control_file(git_file) else {
         return false;
     };
     // Format: "gitdir: <path>\n"
@@ -2645,7 +2645,7 @@ pub fn find_repository_for_file(
             // Submodules have a .git file (not directory) that points to the parent's .git/modules
             if git_path.is_file() {
                 // This is a submodule - read the file to check if it points to modules/
-                if let Ok(content) = std::fs::read_to_string(&git_path)
+                if let Some(content) = read_git_control_file(&git_path)
                     && content.contains("gitdir:")
                     && content.contains("/modules/")
                 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,19 @@ pub(crate) fn read_file_with_limit(
     Ok(bytes)
 }
 
+pub(crate) fn read_text_file_with_limit(
+    path: &Path,
+    max_bytes: u64,
+    kind: &str,
+) -> std::io::Result<String> {
+    String::from_utf8(read_file_with_limit(path, max_bytes, kind)?).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("{kind} is not UTF-8: {error}"),
+        )
+    })
+}
+
 fn resolve_git_ai_exe_from_invocation_path(path: PathBuf) -> PathBuf {
     let canonical_path = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -54,6 +54,23 @@ fn daemon_lock_path(repo: &TestRepo) -> PathBuf {
     DaemonConfig::from_home(&repo.daemon_home_path()).lock_path
 }
 
+#[test]
+fn daemon_pid_metadata_rejects_oversized_file_before_parsing() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let config = DaemonConfig::from_home(&repo.daemon_home_path());
+    let metadata_path = config
+        .lock_path
+        .parent()
+        .expect("daemon lock has a parent")
+        .join("daemon.pid.json");
+    fs::create_dir_all(metadata_path.parent().unwrap()).unwrap();
+    fs::write(&metadata_path, vec![b' '; 64 * 1_024]).unwrap();
+
+    let error =
+        read_daemon_pid(&config).expect_err("oversized daemon PID metadata must be rejected");
+    assert!(error.to_string().contains("byte limit"));
+}
+
 #[allow(clippy::zombie_processes)]
 fn start_daemon_for_repo(repo: &TestRepo) {
     let daemon_home = repo.daemon_home_path();

--- a/tests/integration/daemon_control_metadata_memory.rs
+++ b/tests/integration/daemon_control_metadata_memory.rs
@@ -1,0 +1,103 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::daemon::open_local_socket_stream_with_timeout;
+use std::fs::{self, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::time::Duration;
+
+const CONTROL_FILE_BYTES: u64 = 64 * 1_024 * 1_024;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn oversized_gitdir_control_file_keeps_daemon_bounded_and_attribution_working() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let tracked_path = repo.path().join("tracked.txt");
+    fs::write(&tracked_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut tracked = repo.filename("tracked.txt");
+    tracked.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let fake_git_dir = repo.path().join(".git/ai/control-pressure");
+    fs::create_dir_all(&fake_git_dir).unwrap();
+    let gitdir_path = fake_git_dir.join("gitdir");
+    let mut gitdir = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&gitdir_path)
+        .unwrap();
+    gitdir.write_all(b"/tmp/target/.git\n").unwrap();
+    gitdir
+        .seek(SeekFrom::Start(CONTROL_FILE_BYTES - 1))
+        .unwrap();
+    gitdir.write_all(&[0]).unwrap();
+    gitdir.flush().unwrap();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+
+    let sid = "oversized-control-metadata";
+    let frames = [
+        serde_json::json!({
+            "event": "start",
+            "sid": sid,
+            "argv": ["git", "status"],
+            "cwd": repo.path(),
+            "time_ns": 1,
+        }),
+        serde_json::json!({
+            "event": "def_repo",
+            "sid": sid,
+            "repo": fake_git_dir,
+            "time_ns": 2,
+        }),
+        serde_json::json!({
+            "event": "atexit",
+            "sid": sid,
+            "code": 0,
+            "time_ns": 3,
+        }),
+    ];
+    let mut stream = open_local_socket_stream_with_timeout(
+        &repo.daemon_trace_socket_path(),
+        Duration::from_secs(2),
+    )
+    .expect("connect trace socket");
+    for frame in frames {
+        writeln!(stream, "{frame}").unwrap();
+    }
+    stream.flush().unwrap();
+    drop(stream);
+    std::thread::sleep(Duration::from_millis(500));
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("Git control metadata HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 24 * 1_024,
+            "oversized Git control metadata grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    fs::remove_dir_all(fake_git_dir).unwrap();
+    fs::write(&tracked_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after control metadata pressure")
+        .unwrap();
+    tracked.assert_committed_lines(crate::lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -53,6 +53,7 @@ mod cursor;
 mod daemon_batch_materialization_memory;
 mod daemon_commit_carryover;
 mod daemon_config_memory;
+mod daemon_control_metadata_memory;
 mod daemon_git_config_memory;
 mod daemon_git_output_memory;
 mod daemon_http_memory;

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -2,8 +2,10 @@ use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::attribution_tracker::LineAttribution;
 use git_ai::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord};
+use git_ai::authorship::rewrite_stash::handle_stash_pop_or_apply_with_head;
 use git_ai::authorship::working_log::AgentId;
 use git_ai::git::repo_storage::InitialAttributions;
+use git_ai::git::repository::find_repository_in_path;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
@@ -1605,6 +1607,30 @@ fn test_stash_push_pathspec_excludes_unstashed_file_from_stash_log() {
     repo.stage_all_and_commit("apply partial stash").unwrap();
     a.assert_committed_lines(vec!["a line 1".ai(), "a line 2".ai()]);
     b.assert_committed_lines(vec!["b line 1".ai(), "b line 2".ai()]);
+}
+
+#[test]
+fn test_stash_metadata_rejects_oversized_file_before_parsing() {
+    let repo = TestRepo::new();
+    let mut readme = repo.filename("README.md");
+    readme.set_contents(vec!["# Test Repo".to_string()]);
+    repo.stage_all_and_commit("initial commit").unwrap();
+    readme.assert_committed_lines(vec!["# Test Repo".human()]);
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let metadata_path = gitai_repo
+        .storage
+        .ai_dir
+        .join("stashes_v2")
+        .join("oversized")
+        .join("metadata.json");
+    fs::create_dir_all(metadata_path.parent().unwrap()).unwrap();
+    fs::write(&metadata_path, vec![b' '; 2 * 1_024 * 1_024]).unwrap();
+
+    let error = handle_stash_pop_or_apply_with_head(&gitai_repo, "oversized", false, Some("HEAD"))
+        .expect_err("oversized stash metadata must be rejected");
+    assert!(error.to_string().contains("byte limit"));
+    readme.assert_committed_lines(vec!["# Test Repo".human()]);
 }
 
 crate::reuse_tests_in_worktree!(


### PR DESCRIPTION
## Bug
Small daemon control files were read with unrestricted `read_to_string`: stash metadata, hook state, PID files, symbolic/control Git files, and related rewrite inputs. Sparse or corrupt files could force very large allocations on control paths.

## Fix
Use shared metadata readers with purpose-specific ceilings (4 KiB to 1 MiB), validate size before parsing, and fail closed when a control file exceeds its contract. No new reads or Git work are added to trace ingestion.

## Verification
Unit and daemon-mode tests cover bounded metadata reads. `tests/integration/daemon_control_metadata_memory.rs` uses large/sparse files, and stash attribution tests verify valid metadata behavior.