### PR TITLE
fix(telemetry): prevent catch-up flush loops

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
-use tokio::time::{Duration, interval};
+use tokio::time::{Duration, Instant, sleep_until};
 
 const FLUSH_INTERVAL: Duration = Duration::from_secs(3);
 const DAEMON_LOG_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
@@ -448,14 +448,11 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
 }
 
 async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: String) {
-    let mut ticker = interval(FLUSH_INTERVAL);
     let started_at = std::time::Instant::now();
     let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
-    // The first tick completes immediately; skip it.
-    ticker.tick().await;
 
     loop {
-        ticker.tick().await;
+        sleep_until(next_telemetry_flush_at(Instant::now())).await;
 
         let now = std::time::Instant::now();
         let heartbeat = if now >= next_heartbeat_at && daemon_log_upload_enabled() {
@@ -481,6 +478,7 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
 
         // Flush in a blocking task since the underlying HTTP clients are synchronous.
         let daemon_id_for_flush = daemon_id.clone();
+        let flush_started_at = std::time::Instant::now();
         let requeue_daemon_logs = tokio::task::spawn_blocking(move || {
             if let Some(snapshot) = snapshot {
                 flush_telemetry_batch(snapshot, &daemon_id_for_flush)
@@ -494,6 +492,14 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
             tracing::error!(%e, "telemetry flush task panicked");
             Vec::new()
         });
+        let flush_elapsed = flush_started_at.elapsed();
+        if flush_elapsed > FLUSH_INTERVAL {
+            tracing::warn!(
+                elapsed_ms = flush_elapsed.as_millis(),
+                interval_ms = FLUSH_INTERVAL.as_millis(),
+                "telemetry flush exceeded its scheduling interval"
+            );
+        }
 
         if !requeue_daemon_logs.is_empty() {
             buffer
@@ -502,6 +508,10 @@ async fn telemetry_flush_loop(buffer: Arc<Mutex<TelemetryBuffer>>, daemon_id: St
                 .requeue_failed_daemon_logs(requeue_daemon_logs);
         }
     }
+}
+
+fn next_telemetry_flush_at(completed_at: Instant) -> Instant {
+    completed_at + FLUSH_INTERVAL
 }
 
 fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
@@ -1377,6 +1387,16 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs()
+    }
+
+    #[test]
+    fn telemetry_flush_schedule_is_measured_from_completion() {
+        let completed_at = tokio::time::Instant::now();
+
+        assert_eq!(
+            next_telemetry_flush_at(completed_at),
+            completed_at + FLUSH_INTERVAL
+        );
     }
 
     fn now_ts() -> u32 {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -85,6 +85,7 @@ mod jetbrains_download;
 mod jetbrains_ide_types;
 mod log;
 mod merge_rebase;
+mod metrics_retry_idle;
 mod multi_repo_workspace;
 mod non_utf8_files;
 mod notes_merge_mixed_fanout;

--- a/tests/integration/metrics_retry_idle.rs
+++ b/tests/integration/metrics_retry_idle.rs
@@ -1,0 +1,143 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::sqlite::open_with_memory_limits;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+fn seed_version_4_metrics_db(path: &Path) {
+    let conn = open_with_memory_limits(path).unwrap();
+    conn.execute_batch(
+        r#"
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE schema_metadata (
+            key TEXT PRIMARY KEY NOT NULL,
+            value TEXT NOT NULL
+        );
+        INSERT INTO schema_metadata (key, value) VALUES ('version', '4');
+        CREATE TABLE metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_json TEXT NOT NULL,
+            delivered_ts INTEGER,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            last_sync_error TEXT,
+            last_sync_at INTEGER,
+            next_retry_at INTEGER NOT NULL DEFAULT 0,
+            processing_started_at INTEGER,
+            event_ts INTEGER DEFAULT NULL,
+            event_kind INTEGER DEFAULT NULL,
+            trace_id TEXT DEFAULT NULL,
+            session_id TEXT DEFAULT NULL,
+            parent_session_id TEXT DEFAULT NULL,
+            tool TEXT DEFAULT NULL,
+            external_session_id TEXT DEFAULT NULL,
+            external_parent_session_id TEXT DEFAULT NULL,
+            external_event_id TEXT DEFAULT NULL,
+            external_parent_event_id TEXT DEFAULT NULL,
+            external_tool_use_id TEXT DEFAULT NULL
+        );
+        CREATE INDEX metrics_pending_retry
+            ON metrics (delivered_ts, next_retry_at, id)
+            WHERE delivered_ts IS NULL;
+        CREATE INDEX metrics_processing_started_at
+            ON metrics (processing_started_at)
+            WHERE delivered_ts IS NULL AND processing_started_at IS NOT NULL;
+        WITH RECURSIVE exhausted(n) AS (
+            VALUES(1)
+            UNION ALL
+            SELECT n + 1 FROM exhausted WHERE n < 20000
+        )
+        INSERT INTO metrics (
+            event_json,
+            attempts,
+            last_sync_error,
+            next_retry_at,
+            event_ts,
+            event_kind,
+            tool
+        )
+        SELECT
+            '{"t":1,"e":1,"v":{},"a":{}}',
+            6,
+            'Generic error: Unauthorized',
+            0,
+            unixepoch(),
+            1,
+            'codex'
+        FROM exhausted;
+        "#,
+    )
+    .unwrap();
+}
+
+fn wait_for_schema_migration(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let conn = open_with_memory_limits(path).unwrap();
+        let version: String = conn
+            .query_row(
+                "SELECT value FROM schema_metadata WHERE key = 'version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if version == "5" {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "metrics database did not migrate to schema v5"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[test]
+fn daemon_remains_responsive_after_exhausted_metrics_migration() {
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_path = metrics_dir.path().join("metrics.db");
+    seed_version_4_metrics_db(&metrics_path);
+    let metrics_path_str = metrics_path.to_string_lossy().to_string();
+
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_path_str.as_str(),
+    )]);
+    wait_for_schema_migration(&metrics_path);
+
+    let file_path = repo.path().join("example.md");
+    fs::write(&file_path, "Untracked line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("example.md");
+    file.assert_committed_lines(lines!["Untracked line".unattributed_human()]);
+
+    std::thread::sleep(Duration::from_secs(7));
+    repo.sync_daemon();
+
+    fs::write(&file_path, "Untracked line\nHuman line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.md"])
+        .unwrap();
+    repo.stage_all_and_commit("Human edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Untracked line".unattributed_human(),
+        "Human line".human(),
+    ]);
+
+    let conn = open_with_memory_limits(&metrics_path).unwrap();
+    let terminal_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM metrics WHERE delivered_ts IS NULL AND attempts >= 6",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let retryable_index: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'metrics_retryable'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(terminal_rows, 20000);
+    assert_eq!(retryable_index, 1);
+}


