### PR TITLE
fix(runtime): bound auxiliary process inputs

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -117,15 +117,19 @@ fn resolve_hostname() -> Option<String> {
     {
         return Some(h.trim().to_string());
     }
-    let mut cmd = std::process::Command::new("hostname");
-    #[cfg(windows)]
-    {
-        use crate::utils::CREATE_NO_WINDOW;
-        std::os::windows::process::CommandExt::creation_flags(&mut cmd, CREATE_NO_WINDOW);
+    let output = crate::process_timeout::run_command_with_timeout(
+        "hostname",
+        &[],
+        None,
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_millis(10),
+        &[],
+    )
+    .ok()?;
+    if output.timed_out || output.status != Some(0) {
+        return None;
     }
-    let output = cmd.output().ok()?;
-    let h = String::from_utf8(output.stdout).ok()?;
-    let h = h.trim();
+    let h = output.stdout.trim();
     if h.is_empty() {
         None
     } else {

--- a/src/ci/github.rs
+++ b/src/ci/github.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 
 const GITHUB_CI_TEMPLATE_YAML: &str = include_str!("workflow_templates/github.yaml");
+const MAX_GITHUB_EVENT_PAYLOAD_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 struct GithubCiEventPayload {
@@ -50,9 +51,7 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
         return Ok(None);
     }
 
-    let event_payload =
-        serde_json::from_str::<GithubCiEventPayload>(&std::fs::read_to_string(env_event_path)?)
-            .unwrap_or_default();
+    let event_payload = read_github_event_payload(std::path::Path::new(&env_event_path))?;
     if event_payload.pull_request.is_none() {
         return Ok(None);
     }
@@ -226,6 +225,15 @@ pub fn get_github_ci_context() -> Result<Option<CiContext>, GitAiError> {
     }))
 }
 
