### PR TITLE
feat(config): add bash checkpoints v2 flag

### DIFF
--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -454,6 +454,28 @@ fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAi
         }
     };
 
+    if config::Config::get()
+        .get_feature_flags()
+        .bash_checkpoints_v2
+    {
+        bash_tool::signal_daemon_bash_hook_attempt(
+            BashHookAttemptPhase::Start,
+            BashHookAttemptSignal {
+                original_cwd: e.context.cwd.as_path(),
+                discovered_repo_work_dir: Some(&repo_work_dir),
+                repo_discovery_error: None,
+                session_id: &e.context.external_session_id,
+                tool_use_id: &e.tool_use_id,
+                agent_id: &e.context.agent_id,
+                metadata: &e.context.metadata,
+                trace_id: &e.context.trace_id,
+                timestamp_ns: started_at_ns,
+                command: e.command.as_deref(),
+            },
+        );
+        return Ok(vec![]);
+    }
+
     let dirty_paths = match bash_tool::handle_bash_pre_tool_use_with_context_and_cwd(
         &repo_work_dir,
         e.context.cwd.as_path(),
@@ -528,6 +550,28 @@ fn execute_post_bash_call(e: PostBashCall) -> Result<Vec<CheckpointRequest>, Git
             return Ok(vec![]);
         }
     };
+
+    if config::Config::get()
+        .get_feature_flags()
+        .bash_checkpoints_v2
+    {
+        bash_tool::signal_daemon_bash_hook_attempt(
+            BashHookAttemptPhase::End,
+            BashHookAttemptSignal {
+                original_cwd: e.context.cwd.as_path(),
+                discovered_repo_work_dir: Some(&repo_work_dir),
+                repo_discovery_error: None,
+                session_id: &e.context.external_session_id,
+                tool_use_id: &e.tool_use_id,
+                agent_id: &e.context.agent_id,
+                metadata: &e.context.metadata,
+                trace_id: &e.context.trace_id,
+                timestamp_ns: ended_at_ns,
+                command: e.command.as_deref(),
+            },
+        );
+        return Ok(vec![]);
+    }
 
     let bash_result = bash_tool::handle_bash_post_tool_use_with_cwd(
         &repo_work_dir,

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -82,6 +82,7 @@ define_feature_flags!(
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = true,
     checkpoint_debug_log: checkpoint_debug_log, debug = false, release = false,
+    bash_checkpoints_v2: bash_checkpoints_v2, debug = false, release = false,
     daemon_log_upload: daemon_log_upload, debug = true, release = true,
     rewrite_metrics_events: rewrite_metrics_events, debug = true, release = false,
 );
@@ -137,6 +138,7 @@ mod tests {
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
             assert!(!flags.checkpoint_debug_log);
+            assert!(!flags.bash_checkpoints_v2);
             assert!(flags.daemon_log_upload);
             assert!(flags.rewrite_metrics_events);
         }
@@ -146,6 +148,7 @@ mod tests {
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
             assert!(!flags.checkpoint_debug_log);
+            assert!(!flags.bash_checkpoints_v2);
             assert!(flags.daemon_log_upload);
             assert!(!flags.rewrite_metrics_events);
         }
@@ -234,6 +237,7 @@ mod tests {
             transcript_streaming: true,
             transcript_sweep: true,
             checkpoint_debug_log: false,
+            bash_checkpoints_v2: true,
             daemon_log_upload: true,
             rewrite_metrics_events: true,
         };
@@ -243,6 +247,7 @@ mod tests {
         assert!(serialized.contains("transcript_streaming"));
         assert!(serialized.contains("transcript_sweep"));
         assert!(serialized.contains("checkpoint_debug_log"));
+        assert!(serialized.contains("bash_checkpoints_v2"));
         assert!(serialized.contains("daemon_log_upload"));
         assert!(serialized.contains("rewrite_metrics_events"));
     }
@@ -254,6 +259,7 @@ mod tests {
             transcript_streaming: true,
             transcript_sweep: true,
             checkpoint_debug_log: true,
+            bash_checkpoints_v2: true,
             daemon_log_upload: true,
             rewrite_metrics_events: true,
         };
@@ -262,6 +268,7 @@ mod tests {
         assert_eq!(cloned.transcript_streaming, flags.transcript_streaming);
         assert_eq!(cloned.transcript_sweep, flags.transcript_sweep);
         assert_eq!(cloned.checkpoint_debug_log, flags.checkpoint_debug_log);
+        assert_eq!(cloned.bash_checkpoints_v2, flags.bash_checkpoints_v2);
         assert_eq!(cloned.daemon_log_upload, flags.daemon_log_upload);
         assert_eq!(cloned.rewrite_metrics_events, flags.rewrite_metrics_events);
     }

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -178,6 +178,82 @@ fn test_codex_preset_bash_recovery_minimizes_dirty_untracked_attribution() {
 }
 
 #[test]
+fn test_bash_checkpoints_v2_records_for_recovery_without_working_log_checkpoints() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let mut repo = TestRepo::new_with_daemon_env(&env);
+    repo.patch_git_ai_config(|patch| {
+        patch.feature_flags = Some(json!({"bash_checkpoints_v2": true}));
+    });
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("example.txt");
+
+    fs::write(&file_path, "original line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(lines!["original line".unattributed_human()]);
+
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-transcript.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "bash-v2-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "bash-v2-tool",
+        "tool_input": { "command": "printf 'written by bash\\n' >> example.txt" },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("codex pre-hook checkpoint should succeed");
+
+    fs::write(&file_path, "original line\nwritten by bash\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "bash-v2-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "bash-v2-tool",
+        "tool_input": { "command": "printf 'written by bash\\n' >> example.txt" },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("codex post-hook checkpoint should succeed");
+
+    let checkpoints = repo.current_working_logs().read_all_checkpoints().unwrap();
+    assert!(
+        checkpoints.is_empty(),
+        "bash checkpoints v2 should only record recovery metadata, not normal checkpoints"
+    );
+
+    repo.stage_all_and_commit("After bash v2").unwrap();
+    file.assert_committed_lines(lines![
+        "original line".unattributed_human(),
+        "written by bash".ai(),
+    ]);
+
+    let db = BashHistoryDatabase::open_at_path(std::path::Path::new(&bash_db_path)).unwrap();
+    let calls = db.all_calls_for_test().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].session_id, "bash-v2-session");
+    assert_eq!(calls[0].tool_use_id, "bash-v2-tool");
+    assert_eq!(
+        calls[0].repo_work_dir.as_deref(),
+        Some(repo_root.to_string_lossy().as_ref())
+    );
+    assert!(calls[0].start_trace_id.is_some());
+    assert!(calls[0].end_trace_id.is_some());
+}
+
+#[test]
 fn test_bash_recovery_uses_commit_time_file_timestamps_when_processing_is_delayed() {
     let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
     let env = [

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -19,6 +19,7 @@ fn setup() {
         transcript_streaming: true,
         transcript_sweep: true,
         checkpoint_debug_log: false,
+        bash_checkpoints_v2: false,
         daemon_log_upload: true,
         rewrite_metrics_events: false,
     };


### PR DESCRIPTION
## Summary

- add the `bash_checkpoints_v2` feature flag
- keep both debug and release defaults disabled
- cover defaulting and serialization through the shared feature-flag tests

This is PR 1 of 2 in the bash checkpoints v2 stack. It is intentionally behavior-neutral; #1828 adds the record-only implementation.

## Tests

- `task test TEST_FILTER=feature_flags::tests`
- `task lint`
- `task fmt`
- `task test`