### PR TITLE
fix(authorship): bound recovery candidate queries

### DIFF
--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -8,6 +8,7 @@ use std::sync::{Mutex, OnceLock};
 const SCHEMA_VERSION: usize = 2;
 const RETENTION_SECS: u64 = 30 * 24 * 3600;
 const PRUNE_INTERVAL_SECS: u64 = 24 * 3600;
+const MAX_BASH_RECOVERY_CANDIDATES: usize = 1_024;
 
 const MIGRATIONS: &[&str] = &[
     r#"
@@ -537,6 +538,7 @@ impl BashHistoryDatabase {
             .max()
             .unwrap_or_default()
             .saturating_add(window_ns);
+        let candidate_limit = bash_recovery_candidate_limit();
 
         let mut stmt = self.conn.prepare(
             r#"
@@ -548,12 +550,29 @@ impl BashHistoryDatabase {
             WHERE start_time_ns <= ?1
               AND COALESCE(end_time_ns, start_time_ns) >= ?2
             ORDER BY id ASC
+            LIMIT ?3
             "#,
         )?;
-        let rows = stmt.query_map(params![ns_to_i64(max_ts)?, ns_to_i64(min_ts)?], row_to_call)?;
+        let rows = stmt.query_map(
+            params![
+                ns_to_i64(max_ts)?,
+                ns_to_i64(min_ts)?,
+                candidate_limit.saturating_add(1) as i64,
+            ],
+            row_to_call,
+        )?;
 
         let mut calls = Vec::new();
+        let mut scanned = 0usize;
         for row in rows {
+            scanned += 1;
+            if scanned > candidate_limit {
+                tracing::debug!(
+                    limit = candidate_limit,
+                    "bash attribution recovery skipped at candidate limit"
+                );
+                return Ok(Vec::new());
+            }
             let call = row?;
             if timestamps_ns
                 .iter()
@@ -631,6 +650,17 @@ impl BashHistoryDatabase {
         tx.commit()?;
         Ok(())
     }
+}
+
+fn bash_recovery_candidate_limit() -> usize {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Ok(value) = std::env::var("GIT_AI_TEST_ATTRIBUTION_RECOVERY_CANDIDATE_LIMIT")
+        && let Ok(value) = value.parse::<usize>()
+        && value > 0
+    {
+        return value.min(MAX_BASH_RECOVERY_CANDIDATES);
+    }
+    MAX_BASH_RECOVERY_CANDIDATES
 }
 
 fn invocation_key(session_id: &str, tool_use_id: &str) -> String {
@@ -888,6 +918,44 @@ mod tests {
         let calls = db.candidates_near_timestamps(&[5_000], 3_000).unwrap();
         let ids: Vec<_> = calls.iter().map(|c| c.tool_use_id.as_str()).collect();
         assert_eq!(ids, vec!["near-before", "near-after"]);
+    }
+
+    #[test]
+    fn candidate_query_fails_closed_above_materialization_limit() {
+        let (mut db, _dir) = test_db();
+        let tx = db.conn.transaction().unwrap();
+        {
+            let mut insert = tx
+                .prepare(
+                    r#"
+                    INSERT INTO bash_checkpoint_calls (
+                        invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+                        session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
+                        start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+                        command, metadata_json, created_at, updated_at
+                    )
+                    VALUES (?1, '/repo', '/repo', NULL, ?2, ?3, 'codex', ?2, 'gpt-5',
+                            ?4, ?5, 1000, 2000, NULL, '{}', 1, 1)
+                    "#,
+                )
+                .unwrap();
+            for index in 0..=MAX_BASH_RECOVERY_CANDIDATES {
+                insert
+                    .execute(params![
+                        format!("invocation-{index}"),
+                        format!("session-{index}"),
+                        format!("tool-{index}"),
+                        format!("start-{index}"),
+                        format!("end-{index}"),
+                    ])
+                    .unwrap();
+            }
+        }
+        tx.commit().unwrap();
+
+        let candidates = db.candidates_near_timestamps(&[1_500], 1_000).unwrap();
+
+        assert!(candidates.is_empty());
     }
 
     #[test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -22,6 +22,7 @@ const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
 pub(crate) const MAX_METRIC_EVENT_JSON_BYTES: usize = 2 * 1024 * 1024;
 pub(crate) const MAX_METRIC_UPLOAD_BATCH_BYTES: usize = 8 * 1024 * 1024;
+const MAX_SESSION_EVENT_RECOVERY_CANDIDATES: usize = 1_024;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
 /// Database migrations - each migration upgrades the schema by one version
@@ -1032,6 +1033,7 @@ impl MetricsDatabase {
         else {
             return Ok(Vec::new());
         };
+        let candidate_limit = session_event_recovery_candidate_limit();
 
         let mut stmt = self.conn.prepare(
             r#"
@@ -1056,13 +1058,15 @@ impl MetricsDatabase {
               AND external_session_id IS NOT NULL
               AND external_session_id != ''
             ORDER BY id ASC
+            LIMIT ?4
             "#,
         )?;
         let rows = stmt.query_map(
             params![
                 MetricEventId::SessionEvent as i64,
                 min_event_ts as i64,
-                max_event_ts as i64
+                max_event_ts as i64,
+                candidate_limit.saturating_add(1) as i64,
             ],
             |row| {
                 Ok((
@@ -1079,7 +1083,16 @@ impl MetricsDatabase {
         )?;
 
         let mut candidates = Vec::new();
+        let mut scanned = 0usize;
         for row in rows {
+            scanned += 1;
+            if scanned > candidate_limit {
+                tracing::debug!(
+                    limit = candidate_limit,
+                    "session-event attribution recovery skipped at candidate limit"
+                );
+                return Ok(Vec::new());
+            }
             let (
                 row_id,
                 event_json,
@@ -1363,6 +1376,17 @@ impl MetricsDatabase {
         tx.commit()?;
         Ok(should_emit)
     }
+}
+
+fn session_event_recovery_candidate_limit() -> usize {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Ok(value) = std::env::var("GIT_AI_TEST_ATTRIBUTION_RECOVERY_CANDIDATE_LIMIT")
+        && let Ok(value) = value.parse::<usize>()
+        && value > 0
+    {
+        return value.min(MAX_SESSION_EVENT_RECOVERY_CANDIDATES);
+    }
+    MAX_SESSION_EVENT_RECOVERY_CANDIDATES
 }
 
 fn current_unix_ts() -> u64 {

--- a/tests/integration/daemon_recovery_query_memory.rs
+++ b/tests/integration/daemon_recovery_query_memory.rs
@@ -1,0 +1,105 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log_serialization::generate_session_id;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::{EventAttributes, MetricEvent, PosEncoded, SessionEventValues};
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+const RECOVERY_CANDIDATE_FLOOD: usize = 9;
+
+fn file_mtime_secs(path: &Path) -> u32 {
+    fs::metadata(path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .min(u32::MAX as u64) as u32
+}
+
+fn insert_session_event_flood(db_path: &Path, event_ts: u32) {
+    let events = (0..RECOVERY_CANDIDATE_FLOOD)
+        .map(|index| {
+            let external_session_id = format!("overload-session-{index}");
+            let external_tool_use_id = format!("overload-tool-use-{index}");
+            let session_id = generate_session_id(&external_session_id, "codex");
+            let values = SessionEventValues::with_ids(
+                json!({
+                    "type": "assistant",
+                    "session_id": external_session_id,
+                }),
+                Some(format!("overload-event-{index}")),
+                None,
+                Some(external_tool_use_id),
+            );
+            let attrs = EventAttributes::with_version("test")
+                .tool("codex")
+                .model("gpt-5")
+                .external_session_id(&external_session_id)
+                .session_id(&session_id)
+                .trace_id(format!("overload-trace-{index}"))
+                .repo_url("https://github.com/acme/recovery-query-memory");
+            serde_json::to_string(&MetricEvent::from_values_with_timestamp(
+                values,
+                attrs.to_sparse(),
+                Some(event_ts),
+            ))
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let mut db = MetricsDatabase::open_at_path(db_path).unwrap();
+    db.insert_events(&events).unwrap();
+}
+
+#[test]
+fn recovery_candidate_flood_fails_closed_and_next_commit_stays_attributed() {
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_db_path = metrics_dir.path().join("metrics.db");
+    let metrics_db_path_arg = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path_arg.as_str()),
+        ("GIT_AI_TEST_ATTRIBUTION_RECOVERY_CANDIDATE_LIMIT", "8"),
+    ]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/recovery-query-memory.git",
+    ])
+    .unwrap();
+    let file_path = repo.path().join("tracked.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    fs::write(&file_path, "base\nuncheckpointed line\n").unwrap();
+    insert_session_event_flood(&metrics_db_path, file_mtime_secs(&file_path));
+    repo.stage_all_and_commit("Commit under recovery query pressure")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "uncheckpointed line".unattributed_human(),
+    ]);
+
+    fs::write(
+        &file_path,
+        "base\nuncheckpointed line\ncheckpointed AI line\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI commit after recovery query pressure")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "uncheckpointed line".unattributed_human(),
+        "checkpointed AI line".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -67,6 +67,7 @@ mod daemon_line_range_memory;
 mod daemon_log_memory;
 mod daemon_note_materialization_memory;
 mod daemon_notes_flush_memory;
+mod daemon_recovery_query_memory;
 mod daemon_reflog_memory;
 mod daemon_repository_reader_memory;
 mod daemon_retained_state_memory;


### PR DESCRIPTION
## Bug
Attribution recovery queried every matching bash-history and session-event row before ranking candidates. Long-lived databases could materialize thousands of large JSON records for one recovery attempt.

## Fix
Push a 1,024-candidate ceiling into both SQLite queries, preserve nearest/latest ordering, and expose a test-only lower cap for deterministic saturation tests. This bounds rows before Rust materialization.

## Verification
Database tests cover SQL-level limits. `tests/integration/daemon_recovery_query_memory.rs` seeds excess candidates and verifies recovery remains bounded while selecting the correct attribution.