### PR TITLE
derive Apple signing identities from certificates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,10 +197,9 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
           APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
-          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
         run: |
           set -euo pipefail
-          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY}" ]]; then
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" ]]; then
             if [[ "$DRY_RUN" == "true" ]]; then
               echo "Skipping macOS binary signing for dry run because signing secrets are not configured."
               exit 0
@@ -217,6 +216,11 @@ jobs:
           echo "$APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > app-signing.p12
           security import app-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY="$(security find-identity -v -p codesigning build.keychain | awk -F'"' '/Developer ID Application:/ { print $2; exit }')"
+          if [[ -z "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" ]]; then
+            echo "::error::Imported P12 does not contain a Developer ID Application signing identity."
+            exit 1
+          fi
 
           codesign --force --timestamp --options runtime --sign "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" "release/${{ matrix.artifact_name }}"
           codesign --verify --strict --verbose=2 "release/${{ matrix.artifact_name }}"
@@ -309,10 +313,9 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
           APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
-          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY }}
         run: |
           set -euo pipefail
-          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_IDENTITY}" ]]; then
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD}" ]]; then
             if [[ "$DRY_RUN" == "true" ]]; then
               echo "Skipping macOS binary signing for dry run because signing secrets are not configured."
               exit 0
@@ -329,6 +332,11 @@ jobs:
           echo "$APPLE_DEVELOPER_ID_APPLICATION_P12_BASE64" | base64 --decode > app-signing.p12
           security import app-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_APPLICATION_P12_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          APPLE_DEVELOPER_ID_APPLICATION_IDENTITY="$(security find-identity -v -p codesigning build.keychain | awk -F'"' '/Developer ID Application:/ { print $2; exit }')"
+          if [[ -z "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" ]]; then
+            echo "::error::Imported P12 does not contain a Developer ID Application signing identity."
+            exit 1
+          fi
 
           codesign --force --timestamp --options runtime --sign "$APPLE_DEVELOPER_ID_APPLICATION_IDENTITY" release/git-ai-macos-x64
           codesign --verify --strict --verbose=2 release/git-ai-macos-x64
@@ -422,10 +430,9 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64 }}
           APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
-          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
         run: |
           set -euo pipefail
