### PR TITLE
Read OpenCode streams by external session ID

### DIFF
--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -1102,7 +1102,12 @@ impl StreamWorker {
                 break;
             }
 
-            let batch = agent.read_incremental(&path, current_watermark, &stream.session_id)?;
+            let source_session_id = if stream.external_session_id.is_empty() {
+                stream.session_id.as_str()
+            } else {
+                stream.external_session_id.as_str()
+            };
+            let batch = agent.read_incremental(&path, current_watermark, source_session_id)?;
 
             if batch.events.is_empty() {
                 db.update_watermark(

--- a/src/streams/agent.rs
+++ b/src/streams/agent.rs
@@ -104,7 +104,7 @@ pub trait Agent: Send + Sync {
     ///
     /// * `path` - Path to the transcript file
     /// * `watermark` - Current watermark position to resume from
-    /// * `session_id` - Session ID for context (used in error messages)
+    /// * `session_id` - Source session ID. Readers use this to filter multiplexed sources.
     fn read_incremental(
         &self,
         path: &Path,

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -1,9 +1,14 @@
 use crate::test_utils::fixture_path;
+use git_ai::authorship::authorship_log_serialization::generate_session_id;
 use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
 use git_ai::error::GitAiError;
+use git_ai::metrics::attrs::attr_pos;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
 use serde_json::json;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 fn parse_opencode(hook_input: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
     resolve_preset("opencode")?.parse(hook_input, "t_test")
@@ -360,7 +365,12 @@ fn test_opencode_preset_extracts_apply_patch_paths() {
 fn test_opencode_e2e_checkpoint_and_commit() {
     use crate::repos::test_repo::TestRepo;
 
-    let mut repo = TestRepo::new();
+    let metrics_dir = tempfile::tempdir().unwrap();
+    let metrics_db_path = metrics_dir.path().join("metrics.db");
+    let mut repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_METRICS_DB_PATH",
+        metrics_db_path.to_str().unwrap(),
+    )]);
 
     repo.patch_git_ai_config(|patch| {
         patch.exclude_prompts_in_repositories = Some(vec![]);
@@ -415,6 +425,34 @@ fn test_opencode_e2e_checkpoint_and_commit() {
 
     repo.git_ai(&["checkpoint", "opencode", "--hook-input", &post_hook_input])
         .unwrap();
+
+    let session_id = generate_session_id("test-session-123", "opencode");
+    repo.sync_daemon_force();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let emitted_session_event = loop {
+        let metrics = MetricsDatabase::open_at_path(Path::new(&metrics_db_path)).unwrap();
+        let session_events = metrics
+            .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+            .unwrap();
+        if session_events.iter().any(|record| {
+            record
+                .event
+                .attrs
+                .get(&attr_pos::SESSION_ID.to_string())
+                .and_then(|value| value.as_str())
+                == Some(session_id.as_str())
+        }) {
+            break true;
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert!(
+        emitted_session_event,
+        "OpenCode post-checkpoint should emit transcript events for its generated session ID"
+    );
 
     unsafe {
         std::env::remove_var("GIT_AI_OPENCODE_STORAGE_PATH");


### PR DESCRIPTION
Why: Git AI’s generated session ID does not exist in OpenCode’s SQLite database, so the reader found no messages.

So, read OpenCode’s external session ID so transcript usage reaches Live.
