### PR TITLE
fix(metrics): bound rewrite workers

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5998,6 +5998,23 @@ impl ActorDaemonCoordinator {
             }
         }
 
+        #[cfg(feature = "test-support")]
+        if std::env::var("GIT_AI_TEST_FORCE_REWRITE_METRICS_ON_AMEND").as_deref() == Ok("1")
+            && primary == "commit"
+            && cmd.invoked_args.iter().any(|arg| arg == "--amend")
+            && let Some(worktree) = cmd.worktree.as_ref()
+        {
+            let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+            crate::daemon::rewrite_metrics::spawn_rewrite_commit_metrics(
+                &repo,
+                vec![crate::authorship::rewrite::RewriteMetricCommit::new(
+                    "ffffffffffffffffffffffffffffffffffffffff".to_string(),
+                    vec!["eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_string()],
+                    crate::authorship::rewrite::RewriteMetricOperation::Amend,
+                )],
+            );
+        }
+
         if matches!(cmd.primary_command.as_deref(), Some("checkout" | "switch")) {
             apply_checkout_switch_working_log_side_effect(cmd)?;
         }

--- a/src/daemon/rewrite_metrics.rs
+++ b/src/daemon/rewrite_metrics.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::ignore::effective_ignore_patterns;
@@ -8,6 +9,31 @@ use crate::config::Config;
 use crate::error::GitAiError;
 use crate::git::repository::Repository;
 use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, RewriteCommittedValues};
+
+const MAX_CONCURRENT_REWRITE_METRIC_WORKERS: usize = 2;
+const REWRITE_METRIC_WORKER_STACK_BYTES: usize = 512 * 1024;
+static ACTIVE_REWRITE_METRIC_WORKERS: AtomicUsize = AtomicUsize::new(0);
+
+struct RewriteMetricWorkerPermit {
+    active: &'static AtomicUsize,
+}
+
+impl Drop for RewriteMetricWorkerPermit {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn try_acquire_rewrite_metric_worker(
+    active: &'static AtomicUsize,
+) -> Option<RewriteMetricWorkerPermit> {
+    active
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+            (current < MAX_CONCURRENT_REWRITE_METRIC_WORKERS).then_some(current + 1)
+        })
+        .ok()
+        .map(|_| RewriteMetricWorkerPermit { active })
+}
 
 pub(crate) fn spawn_rewrite_commit_metrics(
     repo: &Repository,
@@ -19,11 +45,19 @@ pub(crate) fn spawn_rewrite_commit_metrics(
     if metric_commits.is_empty() {
         return;
     }
+    let Some(permit) = try_acquire_rewrite_metric_worker(&ACTIVE_REWRITE_METRIC_WORKERS) else {
+        tracing::debug!(
+            limit = MAX_CONCURRENT_REWRITE_METRIC_WORKERS,
+            "rewrite metrics worker skipped at capacity"
+        );
+        return;
+    };
 
     let repo = repo.clone();
     if let Ok(runtime) = tokio::runtime::Handle::try_current() {
         runtime.spawn(async move {
             let result = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
                 build_rewrite_metric_events(&repo, &metric_commits)
             })
             .await;
@@ -32,10 +66,15 @@ pub(crate) fn spawn_rewrite_commit_metrics(
                 Err(err) => tracing::warn!(%err, "rewrite metrics worker panicked"),
             }
         });
-    } else {
-        std::thread::spawn(move || {
+    } else if let Err(error) = std::thread::Builder::new()
+        .name("git-ai-rewrite-metrics".to_string())
+        .stack_size(REWRITE_METRIC_WORKER_STACK_BYTES)
+        .spawn(move || {
+            let _permit = permit;
             submit_events(build_rewrite_metric_events(&repo, &metric_commits));
-        });
+        })
+    {
+        tracing::debug!(%error, "failed to spawn rewrite metrics worker");
     }
 }
 
