### PR TITLE
fix(metrics): index only retryable upload rows

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
-use tokio::time::{Duration, interval};
+use tokio::time::{Duration, Instant, sleep_until};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(3);
 const DAEMON_LOG_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
@@ -448,14 +448,11 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
 }
 
 async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: String) {
-    let mut ticker = interval(FLUSH_INTERVAL);
     let started_at = std::time::Instant::now();
     let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
-    // The first tick completes immediately; skip it.
-    ticker.tick().await;
 
     loop {
-        ticker.tick().await;
+        sleep_until(next_telemetry_flush_at(Instant::now())).await;
 
         let now = std::time::Instant::now();
         let heartbeat = if now >= next_heartbeat_at && daemon_log_upload_enabled() {
@@ -481,6 +478,7 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
 
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
         let daemon_id_for_flush = daemon_id.clone();
+        let flush_started_at = std::time::Instant::now();
         let requeue_daemon_logs = tokio::task::spawn_blocking(move || {
             if let Some(snapshot) = snapshot {
                 flush_telemetry_batch(snapshot, &daemon_id_for_flush)
@@ -494,6 +492,14 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
             tracing::error!(%e, "telemetry flush task panicked");
             Vec::new()
         });
+        let flush_elapsed = flush_started_at.elapsed();
+        if flush_elapsed > FLUSH_INTERVAL {
+            tracing::warn!(
+                elapsed_ms = flush_elapsed.as_millis(),
+                interval_ms = FLUSH_INTERVAL.as_millis(),
+                "telemetry flush exceeded its scheduling interval"
+            );
+        }
 
         if !requeue_daemon_logs.is_empty() {
             buffer
@@ -502,6 +508,10 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
                 .requeue_failed_daemon_logs(requeue_daemon_logs);
         }
     }
+}
+
+fn next_telemetry_flush_at(completed_at: Instant) -> Instant {
+    completed_at + FLUSH_INTERVAL
 }
 
 fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
@@ -1377,6 +1387,16 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs()
+    }
+
+    #[test]
+    fn telemetry_flush_schedule_is_measured_from_completion() {
+        let completed_at = tokio::time::Instant::now();
+
+        assert_eq!(
+            next_telemetry_flush_at(completed_at),
+            completed_at + FLUSH_INTERVAL
+        );
     }
 
     fn now_ts() -> u32 {

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -15,12 +15,24 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 /// Current schema version (must match MIGRATIONS.len())
-const SCHEMA_VERSION: usize = 4;
+const SCHEMA_VERSION: usize = 5;
 
+// This value is part of the metrics retry index schema. Changing it requires a
+// migration that rebuilds `metrics_retryable` with the same literal used by
+// the retry queries below; SQLite cannot prove a parameterized predicate
+// implies a partial-index predicate.
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
 const NS_PER_SECOND: u128 = 1_000_000_000;
+
+const RETRYABLE_METRIC_IDS_SQL: &str = "SELECT id FROM metrics \
+     WHERE delivered_ts IS NULL \
+       AND processing_started_at IS NULL \
+       AND next_retry_at <= ?1 \
+       AND attempts < 6 \
+     ORDER BY next_retry_at ASC, id DESC \
+     LIMIT ?2";
 
 /// Database migrations - each migration upgrades the schema by one version
 const MIGRATIONS: &[&str] = &[
@@ -65,6 +77,17 @@ const MIGRATIONS: &[&str] = &[
         WHERE parent_session_id IS NOT NULL
             AND event_kind IS NOT NULL
             AND event_ts IS NOT NULL;
+    "#,
+    // Migration 4 -> 5: Keep terminal history out of retry lookups. The
+    // predicate and ordering intentionally match dequeue/count queries.
+    r#"
+    CREATE INDEX IF NOT EXISTS metrics_retryable
+        ON metrics (next_retry_at ASC, id DESC)
+        WHERE delivered_ts IS NULL
+            AND processing_started_at IS NULL
+            AND attempts < 6;
+
+    DROP INDEX IF EXISTS metrics_pending_retry;
     "#,
 ];
 
@@ -564,19 +587,10 @@ impl MetricsDatabase {
 
         let tx = self.conn.transaction()?;
         let ids = {
-            let mut stmt = tx.prepare(
-                "SELECT id FROM metrics \
-                 WHERE delivered_ts IS NULL \
-                   AND processing_started_at IS NULL \
-                   AND next_retry_at <= ?1 \
-                   AND attempts < ?2 \
-                 ORDER BY next_retry_at ASC, id DESC \
-                 LIMIT ?3",
-            )?;
-            let rows = stmt.query_map(
-                params![now as i64, MAX_METRIC_UPLOAD_ATTEMPTS as i64, limit as i64],
-                |row| row.get::<_, i64>(0),
-            )?;
+            let mut stmt = tx.prepare(RETRYABLE_METRIC_IDS_SQL)?;
+            let rows = stmt.query_map(params![now as i64, limit as i64], |row| {
+                row.get::<_, i64>(0)
+            })?;
             let mut ids = Vec::new();
             for row in rows {
                 ids.push(row?);
@@ -738,8 +752,8 @@ impl MetricsDatabase {
              WHERE delivered_ts IS NULL \
                AND processing_started_at IS NULL \
                AND next_retry_at <= ?1 \
-               AND attempts < ?2",
-            params![now as i64, MAX_METRIC_UPLOAD_ATTEMPTS as i64],
+               AND attempts < 6",
+            params![now as i64],
             |row| row.get(0),
         )?;
         Ok(count as usize)
@@ -1492,6 +1506,7 @@ fn event_specific_external_tool_use_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rusqlite::StatementStatus;
     use tempfile::TempDir;
 
     fn create_test_db() -> (MetricsDatabase, TempDir) {
@@ -1549,6 +1564,18 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1, "missing index {index}");
+    }
+
+    fn assert_metric_index_missing(db: &MetricsDatabase, index: &str) {
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                params![index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "unexpected index {index}");
     }
 
     fn metric_metadata_rows(db: &MetricsDatabase) -> Vec<(Option<i64>, Option<i64>)> {
@@ -1645,7 +1672,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "4");
+        assert_eq!(version, "5");
 
         for column in [
             "delivered_ts",
@@ -1678,6 +1705,7 @@ mod tests {
         }
 
         for index in [
+            "metrics_retryable",
             "metrics_event_ts_kind",
             "metrics_session_kind_ts",
             "metrics_parent_session_kind_ts",
@@ -1740,7 +1768,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "4");
+        assert_eq!(version, "5");
     }
 
     #[test]
@@ -1779,7 +1807,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "4");
+        assert_eq!(version, "5");
         assert_eq!(db.count().unwrap(), 1);
         assert_eq!(db.count_retryable().unwrap(), 1);
     }
@@ -1822,7 +1850,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "4");
+        assert_eq!(version, "5");
 
         for column in [
             "delivered_ts",
@@ -1891,7 +1919,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "4");
+        assert_eq!(version, "5");
         assert!(db.column_exists("metrics", "event_ts").unwrap());
         assert!(db.column_exists("metrics", "event_kind").unwrap());
         for index in [
@@ -1916,6 +1944,45 @@ mod tests {
                 external_tool_use_id: None,
             }]
         );
+    }
+
+    #[test]
+    fn test_migrates_version_4_to_retryable_only_index() {
+        let (mut db, _temp_dir) = create_test_db();
+        let ids = db.insert_events(&[event_json(days_ago(1))]).unwrap();
+        db.conn
+            .execute(
+                "UPDATE metrics SET attempts = 6 WHERE id = ?1",
+                params![ids[0]],
+            )
+            .unwrap();
+        db.conn
+            .execute_batch(
+                r#"
+                DROP INDEX metrics_retryable;
+                CREATE INDEX metrics_pending_retry
+                    ON metrics (delivered_ts, next_retry_at, id)
+                    WHERE delivered_ts IS NULL;
+                UPDATE schema_metadata SET value = '4' WHERE key = 'version';
+                "#,
+            )
+            .unwrap();
+
+        db.initialize_schema().unwrap();
+
+        let version: String = db
+            .conn
+            .query_row(
+                "SELECT value FROM schema_metadata WHERE key = 'version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(version, "5");
+        assert_metric_index_exists(&db, "metrics_retryable");
+        assert_metric_index_missing(&db, "metrics_pending_retry");
+        assert_eq!(db.count().unwrap(), 1);
+        assert_eq!(db.status().unwrap().stopped_after_errors, 1);
     }
 
     #[test]
@@ -2436,6 +2503,48 @@ mod tests {
         assert!(batch[0].id > batch[1].id);
         assert!(batch[0].event_json.contains(&format!("\"t\":{newest_ts}")));
         assert!(batch[1].event_json.contains(&format!("\"t\":{middle_ts}")));
+    }
+
+    #[test]
+    fn test_retryable_query_work_is_independent_of_exhausted_history() {
+        let (db, _temp_dir) = create_test_db();
+        let now = unix_now() as i64;
+
+        db.conn
+            .execute(
+                "INSERT INTO metrics (event_json, next_retry_at) VALUES (?1, 0)",
+                params![event_json(days_ago(1))],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                r#"
+                WITH RECURSIVE exhausted(n) AS (
+                    VALUES(1)
+                    UNION ALL
+                    SELECT n + 1 FROM exhausted WHERE n < 20000
+                )
+                INSERT INTO metrics (event_json, attempts, next_retry_at)
+                SELECT '{"t":1,"e":1,"v":{},"a":{}}', 6, 0 FROM exhausted
+                "#,
+                [],
+            )
+            .unwrap();
+
+        let mut stmt = db.conn.prepare(RETRYABLE_METRIC_IDS_SQL).unwrap();
+        let ids = stmt
+            .query_map(params![now, 100], |row| row.get::<_, i64>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(ids, vec![1]);
+        assert_eq!(stmt.get_status(StatementStatus::FullscanStep), 0);
+        assert_eq!(stmt.get_status(StatementStatus::Sort), 0);
+        assert!(
+            stmt.get_status(StatementStatus::VmStep) < 1_000,
+            "retryable lookup must not scale with exhausted history"
+        );
     }
 
     #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -85,6 +85,7 @@ mod jetbrains_download;
 mod jetbrains_ide_types;
 mod log;
 mod merge_rebase;
+mod metrics_retry_idle;
 mod multi_repo_workspace;
 mod non_utf8_files;
 mod notes_merge_mixed_fanout;

--- a/tests/integration/metrics_retry_idle.rs
+++ b/tests/integration/metrics_retry_idle.rs
@@ -1,0 +1,143 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::sqlite::open_with_memory_limits;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+fn seed_version_4_metrics_db(path: &Path) {
+    let conn = open_with_memory_limits(path).unwrap();
+    conn.execute_batch(
+        r#"
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE schema_metadata (
+            key TEXT PRIMARY KEY NOT NULL,
+            value TEXT NOT NULL
+        );
+        INSERT INTO schema_metadata (key, value) VALUES ('version', '4');
+        CREATE TABLE metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_json TEXT NOT NULL,
+            delivered_ts INTEGER,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_sync_error TEXT,
+            last_sync_at INTEGER,
+            next_retry_at INTEGER NOT NULL DEFAULT 0,
+            processing_started_at INTEGER,
+            event_ts INTEGER DEFAULT NULL,
+            event_kind INTEGER DEFAULT NULL,
+            trace_id TEXT DEFAULT NULL,
+            session_id TEXT DEFAULT NULL,
+            parent_session_id TEXT DEFAULT NULL,
+            tool TEXT DEFAULT NULL,
+            external_session_id TEXT DEFAULT NULL,
+            external_parent_session_id TEXT DEFAULT NULL,
+            external_event_id TEXT DEFAULT NULL,
+            external_parent_event_id TEXT DEFAULT NULL,
+            external_tool_use_id TEXT DEFAULT NULL
+        );
+        CREATE INDEX metrics_pending_retry
+            ON metrics (delivered_ts, next_retry_at, id)
+            WHERE delivered_ts IS NULL;
+        CREATE INDEX metrics_processing_started_at
+            ON metrics (processing_started_at)
+            WHERE delivered_ts IS NULL AND processing_started_at IS NOT NULL;
+        WITH RECURSIVE exhausted(n) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT n + 1 FROM exhausted WHERE n < 20000
+        )
+        INSERT INTO metrics (
+            event_json,
+            attempts,
+            last_sync_error,
+            next_retry_at,
+            event_ts,
+            event_kind,
+            tool
+        )
+        SELECT
+            '{"t":1,"e":1,"v":{},"a":{}}',
+            6,
+            'Generic error: Unauthorized',
+            0,
+            unixepoch(),
+            1,
+            'codex'
+        FROM exhausted;
+        "#,
+    )
+    .unwrap();
+}
+
+fn wait_for_schema_migration(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let conn = open_with_memory_limits(path).unwrap();
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM schema_metadata WHERE key = 'version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if version == "5" {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "metrics database did not migrate to schema v5"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn daemon_remains_responsive_after_exhausted_metrics_migration() {
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_path = metrics_dir.path().join("metrics.db");
+    seed_version_4_metrics_db(&metrics_path);
+    let metrics_path_str = metrics_path.to_string_lossy().to_string();
+
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_path_str.as_str(),
+    )]);
+    wait_for_schema_migration(&metrics_path);
+
+    let file_path = repo.path().join("example.md");
+    fs::write(&file_path, "Untracked line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("example.md");
+    file.assert_committed_lines(lines!["Untracked line".unattributed_human()]);
+
+    std::thread::sleep(Duration::from_secs(7));
+    repo.sync_daemon();
+
+    fs::write(&file_path, "Untracked line\nHuman line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.md"])
+        .unwrap();
+    repo.stage_all_and_commit("Human edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Untracked line".unattributed_human(),
+        "Human line".human(),
+    ]);
+
+    let conn = open_with_memory_limits(&metrics_path).unwrap();
+    let terminal_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM metrics WHERE delivered_ts IS NULL AND attempts >= 6",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let retryable_index: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'metrics_retryable'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(terminal_rows, 20000);
+    assert_eq!(retryable_index, 1);
+}


