### PR TITLE
fix(metrics): bound retention pruning memory

### DIFF
--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -19,6 +19,7 @@ const SCHEMA_VERSION: usize = 4;
 
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
+const METRIC_PRUNE_SCAN_BATCH_SIZE: usize = 256;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
 pub(crate) const MAX_METRIC_EVENT_JSON_BYTES: usize = 2 * 1024 * 1024;
 pub(crate) const MAX_METRIC_UPLOAD_BATCH_BYTES: usize = 8 * 1024 * 1024;
@@ -139,6 +140,12 @@ struct MetricEventMetadata {
     external_event_id: Option<String>,
     external_parent_event_id: Option<String>,
     external_tool_use_id: Option<String>,
+}
+
+struct MetricPruneScanBatch {
+    ids: Vec<i64>,
+    last_id: Option<i64>,
+    scanned: usize,
 }
 
 /// Database wrapper for metrics storage
@@ -907,45 +914,95 @@ impl MetricsDatabase {
         }
 
         let cutoff = now.saturating_sub(Self::METRICS_RETENTION_SECS);
-        let rows_to_prune = self.old_metric_row_ids(cutoff)?;
+        self.conn.execute(
+            "DELETE FROM metrics \
+             WHERE event_ts IS NOT NULL \
+               AND event_ts >= 0 \
+               AND event_ts < ?1",
+            params![i64::try_from(cutoff).unwrap_or(i64::MAX)],
+        )?;
+
+        let mut after_id = 0i64;
+        loop {
+            let batch = self.old_legacy_metric_row_ids_after(
+                cutoff,
+                after_id,
+                METRIC_PRUNE_SCAN_BATCH_SIZE,
+            )?;
+            if !batch.ids.is_empty() {
+                let tx = self.conn.transaction()?;
+                {
+                    let mut stmt = tx.prepare_cached("DELETE FROM metrics WHERE id = ?1")?;
+                    for id in batch.ids {
+                        stmt.execute(params![id])?;
+                    }
+                }
+                tx.commit()?;
+            }
+            let Some(last_id) = batch.last_id else {
+                break;
+            };
+            after_id = last_id;
+            if batch.scanned < METRIC_PRUNE_SCAN_BATCH_SIZE {
+                break;
+            }
+        }
+
         let tx = self.conn.transaction()?;
         tx.execute(
             "INSERT OR REPLACE INTO schema_metadata (key, value) VALUES ('metrics_last_prune_ts', ?1)",
             params![now.to_string()],
         )?;
-        {
-            let mut stmt = tx.prepare_cached("DELETE FROM metrics WHERE id = ?1")?;
-            for id in rows_to_prune {
-                stmt.execute(params![id])?;
-            }
-        }
         tx.commit()?;
 
         Ok(())
     }
 
-    fn old_metric_row_ids(&self, cutoff: u64) -> Result<Vec<i64>, GitAiError> {
+    fn old_legacy_metric_row_ids_after(
+        &self,
+        cutoff: u64,
+        after_id: i64,
+        limit: usize,
+    ) -> Result<MetricPruneScanBatch, GitAiError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, event_json, event_ts, delivered_ts FROM metrics ORDER BY id ASC",
+            "SELECT id, length(CAST(event_json AS BLOB)), event_json, event_ts, delivered_ts \
+             FROM metrics \
+             WHERE id > ?1 AND (event_ts IS NULL OR event_ts < 0) \
+             ORDER BY id ASC \
+             LIMIT ?2",
         )?;
-        let rows = stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, Option<i64>>(2)?,
-                row.get::<_, Option<i64>>(3)?,
-            ))
-        })?;
+        let mut rows = stmt.query(params![after_id, i64::try_from(limit).unwrap_or(i64::MAX)])?;
 
         let mut ids = Vec::new();
