### PR TITLE
Document MSI and PKG release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://usegitai.com
 
 ### Windows MSI beta
 
-Download the [Windows x64 MSI](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-x64.msi) or [Windows ARM64 MSI](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-arm64.msi), then open it. The MSI installs only for the current user, under local app data, and changes only that user's `PATH`; it does not require an Administrator install.
+Download the [Windows x64 MSI](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-x64.msi) or [Windows ARM64 MSI](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-arm64.msi), then open it. These links always resolve to the newest stable release. The MSI installs only for the current user, under local app data, and changes only that user's `PATH`; it does not require an Administrator install.
 
 For managed installations, pass the Git AI endpoint when invoking the MSI:
 
@@ -60,7 +60,17 @@ The values configure the installing user's Git AI config. Use your endpoint-mana
 
 ### macOS PKG beta
 
-Download the [Apple Silicon PKG](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-arm64.pkg) or [Intel PKG](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-x64.pkg), then open it. macOS asks for permission to install the bootstrap binary; Git AI configures the active logged-in user rather than root.
+Download the [Apple Silicon PKG](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-arm64.pkg) or [Intel PKG](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-x64.pkg), then open it. These links always resolve to the newest stable release. macOS asks for permission to install the bootstrap binary; Git AI configures the active logged-in user rather than root.
+
+For a managed macOS installation, run the following as the developer user after the PKG install. Do not use `sudo` for this step:
+
+```bash
+git-ai setup-package --manager pkg \
+  --api-base https://git-ai.example \
+  --api-key your-api-key
+```
+
+The PKG does not accept API settings as installer properties. This command configures only the current user's Git AI config. Use a device-management or secret-management mechanism for the API key rather than putting a long-lived key in shell history.
 
 The MSI and PKG are first-install options. Existing Git AI auto-updates continue through the current user-level update flow, and the script installs above remain available.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ curl -sSL https://usegitai.com/install.sh | bash
 powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://usegitai.com/install.ps1 | iex"
 ```
 
+### Windows MSI beta
+
+Download the [Windows x64 MSI](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-x64.msi) or [Windows ARM64 MSI](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-arm64.msi), then open it. The MSI installs only for the current user, under local app data, and changes only that user's `PATH`; it does not require an Administrator install.
+
+For managed installations, pass the Git AI endpoint when invoking the MSI:
+
+```powershell
+msiexec /i git-ai-windows-x64.msi API_BASE=https://git-ai.example API_KEY=your-api-key
+```
+
+The values configure the installing user's Git AI config. Use your endpoint-management secret mechanism when possible, because command-line values can be visible in shell history and local process inspection.
+
+### macOS PKG beta
+
+Download the [Apple Silicon PKG](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-arm64.pkg) or [Intel PKG](https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-x64.pkg), then open it. macOS asks for permission to install the bootstrap binary; Git AI configures the active logged-in user rather than root.
+
+The MSI and PKG are first-install options. Existing Git AI auto-updates continue through the current user-level update flow, and the script installs above remain available.
+
 **No per-repo setup or git hooks required.** Commit with the Agent, git, or your favorite git client. Attribution will be linked to commits automatically.
 
 **The [Git AI standard](https://github.com/git-ai-project/git-ai/blob/main/specs/git_ai_standard_v3.0.0.md) is supported by:**

--- a/docs/installer-release-runbook.md
+++ b/docs/installer-release-runbook.md
@@ -12,12 +12,13 @@ This runbook covers the Windows MSI and macOS PKG beta installers. They are firs
 
 ## One-time repository setup
 
-Complete these settings before the first production run:
+Complete these settings before the first release run:
 
-1. Keep signing and notarization credentials in the existing GitHub `release` environment.
-2. Create a `release-prod` environment with exactly one required approval from Sasha or Aidan. It is an approval gate only; do not move signing credentials into it.
-3. Confirm the repository Actions policy permits the pinned Azure signing actions used by `.github/workflows/release.yml`.
-4. Confirm the release workflow can build both `git-ai-windows-x64.msi` and `git-ai-windows-arm64.msi`.
+1. Keep signing and notarization credentials in the GitHub `release` environment, with no required reviewers. A reviewer-protected `release` environment would prompt separately for every signing job.
+2. Create a `release-approval` environment with exactly one required reviewer from Sasha or Aidan. It is an approval gate only and contains no secrets or variables.
+3. Require the workflow to authorize the triggering user before the approval gate. Only trusted release operators may run a workflow that can access the `release` secrets.
+4. Confirm the repository Actions policy permits the pinned Azure signing actions used by `.github/workflows/release.yml`.
+5. Confirm the release workflow can build both `git-ai-windows-x64.msi` and `git-ai-windows-arm64.msi`.
 
 The repository administrator must create the GitHub environment and its protection rule. The workflow cannot create or protect environments itself.
 
@@ -27,11 +28,11 @@ Open **Actions → Release Build → Run workflow** and use the appropriate inpu
 
 | Release kind | `dry_run` | `release_production` | Approval |
 | --- | --- | --- | --- |
-| Validation only | `true` | `false` | None from `release-prod` |
-| Pre-release | `false` | `false` | None from `release-prod` |
-| Production | `false` | `true` | One `release-prod` approval; run from `main` |
+| Validation only | `true` | `false` | None |
+| Pre-release | `false` | `false` | One `release-approval` review |
+| Production | `false` | `true` | One `release-approval` review; run from `main` |
 
-For a production release, wait for the `Approve production release` job, then approve it once. The dependent build and publishing jobs use the existing `release` environment for credentials without adding additional production-approval gates.
+For every non-dry release, approve `Release approval` once at the start. The dependent build, signing, package, test, and publishing jobs use the existing `release` environment for credentials without further approval prompts.
 
 ## What the workflow publishes
 
@@ -41,6 +42,33 @@ For a production release, wait for the `Approve production release` job, then ap
 4. After notarization and PKG validation succeed, `Publish macOS PKG installers` attaches both PKGs and `PKG-SHA256SUMS` to that same release.
 
 If PKG notarization fails or is delayed, investigate or retry the PKG publishing path. Do not recreate the core release just to wait for notarization.
+
+## Stable release asset check
+
+After the first stable release from `main` completes, verify that these customer-facing URLs download the matching release assets before publishing or merging customer documentation:
+
+- `https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-x64.msi`
+- `https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-windows-arm64.msi`
+- `https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-arm64.pkg`
+- `https://github.com/git-ai-project/git-ai/releases/latest/download/git-ai-macos-x64.pkg`
+
+For each downloaded PKG, run:
+
+```bash
+pkgutil --check-signature git-ai-macos-<arch>.pkg
+xcrun stapler validate git-ai-macos-<arch>.pkg
+spctl --assess --type install --verbose=4 git-ai-macos-<arch>.pkg
+```
+
+For each MSI, verify the signature on a Windows test machine:
+
+```powershell
+Get-AuthenticodeSignature .\git-ai-windows-<arch>.msi
+```
+
+## Managed API configuration
+
+The MSI accepts `API_BASE` and `API_KEY` through `msiexec` and persists them for the installing user. The PKG has no equivalent installer-property interface. For a managed macOS install, run `git-ai setup-package --manager pkg --api-base ... --api-key ...` as the target developer user after the PKG installation. Do not use `sudo` for that configuration step, and use a disposable test key for validation.
 
 ## Before production
 

