### PR TITLE
feat: periodically sync agent hooks

### DIFF
--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -309,17 +309,35 @@ fn ensure_daemon(dry_run: bool) {
 
 /// Main entry point for install-hooks command
 pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
+    run_inner(args, true)
+}
+
+/// Reconcile hook configuration without restarting the daemon.
+///
+/// The daemon's periodic hooks worker uses this entry point so it shares the
+/// exact install-hooks behavior while leaving the running daemon untouched.
+pub(crate) fn run_without_daemon_restart(
+    args: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    run_inner(args, false)
+}
+
+fn run_inner(args: &[String], restart_daemon: bool) -> Result<HashMap<String, String>, GitAiError> {
     let options = parse_install_options(args);
 
-    // Daemon trace2 config must be in place before any install work starts.
-    // Non-fatal: the global git config may be read-only (e.g. Nix store symlink).
-    if let Err(e) = configure_daemon_trace2(options.dry_run) {
-        eprintln!("Warning: could not configure trace2 (non-fatal): {e}");
+    if restart_daemon {
+        // Daemon trace2 config must be in place before user-initiated install
+        // work starts. The daemon's periodic hook sync skips this non-atomic
+        // rewrite so concurrent Git commands never lose trace2 routing.
+        // Non-fatal: the global git config may be read-only (e.g. Nix store symlink).
+        if let Err(e) = configure_daemon_trace2(options.dry_run) {
+            eprintln!("Warning: could not configure trace2 (non-fatal): {e}");
+        }
+        ensure_daemon(options.dry_run);
     }
-    ensure_daemon(options.dry_run);
 
-    // Now that the daemon is (re)started, initialize the telemetry handle so
-    // that install-hooks metrics and observability events route through it.
+    // Initialize the telemetry handle so install-hooks metrics and
+    // observability events route through the daemon.
     if !options.dry_run {
         let _ = crate::daemon::telemetry_handle::init_daemon_telemetry_handle();
     }
@@ -330,7 +348,15 @@ pub fn run(args: &[String]) -> Result<HashMap<String, String>, GitAiError> {
     let params = HookInstallerParams { binary_path };
 
     // Run async operations and convert result.
-    let statuses = crate::tokio_runtime::block_on(async_run_install(&params, &options))?;
+    // Only an explicit user invocation treats the absence of `--skills` as a
+    // request to uninstall skills. Periodic daemon reconciliation must leave
+    // the user's existing skills preference untouched.
+    let remove_unrequested_skills = restart_daemon;
+    let statuses = crate::tokio_runtime::block_on(async_run_install(
+        &params,
+        &options,
+        remove_unrequested_skills,
+    ))?;
 
     // Clean up legacy envelope logs directory and related artifacts.
     // These are no longer used — all telemetry now routes through the daemon.
@@ -466,6 +492,7 @@ pub fn run_uninstall(args: &[String]) -> Result<HashMap<String, String>, GitAiEr
 async fn async_run_install(
     params: &HookInstallerParams,
     options: &InstallOptions,
+    remove_unrequested_skills: bool,
 ) -> Result<HashMap<String, InstallStatus>, GitAiError> {
     let mut any_checked = false;
     let mut has_changes = false;
@@ -646,7 +673,8 @@ async fn async_run_install(
         {
             has_changes = true;
         }
-    } else if let Ok(result) = skills_installer::uninstall_skills(options.dry_run, options.verbose)
+    } else if remove_unrequested_skills
+        && let Ok(result) = skills_installer::uninstall_skills(options.dry_run, options.verbose)
         && result.changed
     {
         has_changes = true;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7323,6 +7323,90 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
     }
 }
 
+type HooksSyncFn = Arc<dyn Fn() -> Result<usize, String> + Send + Sync>;
+
+fn run_hooks_sync_in_background(
+    sync_hooks: HooksSyncFn,
+) -> std::io::Result<tokio::sync::oneshot::Receiver<Result<usize, String>>> {
+    let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("git-ai-hooks-sync".to_string())
+        .spawn(move || {
+            let _ = completion_tx.send(sync_hooks());
+        })?;
+    Ok(completion_rx)
+}
+
+async fn daemon_hooks_sync_loop(
+    coordinator: Arc<ActorDaemonCoordinator>,
+    interval: Duration,
+    sync_hooks: HooksSyncFn,
+) {
+    tracing::info!(
+        interval_secs = interval.as_secs(),
+        "hooks sync worker started"
+    );
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = coordinator.wait_for_shutdown() => return,
+            _ = tokio::time::sleep(interval) => {}
+        }
+
+        if coordinator.is_shutting_down() {
+            return;
+        }
+
+        let completion = match run_hooks_sync_in_background(sync_hooks.clone()) {
+            Ok(completion) => completion,
+            Err(error) => {
+                tracing::warn!(%error, "failed to start hooks sync");
+                continue;
+            }
+        };
+
+        tokio::select! {
+            biased;
+            _ = coordinator.wait_for_shutdown() => return,
+            result = completion => match result {
+                Ok(Ok(tool_count)) => {
+                    tracing::info!(tool_count, "hooks sync completed");
+                }
+                Ok(Err(error)) => {
+                    tracing::warn!(%error, "hooks sync failed");
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "hooks sync worker stopped without a result");
+                }
+            }
+        }
+    }
+}
+
+fn spawn_daemon_hooks_sync_worker(
+    coordinator: Arc<ActorDaemonCoordinator>,
+    interval_secs: u64,
+    sync_hooks: HooksSyncFn,
+) -> Option<tokio::task::JoinHandle<()>> {
+    if interval_secs == 0 {
+        tracing::info!("hooks sync worker disabled");
+        return None;
+    }
+
+    Some(tokio::spawn(daemon_hooks_sync_loop(
+        coordinator,
+        Duration::from_secs(interval_secs),
+        sync_hooks,
+    )))
+}
+
+fn sync_agent_hooks() -> Result<usize, String> {
+    crate::commands::install_hooks::run_without_daemon_restart(&[])
+        .map(|statuses| statuses.len())
+        .map_err(|error| error.to_string())
+}
+
 /// After the daemon has fully shut down, attempt to install any pending update.
 ///
 /// On Unix the installer atomically replaces the binary via `mv`; on Windows