-        for row in rows {
-            let (id, event_json, event_ts, delivered_ts) = row?;
-            if metric_row_is_older_than_cutoff(&event_json, event_ts, delivered_ts, cutoff) {
+        let mut last_id = None;
+        let mut scanned = 0usize;
+        while let Some(row) = rows.next()? {
+            let id = row.get::<_, i64>(0)?;
+            let event_json_bytes = row.get::<_, i64>(1)?.max(0);
+            let event_ts = row.get::<_, Option<i64>>(3)?;
+            let delivered_ts = row.get::<_, Option<i64>>(4)?;
+            last_id = Some(id);
+            scanned = scanned.saturating_add(1);
+            let is_old = if event_json_bytes
+                > i64::try_from(MAX_METRIC_EVENT_JSON_BYTES).unwrap_or(i64::MAX)
+            {
+                delivered_ts
+                    .and_then(|timestamp| u64::try_from(timestamp).ok())
+                    .is_some_and(|timestamp| timestamp < cutoff)
+            } else {
+                let event_json = row.get::<_, String>(2)?;
+                metric_row_is_older_than_cutoff(&event_json, event_ts, delivered_ts, cutoff)
+            };
+            if is_old {
                 ids.push(id);
             }
         }
 
-        Ok(ids)
+        Ok(MetricPruneScanBatch {
+            ids,
+            last_id,
+            scanned,
+        })
     }
 
     /// Get count of pending metrics.
@@ -2981,6 +3038,62 @@ mod tests {
             unix_now().saturating_sub(MetricsDatabase::METRICS_RETENTION_SECS + 1);
         db.insert_events_with_delivered_ts(&["not-json".to_string()], Some(old_delivered_ts))
             .unwrap();
+
+        let total: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(total, 0);
+    }
+
+    #[test]
+    fn test_prunes_legacy_rows_after_full_retained_scan_batch() {
+        let (mut db, _temp_dir) = create_test_db();
+        let now = unix_now();
+        let old_delivered_ts = now.saturating_sub(MetricsDatabase::METRICS_RETENTION_SECS + 1);
+        let tx = db.conn.transaction().unwrap();
+        {
+            let mut insert = tx
+                .prepare("INSERT INTO metrics (event_json, delivered_ts) VALUES (?1, ?2)")
+                .unwrap();
+            for index in 0..=METRIC_PRUNE_SCAN_BATCH_SIZE {
+                let delivered_ts = if index == METRIC_PRUNE_SCAN_BATCH_SIZE {
+                    old_delivered_ts
+                } else {
+                    now
+                };
+                insert
+                    .execute(params![format!("not-json-{index}"), delivered_ts as i64])
+                    .unwrap();
+            }
+        }
+        tx.commit().unwrap();
+
+        db.prune_old_metrics_if_due().unwrap();
+
+        let total: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM metrics", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(total, METRIC_PRUNE_SCAN_BATCH_SIZE as i64);
+    }
+
+    #[test]
+    fn test_prunes_oversized_legacy_row_without_parsing_json() {
+        let (mut db, _temp_dir) = create_test_db();
+        let old_delivered_ts =
+            unix_now().saturating_sub(MetricsDatabase::METRICS_RETENTION_SECS + 1);
+        db.conn
+            .execute(
+                "INSERT INTO metrics (event_json, delivered_ts) VALUES (?1, ?2)",
+                params![
+                    "x".repeat(MAX_METRIC_EVENT_JSON_BYTES + 1),
+                    old_delivered_ts as i64,
+                ],
+            )
+            .unwrap();
+
+        db.prune_old_metrics_if_due().unwrap();
 
         let total: i64 = db
             .conn

--- a/tests/integration/daemon_metric_prune_memory.rs
+++ b/tests/integration/daemon_metric_prune_memory.rs
@@ -1,0 +1,132 @@
+#![cfg(target_os = "linux")]
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::db::MetricsDatabase;
+use rusqlite::params;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const OVERSIZED_METRIC_BYTES: usize = 48 * 1_024 * 1_024;
+
+fn codex_checkpoint(repo: &TestRepo, file_path: &Path, hook_event_name: &str) {
+    let hook_input = json!({
+        "session_id": "metric-prune-memory-session",
+        "cwd": repo.canonical_path().to_string_lossy(),
+        "hook_event_name": hook_event_name,
+        "tool_name": "apply_patch",
+        "tool_use_id": "metric-prune-memory-edit",
+        "model": "gpt-5",
+        "tool_input": {
+            "patch": format!("*** Update File: {}\n", file_path.to_string_lossy())
+        },
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
+        .unwrap();
+}
+
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+fn wait_for_metric_database(metrics_db_path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if MetricsDatabase::open_at_path(metrics_db_path).is_ok() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "metrics database was not initialized"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_row_deletion(metrics_db_path: &std::path::Path, row_id: i64) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let conn = git_ai::sqlite::open_with_memory_limits(metrics_db_path).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM metrics WHERE id = ?1",
+                params![row_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if count == 0 {
+            return;
+        }
+        assert!(Instant::now() < deadline, "old metric row was not pruned");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn cached_metric_pruning_does_not_materialize_oversized_json() {
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_db_path = metrics_dir.path().join("metrics.db");
+    let metrics_db_path_arg = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path_arg.as_str(),
+    )]);
+    let file_path = repo.path().join("tracked.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+    wait_for_metric_database(&metrics_db_path);
+
+    let baseline_hwm_kib = daemon_hwm_kib(&repo);
+    let old_event_ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .saturating_sub(366 * 24 * 60 * 60);
+    let oversized_json = format!(r#"{{"payload":"{}"}}"#, "x".repeat(OVERSIZED_METRIC_BYTES));
+    let conn = git_ai::sqlite::open_with_memory_limits(&metrics_db_path).unwrap();
+    conn.execute(
+        "INSERT INTO metrics (event_json, delivered_ts, event_ts, event_kind) \
+         VALUES (?1, ?2, ?3, 1)",
+        params![oversized_json, old_event_ts as i64, old_event_ts as i64],
+    )
+    .unwrap();
+    drop(oversized_json);
+    let oversized_row_id = conn.last_insert_rowid();
+    conn.execute(
+        "INSERT OR REPLACE INTO schema_metadata (key, value) \
+         VALUES ('metrics_last_prune_ts', '0')",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    codex_checkpoint(&repo, &file_path, "PreToolUse");
+    fs::write(&file_path, "base\nai line\n").unwrap();
+    codex_checkpoint(&repo, &file_path, "PostToolUse");
+    repo.stage_all_and_commit("AI commit triggers metric pruning")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    wait_for_row_deletion(&metrics_db_path, oversized_row_id);
+
+    let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm_kib);
+    assert!(
+        hwm_growth_kib < 32 * 1_024,
+        "cached metric pruning grew daemon HWM by {hwm_growth_kib} KiB"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -65,6 +65,7 @@ mod daemon_ignore_memory;
 mod daemon_ipc_memory;
 mod daemon_line_range_memory;
 mod daemon_log_memory;
+mod daemon_metric_prune_memory;
 mod daemon_note_materialization_memory;
 mod daemon_notes_flush_memory;
 mod daemon_recovery_query_memory;


### PR DESCRIPTION
## Bug
Metric retention pruning selected and parsed an unbounded set of rows, including oversized legacy JSON, before deleting expired data. A large telemetry database could spike memory during background maintenance.

## Fix
Scan in 256-row pages, use SQLite byte length to reject oversized legacy payloads before loading them, and continue pagination until retention semantics are satisfied. Work and memory are bounded per page.

## Verification
Unit tests cover full-page continuation and oversized legacy rows. `tests/integration/daemon_metric_prune_memory.rs` seeds a 48 MiB legacy metric and verifies pruning without materialization. The Linux-only fixture is gated at module scope so non-Linux all-target lint remains clean; all 42 memory regressions and the full suite pass on the final stack tip.