### PR TITLE
fix(processes): bound auxiliary command output

### DIFF
--- a/src/auth/credential_backend.rs
+++ b/src/auth/credential_backend.rs
@@ -99,8 +99,6 @@ impl FileBackend {
 
     #[cfg(windows)]
     fn set_file_protection(path: &std::path::Path) -> Result<(), String> {
-        use std::process::Command;
-
         let path_str = path
             .to_str()
             .ok_or_else(|| "Invalid path encoding".to_string())?;
@@ -108,25 +106,33 @@ impl FileBackend {
         let username = std::env::var("USERNAME")
             .map_err(|_| "Could not determine current user".to_string())?;
 
-        let output = Command::new("icacls")
-            .args([
-                path_str,
-                "/inheritance:r",
-                "/grant:r",
-                &format!("{}:F", username),
-            ])
-            .output()
-            .map_err(|e| format!("Failed to run icacls: {}", e))?;
+        let grant = format!("{}:F", username);
+        let output = crate::process_timeout::run_command_with_timeout(
+            "icacls",
+            &[path_str, "/inheritance:r", "/grant:r", &grant],
+            None,
+            std::time::Duration::from_secs(30),
+            std::time::Duration::from_millis(10),
+            &[],
+        )
+        .map_err(|e| format!("Failed to run icacls: {}", e))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if !output.completed_successfully() {
             eprintln!(
-                "Warning: Could not set restrictive permissions on credentials file: {}",
-                stderr
+                "Warning: Could not set restrictive permissions on credentials file: {} {}",
+                output.stderr,
+                output.diagnostics.join("; ")
             );
         }
 
-        let _ = Command::new("attrib").args(["+H", path_str]).output();
+        let _ = crate::process_timeout::run_command_with_timeout(
+            "attrib",
+            &["+H", path_str],
+            None,
+            std::time::Duration::from_secs(30),
+            std::time::Duration::from_millis(10),
+            &[],
+        );
 
         Ok(())
     }

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -679,18 +679,24 @@ fn hard_kill_daemon(config: &DaemonConfig) -> Result<(), String> {
 #[cfg(windows)]
 fn hard_kill_daemon(config: &DaemonConfig) -> Result<(), String> {
     let pid = read_daemon_pid(config).map_err(|e| format!("cannot read daemon pid: {}", e))?;
-    let output = Command::new("taskkill")
-        .args(["/F", "/T", "/PID", &pid.to_string()])
-        .output()
-        .map_err(|e| format!("failed to run taskkill: {}", e))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let pid_string = pid.to_string();
+    let output = crate::process_timeout::run_command_with_timeout(
+        "taskkill",
+        &["/F", "/T", "/PID", &pid_string],
+        None,
+        Duration::from_secs(30),
+        Duration::from_millis(10),
+        &[],
+    )
+    .map_err(|e| format!("failed to run taskkill: {}", e))?;
+    if !output.completed_successfully() {
         // Process already dead is not an error.
-        if !stderr.contains("not found") {
+        if !output.stderr.contains("not found") {
             return Err(format!(
-                "taskkill /F /T /PID {} failed: {}",
+                "taskkill /F /T /PID {} failed: {} {}",
                 pid,
-                stderr.trim()
+                output.stderr,
+                output.diagnostics.join("; ")
             ));
         }
     }

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -937,7 +937,7 @@ fn run_command_capture_with_timeout_and_env(
 }
 
 fn command_output_to_result(output: TimedCommandOutput) -> Result<String, String> {
-    if output.status != Some(0) {
+    if !output.completed_successfully() {
         let mut stderr = output.stderr.trim().to_string();
         append_debug_diagnostics(&mut stderr, &output.diagnostics);
         let code = output

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -5,7 +5,7 @@ use crate::mdm::agents::get_all_installers;
 use crate::mdm::hook_installer::HookInstallerParams;
 use crate::mdm::skills_installer;
 use crate::mdm::spinner::{Spinner, print_diff};
-use crate::mdm::utils::get_current_binary_path;
+use crate::mdm::utils::{get_current_binary_path, run_installer_command};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -132,30 +132,28 @@ fn find_running_pids(process_names: &[&str]) -> Vec<(u32, String)> {
     let output = {
         #[cfg(unix)]
         {
-            Command::new("ps")
-                .args(["axo", "pid,comm"])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .output()
+            let mut command = Command::new("ps");
+            command.args(["axo", "pid,comm"]);
+            run_installer_command(command, "process listing")
         }
         #[cfg(windows)]
         {
-            Command::new("tasklist")
-                .args(["/FO", "CSV", "/NH"])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .output()
+            let mut command = Command::new("tasklist");
+            command.args(["/FO", "CSV", "/NH"]);
+            run_installer_command(command, "process listing")
         }
     };
 
     let Ok(output) = output else {
         return vec![];
     };
+    if output.status != Some(0) {
+        return vec![];
+    }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
     let mut results: Vec<(u32, String)> = Vec::new();
 
-    for line in stdout.lines() {
+    for line in output.stdout.lines() {
         #[cfg(unix)]
         {
             let trimmed = line.trim();
@@ -745,14 +743,12 @@ fn warn_if_git_version_too_old() {
         .stderr(Stdio::null());
     crate::git::repository::apply_internal_git_env(&mut command);
 
-    let output = command.output();
+    let output = run_installer_command(command, "git --version");
 
     let version = match output {
-        Ok(o) => {
-            let text = String::from_utf8_lossy(&o.stdout).into_owned();
-            parse_git_version(&text)
-        }
+        Ok(o) if o.status == Some(0) => parse_git_version(&o.stdout),
         Err(_) => None,
+        _ => None,
     };
 
     if let Some(v) = version {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1413,13 +1413,16 @@ fn resolve_git_path(file_cfg: &Option<FileConfig>) -> String {
     // 3) Windows-only: try `where.exe git.exe` as a PATH-based fallback
     #[cfg(windows)]
     {
-        if let Ok(output) = std::process::Command::new("where.exe")
-            .arg("git.exe")
-            .output()
-            && output.status.success()
+        if let Ok(output) = crate::process_timeout::run_command_with_timeout(
+            "where.exe",
+            &["git.exe"],
+            None,
+            Duration::from_secs(10),
+            Duration::from_millis(10),
+            &[],
+        ) && output.completed_successfully()
         {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
+            for line in output.stdout.lines() {
                 let trimmed = line.trim();
                 let p = Path::new(trimmed);
                 if is_executable(p) && !path_is_git_ai_binary(p) {

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -1,9 +1,9 @@
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
-    MIN_CLAUDE_VERSION, binary_exists, claude_config_dir, generate_diff, get_binary_version,
-    is_git_ai_checkpoint_command, normalize_windows_path_for_shell, parse_version,
-    version_meets_requirement, write_atomic,
+    MIN_CLAUDE_VERSION, binary_exists, claude_config_dir, detected_version_below_requirement,
+    generate_diff, get_binary_version, is_git_ai_checkpoint_command,
+    normalize_windows_path_for_shell, write_atomic,
 };
 use serde_json::{Value, json};
 use std::fs;
@@ -322,9 +322,8 @@ impl HookInstaller for ClaudeCodeInstaller {
         }
 
         if has_binary
-            && let Ok(version_str) = get_binary_version("claude")
-            && let Some(version) = parse_version(&version_str)
-            && !version_meets_requirement(version, MIN_CLAUDE_VERSION)
+            && let Some(version) =
+                detected_version_below_requirement(get_binary_version("claude"), MIN_CLAUDE_VERSION)
         {
             return Err(GitAiError::Generic(format!(
                 "Claude Code version {}.{} detected, but minimum version {}.{} is required",

--- a/src/mdm/agents/cursor.rs
+++ b/src/mdm/agents/cursor.rs
@@ -3,10 +3,9 @@ use crate::mdm::hook_installer::{
     HookCheckResult, HookInstaller, HookInstallerParams, InstallResult,
 };
 use crate::mdm::utils::{
-    MIN_CURSOR_VERSION, generate_diff, get_editor_version, home_dir, install_vsc_editor_extension,
-    is_vsc_editor_extension_installed, parse_version, resolve_editor_cli,
-    settings_paths_for_products, should_process_settings_target, version_meets_requirement,
-    write_atomic,
+    MIN_CURSOR_VERSION, detected_version_below_requirement, generate_diff, get_editor_version,
+    home_dir, install_vsc_editor_extension, is_vsc_editor_extension_installed, resolve_editor_cli,
+    settings_paths_for_products, should_process_settings_target, write_atomic,
 };
 use serde_json::{Value, json};
 use std::fs;
@@ -60,9 +59,8 @@ impl HookInstaller for CursorInstaller {
 
         // If we have a CLI, check version
         if let Some(cli) = &resolved_cli
-            && let Ok(version_str) = get_editor_version(cli)
-            && let Some(version) = parse_version(&version_str)
-            && !version_meets_requirement(version, MIN_CURSOR_VERSION)
+            && let Some(version) =
+                detected_version_below_requirement(get_editor_version(cli), MIN_CURSOR_VERSION)
         {
             return Err(GitAiError::Generic(format!(
                 "Cursor version {}.{} detected, but minimum version {}.{} is required",

--- a/src/mdm/agents/github_copilot.rs
+++ b/src/mdm/agents/github_copilot.rs
@@ -1,9 +1,9 @@
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
-    MIN_CODE_VERSION, generate_diff, get_editor_version, home_dir, parse_version,
-    resolve_editor_cli, settings_paths_for_products, should_process_settings_target,
-    version_meets_requirement, write_atomic,
+    MIN_CODE_VERSION, detected_version_below_requirement, generate_diff, get_editor_version,
+    home_dir, resolve_editor_cli, settings_paths_for_products, should_process_settings_target,
+    write_atomic,
 };
 use serde_json::{Value, json};
 use std::fs;
@@ -76,9 +76,8 @@ impl HookInstaller for GitHubCopilotInstaller {
 
         // If we have a CLI, check version.
         if let Some(cli) = &resolved_cli
-            && let Ok(version_str) = get_editor_version(cli)
-            && let Some(version) = parse_version(&version_str)
-            && !version_meets_requirement(version, MIN_CODE_VERSION)
+            && let Some(version) =
+                detected_version_below_requirement(get_editor_version(cli), MIN_CODE_VERSION)
         {
             return Err(GitAiError::Generic(format!(
                 "VS Code version {}.{} detected, but minimum version {}.{} is required",

--- a/src/mdm/agents/visual_studio.rs
+++ b/src/mdm/agents/visual_studio.rs
@@ -2,6 +2,7 @@ use crate::error::GitAiError;
 use crate::mdm::hook_installer::{
     HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
+use crate::mdm::utils::run_installer_command;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
@@ -225,29 +226,27 @@ fn find_visual_studio_windows() -> Vec<VsInstallation> {
         }
     };
 
-    let output = match std::process::Command::new(&vswhere)
-        .args([
-            "-all",
-            "-format",
-            "json",
-            "-property",
-            "installationPath",
-            "-property",
-            "installationVersion",
-            "-property",
-            "instanceId",
-        ])
-        .output()
-    {
-        Ok(out) if out.status.success() => out,
+    let mut command = std::process::Command::new(&vswhere);
+    command.args([
+        "-all",
+        "-format",
+        "json",
+        "-property",
+        "installationPath",
+        "-property",
+        "installationVersion",
+        "-property",
+        "instanceId",
+    ]);
+    let output = match run_installer_command(command, "vswhere.exe") {
+        Ok(out) if out.status == Some(0) => out,
         _ => {
             tracing::debug!("Visual Studio: vswhere.exe failed");
             return Vec::new();
         }
     };
 
-    let json_str = String::from_utf8_lossy(&output.stdout);
-    let entries: Vec<serde_json::Value> = match serde_json::from_str(&json_str) {
+    let entries: Vec<serde_json::Value> = match serde_json::from_str(&output.stdout) {
         Ok(v) => v,
         Err(e) => {
             tracing::debug!("Visual Studio: Failed to parse vswhere output: {}", e);

--- a/src/mdm/agents/vscode.rs
+++ b/src/mdm/agents/vscode.rs
@@ -3,10 +3,10 @@ use crate::mdm::hook_installer::{
     HookCheckResult, HookInstaller, HookInstallerParams, InstallResult, UninstallResult,
 };
 use crate::mdm::utils::{
-    MIN_CODE_VERSION, get_editor_version, home_dir, install_vsc_editor_extension,
-    is_github_codespaces, is_vsc_editor_extension_installed, parse_version, resolve_editor_cli,
-    settings_paths_for_products, should_process_settings_target, update_vscode_chat_hook_settings,
-    version_meets_requirement,
+    MIN_CODE_VERSION, detected_version_below_requirement, get_editor_version, home_dir,
+    install_vsc_editor_extension, is_github_codespaces, is_vsc_editor_extension_installed,
+    resolve_editor_cli, settings_paths_for_products, should_process_settings_target,
+    update_vscode_chat_hook_settings,
 };
 use std::path::PathBuf;
 
@@ -45,9 +45,8 @@ impl HookInstaller for VSCodeInstaller {
 
         // If we have a CLI, check version
         if let Some(cli) = &resolved_cli
-            && let Ok(version_str) = get_editor_version(cli)
-            && let Some(version) = parse_version(&version_str)
-            && !version_meets_requirement(version, MIN_CODE_VERSION)
+            && let Some(version) =
+                detected_version_below_requirement(get_editor_version(cli), MIN_CODE_VERSION)
         {
             return Err(GitAiError::Generic(format!(
                 "VS Code version {}.{} detected, but minimum version {}.{} is required",

--- a/src/mdm/jetbrains/detection.rs
+++ b/src/mdm/jetbrains/detection.rs
@@ -1,5 +1,7 @@
 use super::ide_types::{DetectedIde, JETBRAINS_IDES, JetBrainsIde};
 use crate::mdm::utils::home_dir;
+#[cfg(target_os = "macos")]
+use crate::mdm::utils::run_installer_command;
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
@@ -84,17 +86,15 @@ fn find_macos_installations() -> Vec<DetectedIde> {
 
 #[cfg(target_os = "macos")]
 fn find_app_by_bundle_id(bundle_id: &str) -> Option<PathBuf> {
-    let output = Command::new("mdfind")
-        .args([&format!("kMDItemCFBundleIdentifier == '{}'", bundle_id)])
-        .output()
-        .ok()?;
+    let mut command = Command::new("mdfind");
+    command.args([&format!("kMDItemCFBundleIdentifier == '{}'", bundle_id)]);
+    let output = run_installer_command(command, "mdfind").ok()?;
 
-    if !output.status.success() {
+    if output.status != Some(0) {
         return None;
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout.lines().next().map(PathBuf::from)
+    output.stdout.lines().next().map(PathBuf::from)
 }
 
 #[cfg(target_os = "macos")]
@@ -173,19 +173,18 @@ fn get_macos_build_metadata(app_path: &Path) -> (Option<String>, Option<u32>, Op
     }
 
     // Fall back to Info.plist
-    let output = Command::new("defaults")
-        .args([
-            "read",
-            &app_path.join("Contents/Info.plist").to_string_lossy(),
-            "CFBundleVersion",
-        ])
-        .output()
-        .ok();
+    let mut command = Command::new("defaults");
+    command.args([
+        "read",
+        &app_path.join("Contents/Info.plist").to_string_lossy(),
+        "CFBundleVersion",
+    ]);
+    let output = run_installer_command(command, "defaults read CFBundleVersion").ok();
 
     if let Some(output) = output
-        && output.status.success()
+        && output.status == Some(0)
     {
-        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let version = output.stdout;
         let major = parse_major_build(&version);
         return (Some(version), major, None);
     }

--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 // Minimum version requirements
 pub const MIN_CURSOR_VERSION: (u32, u32) = (1, 7);
@@ -13,6 +14,8 @@ pub const MIN_CODE_VERSION: (u32, u32) = (1, 99);
 pub const MIN_CLAUDE_VERSION: (u32, u32) = (2, 0);
 pub const MIN_CODEX_VERSION: (u32, u32) = (0, 124);
 pub const MAX_INSTALLER_CONFIG_BYTES: u64 = 2 * 1024 * 1024;
+const INSTALLER_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const INSTALLER_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 pub fn read_installer_config(path: &Path) -> Result<String, GitAiError> {
     Ok(crate::utils::read_text_file_with_limit(
@@ -22,39 +25,74 @@ pub fn read_installer_config(path: &Path) -> Result<String, GitAiError> {
     )?)
 }
 
+pub(crate) fn run_installer_command(
+    command: Command,
+    description: &str,
+) -> Result<crate::process_timeout::TimedCommandOutput, GitAiError> {
+    let output = crate::process_timeout::run_prepared_command_with_timeout(
+        command,
+        INSTALLER_COMMAND_TIMEOUT,
+        INSTALLER_COMMAND_POLL_INTERVAL,
+    )
+    .map_err(|error| GitAiError::Generic(format!("Failed to run {description}: {error}")))?;
+
+    if output.timed_out {
+        return Err(GitAiError::Generic(format!(
+            "{description} timed out after {} seconds",
+            INSTALLER_COMMAND_TIMEOUT.as_secs()
+        )));
+    }
+    if let Some(error) = &output.wait_error {
+        return Err(GitAiError::Generic(format!(
+            "Failed to wait for {description}: {error}"
+        )));
+    }
+    let read_errors: Vec<&str> = output
+        .diagnostics
+        .iter()
+        .map(String::as_str)
+        .filter(|message| message.starts_with("failed to read "))
+        .collect();
+    if !read_errors.is_empty() {
+        return Err(GitAiError::Generic(format!(
+            "{description}: {}",
+            read_errors.join("; ")
+        )));
+    }
+    Ok(output)
+}
+
 /// Get version from a binary's --version output
 pub fn get_binary_version(binary: &str) -> Result<String, GitAiError> {
-    let output = Command::new(binary)
-        .arg("--version")
-        .output()
-        .map_err(|e| GitAiError::Generic(format!("Failed to run {} --version: {}", binary, e)))?;
+    let mut command = Command::new(binary);
+    command.arg("--version");
+    let output = run_installer_command(command, &format!("{binary} --version"))?;
 
-    if !output.status.success() {
+    if output.status != Some(0) {
         return Err(GitAiError::Generic(format!(
-            "{} --version failed with status: {}",
+            "{} --version failed with status: {:?}",
             binary, output.status
         )));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(stdout.trim().to_string())
+    Ok(output.stdout)
 }
 
 /// Get version from an editor CLI command's --version output
 pub fn get_editor_version(cli: &EditorCliCommand) -> Result<String, GitAiError> {
-    let output = cli.command(&["--version"]).output().map_err(|e| {
-        GitAiError::Generic(format!("Failed to run {} --version: {}", cli.program, e))
-    })?;
+    let output = run_installer_command(
+        cli.command(&["--version"]),
+        &format!("{} --version", cli.program),
+    )?;
 
-    if !output.status.success() {
+    if output.status != Some(0) {
         return Err(GitAiError::Generic(format!(
-            "{} --version failed with status: {}",
+            "{} --version failed with status: {:?}",
             cli.program, output.status
         )));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Ok(stdout.trim().to_string())
+    Ok(output.stdout)
 }
 
 /// Parse version string to extract major.minor version
@@ -92,6 +130,16 @@ pub fn version_meets_requirement(version: (u32, u32), min_version: (u32, u32)) -
         return true;
     }
     false
+}
+
+/// Return a successfully detected version only when it is below the minimum.
+/// A failed probe is inconclusive and must not prevent hook installation.
+pub fn detected_version_below_requirement(
+    probe: Result<String, GitAiError>,
+    min_version: (u32, u32),
+) -> Option<(u32, u32)> {
+    let version = parse_version(&probe.ok()?)?;
+    (!version_meets_requirement(version, min_version)).then_some(version)
 }
 
 /// Check if a binary with the given name exists in the system PATH
@@ -626,15 +674,17 @@ pub fn is_vsc_editor_extension_installed(
     // NOTE: We try up to 3 times, because the editor CLI can be flaky (throws intermittent JS errors)
     let mut last_error_message: Option<String> = None;
     for attempt in 1..=3 {
-        let cmd_result = cli.command(&["--list-extensions"]).output();
+        let cmd_result = run_installer_command(
+            cli.command(&["--list-extensions"]),
+            &format!("{} --list-extensions", cli.program),
+        );
 
         match cmd_result {
             Ok(output) => {
-                if !output.status.success() {
-                    last_error_message = Some(String::from_utf8_lossy(&output.stderr).to_string());
+                if output.status != Some(0) {
+                    last_error_message = Some(output.stderr);
                 } else {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    return Ok(stdout.contains(id_or_vsix));
+                    return Ok(output.stdout.contains(id_or_vsix));
                 }
             }
             Err(e) => {
@@ -811,6 +861,24 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    #[cfg(unix)]
+    #[test]
+    fn successful_installer_command_accepts_bounded_truncated_output() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "yes x | head -c 2097152"]);
+
+        let output = run_installer_command(command, "large successful output").unwrap();
+
+        assert_eq!(output.status, Some(0));
+        assert!(output.stdout.len() <= 1024 * 1024);
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("stdout exceeded"))
+        );
+    }
+
     #[test]
     fn oversized_vscode_settings_are_rejected_before_parsing() {
         let temp = tempfile::tempdir().unwrap();
@@ -863,6 +931,25 @@ mod tests {
         // Test large numbers
         assert!(version_meets_requirement((1, 104), (1, 99)));
         assert!(!version_meets_requirement((1, 98), (1, 99)));
+    }
+
+    #[test]
+    fn failed_version_probe_does_not_report_an_unsupported_version() {
+        let probe = Err(GitAiError::Generic("probe failed".to_string()));
+
+        assert_eq!(detected_version_below_requirement(probe, (2, 0)), None);
+    }
+
+    #[test]
+    fn successful_version_probe_reports_only_unsupported_versions() {
+        assert_eq!(
+            detected_version_below_requirement(Ok("1.9.9".to_string()), (2, 0)),
+            Some((1, 9))
+        );
+        assert_eq!(
+            detected_version_below_requirement(Ok("2.0.0".to_string()), (2, 0)),
+            None
+        );
     }
 
     #[test]

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -33,6 +33,12 @@ pub(crate) struct TimedCommandOutput {
     pub wait_error: Option<String>,
 }
 
+impl TimedCommandOutput {
+    pub(crate) fn completed_successfully(&self) -> bool {
+        self.status == Some(0) && !self.timed_out && self.wait_error.is_none()
+    }
+}
+
 enum OutputEvent {
     Stdout(Vec<u8>),
     Stderr(Vec<u8>),
@@ -132,10 +138,7 @@ pub(crate) fn run_command_with_timeout_and_env(
     env_set: &[(&str, &str)],
 ) -> Result<TimedCommandOutput, String> {
     let mut command = Command::new(program);
-    command
-        .args(args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    command.args(args);
     for key in env_remove {
         command.env_remove(key);
     }
@@ -145,6 +148,15 @@ pub(crate) fn run_command_with_timeout_and_env(
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
+    run_prepared_command_with_timeout(command, timeout, poll_interval)
+}
+
+pub(crate) fn run_prepared_command_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<TimedCommandOutput, String> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
     configure_timed_command(&mut command);
 
     let mut child = command
@@ -347,6 +359,41 @@ mod tests {
     use super::*;
 
     #[test]
+    fn successful_timed_command_allows_informational_diagnostics() {
+        let output = TimedCommandOutput {
+            status: Some(0),
+            stdout: "result".to_string(),
+            stderr: String::new(),
+            timed_out: false,
+            diagnostics: vec!["output collection did not finish".to_string()],
+            wait_error: None,
+        };
+
+        assert!(output.completed_successfully());
+    }
+
+    #[test]
+    fn timed_command_success_rejects_process_failures() {
+        let mut output = TimedCommandOutput {
+            status: Some(1),
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+            diagnostics: Vec::new(),
+            wait_error: None,
+        };
+        assert!(!output.completed_successfully());
+
+        output.status = Some(0);
+        output.timed_out = true;
+        assert!(!output.completed_successfully());
+
+        output.timed_out = false;
+        output.wait_error = Some("wait failed".to_string());
+        assert!(!output.completed_successfully());
+    }
+
+    #[test]
     fn output_state_rejects_subprocess_output_beyond_limit() {
         let (tx, rx) = mpsc::channel();
         tx.send(OutputEvent::Stdout(vec![b'x'; 1024 * 1024 + 1]))
@@ -392,6 +439,28 @@ mod tests {
         assert_eq!(
             timed_command_creation_flags(),
             crate::utils::CREATE_NO_WINDOW
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepared_command_output_is_bounded() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "yes x | head -c 2097152"]);
+
+        let output = run_prepared_command_with_timeout(
+            command,
+            Duration::from_secs(5),
+            Duration::from_millis(5),
+        )
+        .unwrap();
+
+        assert!(output.stdout.len() <= MAX_TIMED_COMMAND_OUTPUT_BYTES);
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("stdout exceeded"))
         );
     }
 }

--- a/tests/integration/installer_process_memory.rs
+++ b/tests/integration/installer_process_memory.rs
@@ -1,0 +1,48 @@
+#[cfg(unix)]
+mod unix {
+    use crate::repos::test_file::ExpectedLineExt;
+    use crate::repos::test_repo::TestRepo;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn oversized_agent_version_output_is_bounded_and_inconclusive() {
+        let repo = TestRepo::new();
+        let mut file = repo.filename("tracked.txt");
+        file.set_contents(lines!["first", "second", "third"]);
+        repo.stage_all_and_commit("initial").unwrap();
+        file.assert_committed_lines(lines!["first".human(), "second".human(), "third".human(),]);
+
+        let bin_dir = repo.test_home_path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let claude = bin_dir.join("claude");
+        fs::write(&claude, "#!/bin/sh\nyes x | head -c 2097152\n").unwrap();
+        let mut permissions = fs::metadata(&claude).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&claude, permissions).unwrap();
+
+        let path = format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let output = repo
+            .git_ai_with_env(&["install", "--dry-run"], &[("PATH", &path)])
+            .unwrap();
+        assert!(
+            output.contains("Claude Code: Pending updates"),
+            "unexpected install output: {output}"
+        );
+        assert!(!output.contains("stdout exceeded"));
+        assert!(output.len() < 16 * 1024);
+
+        file.insert_at(3, lines!["AI edit".ai()]);
+        repo.stage_all_and_commit("AI edit").unwrap();
+        file.assert_committed_lines(lines![
+            "first".human(),
+            "second".human(),
+            "third".ai(),
+            "AI edit".ai(),
+        ]);
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -95,6 +95,7 @@ mod ignore_unit;
 mod initial_attributions;
 mod install_hooks_comprehensive;
 mod installer_config_memory;
+mod installer_process_memory;
 mod internal_machine_commands;
 mod internal_spawn_safety;
 mod issue_1204_multi_agent;


### PR DESCRIPTION
## Bug
Installer/detection/auth helpers used unbounded `Command::output`, with inconsistent timeouts. The first bounded migration treated successful truncation as failure, made failed version probes block installation, and left Windows `taskkill`, `where.exe`, and `icacls` success paths dependent on an empty diagnostic list.

## Fix
Route auxiliary commands through the timed 1 MiB helper and keep draining after truncation. A shared success predicate requires exit code zero, no timeout, and no wait error; informational diagnostics remain observable but do not negate success. Failed version probes are inconclusive, while successfully parsed old versions still reject.

## Verification
Process-helper tests cover aggregate caps, a successful 2 MiB output, benign diagnostics, nonzero status, timeout, and wait failure. Version tests cover failed, old, and supported probes. The TestRepo installer regression verifies a noisy version command stays bounded, reports pending updates, and preserves exact later attribution.