### PR TITLE
Prefer per-user updates over package bootstrap binaries

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -256,8 +256,7 @@ function Get-Architecture {
     }
 }
 
-# Ensure $PathToAdd is on the User PATH (appended if absent). No Machine PATH,
-# no admin required, no positioning logic.
+# Ensure $PathToAdd is first on the User PATH. No Machine PATH or admin required.
 function Set-PathEnsureContains {
     param(
         [Parameter(Mandatory = $true)][string]$PathToAdd
@@ -276,16 +275,13 @@ function Set-PathEnsureContains {
         $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
         $entries = @()
         if ($userPath) { $entries = ($userPath -split $sep) | Where-Object { $_ -and $_.Trim() -ne '' } }
-        $alreadyPresent = $false
-        foreach ($e in $entries) {
-            if ((NormalizePath $e) -eq $normalizedAdd) { $alreadyPresent = $true; break }
-        }
-        if ($alreadyPresent) {
-            $userStatus = 'AlreadyPresent'
-        } else {
-            $newUserPath = if ($userPath) { "$userPath$sep$PathToAdd" } else { $PathToAdd }
+        $remainingEntries = @($entries | Where-Object { (NormalizePath $_) -ne $normalizedAdd })
+        $newUserPath = (@($PathToAdd) + $remainingEntries) -join $sep
+        if ($newUserPath -ne $userPath) {
             [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
             $userStatus = 'Updated'
+        } else {
+            $userStatus = 'AlreadyPresent'
         }
     } catch {
         $userStatus = 'Error'
@@ -296,13 +292,8 @@ function Set-PathEnsureContains {
         $procPath = $env:PATH
         $procEntries = @()
         if ($procPath) { $procEntries = ($procPath -split $sep) | Where-Object { $_ -and $_.Trim() -ne '' } }
-        $procHas = $false
-        foreach ($e in $procEntries) {
-            if ((NormalizePath $e) -eq $normalizedAdd) { $procHas = $true; break }
-        }
-        if (-not $procHas) {
-            $env:PATH = if ($procPath) { "$procPath$sep$PathToAdd" } else { $PathToAdd }
-        }
+        $remainingProcEntries = @($procEntries | Where-Object { (NormalizePath $_) -ne $normalizedAdd })
+        $env:PATH = (@($PathToAdd) + $remainingProcEntries) -join $sep
     } catch { }
 
     return [PSCustomObject]@{

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -348,11 +348,10 @@ fn powershell_single_quote_literal(value: &OsStr) -> String {
 
 #[cfg(any(windows, not(any(test, feature = "test-support"))))]
 fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
-    // Use current_git_ai_exe() instead of current_exe() to resolve through
-    // symlinks. When the current exe is the git shim (e.g. ~/.local/bin/git),
-    // current_exe() would spawn `git daemon run` which re-enters handle_git()
-    // instead of handle_git_ai(), causing a fork bomb in async mode.
-    let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
+    // Resolve through git shims and, for a package bootstrap, prefer the
+    // current user's verified update. This avoids re-entering handle_git()
+    // through a `git` shim and keeps package startup on the updated runtime.
+    let exe = crate::utils::daemon_git_ai_exe().map_err(|e| e.to_string())?;
     let runtime_dir = daemon_runtime_dir(config)?;
 
     #[cfg(windows)]
@@ -428,7 +427,7 @@ fn spawn_daemon_run_detached(config: &DaemonConfig) -> Result<(), String> {
 fn spawn_daemon_run_with_piped_stderr(
     config: &DaemonConfig,
 ) -> Result<std::process::Child, String> {
-    let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
+    let exe = crate::utils::daemon_git_ai_exe().map_err(|e| e.to_string())?;
     let runtime_dir = daemon_runtime_dir(config)?;
     let mut child = Command::new(exe);
     child

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6985,7 +6985,7 @@ fn daemon_socket_health_check_interval() -> u64 {
 /// instance.  Returns Ok if the process was spawned; the caller should
 /// still request_shutdown so the current daemon exits promptly.
 fn spawn_self_restart() -> Result<(), String> {
-    let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
+    let exe = crate::utils::daemon_git_ai_exe().map_err(|e| e.to_string())?;
     tracing::info!(?exe, "spawning detached restart process");
 
     let mut cmd = std::process::Command::new(&exe);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,6 +70,46 @@ pub(crate) fn current_git_ai_exe() -> Result<PathBuf, GitAiError> {
     Ok(resolve_git_ai_exe_from_invocation_path(path))
 }
 
+pub(crate) fn daemon_git_ai_exe() -> Result<PathBuf, GitAiError> {
+    let current_exe = current_git_ai_exe()?;
+    Ok(preferred_user_update_exe(
+        &current_exe,
+        dirs::home_dir().as_deref(),
+    ))
+}
+
+fn preferred_user_update_exe(
+    current_exe: &std::path::Path,
+    home: Option<&std::path::Path>,
+) -> PathBuf {
+    if !is_package_bootstrap_exe(current_exe) {
+        return current_exe.to_path_buf();
+    }
+
+    let Some(home) = home else {
+        return current_exe.to_path_buf();
+    };
+    let user_exe = home.join(".git-ai").join("bin").join(if cfg!(windows) {
+        "git-ai.exe"
+    } else {
+        "git-ai"
+    });
+
+    if user_exe.is_file() {
+        user_exe
+    } else {
+        current_exe.to_path_buf()
+    }
+}
+
+fn is_package_bootstrap_exe(path: &std::path::Path) -> bool {
+    let path = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    path.ends_with("/opt/git-ai/bin/git-ai") || path.ends_with("/appdata/local/git ai/git-ai.exe")
+}
+
 fn internal_git_ai_command_with_exe(exe: PathBuf, subcommand: &str) -> Command {
     let mut cmd = Command::new(exe);
     cmd.arg(subcommand)
@@ -1157,6 +1197,49 @@ mod tests {
         assert!(result.is_ok(), "current_git_ai_exe should not fail");
         let path = result.unwrap();
         assert!(!path.as_os_str().is_empty(), "path should not be empty");
+    }
+
+    #[test]
+    fn package_bootstrap_daemon_prefers_an_existing_user_update_binary() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_exe = temp.path().join(".git-ai/bin/git-ai");
+        std::fs::create_dir_all(user_exe.parent().unwrap()).unwrap();
+        std::fs::write(&user_exe, "").unwrap();
+
+        assert_eq!(
+            preferred_user_update_exe(
+                std::path::Path::new("/opt/git-ai/bin/git-ai"),
+                Some(temp.path())
+            ),
+            user_exe
+        );
+    }
+
+    #[test]
+    fn package_bootstrap_daemon_falls_back_when_no_user_update_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let bootstrap = std::path::Path::new("/opt/git-ai/bin/git-ai");
+
+        assert_eq!(
+            preferred_user_update_exe(bootstrap, Some(temp.path())),
+            bootstrap
+        );
+    }
+
+    #[test]
+    fn package_bootstrap_paths_are_recognized_on_both_desktop_platforms() {
+        assert!(is_package_bootstrap_exe(std::path::Path::new(
+            "/opt/git-ai/bin/git-ai"
+        )));
+        assert!(is_package_bootstrap_exe(std::path::Path::new(
+            r"C:\Users\alice\AppData\Local\Git AI\git-ai.exe"
+        )));
+        assert!(!is_package_bootstrap_exe(std::path::Path::new(
+            r"C:\Program Files\Git AI\git-ai.exe"
+        )));
+        assert!(!is_package_bootstrap_exe(std::path::Path::new(
+            "/Users/alice/.git-ai/bin/git-ai"
+        )));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- Puts the per-user PowerShell install directory first on user and process `PATH`.
- Detects MSI/PKG bootstrap locations when selecting the daemon executable.
- Prefers an existing per-user updated binary and falls back to the immutable package bootstrap.
- Uses the same selection for daemon startup and self-restart.

## Why

Package installs must coexist with Git AI’s verified per-user updater without leaving the daemon pinned to an older package bootstrap.

## Validation

- `task test CARGO_TEST_ARGS="--lib" TEST_FILTER=package_bootstrap`
- `task fmt`
- `task lint`

## Stack

3 of 5; depends only on #1883. Primary implementation authored by Siddhant Khare; the updater-selection fix is presented as its own reviewable behavior.