### PR TITLE
Configure MSI API settings for the installing user

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -16,3 +16,14 @@ data directory and changes only that user's `PATH`. It has no all-users or
 Administrator install mode. The macOS PKG installs an immutable bootstrap
 binary, then runs any per-user setup as the active console user rather than
 root.
+
+For an enterprise endpoint, pass configuration to the MSI when installing:
+
+```powershell
+msiexec /i git-ai-windows-x64.msi API_BASE=https://git-ai.example API_KEY=your-api-key
+```
+
+These values configure only the installing user's Git AI config. They are
+hidden from MSI logs, but command-line arguments can still be visible to local
+process inspection and shell history. Use your endpoint-management secret
+mechanism when available.

--- a/packaging/windows/git-ai.wxs
+++ b/packaging/windows/git-ai.wxs
@@ -8,6 +8,8 @@
     Scope="perUser">
     <MajorUpgrade DowngradeErrorMessage="A newer version of Git AI is already installed." />
     <MediaTemplate EmbedCab="yes" />
+    <Property Id="API_BASE" Hidden="yes" Secure="yes" />
+    <Property Id="API_KEY" Hidden="yes" Secure="yes" />
 
     <StandardDirectory Id="LocalAppDataFolder">
       <Directory Id="INSTALLFOLDER" Name="Git AI" />
@@ -30,5 +32,23 @@
     <Feature Id="DefaultFeature" Title="Git AI" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