### PR DESCRIPTION
## Root cause

The metrics retry dequeue ran every three seconds against a 5.23 GB database. Terminal rows remained intentionally retained for local history, but the old partial index included all 1.38 million exhausted rows and did not cover `attempts < 6`. The query therefore scanned terminal history and took 3.36 seconds, making every subsequent interval tick immediately overdue.

## Fix

- Add schema v5 with an exact partial covering index over only unlocked, retryable rows.
- Match the dequeue/count predicate and ordering structurally so SQLite uses the partial index without a table scan or temporary sort.
- Preserve exhausted rows and their `stopped_after_errors` status for local history.
- Drop the legacy pending index after migration.

## Verification

- Regression fixture places 20,000 exhausted rows ahead of one eligible row and asserts zero full-scan steps, zero sorts, and fewer than 1,000 SQLite VM steps.
- v4→v5 migration test verifies terminal history is retained and the old index is removed.
- All 37 metrics DB tests pass; `task build`, `task fmt`, and `task lint` pass.
- On the real 5.23 GB database, the exact query improved from 3.36s to 0.00s and the daemon settled from 100% to 0.0–0.4% CPU.

## Stack

1. This PR: make retry selection cardinality-bound.
2. #1830: prevent telemetry scheduler catch-up loops and add a production-path `TestRepo` regression.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
