### PR TITLE
fix(installer): bound configuration and archive memory

### DIFF
--- a/src/mdm/agents/amp.rs
+++ b/src/mdm/agents/amp.rs
@@ -64,7 +64,8 @@ impl HookInstaller for AmpInstaller {
             });
         }
 
-        let current_content = fs::read_to_string(&plugin_path).unwrap_or_default();
+        let current_content =
+            crate::mdm::utils::read_installer_config(&plugin_path).unwrap_or_default();
         let expected_content = Self::generate_plugin_content(&params.binary_path);
         let is_up_to_date = current_content.trim() == expected_content.trim();
 
@@ -89,7 +90,7 @@ impl HookInstaller for AmpInstaller {
         }
 
         let existing_content = if plugin_path.exists() {
-            fs::read_to_string(&plugin_path)?
+            crate::mdm::utils::read_installer_config(&plugin_path)?
         } else {
             String::new()
         };
@@ -122,7 +123,7 @@ impl HookInstaller for AmpInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(&plugin_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(&plugin_path)?;
         let diff_output = generate_diff(&plugin_path, &existing_content, "");
 
         if !dry_run {

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -78,7 +78,7 @@ impl ClaudeCodeInstaller {
         }
 
         let existing_content = if settings_path.exists() {
-            fs::read_to_string(settings_path)?
+            crate::mdm::utils::read_installer_config(settings_path)?
         } else {
             String::new()
         };
@@ -245,7 +245,7 @@ impl ClaudeCodeInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(settings_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(settings_path)?;
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();
@@ -341,7 +341,7 @@ impl HookInstaller for ClaudeCodeInstaller {
             });
         }
 
-        let content = fs::read_to_string(&settings_path)?;
+        let content = crate::mdm::utils::read_installer_config(&settings_path)?;
         let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
         let (hooks_installed, hooks_up_to_date) = Self::hook_status(&existing);
 

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -691,13 +691,13 @@ impl HookInstaller for CodexInstaller {
 
         let config_path = Self::config_path();
         let config = if config_path.exists() {
-            Self::parse_config_toml(&fs::read_to_string(&config_path)?)?
+            Self::parse_config_toml(&crate::mdm::utils::read_installer_config(&config_path)?)?
         } else {
             TomlValue::Table(Map::new())
         };
         let hooks_json_path = Self::hooks_json_path();
         let hooks_json = if hooks_json_path.exists() {
-            Self::parse_hooks_json(&fs::read_to_string(&hooks_json_path)?)?
+            Self::parse_hooks_json(&crate::mdm::utils::read_installer_config(&hooks_json_path)?)?
         } else {
             json!({})
         };
@@ -749,7 +749,7 @@ impl HookInstaller for CodexInstaller {
         }
 
         let existing_config_content = if config_path.exists() {
-            fs::read_to_string(&config_path)?
+            crate::mdm::utils::read_installer_config(&config_path)?
         } else {
             String::new()
         };
@@ -757,7 +757,7 @@ impl HookInstaller for CodexInstaller {
         let existing_config = Self::parse_config_toml(&existing_config_content)?;
 
         let existing_hooks_content = if hooks_json_path.exists() {
-            fs::read_to_string(&hooks_json_path)?
+            crate::mdm::utils::read_installer_config(&hooks_json_path)?
         } else {
             String::new()
         };
@@ -880,7 +880,7 @@ impl HookInstaller for CodexInstaller {
         }
 
         let existing_config_content = if config_path.exists() {
-            fs::read_to_string(&config_path)?
+            crate::mdm::utils::read_installer_config(&config_path)?
         } else {
             String::new()
         };
@@ -895,7 +895,7 @@ impl HookInstaller for CodexInstaller {
 
         // Check if legacy hooks.json needs cleanup
         let (hooks_json_changed, existing_hooks_content) = if hooks_json_path.exists() {
-            let content = fs::read_to_string(&hooks_json_path)?;
+            let content = crate::mdm::utils::read_installer_config(&hooks_json_path)?;
             let existing_hooks = Self::parse_hooks_json(&content)?;
             let (_cleaned_hooks, changed) = Self::remove_codex_hooks_from_json(&existing_hooks)?;
             (changed, content)

--- a/src/mdm/agents/cursor.rs
+++ b/src/mdm/agents/cursor.rs
@@ -80,7 +80,7 @@ impl HookInstaller for CursorInstaller {
             });
         }
 
-        let content = fs::read_to_string(&hooks_path)?;
+        let content = crate::mdm::utils::read_installer_config(&hooks_path)?;
         let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
 
         let has_hooks = existing
@@ -122,7 +122,7 @@ impl HookInstaller for CursorInstaller {
 
         // Read existing content as string
         let existing_content = if hooks_path.exists() {
-            fs::read_to_string(&hooks_path)?
+            crate::mdm::utils::read_installer_config(&hooks_path)?
         } else {
             String::new()
         };
@@ -271,7 +271,7 @@ impl HookInstaller for CursorInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(&hooks_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(&hooks_path)?;
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();

--- a/src/mdm/agents/droid.rs
+++ b/src/mdm/agents/droid.rs
@@ -110,7 +110,7 @@ impl DroidInstaller {
         }
 
         let existing_content = if settings_path.exists() {
-            fs::read_to_string(settings_path)?
+            crate::mdm::utils::read_installer_config(settings_path)?
         } else {
             String::new()
         };
@@ -283,7 +283,7 @@ impl DroidInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(settings_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(settings_path)?;
         let existing: Value = parse_jsonc_settings(&existing_content)?;
 
         let mut merged = existing.clone();
@@ -372,7 +372,7 @@ impl HookInstaller for DroidInstaller {
             });
         }
 
-        let content = fs::read_to_string(&settings_path)?;
+        let content = crate::mdm::utils::read_installer_config(&settings_path)?;
         let existing: Value = parse_jsonc_settings(&content).unwrap_or_else(|_| json!({}));
         let (hooks_installed, hooks_up_to_date) = Self::hook_status(&existing);
 

--- a/src/mdm/agents/firebender.rs
+++ b/src/mdm/agents/firebender.rs
@@ -50,7 +50,7 @@ impl HookInstaller for FirebenderInstaller {
             });
         }
 
-        let content = fs::read_to_string(&hooks_path)?;
+        let content = crate::mdm::utils::read_installer_config(&hooks_path)?;
         let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
 
         let has_pre = existing
@@ -101,7 +101,7 @@ impl HookInstaller for FirebenderInstaller {
         }
 
         let existing_content = if hooks_path.exists() {
-            fs::read_to_string(&hooks_path)?
+            crate::mdm::utils::read_installer_config(&hooks_path)?
         } else {
             String::new()
         };
@@ -223,7 +223,7 @@ impl HookInstaller for FirebenderInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(&hooks_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(&hooks_path)?;
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();

--- a/src/mdm/agents/gemini.rs
+++ b/src/mdm/agents/gemini.rs
@@ -76,7 +76,7 @@ impl GeminiInstaller {
         }
 
         let existing_content = if settings_path.exists() {
-            fs::read_to_string(settings_path)?
+            crate::mdm::utils::read_installer_config(settings_path)?
         } else {
             String::new()
         };
@@ -255,7 +255,7 @@ impl GeminiInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(settings_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(settings_path)?;
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();
@@ -344,7 +344,7 @@ impl HookInstaller for GeminiInstaller {
             });
         }
 
-        let content = fs::read_to_string(&settings_path)?;
+        let content = crate::mdm::utils::read_installer_config(&settings_path)?;
         let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
         let (hooks_installed, hooks_up_to_date) = Self::hook_status(&existing);
 

--- a/src/mdm/agents/github_copilot.rs
+++ b/src/mdm/agents/github_copilot.rs
@@ -104,7 +104,7 @@ impl HookInstaller for GitHubCopilotInstaller {
             });
         }
 
