### PR TITLE
Keep package setup to MSI and PKG

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -256,8 +256,7 @@ function Get-Architecture {
     }
 }
 
-# Ensure $PathToAdd is on the User PATH (appended if absent). No Machine PATH,
-# no admin required, no positioning logic.
+# Ensure $PathToAdd is first on the User PATH. No Machine PATH or admin required.
 function Set-PathEnsureContains {
     param(
         [Parameter(Mandatory = $true)][string]$PathToAdd
@@ -276,16 +275,13 @@ function Set-PathEnsureContains {
         $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
         $entries = @()
         if ($userPath) { $entries = ($userPath -split $sep) | Where-Object { $_ -and $_.Trim() -ne '' } }
-        $alreadyPresent = $false
-        foreach ($e in $entries) {
-            if ((NormalizePath $e) -eq $normalizedAdd) { $alreadyPresent = $true; break }
-        }
-        if ($alreadyPresent) {
-            $userStatus = 'AlreadyPresent'
-        } else {
-            $newUserPath = if ($userPath) { "$userPath$sep$PathToAdd" } else { $PathToAdd }
+        $remainingEntries = @($entries | Where-Object { (NormalizePath $_) -ne $normalizedAdd })
+        $newUserPath = (@($PathToAdd) + $remainingEntries) -join $sep
+        if ($newUserPath -ne $userPath) {
             [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
             $userStatus = 'Updated'
+        } else {
+            $userStatus = 'AlreadyPresent'
         }
     } catch {
         $userStatus = 'Error'
@@ -296,13 +292,8 @@ function Set-PathEnsureContains {
         $procPath = $env:PATH
         $procEntries = @()
         if ($procPath) { $procEntries = ($procPath -split $sep) | Where-Object { $_ -and $_.Trim() -ne '' } }
-        $procHas = $false
-        foreach ($e in $procEntries) {
-            if ((NormalizePath $e) -eq $normalizedAdd) { $procHas = $true; break }
-        }
-        if (-not $procHas) {
-            $env:PATH = if ($procPath) { "$procPath$sep$PathToAdd" } else { $PathToAdd }
-        }
+        $remainingProcEntries = @($procEntries | Where-Object { (NormalizePath $_) -ne $normalizedAdd })
+        $env:PATH = (@($PathToAdd) + $remainingProcEntries) -join $sep
     } catch { }
 
     return [PSCustomObject]@{

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -348,11 +348,10 @@ fn powershell_single_quote_literal(value: &OsStr) -> String {
 
 #[cfg(any(windows, not(any(test, feature = "test-support"))))]
 fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
-    // Use current_git_ai_exe() instead of current_exe() to resolve through
-    // symlinks. When the current exe is the git shim (e.g. ~/.local/bin/git),
-    // current_exe() would spawn `git daemon run` which re-enters handle_git()
-    // instead of handle_git_ai(), causing a fork bomb in async mode.
-    let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
+    // Resolve through git shims and, for a package bootstrap, prefer the
+    // current user's verified update. This avoids re-entering handle_git()
+    // through a `git` shim and keeps package startup on the updated runtime.
+    let exe = crate::utils::daemon_git_ai_exe().map_err(|e| e.to_string())?;
     let runtime_dir = daemon_runtime_dir(config)?;
 
     #[cfg(windows)]
@@ -428,7 +427,7 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
 fn spawn_daemon_run_with_piped_stderr(
     config: &DaemonConfig,
 ) -> Result<std::process::Child, String> {
-    let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
+    let exe = crate::utils::daemon_git_ai_exe().map_err(|e| e.to_string())?;
     let runtime_dir = daemon_runtime_dir(config)?;
     let mut child = Command::new(exe);
     child

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -52,6 +52,7 @@ pub fn handle_git_ai(args: &[String]) {
             | "upgrade"
             | "install-hooks"
             | "install"
+            | "setup-package"
             | "uninstall-hooks"
             | "usage"
     );
@@ -165,6 +166,17 @@ pub fn handle_git_ai(args: &[String]) {
             }
             Err(e) => {
                 eprintln!("Install hooks failed: {}", e);
+                std::process::exit(1);
+            }
+        },
+        "setup-package" => match commands::package_setup::run(&args[1..]) {
+            Ok(statuses) => {
+                if let Ok(statuses_value) = serde_json::to_value(&statuses) {
+                    log_message("setup-package", "info", Some(statuses_value));
+                }
+            }
+            Err(e) => {
+                eprintln!("Package setup failed: {}", e);
                 std::process::exit(1);
             }
         },
@@ -367,6 +379,7 @@ fn print_help() {
     eprintln!("    --skills               Also install agent skill files");
     eprintln!("    --visual-studio-extension");
     eprintln!("                           Also install the Visual Studio extension on Windows");
+    eprintln!("  setup-package      Complete per-user setup after a package-manager install");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");
     eprintln!("  ci                 Continuous integration utilities");
     eprintln!("    github                 GitHub CI helpers");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod log;
 pub mod login;
 pub mod logout;
 pub mod notes_migrate;
+pub mod package_setup;
 pub mod personal_dashboard;
 pub mod show;
 pub mod show_prompt;

--- a/src/commands/package_setup.rs
+++ b/src/commands/package_setup.rs
@@ -1,0 +1,186 @@
+use crate::commands::install_hooks;
+use crate::error::GitAiError;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PackageManager {
+    Msi,
+    Pkg,
+}
+
+impl PackageManager {
+    fn parse(value: &str) -> Result<Self, GitAiError> {
+        match value {
+            "msi" => Ok(Self::Msi),
+            "pkg" => Ok(Self::Pkg),
+            _ => Err(GitAiError::Generic(format!(
+                "unsupported package manager: {value}"
+            ))),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Msi => "msi",
+            Self::Pkg => "pkg",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PackageSetupOptions {
+    manager: PackageManager,
+    dry_run: bool,
+    target_user: Option<String>,
+}
+
+pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
+    let options = parse_options(args)?;
+
+    if should_skip_user_setup(&options) {
+        print_manual_setup_message(options.manager);
+        return Ok(HashMap::from([(
+            "package_setup".to_string(),
+            "skipped_system_context".to_string(),
+        )]));
+    }
+
+    let mut install_args = vec!["--dry-run=false".to_string()];
+    if options.dry_run {
+        install_args[0] = "--dry-run=true".to_string();
+    }
+    install_hooks::run(&install_args)
+}
+
+fn parse_options(args: &[String]) -> Result<PackageSetupOptions, GitAiError> {
+    let mut manager = None;
+    let mut dry_run = false;
+    let mut target_user = None;
+    let mut iter = args.iter();
+
+    while let Some(arg) = iter.next() {
+        if let Some(value) = arg.strip_prefix("--manager=") {
+            manager = Some(PackageManager::parse(value)?);
+        } else if arg == "--manager" {
+            let value = iter
+                .next()
+                .ok_or_else(|| GitAiError::Generic("missing value for --manager".to_string()))?;
+            manager = Some(PackageManager::parse(value)?);
+        } else if let Some(value) = arg.strip_prefix("--target-user=") {
+            target_user = non_empty_value(value);
+        } else if arg == "--target-user" {
+            let value = iter.next().ok_or_else(|| {
+                GitAiError::Generic("missing value for --target-user".to_string())
+            })?;
+            target_user = non_empty_value(value);
+        } else if arg == "--dry-run" || arg == "--dry-run=true" {
+            dry_run = true;
+        } else if arg == "--dry-run=false" {
+            dry_run = false;
+        } else {
+            return Err(GitAiError::Generic(format!(
+                "unknown setup-package option: {arg}"
+            )));
+        }
+    }
+
+    let manager =
+        manager.ok_or_else(|| GitAiError::Generic("missing required --manager".to_string()))?;
+    Ok(PackageSetupOptions {
+        manager,
+        dry_run,
+        target_user,
+    })
+}
+
+fn non_empty_value(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn should_skip_user_setup(options: &PackageSetupOptions) -> bool {
+    should_skip_user_setup_for_context(options.dry_run, crate::utils::is_running_as_superuser())
+}
+
+fn should_skip_user_setup_for_context(dry_run: bool, is_superuser: bool) -> bool {
+    !dry_run && is_superuser
+}
+
+fn print_manual_setup_message(manager: PackageManager) {
+    eprintln!(
+        "Git AI was installed by {manager}. Run `git-ai install-hooks` as each developer user to enable trace2 integration and editor/agent setup.",
+        manager = manager.as_str()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| arg.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_options_accepts_manager_equals() {
+        let options = parse_options(&strings(&["--manager=msi"])).unwrap();
+        assert_eq!(options.manager, PackageManager::Msi);
+        assert!(!options.dry_run);
+        assert_eq!(options.target_user, None);
+    }
+
+    #[test]
+    fn parse_options_accepts_manager_value_and_dry_run() {
+        let options = parse_options(&strings(&[
+            "--manager",
+            "pkg",
+            "--target-user",
+            "alice",
+            "--dry-run",
+        ]))
+        .unwrap();
+        assert_eq!(options.manager, PackageManager::Pkg);
+        assert!(options.dry_run);
+        assert_eq!(options.target_user.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_options_rejects_missing_manager() {
+        let err = parse_options(&strings(&["--dry-run"])).unwrap_err();
+        assert!(err.to_string().contains("missing required --manager"));
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_manager() {
+        let err = parse_options(&strings(&["--manager", "rpm"])).unwrap_err();
+        assert!(err.to_string().contains("unsupported package manager: rpm"));
+    }
+
+    #[test]
+    fn parse_options_rejects_removed_package_managers() {
+        for manager in ["apt", "brew"] {
+            let err = parse_options(&strings(&["--manager", manager])).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains(&format!("unsupported package manager: {manager}"))
+            );
+        }
+    }
+
+    #[test]
+    fn elevated_processes_always_skip_per_user_setup() {
+        assert!(should_skip_user_setup_for_context(false, true));
+        assert!(!should_skip_user_setup_for_context(true, true));
+        assert!(!should_skip_user_setup_for_context(false, false));
+    }
+
+    #[test]
+    fn parse_options_rejects_unknown_option() {
+        let err = parse_options(&strings(&["--manager", "msi", "--shim"])).unwrap_err();
+        assert!(err.to_string().contains("unknown setup-package option"));
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6985,7 +6985,7 @@ fn daemon_socket_health_check_interval() -> u64 {
 /// instance.  Returns Ok if the process was spawned; the caller should
 /// still request_shutdown so the current daemon exits promptly.
 fn spawn_self_restart() -> Result<(), String> {
-    let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
+    let exe = crate::utils::daemon_git_ai_exe().map_err(|e| e.to_string())?;
     tracing::info!(?exe, "spawning detached restart process");
 
     let mut cmd = std::process::Command::new(&exe);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn is_superuser_exempt_command(args: &[String]) -> bool {
             | "-v"
             | "upgrade"
             | "debug"
+            | "setup-package"
             | "uninstall-hooks"
     ) || (first == "bg" || first == "d" || first == "daemon")
         && args

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,6 +70,46 @@ pub(crate) fn current_git_ai_exe() -> Result<PathBuf, GitAiError> {
     Ok(resolve_git_ai_exe_from_invocation_path(path))
 }
 
+pub(crate) fn daemon_git_ai_exe() -> Result<PathBuf, GitAiError> {
+    let current_exe = current_git_ai_exe()?;
+    Ok(preferred_user_update_exe(
+        &current_exe,
+        dirs::home_dir().as_deref(),
+    ))
+}
+
+fn preferred_user_update_exe(
+    current_exe: &std::path::Path,
+    home: Option<&std::path::Path>,
+) -> PathBuf {
+    if !is_package_bootstrap_exe(current_exe) {
+        return current_exe.to_path_buf();
+    }
+
+    let Some(home) = home else {
+        return current_exe.to_path_buf();
+    };
+    let user_exe = home.join(".git-ai").join("bin").join(if cfg!(windows) {
+        "git-ai.exe"
+    } else {
+        "git-ai"
+    });
+
+    if user_exe.is_file() {
+        user_exe
+    } else {
+        current_exe.to_path_buf()
+    }
+}
+
+fn is_package_bootstrap_exe(path: &std::path::Path) -> bool {
+    let path = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    path.ends_with("/opt/git-ai/bin/git-ai") || path.ends_with("/program files/git ai/git-ai.exe")
+}
+
 fn internal_git_ai_command_with_exe(exe: PathBuf, subcommand: &str) -> Command {
     let mut cmd = Command::new(exe);
     cmd.arg(subcommand)
@@ -1157,6 +1197,46 @@ mod tests {
         assert!(result.is_ok(), "current_git_ai_exe should not fail");
         let path = result.unwrap();
         assert!(!path.as_os_str().is_empty(), "path should not be empty");
+    }
+
+    #[test]
+    fn package_bootstrap_daemon_prefers_an_existing_user_update_binary() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_exe = temp.path().join(".git-ai/bin/git-ai");
+        std::fs::create_dir_all(user_exe.parent().unwrap()).unwrap();
+        std::fs::write(&user_exe, "").unwrap();
+
+        assert_eq!(
+            preferred_user_update_exe(
+                std::path::Path::new("/opt/git-ai/bin/git-ai"),
+                Some(temp.path())
+            ),
+            user_exe
+        );
+    }
+
+    #[test]
+    fn package_bootstrap_daemon_falls_back_when_no_user_update_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let bootstrap = std::path::Path::new("/opt/git-ai/bin/git-ai");
+
+        assert_eq!(
+            preferred_user_update_exe(bootstrap, Some(temp.path())),
+            bootstrap
+        );
+    }
+
+    #[test]
+    fn package_bootstrap_paths_are_recognized_on_both_desktop_platforms() {
+        assert!(is_package_bootstrap_exe(std::path::Path::new(
+            "/opt/git-ai/bin/git-ai"
+        )));
+        assert!(is_package_bootstrap_exe(std::path::Path::new(
+            r"C:\Program Files\Git AI\git-ai.exe"
+        )));
+        assert!(!is_package_bootstrap_exe(std::path::Path::new(
+            "/Users/alice/.git-ai/bin/git-ai"
+        )));
     }
 
     // =========================================================================

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -107,7 +107,7 @@ fn is_package_bootstrap_exe(path: &std::path::Path) -> bool {
         .to_string_lossy()
         .replace('\\', "/")
         .to_ascii_lowercase();
-    path.ends_with("/opt/git-ai/bin/git-ai") || path.ends_with("/program files/git ai/git-ai.exe")
+    path.ends_with("/opt/git-ai/bin/git-ai") || path.ends_with("/appdata/local/git ai/git-ai.exe")
 }
 
 fn internal_git_ai_command_with_exe(exe: PathBuf, subcommand: &str) -> Command {
@@ -1232,6 +1232,9 @@ mod tests {
             "/opt/git-ai/bin/git-ai"
         )));
         assert!(is_package_bootstrap_exe(std::path::Path::new(
+            r"C:\Users\alice\AppData\Local\Git AI\git-ai.exe"
+        )));
+        assert!(!is_package_bootstrap_exe(std::path::Path::new(
             r"C:\Program Files\Git AI\git-ai.exe"
         )));
         assert!(!is_package_bootstrap_exe(std::path::Path::new(


### PR DESCRIPTION
## Summary

- Limits `setup-package` to `msi` and `pkg`.
- Rejects removed apt and brew managers.
- Skips per-user setup for root and Administrator.
- Keeps the existing auto-updater model: the daemon prefers a verified user update and falls back to the package bootstrap.

## Validation

- `task test CARGO_TEST_ARGS="--lib package_setup::tests"`
- `task lint`

## Stack

Depends on #1838.