### PR TITLE
fix(notes): coalesce daemon flush requests

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2623,6 +2623,22 @@ impl Drop for CommitFileTimestampSnapshotPermit {
     }
 }
 
+fn spawn_notes_flush_worker() -> mpsc::Sender<()> {
+    let (tx, mut rx) = mpsc::channel(1);
+    tokio::spawn(async move {
+        while rx.recv().await.is_some() {
+            if let Err(error) = tokio::task::spawn_blocking(|| {
+                crate::daemon::telemetry_worker::flush_notes();
+            })
+            .await
+            {
+                tracing::warn!(%error, "notes flush worker panicked");
+            }
+        }
+    });
+    tx
+}
+
 const COMMIT_FILE_TIMESTAMP_SNAPSHOT_WAIT: Duration = Duration::from_millis(500);
 const SESSION_EVENT_RECOVERY_PREFLIGHT_WAIT: Duration = Duration::from_secs(2);
 const SESSION_EVENT_RECOVERY_PREFLIGHT_POLL: Duration = Duration::from_millis(100);
@@ -2700,6 +2716,7 @@ pub struct ActorDaemonCoordinator {
     // exits via the shutdown select! arm instead of relying on channel closure.
     trace_ingest_tx: std::sync::OnceLock<mpsc::Sender<Value>>,
     telemetry_worker: Option<crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle>,
+    notes_flush_tx: mpsc::Sender<()>,
     stream_worker: Option<crate::daemon::stream_worker::StreamWorkerHandle>,
     transcript_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
     streams_db: Option<Arc<crate::streams::db::StreamsDatabase>>,
@@ -2795,6 +2812,7 @@ impl ActorDaemonCoordinator {
             test_completion_log_lock: Mutex::new(()),
             trace_ingest_tx: std::sync::OnceLock::new(),
             telemetry_worker: None,
+            notes_flush_tx: spawn_notes_flush_worker(),
             stream_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
             streams_db: None,
@@ -6344,11 +6362,13 @@ impl ActorDaemonCoordinator {
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::FlushNotes => {
-                // Trigger an immediate notes flush in a blocking task.
-                // Fire-and-forget: the periodic flush loop is the safety net.
-                tokio::task::spawn_blocking(|| {
-                    crate::daemon::telemetry_worker::flush_notes();
-                });
+                // One active flush and one queued follow-up are sufficient: each
+                // flush drains a batch from the same durable notes database.
+                if let Err(error) = self.notes_flush_tx.try_send(())
+                    && !matches!(error, mpsc::error::TrySendError::Full(_))
+                {
+                    tracing::debug!(%error, "notes flush worker is unavailable");
+                }
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::BashSessionStart {

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -1495,6 +1495,15 @@ pub fn flush_notes() {
     use crate::api::types::{NoteEntry, NotesUploadRequest};
     use crate::config::NotesBackendKind;
 
+    #[cfg(feature = "test-support")]
+    if let Ok(delay_ms) = std::env::var("GIT_AI_TEST_FLUSH_NOTES_DELAY_MS")
+        .unwrap_or_default()
+        .parse::<u64>()
+        && delay_ms > 0
+    {
+        std::thread::sleep(Duration::from_millis(delay_ms));
+    }
+
     let cfg = Config::fresh();
     if cfg.notes_backend_kind() != NotesBackendKind::Http {
         tracing::debug!("notes: skipping flush, backend is not Http");

--- a/tests/integration/daemon_notes_flush_memory.rs
+++ b/tests/integration/daemon_notes_flush_memory.rs
@@ -1,0 +1,54 @@
+#![cfg(target_os = "linux")]
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::daemon::{ControlRequest, send_control_request_with_timeout};
+use std::fs;
+use std::time::Duration;
+
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+#[test]
+fn notes_flush_burst_keeps_threads_bounded_and_attribution_working() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_FLUSH_NOTES_DELAY_MS", "2000")]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let baseline_threads = daemon_thread_count(&repo);
+    for _ in 0..24 {
+        let response = send_control_request_with_timeout(
+            &repo.daemon_control_socket_path(),
+            &ControlRequest::FlushNotes,
+            Duration::from_secs(2),
+        )
+        .expect("notes flush request should complete");
+        assert!(response.ok, "notes flush request should succeed");
+    }
+    std::thread::sleep(Duration::from_millis(250));
+
+    let current_threads = daemon_thread_count(&repo);
+    assert!(
+        current_threads <= baseline_threads + 4,
+        "notes flush burst grew daemon threads from {baseline_threads} to {current_threads}"
+    );
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after notes flush pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -64,6 +64,7 @@ mod daemon_ipc_memory;
 mod daemon_line_range_memory;
 mod daemon_log_memory;
 mod daemon_note_materialization_memory;
+mod daemon_notes_flush_memory;
 mod daemon_reflog_memory;
 mod daemon_repository_reader_memory;
 mod daemon_retained_state_memory;


### PR DESCRIPTION
## Bug
Each daemon notes-flush request scheduled independent flush work even when an equivalent flush was already pending. High commit/checkpoint rates could create an unbounded backlog of redundant database/network work.

## Fix
Coalesce flush requests into a single pending signal and consume it only when the telemetry worker is ready, preserving eventual flush semantics while bounding retained requests to constant space.

## Verification
`tests/integration/daemon_notes_flush_memory.rs` floods a `TestRepo` daemon with flush triggers and verifies the queue coalesces and later valid note work completes. The Linux-only fixture is gated at module scope so non-Linux all-target lint remains clean; all 42 memory regressions and the full suite pass on the final stack tip.