### PR TITLE
fix(daemon): bound client response frames

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7873,22 +7873,42 @@ fn write_all_daemon_client_stream(
     Ok(())
 }
 
-fn read_daemon_client_line<R: BufRead>(
+pub(crate) fn read_daemon_client_line<R: BufRead>(
     reader: &mut R,
     socket_path: &Path,
     response_timeout: Duration,
 ) -> Result<String, GitAiError> {
-    let mut line = String::new();
+    let mut line = Vec::with_capacity(MAX_CONTROL_JSON_LINE_BYTES.min(8 * 1024));
     let deadline = std::time::Instant::now() + response_timeout;
     loop {
-        match reader.read_line(&mut line) {
-            Ok(0) => {
-                return Err(GitAiError::Generic(format!(
-                    "daemon socket {} closed without a response",
-                    socket_path.display()
-                )));
+        match reader.fill_buf() {
+            Ok([]) => {
+                if line.is_empty() {
+                    return Err(GitAiError::Generic(format!(
+                        "daemon socket {} closed without a response",
+                        socket_path.display()
+                    )));
+                }
+                break;
             }
-            Ok(_) => return Ok(line),
+            Ok(available) => {
+                let chunk_len = available
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .map_or(available.len(), |index| index + 1);
+                if line.len().saturating_add(chunk_len) > MAX_CONTROL_JSON_LINE_BYTES {
+                    return Err(GitAiError::Generic(format!(
+                        "daemon response from {} exceeds {} bytes",
+                        socket_path.display(),
+                        MAX_CONTROL_JSON_LINE_BYTES
+                    )));
+                }
+                line.extend_from_slice(&available[..chunk_len]);
+                reader.consume(chunk_len);
+                if line.last() == Some(&b'\n') {
+                    break;
+                }
+            }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(error)
                 if matches!(
@@ -7914,6 +7934,9 @@ fn read_daemon_client_line<R: BufRead>(
             }
         }
     }
+
+    String::from_utf8(line)
+        .map_err(|error| GitAiError::IoError(io::Error::new(io::ErrorKind::InvalidData, error)))
 }
 
 #[cfg(windows)]

--- a/src/daemon/telemetry_handle.rs
+++ b/src/daemon/telemetry_handle.rs
@@ -12,7 +12,7 @@ use crate::daemon::control_api::{
     CasSyncPayload, ControlRequest, ControlResponse, TelemetryEnvelope,
 };
 use crate::daemon::{DaemonClientStream, open_local_socket_stream_with_timeout};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufReader, Write};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
@@ -112,10 +112,12 @@ impl DaemonTelemetryHandle {
             .flush()
             .map_err(|e| format!("flush: {}", e))?;
 
-        let mut line = String::new();
-        self.conn
-            .read_line(&mut line)
-            .map_err(|e| format!("read: {}", e))?;
+        let line = crate::daemon::read_daemon_client_line(
+            &mut self.conn,
+            &self.socket_path,
+            crate::daemon::control_request_response_timeout(request),
+        )
+        .map_err(|e| format!("read: {}", e))?;
         if line.trim().is_empty() {
             return Err("empty response from daemon".to_string());
         }

--- a/tests/integration/daemon_ipc_memory.rs
+++ b/tests/integration/daemon_ipc_memory.rs
@@ -4,10 +4,19 @@ use crate::repos::test_repo::TestRepo;
 use crate::repos::test_repo::new_daemon_test_sync_session_id;
 use git_ai::daemon::open_local_socket_stream_with_timeout;
 #[cfg(not(windows))]
-use git_ai::daemon::{ControlRequest, send_control_request_with_timeout};
+use git_ai::daemon::{ControlRequest, DaemonConfig, send_control_request_with_timeout};
+#[cfg(not(windows))]
+use interprocess::local_socket::{GenericFilePath, ListenerOptions, prelude::*};
 use std::fs;
 use std::io::Write;
+#[cfg(not(windows))]
+use std::io::{BufRead, BufReader};
+#[cfg(not(windows))]
+use std::thread;
 use std::time::Duration;
+
+#[cfg(not(windows))]
+const MAX_CONTROL_RESPONSE_BYTES: usize = 36 * 1024 * 1024;
 
 #[cfg(target_os = "linux")]
 fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
@@ -263,6 +272,73 @@ fn control_connection_limit_backpressures_without_dropping_requests() {
     repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
         .unwrap();
     repo.stage_all_and_commit("AI edit after control pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn oversized_control_response_is_rejected_and_attribution_recovers() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let fake_home = repo.test_home_path().join("oversized-control-response");
+    let socket_path = DaemonConfig::from_home(&fake_home).control_socket_path;
+    fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    let socket_name = socket_path
+        .as_path()
+        .to_fs_name::<GenericFilePath>()
+        .expect("fake control socket path should be valid");
+    let listener = ListenerOptions::new()
+        .name(socket_name)
+        .create_sync()
+        .expect("fake control socket should bind");
+
+    let server = thread::spawn(move || {
+        let stream = listener
+            .incoming()
+            .next()
+            .expect("fake control server should receive a connection")
+            .expect("fake control connection should succeed");
+        let mut stream = BufReader::new(stream);
+        let mut request = String::new();
+        stream
+            .read_line(&mut request)
+            .expect("fake control server should read a request");
+
+        let chunk = [b'x'; 64 * 1024];
+        let mut remaining = MAX_CONTROL_RESPONSE_BYTES + 1;
+        while remaining > 0 {
+            let write_len = remaining.min(chunk.len());
+            if stream.get_mut().write_all(&chunk[..write_len]).is_err() {
+                return;
+            }
+            remaining -= write_len;
+        }
+        let _ = stream.get_mut().write_all(b"\n");
+        let _ = stream.get_mut().flush();
+    });
+
+    let error = send_control_request_with_timeout(
+        &socket_path,
+        &ControlRequest::Ping,
+        Duration::from_secs(10),
+    )
+    .expect_err("oversized control response must be rejected before JSON parsing");
+    assert!(
+        error.to_string().contains("exceeds 37748736 bytes"),
+        "unexpected oversized response error: {error}"
+    );
+    server.join().unwrap();
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after oversized control response")
         .unwrap();
     file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
 }


### PR DESCRIPTION
## Bug
Server-side control requests were bounded, but clients still used unbounded `read_line` for daemon responses. A corrupt or stale socket peer could send an endless response frame and grow every CLI process until exhaustion.

## Fix
Add a shared incremental response reader capped at the 36 MiB control-frame contract and use it from one-shot and persistent clients. Persistent clients set each request's response deadline before reading and restore the default afterward; oversized frames are rejected without retaining their remainder.

## Verification
`tests/integration/daemon_ipc_memory.rs` includes a malicious control server that streams an oversized response and verifies bounded client failure. Persistent-handle tests exercise a response beyond the default two-second socket timeout.