### PR TITLE
fix(streams): bound SQLite transcript fanout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time", "macr
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 interprocess = "2.4"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31", features = ["bundled", "limits"] }
 libc = "0.2"
 jsonc-parser = { version = "0.32", features = ["cst"] }
 dirs = "5.0"

--- a/src/streams/agents/copilot_otel.rs
+++ b/src/streams/agents/copilot_otel.rs
@@ -49,8 +49,12 @@ pub fn read_otel_spans_incremental(
     }
 
     let span_ids: Vec<&str> = spans.iter().map(|s| s.span_id.as_str()).collect();
-    let attributes = read_attributes_for_spans(&conn, &span_ids)?;
-    let events = read_events_for_spans(&conn, &span_ids)?;
+    let mut auxiliary_bytes = 0usize;
+    let mut auxiliary_rows = 0usize;
+    let attributes =
+        read_attributes_for_spans(&conn, &span_ids, &mut auxiliary_rows, &mut auxiliary_bytes)?;
+    let events =
+        read_events_for_spans(&conn, &span_ids, &mut auxiliary_rows, &mut auxiliary_bytes)?;
 
     let last_span = spans.last().unwrap();
     let new_watermark =
@@ -96,6 +100,33 @@ struct SpanRow {
     chat_session_id: Option<String>,
     turn_index: Option<i64>,
     ttft_ms: Option<f64>,
+}
+
+impl SpanRow {
+    fn retained_text_bytes(&self) -> usize {
+        let required = self
+            .span_id
+            .len()
+            .saturating_add(self.trace_id.len())
+            .saturating_add(self.name.len());
+        [
+            self.parent_span_id.as_ref(),
+            self.status_message.as_ref(),
+            self.operation_name.as_ref(),
+            self.provider_name.as_ref(),
+            self.agent_name.as_ref(),
+            self.conversation_id.as_ref(),
+            self.request_model.as_ref(),
+            self.response_model.as_ref(),
+            self.tool_name.as_ref(),
+            self.tool_call_id.as_ref(),
+            self.tool_type.as_ref(),
+            self.chat_session_id.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .fold(required, |bytes, value| bytes.saturating_add(value.len()))
+    }
 }
 
 fn read_spans_after(
@@ -188,21 +219,43 @@ fn read_spans_after(
         })
         .map_err(|e| map_sqlite_error(e, "Failed to query spans"))?;
 
-    rows.collect::<Result<Vec<_>, _>>()
-        .map_err(|e| map_sqlite_error(e, "Failed to read span row"))
+    let mut spans = Vec::new();
+    let mut batch_bytes = 0usize;
+    for row in rows {
+        let span = row.map_err(|e| map_sqlite_error(e, "Failed to read span row"))?;
+        let row_bytes = span.retained_text_bytes();
+        if row_bytes > crate::streams::types::MAX_JSONL_EVENT_BYTES {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL span {} exceeded the {} byte row limit",
+                    span.span_id,
+                    crate::streams::types::MAX_JSONL_EVENT_BYTES
+                ),
+            });
+        }
+        batch_bytes = batch_bytes.saturating_add(row_bytes);
+        spans.push(span);
+        if crate::streams::types::jsonl_batch_limit_reached(spans.len(), limit, batch_bytes) {
+            break;
+        }
+    }
+    Ok(spans)
 }
 
 fn read_attributes_for_spans(
     conn: &Connection,
     span_ids: &[&str],
+    auxiliary_rows: &mut usize,
+    auxiliary_bytes: &mut usize,
 ) -> Result<HashMap<String, HashMap<String, String>>, StreamError> {
     if span_ids.is_empty() {
         return Ok(HashMap::new());
     }
     let placeholders: String = span_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let sql = format!(
-        "SELECT span_id, key, value FROM span_attributes WHERE span_id IN ({})",
-        placeholders
+        "SELECT span_id, key, value FROM span_attributes WHERE span_id IN ({}) LIMIT {}",
+        placeholders,
+        crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH + 1
     );
     let mut stmt = conn
         .prepare(&sql)
@@ -222,6 +275,36 @@ fn read_attributes_for_spans(
     for row in rows {
         let (span_id, key, value) =
             row.map_err(|e| map_sqlite_error(e, "Failed to read attribute row"))?;
+        *auxiliary_rows = auxiliary_rows.saturating_add(1);
+        if *auxiliary_rows > crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL attribute fanout exceeded the {} row limit",
+                    crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH
+                ),
+            });
+        }
+        let row_bytes = span_id
+            .len()
+            .saturating_add(key.len())
+            .saturating_add(value.as_ref().map_or(0, String::len));
+        if row_bytes > crate::streams::types::MAX_JSONL_EVENT_BYTES {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL attribute exceeded the {} byte row limit",
+                    crate::streams::types::MAX_JSONL_EVENT_BYTES
+                ),
+            });
+        }
+        *auxiliary_bytes = auxiliary_bytes.saturating_add(row_bytes);
+        if *auxiliary_bytes > crate::streams::types::MAX_SQLITE_AUX_BATCH_BYTES {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL auxiliary data exceeded the {} byte batch limit",
+                    crate::streams::types::MAX_SQLITE_AUX_BATCH_BYTES
+                ),
+            });
+        }
         if let Some(v) = value {
             result.entry(span_id).or_default().insert(key, v);
         }
