### PR TITLE
fix(authorship): bound compact line ranges

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -945,8 +945,10 @@ fn attested_line_count_for_session(authorship_log: &AuthorshipLog, session_id: &
         .iter()
         .flat_map(|attestation| &attestation.entries)
         .filter(|entry| ai_session_key(&entry.hash) == session_id)
-        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
-        .count()
+        .flat_map(|entry| &entry.line_ranges)
+        .fold(0usize, |total, range| {
+            total.saturating_add(usize::try_from(range.covered_line_count()).unwrap_or(usize::MAX))
+        })
 }
 
 fn select_nearest_commit_metadata_metric_session(
@@ -1510,16 +1512,17 @@ fn unknown_lines_by_file(
     authorship_log: &AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
 ) -> UnknownLinesByFile {
-    let covered = covered_lines_by_file(authorship_log);
+    let covered = covered_ranges_by_file(authorship_log);
     let mut result = BTreeMap::new();
     for (file_path, ranges) in committed_hunks {
-        let covered_lines = covered.get(file_path);
-        let mut unknown = Vec::new();
-        for line in ranges.iter().flat_map(LineRange::expand) {
-            if !covered_lines.is_some_and(|lines| lines.contains(&line)) {
-                unknown.push(line);
-            }
-        }
+        let covered_ranges = covered
+            .get(file_path)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let mut unknown = LineRange::subtract_all(ranges, covered_ranges)
+            .iter()
+            .flat_map(LineRange::expand)
+            .collect::<Vec<_>>();
         unknown.sort_unstable();
         unknown.dedup();
         if !unknown.is_empty() {
@@ -1529,17 +1532,18 @@ fn unknown_lines_by_file(
     result
 }
 
-fn covered_lines_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, HashSet<u32>> {
+fn covered_ranges_by_file(authorship_log: &AuthorshipLog) -> HashMap<String, Vec<LineRange>> {
     let mut covered = HashMap::new();
     for file_attestation in &authorship_log.attestations {
-        let lines = covered
+        let ranges = covered
             .entry(file_attestation.file_path.clone())
-            .or_insert_with(HashSet::new);
+            .or_insert_with(Vec::new);
         for entry in &file_attestation.entries {
-            for line in entry.line_ranges.iter().flat_map(LineRange::expand) {
-                lines.insert(line);
-            }
+            ranges.extend(entry.line_ranges.iter().cloned());
         }
+    }
+    for ranges in covered.values_mut() {
+        *ranges = LineRange::normalize(ranges);
     }
     covered
 }

--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -70,7 +70,9 @@ impl LineAttribution {
         if self.start_line > self.end_line {
             0
         } else {
-            self.end_line - self.start_line + 1
+            self.end_line
+                .saturating_sub(self.start_line)
+                .saturating_add(1)
         }
     }
 

--- a/src/authorship/authorship_log.rs
+++ b/src/authorship/authorship_log.rs
@@ -16,7 +16,143 @@ pub enum LineRange {
     Range(u32, u32), // start, end (inclusive)
 }
 
+pub const MAX_MATERIALIZED_LINE_COUNT: u64 = 1_000_000;
+
 impl LineRange {
+    pub fn inclusive_bounds(&self) -> (u32, u32) {
+        match self {
+            LineRange::Single(line) => (*line, *line),
+            LineRange::Range(start, end) => (*start, *end),
+        }
+    }
+
+    pub fn covered_line_count(&self) -> u64 {
+        let (start, end) = self.inclusive_bounds();
+        if start == 0 || start > end {
+            0
+        } else {
+            u64::from(end) - u64::from(start) + 1
+        }
+    }
+
+    pub fn normalize(ranges: &[LineRange]) -> Vec<LineRange> {
+        let mut intervals = ranges
+            .iter()
+            .map(LineRange::inclusive_bounds)
+            .filter(|(start, end)| *start > 0 && start <= end)
+            .collect::<Vec<_>>();
+        intervals.sort_unstable();
+
+        let mut merged: Vec<(u32, u32)> = Vec::new();
+        for (start, end) in intervals {
+            if let Some((_, current_end)) = merged.last_mut()
+                && start <= current_end.saturating_add(1)
+            {
+                *current_end = (*current_end).max(end);
+            } else {
+                merged.push((start, end));
+            }
+        }
+
+        merged
+            .into_iter()
+            .map(|(start, end)| {
+                if start == end {
+                    LineRange::Single(start)
+                } else {
+                    LineRange::Range(start, end)
+                }
+            })
+            .collect()
+    }
+
+    pub fn subtract_all(ranges: &[LineRange], covered: &[LineRange]) -> Vec<LineRange> {
+        let ranges = LineRange::normalize(ranges);
+        let covered = LineRange::normalize(covered);
+        let mut remaining = Vec::new();
+        let mut covered_index = 0usize;
+
+        for range in ranges {
+            let (start, end) = range.inclusive_bounds();
+            while covered_index < covered.len()
+                && covered[covered_index].inclusive_bounds().1 < start
+            {
+                covered_index += 1;
+            }
+
+            let mut cursor = Some(start);
+            let mut scan_index = covered_index;
+            while let Some(current) = cursor
+                && scan_index < covered.len()
+            {
+                let (covered_start, covered_end) = covered[scan_index].inclusive_bounds();
+                if covered_start > end {
+                    break;
+                }
+                if covered_start > current {
+                    let remaining_end = end.min(covered_start - 1);
+                    remaining.push(if current == remaining_end {
+                        LineRange::Single(current)
+                    } else {
+                        LineRange::Range(current, remaining_end)
+                    });
+                }
+                cursor = if covered_end >= end || covered_end == u32::MAX {
+                    None
+                } else {
+                    Some(current.max(covered_end + 1))
+                };
+                scan_index += 1;
+            }
+
+            if let Some(current) = cursor
+                && current <= end
+            {
+                remaining.push(if current == end {
+                    LineRange::Single(current)
+                } else {
+                    LineRange::Range(current, end)
+                });
+            }
+        }
+        remaining
+    }
+
+    pub fn intersect_all(left: &[LineRange], right: &[LineRange]) -> Vec<LineRange> {
+        let left = LineRange::normalize(left);
+        let right = LineRange::normalize(right);
+        let mut intersections = Vec::new();
+        let (mut left_index, mut right_index) = (0usize, 0usize);
+        while left_index < left.len() && right_index < right.len() {
+            let (left_start, left_end) = left[left_index].inclusive_bounds();
+            let (right_start, right_end) = right[right_index].inclusive_bounds();
+            let start = left_start.max(right_start);
+            let end = left_end.min(right_end);
+            if start <= end {
+                intersections.push(if start == end {
+                    LineRange::Single(start)
+                } else {
+                    LineRange::Range(start, end)
+                });
+            }
+            if left_end <= right_end {
+                left_index += 1;
+            } else {
+                right_index += 1;
+            }
+        }
+        intersections
+    }
+
+    pub fn covered_lines_before(&self, line: u32) -> u64 {
+        let (start, end) = self.inclusive_bounds();
+        if start == 0 || start > end || line <= start {
+            0
+        } else {
+            u64::from(end.min(line.saturating_sub(1))) - u64::from(start) + 1
+        }
+    }
+
     pub fn contains(&self, line: u32) -> bool {
         match self {
             LineRange::Single(l) => *l == line,
@@ -101,7 +237,7 @@ impl LineRange {
         let mut current_end = lines[0];
 
         for &line in &lines[1..] {
-            if line == current_end + 1 {
+            if line == current_end.saturating_add(1) {
                 current_end = line;
             } else {
                 // End current range and start new one
@@ -127,6 +263,10 @@ impl LineRange {
 
     #[allow(dead_code)]
     pub fn expand(&self) -> Vec<u32> {
+        let covered_lines = self.covered_line_count();
+        if covered_lines == 0 || covered_lines > MAX_MATERIALIZED_LINE_COUNT {
+            return Vec::new();
+        }
         match self {
             LineRange::Single(l) => vec![*l],
             LineRange::Range(start, end) => (*start..=*end).collect(),
@@ -292,6 +432,39 @@ mod tests {
         assert_eq!(
             result, None,
             "u32::MAX + 1 should overflow u32 and return None"
+        );
+    }
+
+    #[test]
+    fn oversized_line_range_expansion_fails_closed() {
+        assert!(LineRange::Range(1, 1_000_001).expand().is_empty());
+    }
+
+    #[test]
+    fn line_range_set_operations_stay_compact_at_u32_boundary() {
+        let normalized = LineRange::normalize(&[
+            LineRange::Range(10, 20),
+            LineRange::Range(1, 12),
+            LineRange::Single(u32::MAX),
+        ]);
+        assert_eq!(
+            normalized,
+            vec![LineRange::Range(1, 20), LineRange::Single(u32::MAX)]
+        );
+
+        assert_eq!(
+            LineRange::subtract_all(
+                &[LineRange::Range(1, u32::MAX)],
+                &[LineRange::Range(2, u32::MAX - 1)],
+            ),
+            vec![LineRange::Single(1), LineRange::Single(u32::MAX)]
+        );
+        assert_eq!(
+            LineRange::intersect_all(
+                &[LineRange::Range(1, 10), LineRange::Range(20, 30)],
+                &[LineRange::Range(5, 25)],
+            ),
+            vec![LineRange::Range(5, 10), LineRange::Range(20, 25)]
         );
     }
 }

--- a/src/authorship/authorship_log_serialization.rs
+++ b/src/authorship/authorship_log_serialization.rs
@@ -1,5 +1,5 @@
 use crate::authorship::authorship_log::{
-    Author, HumanRecord, LineRange, PromptRecord, SessionRecord,
+    Author, HumanRecord, LineRange, MAX_MATERIALIZED_LINE_COUNT, PromptRecord, SessionRecord,
 };
 use crate::git::repository::Repository;
 use rand::RngExt;
@@ -10,6 +10,11 @@ use std::fmt;
 
 /// Authorship log format version identifier
 pub const AUTHORSHIP_LOG_VERSION: &str = "authorship/3.0.0";
+const MAX_AUTHORSHIP_FILES: usize = 4_096;
+const MAX_AUTHORSHIP_ENTRIES: usize = 16_384;
+const MAX_AUTHORSHIP_RANGES: usize = 65_536;
+const MAX_AUTHORSHIP_FILE_PATH_BYTES: usize = 16 * 1024;
+const MAX_AUTHORSHIP_HASH_BYTES: usize = 256;
 
 #[cfg(all(debug_assertions, test))]
 pub const GIT_AI_VERSION: &str = "development";
@@ -162,6 +167,9 @@ impl AuthorshipLog {
 
     /// Serialize to the new text format
     pub fn serialize_to_string(&self) -> Result<String, fmt::Error> {
+        if !authorship_line_ranges_are_bounded(&self.attestations) {
+            return Err(fmt::Error);
+        }
         let mut output = String::new();
 
         // Write attestation section
@@ -207,6 +215,9 @@ impl AuthorshipLog {
         // Parse attestation section (before divider)
         let attestation_lines = &lines[..divider_pos];
         let attestations = parse_attestation_section(attestation_lines)?;
+        if !authorship_line_ranges_are_bounded(&attestations) {
+            return Err("authorship line ranges exceeded the materialization limit".into());
+        }
 
         // Parse JSON metadata section (after divider)
         let json_lines = &lines[divider_pos + 1..];
@@ -335,6 +346,44 @@ impl AuthorshipLog {
         }
         None
     }
+}
+
+fn authorship_line_ranges_are_bounded(attestations: &[FileAttestation]) -> bool {
+    if attestations.len() > MAX_AUTHORSHIP_FILES {
+        return false;
+    }
+    let mut covered_lines = 0u64;
+    let mut entry_count = 0usize;
+    let mut range_count = 0usize;
+    for file in attestations {
+        if file.file_path.len() > MAX_AUTHORSHIP_FILE_PATH_BYTES {
+            return false;
+        }
+        entry_count = entry_count.saturating_add(file.entries.len());
+        if entry_count > MAX_AUTHORSHIP_ENTRIES {
+            return false;
+        }
+        for entry in &file.entries {
+            if entry.hash.len() > MAX_AUTHORSHIP_HASH_BYTES {
+                return false;
+            }
+            range_count = range_count.saturating_add(entry.line_ranges.len());
+            if range_count > MAX_AUTHORSHIP_RANGES {
+                return false;
+            }
+            for range in &entry.line_ranges {
+                let range_lines = range.covered_line_count();
+                if range_lines == 0 {
+                    return false;
+                }
+                covered_lines = covered_lines.saturating_add(range_lines);
+                if covered_lines > MAX_MATERIALIZED_LINE_COUNT {
+                    return false;
+                }
+            }
+        }
+    }
+    true
 }
 
 impl Default for AuthorshipLog {
@@ -531,6 +580,22 @@ mod tests {
     fn test_parse_line_ranges() {
         let ranges = parse_line_ranges("1,2,19-222").unwrap();
         assert_debug_snapshot!(ranges);
+    }
+
+    #[test]
+    fn oversized_line_range_is_rejected_during_deserialization() {
+        let metadata = serde_json::to_string(&AuthorshipMetadata::new()).unwrap();
+        let content = format!("large.txt\n  test-hash 1-1000001\n---\n{metadata}");
+
+        assert!(AuthorshipLog::deserialize_from_string(&content).is_err());
+    }
+
+    #[test]
+    fn oversized_attestation_hash_is_rejected_during_deserialization() {
+        let metadata = serde_json::to_string(&AuthorshipMetadata::new()).unwrap();
+        let content = format!("file.txt\n  {} 1\n---\n{metadata}", "x".repeat(257));
+
+        assert!(AuthorshipLog::deserialize_from_string(&content).is_err());
     }
 
     #[test]

--- a/src/authorship/background_agent.rs
+++ b/src/authorship/background_agent.rs
@@ -1,9 +1,9 @@
-use crate::authorship::authorship_log::{LineRange, SessionRecord};
+use crate::authorship::authorship_log::{LineRange, MAX_MATERIALIZED_LINE_COUNT, SessionRecord};
 use crate::authorship::authorship_log_serialization::{
     AttestationEntry, AuthorshipLog, generate_session_id, generate_trace_id,
 };
 use crate::authorship::working_log::AgentId;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 const DEVIN_ID_PATH: &str = "/opt/.devin/devin_id";
 const DEVIN_DIR_PATH: &str = "/opt/.devin";
@@ -119,36 +119,42 @@ pub fn fill_unattributed_lines(
         return false;
     }
 
-    // Collect already-attributed lines per file
-    let mut attributed_lines: HashMap<&str, HashSet<u32>> = HashMap::new();
-    for file_attestation in &authorship_log.attestations {
-        let lines = attributed_lines
-            .entry(&file_attestation.file_path)
-            .or_default();
-        for entry in &file_attestation.entries {
-            for range in &entry.line_ranges {
-                for line in range.expand() {
-                    lines.insert(line);
-                }
-            }
+    let mut committed_line_count = 0u64;
+    for range in committed_hunks.values().flatten() {
+        let range_line_count = range.covered_line_count();
+        if range_line_count == 0 {
+            return false;
+        }
+        committed_line_count = committed_line_count.saturating_add(range_line_count);
+        if committed_line_count > MAX_MATERIALIZED_LINE_COUNT {
+            return false;
         }
     }
 
-    // Find unattributed lines per file
+    // Collect already-attributed ranges per file.
+    let mut attributed_ranges: HashMap<&str, Vec<LineRange>> = HashMap::new();
+    for file_attestation in &authorship_log.attestations {
+        let ranges = attributed_ranges
+            .entry(&file_attestation.file_path)
+            .or_default();
+        for entry in &file_attestation.entries {
+            ranges.extend(entry.line_ranges.iter().cloned());
+        }
+    }
+    for ranges in attributed_ranges.values_mut() {
+        *ranges = LineRange::normalize(ranges);
+    }
+
+    // Find unattributed ranges per file without expanding them per line.
     let mut unattributed_hunks: HashMap<String, Vec<LineRange>> = HashMap::new();
     for (file_path, line_ranges) in committed_hunks {
-        let existing = attributed_lines.get(file_path.as_str());
-        let mut unattributed: Vec<u32> = Vec::new();
-        for range in line_ranges {
-            for line in range.expand() {
-                if existing.is_none_or(|set| !set.contains(&line)) {
-                    unattributed.push(line);
-                }
-            }
-        }
+        let existing = attributed_ranges
+            .get(file_path.as_str())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        let unattributed = LineRange::subtract_all(line_ranges, existing);
         if !unattributed.is_empty() {
-            unattributed.sort();
-            unattributed_hunks.insert(file_path.clone(), LineRange::compress_lines(&unattributed));
+            unattributed_hunks.insert(file_path.clone(), unattributed);
         }
     }
 

--- a/src/authorship/conflict_resolution.rs
+++ b/src/authorship/conflict_resolution.rs
@@ -4,24 +4,11 @@ use crate::authorship::authorship_log::LineRange;
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 
 fn normalize_line_ranges(ranges: &[LineRange]) -> Vec<LineRange> {
-    let mut lines: Vec<u32> = ranges.iter().flat_map(LineRange::expand).collect();
-    lines.sort_unstable();
-    lines.dedup();
-    LineRange::compress_lines(&lines)
+    LineRange::normalize(ranges)
 }
 
 fn subtract_line_ranges(ranges: &[LineRange], covered: &[LineRange]) -> Vec<LineRange> {
-    let mut remaining = ranges.to_vec();
-    for covered_range in covered {
-        remaining = remaining
-            .iter()
-            .flat_map(|range| range.remove(covered_range))
-            .collect();
-        if remaining.is_empty() {
-            break;
-        }
-    }
-    normalize_line_ranges(&remaining)
+    LineRange::subtract_all(ranges, covered)
 }
 
 fn line_coverage_by_file(log: &AuthorshipLog) -> HashMap<String, Vec<LineRange>> {

--- a/src/authorship/rewrite_revert.rs
+++ b/src/authorship/rewrite_revert.rs
@@ -331,11 +331,10 @@ fn clip_file_attestation_to_lines(
     let mut entries = Vec::new();
 
     for entry in &file.entries {
-        let mut lines = entry
-            .line_ranges
+        let mut lines = target_lines
             .iter()
-            .flat_map(LineRange::expand)
-            .filter(|line| target_lines.contains(line))
+            .copied()
+            .filter(|line| entry.line_ranges.iter().any(|range| range.contains(*line)))
             .collect::<Vec<_>>();
         if lines.is_empty() {
             continue;

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -2260,35 +2260,11 @@ impl VirtualAttributions {
         // We should NOT filter out pure insertions even if they overlap with committed line numbers.
         for (file_path, committed_ranges) in &committed_hunks {
             if let Some(unstaged_ranges) = unstaged_hunks.get_mut(file_path) {
-                // Expand both to line numbers for comparison
-                let committed_lines: std::collections::HashSet<u32> =
-                    committed_ranges.iter().flat_map(|r| r.expand()).collect();
-
-                // Get pure insertion lines for this file (these should NOT be filtered out)
-                let pure_insertion_lines: std::collections::HashSet<u32> = pure_insertion_hunks
-                    .get(file_path)
-                    .map(|ranges| ranges.iter().flat_map(|r| r.expand()).collect())
-                    .unwrap_or_default();
-
-                // Filter out any unstaged lines that were also committed
-                // (these are lines that were committed, then modified again in workdir)
-                // BUT keep pure insertions even if they overlap with committed line numbers
-                let mut filtered_unstaged_lines: Vec<u32> = unstaged_ranges
-                    .iter()
-                    .flat_map(|r| r.expand())
-                    .filter(|line| {
-                        // Keep the line if it's NOT in committed, OR if it's a pure insertion
-                        !committed_lines.contains(line) || pure_insertion_lines.contains(line)
-                    })
-                    .collect();
-
-                if filtered_unstaged_lines.is_empty() {
-                    unstaged_ranges.clear();
-                } else {
-                    filtered_unstaged_lines.sort_unstable();
-                    filtered_unstaged_lines.dedup();
-                    *unstaged_ranges = LineRange::compress_lines(&filtered_unstaged_lines);
+                let mut filtered = LineRange::subtract_all(unstaged_ranges, committed_ranges);
+                if let Some(pure_insertions) = pure_insertion_hunks.get(file_path) {
+                    filtered.extend(LineRange::intersect_all(unstaged_ranges, pure_insertions));
                 }
+                *unstaged_ranges = LineRange::normalize(&filtered);
             }
         }
 
@@ -2334,19 +2310,13 @@ impl VirtualAttributions {
                 line_attrs
             };
 
-            // Get unstaged lines for this file (in working directory coordinates).
-            let mut unstaged_lines: Vec<u32> = Vec::new();
+            // Get unstaged ranges for this file (in working directory coordinates).
             let unstaged_lookup = unstaged_hunks.get(&nfc_file_path).or_else(|| {
                 rename_map
                     .get(&nfc_file_path)
                     .and_then(|np| unstaged_hunks.get(np))
             });
-            if let Some(unstaged_ranges) = unstaged_lookup {
-                for range in unstaged_ranges {
-                    unstaged_lines.extend(range.expand());
-                }
-                unstaged_lines.sort_unstable();
-            }
+            let unstaged_ranges = unstaged_lookup.map(Vec::as_slice).unwrap_or_default();
 
             // Split line attributions into committed and uncommitted
             // VirtualAttributions has line numbers in working directory coordinates,
@@ -2366,7 +2336,9 @@ impl VirtualAttributions {
                 // Check each line individually
                 for workdir_line_num in line_attr.start_line..=line_attr.end_line {
                     // Check if this line is unstaged (in working directory but not in commit)
-                    let is_unstaged = unstaged_lines.binary_search(&workdir_line_num).is_ok();
+                    let is_unstaged = unstaged_ranges
+                        .iter()
+                        .any(|range| range.contains(workdir_line_num));
 
                     if is_unstaged {
                         // Line is unstaged, mark as uncommitted
@@ -2378,11 +2350,13 @@ impl VirtualAttributions {
                     } else {
                         // Convert working directory line number to commit line number
                         // by subtracting the count of unstaged lines before this line
-                        let adjustment = unstaged_lines
+                        let adjustment = unstaged_ranges
                             .iter()
-                            .filter(|&&l| l < workdir_line_num)
-                            .count() as u32;
-                        let commit_line_num = workdir_line_num - adjustment;
+                            .map(|range| range.covered_lines_before(workdir_line_num))
+                            .sum::<u64>()
+                            .min(u64::from(u32::MAX))
+                            as u32;
+                        let commit_line_num = workdir_line_num.saturating_sub(adjustment);
 
                         // Check if this commit line number is in any committed hunk
                         let is_committed = if let Some(hunks) = file_committed_hunks {
@@ -3002,8 +2976,6 @@ impl VirtualAttributions {
         session_additions: &HashMap<String, u32>,
         session_deletions: &HashMap<String, u32>,
     ) {
-        use std::collections::HashSet;
-
         // Collect all line attributions
         let all_line_attributions: Vec<&LineAttribution> = attributions
             .values()
@@ -3019,10 +2991,11 @@ impl VirtualAttributions {
                     continue;
                 }
 
-                let line_count = line_attr.end_line - line_attr.start_line + 1;
-                *session_accepted_lines
+                let line_count = line_attr.line_count();
+                let total = session_accepted_lines
                     .entry(line_attr.author_id.clone())
-                    .or_insert(0) += line_count;
+                    .or_insert(0);
+                *total = total.saturating_add(line_count);
             }
         }
 
@@ -3032,13 +3005,10 @@ impl VirtualAttributions {
         let mut session_overridden_lines: HashMap<String, u32> = HashMap::new();
         for line_attr in &all_line_attributions {
             if let Some(overrode_id) = &line_attr.overrode {
-                let mut overridden_lines: HashSet<u32> = HashSet::new();
-                for line in line_attr.start_line..=line_attr.end_line {
-                    overridden_lines.insert(line);
-                }
-                *session_overridden_lines
+                let total = session_overridden_lines
                     .entry(overrode_id.clone())
-                    .or_insert(0) += overridden_lines.len() as u32;
+                    .or_insert(0);
+                *total = total.saturating_add(line_attr.line_count());
             }
         }
 

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -657,14 +657,6 @@ fn get_checkpoint_entry_for_file(
             return Ok(None);
         }
 
-        // Build a set of lines covered by INITIAL attributions
-        let mut initial_covered_lines: HashSet<u32> = HashSet::new();
-        for attr in &initial_attrs_for_file {
-            for line in attr.start_line..=attr.end_line {
-                initial_covered_lines.insert(line);
-            }
-        }
-
         // Start with INITIAL attributions (they win), augmented by parent note
         let mut prev_line_attributions = initial_attrs_for_file.clone();
 
@@ -699,7 +691,10 @@ fn get_checkpoint_entry_for_file(
         if kind.is_ai() {
             let total_lines = current_content.lines().count() as u32;
             for line_num in 1..=total_lines {
-                if !initial_covered_lines.contains(&line_num) && !blamed_lines.contains(&line_num) {
+                let covered_by_initial = initial_attrs_for_file.iter().any(|attribution| {
+                    attribution.start_line <= line_num && line_num <= attribution.end_line
+                });
+                if !covered_by_initial && !blamed_lines.contains(&line_num) {
                     prev_line_attributions.push(LineAttribution {
                         start_line: line_num,
                         end_line: line_num,

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -1,5 +1,7 @@
 use crate::authorship::attribution_tracker::LineAttribution;
-use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord};
+use crate::authorship::authorship_log::{
+    HumanRecord, MAX_MATERIALIZED_LINE_COUNT, PromptRecord, SessionRecord,
+};
 use crate::authorship::authorship_log_serialization::generate_short_hash;
 use crate::authorship::working_log::{CHECKPOINT_API_VERSION, Checkpoint, CheckpointKind};
 use crate::error::GitAiError;
@@ -971,6 +973,35 @@ fn validate_initial_files(files: &HashMap<String, Vec<LineAttribution>>) -> Resu
     for line_attributions in files.values() {
         ensure_batch_git_item_limit("INITIAL line attribution", line_attributions.len())?;
     }
+    validate_line_attribution_ranges(
+        files.values().flat_map(|attributions| attributions.iter()),
+        "INITIAL line attribution",
+    )?;
+    Ok(())
+}
+
+fn validate_line_attribution_ranges<'a>(
+    attributions: impl Iterator<Item = &'a LineAttribution>,
+    kind: &str,
+) -> Result<(), GitAiError> {
+    let mut covered_lines = 0u64;
+    for attribution in attributions {
+        if attribution.start_line == 0 || attribution.start_line > attribution.end_line {
+            return Err(GitAiError::Generic(format!(
+                "{kind} contains an invalid line range {}-{}",
+                attribution.start_line, attribution.end_line
+            )));
+        }
+        let range_lines = u64::from(attribution.end_line)
+            .saturating_sub(u64::from(attribution.start_line))
+            .saturating_add(1);
+        covered_lines = covered_lines.saturating_add(range_lines);
+        if covered_lines > MAX_MATERIALIZED_LINE_COUNT {
+            return Err(GitAiError::Generic(format!(
+                "{kind} exceeded the {MAX_MATERIALIZED_LINE_COUNT} line materialization limit"
+            )));
+        }
+    }
     Ok(())
 }
 
@@ -996,6 +1027,13 @@ fn validate_checkpoint_collections(checkpoint: &Checkpoint) -> Result<(), GitAiE
             entry.line_attributions.len(),
         )?;
     }
+    validate_line_attribution_ranges(
+        checkpoint
+            .entries
+            .iter()
+            .flat_map(|entry| entry.line_attributions.iter()),
+        "working-log line attribution",
+    )?;
     Ok(())
 }
 
@@ -1076,6 +1114,16 @@ mod tests {
 
     fn attr(author: &str) -> Vec<LineAttribution> {
         vec![LineAttribution::new(1, 1, author.to_string(), None)]
+    }
+
+    #[test]
+    fn initial_validation_rejects_oversized_line_attribution_span() {
+        let files = HashMap::from([(
+            "large.txt".to_string(),
+            vec![LineAttribution::new(1, 1_000_001, "test".to_string(), None)],
+        )]);
+
+        assert!(validate_initial_files(&files).is_err());
     }
 
     /// Regression (#9): merge_working_log_dirs (via rename_working_log when the

--- a/tests/integration/daemon_line_range_memory.rs
+++ b/tests/integration/daemon_line_range_memory.rs
@@ -1,0 +1,87 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log::LineRange;
+use git_ai::authorship::authorship_log_serialization::{
+    AttestationEntry, AuthorshipLog, FileAttestation,
+};
+use std::fs;
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn oversized_compact_authorship_range_keeps_daemon_bounded_and_recovers() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let tracked_path = repo.path().join("tracked.txt");
+    fs::write(&tracked_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut tracked = repo.filename("tracked.txt");
+    tracked.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    fs::write(&tracked_path, "base\nsource line\n").unwrap();
+    repo.stage_all_and_commit("Source commit").unwrap();
+    tracked.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "source line".unattributed_human(),
+    ]);
+    let source_sha = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+    let source_sha = source_sha.trim();
+
+    let mut log = AuthorshipLog::new();
+    let mut file = FileAttestation::new("tracked.txt".to_string());
+    file.add_entry(AttestationEntry::new(
+        "malicious-range".to_string(),
+        vec![LineRange::Single(1)],
+    ));
+    log.attestations.push(file);
+    let compact_note = log
+        .serialize_to_string()
+        .unwrap()
+        .replace("malicious-range 1", "malicious-range 1-10000000");
+    repo.git_og(&[
+        "notes",
+        "--ref=ai",
+        "add",
+        "-f",
+        "-m",
+        &compact_note,
+        source_sha,
+    ])
+    .unwrap();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    repo.git(&["revert", "--no-edit", source_sha]).unwrap();
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        eprintln!("compact authorship range HWM growth: {hwm_growth_kib} KiB");
+        assert!(
+            hwm_growth_kib < 24 * 1024,
+            "compact authorship range grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+    tracked.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    fs::write(&tracked_path, "base\nAI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI recovery after range pressure")
+        .unwrap();
+    tracked.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI recovery".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -59,6 +59,7 @@ mod daemon_git_output_memory;
 mod daemon_http_memory;
 mod daemon_ignore_memory;
 mod daemon_ipc_memory;
+mod daemon_line_range_memory;
 mod daemon_log_memory;
 mod daemon_note_materialization_memory;
 mod daemon_reflog_memory;


### PR DESCRIPTION
## Bug
Compact authorship ranges can encode enormous logical line counts in tiny JSON. Deserialization and downstream expansion could allocate vectors proportional to attacker-controlled range endpoints, while file/entry/range collections also lacked aggregate limits.

## Fix
Cap materializable lines at 1,000,000 and validate authorship file, entry, range, path, and hash counts/sizes during deserialization and recovery. Callers use checked range iteration instead of eagerly expanding unchecked spans.

## Verification
Unit tests cover malformed/oversized ranges and aggregate schema limits. `tests/integration/daemon_line_range_memory.rs` feeds compact huge ranges through real note/daemon paths.