### PR TITLE
fix(storage): avoid oversized payload materialization

### DIFF
--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -1,5 +1,6 @@
 use crate::authorship::working_log::AgentId;
 use crate::error::GitAiError;
+use crate::git::repository::BatchMaterializationBudget;
 use rusqlite::{Connection, OptionalExtension, params};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -9,6 +10,7 @@ const SCHEMA_VERSION: usize = 2;
 const RETENTION_SECS: u64 = 30 * 24 * 3600;
 const PRUNE_INTERVAL_SECS: u64 = 24 * 3600;
 const MAX_BASH_RECOVERY_CANDIDATES: usize = 1_024;
+const MAX_BASH_RECOVERY_CANDIDATE_BYTES: usize = 2 * 1024 * 1024;
 
 const MIGRATIONS: &[&str] = &[
     r#"
@@ -542,29 +544,59 @@ impl BashHistoryDatabase {
 
         let mut stmt = self.conn.prepare(
             r#"
-            SELECT id, invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
-                   session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
-                   start_trace_id, end_trace_id, start_time_ns, end_time_ns,
-                   command, metadata_json
-            FROM bash_checkpoint_calls
-            WHERE start_time_ns <= ?1
-              AND COALESCE(end_time_ns, start_time_ns) >= ?2
-            ORDER BY id ASC
-            LIMIT ?3
+            WITH sized AS MATERIALIZED (
+                SELECT id,
+                       octet_length(invocation_key)
+                         + octet_length(original_cwd)
+                         + COALESCE(octet_length(repo_work_dir), 0)
+                         + COALESCE(octet_length(repo_discovery_error), 0)
+                         + octet_length(session_id)
+                         + octet_length(tool_use_id)
+                         + octet_length(agent_tool)
+                         + octet_length(agent_external_id)
+                         + octet_length(agent_model)
+                         + COALESCE(octet_length(start_trace_id), 0)
+                         + COALESCE(octet_length(end_trace_id), 0)
+                         + COALESCE(octet_length(command), 0)
+                         + octet_length(metadata_json) AS retained_bytes
+                FROM bash_checkpoint_calls
+                WHERE start_time_ns <= ?1
+                  AND COALESCE(end_time_ns, start_time_ns) >= ?2
+                ORDER BY id ASC
+                LIMIT ?3
+            )
+            SELECT calls.id,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.invocation_key END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.original_cwd END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.repo_work_dir END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.repo_discovery_error END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.session_id END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.tool_use_id END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.agent_tool END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.agent_external_id END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.agent_model END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.start_trace_id END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.end_trace_id END,
+                   calls.start_time_ns, calls.end_time_ns,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.command END,
+                   CASE WHEN sized.retained_bytes <= ?4 THEN calls.metadata_json END,
+                   sized.retained_bytes
+            FROM sized
+            JOIN bash_checkpoint_calls AS calls ON calls.id = sized.id
+            ORDER BY calls.id ASC
             "#,
         )?;
-        let rows = stmt.query_map(
-            params![
-                ns_to_i64(max_ts)?,
-                ns_to_i64(min_ts)?,
-                candidate_limit.saturating_add(1) as i64,
-            ],
-            row_to_call,
-        )?;
+        let mut rows = stmt.query(params![
+            ns_to_i64(max_ts)?,
+            ns_to_i64(min_ts)?,
+            candidate_limit.saturating_add(1) as i64,
+            MAX_BASH_RECOVERY_CANDIDATE_BYTES as i64,
+        ])?;
 
         let mut calls = Vec::new();
         let mut scanned = 0usize;
-        for row in rows {
+        let mut budget = BatchMaterializationBudget::new();
+        while let Some(row) = rows.next()? {
             scanned += 1;
             if scanned > candidate_limit {
                 tracing::debug!(
@@ -573,7 +605,22 @@ impl BashHistoryDatabase {
                 );
                 return Ok(Vec::new());
             }
-            let call = row?;
+            let retained_bytes = sqlite_byte_len(row, 16, "bash recovery candidate")?;
+            if retained_bytes > MAX_BASH_RECOVERY_CANDIDATE_BYTES {
+                tracing::debug!(
+                    limit = MAX_BASH_RECOVERY_CANDIDATE_BYTES,
+                    "bash attribution recovery skipped at per-candidate payload limit"
+                );
+                return Ok(Vec::new());
+            }
+            if let Err(error) = budget.reserve("bash recovery candidate", retained_bytes) {
+                tracing::debug!(
+                    %error,
+                    "bash attribution recovery skipped at payload limit"
+                );
+                return Ok(Vec::new());
+            }
+            let call = row_to_call(row)?;
             if timestamps_ns
                 .iter()
                 .any(|ts| distance_to_call_window(*ts, &call) <= window_ns)
@@ -687,6 +734,12 @@ fn ns_to_i64(ns: u128) -> Result<i64, GitAiError> {
 
 fn i64_to_ns(ns: i64) -> u128 {
     u128::try_from(ns).unwrap_or_default()
+}
+
+fn sqlite_byte_len(row: &rusqlite::Row<'_>, index: usize, kind: &str) -> Result<usize, GitAiError> {
+    let bytes: i64 = row.get(index)?;
+    usize::try_from(bytes)
+        .map_err(|_| GitAiError::Generic(format!("invalid {kind} byte length: {bytes}")))
 }
 
 fn row_to_call(row: &rusqlite::Row<'_>) -> rusqlite::Result<BashCheckpointCall> {
@@ -954,6 +1007,32 @@ mod tests {
         tx.commit().unwrap();
 
         let candidates = db.candidates_near_timestamps(&[1_500], 1_000).unwrap();
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn candidate_query_fails_closed_above_payload_byte_limit() {
+        let (mut db, _dir) = test_db();
+        let metadata = HashMap::from([(
+            "oversized".to_string(),
+            "x".repeat(MAX_BASH_RECOVERY_CANDIDATE_BYTES),
+        )]);
+        db.record_start(&BashCallStart {
+            original_cwd: "/repo".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
+            session_id: "oversized-session".to_string(),
+            tool_use_id: "oversized-tool".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: "oversized-trace".to_string(),
+            started_at_ns: 1_000,
+            command: None,
+            metadata,
+        })
+        .unwrap();
+
+        let candidates = db.candidates_near_timestamps(&[1_000], 1_000).unwrap();
 
         assert!(candidates.is_empty());
     }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -694,7 +694,7 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
     let mut after_id = 0;
 
     loop {
-        let (summary, last_id) = {
+        let (_, last_id) = {
             let mut db_lock = db
                 .lock()
                 .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
@@ -705,10 +705,6 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
             break;
         };
         after_id = id;
-
-        if summary.scanned < METADATA_BACKFILL_BATCH_SIZE {
-            break;
-        }
     }
 
     Ok(())

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -5,6 +5,7 @@
 //! Server handles idempotency.
 
 use crate::error::GitAiError;
+use crate::git::repository::BatchMaterializationBudget;
 use crate::metrics::attrs::attr_pos;
 use crate::metrics::events::{checkpoint_pos, otel_trace_pos, session_event_pos};
 use crate::metrics::pos_encoded::sparse_get_string;
@@ -575,7 +576,7 @@ impl MetricsDatabase {
         let tx = self.conn.transaction()?;
         let (ids, oversized_ids) = {
             let mut stmt = tx.prepare(
-                "SELECT id, length(CAST(event_json AS BLOB)) FROM metrics \
+                "SELECT id, octet_length(event_json) FROM metrics \
                  WHERE delivered_ts IS NULL \
                    AND processing_started_at IS NULL \
                    AND next_retry_at <= ?1 \
@@ -964,13 +965,17 @@ impl MetricsDatabase {
         after_id: i64,
         limit: usize,
     ) -> Result<MetricPruneScanBatch, GitAiError> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, length(CAST(event_json AS BLOB)), event_json, event_ts, delivered_ts \
+        let sql = format!(
+            "SELECT id, octet_length(event_json), \
+                    CASE WHEN octet_length(event_json) <= {} THEN event_json END, \
+                    event_ts, delivered_ts \
              FROM metrics \
              WHERE id > ?1 AND (event_ts IS NULL OR event_ts < 0) \
              ORDER BY id ASC \
              LIMIT ?2",
-        )?;
+            MAX_METRIC_EVENT_JSON_BYTES
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt.query(params![after_id, i64::try_from(limit).unwrap_or(i64::MAX)])?;
 
         let mut ids = Vec::new();
@@ -990,7 +995,12 @@ impl MetricsDatabase {
                     .and_then(|timestamp| u64::try_from(timestamp).ok())
                     .is_some_and(|timestamp| timestamp < cutoff)
             } else {
-                let event_json = row.get::<_, String>(2)?;
+                let event_json = row.get::<_, Option<String>>(2)?.ok_or_else(|| {
+                    GitAiError::Generic(format!(
+                        "legacy metric payload missing within {} byte limit",
+                        MAX_METRIC_EVENT_JSON_BYTES
+                    ))
+                })?;
                 metric_row_is_older_than_cutoff(&event_json, event_ts, delivered_ts, cutoff)
             };
             if is_old {
@@ -1092,56 +1102,72 @@ impl MetricsDatabase {
         };
         let candidate_limit = session_event_recovery_candidate_limit();
 
-        let mut stmt = self.conn.prepare(
+        let candidate_payload_limit = crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES;
+        let event_payload_limit = MAX_METRIC_EVENT_JSON_BYTES;
+        let sql = format!(
             r#"
+            WITH sized AS MATERIALIZED (
+                SELECT
+                    id,
+                    octet_length(event_json) AS event_bytes,
+                    octet_length(event_json)
+                        + COALESCE(octet_length(session_id), 0)
+                        + COALESCE(octet_length(trace_id), 0)
+                        + COALESCE(octet_length(tool), 0)
+                        + COALESCE(octet_length(external_session_id), 0)
+                        + COALESCE(octet_length(external_tool_use_id), 0) AS retained_bytes
+                FROM metrics
+                WHERE event_kind = ?1
+                  AND event_ts >= ?2
+                  AND event_ts <= ?3
+                  AND octet_length(session_id) > 0
+                  AND octet_length(tool) > 0
+                  AND CASE WHEN octet_length(tool) = 7
+                           THEN tool != 'mock_ai'
+                           ELSE 1 END
+                  AND octet_length(external_session_id) > 0
+                ORDER BY id ASC
+                LIMIT ?4
+            )
             SELECT
-                id,
-                event_json,
-                event_ts,
-                session_id,
-                trace_id,
-                tool,
-                external_session_id,
-                external_tool_use_id
-            FROM metrics
-            WHERE event_kind = ?1
-              AND event_ts >= ?2
-              AND event_ts <= ?3
-              AND session_id IS NOT NULL
-              AND session_id != ''
-              AND tool IS NOT NULL
-              AND tool != ''
-              AND tool != 'mock_ai'
-              AND external_session_id IS NOT NULL
-              AND external_session_id != ''
-            ORDER BY id ASC
-            LIMIT ?4
-            "#,
-        )?;
-        let rows = stmt.query_map(
-            params![
-                MetricEventId::SessionEvent as i64,
-                min_event_ts as i64,
-                max_event_ts as i64,
-                candidate_limit.saturating_add(1) as i64,
-            ],
-            |row| {
-                Ok((
-                    row.get::<_, i64>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, i64>(2)?,
-                    row.get::<_, String>(3)?,
-                    row.get::<_, Option<String>>(4)?,
-                    row.get::<_, String>(5)?,
-                    row.get::<_, String>(6)?,
-                    row.get::<_, Option<String>>(7)?,
-                ))
-            },
-        )?;
+                metrics.id,
+                sized.retained_bytes,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.event_json END,
+                metrics.event_ts,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.session_id END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.trace_id END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.tool END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.external_session_id END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.external_tool_use_id END
+            FROM sized
+            JOIN metrics ON metrics.id = sized.id
+            ORDER BY metrics.id ASC
+            "#
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = stmt.query(params![
+            MetricEventId::SessionEvent as i64,
+            min_event_ts as i64,
+            max_event_ts as i64,
+            candidate_limit.saturating_add(1) as i64,
+        ])?;
 
         let mut candidates = Vec::new();
         let mut scanned = 0usize;
-        for row in rows {
+        let mut budget = BatchMaterializationBudget::new();
+        while let Some(row) = rows.next()? {
             scanned += 1;
             if scanned > candidate_limit {
                 tracing::debug!(
@@ -1150,17 +1176,32 @@ impl MetricsDatabase {
                 );
                 return Ok(Vec::new());
             }
-            let (
-                row_id,
-                event_json,
-                event_ts,
-                session_id,
-                trace_id,
-                tool,
-                external_session_id,
-                external_tool_use_id,
-            ) = row?;
+            let retained_bytes = sqlite_byte_len(row, 1, "session-event recovery candidate")?;
+            if let Err(error) = budget.reserve("session-event recovery candidate", retained_bytes) {
+                tracing::debug!(
+                    %error,
+                    "session-event attribution recovery skipped at payload limit"
+                );
+                return Ok(Vec::new());
+            }
+            let Some(event_json) = row.get::<_, Option<String>>(2)? else {
+                tracing::debug!(
+                    limit = MAX_METRIC_EVENT_JSON_BYTES,
+                    "session-event attribution recovery skipped at event payload limit"
+                );
+                return Ok(Vec::new());
+            };
+            let row_id = row.get::<_, i64>(0)?;
+            let event_ts = row.get::<_, i64>(3)?;
+            let session_id = row.get::<_, String>(4)?;
+            let trace_id = row.get::<_, Option<String>>(5)?;
+            let tool = row.get::<_, String>(6)?;
+            let external_session_id = row.get::<_, String>(7)?;
+            let external_tool_use_id = row.get::<_, Option<String>>(8)?;
             if event_ts < 0 || event_ts > u32::MAX as i64 {
+                continue;
+            }
+            if tool == "mock_ai" {
                 continue;
             }
             let event_ts = event_ts as u32;
@@ -1198,30 +1239,57 @@ impl MetricsDatabase {
         let placeholders = std::iter::repeat_n("?", tools.len())
             .collect::<Vec<_>>()
             .join(", ");
+        let candidate_payload_limit = crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES;
+        let event_payload_limit = MAX_METRIC_EVENT_JSON_BYTES;
         let sql = format!(
             r#"
+            WITH sized AS MATERIALIZED (
+                SELECT
+                    id,
+                    octet_length(event_json) AS event_bytes,
+                    octet_length(event_json)
+                        + COALESCE(octet_length(session_id), 0)
+                        + COALESCE(octet_length(trace_id), 0)
+                        + COALESCE(octet_length(tool), 0)
+                        + COALESCE(octet_length(external_session_id), 0)
+                        + COALESCE(octet_length(external_tool_use_id), 0) AS retained_bytes
+                FROM metrics
+                WHERE event_kind = ?1
+                  AND tool IN ({placeholders})
+                  AND event_ts IS NOT NULL
+                  AND octet_length(session_id) > 0
+                  AND CASE WHEN octet_length(tool) = 7
+                           THEN tool != 'mock_ai'
+                           ELSE 1 END
+                  AND octet_length(external_session_id) > 0
+                ORDER BY event_ts DESC, id DESC
+                LIMIT 100
+            )
             SELECT
-                id,
-                event_json,
-                event_ts,
-                session_id,
-                trace_id,
-                tool,
-                external_session_id,
-                external_tool_use_id
-            FROM metrics
-            WHERE event_kind = ?1
-              AND tool IN ({placeholders})
-              AND event_ts IS NOT NULL
-              AND session_id IS NOT NULL
-              AND session_id != ''
-              AND tool IS NOT NULL
-              AND tool != ''
-              AND tool != 'mock_ai'
-              AND external_session_id IS NOT NULL
-              AND external_session_id != ''
-            ORDER BY event_ts DESC, id DESC
-            LIMIT 100
+                metrics.id,
+                sized.retained_bytes,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.event_json END,
+                metrics.event_ts,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.session_id END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.trace_id END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.tool END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.external_session_id END,
+                CASE WHEN sized.retained_bytes <= {candidate_payload_limit}
+                           AND sized.event_bytes <= {event_payload_limit}
+                     THEN metrics.external_tool_use_id END
+            FROM sized
+            JOIN metrics ON metrics.id = sized.id
+            ORDER BY metrics.event_ts DESC, metrics.id DESC
             "#
         );
 
@@ -1236,32 +1304,37 @@ impl MetricsDatabase {
         );
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_from_iter(values.iter()), |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, i64>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, Option<String>>(4)?,
-                row.get::<_, String>(5)?,
-                row.get::<_, String>(6)?,
-                row.get::<_, Option<String>>(7)?,
-            ))
-        })?;
+        let mut rows = stmt.query(params_from_iter(values.iter()))?;
 
         let mut candidates = Vec::new();
-        for row in rows {
-            let (
-                row_id,
-                event_json,
-                event_ts,
-                session_id,
-                trace_id,
-                tool,
-                external_session_id,
-                external_tool_use_id,
-            ) = row?;
+        let mut budget = BatchMaterializationBudget::new();
+        while let Some(row) = rows.next()? {
+            let retained_bytes = sqlite_byte_len(row, 1, "latest session-event candidate")?;
+            if let Err(error) = budget.reserve("latest session-event candidate", retained_bytes) {
+                tracing::debug!(
+                    %error,
+                    "latest session-event recovery skipped at payload limit"
+                );
+                return Ok(Vec::new());
+            }
+            let Some(event_json) = row.get::<_, Option<String>>(2)? else {
+                tracing::debug!(
+                    limit = MAX_METRIC_EVENT_JSON_BYTES,
+                    "latest session-event recovery skipped at event payload limit"
+                );
+                return Ok(Vec::new());
+            };
+            let row_id = row.get::<_, i64>(0)?;
+            let event_ts = row.get::<_, i64>(3)?;
+            let session_id = row.get::<_, String>(4)?;
+            let trace_id = row.get::<_, Option<String>>(5)?;
+            let tool = row.get::<_, String>(6)?;
+            let external_session_id = row.get::<_, String>(7)?;
+            let external_tool_use_id = row.get::<_, Option<String>>(8)?;
             if event_ts < 0 || event_ts > u32::MAX as i64 {
+                continue;
+            }
+            if tool == "mock_ai" {
                 continue;
             }
 
@@ -1306,10 +1379,6 @@ impl MetricsDatabase {
                 break;
             };
             after_id = id;
-
-            if summary.scanned < METADATA_BACKFILL_BATCH_SIZE {
-                break;
-            }
         }
 
         Ok(total)
@@ -1324,25 +1393,49 @@ impl MetricsDatabase {
             return Ok((MetricMetadataBackfillSummary::default(), None));
         }
 
-        let rows = {
-            let mut stmt = self.conn.prepare(
-                "SELECT id, event_json FROM metrics \
+        let (rows, scanned, last_id) = {
+            let sql = format!(
+                "SELECT id, octet_length(event_json), \
+                        CASE WHEN octet_length(event_json) <= {} THEN event_json END \
+                 FROM metrics \
                  WHERE id > ?1 AND (event_ts IS NULL OR event_kind IS NULL) \
                  ORDER BY id ASC \
                  LIMIT ?2",
-            )?;
-            let mapped = stmt.query_map(params![after_id, limit as i64], |row| {
-                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-            })?;
-            mapped.collect::<Result<Vec<_>, _>>()?
+                MAX_METRIC_EVENT_JSON_BYTES
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let mut query = stmt.query(params![after_id, limit as i64])?;
+            let mut rows = Vec::new();
+            let mut scanned = 0usize;
+            let mut last_id = None;
+            let mut retained_bytes = 0usize;
+            while let Some(row) = query.next()? {
+                let id = row.get::<_, i64>(0)?;
+                let event_bytes = sqlite_byte_len(row, 1, "metric metadata backfill row")?;
+                if event_bytes <= MAX_METRIC_EVENT_JSON_BYTES
+                    && retained_bytes.saturating_add(event_bytes) > MAX_METRIC_UPLOAD_BATCH_BYTES
+                {
+                    break;
+                }
+                scanned = scanned.saturating_add(1);
+                last_id = Some(id);
+                if event_bytes > MAX_METRIC_EVENT_JSON_BYTES {
+                    continue;
+                }
+                let Some(event_json) = row.get::<_, Option<String>>(2)? else {
+                    continue;
+                };
+                retained_bytes = retained_bytes.saturating_add(event_bytes);
+                rows.push((id, event_json));
+            }
+            (rows, scanned, last_id)
         };
 
         let mut summary = MetricMetadataBackfillSummary {
-            scanned: rows.len(),
+            scanned,
             updated: 0,
         };
-        let last_id = rows.last().map(|(id, _)| *id);
-        if rows.is_empty() {
+        if scanned == 0 {
             return Ok((summary, last_id));
         }
 
@@ -1444,6 +1537,12 @@ fn session_event_recovery_candidate_limit() -> usize {
         return value.min(MAX_SESSION_EVENT_RECOVERY_CANDIDATES);
     }
     MAX_SESSION_EVENT_RECOVERY_CANDIDATES
+}
+
+fn sqlite_byte_len(row: &rusqlite::Row<'_>, index: usize, kind: &str) -> Result<usize, GitAiError> {
+    let bytes: i64 = row.get(index)?;
+    usize::try_from(bytes)
+        .map_err(|_| GitAiError::Generic(format!("invalid {kind} byte length: {bytes}")))
 }
 
 fn current_unix_ts() -> u64 {
@@ -2341,6 +2440,59 @@ mod tests {
     }
 
     #[test]
+    fn test_latest_session_event_candidates_filter_tools_and_mock_agent() {
+        let (mut db, _temp_dir) = create_test_db();
+        let ts = seconds_ago(30);
+        db.insert_events(&[
+            session_event_json(ts, "session-codex", "external-codex", "codex", None),
+            session_event_json(
+                ts + 1,
+                "session-claude",
+                "external-claude",
+                "claude-code",
+                None,
+            ),
+            session_event_json(ts + 2, "session-mock", "external-mock", "mock_ai", None),
+        ])
+        .unwrap();
+
+        let candidates = db
+            .latest_session_event_candidates_for_tools(&["codex", "mock_ai"])
+            .unwrap();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].session_id, "session-codex");
+    }
+
+    #[test]
+    fn test_session_event_candidates_reject_oversized_legacy_payload() {
+        let (mut db, _temp_dir) = create_test_db();
+        let ts = seconds_ago(30);
+        let event = format!(
+            r#"{{
+                "t":{ts},
+                "e":5,
+                "v":{{"0":{{"padding":"{}"}}}},
+                "a":{{
+                    "20":"codex",
+                    "21":"gpt-5",
+                    "23":"external-oversized",
+                    "24":"session-oversized",
+                    "25":"trace-oversized"
+                }}
+            }}"#,
+            "x".repeat(MAX_METRIC_EVENT_JSON_BYTES)
+        );
+        db.insert_events(&[event]).unwrap();
+
+        let candidates = db
+            .session_event_candidates_near_timestamps(&[ts as u128 * NS_PER_SECOND], 3_000_000_000)
+            .unwrap();
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
     fn test_insert_events_leaves_event_metadata_null_for_invalid_json() {
         let (mut db, _temp_dir) = create_test_db();
         let recent_event_ts = days_ago(1);
@@ -2525,6 +2677,43 @@ mod tests {
             .unwrap();
         assert_eq!(empty_summary, MetricMetadataBackfillSummary::default());
         assert_eq!(empty_last_id, None);
+    }
+
+    #[test]
+    fn test_backfill_event_metadata_paginates_by_payload_bytes() {
+        let (mut db, _temp_dir) = create_test_db();
+        let tx = db.conn.transaction().unwrap();
+        for index in 0..10 {
+            tx.execute(
+                "INSERT INTO metrics (event_json) VALUES (?1)",
+                params![event_json_with_payload(days_ago(index + 1), 1024 * 1024)],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+
+        let mut after_id = 0;
+        let mut batches = 0;
+        let mut scanned = 0;
+        let mut updated = 0;
+        loop {
+            let (summary, last_id) = db
+                .backfill_event_metadata_batch_after(after_id, 100)
+                .unwrap();
+            scanned += summary.scanned;
+            updated += summary.updated;
+
+            let Some(last_id) = last_id else {
+                break;
+            };
+            assert!(summary.scanned > 0);
+            after_id = last_id;
+            batches += 1;
+        }
+
+        assert_eq!(scanned, 10);
+        assert_eq!(updated, 10);
+        assert!(batches >= 2);
     }
 
     #[test]

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -381,8 +381,10 @@ impl NotesDatabase {
 
         // Read back the locked rows.
         let select_sql = format!(
-            "SELECT commit_sha, length(CAST(content AS BLOB)), content, attempts \
+            "SELECT commit_sha, octet_length(content), \
+                    CASE WHEN octet_length(content) <= {} THEN content END, attempts \
              FROM notes WHERE commit_sha IN ({})",
+            crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES,
             shas.iter()
                 .enumerate()
                 .map(|(i, _)| format!("?{}", i + 1))
@@ -406,7 +408,9 @@ impl NotesDatabase {
                 budget.reserve("pending note content", content_len)?;
                 out.push(PendingNote {
                     commit_sha: row.get(0)?,
-                    content: row.get(2)?,
+                    content: row.get::<_, Option<String>>(2)?.ok_or_else(|| {
+                        GitAiError::Generic("pending note content exceeded limit".to_string())
+                    })?,
                     attempts: row.get(3)?,
                 });
             }
@@ -480,9 +484,13 @@ impl NotesDatabase {
 
     /// Retrieve the note content for a single commit SHA.
     pub fn get_note(&self, commit_sha: &str) -> Result<Option<String>, GitAiError> {
-        let mut stmt = self.conn.prepare(
-            "SELECT length(CAST(content AS BLOB)), content FROM notes WHERE commit_sha = ?1",
-        )?;
+        let sql = format!(
+            "SELECT octet_length(content), \
+                    CASE WHEN octet_length(content) <= {} THEN content END \
+             FROM notes WHERE commit_sha = ?1",
+            crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt.query(params![commit_sha])?;
         let Some(row) = rows.next()? else {
             return Ok(None);
@@ -490,7 +498,9 @@ impl NotesDatabase {
         let content_len = note_content_len(row, 0)?;
         let mut budget = BatchMaterializationBudget::new();
         budget.reserve("note content", content_len)?;
-        Ok(Some(row.get(1)?))
+        Ok(Some(row.get::<_, Option<String>>(1)?.ok_or_else(|| {
+            GitAiError::Generic("note content exceeded limit".to_string())
+        })?))
     }
 
     /// Return the subset of `commit_shas` that exist in the DB with `synced = 1`.
@@ -538,8 +548,10 @@ impl NotesDatabase {
             .collect::<Vec<_>>()
             .join(",");
         let sql = format!(
-            "SELECT commit_sha, length(CAST(content AS BLOB)), content \
+            "SELECT commit_sha, octet_length(content), \
+                    CASE WHEN octet_length(content) <= {} THEN content END \
              FROM notes WHERE commit_sha IN ({})",
+            crate::git::repository::MAX_BATCH_MATERIALIZED_CONTENT_BYTES,
             placeholders
         );
         let params_vec: Vec<&dyn rusqlite::ToSql> = commit_shas
@@ -555,7 +567,12 @@ impl NotesDatabase {
         while let Some(row) = rows.next()? {
             let content_len = note_content_len(row, 1)?;
             budget.reserve("note content", content_len)?;
-            result.insert(row.get(0)?, row.get(2)?);
+            result.insert(
+                row.get(0)?,
+                row.get::<_, Option<String>>(2)?.ok_or_else(|| {
+                    GitAiError::Generic("note content exceeded limit".to_string())
+                })?,
+            );
         }
         Ok(result)
     }

--- a/tests/integration/daemon_recovery_query_memory.rs
+++ b/tests/integration/daemon_recovery_query_memory.rs
@@ -1,9 +1,12 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::generate_session_id;
+use git_ai::authorship::working_log::AgentId;
+use git_ai::daemon::bash_history_db::{BashCallStart, BashHistoryDatabase};
 use git_ai::metrics::db::MetricsDatabase;
 use git_ai::metrics::{EventAttributes, MetricEvent, PosEncoded, SessionEventValues};
 use serde_json::json;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
@@ -21,8 +24,23 @@ fn file_mtime_secs(path: &Path) -> u32 {
         .min(u32::MAX as u64) as u32
 }
 
-fn insert_session_event_flood(db_path: &Path, event_ts: u32) {
-    let events = (0..RECOVERY_CANDIDATE_FLOOD)
+fn file_mtime_ns(path: &Path) -> u128 {
+    fs::metadata(path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}
+
+fn insert_session_event_flood(
+    db_path: &Path,
+    event_ts: u32,
+    candidate_count: usize,
+    padding_bytes: usize,
+) {
+    let events = (0..candidate_count)
         .map(|index| {
             let external_session_id = format!("overload-session-{index}");
             let external_tool_use_id = format!("overload-tool-use-{index}");
@@ -31,6 +49,7 @@ fn insert_session_event_flood(db_path: &Path, event_ts: u32) {
                 json!({
                     "type": "assistant",
                     "session_id": external_session_id,
+                    "padding": "x".repeat(padding_bytes),
                 }),
                 Some(format!("overload-event-{index}")),
                 None,
@@ -56,13 +75,48 @@ fn insert_session_event_flood(db_path: &Path, event_ts: u32) {
     db.insert_events(&events).unwrap();
 }
 
+fn clear_metrics(db_path: &Path) {
+    let conn = git_ai::sqlite::open_with_memory_limits(db_path).unwrap();
+    conn.execute("DELETE FROM metrics", []).unwrap();
+}
+
+fn replace_cached_metric_session_id(db_path: &Path, session_id: &str) {
+    let conn = git_ai::sqlite::open_with_memory_limits(db_path).unwrap();
+    conn.execute(
+        "UPDATE metrics SET session_id = ?1",
+        rusqlite::params![session_id],
+    )
+    .unwrap();
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_hwm_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmHWM:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmHWM")
+}
+
 #[test]
 fn recovery_candidate_flood_fails_closed_and_next_commit_stays_attributed() {
     let metrics_dir = tempfile::tempdir().unwrap();
     let metrics_db_path = metrics_dir.path().join("metrics.db");
+    let bash_db_path = metrics_dir.path().join("bash.db");
+    drop(BashHistoryDatabase::open_at_path(&bash_db_path).unwrap());
     let metrics_db_path_arg = metrics_db_path.to_string_lossy().to_string();
+    let bash_db_path_arg = bash_db_path.to_string_lossy().to_string();
     let repo = TestRepo::new_with_daemon_env(&[
         ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path_arg.as_str()),
+        (
+            "GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH",
+            bash_db_path_arg.as_str(),
+        ),
         ("GIT_AI_TEST_ATTRIBUTION_RECOVERY_CANDIDATE_LIMIT", "8"),
     ]);
     repo.git(&[
@@ -80,7 +134,12 @@ fn recovery_candidate_flood_fails_closed_and_next_commit_stays_attributed() {
     file.assert_committed_lines(lines!["base".unattributed_human()]);
 
     fs::write(&file_path, "base\nuncheckpointed line\n").unwrap();
-    insert_session_event_flood(&metrics_db_path, file_mtime_secs(&file_path));
+    insert_session_event_flood(
+        &metrics_db_path,
+        file_mtime_secs(&file_path),
+        RECOVERY_CANDIDATE_FLOOD,
+        0,
+    );
     repo.stage_all_and_commit("Commit under recovery query pressure")
         .unwrap();
     file.assert_committed_lines(lines![
@@ -88,9 +147,116 @@ fn recovery_candidate_flood_fails_closed_and_next_commit_stays_attributed() {
         "uncheckpointed line".unattributed_human(),
     ]);
 
+    clear_metrics(&metrics_db_path);
     fs::write(
         &file_path,
-        "base\nuncheckpointed line\ncheckpointed AI line\n",
+        "base\nuncheckpointed line\nmetric payload pressure line\n",
+    )
+    .unwrap();
+    insert_session_event_flood(
+        &metrics_db_path,
+        file_mtime_secs(&file_path),
+        1,
+        16 * 1024 * 1024,
+    );
+    #[cfg(target_os = "linux")]
+    let metric_baseline_hwm = daemon_hwm_kib(&repo);
+    repo.stage_all_and_commit("Commit under metric payload pressure")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "uncheckpointed line".unattributed_human(),
+        "metric payload pressure line".unattributed_human(),
+    ]);
+    #[cfg(target_os = "linux")]
+    {
+        let growth_kib = daemon_hwm_kib(&repo).saturating_sub(metric_baseline_hwm);
+        eprintln!("oversized metric recovery candidate HWM growth: {growth_kib} KiB");
+        assert!(
+            growth_kib < 32 * 1024,
+            "oversized metric recovery candidate grew daemon HWM by {growth_kib} KiB"
+        );
+    }
+
+    clear_metrics(&metrics_db_path);
+    fs::write(
+        &file_path,
+        "base\nuncheckpointed line\nmetric payload pressure line\nmetric cached id pressure line\n",
+    )
+    .unwrap();
+    insert_session_event_flood(&metrics_db_path, file_mtime_secs(&file_path), 1, 0);
+    replace_cached_metric_session_id(&metrics_db_path, &"s".repeat(32 * 1024 * 1024));
+    #[cfg(target_os = "linux")]
+    let metric_cached_id_baseline_hwm = daemon_hwm_kib(&repo);
+    repo.stage_all_and_commit("Commit under metric cached identifier pressure")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "uncheckpointed line".unattributed_human(),
+        "metric payload pressure line".unattributed_human(),
+        "metric cached id pressure line".unattributed_human(),
+    ]);
+    #[cfg(target_os = "linux")]
+    {
+        let growth_kib = daemon_hwm_kib(&repo).saturating_sub(metric_cached_id_baseline_hwm);
+        eprintln!("oversized metric cached identifier HWM growth: {growth_kib} KiB");
+        assert!(
+            growth_kib < 32 * 1024,
+            "oversized metric cached identifier grew daemon HWM by {growth_kib} KiB"
+        );
+    }
+
+    clear_metrics(&metrics_db_path);
+    fs::write(
+        &file_path,
+        "base\nuncheckpointed line\nmetric payload pressure line\nmetric cached id pressure line\nbash payload pressure line\n",
+    )
+    .unwrap();
+    let repo_work_dir = repo.canonical_path().to_string_lossy().to_string();
+    let mut bash_db = BashHistoryDatabase::open_at_path(&bash_db_path).unwrap();
+    bash_db
+        .record_start(&BashCallStart {
+            original_cwd: repo_work_dir.clone(),
+            repo_work_dir: Some(repo_work_dir),
+            repo_discovery_error: None,
+            session_id: "bash-payload-session".to_string(),
+            tool_use_id: "bash-payload-tool".to_string(),
+            agent_id: AgentId {
+                tool: "codex".to_string(),
+                id: "bash-payload-session".to_string(),
+                model: "gpt-5".to_string(),
+            },
+            start_trace_id: "bash-payload-trace".to_string(),
+            started_at_ns: file_mtime_ns(&file_path),
+            command: Some("printf pressure".to_string()),
+            metadata: HashMap::from([("payload".to_string(), "x".repeat(16 * 1024 * 1024))]),
+        })
+        .unwrap();
+    drop(bash_db);
+    #[cfg(target_os = "linux")]
+    let bash_baseline_hwm = daemon_hwm_kib(&repo);
+    repo.stage_all_and_commit("Commit under bash payload pressure")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "uncheckpointed line".unattributed_human(),
+        "metric payload pressure line".unattributed_human(),
+        "metric cached id pressure line".unattributed_human(),
+        "bash payload pressure line".unattributed_human(),
+    ]);
+    #[cfg(target_os = "linux")]
+    {
+        let growth_kib = daemon_hwm_kib(&repo).saturating_sub(bash_baseline_hwm);
+        eprintln!("oversized bash recovery candidate HWM growth: {growth_kib} KiB");
+        assert!(
+            growth_kib < 32 * 1024,
+            "oversized bash recovery candidate grew daemon HWM by {growth_kib} KiB"
+        );
+    }
+
+    fs::write(
+        &file_path,
+        "base\nuncheckpointed line\nmetric payload pressure line\nmetric cached id pressure line\nbash payload pressure line\ncheckpointed AI line\n",
     )
     .unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "tracked.txt"])
@@ -100,6 +266,9 @@ fn recovery_candidate_flood_fails_closed_and_next_commit_stays_attributed() {
     file.assert_committed_lines(lines![
         "base".unattributed_human(),
         "uncheckpointed line".unattributed_human(),
+        "metric payload pressure line".unattributed_human(),
+        "metric cached id pressure line".unattributed_human(),
+        "bash payload pressure line".unattributed_human(),
         "checkpointed AI line".ai(),
     ]);
 }


### PR DESCRIPTION
## Bug
Several SQLite queries selected full payload columns before Rust-side size checks. SQLite/rusqlite therefore materialized oversized legacy metric, note, and recovery JSON even though the caller subsequently rejected it; candidate batches also lacked a shared byte budget.

## Fix
Compute byte lengths in SQL and return payload columns only through size-guarded `CASE` expressions, add aggregate budgets for bash/session recovery candidates and metadata backfill, and preserve forward progress past rejected rows. The stash fixture now exceeds the real configurable storage limit without making its valid seed checkpoint invalid.

## Verification
Database tests cover oversized legacy payloads and byte-paginated backfill. `daemon_recovery_query_memory` and stash `TestRepo` tests verify bounded rejection and exact post-commit attribution.