@@ -232,6 +315,8 @@ fn read_attributes_for_spans(
 fn read_events_for_spans(
     conn: &Connection,
     span_ids: &[&str],
+    auxiliary_rows: &mut usize,
+    auxiliary_bytes: &mut usize,
 ) -> Result<HashMap<String, Vec<serde_json::Value>>, StreamError> {
     if span_ids.is_empty() {
         return Ok(HashMap::new());
@@ -239,8 +324,9 @@ fn read_events_for_spans(
     let placeholders: String = span_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
     let sql = format!(
         "SELECT span_id, name, CAST(timestamp_ms AS INTEGER), attributes FROM span_events \
-         WHERE span_id IN ({}) ORDER BY timestamp_ms ASC",
-        placeholders
+         WHERE span_id IN ({}) ORDER BY timestamp_ms ASC LIMIT {}",
+        placeholders,
+        crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH + 1
     );
     let mut stmt = conn
         .prepare(&sql)
@@ -261,6 +347,36 @@ fn read_events_for_spans(
     for row in rows {
         let (span_id, name, timestamp_ms, attributes_json) =
             row.map_err(|e| map_sqlite_error(e, "Failed to read event row"))?;
+        *auxiliary_rows = auxiliary_rows.saturating_add(1);
+        if *auxiliary_rows > crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL span-event fanout exceeded the {} row limit",
+                    crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH
+                ),
+            });
+        }
+        let row_bytes = span_id
+            .len()
+            .saturating_add(name.len())
+            .saturating_add(attributes_json.as_ref().map_or(0, String::len));
+        if row_bytes > crate::streams::types::MAX_JSONL_EVENT_BYTES {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL span event exceeded the {} byte row limit",
+                    crate::streams::types::MAX_JSONL_EVENT_BYTES
+                ),
+            });
+        }
+        *auxiliary_bytes = auxiliary_bytes.saturating_add(row_bytes);
+        if *auxiliary_bytes > crate::streams::types::MAX_SQLITE_AUX_BATCH_BYTES {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "Copilot OTEL auxiliary data exceeded the {} byte batch limit",
+                    crate::streams::types::MAX_SQLITE_AUX_BATCH_BYTES
+                ),
+            });
+        }
         let attrs: serde_json::Value = attributes_json
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or(serde_json::Value::Null);
@@ -535,6 +651,32 @@ mod tests {
         assert_eq!(events[0]["name"], "tool_call");
         assert_eq!(events[0]["timestamp_ms"], 500);
         assert_eq!(events[0]["attributes"]["tool"], "read_file");
+    }
+
+    #[test]
+    fn test_span_event_fanout_exceeding_row_limit_is_rejected() {
+        let (_dir, db_path) = create_test_otel_db();
+        let mut conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
+        insert_span(&conn, "span1", 1000, 100, 50);
+        let transaction = conn.transaction().unwrap();
+        {
+            let mut statement = transaction
+                .prepare(
+                    "INSERT INTO span_events (span_id, name, timestamp_ms, attributes) VALUES ('span1', 'tool_call', ?1, '{}')",
+                )
+                .unwrap();
+            for index in 0..4_097 {
+                statement.execute([index]).unwrap();
+            }
+        }
+        transaction.commit().unwrap();
+        drop(conn);
+
+        let watermark: Box<dyn WatermarkStrategy> = Box::new(TimestampCursorWatermark::initial());
+        match read_otel_spans_incremental(&db_path, watermark, 100) {
+            Err(error) => assert!(error.to_string().contains("row limit")),
+            Ok(_) => panic!("unbounded span-event fanout should be rejected"),
+        }
     }
 
     #[test]