### PR DESCRIPTION
## Purpose

This is the defensive second layer for the metrics CPU incident fixed in #1829. Even if a future blocking telemetry operation exceeds its intended cadence, the worker must not convert an overrun into a continuous catch-up loop.

## Fix

- Schedule each telemetry flush three seconds after the previous cycle completes instead of using Tokio interval catch-up semantics.
- Emit a structured warning when a blocking flush exceeds the configured interval.
- Preserve the existing initial delay, batching, retry, and daemon-log requeue behavior.

## Verification

- Scheduler unit test locks completion-based timing semantics.
- New production-path `TestRepo` regression starts a dedicated daemon with a v4 database containing 20,000 exhausted rows, verifies the v5 migration, waits across multiple flush cycles, synchronizes the daemon, commits another edit, and validates line-level attribution after every commit.
- The integration regression preserves all 20,000 terminal rows and confirms the retryable index exists.
- All 16 telemetry-worker tests and the new integration test pass; `task build`, `task fmt`, and `task lint` pass.
- Full local suite result: 2,050 library tests passed; the sole failure is the pre-existing environment-sensitive Droid installation test, which also fails alone and is untouched by this stack.

## Stack

1. #1829: make retry selection cardinality-bound.
2. This PR: prevent catch-up scheduling and verify production daemon behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
