### PR TITLE
Clarify disabled blame mode

### DIFF
--- a/agent-support/vscode/package.json
+++ b/agent-support/vscode/package.json
@@ -44,7 +44,7 @@
           "default": "line",
           "scope": "application",
           "enumDescriptions": [
-            "Disable gutter decorations (status bar still shows current line info)",
+            "Disable gutter decorations",
             "Show gutter decorations for the current line's prompt only",
             "Show gutter decorations for all AI-authored lines in the file"
           ],


### PR DESCRIPTION
## What changed

Removed the parenthetical from the VS Code `gitai.blameMode` **off** option. It now simply reads “Disable gutter decorations.”

## Why

The previous copy implied that disabling blame still left some line information visible. The setting should communicate a clear off state for gutter blame decorations.

## Validation

- Parsed `agent-support/vscode/package.json` and verified the `off` enum description.
- Ran `git diff --check`.
- Attempted the extension lint/compile checks after `npm ci`; they remain unavailable because the installed dependency directories are empty (`eslint` cannot be found and TypeScript cannot resolve `@types/node` / `@types/mocha`).