### PR TITLE
fix: sync stats before reading authorship notes

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::io::IsTerminal;
 use std::io::Read;
+use std::time::Duration;
 
 pub fn handle_git_ai(args: &[String]) {
     let perf_entry =
@@ -1068,7 +1069,15 @@ fn sync_daemon_family_before_stats_read(repo: &Repository) {
         repo_working_dir: workdir.to_string_lossy().to_string(),
     };
 
-    match crate::daemon::telemetry_handle::send_via_daemon(&request) {
+    let config = match crate::commands::daemon::ensure_daemon_running(Duration::from_secs(2)) {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::debug!(%error, "stats daemon sync unavailable");
+            return;
+        }
+    };
+
+    match crate::daemon::send_control_request(&config.control_socket_path, &request) {
         Ok(response) if response.ok => {}
         Ok(response) => {
             tracing::debug!(

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -1020,6 +1020,7 @@ fn handle_stats(args: &[String]) {
     }
 
     let effective_patterns = effective_ignore_patterns(&repo, &ignore_patterns, &[]);
+    sync_daemon_family_before_stats_read(&repo);
 
     // Handle commit range if detected
     if let Some(range) = commit_range {
@@ -1055,6 +1056,29 @@ fn handle_stats(args: &[String]) {
             }
         }
         std::process::exit(1);
+    }
+}
+
+fn sync_daemon_family_before_stats_read(repo: &Repository) {
+    let Ok(workdir) = repo.workdir() else {
+        return;
+    };
+
+    let request = ControlRequest::SyncFamily {
+        repo_working_dir: workdir.to_string_lossy().to_string(),
+    };
+
+    match crate::daemon::telemetry_handle::send_via_daemon(&request) {
+        Ok(response) if response.ok => {}
+        Ok(response) => {
+            tracing::debug!(
+                error = response.error.as_deref().unwrap_or("unknown daemon error"),
+                "stats daemon sync failed"
+            );
+        }
+        Err(error) => {
+            tracing::debug!(%error, "stats daemon sync unavailable");
+        }
     }
 }
 

--- a/tests/integration/stats_unit.rs
+++ b/tests/integration/stats_unit.rs
@@ -61,6 +61,41 @@ fn test_stats_for_simple_ai_commit() {
 }
 
 #[test]
+fn test_stats_waits_for_pending_commit_authorship_note() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_SIDE_EFFECT_MS_FOR_COMMAND",
+        "commit=1000",
+    )]);
+    let file_path = repo.path().join("stats_race.txt");
+
+    std::fs::write(&file_path, "Base line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "stats_race.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    std::fs::write(
+        &file_path,
+        "Base line\nAI line 1\nAI line 2\nAI line 3\nAI line 4\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "stats_race.txt"])
+        .unwrap();
+    repo.git_without_test_sync_for_test(&["add", "stats_race.txt"], &[])
+        .unwrap();
+    repo.git_without_test_sync_for_test(&["commit", "-m", "Delayed AI commit"], &[])
+        .unwrap();
+
+    let output = repo
+        .git_ai_without_pre_sync_for_test(&["stats", "--json", "HEAD"])
+        .expect("stats should succeed after syncing pending commit side effects");
+    let stats: CommitStats =
+        serde_json::from_str(output.trim()).expect("stats should emit JSON only");
+
+    assert_eq!(stats.ai_additions, 4, "stats output: {output}");
+    assert_eq!(stats.unknown_additions, 0, "stats output: {output}");
+}
+
+#[test]
 fn test_stats_for_mixed_commit() {
     let repo = TestRepo::new();
 


### PR DESCRIPTION
Stack 2/2 for PD-119 / #1845. This fixes the fresh-repo repro where immediate `git-ai stats --json HEAD` after commit can read before the daemon writes the authorship note and report AI lines as unknown.

Change: stats now syncs the repo family through the normal daemon control request path, so it gets the long `sync.family` timeout instead of the 2s telemetry timeout.

Validation: `main` failed the 4-line repro 20/20 (`0 AI / 4 unknown`); this branch passed 20/20 (`4 AI / 0 unknown`).