### PR TITLE
Use `notes_api` instead of `refs` when handling amends

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -687,15 +687,16 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
         commit_tree_snapshot_for_files(repo, amended_commit, &pathspecs)?;
     final_state_snapshot.extend(observed_snapshot);
 
-    // Check if original commit has existing authorship data
-    let has_existing_data =
-        crate::git::refs::get_reference_as_authorship_log_v3(repo, original_commit)
-            .map(|log| {
-                !log.metadata.prompts.is_empty()
-                    || !log.metadata.humans.is_empty()
-                    || !log.metadata.sessions.is_empty()
-            })
-            .unwrap_or(false);
+    // Check if original commit has existing authorship data. Read through
+    // notes_api so the HTTP notes backend is honored (the note may only exist
+    // in the notes-db cache, not refs/notes/ai).
+    let has_existing_data = crate::git::notes_api::read_authorship_v3(repo, original_commit)
+        .map(|log| {
+            !log.metadata.prompts.is_empty()
+                || !log.metadata.humans.is_empty()
+                || !log.metadata.sessions.is_empty()
+        })
+        .unwrap_or(false);
 
     let working_va = crate::tokio_runtime::block_on(async {
         VirtualAttributions::from_working_log_for_commit_snapshot(
@@ -783,10 +784,11 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
     )?;
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 
-    // Preserve human/session metadata from the original commit's note
-    if let Ok(original_log) =
-        crate::git::refs::get_reference_as_authorship_log_v3(repo, original_commit)
-    {
+    // Preserve human/session metadata from the original commit's note. Read
+    // through notes_api so the HTTP notes backend is honored — with refs-only
+    // reads the amended note keeps its s_/h_ attestation hashes but silently
+    // loses the sessions/humans records they resolve through.
+    if let Ok(original_log) = crate::git::notes_api::read_authorship_v3(repo, original_commit) {
         for (id, record) in original_log.metadata.humans {
             authorship_log.metadata.humans.entry(id).or_insert(record);
         }

--- a/tests/integration/sessions_cutover.rs
+++ b/tests/integration/sessions_cutover.rs
@@ -2627,3 +2627,129 @@ fn test_diff_json_stats_with_old_format_note_only() {
         "sessions should be empty for old-format-only commit"
     );
 }
+
+// Regression: under the HTTP notes backend (notes live in the local notes-db,
+// NOT in refs/notes/ai), amending a commit must preserve the sessions
+// metadata on the rebuilt note. The amend pipeline re-reads the original note
+// and session history through refs/notes/ai-only helpers
+// (`refs::get_reference_as_authorship_log_v3`, `refs::grep_ai_notes`), which
+// find nothing under the HTTP backend — so the amended note keeps its s_::t_
+// attestation hashes but silently loses `metadata.sessions`, and downstream
+// consumers bucket every AI line as tool=unknown.
+#[test]
+fn test_amend_preserves_sessions_under_http_notes_backend() {
+    use git_ai::config::{ConfigPatch, NotesBackendConfig, NotesBackendKind};
+    use git_ai::notes::db::NotesDatabase;
+
+    // The daemon owns note writes and the amend rebuild, so the DAEMON must run
+    // with the HTTP backend. The test-home config.json writer does not cover
+    // notes_backend and the daemon caches config at startup, so pass the patch
+    // via env at daemon spawn.
+    let daemon_patch = ConfigPatch {
+        exclude_prompts_in_repositories: Some(vec![]),
+        prompt_storage: Some("notes".to_string()),
+        notes_backend: Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        }),
+        ..Default::default()
+    };
+    let daemon_patch_json =
+        serde_json::to_string(&daemon_patch).expect("serialize daemon config patch");
+    let mut repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_CONFIG_PATCH", daemon_patch_json.as_str())]);
+    // CLI invocations (checkpoint, blame) should use the HTTP backend too.
+    repo.patch_git_ai_config(|patch| {
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        });
+    });
+
+    // Poll the notes-db for a commit's note: post-commit note writes land in the
+    // daemon's notes-db queue (never refs/notes/ai), so the harness's usual
+    // "note visible in refs/notes/ai" commit assertion cannot be used here.
+    let notes_db_path = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("notes-db");
+    let read_note_from_db = |sha: &str| -> Option<String> {
+        for _ in 0..100 {
+            if let Ok(db) = NotesDatabase::open_at_path(&notes_db_path)
+                && let Ok(Some(content)) = db.get_note(sha)
+            {
+                return Some(content);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        None
+    };
+
+    let file_path = repo.path().join("http_amend.txt");
+    fs::write(&file_path, "Human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "http_amend.txt"])
+        .unwrap();
+    fs::write(&file_path, "Human line\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "http_amend.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "AI commit"]).unwrap();
+    repo.sync_daemon();
+    let original_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    let original_note =
+        read_note_from_db(&original_sha).expect("original commit should have a note in notes-db");
+    // Under the HTTP backend the note must be in notes-db, not refs/notes/ai.
+    assert!(
+        repo.read_authorship_note(&original_sha).is_none(),
+        "HTTP backend should not write to refs/notes/ai"
+    );
+    let original_log =
+        AuthorshipLog::deserialize_from_string(&original_note).expect("parse original note");
+    assert!(
+        !original_log.metadata.sessions.is_empty(),
+        "original note should carry sessions metadata"
+    );
+
+    // Amend the commit message only — the attributed content is unchanged, so
+    // the rebuilt note must still attest the AI line to the same session.
+    repo.git(&["commit", "--amend", "-m", "Amended commit"])
+        .unwrap();
+    repo.sync_daemon();
+    let amended_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(amended_sha, original_sha, "amend should rewrite HEAD");
+
+    let amended_note =
+        read_note_from_db(&amended_sha).expect("amended commit should have a note in notes-db");
+    let amended_log =
+        AuthorshipLog::deserialize_from_string(&amended_note).expect("parse amended note");
+
+    // The AI line's attestation must still use the session format...
+    let has_session_attestation = amended_log
+        .attestations
+        .iter()
+        .flat_map(|fa| fa.entries.iter())
+        .any(|entry| entry.hash.starts_with("s_"));
+    assert!(
+        has_session_attestation,
+        "amended note should still attest AI lines to a session hash:\n{}",
+        amended_note
+    );
+
+    // ...and the sessions map those hashes resolve through must survive the amend.
+    assert!(
+        !amended_log.metadata.sessions.is_empty(),
+        "amended note lost metadata.sessions — session attestations no longer resolve to a tool:\n{}",
+        amended_note
+    );
+
+    // The surviving record must be the same session as the original note.
+    for session_id in original_log.metadata.sessions.keys() {
+        assert!(
+            amended_log.metadata.sessions.contains_key(session_id),
+            "session {} from the original note is missing after amend",
+            session_id
+        );
+    }
+}


### PR DESCRIPTION
Problem: path for updating notes on commit amend was not using the `notes_api` to access commit authorship data, so when a custom HTTP notes backend was enabled, the notes on amend would be incorrect. 

<details>

<summary>Here's an (anonymized) example from real-life usage:</summary>

**Valid note (pre-amend, never pushed to GitHub)**

Commit: `7c1f20476f91a172d2bccdbbb7fd46fb33d54681`
Note written: 2026-07-14 03:31:30

```
path/to/file.kt
  s_46dcc697a1f9ae::t_e01adbd3e1e2bb 18,48-49
---
{
  "schema_version": "authorship/3.0.0",
  "git_ai_version": "1.6.10",
  "base_commit_sha": "7c1f20476f91a172d2bccdbbb7fd46fb33d54681",
  "prompts": {},
  "sessions": {
    "s_46dcc697a1f9ae": {
      "agent_id": {
        "tool": "claude",
        "id": "fa83d539-eadf-46a7-bc66-4f22e5d8a6aa",
        "model": "unknown"
      },
      "human_author": "author <author@company.com>"
    }
  }
}
```

**Invalid / malformed note (post-amend, the actual PR commit)**

Commit: `87f74996540ad5e6fe6d65f96d3d6542924c51a3`
Author date: 2026-07-14 03:31:26 · Commit date: 2026-07-14 03:32:10 · Note written: 2026-07-14 03:32:18

```
path/to/file.kt
  s_46dcc697a1f9ae::t_e01adbd3e1e2bb 18,48-49
---
{
  "schema_version": "authorship/3.0.0",
  "git_ai_version": "1.6.10",
  "base_commit_sha": "87f74996540ad5e6fe6d65f96d3d6542924c51a3",
  "prompts": {}
}
```

Note: same file, same attestation hash, same line ranges (18, 48-49) as the valid note — but the
`sessions` key is gone entirely.
</details>

The regression test in this PR reproduces this case exactly.

Solution: use `notes_api::read_authorship_v3` instead of `refs::get_reference_as_authorship_log_v3` in the amend path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->