+
+    <SetProperty
+      Id="ConfigureGitAi"
+      Value="setup-package --manager msi --api-base &quot;[API_BASE]&quot; --api-key &quot;[API_KEY]&quot;"
+      Before="ConfigureGitAi"
+      Sequence="execute"
+      Condition="NOT Installed" />
+    <CustomAction
+      Id="ConfigureGitAi"
+      FileRef="GitAiExe"
+      ExeCommand="[ConfigureGitAi]"
+      Execute="deferred"
+      Impersonate="yes"
+      Return="check"
+      HideTarget="yes" />
+    <InstallExecuteSequence>
+      <Custom Action="ConfigureGitAi" After="InstallFiles" Condition="NOT Installed" />
+    </InstallExecuteSequence>
   </Package>
 </Wix>

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -309,6 +309,21 @@ fn ensure_daemon(dry_run: bool) {
 
 /// Main entry point for install-hooks command
 pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
+    run_with_config(args, install_config_from_environment())
+}
+
+pub(crate) fn run_with_package_config(
+    args: &[String],
+    api_base: Option<String>,
+    api_key: Option<String>,
+) -> Result<HashMap<String, String>, GitAiError> {
+    run_with_config(args, InstallConfig { api_base, api_key })
+}
+
+fn run_with_config(
+    args: &[String],
+    install_config: InstallConfig,
+) -> Result<HashMap<String, String>, GitAiError> {
     let options = parse_install_options(args);
 
     // Daemon trace2 config must be in place before any install work starts.
@@ -326,7 +341,7 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
 
     // Get absolute path to the current binary
     let binary_path = get_current_binary_path()?;
-    persist_install_config(&binary_path, options.dry_run)?;
+    persist_install_config_with_values(&binary_path, options.dry_run, &install_config)?;
     let params = HookInstallerParams { binary_path };
 
     // Run async operations and convert result.
@@ -361,13 +376,35 @@ fn should_include_installer(id: &str, options: &InstallOptions) -> bool {
     options.include_visual_studio_extension || id != VISUAL_STUDIO_INSTALLER_ID
 }
 
+#[derive(Default)]
+struct InstallConfig {
+    api_base: Option<String>,
+    api_key: Option<String>,
+}
+
+#[cfg(test)]
 fn persist_install_config(binary_path: &Path, dry_run: bool) -> Result<bool, GitAiError> {
+    persist_install_config_with_values(binary_path, dry_run, &install_config_from_environment())
+}
+
+fn install_config_from_environment() -> InstallConfig {
+    InstallConfig {
+        api_base: std::env::var("API_BASE").ok().filter(|s| !s.is_empty()),
+        api_key: std::env::var("API_KEY").ok().filter(|s| !s.is_empty()),
+    }
+}
+
+fn persist_install_config_with_values(
+    binary_path: &Path,
+    dry_run: bool,
+    install_config: &InstallConfig,
+) -> Result<bool, GitAiError> {
     if dry_run {
         return Ok(false);
     }
 
-    let api_base = std::env::var("API_BASE").ok().filter(|s| !s.is_empty());
-    let api_key = std::env::var("API_KEY").ok().filter(|s| !s.is_empty());
+    let api_base = &install_config.api_base;
+    let api_key = &install_config.api_key;
 
     if api_base.is_none() && api_key.is_none() {
         return Ok(false);
@@ -376,14 +413,14 @@ fn persist_install_config(binary_path: &Path, dry_run: bool) -> Result<bool, Git
     let mut file_config = crate::config::load_file_config_public().map_err(GitAiError::Generic)?;
     let mut changed = false;
 
-    if let Some(ref api_base) = api_base
+    if let Some(api_base) = api_base
         && file_config.api_base_url.as_deref() != Some(api_base.as_str())
     {
         file_config.api_base_url = Some(api_base.clone());
         changed = true;
     }
 
-    if let Some(ref api_key) = api_key
+    if let Some(api_key) = api_key
         && file_config.api_key.as_deref() != Some(api_key.as_str())
     {
         file_config.api_key = Some(api_key.clone());

--- a/src/commands/package_setup.rs
+++ b/src/commands/package_setup.rs
@@ -32,6 +32,8 @@ struct PackageSetupOptions {
     manager: PackageManager,
     dry_run: bool,
     target_user: Option<String>,
+    api_base: Option<String>,
+    api_key: Option<String>,
 }
 
 pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
@@ -49,13 +51,15 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
     if options.dry_run {
         install_args[0] = "--dry-run=true".to_string();
     }
-    install_hooks::run(&install_args)
+    install_hooks::run_with_package_config(&install_args, options.api_base, options.api_key)
 }
 
 fn parse_options(args: &[String]) -> Result<PackageSetupOptions, GitAiError> {
     let mut manager = None;
     let mut dry_run = false;
     let mut target_user = None;
+    let mut api_base = None;
+    let mut api_key = None;
     let mut iter = args.iter();
 
     while let Some(arg) = iter.next() {
@@ -73,6 +77,20 @@ fn parse_options(args: &[String]) -> Result<PackageSetupOptions, GitAiError> {
                 GitAiError::Generic("missing value for --target-user".to_string())
             })?;
             target_user = non_empty_value(value);
+        } else if let Some(value) = arg.strip_prefix("--api-base=") {
+            api_base = non_empty_value(value);
+        } else if arg == "--api-base" {
+            let value = iter
+                .next()
+                .ok_or_else(|| GitAiError::Generic("missing value for --api-base".to_string()))?;
+            api_base = non_empty_value(value);
+        } else if let Some(value) = arg.strip_prefix("--api-key=") {
+            api_key = non_empty_value(value);
+        } else if arg == "--api-key" {
+            let value = iter
+                .next()
+                .ok_or_else(|| GitAiError::Generic("missing value for --api-key".to_string()))?;
+            api_key = non_empty_value(value);
         } else if arg == "--dry-run" || arg == "--dry-run=true" {
             dry_run = true;
         } else if arg == "--dry-run=false" {
@@ -90,6 +108,8 @@ fn parse_options(args: &[String]) -> Result<PackageSetupOptions, GitAiError> {
         manager,
         dry_run,
         target_user,
+        api_base,
+        api_key,
     })
 }
 
@@ -146,6 +166,23 @@ mod tests {
         assert_eq!(options.manager, PackageManager::Pkg);
         assert!(options.dry_run);
         assert_eq!(options.target_user.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_options_accepts_msi_api_configuration() {
+        let options = parse_options(&strings(&[
+            "--manager=msi",
+            "--api-base=https://enterprise.example",
+            "--api-key",
+            "sk-enterprise-key",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            options.api_base.as_deref(),
+            Some("https://enterprise.example")
+        );
+        assert_eq!(options.api_key.as_deref(), Some("sk-enterprise-key"));
     }
 
     #[test]

--- a/tests/package_installers.rs
+++ b/tests/package_installers.rs
@@ -19,6 +19,23 @@ fn msi_is_per_user_and_updates_only_the_user_path() {
 }
 
 #[test]
+fn msi_accepts_hidden_api_properties_and_configures_the_installing_user() {
+    let wix = std::fs::read_to_string(packaging_path("windows/git-ai.wxs")).unwrap();
+    let readme = std::fs::read_to_string(packaging_path("README.md")).unwrap();
+
+    assert!(wix.contains("Property Id=\"API_BASE\" Hidden=\"yes\""));
+    assert!(wix.contains("Property Id=\"API_KEY\" Hidden=\"yes\""));
+    assert!(wix.contains("FileRef=\"GitAiExe\""));
+    assert!(wix.contains("Execute=\"deferred\""));
+    assert!(wix.contains("Impersonate=\"yes\""));
+    assert!(wix.contains("HideTarget=\"yes\""));
+    assert!(wix.contains("setup-package --manager msi"));
+    assert!(readme.contains("msiexec /i"));
+    assert!(readme.contains("API_BASE="));
+    assert!(readme.contains("API_KEY="));
+}
+
+#[test]
 fn packaging_supports_only_msi_and_pkg() {
     assert!(packaging_path("windows").is_dir());
     assert!(packaging_path("macos").is_dir());


### PR DESCRIPTION
## Summary

- Supports `API_BASE` and `API_KEY` in the documented `msiexec` command.
- Passes them to a deferred, user-context MSI action.
- Marks MSI properties and custom-action data hidden.
- Persists settings through the existing user config flow.

## Validation

- `task test CARGO_TEST_ARGS="--lib install_hooks::tests"`
- `task test CARGO_TEST_ARGS="--lib package_setup::tests"`
- `task test CARGO_TEST_ARGS="--test package_installers"`

## Stack

Depends on #1714.