@@ -7492,7 +7576,18 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
         daemon_socket_health_check_loop(health_coord, health_control, health_trace);
     });
 
+    let hooks_sync_handle = spawn_daemon_hooks_sync_worker(
+        coordinator.clone(),
+        config::Config::get()
+            .get_feature_flags()
+            .hooks_sync_interval,
+        Arc::new(sync_agent_hooks),
+    );
+
     coordinator.wait_for_shutdown().await;
+    if let Some(handle) = hooks_sync_handle {
+        handle.abort();
+    }
 
     // Best-effort wake listeners to allow clean process exit.
     // Connect to each socket to unblock `accept()`.  If the socket files
@@ -9238,5 +9333,77 @@ mod tests {
             tokio::task::yield_now().await;
         }
         coord.request_shutdown();
+    }
+
+    #[tokio::test]
+    async fn hooks_sync_worker_runs_after_its_interval() {
+        let coordinator = Arc::new(ActorDaemonCoordinator::new());
+        let completed = Arc::new(tokio::sync::Notify::new());
+        let completed_for_sync = completed.clone();
+        let sync_hooks: HooksSyncFn = Arc::new(move || {
+            completed_for_sync.notify_one();
+            Ok(1)
+        });
+
+        let handle = tokio::spawn(daemon_hooks_sync_loop(
+            coordinator.clone(),
+            Duration::from_millis(10),
+            sync_hooks,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), completed.notified())
+            .await
+            .expect("hooks sync should run after the configured interval");
+        coordinator.request_shutdown();
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("hooks sync worker should stop after shutdown")
+            .expect("hooks sync worker should not panic");
+    }
+
+    #[tokio::test]
+    async fn zero_hooks_sync_interval_does_not_spawn_worker() {
+        let coordinator = Arc::new(ActorDaemonCoordinator::new());
+        let sync_hooks: HooksSyncFn = Arc::new(|| panic!("disabled hooks sync must not run"));
+
+        let handle = spawn_daemon_hooks_sync_worker(coordinator, 0, sync_hooks);
+
+        assert!(handle.is_none());
+    }
+
+    #[tokio::test]
+    async fn hooks_sync_does_not_block_daemon_shutdown() {
+        let coordinator = Arc::new(ActorDaemonCoordinator::new());
+        let started = Arc::new(tokio::sync::Notify::new());
+        let started_for_sync = started.clone();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let sync_hooks: HooksSyncFn = Arc::new(move || {
+            started_for_sync.notify_one();
+            release_rx
+                .lock()
+                .expect("release receiver lock should not be poisoned")
+                .recv()
+                .expect("test should release the hook sync thread");
+            Ok(1)
+        });
+
+        let handle = tokio::spawn(daemon_hooks_sync_loop(
+            coordinator.clone(),
+            Duration::from_millis(1),
+            sync_hooks,
+        ));
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("hook sync should begin");
+
+        coordinator.request_shutdown();
+        tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("daemon shutdown must not wait for an in-progress hooks sync")
+            .expect("hooks sync worker should not panic");
+        release_tx
+            .send(())
+            .expect("hook sync test thread should still be waiting");
     }
 }

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -5,7 +5,7 @@ mod repos;
 use git_ai::daemon::control_api::CasSyncPayload;
 use git_ai::daemon::{
     ControlRequest, ControlResponse, DaemonConfig, TelemetryEnvelope,
-    local_socket_connects_with_timeout, open_local_socket_stream_with_timeout,
+    local_socket_connects_with_timeout, open_local_socket_stream_with_timeout, read_daemon_pid,
     send_control_request,
 };
 use repos::test_repo::{DaemonTestScope, TestRepo, get_binary_path, real_git_executable};
