### PR TITLE
fix(hooks): bound post-notes dispatch

### DIFF
--- a/src/authorship/git_ai_hooks.rs
+++ b/src/authorship/git_ai_hooks.rs
@@ -1,16 +1,27 @@
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 
 use crate::config::Config;
 use crate::git::repository::Repository;
 #[cfg(windows)]
 use crate::utils::CREATE_NO_WINDOW;
+use serde::Serialize;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 
 const POST_NOTES_UPDATED_HOOK: &str = "post_notes_updated";
 const HOOK_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
-const HOOK_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const MAX_CONCURRENT_HOOK_COMMANDS: usize = 4;
+const MAX_HOOK_BATCHES_IN_FLIGHT: usize = 2;
+const MAX_HOOK_PAYLOAD_BYTES: usize = 16 * 1_024 * 1_024;
+const HOOK_THREAD_STACK_BYTES: usize = 512 * 1_024;
+const HOOK_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const HOOK_CHILD_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+static HOOK_BATCHES_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+static HOOK_DISPATCHER: OnceLock<Mutex<Option<mpsc::SyncSender<HookBatch>>>> = OnceLock::new();
 
 struct RepoHookContext {
     repo_url: String,
@@ -19,110 +30,260 @@ struct RepoHookContext {
     is_default_branch: bool,
 }
 
+#[derive(Serialize)]
+struct PostNotesUpdatedEntry<'a> {
+    commit_sha: &'a str,
+    repo_url: &'a str,
+    repo_name: &'a str,
+    branch: &'a str,
+    is_default_branch: bool,
+    note_content: &'a str,
+}
+
+struct HookBatchPermit;
+
+impl HookBatchPermit {
+    fn try_acquire() -> Option<Self> {
+        HOOK_BATCHES_IN_FLIGHT
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |in_flight| {
+                (in_flight < MAX_HOOK_BATCHES_IN_FLIGHT).then_some(in_flight + 1)
+            })
+            .ok()
+            .map(|_| Self)
+    }
+}
+
+impl Drop for HookBatchPermit {
+    fn drop(&mut self) {
+        HOOK_BATCHES_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+struct HookBatch {
+    commands: Vec<String>,
+    payload: Arc<Vec<u8>>,
+    completion_tx: mpsc::Sender<()>,
+    _permit: HookBatchPermit,
+}
+
 /// Dispatch configured `git_ai_hooks.post_notes_updated` shell commands.
 ///
 /// The hook input is always passed through stdin as a JSON array of 1..N note entries.
-/// Commands are started in parallel, and we wait up to 3 seconds for completion before
-/// detaching and continuing so git-ai does not block.
+/// Up to four commands are started in parallel by a single bounded dispatcher. The caller
+/// waits up to 3 seconds for completion, while the dispatcher keeps ownership of unfinished
+/// children so repeated slow hooks cannot create unbounded processes or threads.
 pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
     if notes.is_empty() {
         return;
     }
 
-    let hook_commands = Config::get()
-        .git_ai_hook_commands(POST_NOTES_UPDATED_HOOK)
-        .cloned()
-        .unwrap_or_default();
+    let Some(configured_commands) = Config::get().git_ai_hook_commands(POST_NOTES_UPDATED_HOOK)
+    else {
+        return;
+    };
+    let hook_commands = configured_commands.clone();
     if hook_commands.is_empty() {
         return;
     }
 
-    let context = build_repo_hook_context(repo);
-    let repo_url = context.repo_url;
-    let repo_name = context.repo_name;
-    let branch = context.branch;
-    let is_default_branch = context.is_default_branch;
-    let payload = notes
-        .iter()
-        .map(|(commit_sha, note_content)| {
-            serde_json::json!({
-                "commit_sha": commit_sha,
-                "repo_url": repo_url.as_str(),
-                "repo_name": repo_name.as_str(),
-                "branch": branch.as_str(),
-                "is_default_branch": is_default_branch,
-                "note_content": note_content,
-            })
-        })
-        .collect::<Vec<_>>();
-    let payload_json = match serde_json::to_string(&payload) {
-        Ok(json) => json,
-        Err(e) => {
-            tracing::debug!(
-                "[git_ai_hooks] Failed to serialize post_notes_updated payload: {}",
-                e
-            );
-            return;
-        }
+    let Some(permit) = HookBatchPermit::try_acquire() else {
+        tracing::debug!(
+            "[git_ai_hooks] Skipping post_notes_updated hooks because {} batches are already active or queued",
+            MAX_HOOK_BATCHES_IN_FLIGHT
+        );
+        return;
     };
 
-    let mut running_children = Vec::new();
-    for hook_command in hook_commands {
-        let mut child = match spawn_shell_command(&hook_command) {
-            Ok(child) => child,
+    let context = build_repo_hook_context(repo);
+    let payload = notes
+        .iter()
+        .map(|(commit_sha, note_content)| PostNotesUpdatedEntry {
+            commit_sha,
+            repo_url: &context.repo_url,
+            repo_name: &context.repo_name,
+            branch: &context.branch,
+            is_default_branch: context.is_default_branch,
+            note_content,
+        })
+        .collect::<Vec<_>>();
+    let payload_json =
+        match crate::http::serialize_json_with_limit(&payload, MAX_HOOK_PAYLOAD_BYTES) {
+            Ok(json) => json,
             Err(e) => {
                 tracing::debug!(
-                    "[git_ai_hooks] Failed to spawn post_notes_updated hook '{}': {}",
-                    hook_command,
+                    "[git_ai_hooks] Failed to serialize post_notes_updated payload: {}",
                     e
                 );
-                continue;
+                return;
             }
         };
 
-        if let Some(mut stdin) = child.stdin.take() {
-            let payload_for_stdin = payload_json.clone();
-            let command_for_log = hook_command.clone();
-            std::thread::spawn(move || {
-                use std::io::Write;
-                if let Err(e) = stdin.write_all(payload_for_stdin.as_bytes()) {
+    let (completion_tx, completion_rx) = mpsc::channel();
+    let batch = HookBatch {
+        commands: hook_commands,
+        payload: Arc::new(payload_json.into_bytes()),
+        completion_tx,
+        _permit: permit,
+    };
+
+    match try_send_with_restart(hook_dispatcher(), batch, start_hook_dispatcher) {
+        Ok(()) => {}
+        Err(mpsc::TrySendError::Full(_)) => {
+            tracing::debug!("[git_ai_hooks] Post-notes hook dispatcher queue is full");
+            return;
+        }
+        Err(mpsc::TrySendError::Disconnected(_)) => {
+            tracing::debug!("[git_ai_hooks] Post-notes hook dispatcher is unavailable");
+            return;
+        }
+    }
+
+    match completion_rx.recv_timeout(HOOK_WAIT_TIMEOUT) {
+        Ok(()) => {}
+        Err(mpsc::RecvTimeoutError::Timeout) => tracing::debug!(
+            "[git_ai_hooks] Continuing with post-notes hook batch after {}ms",
+            HOOK_WAIT_TIMEOUT.as_millis()
+        ),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            tracing::debug!("[git_ai_hooks] Post-notes hook dispatcher stopped unexpectedly")
+        }
+    }
+}
+
+fn hook_dispatcher() -> &'static Mutex<Option<mpsc::SyncSender<HookBatch>>> {
+    HOOK_DISPATCHER.get_or_init(|| Mutex::new(None))
+}
+
+fn start_hook_dispatcher() -> Option<mpsc::SyncSender<HookBatch>> {
+    let (tx, rx) = mpsc::sync_channel(MAX_HOOK_BATCHES_IN_FLIGHT);
+    match std::thread::Builder::new()
+        .name("git-ai-note-hooks".to_string())
+        .stack_size(HOOK_THREAD_STACK_BYTES)
+        .spawn(move || hook_dispatch_loop(rx))
+    {
+        Ok(_) => Some(tx),
+        Err(error) => {
+            tracing::debug!("[git_ai_hooks] Failed to start hook dispatcher: {}", error);
+            None
+        }
+    }
+}
+
+fn try_send_with_restart<T>(
+    slot: &Mutex<Option<mpsc::SyncSender<T>>>,
+    mut value: T,
+    mut start: impl FnMut() -> Option<mpsc::SyncSender<T>>,
+) -> Result<(), mpsc::TrySendError<T>> {
+    let mut sender = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    for _ in 0..2 {
+        if sender.is_none() {
+            *sender = start();
+        }
+        let Some(active_sender) = sender.as_ref() else {
+            return Err(mpsc::TrySendError::Disconnected(value));
+        };
+        match active_sender.try_send(value) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::TrySendError::Full(value)) => {
+                return Err(mpsc::TrySendError::Full(value));
+            }
+            Err(mpsc::TrySendError::Disconnected(returned)) => {
+                value = returned;
+                *sender = None;
+            }
+        }
+    }
+    Err(mpsc::TrySendError::Disconnected(value))
+}
+
+fn hook_dispatch_loop(rx: mpsc::Receiver<HookBatch>) {
+    while let Ok(batch) = rx.recv() {
+        run_hook_batch(batch);
+    }
+}
+
+fn run_hook_batch(batch: HookBatch) {
+    let command_timeout = hook_command_timeout();
+    for command_group in batch.commands.chunks(MAX_CONCURRENT_HOOK_COMMANDS) {
+        let mut running_children = Vec::with_capacity(command_group.len());
+        for hook_command in command_group {
+            let mut child = match spawn_shell_command(hook_command) {
+                Ok(child) => child,
+                Err(e) => {
                     tracing::debug!(
-                        "[git_ai_hooks] Failed to write post_notes_updated stdin for '{}': {}",
-                        command_for_log,
+                        "[git_ai_hooks] Failed to spawn post_notes_updated hook '{}': {}",
+                        hook_command,
                         e
                     );
+                    continue;
                 }
-            });
-        } else {
-            tracing::debug!(
-                "[git_ai_hooks] Hook '{}' was spawned without a stdin pipe",
-                hook_command
-            );
+            };
+
+            let writer = if let Some(mut stdin) = child.stdin.take() {
+                let payload_for_stdin = Arc::clone(&batch.payload);
+                let command_for_log = hook_command.clone();
+                match std::thread::Builder::new()
+                    .name("git-ai-hook-stdin".to_string())
+                    .stack_size(HOOK_THREAD_STACK_BYTES)
+                    .spawn(move || {
+                        use std::io::Write;
+                        if let Err(e) = stdin.write_all(payload_for_stdin.as_slice()) {
+                            tracing::debug!(
+                                "[git_ai_hooks] Failed to write post_notes_updated stdin for '{}': {}",
+                                command_for_log,
+                                e
+                            );
+                        }
+                    }) {
+                    Ok(writer) => Some(writer),
+                    Err(error) => {
+                        tracing::debug!(
+                            "[git_ai_hooks] Failed to start stdin writer for '{}': {}",
+                            hook_command,
+                            error
+                        );
+                        None
+                    }
+                }
+            } else {
+                tracing::debug!(
+                    "[git_ai_hooks] Hook '{}' was spawned without a stdin pipe",
+                    hook_command
+                );
+                None
+            };
+
+            running_children.push((hook_command.as_str(), child, writer));
         }
 
-        running_children.push((hook_command, child));
+        wait_for_hook_children(running_children, command_timeout);
     }
 
-    wait_for_hooks_or_detach(running_children);
+    let _ = batch.completion_tx.send(());
 }
 
-pub fn post_notes_updated_single(repo: &Repository, commit_sha: &str, note_content: &str) {
-    let note_batch = vec![(commit_sha.to_string(), note_content.to_string())];
-    post_notes_updated(repo, &note_batch);
-}
-
-fn wait_for_hooks_or_detach(mut children: Vec<(String, Child)>) {
-    if children.is_empty() {
-        return;
+fn hook_command_timeout() -> Duration {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(timeout) = std::env::var("GIT_AI_TEST_HOOK_COMMAND_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+    {
+        return Duration::from_millis(timeout);
     }
+    HOOK_COMMAND_TIMEOUT
+}
 
-    let deadline = Instant::now() + HOOK_WAIT_TIMEOUT;
+type RunningHook<'a> = (&'a str, Child, Option<std::thread::JoinHandle<()>>);
 
-    loop {
-        let mut still_running = Vec::new();
-        for (command, mut child) in children {
-            match child.try_wait() {
+fn wait_for_hook_children(mut children: Vec<RunningHook<'_>>, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while !children.is_empty() && Instant::now() < deadline {
+        let mut index = 0;
+        while index < children.len() {
+            match children[index].1.try_wait() {
                 Ok(Some(status)) => {
+                    let (command, _child, writer) = children.swap_remove(index);
                     if !status.success() {
                         tracing::debug!(
                             "[git_ai_hooks] Hook '{}' exited with status {}",
@@ -130,53 +291,60 @@ fn wait_for_hooks_or_detach(mut children: Vec<(String, Child)>) {
                             status
                         );
                     }
+                    join_hook_writer(writer);
                 }
-                Ok(None) => still_running.push((command, child)),
-                Err(e) => {
-                    tracing::debug!("[git_ai_hooks] Failed to poll hook '{}': {}", command, e);
+                Ok(None) => index += 1,
+                Err(error) => {
+                    let (command, mut child, writer) = children.swap_remove(index);
+                    tracing::debug!(
+                        "[git_ai_hooks] Failed waiting for hook '{}': {}",
+                        command,
+                        error
+                    );
+                    terminate_hook_child(&mut child);
+                    join_hook_writer(writer);
                 }
             }
         }
-
-        if still_running.is_empty() {
-            return;
+        if !children.is_empty() {
+            std::thread::sleep(HOOK_CHILD_POLL_INTERVAL);
         }
-
-        if Instant::now() >= deadline {
-            let detached_count = still_running.len();
-            tracing::debug!(
-                "[git_ai_hooks] Detaching {} unfinished hook command(s) after {}ms",
-                detached_count,
-                HOOK_WAIT_TIMEOUT.as_millis()
-            );
-            std::thread::spawn(move || {
-                for (command, mut child) in still_running {
-                    match child.wait() {
-                        Ok(status) => {
-                            if !status.success() {
-                                tracing::debug!(
-                                    "[git_ai_hooks] Detached hook '{}' exited with status {}",
-                                    command,
-                                    status
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            tracing::debug!(
-                                "[git_ai_hooks] Failed waiting detached hook '{}': {}",
-                                command,
-                                e
-                            );
-                        }
-                    }
-                }
-            });
-            return;
-        }
-
-        children = still_running;
-        std::thread::sleep(HOOK_POLL_INTERVAL);
     }
+
+    for (command, mut child, writer) in children {
+        tracing::debug!(
+            "[git_ai_hooks] Hook '{}' exceeded the {}ms command timeout",
+            command,
+            timeout.as_millis()
+        );
+        terminate_hook_child(&mut child);
+        join_hook_writer(writer);
+    }
+}
+
+fn join_hook_writer(writer: Option<std::thread::JoinHandle<()>>) {
+    if let Some(writer) = writer {
+        let _ = writer.join();
+    }
+}
+
+fn terminate_hook_child(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        let process_group = -(child.id() as libc::pid_t);
+        // SAFETY: the hook child is started as the leader of this process group.
+        if unsafe { libc::kill(process_group, libc::SIGKILL) } != 0 {
+            let _ = child.kill();
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+pub fn post_notes_updated_single(repo: &Repository, commit_sha: &str, note_content: &str) {
+    let note_batch = vec![(commit_sha.to_string(), note_content.to_string())];
+    post_notes_updated(repo, &note_batch);
 }
 
 #[cfg(windows)]
@@ -195,6 +363,11 @@ fn shell_command(command: &str) -> Command {
 
 fn spawn_shell_command(command: &str) -> std::io::Result<Child> {
     let mut cmd = shell_command(command);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
     #[cfg(windows)]
     {
         cmd.creation_flags(CREATE_NO_WINDOW);
@@ -251,5 +424,44 @@ fn build_repo_hook_context(repo: &Repository) -> RepoHookContext {
         repo_name,
         branch: branch.clone(),
         is_default_branch: branch == default_branch,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatcher_start_failure_leaves_slot_retryable() {
+        let slot = Mutex::new(None);
+
+        let failed = try_send_with_restart(&slot, 1_u8, || None);
+
+        assert!(matches!(failed, Err(mpsc::TrySendError::Disconnected(1))));
+        assert!(slot.lock().unwrap().is_none());
+
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let mut sender = Some(sender);
+        assert!(
+            try_send_with_restart(&slot, 2_u8, || sender.take()).is_ok(),
+            "a later call should retry dispatcher startup"
+        );
+        assert_eq!(receiver.recv().unwrap(), 2);
+    }
+
+    #[test]
+    fn disconnected_dispatcher_restarts_without_replaying_value() {
+        let (disconnected_sender, disconnected_receiver) = mpsc::sync_channel(1);
+        drop(disconnected_receiver);
+        let slot = Mutex::new(Some(disconnected_sender));
+        let (replacement_sender, replacement_receiver) = mpsc::sync_channel(1);
+        let mut replacement_sender = Some(replacement_sender);
+
+        assert!(
+            try_send_with_restart(&slot, 7_u8, || replacement_sender.take()).is_ok(),
+            "a disconnected dispatcher should be replaced"
+        );
+        assert_eq!(replacement_receiver.recv().unwrap(), 7);
+        assert!(replacement_receiver.try_recv().is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,6 +334,8 @@ pub struct ConfigPatch {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_attributes: Option<HashMap<String, String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_ai_hooks: Option<HashMap<String, Vec<String>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub feature_flags: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_hooks_format: Option<String>,
@@ -1485,20 +1487,24 @@ fn bound_file_config_collections(config: &mut FileConfig) {
         bound_string_map(attributes);
     }
     if let Some(hooks) = &mut config.git_ai_hooks {
-        hooks.retain(|name, commands| {
-            if name.len() > MAX_CONFIG_MAP_VALUE_BYTES {
-                return false;
-            }
-            commands.retain(|command| command.len() <= MAX_CONFIG_MAP_VALUE_BYTES);
-            commands.truncate(MAX_CONFIG_COLLECTION_ITEMS);
-            !commands.is_empty()
-        });
-        if hooks.len() > MAX_CONFIG_COLLECTION_ITEMS {
-            *hooks = std::mem::take(hooks)
-                .into_iter()
-                .take(MAX_CONFIG_COLLECTION_ITEMS)
-                .collect();
+        bound_git_ai_hooks(hooks);
+    }
+}
+
+fn bound_git_ai_hooks(hooks: &mut HashMap<String, Vec<String>>) {
+    hooks.retain(|name, commands| {
+        if name.len() > MAX_CONFIG_MAP_VALUE_BYTES {
+            return false;
         }
+        commands.retain(|command| command.len() <= MAX_CONFIG_MAP_VALUE_BYTES);
+        commands.truncate(MAX_CONFIG_COLLECTION_ITEMS);
+        !commands.is_empty()
+    });
+    if hooks.len() > MAX_CONFIG_COLLECTION_ITEMS {
+        *hooks = std::mem::take(hooks)
+            .into_iter()
+            .take(MAX_CONFIG_COLLECTION_ITEMS)
+            .collect();
     }
 }
 
@@ -1737,6 +1743,11 @@ fn apply_test_config_patch(config: &mut Config) {
             let mut custom_attributes = custom_attributes;
             bound_string_map(&mut custom_attributes);
             config.custom_attributes = custom_attributes;
+        }
+        if let Some(git_ai_hooks) = patch.git_ai_hooks {
+            let mut git_ai_hooks = git_ai_hooks;
+            bound_git_ai_hooks(&mut git_ai_hooks);
+            config.git_ai_hooks = git_ai_hooks;
         }
         if let Some(author) = patch.author {
             config.author = author.normalized();

--- a/src/http.rs
+++ b/src/http.rs
@@ -84,7 +84,7 @@ impl Write for BoundedJsonWriter {
         let remaining = self.limit.saturating_sub(self.bytes.len());
         if buf.len() > remaining {
             return Err(std::io::Error::other(format!(
-                "HTTP JSON request body exceeded the {} byte limit",
+                "JSON serialization exceeded the {} byte limit",
                 self.limit
             )));
         }
@@ -103,7 +103,7 @@ pub(crate) fn serialize_json_body<T: serde::Serialize + ?Sized>(
     serialize_json_with_limit(body, MAX_HTTP_REQUEST_BODY_BYTES)
 }
 
-fn serialize_json_with_limit<T: serde::Serialize + ?Sized>(
+pub(crate) fn serialize_json_with_limit<T: serde::Serialize + ?Sized>(
     body: &T,
     limit: usize,
 ) -> Result<String, serde_json::Error> {

--- a/tests/integration/daemon_hook_memory.rs
+++ b/tests/integration/daemon_hook_memory.rs
@@ -1,0 +1,109 @@
+#![cfg(target_os = "linux")]
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use serde_json::json;
+use std::fs;
+
+fn daemon_child_count(repo: &TestRepo) -> usize {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let mut children = std::collections::HashSet::new();
+    for task in fs::read_dir(format!("/proc/{pid}/task")).unwrap() {
+        let task = task.unwrap();
+        let child_list = fs::read_to_string(task.path().join("children")).unwrap_or_default();
+        children.extend(child_list.split_whitespace().map(str::to_string));
+    }
+    children.len()
+}
+
+#[test]
+fn post_notes_hook_burst_keeps_children_bounded_and_attribution_working() {
+    let hook_dir = tempfile::tempdir().unwrap();
+    let marker = hook_dir.path().join("hook-ran");
+    let gate = hook_dir.path().join("keep-hook-running");
+    fs::write(&gate, "").unwrap();
+    let hook_command = format!(
+        "touch {}; while [ -e {} ]; do sleep 0.05; done",
+        marker.display(),
+        gate.display()
+    );
+    let config_patch = json!({
+        "git_ai_hooks": {
+            "post_notes_updated": vec![hook_command; 8],
+        }
+    })
+    .to_string();
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_CONFIG_PATCH", &config_patch)]);
+    let file_path = repo.path().join("tracked.txt");
+
+    fs::write(&file_path, "ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit with hook pressure")
+        .unwrap();
+    assert!(marker.exists(), "post-notes hook should execute");
+    let children = daemon_child_count(&repo);
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["ai line".ai()]);
+
+    assert!(
+        children <= 4,
+        "post-notes hook burst left {children} daemon child processes"
+    );
+    fs::remove_file(&gate).unwrap();
+
+    fs::write(&file_path, "ai line\nsecond ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI edit after hook pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["ai line".ai(), "second ai line".ai()]);
+}
+
+#[test]
+fn timed_out_post_notes_hook_does_not_block_later_batches() {
+    let hook_dir = tempfile::tempdir().unwrap();
+    let first_marker = hook_dir.path().join("first-hook-started");
+    let recovered_marker = hook_dir.path().join("later-hook-ran");
+    let hook_command = format!(
+        "if [ ! -e {} ]; then touch {}; exec sleep 10; else touch {}; fi",
+        first_marker.display(),
+        first_marker.display(),
+        recovered_marker.display()
+    );
+    let config_patch = json!({
+        "git_ai_hooks": {
+            "post_notes_updated": [hook_command],
+        }
+    })
+    .to_string();
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_CONFIG_PATCH", &config_patch),
+        ("GIT_AI_TEST_HOOK_COMMAND_TIMEOUT_MS", "100"),
+    ]);
+    let file_path = repo.path().join("tracked.txt");
+    let mut file = repo.filename("tracked.txt");
+
+    fs::write(&file_path, "first ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit with hanging hook")
+        .unwrap();
+    file.assert_committed_lines(lines!["first ai line".ai()]);
+    assert!(first_marker.exists(), "first hook should have started");
+    assert!(
+        !recovered_marker.exists(),
+        "first hook invocation should have timed out before recovery"
+    );
+
+    fs::write(&file_path, "first ai line\nsecond ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit after hanging hook")
+        .unwrap();
+    file.assert_committed_lines(lines!["first ai line".ai(), "second ai line".ai()]);
+    assert!(
+        recovered_marker.exists(),
+        "a timed-out hook must not block later hook batches"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -59,6 +59,7 @@ mod daemon_config_memory;
 mod daemon_control_metadata_memory;
 mod daemon_git_config_memory;
 mod daemon_git_output_memory;
+mod daemon_hook_memory;
 mod daemon_http_memory;
 mod daemon_ignore_memory;
 mod daemon_ipc_memory;


### PR DESCRIPTION
## Bug
Post-notes hooks spawned threads and child commands for every batch with unbounded payloads and configuration expansion. Slow hooks could accumulate processes and queued work; a dispatcher startup failure or one hanging hook could permanently disable every later batch.

## Fix
Bound hook payloads at 16 MiB, batches in flight at two, commands per wave at four, configured collections/strings, and thread stacks at 512 KiB. The dispatcher stores a retryable optional sender, restarts after startup failure or disconnection without replay, and gives each command 30 seconds. Timed-out Unix hooks have their process group killed and reaped so descendants cannot hold the dispatcher.

## Verification
Unit tests cover saturation, startup retry, and disconnected-sender restart. `tests/integration/daemon_hook_memory.rs` verifies bounded child counts and uses a timed-out hook followed by a second real commit, asserting the later hook runs and exact line attribution survives. The Linux-only fixture is gated at module scope so non-Linux all-target lint remains clean; all 42 memory regressions and the full suite pass on the final stack tip.