### PR TITLE
Publish MSI/PKG releases without notarization delay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release Build
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -47,6 +48,7 @@ jobs:
       inputs.dry_run == true ||
       needs.release-prod-approval.result == 'success')
     runs-on: ${{ matrix.os }}
+    environment: release
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     strategy:
@@ -188,6 +190,37 @@ jobs:
         run: |
           cp target/${{ matrix.target }}/release/git-ai release/${{ matrix.artifact_name }}
 
+      - name: Sign macOS binary
+        if: contains(matrix.os, 'macos')
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Skipping macOS binary signing for dry run because signing secrets are not configured."
+              exit 0
+            fi
+            echo "::error::Missing Apple Developer ID Application signing secrets."
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > app-signing.p12
+          security import app-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          codesign --force --timestamp --options runtime --sign "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" "release/${{ matrix.artifact_name }}"
+          codesign --verify --strict --verbose=2 "release/${{ matrix.artifact_name }}"
+
       - name: Upload artifact (Windows)
         if: contains(matrix.os, 'windows')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -213,6 +246,7 @@ jobs:
       inputs.dry_run == true ||
       needs.release-prod-approval.result == 'success')
     runs-on: macos-15-intel
+    environment: release
     outputs:
       version: ${{ steps.get-version.outputs.version }}
 
@@ -269,6 +303,36 @@ jobs:
         run: |
           cp target/x86_64-apple-darwin/release/git-ai release/git-ai-macos-x64
 
+      - name: Sign macOS binary
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Skipping macOS binary signing for dry run because signing secrets are not configured."
+              exit 0
+            fi
+            echo "::error::Missing Apple Developer ID Application signing secrets."
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > app-signing.p12
+          security import app-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          codesign --force --timestamp --options runtime --sign "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" release/git-ai-macos-x64
+          codesign --verify --strict --verbose=2 release/git-ai-macos-x64
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -276,15 +340,216 @@ jobs:
           path: release/git-ai-macos-x64
           retention-days: 30
 