@@ -33,6 +33,20 @@ fn read_global_git_config(repo: &TestRepo, key: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+fn set_global_git_config(repo: &TestRepo, key: &str, value: &str) {
+    let mut command = Command::new(real_git_executable());
+    command.args(["config", "--global", key, value]);
+    command.current_dir(repo.path());
+    configure_test_home_env(&mut command, repo);
+    let output = command.output().expect("failed to write global git config");
+    assert!(
+        output.status.success(),
+        "failed to set {key}: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 fn daemon_trace_socket_path(repo: &TestRepo) -> PathBuf {
@@ -77,13 +91,17 @@ fn configure_test_daemon_env(command: &mut Command, repo: &TestRepo) {
 }
 
 fn write_daemon_config(repo: &TestRepo) {
+    write_daemon_config_with_feature_flags(repo, serde_json::json!({}));
+}
+
+fn write_daemon_config_with_feature_flags(repo: &TestRepo, feature_flags: Value) {
     let config_dir = repo.test_home_path().join(".git-ai");
     fs::create_dir_all(&config_dir).expect("failed to create daemon config dir");
     let config_path = config_dir.join("config.json");
     let config = serde_json::json!({
         "git_path": real_git_executable(),
         "disable_auto_updates": true,
-        "feature_flags": {},
+        "feature_flags": feature_flags,
         "quiet": false
     });
     fs::write(
@@ -212,6 +230,21 @@ fn start_daemon(repo: &TestRepo) {
     daemon_cmd.spawn().expect("failed to start daemon");
 }
 
+fn start_daemon_without_test_db_marker(repo: &TestRepo) -> Child {
+    let mut daemon_cmd = Command::new(repos::test_repo::get_binary_path());
+    daemon_cmd
+        .arg("bg")
+        .arg("run")
+        .current_dir(repo.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .env_remove("GIT_AI_TEST_DB_PATH")
+        .env_remove("GITAI_TEST_DB_PATH");
+    configure_test_home_env(&mut daemon_cmd, repo);
+    configure_test_daemon_env(&mut daemon_cmd, repo);
+    daemon_cmd.spawn().expect("failed to start daemon")
+}
+
 fn shutdown_daemon(home_repo: &TestRepo) {
     let output = daemon_command_output(home_repo, &["bg", "shutdown"], home_repo.test_home_path());
     assert!(
@@ -232,6 +265,138 @@ fn wait_for_child_exit(child: &mut Child) {
     }
     let _ = child.kill();
     let _ = child.wait();
+}
+
+fn cursor_hooks_path(repo: &TestRepo) -> PathBuf {
+    repo.test_home_path().join(".cursor").join("hooks.json")
+}
+
+fn write_stale_cursor_hooks(repo: &TestRepo) -> PathBuf {
+    let hooks_path = cursor_hooks_path(repo);
+    fs::create_dir_all(
+        hooks_path
+            .parent()
+            .expect("hooks path should have a parent"),
+    )
+    .expect("failed to create Cursor config directory");
+    fs::write(
+        &hooks_path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{"command": "/old/git-ai checkpoint cursor"}],
+                "postToolUse": [{"command": "/old/git-ai checkpoint cursor"}]
+            }
+        }))
+        .expect("failed to serialize stale Cursor hooks"),
+    )
+    .expect("failed to write stale Cursor hooks");
+    hooks_path
+}
+
+fn cursor_hooks_use_current_binary(hooks_path: &Path) -> bool {
+    let Ok(contents) = fs::read_to_string(hooks_path) else {
+        return false;
+    };
+    let Ok(hooks) = serde_json::from_str::<Value>(&contents) else {
+        return false;
+    };
+    let expected_binary = get_binary_path()
+        .canonicalize()
+        .expect("test binary should be canonicalizable")
+        .to_string_lossy()
+        .to_string();
+
+    ["preToolUse", "postToolUse"].iter().all(|hook_name| {
+        hooks["hooks"][hook_name].as_array().is_some_and(|entries| {
+            entries.iter().any(|entry| {
+                entry["command"]
+                    .as_str()
+                    .is_some_and(|command| command.starts_with(&expected_binary))
+            })
+        })
+    })
+}
+
+#[test]
+fn daemon_periodically_syncs_agent_hooks() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    write_daemon_config_with_feature_flags(&repo, serde_json::json!({"hooks_sync_interval": 1}));
+    let hooks_path = write_stale_cursor_hooks(&repo);
+    let installed_skill = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("skills")
+        .join("existing-skill")
+        .join("SKILL.md");
+    fs::create_dir_all(
+        installed_skill
+            .parent()
+            .expect("installed skill should have a parent directory"),
+    )
+    .expect("failed to create installed skill directory");
+    fs::write(&installed_skill, "# Existing skill\n")
+        .expect("failed to write installed skill marker");
+    set_global_git_config(&repo, "trace2.configParams", "hooks-sync-sentinel");
+
+    let mut daemon = start_daemon_without_test_db_marker(&repo);
+    wait_for_daemon_sockets(&repo);
+    let daemon_config = DaemonConfig::from_home(repo.test_home_path());
+    let initial_pid = read_daemon_pid(&daemon_config).expect("daemon PID should be readable");
+
+    for _ in 0..100 {
+        if cursor_hooks_use_current_binary(&hooks_path) {
+            assert_eq!(
+                read_daemon_pid(&daemon_config).expect("daemon PID should remain readable"),
+                initial_pid,
+                "periodic install-hooks reconciliation must not restart the daemon"
+            );
+            assert_eq!(
+                read_global_git_config(&repo, "trace2.configParams").as_deref(),
+                Some("hooks-sync-sentinel"),
+                "periodic hook sync must not rewrite global trace2 configuration"
+            );
+            assert_eq!(
+                read_global_git_config(&repo, "trace2.eventTarget"),
+                None,
+                "periodic hook sync must not install trace2 configuration"
+            );
+            assert!(
+                installed_skill.exists(),
+                "periodic hook sync must preserve installed skills"
+            );
+            shutdown_daemon(&repo);
+            wait_for_child_exit(&mut daemon);
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    shutdown_daemon(&repo);
+    wait_for_child_exit(&mut daemon);
+    panic!(
+        "daemon did not reconcile stale Cursor hooks: {}",
+        fs::read_to_string(&hooks_path).unwrap_or_else(|error| error.to_string())
+    );
+}
+
+#[test]
+fn zero_hooks_sync_interval_disables_automatic_sync() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    write_daemon_config_with_feature_flags(&repo, serde_json::json!({"hooks_sync_interval": 0}));
+    let hooks_path = write_stale_cursor_hooks(&repo);
+    let original = fs::read_to_string(&hooks_path).expect("failed to read stale Cursor hooks");
+
+    start_daemon(&repo);
+    wait_for_daemon_sockets(&repo);
+    thread::sleep(Duration::from_millis(1_250));
+    shutdown_daemon(&repo);
+
+    assert_eq!(
+        fs::read_to_string(&hooks_path).expect("failed to read Cursor hooks after daemon run"),
+        original,
+        "hooks_sync_interval=0 must leave agent hooks untouched"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Reuse the existing `install-hooks` implementation through a daemon-safe entry point that skips daemon restart.
- Run hook reconciliation on a six-hour async timer by default, with `hooks_sync_interval = 0` disabling the worker.
- Delegate blocking reconciliation to a detached, named thread while the async worker waits on either completion or daemon shutdown.
- Add end-to-end `TestRepo` coverage for real Cursor hook repair, disabled automation, and preserving the daemon PID.
- Add lifecycle tests proving the worker waits for its interval and cannot delay shutdown even when reconciliation is still blocked.

## Why

Agent hook formats and user preferences can change while the long-lived daemon is running. Periodic reconciliation keeps those files current without adding work to trace2 ingestion or restarting the daemon.

## Validation

- `task fmt`
- `task lint`
- `task test`
- Production-like e2e daemon test with the test DB marker removed

Stack: 2 of 2. Depends on #1866.