--- a/docs/installer-release-runbook.md
+++ b/docs/installer-release-runbook.md
@@ -1,0 +1,54 @@
+# MSI/PKG release runbook
+
+This runbook covers the Windows MSI and macOS PKG beta installers. They are first-install bootstrap packages; the existing user-level update flow remains the source of subsequent updates.
+
+## Scope and guardrails
+
+- Ship only Windows MSI and macOS PKG installers in this release path.
+- The Windows MSI is per-user only. It installs to the current user's local app data and updates that user's `PATH`; there is no all-users mode in this release.
+- The macOS PKG writes its bootstrap binary with installer privileges, then runs user setup as the active console user. It must not create root-owned state in that user's home directory.
+- Do not add a Git shim or wrapper to either package.
+- The release body must contain the MSI/PKG beta warning. Do not put the warning in the release title or asset names.
+
+## One-time repository setup
+
+Complete these settings before the first production run:
+
+1. Keep signing and notarization credentials in the existing GitHub `release` environment.
+2. Create a `release-prod` environment with exactly one required approval from Sasha or Aidan. It is an approval gate only; do not move signing credentials into it.
+3. Confirm the repository Actions policy permits the pinned Azure signing actions used by `.github/workflows/release.yml`.
+4. Confirm the release workflow can build both `git-ai-windows-x64.msi` and `git-ai-windows-arm64.msi`.
+
+The repository administrator must create the GitHub environment and its protection rule. The workflow cannot create or protect environments itself.
+
+## Run the release workflow
+
+Open **Actions → Release Build → Run workflow** and use the appropriate inputs:
+
+| Release kind | `dry_run` | `release_production` | Approval |
+| --- | --- | --- | --- |
+| Validation only | `true` | `false` | None from `release-prod` |
+| Pre-release | `false` | `false` | None from `release-prod` |
+| Production | `false` | `true` | One `release-prod` approval; run from `main` |
+
+For a production release, wait for the `Approve production release` job, then approve it once. The dependent build and publishing jobs use the existing `release` environment for credentials without adding additional production-approval gates.
+
+## What the workflow publishes
+
+1. The workflow builds the regular binaries, x64 and ARM64 MSIs, and Intel and Apple Silicon PKGs.
+2. It signs the MSIs, validates an MSI install on Windows, then creates the core GitHub release with the automatic MSI/PKG beta warning in the release body.
+3. macOS notarization runs separately. The core release does not depend on the PKG packaging or notarization jobs, so notarization cannot block an emergency release.
+4. After notarization and PKG validation succeed, `Publish macOS PKG installers` attaches both PKGs and `PKG-SHA256SUMS` to that same release.
+
+If PKG notarization fails or is delayed, investigate or retry the PKG publishing path. Do not recreate the core release just to wait for notarization.
+
+## Before production
+
+Run a non-production release first, then complete the manual validation matrix:
+
+- macOS: install the PKG with installer privilege and verify normal-user setup, no root-owned `~/.git-ai` state, the CLI, and the daemon runtime selection.
+- Windows ARM64: install the ARM64 MSI in UTM on Apple Silicon as a standard user and as an Administrator; verify that the default per-user install does not create Administrator-owned user state.
+- Windows x64: repeat the MSI checks on a physical Windows machine.
+- On both platforms, install the package, run the existing update flow, and confirm the CLI and daemon use the user runtime after the update.
+
+Record the results with the release. Production is ready only after the non-production release and this matrix pass.