-        let content = fs::read_to_string(&hooks_path)?;
+        let content = crate::mdm::utils::read_installer_config(&hooks_path)?;
         let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
 
         let pre_desired = format!(
@@ -193,7 +193,7 @@ impl HookInstaller for GitHubCopilotInstaller {
         }
 
         let existing_content = if hooks_path.exists() {
-            fs::read_to_string(&hooks_path)?
+            crate::mdm::utils::read_installer_config(&hooks_path)?
         } else {
             String::new()
         };
@@ -353,7 +353,7 @@ impl HookInstaller for GitHubCopilotInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(&hooks_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(&hooks_path)?;
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -66,7 +66,8 @@ impl HookInstaller for OpenCodeInstaller {
         }
 
         // Check if plugin is up to date (compare against content with binary path substituted)
-        let current_content = fs::read_to_string(&plugin_path).unwrap_or_default();
+        let current_content =
+            crate::mdm::utils::read_installer_config(&plugin_path).unwrap_or_default();
         let expected_content = Self::generate_plugin_content(&params.binary_path);
         let is_up_to_date = current_content.trim() == expected_content.trim();
 
@@ -103,7 +104,7 @@ impl HookInstaller for OpenCodeInstaller {
 
         // Read existing content if present
         let existing_content = if plugin_path.exists() {
-            fs::read_to_string(&plugin_path)?
+            crate::mdm::utils::read_installer_config(&plugin_path)?
         } else {
             String::new()
         };
@@ -151,7 +152,7 @@ impl HookInstaller for OpenCodeInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(&plugin_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(&plugin_path)?;
         let diff_output = generate_diff(&plugin_path, &existing_content, "");
 
         if !dry_run {

--- a/src/mdm/agents/pi.rs
+++ b/src/mdm/agents/pi.rs
@@ -57,7 +57,8 @@ impl HookInstaller for PiInstaller {
             });
         }
 
-        let current_content = fs::read_to_string(&extension_path).unwrap_or_default();
+        let current_content =
+            crate::mdm::utils::read_installer_config(&extension_path).unwrap_or_default();
         let expected_content = Self::generate_extension_content(&params.binary_path);
 
         Ok(HookCheckResult {
@@ -81,7 +82,7 @@ impl HookInstaller for PiInstaller {
         }
 
         let existing_content = if extension_path.exists() {
-            fs::read_to_string(&extension_path)?
+            crate::mdm::utils::read_installer_config(&extension_path)?
         } else {
             String::new()
         };
@@ -114,7 +115,7 @@ impl HookInstaller for PiInstaller {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(&extension_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(&extension_path)?;
         let diff_output = generate_diff(&extension_path, &existing_content, "");
 
         if !dry_run {

--- a/src/mdm/agents/visual_studio.rs
+++ b/src/mdm/agents/visual_studio.rs
@@ -320,7 +320,8 @@ fn extension_dir_contains_extension(dir: &std::path::Path, remaining_depth: usiz
 }
 
 fn manifest_contains_extension(manifest: &std::path::Path) -> bool {
-    std::fs::read_to_string(manifest).is_ok_and(|content| manifest_declares_vsix_identity(&content))
+    crate::mdm::utils::read_installer_config(manifest)
+        .is_ok_and(|content| manifest_declares_vsix_identity(&content))
 }
 
 fn manifest_declares_vsix_identity(content: &str) -> bool {

--- a/src/mdm/agents/windsurf.rs
+++ b/src/mdm/agents/windsurf.rs
@@ -9,7 +9,7 @@ use crate::mdm::utils::{
 
 use serde_json::{Value, json};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const WINDSURF_CHECKPOINT_CMD: &str = "checkpoint windsurf --hook-input stdin";
 
@@ -39,7 +39,7 @@ impl WindsurfInstaller {
 
     /// Install hooks into a single hooks.json file, returning a diff if changes were made.
     fn install_hooks_at(
-        hooks_path: &PathBuf,
+        hooks_path: &Path,
         desired_cmd: &str,
         dry_run: bool,
     ) -> Result<Option<String>, GitAiError> {
@@ -48,7 +48,7 @@ impl WindsurfInstaller {
         }
 
         let existing_content = if hooks_path.exists() {
-            fs::read_to_string(hooks_path)?
+            crate::mdm::utils::read_installer_config(hooks_path)?
         } else {
             String::new()
         };
@@ -142,15 +142,12 @@ impl WindsurfInstaller {
     }
 
     /// Remove hooks from a single hooks.json file, returning a diff if changes were made.
-    fn uninstall_hooks_at(
-        hooks_path: &PathBuf,
-        dry_run: bool,
-    ) -> Result<Option<String>, GitAiError> {
+    fn uninstall_hooks_at(hooks_path: &Path, dry_run: bool) -> Result<Option<String>, GitAiError> {
         if !hooks_path.exists() {
             return Ok(None);
         }
 
-        let existing_content = fs::read_to_string(hooks_path)?;
+        let existing_content = crate::mdm::utils::read_installer_config(hooks_path)?;
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();
@@ -231,7 +228,7 @@ impl HookInstaller for WindsurfInstaller {
                 continue;
             }
 
-            let content = fs::read_to_string(&hooks_path)?;
+            let content = crate::mdm::utils::read_installer_config(&hooks_path)?;
             let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
 
             let has_hooks = HOOK_EVENTS.iter().all(|event| {

--- a/src/mdm/jetbrains/detection.rs
+++ b/src/mdm/jetbrains/detection.rs
@@ -160,7 +160,7 @@ fn get_macos_build_metadata(app_path: &Path) -> (Option<String>, Option<u32>, Op
     // Try product-info.json first (newer JetBrains IDEs)
     let product_info_path = app_path.join("Contents/Resources/product-info.json");
     if product_info_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&product_info_path)
+        && let Ok(content) = crate::mdm::utils::read_installer_config(&product_info_path)
         && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
         && let Some(build) = json.get("buildNumber").and_then(|v| v.as_str())
     {
@@ -315,7 +315,7 @@ fn get_windows_build_metadata(
 ) -> (Option<String>, Option<u32>, Option<String>) {
     let product_info_path = install_path.join("product-info.json");
     if product_info_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&product_info_path)
+        && let Ok(content) = crate::mdm::utils::read_installer_config(&product_info_path)
         && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
         && let Some(build) = json.get("buildNumber").and_then(|v| v.as_str())
     {
@@ -451,7 +451,7 @@ fn detect_linux_ide(ide: &'static JetBrainsIde, install_path: &Path) -> Option<D
 fn get_linux_build_metadata(install_path: &Path) -> (Option<String>, Option<u32>, Option<String>) {
     let product_info_path = install_path.join("product-info.json");
     if product_info_path.exists()
-        && let Ok(content) = std::fs::read_to_string(&product_info_path)
+        && let Ok(content) = crate::mdm::utils::read_installer_config(&product_info_path)
         && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
         && let Some(build) = json.get("buildNumber").and_then(|v| v.as_str())
     {

--- a/src/mdm/jetbrains/download.rs
+++ b/src/mdm/jetbrains/download.rs
@@ -1,6 +1,25 @@
 use crate::error::GitAiError;
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Write};
 use std::path::Path;
+
+const MAX_PLUGIN_ARCHIVE_ENTRIES: usize = 4_096;
+const MAX_PLUGIN_ENTRY_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_PLUGIN_EXTRACTED_BYTES: u64 = 256 * 1024 * 1024;
+
+fn copy_with_limit(
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+    max_bytes: u64,
+) -> Result<u64, GitAiError> {
+    let copied = std::io::copy(&mut reader.take(max_bytes), writer)?;
+    let mut extra = [0u8; 1];
+    if reader.read(&mut extra)? != 0 {
+        return Err(GitAiError::Generic(format!(
+            "ZIP entry exceeded the {max_bytes} byte limit"
+        )));
+    }
+    Ok(copied)
+}
 
 /// Download plugin from JetBrains Marketplace
 ///
@@ -59,11 +78,27 @@ pub fn install_plugin_to_directory(zip_data: &[u8], plugin_dir: &Path) -> Result
     let cursor = Cursor::new(zip_data);
     let mut archive = ZipArchive::new(cursor)
         .map_err(|e| GitAiError::Generic(format!("Failed to read plugin ZIP: {}", e)))?;
+    if archive.len() > MAX_PLUGIN_ARCHIVE_ENTRIES {
+        return Err(GitAiError::Generic(format!(
+            "Plugin ZIP exceeded the {MAX_PLUGIN_ARCHIVE_ENTRIES} entry limit ({})",
+            archive.len()
+        )));
+    }
+    let mut extracted_bytes = 0u64;
 
     for i in 0..archive.len() {
         let mut file = archive
             .by_index(i)
             .map_err(|e| GitAiError::Generic(format!("Failed to read ZIP entry: {}", e)))?;
+        if file.size() > MAX_PLUGIN_ENTRY_BYTES
+            || extracted_bytes.saturating_add(file.size()) > MAX_PLUGIN_EXTRACTED_BYTES
+        {
+            return Err(GitAiError::Generic(format!(
+                "Plugin ZIP entry exceeded extraction limits: {} ({} bytes)",
+                file.name(),
+                file.size()
+            )));
+        }
 
         let outpath = match file.enclosed_name() {
             Some(path) => plugin_dir.join(path),
@@ -101,20 +136,21 @@ pub fn install_plugin_to_directory(zip_data: &[u8], plugin_dir: &Path) -> Result
                 ))
             })?;
 
-            let mut buffer = Vec::new();
-            file.read_to_end(&mut buffer).map_err(|e| {
-                GitAiError::Generic(format!("Failed to read ZIP file contents: {}", e))
-            })?;
-
-            std::io::Write::write_all(&mut outfile, &buffer).map_err(|e| {
-                GitAiError::Generic(format!("Failed to write file {}: {}", outpath.display(), e))
-            })?;
+            #[cfg(unix)]
+            let mode = file.unix_mode();
+            let remaining_bytes = MAX_PLUGIN_EXTRACTED_BYTES.saturating_sub(extracted_bytes);
+            let copied = copy_with_limit(
+                &mut file,
+                &mut outfile,
+                MAX_PLUGIN_ENTRY_BYTES.min(remaining_bytes),
+            )?;
+            extracted_bytes = extracted_bytes.saturating_add(copied);
 
             // Set executable permissions on Unix
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                if let Some(mode) = file.unix_mode() {
+                if let Some(mode) = mode {
                     let permissions = std::fs::Permissions::from_mode(mode);
                     let _ = std::fs::set_permissions(&outpath, permissions);
                 }
@@ -131,28 +167,23 @@ pub fn install_plugin_to_directory(zip_data: &[u8], plugin_dir: &Path) -> Result
 ///
 /// Returns Ok(true) if installation succeeded, Ok(false) if CLI failed
 pub fn install_plugin_via_cli(binary_path: &Path, plugin_id: &str) -> Result<bool, GitAiError> {
-    use std::process::Command;
+    use std::process::{Command, Stdio};
 
     tracing::debug!("JetBrains: Trying CLI installation with {:?}", binary_path);
 
-    #[cfg(windows)]
     let result = Command::new(binary_path)
         .args(["installPlugins", plugin_id])
-        .output();
-
-    #[cfg(not(windows))]
-    let result = Command::new(binary_path)
-        .args(["installPlugins", plugin_id])
-        .output();
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 
     match result {
-        Ok(output) => {
-            if output.status.success() {
+        Ok(status) => {
+            if status.success() {
                 tracing::debug!("JetBrains: CLI installation succeeded");
                 Ok(true)
             } else {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                tracing::debug!("JetBrains: CLI installation failed: {}", stderr);
+                tracing::debug!("JetBrains: CLI installation failed with status {}", status);
                 Ok(false)
             }
         }
@@ -160,5 +191,21 @@ pub fn install_plugin_via_cli(binary_path: &Path, plugin_id: &str) -> Result<boo
             tracing::debug!("JetBrains: Failed to run CLI: {}", e);
             Ok(false)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::copy_with_limit;
+
+    #[test]
+    fn zip_entry_copy_rejects_data_beyond_limit_without_buffering_it() {
+        let mut input = std::io::Cursor::new(vec![b'x'; 1025]);
+        let mut output = Vec::new();
+
+        let error = copy_with_limit(&mut input, &mut output, 1024)
+            .expect_err("oversized entry must be rejected");
+        assert!(error.to_string().contains("byte limit"));
+        assert_eq!(output.len(), 1024);
     }
 }

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -12,6 +12,15 @@ pub const MIN_CURSOR_VERSION: (u32, u32) = (1, 7);
 pub const MIN_CODE_VERSION: (u32, u32) = (1, 99);
 pub const MIN_CLAUDE_VERSION: (u32, u32) = (2, 0);
 pub const MIN_CODEX_VERSION: (u32, u32) = (0, 124);
+pub const MAX_INSTALLER_CONFIG_BYTES: u64 = 2 * 1024 * 1024;
+
+pub fn read_installer_config(path: &Path) -> Result<String, GitAiError> {
+    Ok(crate::utils::read_text_file_with_limit(
+        path,
+        MAX_INSTALLER_CONFIG_BYTES,
+        "agent configuration",
+    )?)
+}
 
 /// Get version from a binary's --version output
 pub fn get_binary_version(binary: &str) -> Result<String, GitAiError> {
@@ -732,7 +741,7 @@ pub fn update_vscode_chat_hook_settings(
     dry_run: bool,
 ) -> Result<Option<String>, GitAiError> {
     let original = if settings_path.exists() {
-        fs::read_to_string(settings_path)?
+        read_installer_config(settings_path)?
     } else {
         String::new()
     };
@@ -801,6 +810,18 @@ mod tests {
     use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn oversized_vscode_settings_are_rejected_before_parsing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(2 * 1024 * 1024 + 1).unwrap();
+
+        let error = update_vscode_chat_hook_settings(&path, true)
+            .expect_err("oversized settings must be rejected");
+        assert!(error.to_string().contains("byte limit"));
+    }
 
     #[test]
     fn test_parse_version() {

--- a/tests/integration/installer_config_memory.rs
+++ b/tests/integration/installer_config_memory.rs
@@ -1,0 +1,34 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+#[test]
+fn oversized_agent_config_is_rejected_and_attribution_recovers() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("tracked.txt");
+    file.set_contents(lines!["first", "second", "third"]);
+    repo.stage_all_and_commit("initial").unwrap();
+    file.assert_committed_lines(lines!["first".human(), "second".human(), "third".human(),]);
+
+    let claude_dir = repo.test_home_path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    let settings_path = claude_dir.join("settings.json");
+    let settings = fs::File::create(&settings_path).unwrap();
+    settings.set_len(2 * 1024 * 1024 + 1).unwrap();
+
+    let output = repo.git_ai(&["install", "--dry-run"]).unwrap();
+    assert!(
+        output.contains("agent configuration exceeded the 2097152 byte limit"),
+        "unexpected install output: {output}"
+    );
+
+    fs::remove_file(settings_path).unwrap();
+    file.insert_at(3, lines!["AI edit".ai()]);
+    repo.stage_all_and_commit("AI edit").unwrap();
+    file.assert_committed_lines(lines![
+        "first".human(),
+        "second".human(),
+        "third".ai(),
+        "AI edit".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -94,6 +94,7 @@ mod ignore_prompts;
 mod ignore_unit;
 mod initial_attributions;
 mod install_hooks_comprehensive;
+mod installer_config_memory;
 mod internal_machine_commands;
 mod internal_spawn_safety;
 mod issue_1204_multi_agent;


### PR DESCRIPTION
## Bug
Installer configuration readers loaded arbitrary files, and JetBrains plugin extraction trusted archive entry count and declared sizes. A large config or ZIP bomb could exhaust memory/disk during installation.

## Fix
Use a shared 2 MiB installer-config reader across agent integrations and bound plugin ZIPs to 4,096 entries, 64 MiB per entry, and 256 MiB total extracted content with bounded copying.

## Verification
Unit tests cover archive and config limits. `tests/integration/installer_config_memory.rs` exercises oversized installer inputs without changing normal detection behavior. The Unix mode lookup is compiled only on Unix, keeping Windows all-target lint warning-free. All 17 focused installer tests, host lint/build, and the full suite pass on the final stack tip.