### PR TITLE
fix(checkpoint): bound request construction memory

### DIFF
--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -11,7 +11,7 @@ use crate::error::GitAiError;
 use crate::git::repo_state::{read_head_state_for_worktree, worktree_root_for_path};
 use crate::git::repository::discover_repository_in_path_no_git_exec;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -57,15 +57,104 @@ struct RepoContext {
 }
 
 const MAX_CHECKPOINT_FILES: usize = 1000;
+const MAX_CHECKPOINT_REPOSITORIES: usize = 64;
+const MAX_CHECKPOINT_CONTEXT_STRING_BYTES: usize = 64 * 1024;
+const MAX_CHECKPOINT_METADATA_ITEMS: usize = 64;
+const MAX_CHECKPOINT_METADATA_KEY_BYTES: usize = 1024;
+const MAX_CHECKPOINT_METADATA_VALUE_BYTES: usize = 64 * 1024;
+const MAX_CHECKPOINT_METADATA_BYTES: usize = 256 * 1024;
+const MAX_CHECKPOINT_COMMAND_BYTES: usize = 1024 * 1024;
+pub(crate) const MAX_CHECKPOINT_HOOK_INPUT_BYTES: usize = 32 * 1024 * 1024;
 
-fn apply_checkpoint_content_budget(files: &mut [CheckpointFile]) {
-    let mut budget = CheckpointContentBudget::from_config(config::Config::get());
-    for file in files {
-        let Some(content) = file.content.as_ref() else {
-            continue;
-        };
-        if !budget.reserve(file.path.display(), content) {
-            file.content = None;
+fn agent_identity_is_bounded(agent: &AgentId) -> bool {
+    [agent.tool.as_str(), agent.id.as_str(), agent.model.as_str()]
+        .into_iter()
+        .all(|value| value.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES)
+}
+
+fn stream_source_is_bounded(source: &StreamSource) -> bool {
+    source.path.to_string_lossy().len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+        && source.session_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+        && source.external_session_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+        && source
+            .external_parent_session_id
+            .as_ref()
+            .is_none_or(|value| value.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES)
+}
+
+fn metadata_is_bounded(metadata: &HashMap<String, String>) -> bool {
+    if metadata.len() > MAX_CHECKPOINT_METADATA_ITEMS {
+        return false;
+    }
+    let mut total_bytes = 0usize;
+    metadata.iter().all(|(key, value)| {
+        total_bytes = total_bytes
+            .saturating_add(key.len())
+            .saturating_add(value.len());
+        key.len() <= MAX_CHECKPOINT_METADATA_KEY_BYTES
+            && value.len() <= MAX_CHECKPOINT_METADATA_VALUE_BYTES
+            && total_bytes <= MAX_CHECKPOINT_METADATA_BYTES
+    })
+}
+
+fn preset_context_is_bounded(
+    context: &crate::commands::checkpoint_agent::presets::PresetContext,
+) -> bool {
+    agent_identity_is_bounded(&context.agent_id)
+        && context.external_session_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+        && context.trace_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+        && context.cwd.to_string_lossy().len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+        && metadata_is_bounded(&context.metadata)
+}
+
+fn parsed_hook_event_is_bounded(event: &ParsedHookEvent) -> bool {
+    match event {
+        ParsedHookEvent::PreFileEdit(event) => {
+            preset_context_is_bounded(&event.context)
+                && event
+                    .tool_use_id
+                    .as_ref()
+                    .is_none_or(|value| value.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES)
+        }
+        ParsedHookEvent::PostFileEdit(event) => {
+            preset_context_is_bounded(&event.context)
+                && event
+                    .tool_use_id
+                    .as_ref()
+                    .is_none_or(|value| value.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES)
+                && event
+                    .stream_source
+                    .as_ref()
+                    .is_none_or(stream_source_is_bounded)
+        }
+        ParsedHookEvent::PreBashCall(event) => {
+            preset_context_is_bounded(&event.context)
+                && event.tool_use_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+                && event
+                    .command
+                    .as_ref()
+                    .is_none_or(|value| value.len() <= MAX_CHECKPOINT_COMMAND_BYTES)
+        }
+        ParsedHookEvent::PostBashCall(event) => {
+            preset_context_is_bounded(&event.context)
+                && event.tool_use_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+                && event
+                    .command
+                    .as_ref()
+                    .is_none_or(|value| value.len() <= MAX_CHECKPOINT_COMMAND_BYTES)
+                && event
+                    .stream_source
+                    .as_ref()
+                    .is_none_or(stream_source_is_bounded)
+        }
+        ParsedHookEvent::KnownHumanEdit(event) => {
+            event.trace_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+                && event.cwd.to_string_lossy().len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+                && metadata_is_bounded(&event.editor_metadata)
+        }
+        ParsedHookEvent::UntrackedEdit(event) => {
+            event.trace_id.len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
+                && event.cwd.to_string_lossy().len() <= MAX_CHECKPOINT_CONTEXT_STRING_BYTES
         }
     }
 }
@@ -74,12 +163,22 @@ fn apply_dirty_file_overrides(
     files: &mut [CheckpointFile],
     dirty_files: &HashMap<PathBuf, String>,
 ) {
-    for file in &mut *files {
+    let mut budget = CheckpointContentBudget::from_config(config::Config::get());
+    for file in files {
         if let Some(override_content) = dirty_files.get(&file.path) {
-            file.content = Some(override_content.clone());
+            file.content = if budget.reserve(file.path.display(), override_content) {
+                Some(override_content.clone())
+            } else {
+                None
+            };
+        } else if file
+            .content
+            .as_ref()
+            .is_some_and(|content| !budget.reserve(file.path.display(), content))
+        {
+            file.content = None;
         }
     }
-    apply_checkpoint_content_budget(files);
 }
 
 fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>, GitAiError> {
@@ -92,14 +191,16 @@ fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>,
             MAX_CHECKPOINT_FILES,
         );
     }
-    let capped_paths = &file_paths[..file_paths.len().min(MAX_CHECKPOINT_FILES)];
-
     let mut repo_cache: HashMap<PathBuf, RepoContext> = HashMap::new();
     let mut files = Vec::new();
     let mut content_budget = CheckpointContentBudget::from_config(config::Config::get());
     let max_size = content_budget.max_file_size_bytes();
+    let mut seen_paths = HashSet::new();
 
-    for path in capped_paths {
+    for path in file_paths.iter().take(MAX_CHECKPOINT_FILES) {
+        if !seen_paths.insert(path.clone()) {
+            continue;
+        }
         if !path.is_absolute() {
             return Err(GitAiError::PresetError(format!(
                 "file path must be absolute: {}",
@@ -149,7 +250,7 @@ fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>,
 
         let t_read = std::time::Instant::now();
         let content = if let Ok(meta) = fs::metadata(path) {
-            if meta.len() as usize > max_size {
+            if meta.len() > max_size as u64 {
                 tracing::warn!(
                     "skipping file larger than max_checkpoint_file_size_bytes: {} ({} bytes)",
                     path.display(),
@@ -157,7 +258,7 @@ fn build_checkpoint_files(file_paths: &[PathBuf]) -> Result<Vec<CheckpointFile>,
                 );
                 continue;
             }
-            fs::read_to_string(path).ok()
+            crate::utils::read_text_file_with_limit(path, max_size as u64, "checkpoint file").ok()
         } else {
             Some(String::new())
         };
@@ -187,6 +288,13 @@ pub fn execute_preset_checkpoint(
     preset_name: &str,
     hook_input: &str,
 ) -> Result<Vec<CheckpointRequest>, GitAiError> {
+    if hook_input.len() > MAX_CHECKPOINT_HOOK_INPUT_BYTES {
+        return Err(GitAiError::PresetError(format!(
+            "hook input exceeded the {} byte limit ({})",
+            MAX_CHECKPOINT_HOOK_INPUT_BYTES,
+            hook_input.len()
+        )));
+    }
     let perf = std::env::var("GIT_AI_DEBUG_PERFORMANCE").is_ok_and(|v| !v.is_empty() && v != "0");
     let t0 = std::time::Instant::now();
 
@@ -205,6 +313,10 @@ pub fn execute_preset_checkpoint(
 
     let mut requests = Vec::new();
     for event in events {
+        if !parsed_hook_event_is_bounded(&event) {
+            tracing::warn!("skipping checkpoint event with oversized context");
+            continue;
+        }
         let t_event = std::time::Instant::now();
         let event_name = format!("{:?}", std::mem::discriminant(&event));
         let new_requests = execute_event(event, preset_name)?;
@@ -321,13 +433,53 @@ fn split_files_into_requests(
     stream_source: Option<StreamSource>,
     metadata: HashMap<String, String>,
 ) -> Vec<CheckpointRequest> {
+    if agent_id
+        .as_ref()
+        .is_some_and(|agent| !agent_identity_is_bounded(agent))
+    {
+        tracing::warn!("skipping checkpoint with oversized agent identity");
+        return Vec::new();
+    }
+    if stream_source
+        .as_ref()
+        .is_some_and(|source| !stream_source_is_bounded(source))
+    {
+        tracing::warn!("skipping checkpoint with oversized stream source");
+        return Vec::new();
+    }
+
+    let mut bounded_metadata = HashMap::new();
+    let mut metadata_bytes = 0usize;
+    for (key, value) in metadata {
+        let item_bytes = key.len().saturating_add(value.len());
+        if bounded_metadata.len() >= MAX_CHECKPOINT_METADATA_ITEMS
+            || key.len() > MAX_CHECKPOINT_METADATA_KEY_BYTES
+            || value.len() > MAX_CHECKPOINT_METADATA_VALUE_BYTES
+            || metadata_bytes.saturating_add(item_bytes) > MAX_CHECKPOINT_METADATA_BYTES
+        {
+            tracing::warn!("dropping oversized checkpoint metadata item");
+            continue;
+        }
+        metadata_bytes += item_bytes;
+        bounded_metadata.insert(key, value);
+    }
+
     let all_files: Vec<CheckpointFile> = all_files
         .into_iter()
         .filter(|f| f.content.is_some())
         .collect();
     let mut by_repo: HashMap<PathBuf, Vec<CheckpointFile>> = HashMap::new();
     for f in all_files {
-        by_repo.entry(f.repo_work_dir.clone()).or_default().push(f);
+        if let Some(repo_files) = by_repo.get_mut(&f.repo_work_dir) {
+            repo_files.push(f);
+        } else if by_repo.len() < MAX_CHECKPOINT_REPOSITORIES {
+            by_repo.insert(f.repo_work_dir.clone(), vec![f]);
+        } else {
+            tracing::warn!(
+                max_repositories = MAX_CHECKPOINT_REPOSITORIES,
+                "dropping checkpoint file beyond repository fanout limit"
+            );
+        }
     }
 
     by_repo
@@ -339,7 +491,7 @@ fn split_files_into_requests(
             files,
             path_role,
             stream_source: stream_source.clone(),
-            metadata: metadata.clone(),
+            metadata: bounded_metadata.clone(),
         })
         .collect()
 }
@@ -576,4 +728,70 @@ fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, Git
         e.stream_source,
         metadata,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn checkpoint_file(repo: &str) -> CheckpointFile {
+        CheckpointFile {
+            path: PathBuf::from(format!("/{repo}/file.txt")),
+            content: Some("content".to_string()),
+            repo_work_dir: PathBuf::from(format!("/{repo}")),
+            base_commit: BaseCommit::Initial,
+        }
+    }
+
+    fn split_for_test(
+        files: Vec<CheckpointFile>,
+        agent_id: Option<AgentId>,
+        metadata: HashMap<String, String>,
+    ) -> Vec<CheckpointRequest> {
+        split_files_into_requests(
+            files,
+            "trace".to_string(),
+            CheckpointKind::AiAgent,
+            agent_id,
+            PreparedPathRole::Edited,
+            None,
+            metadata,
+        )
+    }
+
+    #[test]
+    fn split_checkpoint_requests_bounds_repository_fanout() {
+        let files = (0..65)
+            .map(|index| checkpoint_file(&format!("repo-{index}")))
+            .collect();
+
+        assert_eq!(split_for_test(files, None, HashMap::new()).len(), 64);
+    }
+
+    #[test]
+    fn split_checkpoint_requests_rejects_oversized_agent_identity() {
+        let agent_id = AgentId {
+            tool: "tool".to_string(),
+            id: "x".repeat(64 * 1024 + 1),
+            model: "model".to_string(),
+        };
+
+        assert!(
+            split_for_test(
+                vec![checkpoint_file("repo")],
+                Some(agent_id),
+                HashMap::new()
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn split_checkpoint_requests_drops_oversized_metadata_values() {
+        let metadata = HashMap::from([("command".to_string(), "x".repeat(64 * 1024 + 1))]);
+        let requests = split_for_test(vec![checkpoint_file("repo")], None, metadata);
+
+        assert_eq!(requests.len(), 1);
+        assert!(!requests[0].metadata.contains_key("command"));
+    }
 }

--- a/src/commands/checkpoint_agent/presets/amp.rs
+++ b/src/commands/checkpoint_agent/presets/amp.rs
@@ -144,18 +144,8 @@ impl AmpPreset {
                 continue;
             }
 
-            // Quick string check before full parse
-            let content = match std::fs::read_to_string(&path) {
-                Ok(c) => c,
-                Err(_) => continue,
-            };
-            if !content.contains(tool_use_id) {
-                continue;
-            }
-
-            // Verify structurally: look for tool_use content block with matching id
-            let parsed: serde_json::Value = match serde_json::from_str(&content) {
-                Ok(v) => v,
+            let parsed = match crate::streams::types::read_monolithic_transcript_json(&path) {
+                Ok(parsed) => parsed,
                 Err(_) => continue,
             };
             let has_match = parsed
@@ -377,6 +367,7 @@ mod tests {
     use super::*;
     use crate::commands::checkpoint_agent::presets::*;
     use serde_json::json;
+    use std::io::Write;
 
     fn make_amp_input(event: &str, tool: &str) -> String {
         json!({
@@ -541,5 +532,25 @@ mod tests {
             }
             _ => panic!("Expected PostFileEdit"),
         }
+    }
+
+    #[test]
+    fn oversized_thread_file_is_not_materialized_during_fallback_search() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("oversized.json");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(br#"{"padding":""#).unwrap();
+        let chunk = vec![b'x'; 1024 * 1024];
+        for _ in 0..33 {
+            file.write_all(&chunk).unwrap();
+        }
+        file.write_all(br#"","messages":[{"content":[{"type":"tool_use","id":"needle"}]}]}"#)
+            .unwrap();
+        file.flush().unwrap();
+
+        assert_eq!(
+            AmpPreset::find_thread_file_by_tool_use_id(temp.path(), "needle"),
+            None
+        );
     }
 }

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -397,10 +397,27 @@ fn handle_checkpoint(args: &[String]) {
                 if i + 1 < args.len() {
                     hook_input = Some(strip_utf8_bom(args[i + 1].clone()));
                     if hook_input.as_ref().unwrap() == "stdin" {
-                        let mut stdin = std::io::stdin();
+                        let stdin = std::io::stdin();
                         let mut buffer = Vec::new();
-                        if let Err(e) = stdin.read_to_end(&mut buffer) {
+                        if let Err(e) = stdin
+                            .take(
+                                crate::commands::checkpoint_agent::orchestrator::MAX_CHECKPOINT_HOOK_INPUT_BYTES
+                                    as u64
+                                    + 1,
+                            )
+                            .read_to_end(&mut buffer)
+                        {
                             eprintln!("Failed to read stdin for hook input: {}", e);
+                            std::process::exit(0);
+                        }
+                        if buffer.len()
+                            > crate::commands::checkpoint_agent::orchestrator::MAX_CHECKPOINT_HOOK_INPUT_BYTES
+                        {
+                            eprintln!(
+                                "Failed to read stdin for hook input: hook input exceeded the {} byte limit ({})",
+                                crate::commands::checkpoint_agent::orchestrator::MAX_CHECKPOINT_HOOK_INPUT_BYTES,
+                                buffer.len()
+                            );
                             std::process::exit(0);
                         }
                         let buffer = match decode_hook_input_bytes(buffer) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@ pub const DEFAULT_API_BASE_URL: &str = "https://usegitai.com";
 pub const DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES: usize = 3 * 1024 * 1024;
 pub const DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES: usize = 32 * 1024 * 1024;
 pub const DEFAULT_MAX_CHECKPOINT_TOTAL_LINES: usize = 500_000;
+pub const HARD_MAX_CHECKPOINT_FILE_SIZE_BYTES: usize = 16 * 1024 * 1024;
+pub const HARD_MAX_CHECKPOINT_TOTAL_SIZE_BYTES: usize = 32 * 1024 * 1024;
+pub const HARD_MAX_CHECKPOINT_TOTAL_LINES: usize = 1_000_000;
 const MAX_CONFIG_FILE_BYTES: u64 = 1024 * 1024;
 const MAX_CONFIG_COLLECTION_ITEMS: usize = 4_096;
 const MAX_CONFIG_PATTERN_BYTES: usize = 4 * 1024;
@@ -653,16 +656,19 @@ impl Config {
     /// Returns the per-file size limit for checkpoint content reads.
     pub fn max_checkpoint_file_size_bytes(&self) -> usize {
         self.max_checkpoint_file_size_bytes
+            .min(HARD_MAX_CHECKPOINT_FILE_SIZE_BYTES)
     }
 
     /// Returns the total byte budget for content in one checkpoint request.
     pub fn max_checkpoint_total_size_bytes(&self) -> usize {
         self.max_checkpoint_total_size_bytes
+            .min(HARD_MAX_CHECKPOINT_TOTAL_SIZE_BYTES)
     }
 
     /// Returns the total line budget for content in one checkpoint request.
     pub fn max_checkpoint_total_lines(&self) -> usize {
         self.max_checkpoint_total_lines
+            .min(HARD_MAX_CHECKPOINT_TOTAL_LINES)
     }
 
     /// Returns true if quiet mode is enabled (suppresses chart output after commits)

--- a/tests/integration/checkpoint_size.rs
+++ b/tests/integration/checkpoint_size.rs
@@ -4,6 +4,7 @@ use git_ai::authorship::working_log::CheckpointKind;
 use git_ai::git::repository::find_repository_in_path;
 use rand::{RngExt, distr::Alphanumeric};
 use serde_json::json;
+use std::io::Write;
 use std::{fs, time::Instant};
 
 #[cfg(target_os = "linux")]
@@ -18,6 +19,20 @@ fn daemon_vm_size_kib(repo: &TestRepo) -> u64 {
                 .and_then(|value| value.parse().ok())
         })
         .expect("daemon status should include VmSize")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
 }
 
 #[test]
@@ -340,6 +355,130 @@ fn test_repeated_checkpoints_plateau_after_runtime_warmup() {
             "late checkpoint window grew daemon VmSize by {late_window_growth_kib} KiB"
         );
     }
+}
+
+#[test]
+fn test_checkpoint_hard_limit_keeps_smaller_file_attribution_working() {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    repo.patch_git_ai_config(|patch| {
+        patch.max_checkpoint_file_size_bytes = Some(usize::MAX);
+        patch.max_checkpoint_total_size_bytes = Some(usize::MAX);
+        patch.max_checkpoint_total_lines = Some(usize::MAX);
+    });
+
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut base = repo.filename("base.txt");
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let small_path = repo.path().join("small.txt");
+    fs::write(&small_path, "AI line\n").unwrap();
+    let oversized_path = repo.path().join("oversized.txt");
+    let mut oversized = fs::File::create(&oversized_path).unwrap();
+    let chunk = vec![b'x'; 1024 * 1024];
+    for _ in 0..40 {
+        oversized.write_all(&chunk).unwrap();
+    }
+    oversized.flush().unwrap();
+    drop(oversized);
+
+    repo.git_ai(&["checkpoint", "mock_ai", "small.txt", "oversized.txt"])
+        .unwrap();
+    fs::remove_file(oversized_path).unwrap();
+    repo.git(&["add", "small.txt"]).unwrap();
+    repo.commit("AI edit with oversized sibling").unwrap();
+
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    let mut small = repo.filename("small.txt");
+    small.assert_committed_lines(crate::lines!["AI line".ai()]);
+}
+
+#[test]
+fn test_checkpoint_rejects_oversized_stdin_and_recovers() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let tracked_path = repo.path().join("tracked.txt");
+    fs::write(&tracked_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut tracked = repo.filename("tracked.txt");
+    tracked.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let oversized_input = vec![b' '; 32 * 1024 * 1024 + 1];
+    let output = repo
+        .git_ai_with_stdin(
+            &["checkpoint", "codex", "--hook-input", "stdin"],
+            &oversized_input,
+        )
+        .unwrap();
+    assert!(
+        output.contains("byte limit"),
+        "oversized hook input should fail at the byte limit: {output}"
+    );
+    drop(oversized_input);
+
+    fs::write(&tracked_path, "base\nAI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI recovery after oversized input")
+        .unwrap();
+    tracked.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI recovery".ai(),
+    ]);
+}
+
+#[test]
+fn test_duplicate_dirty_file_paths_keep_daemon_bounded_and_recover() {
+    let repo = TestRepo::new_dedicated_daemon();
+    fs::write(repo.path().join("base.txt"), "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut base = repo.filename("base.txt");
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let pressure_path = repo.canonical_path().join("pressure.txt");
+    let pressure_content = "x".repeat(64 * 1024);
+    fs::write(&pressure_path, &pressure_content).unwrap();
+    let duplicate_paths = vec![pressure_path.to_string_lossy().to_string(); 1000];
+    let hook_input = json!({
+        "hook_event_name": "after_edit",
+        "tool": "memory-test",
+        "model": "memory-test",
+        "repo_working_dir": repo.canonical_path(),
+        "completion_id": "duplicate-dirty-files",
+        "edited_filepaths": duplicate_paths,
+        "dirty_files": {
+            pressure_path.to_string_lossy().to_string(): pressure_content,
+        },
+    })
+    .to_string();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    repo.git_ai_with_stdin(
+        &["checkpoint", "ai_tab", "--hook-input", "stdin"],
+        hook_input.as_bytes(),
+    )
+    .unwrap();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("duplicate dirty-file checkpoint HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 24 * 1024,
+            "duplicate dirty-file checkpoint grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    fs::remove_file(pressure_path).unwrap();
+    fs::write(repo.path().join("recovery.txt"), "AI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "recovery.txt"])
+        .unwrap();
+    repo.git(&["add", "recovery.txt"]).unwrap();
+    repo.commit("AI recovery after duplicate pressure").unwrap();
+    base.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    let mut recovery = repo.filename("recovery.txt");
+    recovery.assert_committed_lines(crate::lines!["AI recovery".ai()]);
 }
 
 crate::reuse_tests_in_worktree!(test_checkpoint_size_logging_large_ai_rewrites,);


### PR DESCRIPTION
## Bug
Checkpoint orchestration copied unbounded hook input, repository/file lists, context strings, commands, and metadata into control requests. One agent hook could create a very large in-memory request before the daemon's storage limits applied.

## Fix
Cap hook input at 32 MiB, repositories at 64, metadata count/aggregate bytes, context strings, command text, and checkpoint file expansion. Invalid oversized contexts are discarded or rejected before request construction and IPC serialization.

## Verification
Orchestrator unit tests cover every request budget. `tests/integration/checkpoint_size.rs` exercises oversized hooks, metadata, repositories, and file sets through `TestRepo` with attribution assertions.

## Windows CI follow-up
The duplicate-path pressure regression now sends its large hook payload through `--hook-input stdin`, matching production agent presets. This preserves the 1,000-path deduplication and exact-attribution assertions while avoiding Windows' process command-line limit before git-ai can receive the request.