--- a/tests/package_installers.rs
+++ b/tests/package_installers.rs
@@ -52,10 +52,15 @@ fn installer_docs_cover_customer_setup_and_internal_release_policy() {
     assert!(customer_readme.contains("git-ai-macos-arm64.pkg"));
     assert!(customer_readme.contains("API_BASE="));
     assert!(customer_readme.contains("API_KEY="));
-    assert!(release_runbook.contains("release-prod"));
+    assert!(customer_readme.contains("setup-package --manager pkg"));
+    assert!(customer_readme.contains("--api-base"));
+    assert!(customer_readme.contains("--api-key"));
+    assert!(release_runbook.contains("release-approval"));
     assert!(release_runbook.contains("release_production"));
     assert!(release_runbook.contains("PKG-SHA256SUMS"));
     assert!(release_runbook.contains("UTM"));
+    assert!(release_runbook.contains("pkgutil --check-signature"));
+    assert!(release_runbook.contains("Get-AuthenticodeSignature"));
     assert!(!release_runbook.contains("Homebrew"));
     assert!(!release_runbook.contains("apt"));
 }

--- a/tests/package_installers.rs
+++ b/tests/package_installers.rs
@@ -42,3 +42,20 @@ fn packaging_supports_only_msi_and_pkg() {
     assert!(!packaging_path("debian/build-deb.sh").exists());
     assert!(!packaging_path("homebrew/update-formula.sh").exists());
 }
+
+#[test]
+fn installer_docs_cover_customer_setup_and_internal_release_policy() {
+    let customer_readme = std::fs::read_to_string("README.md").unwrap();
+    let release_runbook = std::fs::read_to_string("docs/installer-release-runbook.md").unwrap();
+
+    assert!(customer_readme.contains("git-ai-windows-x64.msi"));
+    assert!(customer_readme.contains("git-ai-macos-arm64.pkg"));
+    assert!(customer_readme.contains("API_BASE="));
+    assert!(customer_readme.contains("API_KEY="));
+    assert!(release_runbook.contains("release-prod"));
+    assert!(release_runbook.contains("release_production"));
+    assert!(release_runbook.contains("PKG-SHA256SUMS"));
+    assert!(release_runbook.contains("UTM"));
+    assert!(!release_runbook.contains("Homebrew"));
+    assert!(!release_runbook.contains("apt"));
+}


### PR DESCRIPTION
## Summary

- Adds a customer-facing MSI/PKG beta install section to the README.
- Documents the supported `msiexec` API base/key configuration command.
- Adds an internal release runbook covering the single production approval, separate PKG notarization, and manual validation matrix.
- Adds regression coverage for the documentation contract.

## Validation

- `task test CARGO_TEST_ARGS="--test package_installers"`
- `task fmt`
- `task lint`

## Stack

Sibling follow-up to #1839.