### PR TITLE
fix: ignore malformed initial attributions

### DIFF
--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -7,9 +7,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::authorship::attribution_tracker::LineAttribution;
 use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord};
 use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
-use crate::authorship::working_log::{Checkpoint, CheckpointKind};
+use crate::authorship::working_log::Checkpoint;
 use crate::error::GitAiError;
-use crate::git::repo_storage::{InitialAttributions, PersistedWorkingLog};
+use crate::git::repo_storage::{
+    InitialAttributions, PersistedWorkingLog, trim_initial_metadata_to_referenced_authors,
+};
 use crate::git::repository::{
     Repository, batch_read_paths_at_treeishes, disable_internal_git_hooks,
     exec_git_allow_nonzero_with_env,
@@ -355,41 +357,6 @@ fn copy_blob_sha(
     fs::create_dir_all(&target_blobs)?;
     fs::copy(source, target_blobs.join(blob_sha))?;
     Ok(())
-}
-
-fn trim_initial_metadata_to_referenced_authors(initial: &mut InitialAttributions) {
-    let human_sentinel = CheckpointKind::Human.to_str();
-    let mut referenced_authors = HashSet::new();
-    let mut referenced_sessions = HashSet::new();
-
-    for attrs in initial.files.values() {
-        for attr in attrs {
-            if attr.author_id == human_sentinel {
-                continue;
-            }
-
-            referenced_authors.insert(attr.author_id.clone());
-            if attr.author_id.starts_with("s_") {
-                let session_key = attr
-                    .author_id
-                    .split("::")
-                    .next()
-                    .unwrap_or(&attr.author_id)
-                    .to_string();
-                referenced_sessions.insert(session_key);
-            }
-        }
-    }
-
-    initial
-        .prompts
-        .retain(|author_id, _| referenced_authors.contains(author_id));
-    initial
-        .humans
-        .retain(|author_id, _| referenced_authors.contains(author_id));
-    initial
-        .sessions
-        .retain(|session_id, _| referenced_sessions.contains(session_id));
 }
 
 fn restore_stash_attributions(

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -907,39 +907,39 @@ impl PersistedWorkingLog {
     }
 }
 
-fn trim_initial_metadata_to_referenced_authors(initial: &mut InitialAttributions) {
-    let mut prompt_ids = HashSet::new();
-    let mut human_ids = HashSet::new();
-    let mut session_ids = HashSet::new();
+pub(crate) fn trim_initial_metadata_to_referenced_authors(initial: &mut InitialAttributions) {
+    let human_sentinel = CheckpointKind::Human.to_str();
+    let mut referenced_authors = HashSet::new();
+    let mut referenced_sessions = HashSet::new();
 
     for attrs in initial.files.values() {
         for attr in attrs {
-            let author_id = attr.author_id.as_str();
-            if author_id.starts_with("s_") {
-                session_ids.insert(
-                    author_id
-                        .split("::")
-                        .next()
-                        .unwrap_or(author_id)
-                        .to_string(),
-                );
-            } else if author_id.starts_with("h_") {
-                human_ids.insert(author_id.to_string());
-            } else {
-                prompt_ids.insert(author_id.to_string());
+            if attr.author_id == human_sentinel {
+                continue;
+            }
+
+            referenced_authors.insert(attr.author_id.clone());
+            if attr.author_id.starts_with("s_") {
+                let session_key = attr
+                    .author_id
+                    .split("::")
+                    .next()
+                    .unwrap_or(&attr.author_id)
+                    .to_string();
+                referenced_sessions.insert(session_key);
             }
         }
     }
 
     initial
         .prompts
-        .retain(|prompt_id, _| prompt_ids.contains(prompt_id));
+        .retain(|author_id, _| referenced_authors.contains(author_id));
     initial
         .humans
-        .retain(|human_id, _| human_ids.contains(human_id));
+        .retain(|author_id, _| referenced_authors.contains(author_id));
     initial
         .sessions
-        .retain(|session_id, _| session_ids.contains(session_id));
+        .retain(|session_id, _| referenced_sessions.contains(session_id));
 }
 
 #[cfg(test)]

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -780,34 +780,58 @@ impl PersistedWorkingLog {
 
     /// Write a fully-formed INITIAL state, preserving any persisted blob references.
     pub fn write_initial(&self, initial: InitialAttributions) -> Result<(), GitAiError> {
-        let filtered_files: HashMap<String, Vec<LineAttribution>> = initial
-            .files
-            .into_iter()
-            .filter(|(_, attrs)| !attrs.is_empty())
-            .collect();
+        let initial_data = self.sanitize_initial_attributions(initial);
 
-        if filtered_files.is_empty() {
+        if initial_data.files.is_empty() {
             if self.initial_file.exists() {
                 fs::remove_file(&self.initial_file)?;
             }
             return Ok(());
         }
 
+        let json = serde_json::to_string_pretty(&initial_data)?;
+        fs::write(&self.initial_file, json)?;
+
+        Ok(())
+    }
+
+    fn sanitize_initial_attributions(&self, initial: InitialAttributions) -> InitialAttributions {
         let mut file_blobs = initial.file_blobs;
+        let filtered_files: HashMap<String, Vec<LineAttribution>> = initial
+            .files
+            .into_iter()
+            .filter(|(_, attrs)| !attrs.is_empty())
+            .filter(|(file_path, _)| {
+                let Some(blob_sha) = file_blobs.get(file_path) else {
+                    tracing::debug!(
+                        "Dropping INITIAL attribution for {} because it has no persisted file snapshot",
+                        file_path
+                    );
+                    return false;
+                };
+
+                let blob_exists = self.dir.join("blobs").join(blob_sha).is_file();
+                if !blob_exists {
+                    tracing::debug!(
+                        "Dropping INITIAL attribution for {} because its persisted file snapshot is missing",
+                        file_path
+                    );
+                }
+                blob_exists
+            })
+            .collect();
+
         file_blobs.retain(|file_path, _| filtered_files.contains_key(file_path));
 
-        let initial_data = InitialAttributions {
+        let mut initial_data = InitialAttributions {
             files: filtered_files,
             prompts: initial.prompts,
             file_blobs,
             humans: initial.humans,
             sessions: initial.sessions,
         };
-
-        let json = serde_json::to_string_pretty(&initial_data)?;
-        fs::write(&self.initial_file, json)?;
-
-        Ok(())
+        trim_initial_metadata_to_referenced_authors(&mut initial_data);
+        initial_data
     }
 
     pub fn initial_file_content_from(
@@ -869,7 +893,7 @@ impl PersistedWorkingLog {
 
         match fs::read_to_string(&self.initial_file) {
             Ok(content) => match serde_json::from_str(&content) {
-                Ok(initial_data) => initial_data,
+                Ok(initial_data) => self.sanitize_initial_attributions(initial_data),
                 Err(e) => {
                     tracing::debug!("Failed to parse INITIAL file: {}. Returning empty.", e);
                     InitialAttributions::default()
@@ -881,6 +905,41 @@ impl PersistedWorkingLog {
             }
         }
     }
+}
+
+fn trim_initial_metadata_to_referenced_authors(initial: &mut InitialAttributions) {
+    let mut prompt_ids = HashSet::new();
+    let mut human_ids = HashSet::new();
+    let mut session_ids = HashSet::new();
+
+    for attrs in initial.files.values() {
+        for attr in attrs {
+            let author_id = attr.author_id.as_str();
+            if author_id.starts_with("s_") {
+                session_ids.insert(
+                    author_id
+                        .split("::")
+                        .next()
+                        .unwrap_or(author_id)
+                        .to_string(),
+                );
+            } else if author_id.starts_with("h_") {
+                human_ids.insert(author_id.to_string());
+            } else {
+                prompt_ids.insert(author_id.to_string());
+            }
+        }
+    }
+
+    initial
+        .prompts
+        .retain(|prompt_id, _| prompt_ids.contains(prompt_id));
+    initial
+        .humans
+        .retain(|human_id, _| human_ids.contains(human_id));
+    initial
+        .sessions
+        .retain(|session_id, _| session_ids.contains(session_id));
 }
 
 #[cfg(test)]
@@ -910,6 +969,8 @@ mod tests {
 
         // OLD base: shared.txt -> old author, plus a unique old-only file.
         let old_log = storage.working_log_for_base_commit(old_sha).unwrap();
+        let old_shared_blob = old_log.persist_file_version("OLD CONTENT").unwrap();
+        let old_only_blob = old_log.persist_file_version("OLD ONLY CONTENT").unwrap();
         let mut old_initial = InitialAttributions::default();
         old_initial.files.insert("shared.txt".into(), attr("h_OLD"));
         old_initial
@@ -917,11 +978,16 @@ mod tests {
             .insert("old_only.txt".into(), attr("h_OLD"));
         old_initial
             .file_blobs
-            .insert("shared.txt".into(), "OLD CONTENT".into());
+            .insert("shared.txt".into(), old_shared_blob.clone());
+        old_initial
+            .file_blobs
+            .insert("old_only.txt".into(), old_only_blob);
         old_log.write_initial(old_initial).unwrap();
 
         // NEW base: shared.txt -> new author (conflict), plus a unique new-only file.
         let new_log = storage.working_log_for_base_commit(new_sha).unwrap();
+        let new_shared_blob = new_log.persist_file_version("NEW CONTENT").unwrap();
+        let new_only_blob = new_log.persist_file_version("NEW ONLY CONTENT").unwrap();
         let mut new_initial = InitialAttributions::default();
         new_initial
             .files
@@ -931,7 +997,10 @@ mod tests {
             .insert("new_only.txt".into(), attr("ai_NEW"));
         new_initial
             .file_blobs
-            .insert("shared.txt".into(), "NEW CONTENT".into());
+            .insert("shared.txt".into(), new_shared_blob);
+        new_initial
+            .file_blobs
+            .insert("new_only.txt".into(), new_only_blob);
         new_log.write_initial(new_initial).unwrap();
 
         // Merge old into new (destination already exists).
@@ -943,6 +1012,7 @@ mod tests {
             .read_initial_attributions();
 
         // Shared key: OLD base wins.
+        let merged_log = storage.working_log_for_base_commit(new_sha).unwrap();
         assert_eq!(
             merged
                 .files
@@ -953,8 +1023,15 @@ mod tests {
         );
         assert_eq!(
             merged.file_blobs.get("shared.txt").map(|s| s.as_str()),
-            Some("OLD CONTENT"),
+            Some(old_shared_blob.as_str()),
             "old-base blob must win on a shared path (kept consistent with files)"
+        );
+        assert_eq!(
+            merged_log
+                .stored_initial_file_content_from(&merged, "shared.txt")
+                .as_deref(),
+            Some("OLD CONTENT"),
+            "merged old-base blob must be readable from the destination working log"
         );
         // Both sides' unique entries survive.
         assert!(merged.files.contains_key("old_only.txt"));

--- a/tests/integration/checkpoint_unit.rs
+++ b/tests/integration/checkpoint_unit.rs
@@ -1261,12 +1261,12 @@ fn test_checkpoint_stale_crlf_blob_causes_ai_reattribution() {
     );
 }
 
-/// Regression test: INITIAL attributions without stored file_blobs are invalid.
+/// Regression test: INITIAL attributions without stored file_blobs are ignored.
 /// Line attributions are only meaningful relative to the exact file snapshot
-/// they describe, so checkpointing must fail loudly instead of guessing from
-/// dirty-file content.
+/// they describe, so malformed legacy INITIAL state must not seed new checkpoints
+/// or make status/post-commit disagree.
 #[test]
-fn test_checkpoint_fails_with_initial_missing_blobs() {
+fn test_checkpoint_ignores_initial_missing_blobs() {
     let repo = TestRepo::new();
     let file_a = repo.path().join("file_a.txt");
     let file_b = repo.path().join("file_b.txt");
@@ -1318,7 +1318,8 @@ fn test_checkpoint_fails_with_initial_missing_blobs() {
     // Directly invoke checkpoint daemon logic on file_b only. The no-blob INITIAL
     // state is invalid even though dirty_files contains file_b, because INITIAL
     // also references file_a and neither attribution can be resolved against the
-    // exact snapshot it describes.
+    // exact snapshot it describes. The malformed INITIAL should be ignored rather
+    // than trusted or allowed to abort checkpointing.
     let mut dirty_files = HashMap::new();
     dirty_files.insert(
         "file_b.txt".to_string(),
@@ -1354,19 +1355,19 @@ fn test_checkpoint_fails_with_initial_missing_blobs() {
         metadata: HashMap::new(),
     };
 
-    let result = execute_resolved_checkpoint_from_daemon(
+    execute_resolved_checkpoint_from_daemon(
         &git_ai_repo,
         "test",
         CheckpointKind::AiAgent,
         checkpoint_request,
         resolved,
-    );
-    let error = result.expect_err("checkpoint should reject INITIAL without persisted blobs");
+    )
+    .expect("checkpoint should ignore INITIAL entries without persisted blobs");
+
+    let sanitized = working_log.read_initial_attributions();
     assert!(
-        error
-            .to_string()
-            .contains("INITIAL missing persisted file snapshot"),
-        "unexpected error: {error}"
+        sanitized.files.is_empty(),
+        "malformed INITIAL entries without file_blobs should not be returned"
     );
 }
 

--- a/tests/integration/repo_storage_unit.rs
+++ b/tests/integration/repo_storage_unit.rs
@@ -419,6 +419,153 @@ fn test_write_initial_with_contents_rejects_missing_snapshot() {
     );
 }
 
+#[test]
+fn test_read_initial_drops_entries_without_snapshot_blob_mappings() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+
+    let valid_blob = working_log
+        .persist_file_version("valid content\n")
+        .expect("persist valid snapshot");
+
+    let initial = InitialAttributions {
+        files: HashMap::from([
+            (
+                "valid.txt".to_string(),
+                vec![LineAttribution {
+                    start_line: 1,
+                    end_line: 1,
+                    author_id: "ai-valid".to_string(),
+                    overrode: None,
+                }],
+            ),
+            (
+                "missing_mapping.txt".to_string(),
+                vec![LineAttribution {
+                    start_line: 1,
+                    end_line: 1,
+                    author_id: "ai-missing-mapping".to_string(),
+                    overrode: None,
+                }],
+            ),
+            (
+                "missing_blob.txt".to_string(),
+                vec![LineAttribution {
+                    start_line: 1,
+                    end_line: 1,
+                    author_id: "ai-missing-blob".to_string(),
+                    overrode: None,
+                }],
+            ),
+        ]),
+        prompts: HashMap::new(),
+        file_blobs: HashMap::from([
+            ("valid.txt".to_string(), valid_blob),
+            (
+                "missing_blob.txt".to_string(),
+                "missing-snapshot-blob".to_string(),
+            ),
+        ]),
+        humans: std::collections::BTreeMap::new(),
+        sessions: std::collections::BTreeMap::new(),
+    };
+
+    let json = serde_json::to_string_pretty(&initial).unwrap();
+    fs::write(&working_log.initial_file, json).unwrap();
+
+    let sanitized = working_log.read_initial_attributions();
+    assert!(
+        sanitized.files.contains_key("valid.txt"),
+        "valid INITIAL entry should be preserved"
+    );
+    assert!(
+        !sanitized.files.contains_key("missing_mapping.txt"),
+        "INITIAL entry without file_blobs mapping must be dropped"
+    );
+    assert!(
+        !sanitized.files.contains_key("missing_blob.txt"),
+        "INITIAL entry with a missing snapshot blob file must be dropped"
+    );
+    assert_eq!(
+        sanitized.file_blobs.keys().cloned().collect::<Vec<_>>(),
+        vec!["valid.txt".to_string()]
+    );
+}
+
+#[test]
+fn test_write_initial_drops_entries_without_snapshot_blob_mappings() {
+    let repo = TestRepo::new();
+    let repo_storage = storage_for(&repo);
+    let working_log = repo_storage
+        .working_log_for_base_commit("test-commit-sha")
+        .unwrap();
+
+    let valid_blob = working_log
+        .persist_file_version("valid content\n")
+        .expect("persist valid snapshot");
+
+    working_log
+        .write_initial(InitialAttributions {
+            files: HashMap::from([
+                (
+                    "valid.txt".to_string(),
+                    vec![LineAttribution {
+                        start_line: 1,
+                        end_line: 1,
+                        author_id: "ai-valid".to_string(),
+                        overrode: None,
+                    }],
+                ),
+                (
+                    "missing.txt".to_string(),
+                    vec![LineAttribution {
+                        start_line: 1,
+                        end_line: 1,
+                        author_id: "ai-missing".to_string(),
+                        overrode: None,
+                    }],
+                ),
+                (
+                    "missing_blob.txt".to_string(),
+                    vec![LineAttribution {
+                        start_line: 1,
+                        end_line: 1,
+                        author_id: "ai-missing-blob".to_string(),
+                        overrode: None,
+                    }],
+                ),
+            ]),
+            prompts: HashMap::new(),
+            file_blobs: HashMap::from([
+                ("valid.txt".to_string(), valid_blob),
+                (
+                    "missing_blob.txt".to_string(),
+                    "missing-snapshot-blob".to_string(),
+                ),
+            ]),
+            humans: std::collections::BTreeMap::new(),
+            sessions: std::collections::BTreeMap::new(),
+        })
+        .expect("write INITIAL");
+
+    let initial = working_log.read_initial_attributions();
+    assert!(
+        initial.files.contains_key("valid.txt"),
+        "valid INITIAL entry should be preserved"
+    );
+    assert!(
+        !initial.files.contains_key("missing.txt"),
+        "writer must not persist INITIAL attribution without a snapshot blob"
+    );
+    assert!(
+        !initial.files.contains_key("missing_blob.txt"),
+        "writer must not persist INITIAL attribution with a missing snapshot blob file"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 9. test_write_initial_empty_removes_existing_file
 // ---------------------------------------------------------------------------

--- a/tests/integration/rewrite_ops_attribution.rs
+++ b/tests/integration/rewrite_ops_attribution.rs
@@ -80,7 +80,7 @@ fn test_raw_git_commit_before_traced_commit_does_not_poison_ref_cursor() {
 }
 
 #[test]
-fn test_daemon_reports_post_commit_side_effect_error() {
+fn test_daemon_ignores_malformed_initial_without_side_effect_error() {
     let repo = TestRepo::new();
 
     let base_path = repo.path().join("base.txt");
@@ -100,25 +100,27 @@ fn test_daemon_reports_post_commit_side_effect_error() {
             overrode: None,
         }],
     );
-    working_log
-        .write_initial(InitialAttributions {
+    fs::write(
+        &working_log.initial_file,
+        serde_json::to_string_pretty(&InitialAttributions {
             files,
             ..InitialAttributions::default()
         })
-        .unwrap();
+        .unwrap(),
+    )
+    .unwrap();
 
     fs::write(repo.path().join("broken.txt"), "broken\n").unwrap();
     repo.git(&["add", "broken.txt"]).unwrap();
     repo.git(&["commit", "-m", "commit with broken initial"])
         .unwrap();
 
-    let sync = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        repo.sync_daemon_force();
-    }));
-    assert!(
-        sync.is_err(),
-        "post-commit side-effect failure must be reported through daemon sync"
-    );
+    repo.sync_daemon_force();
+
+    let stats = repo.git_ai(&["stats", "HEAD", "--json"]).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stats).unwrap();
+    assert_eq!(parsed["ai_additions"], 0);
+    assert_eq!(parsed["unknown_additions"], 1);
 }
 
 #[test]

--- a/tests/integration/status_unit.rs
+++ b/tests/integration/status_unit.rs
@@ -258,6 +258,47 @@ fn test_ai_accepted_respects_ignore_patterns() {
     );
 }
 
+#[test]
+fn test_status_ignores_initial_entries_without_snapshot_blobs() {
+    let repo = TestRepo::new();
+
+    write_file(&repo, "example.txt", "Base line\n");
+    repo.stage_all_and_commit("initial").unwrap();
+
+    repo.git_ai(&["checkpoint", "human", "example.txt"])
+        .unwrap();
+    write_file(&repo, "example.txt", "Base line\nAI line 1\nAI line 2\n");
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+
+    // Commit only the first AI line. Post-commit carryover writes the second AI
+    // line to INITIAL with a persisted snapshot blob.
+    write_file(&repo, "example.txt", "Base line\nAI line 1\n");
+    repo.git(&["add", "example.txt"]).unwrap();
+    write_file(&repo, "example.txt", "Base line\nAI line 1\nAI line 2\n");
+    repo.commit("commit first AI line").unwrap();
+
+    let working_log = repo.current_working_logs();
+    let mut initial = working_log.read_initial_attributions();
+    assert!(
+        initial.files.contains_key("example.txt"),
+        "test setup should leave the remaining AI line in INITIAL"
+    );
+
+    initial.file_blobs.clear();
+    fs::write(
+        &working_log.initial_file,
+        serde_json::to_string_pretty(&initial).unwrap(),
+    )
+    .unwrap();
+
+    let status = status_json(&repo);
+    assert_eq!(
+        status.stats.ai_accepted, 0,
+        "status must not claim AI attribution from INITIAL entries that lack snapshot blobs"
+    );
+}
+
 /// `--diff-only` must keep the same diff-scoped `stats` as a plain `--json`
 /// run, while omitting the per-checkpoint breakdown.
 #[test]


### PR DESCRIPTION
Stack 1/2 for PD-119 / #1845. This makes `INITIAL` recovery defensive: entries are only trusted when their matching snapshot blob exists, and stale metadata is trimmed through the shared helper.

Why: malformed or archived working logs should not seed misleading attribution after status/checkpoint/post-commit paths run.

Note: I could not reproduce a normal current command path that writes blob-less `INITIAL`; partial-stage repros on `main` and this branch wrote valid blobs, so this PR is the recovery guard.