@@ -94,6 +133,15 @@ fn build_rewrite_metric_events(
     repo: &Repository,
     metric_commits: &[RewriteMetricCommit],
 ) -> Vec<MetricEvent> {
+    #[cfg(feature = "test-support")]
+    if let Ok(delay_ms) = std::env::var("GIT_AI_TEST_REWRITE_METRICS_DELAY_MS")
+        .unwrap_or_default()
+        .parse::<u64>()
+        && delay_ms > 0
+    {
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+    }
+
     let mut metric_commits = dedupe_metric_commits(metric_commits.to_vec());
     hydrate_missing_parent_shas(repo, &mut metric_commits);
     hydrate_missing_parent_diffs(repo, &mut metric_commits);
@@ -414,6 +462,28 @@ mod tests {
     use crate::metrics::EventValues;
     use crate::metrics::events::rewrite_committed_pos;
     use std::collections::HashMap;
+
+    #[test]
+    fn rewrite_metric_worker_slots_are_bounded_and_reusable() {
+        static ACTIVE: AtomicUsize = AtomicUsize::new(0);
+        let first = try_acquire_rewrite_metric_worker(&ACTIVE)
+            .expect("first rewrite metric worker slot should be available");
+        let second = try_acquire_rewrite_metric_worker(&ACTIVE)
+            .expect("second rewrite metric worker slot should be available");
+
+        assert!(
+            try_acquire_rewrite_metric_worker(&ACTIVE).is_none(),
+            "rewrite metric workers must stop spawning at capacity"
+        );
+        assert_eq!(ACTIVE.load(Ordering::Acquire), 2);
+
+        drop(first);
+        let replacement = try_acquire_rewrite_metric_worker(&ACTIVE)
+            .expect("released rewrite metric worker slots must be reusable");
+        drop(second);
+        drop(replacement);
+        assert_eq!(ACTIVE.load(Ordering::Acquire), 0);
+    }
 
     fn metric_commit(
         new_sha: &str,

--- a/tests/integration/daemon_rewrite_metrics_memory.rs
+++ b/tests/integration/daemon_rewrite_metrics_memory.rs
@@ -1,0 +1,59 @@
+#![cfg(target_os = "linux")]
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+fn daemon_thread_count(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("Threads:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .expect("daemon status should include Threads")
+}
+
+#[test]
+fn rewrite_metric_burst_keeps_threads_bounded_and_attribution_working() {
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_REWRITE_METRICS_DELAY_MS", "5000"),
+        ("GIT_AI_TEST_FORCE_REWRITE_METRICS_ON_AMEND", "1"),
+    ]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit").unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+
+    let baseline_threads = daemon_thread_count(&repo);
+    for _ in 0..8 {
+        repo.git(&["commit", "--amend", "--no-edit"]).unwrap();
+        file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    }
+
+    let current_threads = daemon_thread_count(&repo);
+    assert!(
+        current_threads <= baseline_threads + 4,
+        "rewrite metric burst grew daemon threads from {baseline_threads} to {current_threads}"
+    );
+
+    fs::write(&file_path, "base\nai line\nsecond ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after rewrite metric pressure")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "ai line".ai(),
+        "second ai line".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -68,6 +68,7 @@ mod daemon_notes_flush_memory;
 mod daemon_reflog_memory;
 mod daemon_repository_reader_memory;
 mod daemon_retained_state_memory;
+mod daemon_rewrite_metrics_memory;
 mod daemon_snapshot_memory;
 mod daemon_working_log_memory;
 mod diff;


### PR DESCRIPTION
## Bug
Rewrite-metric emission spawned a detached OS thread for every rewrite. Large rebases/restacks could produce unbounded simultaneous thread stacks and database work.

## Fix
Gate rewrite-metric workers with a two-permit atomic limiter, use 512 KiB stacks, and release permits through RAII on all exits. Saturated metrics are skipped without affecting rewrite attribution or trace ingestion.

## Verification
Unit tests cover acquisition/release. `tests/integration/daemon_rewrite_metrics_memory.rs` drives a rewrite burst through `TestRepo` and verifies bounded workers and correct repository state. The Linux-only fixture is gated at module scope so non-Linux all-target lint remains clean; all 42 memory regressions and the full suite pass on the final stack tip.