+fn read_github_event_payload(path: &std::path::Path) -> Result<GithubCiEventPayload, GitAiError> {
+    let content = crate::utils::read_text_file_with_limit(
+        path,
+        MAX_GITHUB_EVENT_PAYLOAD_BYTES,
+        "GitHub event payload",
+    )?;
+    Ok(serde_json::from_str(&content).unwrap_or_default())
+}
+
 fn authenticate_clone_url(clone_url: &str, token: &str) -> String {
     format!(
         "https://x-access-token:{}@{}",
@@ -313,5 +321,16 @@ mod tests {
         assert!(!pull_request.merged);
         assert_eq!(pull_request.base.ref_name, "main");
         assert_eq!(pull_request.head.ref_name, "feature");
+    }
+
+    #[test]
+    fn oversized_github_event_payload_is_rejected_before_parsing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("event.json");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_GITHUB_EVENT_PAYLOAD_BYTES + 1).unwrap();
+
+        let error = read_github_event_payload(&path).expect_err("payload must be rejected");
+        assert!(error.to_string().contains("byte limit"));
     }
 }

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -6,6 +6,8 @@ use crate::daemon::{
 use crate::utils::LockFile;
 #[cfg(windows)]
 use crate::utils::{CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
+#[cfg(not(windows))]
+use std::io::Read;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -100,6 +102,24 @@ fn daemon_startup_timeout() -> Duration {
     }
 }
 
+#[cfg(not(windows))]
+const MAX_DAEMON_STARTUP_STDERR_BYTES: usize = 1024 * 1024;
+
+#[cfg(not(windows))]
+fn read_daemon_startup_stderr(reader: impl Read) -> String {
+    let mut bytes = Vec::new();
+    let _ = reader
+        .take(MAX_DAEMON_STARTUP_STDERR_BYTES as u64 + 1)
+        .read_to_end(&mut bytes);
+    let truncated = bytes.len() > MAX_DAEMON_STARTUP_STDERR_BYTES;
+    bytes.truncate(MAX_DAEMON_STARTUP_STDERR_BYTES);
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    if truncated {
+        text.push_str("\n[daemon startup stderr truncated at byte limit]");
+    }
+    text
+}
+
 /// Spawn a daemon and wait for it to become healthy. Used by explicit CLI
 /// commands (`bg start`, `bg restart`) — NOT guarded for test builds.
 ///
@@ -131,11 +151,11 @@ fn ensure_daemon_running_attached(timeout: Duration) -> Result<DaemonConfig, Str
             }
             match child.try_wait() {
                 Ok(Some(status)) if !status.success() => {
-                    let mut stderr_buf = String::new();
-                    if let Some(mut stderr) = child.stderr.take() {
-                        use std::io::Read;
-                        let _ = stderr.read_to_string(&mut stderr_buf);
-                    }
+                    let stderr_buf = child
+                        .stderr
+                        .take()
+                        .map(read_daemon_startup_stderr)
+                        .unwrap_or_default();
                     let detail = if stderr_buf.trim().is_empty() {
                         format!("daemon process exited with {}", status)
                     } else {
@@ -839,5 +859,14 @@ mod tests {
         });
 
         assert!(peak.load(Ordering::SeqCst) <= DAEMON_RUNTIME_MAX_BLOCKING_THREADS);
+    }
+
+    #[test]
+    fn daemon_startup_stderr_is_bounded() {
+        let input = std::io::Cursor::new(vec![b'x'; MAX_DAEMON_STARTUP_STDERR_BYTES + 1]);
+        let output = read_daemon_startup_stderr(input);
+
+        assert!(output.len() < MAX_DAEMON_STARTUP_STDERR_BYTES + 100);
+        assert!(output.contains("byte limit"));
     }
 }

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -415,7 +415,14 @@ fn detect_install_git_path(binary_path: &Path) -> Option<String> {
 
     #[cfg(windows)]
     {
-        parse_git_og_cmd_path(&fs::read_to_string(install_dir.join("git-og.cmd")).ok()?)
+        parse_git_og_cmd_path(
+            &crate::utils::read_text_file_with_limit(
+                &install_dir.join("git-og.cmd"),
+                64 * 1024,
+                "git-og command shim",
+            )
+            .ok()?,
+        )
     }
 
     #[cfg(not(windows))]

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -136,7 +136,7 @@ fn get_update_check_cache_path() -> Option<PathBuf> {
 
 fn read_update_cache() -> Option<UpdateCache> {
     let path = get_update_check_cache_path()?;
-    let bytes = fs::read(path).ok()?;
+    let bytes = crate::utils::read_file_with_limit(&path, 64 * 1024, "update cache").ok()?;
     serde_json::from_slice(&bytes).ok()
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2193,21 +2193,35 @@ fn pid_metadata_path(config: &DaemonConfig) -> PathBuf {
 
 const MAX_PID_METADATA_BYTES: u64 = 4 * 1_024;
 
-fn read_pid_metadata(config: &DaemonConfig) -> Result<DaemonPidMeta, GitAiError> {
+fn read_pid_metadata_if_present(
+    config: &DaemonConfig,
+) -> Result<Option<DaemonPidMeta>, GitAiError> {
     let meta_path = pid_metadata_path(config);
-    let contents = crate::utils::read_text_file_with_limit(
+    let contents = match crate::utils::read_text_file_with_limit(
         &meta_path,
         MAX_PID_METADATA_BYTES,
         "daemon PID metadata",
-    )
-    .map_err(|e| {
+    ) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(GitAiError::Generic(format!(
+                "failed to read daemon pid metadata at {}: {}",
+                meta_path.display(),
+                error
+            )));
+        }
+    };
+    Ok(Some(serde_json::from_str(&contents)?))
+}
+
+fn read_pid_metadata(config: &DaemonConfig) -> Result<DaemonPidMeta, GitAiError> {
+    read_pid_metadata_if_present(config)?.ok_or_else(|| {
         GitAiError::Generic(format!(
-            "failed to read daemon pid metadata at {}: {}",
-            meta_path.display(),
-            e
+            "daemon pid metadata does not exist at {}",
+            pid_metadata_path(config).display()
         ))
-    })?;
-    Ok(serde_json::from_str(&contents)?)
+    })
 }
 
 /// Returns the log file path for the currently running daemon, if any.
@@ -2231,6 +2245,16 @@ fn write_pid_metadata(config: &DaemonConfig) -> Result<(), GitAiError> {
 /// Read the PID of the currently running daemon from the pid metadata file.
 pub fn read_daemon_pid(config: &DaemonConfig) -> Result<u32, GitAiError> {
     Ok(read_pid_metadata(config)?.pid)
+}
+
+pub fn read_daemon_started_at_ns(config: &DaemonConfig) -> Result<u128, GitAiError> {
+    Ok(read_pid_metadata(config)?.started_at_ns)
+}
+
+pub fn read_daemon_started_at_ns_if_present(
+    config: &DaemonConfig,
+) -> Result<Option<u128>, GitAiError> {
+    Ok(read_pid_metadata_if_present(config)?.map(|metadata| metadata.started_at_ns))
 }
 
 fn remove_pid_metadata(config: &DaemonConfig) -> Result<(), GitAiError> {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -19,6 +19,7 @@ const SELF_CHECK_CONTENT_AI: &str = "Untracked line\nKnown human line\nAI line\n
 const TRACE2_EVENT_TARGET_KEY: &str = "trace2.eventTarget";
 const TRACE2_EVENT_NESTING_KEY: &str = "trace2.eventNesting";
 const TRACE2_EVENT_NESTING_VALUE: &str = "0";
+const MAX_SELF_CHECK_TRACE_BYTES: u64 = 1024 * 1024;
 const SELF_CHECK_TRACE_ENV_REMOVE: &[&str] = &[
     "GIT_TRACE2_PARENT_SID",
     "GIT_TRACE2_PARENT_NAME",
@@ -507,8 +508,12 @@ pub fn run_trace2_file_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
             deadline,
         )?;
 
-        let trace2_json = fs::read_to_string(&trace_path)
-            .map_err(|e| format!("failed to read {}: {}", trace_path.display(), e))?;
+        let trace2_json = crate::utils::read_text_file_with_limit(
+            &trace_path,
+            MAX_SELF_CHECK_TRACE_BYTES,
+            "diagnostic trace2 file",
+        )
+        .map_err(|e| format!("failed to read {}: {}", trace_path.display(), e))?;
         let details = validate_trace2_command_events(&trace2_json, "init")?;
         Ok((details, trace2_json))
     })();
@@ -946,23 +951,7 @@ fn daemon_binary_is_stale(config: &crate::daemon::DaemonConfig) -> Result<bool, 
 }
 
 fn read_daemon_started_at_ns(config: &crate::daemon::DaemonConfig) -> Result<Option<u128>, String> {
-    let pid_path = config.internal_dir.join("daemon").join("daemon.pid.json");
-    let contents = match fs::read_to_string(&pid_path) {
-        Ok(contents) => contents,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(format!(
-                "failed to read daemon pid metadata at {}: {}",
-                pid_path.display(),
-                err
-            ));
-        }
-    };
-    let value: Value = serde_json::from_str(&contents).map_err(|e| e.to_string())?;
-    Ok(value
-        .get("started_at_ns")
-        .and_then(Value::as_u64)
-        .map(u128::from))
+    crate::daemon::read_daemon_started_at_ns_if_present(config).map_err(|error| error.to_string())
 }
 
 fn current_binary_modified_ns() -> Result<u128, String> {
@@ -1373,6 +1362,27 @@ fn format_status(status: Option<i32>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn daemon_started_at_uses_lock_path_metadata_and_handles_missing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let internal_dir = temp.path().join("long").join("internal");
+        let daemon_dir = temp.path().join("relocated-daemon");
+        fs::create_dir_all(&daemon_dir).unwrap();
+        let config = crate::daemon::DaemonConfig {
+            internal_dir,
+            lock_path: daemon_dir.join("daemon.lock"),
+            trace_socket_path: daemon_dir.join("trace.sock"),
+            control_socket_path: daemon_dir.join("control.sock"),
+        };
+        let metadata_path = daemon_dir.join("daemon.pid.json");
+        fs::write(&metadata_path, r#"{"pid":42,"started_at_ns":1234}"#).unwrap();
+
+        assert_eq!(read_daemon_started_at_ns(&config).unwrap(), Some(1234));
+
+        fs::remove_file(metadata_path).unwrap();
+        assert_eq!(read_daemon_started_at_ns(&config).unwrap(), None);
+    }
 
     #[cfg(not(windows))]
     fn stdout_stderr_sleep_command() -> (&'static str, Vec<&'static str>) {

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -6,6 +6,22 @@ use std::time::{Duration, Instant};
 
 const OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(200);
 const OUTPUT_DRAIN_POLL: Duration = Duration::from_millis(10);
+const MAX_TIMED_COMMAND_OUTPUT_BYTES: usize = 1024 * 1024;
+
+#[cfg(windows)]
+fn timed_command_creation_flags() -> u32 {
+    crate::utils::CREATE_NO_WINDOW
+}
+
+fn configure_timed_command(command: &mut Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(timed_command_creation_flags());
+    }
+    #[cfg(not(windows))]
+    let _ = command;
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct TimedCommandOutput {
@@ -24,6 +40,8 @@ enum OutputEvent {
     StderrDone,
     StdoutError(String),
     StderrError(String),
+    StdoutTruncated,
+    StderrTruncated,
 }
 
 #[derive(Default)]
@@ -32,12 +50,48 @@ struct OutputState {
     stderr: Vec<u8>,
     stdout_done: bool,
     stderr_done: bool,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
     diagnostics: Vec<String>,
 }
 
 impl OutputState {
     fn complete(&self) -> bool {
         self.stdout_done && self.stderr_done
+    }
+
+    fn append_output(&mut self, bytes: &[u8], stdout: bool) {
+        let (buffer, truncated) = if stdout {
+            (&mut self.stdout, &mut self.stdout_truncated)
+        } else {
+            (&mut self.stderr, &mut self.stderr_truncated)
+        };
+        let remaining = MAX_TIMED_COMMAND_OUTPUT_BYTES.saturating_sub(buffer.len());
+        buffer.extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+        if bytes.len() > remaining && !*truncated {
+            *truncated = true;
+            self.diagnostics.push(format!(
+                "{} exceeded the {} byte limit; additional output was discarded",
+                if stdout { "stdout" } else { "stderr" },
+                MAX_TIMED_COMMAND_OUTPUT_BYTES
+            ));
+        }
+    }
+
+    fn mark_truncated(&mut self, stdout: bool) {
+        let truncated = if stdout {
+            &mut self.stdout_truncated
+        } else {
+            &mut self.stderr_truncated
+        };
+        if !*truncated {
+            *truncated = true;
+            self.diagnostics.push(format!(
+                "{} exceeded the {} byte limit; additional output was discarded",
+                if stdout { "stdout" } else { "stderr" },
+                MAX_TIMED_COMMAND_OUTPUT_BYTES
+            ));
+        }
     }
 
     fn finish(
@@ -91,6 +145,7 @@ pub(crate) fn run_command_with_timeout_and_env(
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
+    configure_timed_command(&mut command);
 
     let mut child = command
         .spawn()
@@ -194,17 +249,35 @@ where
 {
     std::thread::spawn(move || {
         let mut buf = [0_u8; 8192];
+        let mut retained = 0usize;
+        let mut reported_truncation = false;
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    let event = if stdout {
-                        OutputEvent::Stdout(buf[..n].to_vec())
-                    } else {
-                        OutputEvent::Stderr(buf[..n].to_vec())
-                    };
-                    if tx.send(event).is_err() {
-                        return;
+                    let remaining = MAX_TIMED_COMMAND_OUTPUT_BYTES.saturating_sub(retained);
+                    let keep = n.min(remaining);
+                    if keep > 0 {
+                        let event = if stdout {
+                            OutputEvent::Stdout(buf[..keep].to_vec())
+                        } else {
+                            OutputEvent::Stderr(buf[..keep].to_vec())
+                        };
+                        if tx.send(event).is_err() {
+                            return;
+                        }
+                        retained += keep;
+                    }
+                    if keep < n && !reported_truncation {
+                        reported_truncation = true;
+                        let event = if stdout {
+                            OutputEvent::StdoutTruncated
+                        } else {
+                            OutputEvent::StderrTruncated
+                        };
+                        if tx.send(event).is_err() {
+                            return;
+                        }
                     }
                 }
                 Err(e) => {
@@ -247,8 +320,8 @@ fn collect_output_until(
 fn drain_output_events(rx: &Receiver<OutputEvent>, output: &mut OutputState) {
     while let Ok(event) = rx.try_recv() {
         match event {
-            OutputEvent::Stdout(bytes) => output.stdout.extend(bytes),
-            OutputEvent::Stderr(bytes) => output.stderr.extend(bytes),
+            OutputEvent::Stdout(bytes) => output.append_output(&bytes, true),
+            OutputEvent::Stderr(bytes) => output.append_output(&bytes, false),
             OutputEvent::StdoutDone => output.stdout_done = true,
             OutputEvent::StderrDone => output.stderr_done = true,
             OutputEvent::StdoutError(err) => {
@@ -263,6 +336,62 @@ fn drain_output_events(rx: &Receiver<OutputEvent>, output: &mut OutputState) {
                     .push(format!("failed to read stderr: {}", err));
                 output.stderr_done = true;
             }
+            OutputEvent::StdoutTruncated => output.mark_truncated(true),
+            OutputEvent::StderrTruncated => output.mark_truncated(false),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_state_rejects_subprocess_output_beyond_limit() {
+        let (tx, rx) = mpsc::channel();
+        tx.send(OutputEvent::Stdout(vec![b'x'; 1024 * 1024 + 1]))
+            .unwrap();
+        drop(tx);
+        let mut output = OutputState::default();
+
+        drain_output_events(&rx, &mut output);
+
+        assert!(output.stdout.len() <= 1024 * 1024);
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("byte limit"))
+        );
+    }
+
+    #[test]
+    fn output_reader_stops_queueing_after_limit() {
+        let input = std::io::Cursor::new(vec![b'x'; MAX_TIMED_COMMAND_OUTPUT_BYTES + 8192]);
+        let (tx, rx) = mpsc::channel();
+        spawn_output_reader(input, tx, true);
+
+        let mut queued_bytes = 0usize;
+        let mut truncated = false;
+        while let Ok(event) = rx.recv_timeout(Duration::from_secs(1)) {
+            match event {
+                OutputEvent::Stdout(bytes) => queued_bytes += bytes.len(),
+                OutputEvent::StdoutTruncated => truncated = true,
+                OutputEvent::StdoutDone => break,
+                _ => {}
+            }
+        }
+
+        assert_eq!(queued_bytes, MAX_TIMED_COMMAND_OUTPUT_BYTES);
+        assert!(truncated);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn timed_commands_do_not_create_console_windows() {
+        assert_eq!(
+            timed_command_creation_flags(),
+            crate::utils::CREATE_NO_WINDOW
+        );
     }
 }

--- a/tests/integration/auxiliary_input_memory.rs
+++ b/tests/integration/auxiliary_input_memory.rs
@@ -1,0 +1,39 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+#[test]
+fn oversized_github_event_is_rejected_and_checkpoint_recovers() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let tracked_path = repo.path().join("tracked.txt");
+    fs::write(&tracked_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut tracked = repo.filename("tracked.txt");
+    tracked.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let event_path = repo.path().join("oversized-event.json");
+    let event = fs::File::create(&event_path).unwrap();
+    event.set_len(16 * 1024 * 1024 + 1).unwrap();
+    let event_path_string = event_path.to_string_lossy().to_string();
+    let error = repo
+        .git_ai_with_env(
+            &["ci", "github", "run"],
+            &[
+                ("GITHUB_EVENT_NAME", "pull_request"),
+                ("GITHUB_EVENT_PATH", event_path_string.as_str()),
+            ],
+        )
+        .expect_err("oversized event must be rejected");
+    assert!(error.contains("byte limit"), "unexpected error: {error}");
+    fs::remove_file(event_path).unwrap();
+
+    fs::write(&tracked_path, "base\nAI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI recovery after auxiliary input pressure")
+        .unwrap();
+    tracked.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI recovery".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,6 +14,7 @@ mod ai_tab;
 mod amend;
 mod amp;
 mod attribution_tracker_comprehensive;
+mod auxiliary_input_memory;
 mod background_agent_attribution;
 mod bash_attribution;
 mod bash_tool_benchmark;


### PR DESCRIPTION
## Bug
Auxiliary inputs and child diagnostics were collected without ceilings, so failures could allocate in proportion to external output. The timeout migration also dropped Windows console suppression, and diagnostic staleness checks probed a non-authoritative PID path before reading, creating a restart race.

## Fix
Apply bounded file readers, cap startup/self-check data at 1 MiB, and drain child streams concurrently into a shared 1 MiB budget. Every timed command receives `CREATE_NO_WINDOW` on Windows. PID metadata now has one bounded optional read at the authoritative lock-directory path, atomically treating a missing file as a stopped daemon.

## Verification
Unit tests cover bounded drains, truncation diagnostics, Windows creation flags, relocated PID metadata, and disappearance between probes. `tests/integration/auxiliary_input_memory.rs` verifies oversized event/process inputs are rejected safely while attribution recovers.