### PR TITLE
fix(blame): bound alternate content inputs

### DIFF
--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -11,9 +11,59 @@ use crate::utils::normalize_to_posix;
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fs;
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use std::sync::LazyLock;
+
+const MAX_BLAME_CONTENT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_BLAME_CONTENT_LINES: usize = 1_000_000;
+
+fn validate_blame_content(data: &[u8], kind: &str) -> Result<(), GitAiError> {
+    if data.len() > MAX_BLAME_CONTENT_BYTES {
+        return Err(GitAiError::Generic(format!(
+            "{kind} exceeded the {MAX_BLAME_CONTENT_BYTES} byte limit ({})",
+            data.len()
+        )));
+    }
+    let line_count = data
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+        .saturating_add(usize::from(!data.is_empty() && !data.ends_with(b"\n")));
+    if line_count > MAX_BLAME_CONTENT_LINES {
+        return Err(GitAiError::Generic(format!(
+            "{kind} exceeded the {MAX_BLAME_CONTENT_LINES} line limit ({line_count})"
+        )));
+    }
+    Ok(())
+}
+
+fn read_blame_input_with_limit(
+    reader: impl Read,
+    max_bytes: usize,
+    kind: &str,
+) -> Result<Vec<u8>, GitAiError> {
+    let mut bytes = Vec::new();
+    reader
+        .take(max_bytes.saturating_add(1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(GitAiError::IoError)?;
+    if bytes.len() > max_bytes {
+        return Err(GitAiError::Generic(format!(
+            "{kind} exceeded the {max_bytes} byte limit ({})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
+}
+
+fn read_blame_input(reader: impl Read, kind: &str) -> Result<Vec<u8>, GitAiError> {
+    read_blame_input_with_limit(reader, MAX_BLAME_CONTENT_BYTES, kind)
+}
+
+fn decode_blame_content(data: &[u8], kind: &str) -> Result<String, GitAiError> {
+    validate_blame_content(data, kind)?;
+    Ok(String::from_utf8_lossy(data).into_owned())
+}
 
 //🐰🥚 @todo use actual date Git AI was installed in each repo
 pub static OLDEST_AI_BLAME_DATE: LazyLock<DateTime<FixedOffset>> = LazyLock::new(|| {
@@ -314,7 +364,7 @@ impl Repository {
         // 3. The working directory
         if let Some(ref data) = options.contents_data {
             // Use pre-read contents data (from --contents stdin or file)
-            Ok(String::from_utf8_lossy(data).to_string())
+            decode_blame_content(data, "blame contents")
         } else if let Some(ref commit) = options.newest_commit {
             // Read file content from the specified commit.
             // This ensures blame is independent of which branch is checked out.
@@ -324,8 +374,8 @@ impl Repository {
             match tree.get_path(std::path::Path::new(relative_file_path)) {
                 Ok(entry) => {
                     if let Ok(blob) = self.find_blob(entry.id()) {
-                        let blob_content = blob.content().unwrap_or_default();
-                        Ok(String::from_utf8_lossy(&blob_content).to_string())
+                        let blob_content = blob.content()?;
+                        decode_blame_content(&blob_content, "blame commit blob")
                     } else {
                         Err(GitAiError::Generic(format!(
                             "File '{}' is not a blob in commit {}",
@@ -352,8 +402,12 @@ impl Repository {
                 )));
             }
 
-            let raw_bytes = fs::read(&abs_file_path)?;
-            Ok(String::from_utf8_lossy(&raw_bytes).into_owned())
+            let raw_bytes = crate::utils::read_file_with_limit(
+                &abs_file_path,
+                MAX_BLAME_CONTENT_BYTES as u64,
+                "blame working file",
+            )?;
+            decode_blame_content(&raw_bytes, "blame working file")
         }
     }
 
@@ -362,6 +416,9 @@ impl Repository {
         file_path: &str,
         options: &GitAiBlameOptions,
     ) -> Result<PreparedBlameRequest, GitAiError> {
+        if let Some(data) = &options.contents_data {
+            validate_blame_content(data, "blame contents")?;
+        }
         let relative_file_path = self.normalize_blame_file_path(file_path)?;
         let options = Self::effective_blame_options(options);
         let file_content = self.read_blame_file_content(&relative_file_path, &options)?;
@@ -2121,21 +2178,21 @@ pub fn parse_blame_args(args: &[String]) -> Result<(String, GitAiBlameOptions), 
                 // Read the contents now - either from stdin or from a file
                 let data = if contents_arg == "-" {
                     // Read from stdin
-                    use std::io::Read;
-                    let mut buffer = Vec::new();
-                    io::stdin().read_to_end(&mut buffer).map_err(|e| {
-                        GitAiError::Generic(format!("Failed to read from stdin: {}", e))
-                    })?;
-                    buffer
+                    read_blame_input(io::stdin(), "blame contents stdin")?
                 } else {
                     // Read from file
-                    fs::read(contents_arg).map_err(|e| {
+                    crate::utils::read_file_with_limit(
+                        std::path::Path::new(contents_arg),
+                        MAX_BLAME_CONTENT_BYTES as u64,
+                        "blame contents file",
+                    )
+                    .map_err(|error| {
                         GitAiError::Generic(format!(
-                            "Failed to read contents file '{}': {}",
-                            contents_arg, e
+                            "Failed to read contents file '{contents_arg}': {error}"
                         ))
                     })?
                 };
+                validate_blame_content(&data, "blame contents")?;
                 options.contents_data = Some(data);
                 i += 2;
             }
@@ -2235,4 +2292,26 @@ fn parse_line_range(range_str: &str) -> Option<(u32, u32)> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod memory_tests {
+    use super::*;
+
+    #[test]
+    fn blame_input_reader_stops_after_limit() {
+        let error = read_blame_input_with_limit(std::io::repeat(b'x'), 1024, "test input")
+            .expect_err("unbounded reader must be capped");
+
+        assert!(error.to_string().contains("1024 byte limit"));
+    }
+
+    #[test]
+    fn blame_content_rejects_excessive_line_count() {
+        let contents = vec![b'\n'; MAX_BLAME_CONTENT_LINES + 1];
+        let error = validate_blame_content(&contents, "test input")
+            .expect_err("excessive line index must be rejected");
+
+        assert!(error.to_string().contains("1000000 line limit"));
+    }
 }

--- a/tests/integration/blame_contents_memory.rs
+++ b/tests/integration/blame_contents_memory.rs
@@ -1,0 +1,71 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+#[test]
+fn oversized_blame_contents_file_is_rejected_and_attribution_recovers() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("tracked.txt");
+    file.set_contents(lines!["first", "second", "third"]);
+    repo.stage_all_and_commit("initial").unwrap();
+    file.assert_committed_lines(lines!["first".human(), "second".human(), "third".human(),]);
+
+    let contents_path = repo.test_home_path().join("oversized-contents.txt");
+    let contents = fs::File::create(&contents_path).unwrap();
+    contents.set_len(32 * 1024 * 1024 + 1).unwrap();
+    let contents_path = contents_path.to_string_lossy().to_string();
+
+    let error = repo
+        .git_ai(&["blame", "--contents", &contents_path, "tracked.txt"])
+        .expect_err("oversized blame contents must fail");
+    assert!(
+        error.contains("blame contents file exceeded the 33554432 byte limit"),
+        "unexpected blame error: {error}"
+    );
+
+    file.insert_at(3, lines!["AI recovery".ai()]);
+    repo.stage_all_and_commit("AI recovery").unwrap();
+    file.assert_committed_lines(lines![
+        "first".human(),
+        "second".human(),
+        "third".ai(),
+        "AI recovery".ai(),
+    ]);
+}
+
+#[test]
+fn oversized_blame_contents_stdin_reports_one_error_and_attribution_recovers() {
+    let repo = TestRepo::new();
+    let tracked_path = repo.path().join("tracked.txt");
+    fs::write(&tracked_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let oversized_input = vec![b'x'; 32 * 1024 * 1024 + 1];
+    let error = repo
+        .git_ai_with_stdin(
+            &["blame", "--contents", "-", "tracked.txt"],
+            &oversized_input,
+        )
+        .expect_err("oversized blame stdin must fail");
+    assert_eq!(
+        error.matches("Generic error:").count(),
+        1,
+        "blame stdin error must not be wrapped twice: {error}"
+    );
+    assert!(
+        error.contains(
+            "Failed to parse blame arguments: Generic error: blame contents stdin exceeded the \
+             33554432 byte limit (33554433)"
+        ),
+        "unexpected blame stdin error: {error}"
+    );
+    drop(oversized_input);
+
+    fs::write(&tracked_path, "base\nAI recovery\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI recovery").unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "AI recovery".ai(),]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -22,6 +22,7 @@ mod bash_tool_conformance;
 mod bash_tool_provenance;
 mod bash_tool_timeouts;
 mod blame_comprehensive;
+mod blame_contents_memory;
 mod blame_flags;
 mod blame_subdirectory;
 mod checkout_switch;


### PR DESCRIPTION
## Bug
`git-ai blame --contents` and alternate-content paths read stdin/files without byte or line ceilings. A compact input containing millions of empty lines could also trigger very large line-index allocations.

## Fix
Bound alternate blame content to 32 MiB and 1,000,000 lines, reject oversize before attribution work, and use the same checked reader for stdin and file-backed inputs. Propagate stdin reader errors directly so oversized input reports one clear `Generic error:` prefix.

## Verification
Unit tests cover byte and newline amplification. `tests/integration/blame_contents_memory.rs` runs oversized file and stdin content through real `TestRepo` blame workflows, asserts the exact single-prefix failure behavior, then verifies line-level attribution recovery after each failure. The complete local suite passes (2,203 library, 58 daemon, 3,279 integration, 20 note-sync, and active doctests).