-          if [[ -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_IDENTITY}" ]]; then
+          if [[ -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64}" || -z "${APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD}" ]]; then
             if [[ "$DRY_RUN" == "true" ]]; then
               echo "Skipping PKG signing for dry run because signing secrets are not configured."
               exit 0
@@ -442,11 +449,15 @@ jobs:
           echo "$APPLE_DEVELOPER_ID_INSTALLER_P12_BASE64" | base64 --decode > installer-signing.p12
           security import installer-signing.p12 -k build.keychain -P "$APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD" -T /usr/bin/productsign
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY="$(security find-identity -v -p basic build.keychain | awk -F'"' '/Developer ID Installer:/ { print $2; exit }')"
+          if [[ -z "$APPLE_DEVELOPER_ID_INSTALLER_IDENTITY" ]]; then
+            echo "::error::Imported P12 does not contain a Developer ID Installer signing identity."
+            exit 1
+          fi
+          echo "APPLE_DEVELOPER_ID_INSTALLER_IDENTITY=$APPLE_DEVELOPER_ID_INSTALLER_IDENTITY" >> "$GITHUB_ENV"
 
       - name: Build PKG installers
         shell: bash
-        env:
-          APPLE_DEVELOPER_ID_INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
         run: |
           set -euo pipefail
           VERSION="${{ needs.build.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,7 @@ jobs:
   package-msi:
     name: Build Windows MSI installers
     needs: build
+    if: always() && needs.build.result == 'success'
     runs-on: windows-latest
     environment: release
     steps:
@@ -406,6 +407,10 @@ jobs:
   package-pkg:
     name: Build macOS PKG installers
     needs: [build, build-macos-intel]
+    if: >-
+      always() &&
+      needs.build.result == 'success' &&
+      needs.build-macos-intel.result == 'success'
     runs-on: macos-latest
     environment: release
     steps:
@@ -507,6 +512,7 @@ jobs:
   test-msi:
     name: Test Windows MSI installer
     needs: package-msi
+    if: always() && needs.package-msi.result == 'success'
     runs-on: windows-latest
     steps:
       - name: Download MSI artifacts
@@ -530,6 +536,7 @@ jobs:
   test-pkg:
     name: Test macOS PKG installer
     needs: package-pkg
+    if: always() && needs.package-pkg.result == 'success'
     runs-on: macos-latest
     steps:
       - name: Download PKG artifacts

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -24,16 +24,14 @@ New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
 New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
 Copy-Item -Force -LiteralPath $BinaryPath -Destination $stagedExe
 
-$wix = Get-Command wix -ErrorAction SilentlyContinue
-if (-not $wix) {
-    Write-Host 'Installing WiX .NET tool...'
-    dotnet tool update --global wix | Out-Host
-    $env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
-    $wix = Get-Command wix -ErrorAction Stop
-}
+$wixVersion = '7.0.0'
+Write-Host "Installing WiX .NET tool v$wixVersion..."
+dotnet tool update --global wix --version $wixVersion | Out-Host
+$env:PATH = "$env:USERPROFILE\.dotnet\tools;$env:PATH"
+$wix = Get-Command wix -ErrorAction Stop
 
 $platform = if ($Architecture -eq 'arm64') { 'arm64' } else { 'x64' }
-& $wix.Source build $wxsPath `
+& $wix.Source build -acceptEula wix7 $wxsPath `
     -arch $platform `
     -d "ProductVersion=$Version" `
     -d "GitAiExe=$stagedExe" `

--- a/tests/package_installers.rs
+++ b/tests/package_installers.rs
@@ -42,3 +42,12 @@ fn packaging_supports_only_msi_and_pkg() {
     assert!(!packaging_path("debian/build-deb.sh").exists());
     assert!(!packaging_path("homebrew/update-formula.sh").exists());
 }
+
+#[test]
+fn msi_builder_uses_the_sponsored_wix_v7_toolchain() {
+    let builder = std::fs::read_to_string(packaging_path("windows/build-msi.ps1")).unwrap();
+
+    assert!(builder.contains("$wixVersion = '7.0.0'"));
+    assert!(builder.contains("dotnet tool update --global wix --version $wixVersion"));
+    assert!(builder.contains("-acceptEula wix7"));
+}

--- a/tests/package_release_workflow.rs
+++ b/tests/package_release_workflow.rs
@@ -62,3 +62,19 @@ fn apple_signing_identities_are_derived_from_the_imported_certificates() {
     assert!(!workflow.contains("secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"));
     assert!(!workflow.contains("secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY"));
 }
+
+#[test]
+fn prerelease_packages_continue_after_the_skipped_production_approval() {
+    let workflow = release_workflow();
+
+    assert!(job(&workflow, "package-msi").contains("always() && needs.build.result == 'success'"));
+    assert!(job(&workflow, "package-pkg").contains(
+        "always() &&\n      needs.build.result == 'success' &&\n      needs.build-macos-intel.result == 'success'"
+    ));
+    assert!(
+        job(&workflow, "test-msi").contains("always() && needs.package-msi.result == 'success'")
+    );
+    assert!(
+        job(&workflow, "test-pkg").contains("always() && needs.package-pkg.result == 'success'")
+    );
+}

--- a/tests/package_release_workflow.rs
+++ b/tests/package_release_workflow.rs
@@ -52,3 +52,13 @@ fn release_credentials_stay_in_the_release_environment() {
         assert!(job(&workflow, job_name).contains("environment: release"));
     }
 }
+
+#[test]
+fn apple_signing_identities_are_derived_from_the_imported_certificates() {
+    let workflow = release_workflow();
+
+    assert!(workflow.contains("security find-identity -v -p codesigning build.keychain"));
+    assert!(workflow.contains("security find-identity -v -p basic build.keychain"));
+    assert!(!workflow.contains("secrets.APPLE_DEVELOPER_ID_APPLICATION_IDENTITY"));
+    assert!(!workflow.contains("secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY"));
+}


### PR DESCRIPTION
## Why

The release environment has Apple P12 and password secrets but no separate certificate identity secrets. The macOS signing jobs stopped before signing.

The first non-production run then signed the core binaries but skipped MSI and PKG jobs because GitHub propagated the intentionally skipped production approval through the dependency chain.

WiX v7 also now requires explicit Open Source Maintenance Fee EULA acceptance. Sasha verified the git-ai-project sponsorship.

## Change

- Derive the Developer ID Application and Installer identities from the imported P12 certificates.
- Continue non-production package and installer-test jobs when their direct build dependency succeeds.
- Pin WiX 7.0.0 and pass the documented EULA acceptance switch for MSI builds.
- Add regression coverage for each workflow contract.

## Validation

- Package installer and release workflow tests passed.
- Formatting and lint passed.