+  package-msi:
+    name: Build Windows MSI installers
+    needs: build
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download Windows x64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-windows-x64
+          path: artifacts
+
+      - name: Download Windows ARM64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-windows-arm64
+          path: artifacts
+
+      - name: Build MSI installers
+        shell: pwsh
+        run: |
+          $version = "${{ needs.build.outputs.version }}".TrimStart('v')
+          New-Item -ItemType Directory -Force -Path release | Out-Null
+          .\packaging\windows\build-msi.ps1 -BinaryPath "artifacts\git-ai-windows-x64.exe" -Architecture x64 -Version $version -OutputPath "release\git-ai-windows-x64.msi"
+          .\packaging\windows\build-msi.ps1 -BinaryPath "artifacts\git-ai-windows-arm64.exe" -Architecture arm64 -Version $version -OutputPath "release\git-ai-windows-arm64.msi"
+
+      - name: Azure login for MSI signing
+        if: inputs.dry_run != true
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign MSI installers
+        if: inputs.dry_run != true
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_CERT_PROFILE }}
+          files-folder: ${{ github.workspace }}\release
+          files-folder-filter: msi
+          file-digest: SHA256
+
+      - name: Upload MSI artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-ai-windows-msi
+          path: release/*.msi
+          retention-days: 30
+
+  package-pkg:
+    name: Build macOS PKG installers
+    needs: [build, build-macos-intel]
+    runs-on: macos-latest
+    environment: release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download macOS ARM64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-arm64
+          path: artifacts
+
+      - name: Download macOS x64 binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-x64
+          path: artifacts
+
+      - name: Import Apple installer certificate
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
+          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_IDENTITY}" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "Skipping PKG signing for dry run because signing secrets are not configured."
+              exit 0
+            fi
+            echo "::error::Missing Apple Developer ID Installer signing secrets."
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          echo "$APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64" | base64 --decode > installer-signing.p12
+          security import installer-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD" -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+      - name: Build PKG installers
+        shell: bash
+        env:
+          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.build.outputs.version }}"
+          VERSION="${VERSION#v}"
+          mkdir -p release
+          chmod +x artifacts/git-ai-macos-arm64 artifacts/git-ai-macos-x64
+          packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-arm64 --arch arm64 --version "$VERSION" --output release/git-ai-macos-arm64.pkg
+          packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-x64 --arch x64 --version "$VERSION" --output release/git-ai-macos-x64.pkg
+
+      - name: Notarize PKG installers
+        if: inputs.dry_run != true
+        shell: bash
+        env:
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_NOTARY_KEY_ID}" || -z "${APPLE_NOTARY_ISSUER_ID}" || -z "${APPLE_NOTARY_KEY_P8_BASE64}" ]]; then
+            echo "::error::Missing Apple notarization secrets."
+            exit 1
+          fi
+          mkdir -p private_keys
+          echo "$APPLE_NOTARY_KEY_P8_BASE64" | base64 --decode > "private_keys/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+          for pkg in release/*.pkg; do
+            xcrun notarytool submit "$pkg" --key "private_keys/AuthKey_${APPLE_NOTARY_KEY_ID}.p8" --key-id "$APPLE_NOTARY_KEY_ID" --issuer "$APPLE_NOTARY_ISSUER_ID" --wait
+            xcrun stapler staple "$pkg"
+            xcrun stapler validate "$pkg"
+          done
+
+      - name: Create PKG checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release
+          shasum -a 256 git-ai-macos-*.pkg | sort > PKG-SHA256SUMS
+
+      - name: Upload PKG artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: git-ai-macos-pkg
+          path: |
+            release/*.pkg
+            release/PKG-SHA256SUMS
+          retention-days: 30
+
+  test-msi:
+    name: Test Windows MSI installer
+    needs: package-msi
+    runs-on: windows-latest
+    steps:
+      - name: Download MSI artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-windows-msi
+          path: release
+
+      - name: Install and uninstall MSI
+        shell: pwsh
+        run: |
+          $msi = (Get-ChildItem release\git-ai-windows-x64.msi).FullName
+          $install = Start-Process msiexec -ArgumentList "/i `"$msi`" /qn /norestart" -Wait -PassThru
+          if ($install.ExitCode -ne 0) { throw "MSI install failed with exit code $($install.ExitCode)" }
+          $gitAi = Join-Path $env:LOCALAPPDATA 'Git AI\git-ai.exe'
+          & $gitAi --version
+          if (Test-Path (Join-Path $env:LOCALAPPDATA 'Git AI\git.exe')) { throw "MSI installed a git.exe shim" }
+          $uninstall = Start-Process msiexec -ArgumentList "/x `"$msi`" /qn /norestart" -Wait -PassThru
+          if ($uninstall.ExitCode -ne 0) { throw "MSI uninstall failed with exit code $($uninstall.ExitCode)" }
+
+  test-pkg:
+    name: Test macOS PKG installer
+    needs: package-pkg
+    runs-on: macos-latest
+    steps:
+      - name: Download PKG artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-pkg
+          path: release
+
+      - name: Install PKG
+        run: |
+          if [ "$(uname -m)" = "arm64" ]; then
+            PKG=release/git-ai-macos-arm64.pkg
+          else
+            PKG=release/git-ai-macos-x64.pkg
+          fi
+          sudo installer -pkg "$PKG" -target /
+          /usr/local/bin/git-ai --version
+          test ! -e /usr/local/bin/git
+          pkgutil --pkg-info com.git-ai.git-ai
+
   create-release:
     name: Create Release
-    needs: [build, build-macos-intel, release-prod-approval]
+    needs: [build, build-macos-intel, package-msi, test-msi, release-prod-approval]
     runs-on: ubuntu-latest
     if: >-
       always() &&
       inputs.dry_run != true &&
       needs.build.result == 'success' &&
       needs.build-macos-intel.result == 'success' &&
+      needs.package-msi.result == 'success' &&
+      needs.test-msi.result == 'success' &&
       (inputs.release_production != true ||
       needs.release-prod-approval.result == 'success')
     environment: release
@@ -331,7 +596,7 @@ jobs:
 
       - name: Move artifacts to release directory
         run: |
-          find artifacts -name "git-ai-*" -exec cp {} release/ \;
+          find artifacts -type f \( -name "git-ai-*" -o -name "git-ai_*" \) -exec cp {} release/ \;
 
       - name: List available artifacts
         run: |
@@ -341,8 +606,10 @@ jobs:
       - name: Create checksums
         run: |
           cd release
-          if ls git-ai-* 1> /dev/null 2>&1; then
-            sha256sum git-ai-* > SHA256SUMS
+          shopt -s nullglob
+          artifacts=(git-ai-* git-ai_*)
+          if [ ${#artifacts[@]} -gt 0 ]; then
+            sha256sum "${artifacts[@]}" | sort > SHA256SUMS
           else
             echo "No binaries found to create checksums for"
             touch SHA256SUMS
@@ -401,6 +668,7 @@ jobs:
         with:
           subject-path: |
             release/git-ai-*
+            release/git-ai_*
             release/install.sh
             release/install.ps1
             release/SHA256SUMS
@@ -416,6 +684,8 @@ jobs:
 
             ### Release Channel
             `${{ steps.release-meta.outputs.channel_label }}`
+
+            > **Beta:** The Windows MSI and macOS PKG installers are beta.
 
             ${{ steps.release-meta.outputs.prerelease != 'true' && '---' || '' }}
 
@@ -441,8 +711,12 @@ jobs:
             - **Linux (ARM64)**: `git-ai-linux-arm64`
             - **Windows (x64)**: `git-ai-windows-x64.exe`
             - **Windows (ARM64)**: `git-ai-windows-arm64.exe`
+            - **Windows MSI (x64)**: `git-ai-windows-x64.msi`
+            - **Windows MSI (ARM64)**: `git-ai-windows-arm64.msi`
             - **macOS (Intel)**: `git-ai-macos-x64`
             - **macOS (Apple Silicon)**: `git-ai-macos-arm64`
+            - **macOS PKG (Intel)**: `git-ai-macos-x64.pkg`
+            - **macOS PKG (Apple Silicon)**: `git-ai-macos-arm64.pkg`
 
             ### SHA256 Checksums
             ```
@@ -456,6 +730,7 @@ jobs:
             ```
           files: |
             release/git-ai-*
+            release/git-ai_*
             release/SHA256SUMS
             release/install.sh
             release/install.ps1
@@ -538,3 +813,44 @@ jobs:
                 "tag": "${{ steps.release-meta.outputs.tag_name }}"
               }
             }'
+
+  publish-pkg:
+    name: Publish macOS PKG installers
+    needs: [create-release, package-pkg, test-pkg, build]
+    if: inputs.dry_run != true && needs.create-release.result == 'success' && needs.package-pkg.result == 'success' && needs.test-pkg.result == 'success'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download notarized PKG artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: git-ai-macos-pkg
+          path: release
+
+      - name: Generate attestations for notarized PKGs
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            release/git-ai-macos-*.pkg
+            release/PKG-SHA256SUMS
+
+      - name: Attach notarized PKGs to the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_VERSION: ${{ needs.build.outputs.version }}
+          IS_PRODUCTION: ${{ inputs.release_production }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          if [[ "$IS_PRODUCTION" == 'true' ]]; then
+            RELEASE_TAG="$BASE_VERSION"
+          else
+            RELEASE_TAG="${BASE_VERSION}-next-${SHORT_SHA}"
+          fi
+
+          gh release upload "$RELEASE_TAG" release/git-ai-macos-*.pkg release/PKG-SHA256SUMS --clobber

--- a/tests/package_release_workflow.rs
+++ b/tests/package_release_workflow.rs
@@ -1,0 +1,54 @@
+fn release_workflow() -> String {
+    std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/.github/workflows/release.yml"
+    ))
+    .unwrap()
+}
+
+fn job<'a>(workflow: &'a str, name: &str) -> &'a str {
+    let start = workflow.find(&format!("  {name}:\n")).unwrap();
+    let remainder = &workflow[start..];
+    let end = remainder
+        .match_indices("\n  ")
+        .find_map(|(offset, _)| (!remainder[offset + 3..].starts_with(' ')).then_some(offset))
+        .unwrap_or(remainder.len());
+    &remainder[..end]
+}
+
+#[test]
+fn releases_publish_core_artifacts_before_notarized_pkgs() {
+    let workflow = release_workflow();
+    let create_release = job(&workflow, "create-release");
+
+    assert!(!create_release.contains("package-pkg"));
+    assert!(!create_release.contains("test-pkg"));
+    assert!(workflow.contains("  publish-pkg:\n"));
+    assert!(workflow.contains("PKG-SHA256SUMS"));
+}
+
+#[test]
+fn release_workflow_only_builds_msi_and_pkg_installers() {
+    let workflow = release_workflow();
+
+    assert!(!workflow.contains("package-deb"));
+    assert!(!workflow.contains("test-deb"));
+    assert!(!workflow.contains("homebrew"));
+    assert!(workflow.contains("**Beta:** The Windows MSI and macOS PKG installers are beta."));
+}
+
+#[test]
+fn release_credentials_stay_in_the_release_environment() {
+    let workflow = release_workflow();
+
+    for job_name in [
+        "build",
+        "build-macos-intel",
+        "package-msi",
+        "package-pkg",
+        "create-release",
+        "publish-pkg",
+    ] {
+        assert!(job(&workflow, job_name).contains("environment: release"));
+    }
+}


### PR DESCRIPTION
## Summary

- Removes deb and Homebrew release work. The release scope is MSI and PKG only.
- Keeps release credentials environment-scoped on the jobs that consume them.
- Creates the core release after the MSI is ready, without waiting for macOS notarization.
- Publishes notarized PKGs afterward with `PKG-SHA256SUMS`.
- Adds the MSI/PKG beta warning to the release body.

## Validation

- `task test CARGO_TEST_ARGS="--test package_release_workflow"`
- Release YAML parse

## Stack

Depends on #1841.