--- a/src/streams/agents/opencode.rs
+++ b/src/streams/agents/opencode.rs
@@ -33,6 +33,11 @@ pub fn open_sqlite_readonly(path: &Path) -> Result<Connection, StreamError> {
                 message: format!("Failed to open OpenCode database {}: {}", path.display(), e),
             })?;
 
+    conn.set_limit(
+        rusqlite::limits::Limit::SQLITE_LIMIT_LENGTH,
+        crate::streams::types::MAX_SQLITE_TRANSCRIPT_ROW_BYTES as i32,
+    );
+
     conn.execute_batch("PRAGMA busy_timeout = 5000;")
         .map_err(|e| StreamError::Fatal {
             message: format!("Failed to set PRAGMAs: {}", e),
@@ -74,11 +79,26 @@ fn read_session_messages_raw_with_limit(
         })?;
 
     let mut messages = Vec::new();
+    let mut batch_bytes = 0usize;
     for row in rows {
         let (id, row_session_id, time_created, time_updated, data) =
             row.map_err(|e| StreamError::Fatal {
                 message: format!("Failed to read message row: {}", e),
             })?;
+
+        if data.len() > crate::streams::types::MAX_JSONL_EVENT_BYTES {
+            return Err(StreamError::Fatal {
+                message: format!(
+                    "OpenCode message {} exceeded the {} byte row limit",
+                    id,
+                    crate::streams::types::MAX_JSONL_EVENT_BYTES
+                ),
+            });
+        }
+        let row_bytes = id
+            .len()
+            .saturating_add(row_session_id.len())
+            .saturating_add(data.len());
 
         let parsed_data: serde_json::Value =
             serde_json::from_str(&data).map_err(|e| StreamError::Parse {
@@ -104,6 +124,10 @@ fn read_session_messages_raw_with_limit(
         map.insert("data".into(), parsed_data);
 
         messages.push((id, time_updated, serde_json::Value::Object(map)));
+        batch_bytes = batch_bytes.saturating_add(row_bytes);
+        if crate::streams::types::jsonl_batch_limit_reached(messages.len(), limit, batch_bytes) {
+            break;
+        }
     }
 
     Ok(messages)
@@ -115,74 +139,111 @@ fn read_session_messages_raw_with_limit(
 /// grouped by message_id.
 fn read_parts_for_messages_with_limit(
     conn: &Connection,
-    session_id: &str,
-    after_updated: i64,
-    limit: usize,
+    message_ids: &[String],
 ) -> Result<HashMap<String, Vec<serde_json::Value>>, StreamError> {
-    let mut stmt = conn
-        .prepare(
+    let mut parts_by_message: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+    let mut row_count = 0usize;
+    let mut batch_bytes = 0usize;
+    const QUERY_IDS_PER_CHUNK: usize = 512;
+
+    for message_id_chunk in message_ids.chunks(QUERY_IDS_PER_CHUNK) {
+        let placeholders = std::iter::repeat_n("?", message_id_chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
             "SELECT id, message_id, session_id, time_created, time_updated, data FROM part \
-             WHERE message_id IN ( \
-                 SELECT id FROM message WHERE session_id = ? AND time_updated > ? ORDER BY time_updated ASC, id ASC LIMIT ? \
-             ) \
-             ORDER BY message_id ASC, time_updated ASC, id ASC",
-        )
-        .map_err(|e| StreamError::Fatal {
+             WHERE message_id IN ({placeholders}) \
+             ORDER BY message_id ASC, time_updated ASC, id ASC \
+             LIMIT {}",
+            crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH + 1
+        );
+        let mut stmt = conn.prepare(&sql).map_err(|e| StreamError::Fatal {
             message: format!("Failed to prepare part query: {}", e),
         })?;
-
-    let rows = stmt
-        .query_map(rusqlite::params![session_id, after_updated, limit], |row| {
-            let id: String = row.get(0)?;
-            let message_id: String = row.get(1)?;
-            let row_session_id: String = row.get(2)?;
-            let time_created: i64 = row.get(3)?;
-            let time_updated: i64 = row.get(4)?;
-            let data: String = row.get(5)?;
-            Ok((
-                id,
-                message_id,
-                row_session_id,
-                time_created,
-                time_updated,
-                data,
-            ))
-        })
-        .map_err(|e| StreamError::Fatal {
-            message: format!("Failed to query parts: {}", e),
-        })?;
-
-    let mut parts_by_message: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
-    for row in rows {
-        let (id, message_id, row_session_id, time_created, time_updated, data) =
-            row.map_err(|e| StreamError::Fatal {
-                message: format!("Failed to read part row: {}", e),
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(message_id_chunk.iter()), |row| {
+                let id: String = row.get(0)?;
+                let message_id: String = row.get(1)?;
+                let row_session_id: String = row.get(2)?;
+                let time_created: i64 = row.get(3)?;
+                let time_updated: i64 = row.get(4)?;
+                let data: String = row.get(5)?;
+                Ok((
+                    id,
+                    message_id,
+                    row_session_id,
+                    time_created,
+                    time_updated,
+                    data,
+                ))
+            })
+            .map_err(|e| StreamError::Fatal {
+                message: format!("Failed to query parts: {}", e),
             })?;
 
-        if let Ok(parsed_data) = serde_json::from_str::<serde_json::Value>(&data) {
-            let mut map = serde_json::Map::with_capacity(6);
-            map.insert("id".into(), serde_json::Value::String(id));
-            map.insert(
-                "message_id".into(),
-                serde_json::Value::String(message_id.clone()),
-            );
-            map.insert(
-                "session_id".into(),
-                serde_json::Value::String(row_session_id),
-            );
-            map.insert(
-                "time_created".into(),
-                serde_json::Value::Number(time_created.into()),
-            );
-            map.insert(
-                "time_updated".into(),
-                serde_json::Value::Number(time_updated.into()),
-            );
-            map.insert("data".into(), parsed_data);
-            parts_by_message
-                .entry(message_id)
-                .or_default()
-                .push(serde_json::Value::Object(map));
+        for row in rows {
+            let (id, message_id, row_session_id, time_created, time_updated, data) =
+                row.map_err(|e| StreamError::Fatal {
+                    message: format!("Failed to read part row: {}", e),
+                })?;
+            row_count = row_count.saturating_add(1);
+            if row_count > crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH {
+                return Err(StreamError::Fatal {
+                    message: format!(
+                        "OpenCode part fanout exceeded the {} row limit",
+                        crate::streams::types::MAX_SQLITE_AUX_ROWS_PER_BATCH
+                    ),
+                });
+            }
+            if data.len() > crate::streams::types::MAX_JSONL_EVENT_BYTES {
+                return Err(StreamError::Fatal {
+                    message: format!(
+                        "OpenCode part {} exceeded the {} byte row limit",
+                        id,
+                        crate::streams::types::MAX_JSONL_EVENT_BYTES
+                    ),
+                });
+            }
+            let row_bytes = id
+                .len()
+                .saturating_add(message_id.len())
+                .saturating_add(row_session_id.len())
+                .saturating_add(data.len());
+            batch_bytes = batch_bytes.saturating_add(row_bytes);
+            if batch_bytes > crate::streams::types::MAX_SQLITE_AUX_BATCH_BYTES {
+                return Err(StreamError::Fatal {
+                    message: format!(
+                        "OpenCode part fanout exceeded the SQLite batch byte limit of {}",
+                        crate::streams::types::MAX_SQLITE_AUX_BATCH_BYTES
+                    ),
+                });
+            }
+
+            if let Ok(parsed_data) = serde_json::from_str::<serde_json::Value>(&data) {
+                let mut map = serde_json::Map::with_capacity(6);
+                map.insert("id".into(), serde_json::Value::String(id));
+                map.insert(
+                    "message_id".into(),
+                    serde_json::Value::String(message_id.clone()),
+                );
+                map.insert(
+                    "session_id".into(),
+                    serde_json::Value::String(row_session_id),
+                );
+                map.insert(
+                    "time_created".into(),
+                    serde_json::Value::Number(time_created.into()),
+                );
+                map.insert(
+                    "time_updated".into(),
+                    serde_json::Value::Number(time_updated.into()),
+                );
+                map.insert("data".into(), parsed_data);
+                parts_by_message
+                    .entry(message_id)
+                    .or_default()
+                    .push(serde_json::Value::Object(map));
+            }
         }
     }
 
@@ -249,13 +310,13 @@ impl Agent for OpenCodeAgent {
             });
         }
 
-        // Read only parts for the matched messages (IN-subquery, single scan)
-        let mut parts_by_message = read_parts_for_messages_with_limit(
-            &conn,
-            session_id,
-            watermark_millis,
-            self.batch_size,
-        )?;
+        // Read only parts for the matched messages in a constant number of
+        // bounded IN queries.
+        let message_ids = messages
+            .iter()
+            .map(|(message_id, _, _)| message_id.clone())
+            .collect::<Vec<_>>();
+        let mut parts_by_message = read_parts_for_messages_with_limit(&conn, &message_ids)?;
 
         let mut max_updated: i64 = watermark_millis;
         let mut events = Vec::with_capacity(messages.len());
@@ -539,6 +600,20 @@ mod tests {
     }
 
     #[test]
+    fn test_sqlite_open_sets_external_row_size_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        drop(crate::sqlite::open_with_memory_limits(&db_path).unwrap());
+
+        let conn = open_sqlite_readonly(&db_path).unwrap();
+
+        assert_eq!(
+            conn.limit(rusqlite::limits::Limit::SQLITE_LIMIT_LENGTH),
+            crate::streams::types::MAX_SQLITE_TRANSCRIPT_ROW_BYTES as i32
+        );
+    }
+
+    #[test]
     fn test_limit_caps_memory_and_watermark_still_drains_all() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.db");
@@ -586,15 +661,48 @@ mod tests {
     }
 
     #[test]
+    fn test_part_fanout_exceeding_batch_bytes_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        create_test_db(&db_path, 1);
+
+        let mut conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
+        let transaction = conn.transaction().unwrap();
+        let payload = format!(r#"{{"type":"text","text":"{}"}}"#, "x".repeat(256 * 1024));
+        for index in 1..40 {
+            transaction
+                .execute(
+                    "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?1, 'msg-0', 'test-session', ?2, ?2, ?3)",
+                    rusqlite::params![format!("fanout-part-{index}"), 1001 + index, payload],
+                )
+                .unwrap();
+        }
+        transaction.commit().unwrap();
+        drop(conn);
+
+        let watermark: Box<dyn WatermarkStrategy> = Box::new(TimestampWatermark::new(
+            chrono::DateTime::<chrono::Utc>::UNIX_EPOCH,
+        ));
+        let result = OpenCodeAgent::new().read_incremental(&db_path, watermark, "test-session");
+        match result {
+            Err(error) => assert!(error.to_string().contains("batch byte limit")),
+            Ok(_) => panic!("unbounded part fanout should be rejected"),
+        }
+    }
+
+    #[test]
     fn test_parts_are_batch_loaded_not_per_message() {
         let db_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/fixtures/opencode-sqlite/opencode.db");
         let conn = open_sqlite_readonly(&db_path).unwrap();
         // watermark=0 matches all messages in the fixture
-        let parts = read_parts_for_messages_with_limit(&conn, "test-session-123", 0, 1000).unwrap();
-        // Verify IN-subquery loading returns parts grouped by message_id.
-        // Single query with IN-subquery instead of one per message,
-        // prevents full-table-scan memory blowup on large unindexed databases.
+        let message_ids = read_session_messages_raw_with_limit(&conn, "test-session-123", 0, 1000)
+            .unwrap()
+            .into_iter()
+            .map(|(message_id, _, _)| message_id)
+            .collect::<Vec<_>>();
+        let parts = read_parts_for_messages_with_limit(&conn, &message_ids).unwrap();
+        // Verify batched IN loading returns parts grouped by message_id.
         assert!(
             !parts.is_empty(),
             "batch parts query must return data from fixture"

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -18,6 +18,18 @@ pub const MAX_MONOLITHIC_JSON_BYTES: u64 = 32 * 1024 * 1024;
 /// Maximum size of auxiliary JSON metadata consulted during transcript processing.
 pub const MAX_JSON_METADATA_BYTES: u64 = 1024 * 1024;
 
+/// Maximum SQLite string/BLOB or aggregate table-row size accepted from an
+/// external transcript database. This is slightly larger than one event so
+/// SQLite can return the event plus its identifying columns.
+pub const MAX_SQLITE_TRANSCRIPT_ROW_BYTES: usize = 2 * 1024 * 1024;
+
+/// Maximum number of auxiliary rows (parts, attributes, or span events)
+/// materialized for one SQLite transcript batch.
+pub const MAX_SQLITE_AUX_ROWS_PER_BATCH: usize = 4_096;
+
+/// Maximum raw auxiliary data retained for one SQLite transcript batch.
+pub const MAX_SQLITE_AUX_BATCH_BYTES: usize = MAX_JSONL_BATCH_BYTES;
+
 pub fn read_bounded_json_file(
     path: &std::path::Path,
     kind: &str,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -171,6 +171,7 @@ mod transcript_discovery_memory;
 mod transcript_memory;
 mod transcript_monolithic_memory;
 mod transcript_queue_memory;
+mod transcript_sqlite_memory;
 mod utf8_filenames;
 mod virtual_attribution_unit;
 mod windsurf;

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -16,6 +16,7 @@ const AI_AUTHOR_NAMES: &[&str] = &[
     "gemini",
     "amp",
     "windsurf",
+    "opencode",
     "devin",
     "cloud-agent",
     "codex-cloud",

--- a/tests/integration/transcript_sqlite_memory.rs
+++ b/tests/integration/transcript_sqlite_memory.rs
@@ -1,0 +1,199 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log_serialization::generate_session_id;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
+use git_ai::metrics::{PosEncoded, SessionEventValues};
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+const EXTERNAL_SESSION_ID: &str = "sqlite-memory-session";
+
+fn create_oversized_opencode_db(path: &Path) {
+    let mut conn = git_ai::sqlite::open_with_memory_limits(path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT);
+         CREATE TABLE message (
+             id TEXT PRIMARY KEY,
+             session_id TEXT NOT NULL,
+             time_created INTEGER NOT NULL,
+             time_updated INTEGER NOT NULL,
+             data TEXT NOT NULL
+         );
+         CREATE TABLE part (
+             id TEXT PRIMARY KEY,
+             message_id TEXT NOT NULL,
+             session_id TEXT NOT NULL,
+             time_created INTEGER NOT NULL,
+             time_updated INTEGER NOT NULL,
+             data TEXT NOT NULL
+         );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO session (id, parent_id) VALUES (?1, NULL)",
+        [EXTERNAL_SESSION_ID],
+    )
+    .unwrap();
+    let internal_session_id = generate_session_id(EXTERNAL_SESSION_ID, "opencode");
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('sqlite-memory-message', ?1, 1000, 1000, ?2)",
+        rusqlite::params![
+            internal_session_id,
+            json!({"role": "assistant", "modelID": "gpt-5"}).to_string()
+        ],
+    )
+    .unwrap();
+
+    let payload = json!({
+        "type": "text",
+        "text": "x".repeat(256 * 1024),
+    })
+    .to_string();
+    let transaction = conn.transaction().unwrap();
+    {
+        let mut statement = transaction
+            .prepare(
+                "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?1, 'sqlite-memory-message', ?2, ?3, ?3, ?4)",
+            )
+            .unwrap();
+        for index in 0..40 {
+            statement
+                .execute(rusqlite::params![
+                    format!("sqlite-memory-part-{index}"),
+                    internal_session_id,
+                    1001 + index,
+                    payload,
+                ])
+                .unwrap();
+        }
+    }
+    transaction.commit().unwrap();
+}
+
+fn repair_opencode_db(path: &Path) {
+    let conn = git_ai::sqlite::open_with_memory_limits(path).unwrap();
+    conn.execute("DELETE FROM part", []).unwrap();
+    conn.execute(
+        "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES ('sqlite-memory-recovery-part', 'sqlite-memory-message', ?1, 1001, 1001, ?2)",
+        rusqlite::params![
+            generate_session_id(EXTERNAL_SESSION_ID, "opencode"),
+            json!({"type": "text", "text": "recovered"}).to_string(),
+        ],
+    )
+    .unwrap();
+}
+
+fn wait_for_recovery_event(metrics_db_path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(db) = MetricsDatabase::open_at_path(metrics_db_path)
+            && db
+                .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+                .unwrap_or_default()
+                .iter()
+                .any(|record| {
+                    SessionEventValues::from_sparse(&record.event.values)
+                        .raw_json
+                        .get("message")
+                        .and_then(|message| message.get("id"))
+                        .and_then(|value| value.as_str())
+                        == Some("sqlite-memory-message")
+                })
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "repaired SQLite transcript was not processed"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
+#[test]
+fn sqlite_transcript_fanout_keeps_daemon_bounded_and_recovers() {
+    let fixture = tempfile::tempdir().unwrap();
+    let storage_path = fixture.path().join("opencode");
+    fs::create_dir_all(&storage_path).unwrap();
+    let db_path = storage_path.join("opencode.db");
+    create_oversized_opencode_db(&db_path);
+
+    let metrics_db_path = fixture.path().join("metrics.db");
+    let metrics_db_path_str = metrics_db_path.to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path_str.as_str(),
+    )]);
+    let file_path = repo.path().join("tracked.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("tracked.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let hook_input = |hook_event_name: &str| {
+        json!({
+            "hook_event_name": hook_event_name,
+            "session_id": EXTERNAL_SESSION_ID,
+            "cwd": repo.canonical_path(),
+            "tool_name": "edit",
+            "tool_input": {"filePath": file_path},
+        })
+        .to_string()
+    };
+    let storage_path_str = storage_path.to_string_lossy().to_string();
+    let pre_hook = hook_input("PreToolUse");
+    repo.git_ai_with_env(
+        &["checkpoint", "opencode", "--hook-input", &pre_hook],
+        &[("GIT_AI_OPENCODE_STORAGE_PATH", storage_path_str.as_str())],
+    )
+    .unwrap();
+    fs::write(&file_path, "base\nai line\n").unwrap();
+
+    #[cfg(target_os = "linux")]
+    let baseline_hwm = daemon_hwm_kib(&repo);
+    let post_hook = hook_input("PostToolUse");
+    repo.git_ai_with_env(
+        &["checkpoint", "opencode", "--hook-input", &post_hook],
+        &[("GIT_AI_OPENCODE_STORAGE_PATH", storage_path_str.as_str())],
+    )
+    .unwrap();
+    std::thread::sleep(Duration::from_secs(2));
+
+    #[cfg(target_os = "linux")]
+    {
+        let hwm_growth_kib = daemon_hwm_kib(&repo).saturating_sub(baseline_hwm);
+        assert!(
+            hwm_growth_kib < 48 * 1024,
+            "SQLite transcript fanout grew daemon HWM by {hwm_growth_kib} KiB"
+        );
+    }
+
+    repair_opencode_db(&db_path);
+    repo.git_ai_with_env(
+        &["checkpoint", "opencode", "--hook-input", &post_hook],
+        &[("GIT_AI_OPENCODE_STORAGE_PATH", storage_path_str.as_str())],
+    )
+    .unwrap();
+    wait_for_recovery_event(&metrics_db_path);
+
+    repo.stage_all_and_commit("AI edit after SQLite transcript pressure")
+        .unwrap();
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+}


### PR DESCRIPTION
## Bug
SQLite-backed Copilot/OpenCode transcript readers could fan one span/message into unlimited auxiliary rows and bytes. SQLite itself also allowed an external database row large enough to allocate before application checks ran.

## Fix
Set SQLite's length limit to 2 MiB, cap auxiliary fanout at 4,096 rows and 8 MiB per batch, constrain SQL queries, and account each row before retaining it. Oversized external rows/fanout are rejected before event construction.

## Verification
Unit tests cover SQLite length, row-count, and byte budgets. `tests/integration/transcript_sqlite_memory.rs` builds oversized/fanout databases and verifies bounded transcript processing.