### PR TITLE
fix(runtime): bound daemon worker arenas

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -16,6 +16,12 @@ use std::time::{Duration, Instant};
 #[cfg(windows)]
 use std::{ffi::OsStr, path::Path};
 
+// CPU-count defaults and the 512-thread blocking default reserve large per-thread
+// allocator arenas in this long-lived process. Daemon work already has narrower
+// queues and semaphores, so fixed pools preserve concurrency without arena growth.
+const DAEMON_RUNTIME_WORKER_THREADS: usize = 4;
+const DAEMON_RUNTIME_MAX_BLOCKING_THREADS: usize = 16;
+
 pub fn handle_daemon(args: &[String]) {
     if args.is_empty() || is_help(args[0].as_str()) {
         print_help();
@@ -186,10 +192,8 @@ fn handle_run(args: &[String]) -> Result<(), String> {
             e
         )
     })?;
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| e.to_string())?;
+    let runtime = build_daemon_runtime()?;
+    crate::tokio_runtime::initialize();
     let exit_action = runtime
         .block_on(async move { crate::daemon::run_daemon(config).await })
         .map_err(|e| e.to_string())?;
@@ -219,6 +223,15 @@ fn handle_run(args: &[String]) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn build_daemon_runtime() -> Result<tokio::runtime::Runtime, String> {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(DAEMON_RUNTIME_WORKER_THREADS)
+        .max_blocking_threads(DAEMON_RUNTIME_MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())
 }
 
 pub(crate) fn ensure_daemon_running(
@@ -785,4 +798,46 @@ fn print_help() {
     eprintln!("  git-ai bg shutdown [--hard]");
     eprintln!("  git-ai bg restart [--hard]");
     eprintln!("  git-ai bg tail [-n <lines>] [--full] [-f | --follow]");
+}
+#[cfg(all(test, not(windows)))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_runtime_worker_pool_is_bounded() {
+        let runtime = build_daemon_runtime().unwrap();
+
+        assert_eq!(
+            runtime.metrics().num_workers(),
+            DAEMON_RUNTIME_WORKER_THREADS
+        );
+    }
+
+    #[test]
+    fn daemon_runtime_blocking_pool_is_bounded() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let runtime = build_daemon_runtime().unwrap();
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        runtime.block_on(async {
+            let mut tasks = Vec::new();
+            for _ in 0..=DAEMON_RUNTIME_MAX_BLOCKING_THREADS {
+                let active = Arc::clone(&active);
+                let peak = Arc::clone(&peak);
+                tasks.push(tokio::task::spawn_blocking(move || {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(100));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+            for task in tasks {
+                task.await.unwrap();
+            }
+        });
+
+        assert!(peak.load(Ordering::SeqCst) <= DAEMON_RUNTIME_MAX_BLOCKING_THREADS);
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2483,6 +2483,7 @@ enum RecentReplayPrerequisite {
 struct TraceIngressState {
     root_worktrees: HashMap<String, PathBuf>,
     root_families: HashMap<String, String>,
+    root_saw_def_repo: HashSet<String>,
     root_argv: HashMap<String, Vec<String>>,
     root_started_at_ns: HashMap<String, u128>,
     root_reflog_start_offsets: HashMap<String, HashMap<String, u64>>,
@@ -3398,6 +3399,7 @@ impl ActorDaemonCoordinator {
     fn clear_trace_ingress_root_locked(ingress: &mut TraceIngressState, root_sid: &str) {
         ingress.root_worktrees.remove(root_sid);
         ingress.root_families.remove(root_sid);
+        ingress.root_saw_def_repo.remove(root_sid);
         ingress.root_argv.remove(root_sid);
         ingress.root_started_at_ns.remove(root_sid);
         ingress.root_reflog_start_offsets.remove(root_sid);
@@ -3890,7 +3892,15 @@ impl ActorDaemonCoordinator {
                 .or_insert(started_at_ns);
         }
 
-        if let Some(worktree) = worktree_hint.clone() {
+        let root_def_repo = event == "def_repo" && sid == root;
+        let may_update_root_location = if root_def_repo {
+            ingress.root_saw_def_repo.insert(root.clone())
+        } else if event == "start" && sid == root {
+            true
+        } else {
+            !ingress.root_worktrees.contains_key(&root)
+        };
+        if may_update_root_location && let Some(worktree) = worktree_hint.clone() {
             if let Some(common_dir) = common_dir_for_worktree(&worktree) {
                 let family = common_dir.canonicalize().unwrap_or(common_dir);
                 ingress
@@ -3954,6 +3964,7 @@ impl ActorDaemonCoordinator {
         if terminal {
             ingress.root_worktrees.remove(&root);
             ingress.root_families.remove(&root);
+            ingress.root_saw_def_repo.remove(&root);
             ingress.root_argv.remove(&root);
             ingress.root_started_at_ns.remove(&root);
             ingress.root_reflog_start_offsets.remove(&root);
@@ -8421,6 +8432,55 @@ mod tests {
             "enqueue must allocate an ingest sequence number"
         );
         coord.request_shutdown();
+    }
+
+    #[tokio::test]
+    async fn later_def_repo_does_not_overwrite_root_ingress_worktree() {
+        let coord = ActorDaemonCoordinator::new();
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("parent");
+        let nested = parent.join("nested");
+        std::fs::create_dir_all(parent.join(".git")).unwrap();
+        std::fs::create_dir_all(nested.join(".git")).unwrap();
+
+        let root_sid = "commit-with-nested-repo";
+        let mut start = serde_json::json!({
+            "event": "start",
+            "sid": root_sid,
+            "argv": ["git", "commit", "-m", "parent commit"],
+            "worktree": parent,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut start));
+
+        let mut root_def_repo = serde_json::json!({
+            "event": "def_repo",
+            "sid": root_sid,
+            "worktree": parent,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut root_def_repo));
+
+        let mut second_root_def_repo = serde_json::json!({
+            "event": "def_repo",
+            "sid": root_sid,
+            "worktree": nested,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut second_root_def_repo));
+
+        let mut nested_child_def_repo = serde_json::json!({
+            "event": "def_repo",
+            "sid": format!("{root_sid}/child-status"),
+            "worktree": nested,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut nested_child_def_repo));
+
+        let mut atexit = make_atexit_payload(root_sid);
+        assert!(coord.prepare_trace_payload_for_ingest(&mut atexit));
+        assert_eq!(
+            atexit
+                .get(TRACE_ROOT_WORKTREE_FIELD)
+                .and_then(Value::as_str),
+            Some(parent.to_string_lossy().as_ref())
+        );
     }
 
     #[tokio::test]

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -348,7 +348,7 @@ impl<B: GitBackend> TraceNormalizer<B> {
     fn handle_def_repo(
         &mut self,
         payload: &Value,
-        _sid: &str,
+        sid: &str,
         root_sid: &str,
     ) -> Result<Option<NormalizedCommand>, GitAiError> {
         let payload_worktree = payload_worktree(payload);
@@ -371,21 +371,17 @@ impl<B: GitBackend> TraceNormalizer<B> {
             .and_then(|pending| argv_primary_command(&pending.raw_argv))
             .is_some_and(|command| matches!(command.as_str(), "clone" | "init"));
 
-        // For clone/init the root process's def_repo carries the newly created
-        // repo path.  Child processes (remote-https, index-pack, rev-list, …)
-        // inherit the parent CWD and their def_repo reports that CWD — not the
-        // clone destination.  Once we've captured the root def_repo (first
-        // arrival), skip subsequent child def_repo events entirely to prevent
-        // overwriting the correct worktree, family, and sid lookup maps.
-        if prefer_def_repo_target {
-            let already_saw_def_repo = self
-                .state
-                .pending
-                .get(root_sid)
-                .is_some_and(|pending| pending.saw_def_repo);
-            if already_saw_def_repo {
-                return Ok(None);
-            }
+        let already_saw_root_def_repo = self
+            .state
+            .pending
+            .get(root_sid)
+            .is_some_and(|pending| pending.saw_def_repo);
+
+        // Git can report nested repositories under both the root SID and child
+        // SIDs. The first root def_repo identifies the invoked command; later
+        // discoveries must not retarget its worktree or family.
+        if sid != root_sid || already_saw_root_def_repo {
+            return Ok(None);
         }
 
         // Trace2 `def_repo.repo` may point at a common-dir `.git` path for worktrees.
@@ -1950,6 +1946,79 @@ mod tests {
             cmd.worktree.as_ref(),
             Some(&clone_dest),
             "clone worktree should be the destination, not the parent CWD"
+        );
+    }
+
+    #[test]
+    fn commit_later_def_repo_does_not_overwrite_root_worktree() {
+        let backend = Arc::new(MockBackend::default());
+        let mut normalizer = TraceNormalizer::new(backend);
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let parent = temp.path().join("parent");
+        let nested = parent.join("nested");
+        fs::create_dir_all(parent.join(".git")).expect("create parent git dir");
+        fs::create_dir_all(nested.join(".git")).expect("create nested git dir");
+
+        let root_sid = "commit-with-nested-repo";
+        let child_sid = format!("{root_sid}/child-status");
+        let start = serde_json::json!({
+            "event": "start",
+            "sid": root_sid,
+            "ts": 1,
+            "argv": ["git", "commit", "-m", "parent commit"],
+            "worktree": parent,
+        });
+        let root_def_repo = serde_json::json!({
+            "event": "def_repo",
+            "sid": root_sid,
+            "ts": 2,
+            "worktree": parent,
+        });
+        let second_root_def_repo = serde_json::json!({
+            "event": "def_repo",
+            "sid": root_sid,
+            "ts": 3,
+            "worktree": nested,
+        });
+        let nested_child_def_repo = serde_json::json!({
+            "event": "def_repo",
+            "sid": child_sid,
+            "ts": 4,
+            "worktree": nested,
+        });
+        let exit = serde_json::json!({
+            "event": "exit",
+            "sid": root_sid,
+            "ts": 5,
+            "code": 0,
+        });
+        let atexit = atexit_payload(root_sid, 6);
+
+        assert!(normalizer.ingest_payload(&start).unwrap().is_none());
+        assert!(normalizer.ingest_payload(&root_def_repo).unwrap().is_none());
+        assert!(
+            normalizer
+                .ingest_payload(&second_root_def_repo)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            normalizer
+                .ingest_payload(&nested_child_def_repo)
+                .unwrap()
+                .is_none()
+        );
+        assert!(normalizer.ingest_payload(&exit).unwrap().is_none());
+        let command = normalizer.ingest_payload(&atexit).unwrap().unwrap();
+
+        assert_eq!(command.worktree.as_deref(), Some(parent.as_path()));
+        let expected_family = parent
+            .join(".git")
+            .canonicalize()
+            .unwrap_or_else(|_| parent.join(".git"));
+        assert_eq!(
+            command.family_key.as_ref().map(|family| family.0.as_str()),
+            Some(expected_family.to_string_lossy().as_ref())
         );
     }
 

--- a/src/tokio_runtime.rs
+++ b/src/tokio_runtime.rs
@@ -1,12 +1,28 @@
 use std::future::Future;
+use std::sync::OnceLock;
 
 use crate::error::GitAiError;
 
-fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("failed to create Tokio runtime")
+const HELPER_RUNTIME_WORKER_THREADS: usize = 2;
+const HELPER_RUNTIME_MAX_BLOCKING_THREADS: usize = 4;
+
+// Recreating a CPU-sized runtime here leaves one allocator arena per worker in
+// long-lived daemon processes. Keep one small pool warm and reuse it instead.
+fn runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(HELPER_RUNTIME_WORKER_THREADS)
+            .max_blocking_threads(HELPER_RUNTIME_MAX_BLOCKING_THREADS)
+            .thread_keep_alive(std::time::Duration::from_secs(60))
+            .enable_all()
+            .build()
+            .expect("failed to create Tokio helper runtime")
+    })
+}
+
+pub(crate) fn initialize() {
+    let _ = runtime();
 }
 
 pub fn block_on<F>(future: F) -> F::Output
@@ -34,4 +50,64 @@ where
     tokio::task::spawn_blocking(task)
         .await
         .map_err(|err| GitAiError::Generic(format!("Tokio blocking task failed: {err}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_block_on_uses_shared_helper_runtime() {
+        let outer = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        outer.block_on(async {
+            let outer_id = tokio::runtime::Handle::current().id();
+            let (nested_id, nested_flavor) = block_on(async {
+                let handle = tokio::runtime::Handle::current();
+                (handle.id(), handle.runtime_flavor())
+            });
+
+            assert_ne!(nested_id, outer_id);
+            assert_eq!(nested_flavor, tokio::runtime::RuntimeFlavor::MultiThread);
+        });
+    }
+
+    #[test]
+    fn repeated_block_on_reuses_helper_runtime() {
+        let first_id = block_on(async { tokio::runtime::Handle::current().id() });
+        let second_id = block_on(async { tokio::runtime::Handle::current().id() });
+
+        assert_eq!(first_id, second_id);
+    }
+
+    #[test]
+    fn helper_runtime_blocking_pool_is_bounded() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        block_on(async {
+            let mut tasks = Vec::new();
+            for _ in 0..=HELPER_RUNTIME_MAX_BLOCKING_THREADS {
+                let active = Arc::clone(&active);
+                let peak = Arc::clone(&peak);
+                tasks.push(tokio::task::spawn_blocking(move || {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+            for task in tasks {
+                task.await.unwrap();
+            }
+        });
+
+        assert!(peak.load(Ordering::SeqCst) <= HELPER_RUNTIME_MAX_BLOCKING_THREADS);
+    }
 }

--- a/tests/integration/checkpoint_size.rs
+++ b/tests/integration/checkpoint_size.rs
@@ -1,9 +1,24 @@
+use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::working_log::CheckpointKind;
 use git_ai::git::repository::find_repository_in_path;
 use rand::{RngExt, distr::Alphanumeric};
 use serde_json::json;
 use std::{fs, time::Instant};
+
+#[cfg(target_os = "linux")]
+fn daemon_vm_size_kib(repo: &TestRepo) -> u64 {
+    let pid = repo.daemon_pid().expect("test repo should own a daemon");
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    status
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("VmSize:")
+                .and_then(|value| value.split_whitespace().next())
+                .and_then(|value| value.parse().ok())
+        })
+        .expect("daemon status should include VmSize")
+}
 
 #[test]
 fn test_checkpoint_size_logging_large_ai_rewrites() {
@@ -268,6 +283,52 @@ fn test_checkpoint_total_size_budget_applies_to_bash_checkpoints() {
         "expected aggregate budget to apply to bash checkpoint payload"
     );
     assert_eq!(latest_ai.entries[0].file, "a_kept.txt");
+}
+
+#[test]
+fn test_repeated_checkpoints_plateau_after_runtime_warmup() {
+    let repo = TestRepo::new_dedicated_daemon();
+
+    let file_path = repo.path().join("runtime.txt");
+    let mut content = "base\n".to_string();
+    fs::write(&file_path, &content).unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("runtime.txt");
+    let mut expected = vec!["base".unattributed_human()];
+    file.assert_committed_lines(expected.clone());
+
+    let mut checkpoint_and_commit = |iteration| {
+        repo.git_ai(&["checkpoint", "human", "runtime.txt"])
+            .unwrap();
+        content.push_str(&format!("AI line {iteration}\n"));
+        fs::write(&file_path, &content).unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", "runtime.txt"])
+            .unwrap();
+        repo.stage_all_and_commit(&format!("AI checkpoint {iteration}"))
+            .unwrap();
+        expected.push(format!("AI line {iteration}").ai());
+        file.assert_committed_lines(expected.clone());
+    };
+
+    for iteration in 1..=12 {
+        checkpoint_and_commit(iteration);
+    }
+    #[cfg(target_os = "linux")]
+    let warmed_vm_size_kib = daemon_vm_size_kib(&repo);
+
+    for iteration in 13..=32 {
+        checkpoint_and_commit(iteration);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let growth_kib = daemon_vm_size_kib(&repo).saturating_sub(warmed_vm_size_kib);
+        eprintln!("post-warmup checkpoint daemon VmSize growth: {growth_kib} KiB");
+        assert!(
+            growth_kib < 256 * 1024,
+            "post-warmup checkpoints grew daemon VmSize by {growth_kib} KiB"
+        );
+    }
 }
 
 crate::reuse_tests_in_worktree!(test_checkpoint_size_logging_large_ai_rewrites,);

--- a/tests/integration/cross_repo_cwd_attribution.rs
+++ b/tests/integration/cross_repo_cwd_attribution.rs
@@ -910,12 +910,14 @@ fn test_nested_subrepo_mixed_edits_mock_ai() {
     let mut parent_readme = parent.filename("README.md");
     parent_readme.set_contents(crate::lines!["# Parent"]);
     parent.stage_all_and_commit("initial parent").unwrap();
+    parent_readme.assert_committed_lines(crate::lines!["# Parent".human()]);
 
     let subrepo_path = parent_path.join("subrepo");
     let subrepo = TestRepo::new_at_path(&subrepo_path);
     let mut subrepo_readme = subrepo.filename("README.md");
     subrepo_readme.set_contents(crate::lines!["# Subrepo"]);
     subrepo.stage_all_and_commit("initial subrepo").unwrap();
+    subrepo_readme.assert_committed_lines(crate::lines!["# Subrepo".human()]);
 
     // Write AI content in both repos
     fs::write(parent_path.join("parent_feature.txt"), "Parent AI\n").unwrap();
@@ -948,6 +950,9 @@ fn test_nested_subrepo_mixed_edits_mock_ai() {
         !parent_commit.authorship_log.attestations.is_empty(),
         "Scenario 7 (mixed): Parent repo should have AI attestations for its own files."
     );
+    parent
+        .filename("parent_feature.txt")
+        .assert_committed_lines(crate::lines!["Parent AI".ai()]);
 
     // Verify subrepo has attestation
     let subrepo_commit = subrepo.stage_all_and_commit("AI edits in subrepo").unwrap();
@@ -955,6 +960,9 @@ fn test_nested_subrepo_mixed_edits_mock_ai() {
         !subrepo_commit.authorship_log.attestations.is_empty(),
         "Scenario 7 (mixed): Nested subrepo should have AI attestations for its own files."
     );
+    subrepo
+        .filename("subrepo_feature.txt")
+        .assert_committed_lines(crate::lines!["Subrepo AI".ai()]);
 
     let _ = fs::remove_dir_all(&workspace);
 }

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -52,14 +52,8 @@ const DAEMON_TEST_READY_TOTAL_TIMEOUT: Duration = Duration::from_secs(120);
 #[cfg(not(windows))]
 const DAEMON_TEST_READY_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
 const DAEMON_TEST_READY_CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
-#[cfg(windows)]
 const DAEMON_TEST_SYNC_TOTAL_TIMEOUT: Duration = Duration::from_secs(120);
-#[cfg(not(windows))]
-const DAEMON_TEST_SYNC_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
-#[cfg(windows)]
 const DAEMON_TEST_SYNC_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
-#[cfg(not(windows))]
-const DAEMON_TEST_SYNC_IDLE_TIMEOUT: Duration = Duration::from_secs(20);
 const DAEMON_TEST_TRACE_READY_TIMEOUT: Duration = Duration::from_secs(15);
 #[cfg(windows)]
 const TEST_SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(120);
@@ -1751,6 +1745,10 @@ impl TestRepo {
             .as_ref()
             .map(|daemon| daemon.daemon_home.clone())
             .unwrap_or_else(|| self.test_home.clone())
+    }
+
+    pub(crate) fn daemon_pid(&self) -> Option<u32> {
+        self.daemon_process.as_ref().map(|daemon| daemon.pid)
     }
 
     pub(crate) fn daemon_trace_socket_path(&self) -> PathBuf {

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -1356,7 +1356,9 @@ fn test_repeated_stash_pop_does_not_duplicate_checkpoints() {
 
 #[test]
 fn test_partial_stash_truncates_oversized_live_checkpoints_before_filtering() {
-    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_CHECKPOINTS_JSONL_MAX_BYTES", "64")]);
+    const TEST_CHECKPOINT_LIMIT_BYTES: usize = 64 * 1_024;
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_CHECKPOINTS_JSONL_MAX_BYTES", "65536")]);
     fs::write(repo.path().join("a.txt"), "base a\n").unwrap();
     fs::write(repo.path().join("b.txt"), "base b\n").unwrap();
     repo.stage_all_and_commit("initial").unwrap();
@@ -1373,9 +1375,10 @@ fn test_partial_stash_truncates_oversized_live_checkpoints_before_filtering() {
         .find(|line| !line.trim().is_empty())
         .expect("checkpoint fixture should contain one line")
         .to_string();
+    let repetitions = TEST_CHECKPOINT_LIMIT_BYTES / (checkpoint_line.len() + 1) + 2;
     fs::write(
         &checkpoints_file,
-        (0..8)
+        (0..repetitions)
             .map(|_| checkpoint_line.as_str())
             .collect::<Vec<_>>()
             .join("\n")
@@ -1383,7 +1386,7 @@ fn test_partial_stash_truncates_oversized_live_checkpoints_before_filtering() {
     )
     .expect("inflate checkpoint file above test limit");
     assert!(
-        fs::metadata(&checkpoints_file).unwrap().len() > 64,
+        fs::metadata(&checkpoints_file).unwrap().len() > TEST_CHECKPOINT_LIMIT_BYTES as u64,
         "test setup should exceed the daemon's test checkpoint size limit"
     );
 


### PR DESCRIPTION
## Bug
The daemon used Tokio's CPU-count worker default (32 here), and every checkpoint created another CPU-sized helper runtime on a scoped OS thread. Glibc retained a 64 MiB arena per worker: the old installed daemon grew virtual memory by 2.27 GiB over 100 commits and started with 40 threads.

Constrained CI also exposed a pre-existing trace2 routing race. A parent-repository commit can discover an embedded repository and emit a second `def_repo` on the root SID, followed by child-SID frames for that nested repository. Both ingress metadata and `TraceNormalizer` previously let those later frames overwrite the command's parent worktree. Under scheduler pressure, the parent commit could therefore be analyzed as a subrepo command and finish without its authorship note.

## Fix
Use a fixed four-worker/16-blocker daemon runtime and one eagerly initialized shared helper runtime with two workers/four blockers. Nested synchronous bridges reuse that helper instead of constructing runtimes, eliminating repeated allocator-arena growth.

Treat the first root-SID `def_repo` as authoritative in both trace ingress and normalization. Later root-SID discoveries and child-SID `def_repo` frames cannot retarget the command. The ingress guard is a bounded per-root hash-set entry that is removed at terminal cleanup; it adds no Git calls, repository reads, or non-constant-time work to the critical path.

This root-cause fix is intentionally the base of the memory-hardening stack, so every later TestRepo daemon and CI layer runs on bounded pools and correct repository routing. The base also gives bounded-runtime TestRepo work the existing cross-platform 120-second total/45-second idle sync budget and seeds the oversized-stash fixture below a realistic 64 KiB test limit, preventing the harness from racing its own 64-byte truncation threshold.

## TDD coverage
Runtime unit tests assert worker/blocker ceilings and shared helper reuse. The TestRepo plateau regression performs 12 fully attributed warmup commits, records a 20-commit bounded-initialization window, then requires a second 20-commit window to grow `VmSize` by less than 256 MiB. Three simultaneous stress runs recorded first-window growth of 67,668 KiB, 0 KiB, and 67,668 KiB and late-window growth of 0 KiB in all three. Measuring the late window distinguishes sustained per-checkpoint growth from bounded lazy pool initialization.

For routing, deterministic unit tests reproduce both the second root-SID `def_repo` and child-SID nested-repository frames at ingress and normalization. They failed before the change and now require the terminal command to retain the parent worktree and family. The family assertion canonicalizes the expected `.git` path so macOS's `/var` to `/private/var` alias cannot create a false failure while the parent-vs-nested check remains exact. The existing nested-subrepo TestRepo regression now asserts exact human and AI line attribution after every commit. The unfixed root failed the real test in repeated four-process/four-core pressure rounds by rounds 3 and 5; the fix completed 48/48 concurrent reproductions.

## Verification
After the final restack and review follow-ups, `task fmt`, `task lint`, and `task build` pass. The complete `task test` matrix passes: 2,213 library tests, 58 daemon tests, 3,282 integration tests (85 expected ignores), 20 notes-sync tests, and four doctests (two expected ignores). A separate four-core/four-thread integration run passed all 3,282 executed tests in 477.22 seconds, including the nested-subrepo regression, saturated IPC backpressure, contended telemetry delivery, missing working-log blob recovery, Graphite, rebase, subdirectory, overload, memory, and exact-attribution workflows.

With exact final tip `3a467a77b8` installed through `task dev`, a fresh 300-commit checkpoint workload warmed from 1,115,328 KiB to 1,384,980 KiB `VmSize` by commit 50, then changed by 0 KiB through commit 300. RSS/HWM ended at 45,316 KiB with 17 threads. Blame reported 301 lines with exactly 300 `mock_ai` owners and one initial Codex line; all 301 commits had authorship notes.

On the same detached installed process, a 64-file fanout repository exercised the warm bounded pools. The three-pass workload issued 192 checkpoints while holding the same daemon PID; `VmSize` stayed within a 40 KiB band and ended at 1,384,940 KiB. RSS/HWM ended at 47,668 KiB with 15 threads. Exact blame across all files reported 192 `mock_ai` lines, 64 initial Codex lines, four authorship notes, and no other owners.
