### PR TITLE
Use `notes_api` instead of `refs` across codebase

### DIFF
--- a/benches/notes_io.rs
+++ b/benches/notes_io.rs
@@ -32,10 +32,10 @@
 //! rather than routing through `notes_api`. This is more accurate (no dispatch
 //! overhead) and avoids the singleton constraint.
 //!
-//!   - git_notes write  : `git_ai::git::refs::notes_add`
-//!   - git_notes read   : `git_ai::git::refs::show_authorship_note`
-//!   - git_notes batch  : `git_ai::git::refs::notes_add_batch`
-//!   - git_notes commits_with_notes: `git_ai::git::refs::commits_with_authorship_notes`
+//!   - git_notes write  : `git_ai::git::refs::git_backend_for_tests::notes_add`
+//!   - git_notes read   : `git_ai::git::refs::git_backend_for_tests::show_authorship_note`
+//!   - git_notes batch  : `git_ai::git::refs::git_backend_for_tests::notes_add_batch`
+//!   - git_notes commits_with_notes: `git_ai::git::refs::git_backend_for_tests::commits_with_authorship_notes`
 //!   - http write       : `NotesDatabase::upsert_note`
 //!   - http read        : `NotesDatabase::get_note`
 //!   - http batch write : `NotesDatabase::upsert_notes_batch`
@@ -165,8 +165,12 @@ impl BenchRepo {
 
         // Pre-write into git-notes (for git_notes read benchmarks).
         for sha in &shas {
-            git_ai::git::refs::notes_add(repo.gitai_repo(), sha, NOTE_CONTENT)
-                .expect("bench setup: notes_add");
+            git_ai::git::refs::git_backend_for_tests::notes_add(
+                repo.gitai_repo(),
+                sha,
+                NOTE_CONTENT,
+            )
+            .expect("bench setup: notes_add");
         }
 
         // Pre-write into notes-db (for http read benchmarks).
@@ -204,8 +208,12 @@ fn bench_write_single(c: &mut Criterion) {
         &target_sha,
         |b, sha| {
             b.iter(|| {
-                git_ai::git::refs::notes_add(bench.repo.gitai_repo(), sha, NOTE_CONTENT)
-                    .expect("notes_add failed");
+                git_ai::git::refs::git_backend_for_tests::notes_add(
+                    bench.repo.gitai_repo(),
+                    sha,
+                    NOTE_CONTENT,
+                )
+                .expect("notes_add failed");
             });
         },
     );
@@ -245,8 +253,11 @@ fn bench_write_batch_100(c: &mut Criterion) {
     // --- git_notes backend ---
     group.bench_function(BenchmarkId::new("git_notes", "100_notes"), |b| {
         b.iter(|| {
-            git_ai::git::refs::notes_add_batch(bench.repo.gitai_repo(), &batch)
-                .expect("notes_add_batch failed");
+            git_ai::git::refs::git_backend_for_tests::notes_add_batch(
+                bench.repo.gitai_repo(),
+                &batch,
+            )
+            .expect("notes_add_batch failed");
         });
     });
 
@@ -282,7 +293,10 @@ fn bench_read_single_hot(c: &mut Criterion) {
         &hot_sha,
         |b, sha| {
             b.iter(|| {
-                let _ = git_ai::git::refs::show_authorship_note(bench.repo.gitai_repo(), sha);
+                let _ = git_ai::git::refs::git_backend_for_tests::show_authorship_note(
+                    bench.repo.gitai_repo(),
+                    sha,
+                );
             });
         },
     );
@@ -326,7 +340,10 @@ fn bench_read_single_cold(c: &mut Criterion) {
         &cold_sha,
         |b, sha| {
             b.iter(|| {
-                let _ = git_ai::git::refs::show_authorship_note(bench.repo.gitai_repo(), sha);
+                let _ = git_ai::git::refs::git_backend_for_tests::show_authorship_note(
+                    bench.repo.gitai_repo(),
+                    sha,
+                );
             });
         },
     );
@@ -360,9 +377,11 @@ fn bench_read_batch_100(c: &mut Criterion) {
     // --- git_notes backend ---
     group.bench_function(BenchmarkId::new("git_notes", "100_reads"), |b| {
         b.iter(|| {
-            let _ =
-                git_ai::git::refs::note_blob_oids_for_commits(bench.repo.gitai_repo(), &batch_shas)
-                    .expect("note_blob_oids_for_commits failed");
+            let _ = git_ai::git::refs::git_backend_for_tests::note_blob_oids_for_commits(
+                bench.repo.gitai_repo(),
+                &batch_shas,
+            )
+            .expect("note_blob_oids_for_commits failed");
         });
     });
 
@@ -401,7 +420,7 @@ fn bench_commits_with_notes_500(c: &mut Criterion) {
     // --- git_notes backend ---
     group.bench_function(BenchmarkId::new("git_notes", "500_shas"), |b| {
         b.iter(|| {
-            let _ = git_ai::git::refs::commits_with_authorship_notes(
+            let _ = git_ai::git::refs::git_backend_for_tests::commits_with_authorship_notes(
                 bench.repo.gitai_repo(),
                 &check_shas,
             )

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -687,15 +687,16 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
         commit_tree_snapshot_for_files(repo, amended_commit, &pathspecs)?;
     final_state_snapshot.extend(observed_snapshot);
 
-    // Check if original commit has existing authorship data
-    let has_existing_data =
-        crate::git::refs::get_reference_as_authorship_log_v3(repo, original_commit)
-            .map(|log| {
-                !log.metadata.prompts.is_empty()
-                    || !log.metadata.humans.is_empty()
-                    || !log.metadata.sessions.is_empty()
-            })
-            .unwrap_or(false);
+    // Check if original commit has existing authorship data. Read through
+    // notes_api so the HTTP notes backend is honored (the note may only exist
+    // in the notes-db cache, not refs/notes/ai).
+    let has_existing_data = crate::git::notes_api::read_authorship_v3(repo, original_commit)
+        .map(|log| {
+            !log.metadata.prompts.is_empty()
+                || !log.metadata.humans.is_empty()
+                || !log.metadata.sessions.is_empty()
+        })
+        .unwrap_or(false);
 
     let working_va = crate::tokio_runtime::block_on(async {
         VirtualAttributions::from_working_log_for_commit_snapshot(
@@ -783,10 +784,11 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
     )?;
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 
-    // Preserve human/session metadata from the original commit's note
-    if let Ok(original_log) =
-        crate::git::refs::get_reference_as_authorship_log_v3(repo, original_commit)
-    {
+    // Preserve human/session metadata from the original commit's note. Read
+    // through notes_api so the HTTP notes backend is honored — with refs-only
+    // reads the amended note keeps its s_/h_ attestation hashes but silently
+    // loses the sessions/humans records they resolve through.
+    if let Ok(original_log) = crate::git::notes_api::read_authorship_v3(repo, original_commit) {
         for (id, record) in original_log.metadata.humans {
             authorship_log.metadata.humans.entry(id).or_insert(record);
         }

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -12,7 +12,7 @@ use crate::authorship::virtual_attribution::{AuthorshipLogDiffContext, VirtualAt
 use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry};
 use crate::config::Config;
 use crate::error::GitAiError;
-use crate::git::notes_api::write_note as notes_add;
+use crate::git::notes_api::write_note;
 use crate::git::repository::{Repository, batch_read_paths_at_treeishes, exec_git};
 use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
@@ -427,7 +427,7 @@ where
         .serialize_to_string()
         .map_err(|_| GitAiError::Generic("Failed to serialize authorship log".to_string()))?;
 
-    notes_add(repo, &commit_sha, &authorship_note_str)?;
+    write_note(repo, &commit_sha, &authorship_note_str)?;
 
     // Compute stats once (needed for both metrics and terminal output), unless preflight
     // estimate predicts this would be too expensive for the commit hook path.
@@ -832,7 +832,7 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
     let authorship_note_str = authorship_log
         .serialize_to_string()
         .map_err(|_| GitAiError::Generic("Failed to serialize authorship log".to_string()))?;
-    notes_add(repo, amended_commit, &authorship_note_str)?;
+    write_note(repo, amended_commit, &authorship_note_str)?;
 
     // Write INITIAL file for uncommitted attributions
     if !initial_attributions.files.is_empty() {

--- a/src/authorship/prompt_utils.rs
+++ b/src/authorship/prompt_utils.rs
@@ -1,6 +1,6 @@
 use crate::authorship::authorship_log::PromptRecord;
 use crate::error::GitAiError;
-use crate::git::notes_api::{read_authorship as get_authorship, search_notes as grep_ai_notes};
+use crate::git::notes_api::{read_authorship, search_notes};
 use crate::git::repository::Repository;
 
 /// Find a prompt in the repository history
@@ -33,7 +33,7 @@ pub fn find_prompt_in_commit(
     let commit_sha = commit.id();
 
     // Get the authorship log for this commit
-    let authorship_log = get_authorship(repo, &commit_sha).ok_or_else(|| {
+    let authorship_log = read_authorship(repo, &commit_sha).ok_or_else(|| {
         GitAiError::Generic(format!(
             "No authorship data found for commit: {}",
             commit_rev
@@ -78,8 +78,8 @@ pub fn find_prompt_in_history(
     };
 
     // Use git grep to search for the prompt ID in authorship notes
-    // grep_ai_notes returns commits sorted by date (newest first)
-    let shas = grep_ai_notes(repo, &format!("\"{}\"", session_key)).unwrap_or_default();
+    // search_notes returns commits sorted by date (newest first)
+    let shas = search_notes(repo, &format!("\"{}\"", session_key)).unwrap_or_default();
 
     if shas.is_empty() {
         return Err(GitAiError::Generic(format!(
@@ -91,7 +91,7 @@ pub fn find_prompt_in_history(
     // Iterate through commits, looking for the prompt and counting occurrences
     let mut found_count = 0;
     for sha in &shas {
-        if let Some(authorship_log) = get_authorship(repo, sha) {
+        if let Some(authorship_log) = read_authorship(repo, sha) {
             // Check prompts map first
             if let Some(prompt) = authorship_log.metadata.prompts.get(prompt_id) {
                 if found_count == offset {

--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -8,9 +8,7 @@ use crate::authorship::diff_ai_accepted::diff_ai_accepted_stats;
 use crate::authorship::ignore::{build_ignore_matcher, should_ignore_file_with_matcher};
 use crate::authorship::stats::{CommitStats, stats_for_commit_stats, stats_from_authorship_log};
 use crate::error::GitAiError;
-use crate::git::notes_api::{
-    CommitAuthorship, filter_commits_with_notes as get_commits_with_notes_from_list,
-};
+use crate::git::notes_api::{CommitAuthorship, filter_commits_with_notes};
 use crate::git::repository::{CommitRange, InternalGitProfile, Repository, exec_git_with_profile};
 use std::io::IsTerminal;
 
@@ -116,7 +114,7 @@ pub fn range_authorship(
             .map(|c| c.id().to_string())
             .collect(),
     };
-    let commit_authorship = get_commits_with_notes_from_list(repository, &commit_shas)?;
+    let commit_authorship = filter_commits_with_notes(repository, &commit_shas)?;
 
     // Calculate range stats - pass commit_shas directly to avoid re-fetching
     let range_stats = calculate_range_stats_direct(

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -1,7 +1,7 @@
 use crate::authorship::authorship_log::LineRange;
 use crate::authorship::ignore::{build_ignore_matcher, should_ignore_file_with_matcher};
 use crate::error::GitAiError;
-use crate::git::notes_api::read_authorship as get_authorship;
+use crate::git::notes_api::read_authorship;
 use crate::git::repository::Repository;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -379,7 +379,7 @@ pub fn stats_for_commit_stats(
     commit_sha: &str,
     ignore_patterns: &[String],
 ) -> Result<CommitStats, GitAiError> {
-    let authorship_log = get_authorship(repo, commit_sha);
+    let authorship_log = read_authorship(repo, commit_sha);
     stats_for_commit_stats_with_authorship(
         repo,
         commit_sha,

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -239,11 +239,12 @@ impl VirtualAttributions {
         repo: &Repository,
         session_id: &str,
     ) -> Result<SessionRecord, GitAiError> {
-        let shas = crate::git::refs::grep_ai_notes(repo, &format!("\"{}\"", session_id))
+        // Go through notes_api (not refs::) so the HTTP notes backend is honored.
+        let shas = crate::git::notes_api::search_notes(repo, &format!("\"{}\"", session_id))
             .unwrap_or_default();
 
         if let Some(latest_sha) = shas.first()
-            && let Ok(log) = crate::git::refs::get_reference_as_authorship_log_v3(repo, latest_sha)
+            && let Ok(log) = crate::git::notes_api::read_authorship_v3(repo, latest_sha)
             && let Some(session) = log.metadata.sessions.get(session_id)
         {
             return Ok(session.clone());

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -1,12 +1,9 @@
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::rewrite::{RewriteEvent, handle_rewrite_event};
 use crate::error::GitAiError;
-use crate::git::notes_api::{
-    read_authorship_v3 as get_reference_as_authorship_log_v3, read_note as show_authorship_note,
-};
+use crate::git::notes_api::{read_authorship_v3, read_note};
 use crate::git::refs::{
-    AI_AUTHORSHIP_FORK_TRACKING_REF, copy_missing_notes_for_commits_from_ref,
-    note_blob_oids_for_commits, ref_exists,
+    AI_AUTHORSHIP_FORK_TRACKING_REF, copy_missing_notes_for_commits_from_ref, ref_exists,
 };
 use crate::git::repository::{
     CommitRange, Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin,
@@ -127,7 +124,7 @@ impl CiContext {
                 }
 
                 // Check if authorship already exists for this commit
-                match get_reference_as_authorship_log_v3(&self.repo, merge_commit_sha) {
+                match read_authorship_v3(&self.repo, merge_commit_sha) {
                     Ok(existing_log) => {
                         println!("{} already has authorship", merge_commit_sha);
                         return Ok(CiRunResult::AlreadyExists {
@@ -135,7 +132,7 @@ impl CiContext {
                         });
                     }
                     Err(e) => {
-                        if show_authorship_note(&self.repo, merge_commit_sha).is_some() {
+                        if read_note(&self.repo, merge_commit_sha).is_some() {
                             return Err(e);
                         }
                     }
@@ -361,7 +358,7 @@ impl CiContext {
                 println!("Rewrote authorship.");
 
                 // Check if authorship was created for THIS specific commit
-                match get_reference_as_authorship_log_v3(&self.repo, merge_commit_sha) {
+                match read_authorship_v3(&self.repo, merge_commit_sha) {
                     Ok(authorship_log) => {
                         // A note may be reconstructed with only human attestations
                         // (e.g. a PR whose contributor never used git-ai, so there
@@ -385,7 +382,7 @@ impl CiContext {
                         Ok(CiRunResult::AuthorshipRewritten { authorship_log })
                     }
                     Err(e) => {
-                        if show_authorship_note(&self.repo, merge_commit_sha).is_some() {
+                        if read_note(&self.repo, merge_commit_sha).is_some() {
                             return Err(e);
                         }
                         println!(
@@ -683,7 +680,9 @@ impl CiContext {
     }
 
     fn has_notes_for_any_commit(&self, commit_shas: &[String]) -> Result<bool, GitAiError> {
-        Ok(!note_blob_oids_for_commits(&self.repo, commit_shas)?.is_empty())
+        // Backend-aware: on the HTTP backend notes live in the notes-db cache,
+        // so a refs/notes/ai-only check would always report "no notes".
+        Ok(!crate::git::notes_api::commits_with_notes(&self.repo, commit_shas)?.is_empty())
     }
 
     fn original_pr_commits(
@@ -831,7 +830,7 @@ fn commits_in_range_oldest_first(
 fn count_commits_with_authorship_notes(repo: &Repository, commits: &[String]) -> usize {
     commits
         .iter()
-        .filter(|sha| show_authorship_note(repo, sha).is_some())
+        .filter(|sha| read_note(repo, sha).is_some())
         .count()
 }
 

--- a/src/commands/blame.rs
+++ b/src/commands/blame.rs
@@ -3,7 +3,7 @@ use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::working_log::CheckpointKind;
 use crate::error::GitAiError;
-use crate::git::notes_api::read_authorship_v3 as get_reference_as_authorship_log_v3;
+use crate::git::notes_api::read_authorship_v3;
 use crate::git::repository::Repository;
 use crate::git::repository::{exec_git, exec_git_stdin};
 #[cfg(windows)]
@@ -959,7 +959,7 @@ impl Repository {
             {
                 cached.clone()
             } else {
-                let authorship = get_reference_as_authorship_log_v3(self, &hunk.commit_sha).ok();
+                let authorship = read_authorship_v3(self, &hunk.commit_sha).ok();
                 commit_authorship_cache.insert(hunk.commit_sha.clone(), authorship.clone());
                 authorship
             };
@@ -1082,7 +1082,7 @@ fn overlay_ai_authorship(
             cached.clone()
         } else {
             // Try to get authorship log for this commit
-            let authorship = get_reference_as_authorship_log_v3(repo, &hunk.commit_sha).ok();
+            let authorship = read_authorship_v3(repo, &hunk.commit_sha).ok();
             commit_authorship_cache.insert(hunk.commit_sha.clone(), authorship.clone());
             authorship
         };

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -5,7 +5,7 @@ use crate::authorship::ignore::{
 };
 use crate::commands::blame::GitAiBlameOptions;
 use crate::error::GitAiError;
-use crate::git::notes_api::{read_authorship as get_authorship, read_note as show_authorship_note};
+use crate::git::notes_api::{read_authorship, read_note};
 use crate::git::repository::{InternalGitProfile, Repository, exec_git_with_profile};
 use serde::{Deserialize, Serialize, Serializer};
 use sha2::{Digest, Sha256};
@@ -1611,7 +1611,7 @@ fn load_commit_metadata(
     let msg = parts.next().unwrap_or("").trim().to_string();
     let full_msg = parts.next().unwrap_or("").trim_end().to_string();
     let author = format_git_ident(author_name, author_email);
-    let authorship_note = show_authorship_note(repo, commit_sha);
+    let authorship_note = read_note(repo, commit_sha);
 
     Ok(DiffCommitMetadata {
         authored_time,
@@ -1640,7 +1640,7 @@ fn merge_missing_prompts_and_sessions_from_authorship_note(
     prompts: &mut BTreeMap<String, PromptRecord>,
     sessions: &mut BTreeMap<String, SessionRecord>,
 ) {
-    if let Some(authorship_log) = get_authorship(repo, commit_sha) {
+    if let Some(authorship_log) = read_authorship(repo, commit_sha) {
         for (prompt_id, prompt_record) in &authorship_log.metadata.prompts {
             prompts
                 .entry(prompt_id.clone())

--- a/src/commands/git_handlers.rs
+++ b/src/commands/git_handlers.rs
@@ -202,7 +202,7 @@ fn maybe_show_async_post_commit_stats(parsed: &ParsedGitInvocation, repo: &Repos
     use crate::authorship::ignore::effective_ignore_patterns;
     use crate::authorship::stats::{stats_for_commit_stats, write_stats_to_terminal};
     use crate::git::cli_parser::is_dry_run;
-    use crate::git::notes_api::read_note as show_authorship_note;
+    use crate::git::notes_api::read_note;
     use std::io::IsTerminal;
 
     // Respect the same suppression flags as the synchronous wrapper path.
@@ -246,7 +246,7 @@ fn maybe_show_async_post_commit_stats(parsed: &ParsedGitInvocation, repo: &Repos
     let poll_interval = std::time::Duration::from_millis(25);
     let start = std::time::Instant::now();
     let note_found = loop {
-        if show_authorship_note(repo, &commit_sha).is_some() {
+        if read_note(repo, &commit_sha).is_some() {
             break true;
         }
         if start.elapsed() >= timeout {

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,8 +1,6 @@
 use crate::error::GitAiError;
 use crate::git::find_repository;
-use crate::git::notes_api::{
-    CommitAuthorship, filter_commits_with_notes as get_commits_with_notes_from_list,
-};
+use crate::git::notes_api::{CommitAuthorship, filter_commits_with_notes};
 use crate::git::repository::{CommitRange, Repository};
 
 const NO_AUTHORSHIP_DATA_MESSAGE: &str = "No authorship data found for this revision";
@@ -39,7 +37,7 @@ fn show_authorship(repo: &Repository, spec: &str) -> Result<(), GitAiError> {
         return Ok(());
     }
 
-    let entries = get_commits_with_notes_from_list(repo, &commits)?;
+    let entries = filter_commits_with_notes(repo, &commits)?;
 
     let multiple_commits = entries.len() > 1;
     for (index, entry) in entries.iter().enumerate() {

--- a/src/git/authorship_traversal.rs
+++ b/src/git/authorship_traversal.rs
@@ -2,10 +2,7 @@ use std::collections::HashSet;
 
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::error::GitAiError;
-use crate::git::notes_api::{
-    commits_with_notes as commits_with_authorship_notes,
-    read_note_blob_oids as note_blob_oids_for_commits,
-};
+use crate::git::notes_api::{commits_with_notes, read_note_blob_oids};
 #[cfg(test)]
 use crate::git::repository::exec_git;
 use crate::git::repository::{Repository, exec_git_stdin};
@@ -21,7 +18,7 @@ pub async fn load_ai_touched_files_for_commits(
             return Ok(HashSet::new());
         }
 
-        let note_blob_map = note_blob_oids_for_commits(&repo, &commit_shas)?;
+        let note_blob_map = read_note_blob_oids(&repo, &commit_shas)?;
         if note_blob_map.is_empty() {
             return Ok(HashSet::new());
         }
@@ -56,7 +53,7 @@ pub fn commits_have_authorship_notes(
         return Ok(false);
     }
 
-    Ok(!commits_with_authorship_notes(repo, commit_shas)?.is_empty())
+    Ok(!commits_with_notes(repo, commit_shas)?.is_empty())
 }
 
 /// Get all notes as (note_blob_sha, commit_sha) pairs

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -244,8 +244,34 @@ pub fn filter_commits_with_notes(
 
 // --- Search ---
 
+/// Search authorship-note content for a literal substring and return matching
+/// commit SHAs, newest first.
+///
+/// On the HTTP backend this searches the notes-db cache and unions in any
+/// matches from local git notes (transition-period repos may have both); on
+/// the GitNotes backend it greps `refs/notes/ai` directly.
 pub fn search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
-    crate::git::refs::grep_ai_notes(repo, pattern)
+    match Config::get().notes_backend_kind() {
+        NotesBackendKind::Http => http_search_notes(repo, pattern),
+        NotesBackendKind::GitNotes => crate::git::refs::grep_ai_notes(repo, pattern),
+    }
+}
+
+fn http_search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
+    let mut shas: HashSet<String> = {
+        let db = crate::notes::db::NotesDatabase::global()?;
+        let db_lock = db
+            .lock()
+            .map_err(|e| GitAiError::Generic(format!("notes-db lock: {}", e)))?;
+        db_lock.search_notes_content(pattern)?.into_iter().collect()
+    };
+
+    // Union in matches from local git notes for transition-period repos.
+    if let Ok(git_shas) = crate::git::refs::grep_ai_notes(repo, pattern) {
+        shas.extend(git_shas);
+    }
+
+    crate::git::refs::sort_commit_shas_by_date_desc(repo, shas)
 }
 
 // --- Materialization (for git ai log) ---
@@ -668,6 +694,44 @@ mod tests {
         assert_eq!(result.get(&sha1), Some(&"content-a".to_string()));
         assert_eq!(result.get(&sha2), Some(&"content-b".to_string()));
         assert!(!result.contains_key(&sha3));
+
+        unsafe {
+            env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
+        }
+    }
+
+    /// Under the HTTP backend, note search must find notes that only exist in
+    /// the notes-db cache (refs/notes/ai is empty there). Regression: search was
+    /// a pure pass-through to `git grep refs/notes/ai`, so session/prompt history
+    /// lookups silently found nothing under the HTTP backend.
+    #[test]
+    #[serial_test::serial(notes_db_env)]
+    fn http_search_notes_finds_cached_note_content() {
+        use crate::git::test_utils::TmpRepo;
+        use std::env;
+
+        let tmp_db = tempfile::NamedTempFile::new().expect("tmp file");
+        let db_path = tmp_db.path().to_str().unwrap().to_string();
+        unsafe {
+            env::set_var("GIT_AI_TEST_NOTES_DB_PATH", &db_path);
+        }
+
+        let tmp = TmpRepo::new().expect("TmpRepo::new");
+        let sha = "dddddddddddddddddddddddddddddddddddddddd";
+        http_write_note(sha, r#"{"sessions": {"s_searchable123456": {}}}"#).expect("write");
+
+        let matches =
+            http_search_notes(tmp.gitai_repo(), "\"s_searchable123456\"").expect("search");
+        assert_eq!(
+            matches,
+            vec![sha.to_string()],
+            "search must find notes that only exist in the notes-db cache"
+        );
+
+        // A needle that appears nowhere must return no matches (LIKE wildcards in
+        // the needle must not be interpreted).
+        let no_matches = http_search_notes(tmp.gitai_repo(), "\"s_%_absent%\"").expect("search");
+        assert!(no_matches.is_empty(), "got: {:?}", no_matches);
 
         unsafe {
             env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -1,7 +1,7 @@
 use crate::authorship::authorship_log_serialization::{AUTHORSHIP_LOG_VERSION, AuthorshipLog};
 use crate::authorship::working_log::Checkpoint;
 use crate::error::GitAiError;
-use crate::git::repository::{Repository, exec_git, exec_git_stdin};
+use crate::git::repository::{Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin};
 use serde_json;
 use std::collections::{HashMap, HashSet};
 
@@ -11,7 +11,7 @@ pub const AI_AUTHORSHIP_FULL_REF: &str = "refs/notes/ai";
 pub const AI_AUTHORSHIP_FORK_TRACKING_REF: &str = "refs/notes/ai-remote/fork";
 pub const AI_AUTHORSHIP_PUSH_REFSPEC: &str = "refs/notes/ai:refs/notes/ai";
 
-pub fn notes_add(
+pub(in crate::git) fn notes_add(
     repo: &Repository,
     commit_sha: &str,
     note_content: &str,
@@ -151,7 +151,7 @@ fn batch_read_blob_contents(
 /// Resolve authorship note blob OIDs for a set of commits using one batched cat-file call.
 ///
 /// Returns a map of commit SHA -> note blob SHA for commits that currently have notes.
-pub fn note_blob_oids_for_commits(
+pub(in crate::git) fn note_blob_oids_for_commits(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, GitAiError> {
@@ -162,7 +162,7 @@ pub fn note_blob_oids_for_commits(
 ///
 /// Returns a map of commit SHA -> raw note content for commits that currently
 /// have notes in `refs/notes/ai`.
-pub fn notes_for_commits(
+pub(in crate::git) fn notes_for_commits(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, GitAiError> {
@@ -368,7 +368,10 @@ pub fn copy_missing_notes_for_commits_from_ref(
     Ok(copied)
 }
 
-pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Result<(), GitAiError> {
+pub(in crate::git) fn notes_add_batch(
+    repo: &Repository,
+    entries: &[(String, String)],
+) -> Result<(), GitAiError> {
     if entries.is_empty() {
         return Ok(());
     }
@@ -441,7 +444,7 @@ pub fn notes_add_batch(repo: &Repository, entries: &[(String, String)]) -> Resul
 ///
 /// Each entry is (commit_sha, existing_note_blob_oid).
 #[allow(dead_code)]
-pub fn notes_add_blob_batch(
+pub(in crate::git) fn notes_add_blob_batch(
     repo: &Repository,
     entries: &[(String, String)],
 ) -> Result<(), GitAiError> {
@@ -554,7 +557,7 @@ pub enum CommitAuthorship {
         authorship_log: AuthorshipLog,
     },
 }
-pub fn get_commits_with_notes_from_list(
+pub(in crate::git) fn get_commits_with_notes_from_list(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<Vec<CommitAuthorship>, GitAiError> {
@@ -639,7 +642,7 @@ pub fn get_commits_with_notes_from_list(
 }
 
 // Show an authorship note and return its JSON content if found, or None if it doesn't exist.
-pub fn show_authorship_note(repo: &Repository, commit_sha: &str) -> Option<String> {
+pub(in crate::git) fn show_authorship_note(repo: &Repository, commit_sha: &str) -> Option<String> {
     let mut args = repo.global_args_for_exec();
     args.push("notes".to_string());
     args.push("--ref=ai".to_string());
@@ -660,7 +663,7 @@ pub fn show_authorship_note(repo: &Repository, commit_sha: &str) -> Option<Strin
 ///
 /// This uses a single `git notes --ref=ai list` invocation instead of one
 /// `git notes show` call per commit.
-pub fn commits_with_authorship_notes(
+pub(in crate::git) fn commits_with_authorship_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashSet<String>, GitAiError> {
@@ -670,7 +673,7 @@ pub fn commits_with_authorship_notes(
 }
 
 // Show an authorship note and return its JSON content if found, or None if it doesn't exist.
-pub fn get_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
+pub(in crate::git) fn get_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
     let content = show_authorship_note(repo, commit_sha)?;
     let mut authorship_log = AuthorshipLog::deserialize_from_string(&content).ok()?;
     // Keep metadata aligned with the commit where this note is attached.
@@ -689,7 +692,7 @@ pub fn get_reference_as_working_log(
     Ok(working_log)
 }
 
-pub fn get_reference_as_authorship_log_v3(
+pub(in crate::git) fn get_reference_as_authorship_log_v3(
     repo: &Repository,
     commit_sha: &str,
 ) -> Result<AuthorshipLog, GitAiError> {
@@ -902,7 +905,10 @@ pub fn copy_ref(repo: &Repository, source_ref: &str, dest_ref: &str) -> Result<(
 
 /// Search AI notes for a pattern and return matching commit SHAs ordered by commit date (newest first)
 /// Uses git grep to search through refs/notes/ai
-pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
+pub(in crate::git) fn grep_ai_notes(
+    repo: &Repository,
+    pattern: &str,
+) -> Result<Vec<String>, GitAiError> {
     let mut args = repo.global_args_for_exec();
     args.push("--no-pager".to_string());
     args.push("grep".to_string());
@@ -929,24 +935,107 @@ pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
     }
 
     // If we have multiple results, sort by commit date (newest first)
-    if shas.len() > 1 {
-        let sha_vec: Vec<String> = shas.into_iter().collect();
-        let mut args = repo.global_args_for_exec();
-        args.push("log".to_string());
-        args.push("--format=%H".to_string());
-        args.push("--date-order".to_string());
-        args.push("--no-walk".to_string());
-        for sha in &sha_vec {
-            args.push(sha.clone());
+    sort_commit_shas_by_date_desc(repo, shas)
+}
+
+/// Sort commit SHAs by commit date, newest first, using a single `git log
+/// --no-walk` call. Best-effort: if git cannot resolve every SHA (e.g. a
+/// cache-only note references a commit that was never fetched locally), the
+/// input is returned in lexicographic order instead so callers still get a
+/// deterministic result.
+pub(crate) fn sort_commit_shas_by_date_desc(
+    repo: &Repository,
+    shas: HashSet<String>,
+) -> Result<Vec<String>, GitAiError> {
+    if shas.len() <= 1 {
+        return Ok(shas.into_iter().collect());
+    }
+
+    let mut sha_vec: Vec<String> = shas.into_iter().collect();
+    let mut args = repo.global_args_for_exec();
+    args.push("log".to_string());
+    args.push("--format=%H".to_string());
+    args.push("--date-order".to_string());
+    args.push("--no-walk".to_string());
+    for sha in &sha_vec {
+        args.push(sha.clone());
+    }
+
+    if let Ok(output) = exec_git_allow_nonzero(&args)
+        && output.status.success()
+        && let Ok(stdout) = String::from_utf8(output.stdout)
+    {
+        let sorted: Vec<String> = stdout.lines().map(|s| s.to_string()).collect();
+        if sorted.len() == sha_vec.len() {
+            return Ok(sorted);
         }
+    }
 
-        let output = exec_git(&args)?;
-        let stdout = String::from_utf8(output.stdout)
-            .map_err(|_| GitAiError::Generic("Failed to parse git log output".to_string()))?;
+    sha_vec.sort();
+    Ok(sha_vec)
+}
 
-        Ok(stdout.lines().map(|s| s.to_string()).collect())
-    } else {
-        Ok(shas.into_iter().collect())
+/// Direct access to the raw git-notes backend, for TESTS ONLY.
+///
+/// Production code must go through `crate::git::notes_api`, which dispatches on
+/// the configured notes backend — calling these directly silently ignores the
+/// HTTP backend (notes live in the notes-db cache there, not refs/notes/ai).
+/// The underlying functions are `pub(in crate::git)` to enforce that; these
+/// wrappers exist so backend unit tests can exercise the raw git
+/// implementation regardless of backend configuration.
+#[cfg(feature = "test-support")]
+pub mod git_backend_for_tests {
+    use super::*;
+
+    pub fn notes_add(
+        repo: &Repository,
+        commit_sha: &str,
+        note_content: &str,
+    ) -> Result<(), GitAiError> {
+        super::notes_add(repo, commit_sha, note_content)
+    }
+
+    pub fn show_authorship_note(repo: &Repository, commit_sha: &str) -> Option<String> {
+        super::show_authorship_note(repo, commit_sha)
+    }
+
+    pub fn commits_with_authorship_notes(
+        repo: &Repository,
+        commit_shas: &[String],
+    ) -> Result<HashSet<String>, GitAiError> {
+        super::commits_with_authorship_notes(repo, commit_shas)
+    }
+
+    pub fn get_commits_with_notes_from_list(
+        repo: &Repository,
+        commit_shas: &[String],
+    ) -> Result<Vec<CommitAuthorship>, GitAiError> {
+        super::get_commits_with_notes_from_list(repo, commit_shas)
+    }
+
+    pub fn grep_ai_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
+        super::grep_ai_notes(repo, pattern)
+    }
+
+    pub fn note_blob_oids_for_commits(
+        repo: &Repository,
+        commit_shas: &[String],
+    ) -> Result<HashMap<String, String>, GitAiError> {
+        super::note_blob_oids_for_commits(repo, commit_shas)
+    }
+
+    pub fn notes_add_batch(
+        repo: &Repository,
+        entries: &[(String, String)],
+    ) -> Result<(), GitAiError> {
+        super::notes_add_batch(repo, entries)
+    }
+
+    pub fn notes_add_blob_batch(
+        repo: &Repository,
+        entries: &[(String, String)],
+    ) -> Result<(), GitAiError> {
+        super::notes_add_blob_batch(repo, entries)
     }
 }
 

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -118,28 +118,14 @@ pub fn fetch_missing_notes_for_commits(
 ) -> Result<(), GitAiError> {
     use std::collections::HashSet;
 
-    fn noted_commits(repository: &Repository) -> HashSet<String> {
-        // Fetch the full set of locally-noted commits in one subprocess call.
-        // `git notes --ref=refs/notes/ai list` outputs "<note-sha> <commit-sha>" per line.
-        let mut args = repository.global_args_for_exec();
-        args.extend(
-            ["notes", "--ref=refs/notes/ai", "list"]
-                .iter()
-                .map(|s| s.to_string()),
-        );
-        exec_git(&args)
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| {
-                String::from_utf8_lossy(&o.stdout)
-                    .lines()
-                    .filter_map(|line| line.split_whitespace().nth(1).map(|s| s.to_string()))
-                    .collect()
-            })
-            .unwrap_or_default()
+    fn noted_commits(repository: &Repository, commit_shas: &[String]) -> HashSet<String> {
+        // Backend-aware presence check: on the HTTP backend notes live in the
+        // notes-db cache, not refs/notes/ai — without this, every rewrite of
+        // cached-note commits triggered pointless notes fetches from all remotes.
+        crate::git::notes_api::commits_with_notes(repository, commit_shas).unwrap_or_default()
     }
 
-    let noted_before_fetch = noted_commits(repository);
+    let noted_before_fetch = noted_commits(repository, source_commits);
 
     let missing: Vec<&String> = source_commits
         .iter()
@@ -172,7 +158,7 @@ pub fn fetch_missing_notes_for_commits(
     }
 
     if let Some(error) = first_fetch_error {
-        let noted_after_fetch = noted_commits(repository);
+        let noted_after_fetch = noted_commits(repository, source_commits);
         let still_missing: Vec<&String> = source_commits
             .iter()
             .filter(|sha| !noted_after_fetch.contains(sha.as_str()))

--- a/src/notes/db.rs
+++ b/src/notes/db.rs
@@ -539,6 +539,27 @@ impl NotesDatabase {
         Ok(result)
     }
 
+    /// Return the commit SHAs of notes whose content contains `needle` as a
+    /// literal substring (LIKE wildcards in the needle are escaped).
+    pub fn search_notes_content(&self, needle: &str) -> Result<Vec<String>, GitAiError> {
+        let escaped = needle
+            .replace('\\', r"\\")
+            .replace('%', r"\%")
+            .replace('_', r"\_");
+        let pattern = format!("%{}%", escaped);
+
+        let mut stmt = self
+            .conn
+            .prepare(r"SELECT commit_sha FROM notes WHERE content LIKE ?1 ESCAPE '\'")?;
+        let rows = stmt.query_map(params![pattern], |row| row.get::<_, String>(0))?;
+
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row?);
+        }
+        Ok(result)
+    }
+
     /// Evict synced cache entries older than `max_age_secs` when the total row
     /// count exceeds `max_rows`. Returns the number of rows deleted.
     pub fn evict_stale_cache(

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -8,7 +8,7 @@ mod repos;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::daemon::open_local_socket_stream_with_timeout;
 use git_ai::git::find_repository_in_path;
-use git_ai::git::refs::show_authorship_note;
+use git_ai::git::notes_api::read_note;
 use git_ai::git::repository::Repository as GitAiRepository;
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::{TestRepo, new_daemon_test_sync_session_id, real_git_executable};
@@ -1330,7 +1330,7 @@ fn test_commit_tree_update_ref_preserves_authorship_notes_on_reparent() {
 
     let git_ai_repo = open_repo(&repo);
     assert!(
-        show_authorship_note(&git_ai_repo, &feature_commit.commit_sha).is_some(),
+        read_note(&git_ai_repo, &feature_commit.commit_sha).is_some(),
         "expected initial feature commit to have an authorship note",
     );
 
@@ -1355,7 +1355,7 @@ fn test_commit_tree_update_ref_preserves_authorship_notes_on_reparent() {
 
     let git_ai_repo = open_repo(&repo);
     assert!(
-        show_authorship_note(&git_ai_repo, &new_head).is_some(),
+        read_note(&git_ai_repo, &new_head).is_some(),
         "expected rewritten commit {} to preserve authorship note from {}",
         new_head,
         old_head,
@@ -1453,7 +1453,7 @@ fn test_reset_keep_rewrite_preserves_authorship_notes_on_current_branch() {
 
     let git_ai_repo = open_repo(&repo);
     assert!(
-        show_authorship_note(&git_ai_repo, &feature_commit.commit_sha).is_some(),
+        read_note(&git_ai_repo, &feature_commit.commit_sha).is_some(),
         "expected initial feature commit to have an authorship note",
     );
 
@@ -1478,7 +1478,7 @@ fn test_reset_keep_rewrite_preserves_authorship_notes_on_current_branch() {
 
     let git_ai_repo = open_repo(&repo);
     assert!(
-        show_authorship_note(&git_ai_repo, &new_head).is_some(),
+        read_note(&git_ai_repo, &new_head).is_some(),
         "expected rewritten current-branch commit {} to preserve authorship note from {}",
         new_head,
         old_head,
@@ -1511,7 +1511,7 @@ fn test_update_ref_restack_after_parent_amend_preserves_child_attribution() {
 
     let git_ai_repo = open_repo(&repo);
     assert!(
-        show_authorship_note(&git_ai_repo, &child_commit.commit_sha).is_some(),
+        read_note(&git_ai_repo, &child_commit.commit_sha).is_some(),
         "expected initial child commit to have an authorship note",
     );
 
@@ -1541,7 +1541,7 @@ fn test_update_ref_restack_after_parent_amend_preserves_child_attribution() {
 
     let git_ai_repo = open_repo(&repo);
     assert!(
-        show_authorship_note(&git_ai_repo, &new_child_head).is_some(),
+        read_note(&git_ai_repo, &new_child_head).is_some(),
         "expected rewritten child commit {} to preserve authorship note from {}",
         new_child_head,
         child_commit.commit_sha,
@@ -1602,7 +1602,7 @@ fn test_graphite_style_multi_commit_single_update_ref() {
     let git_ai_repo = open_repo(&repo);
     for &sha in &feature_commits {
         assert!(
-            show_authorship_note(&git_ai_repo, sha).is_some(),
+            read_note(&git_ai_repo, sha).is_some(),
             "pre-rebase: commit {} should have authorship note",
             sha
         );
@@ -1693,7 +1693,7 @@ fn test_graphite_style_multi_commit_single_update_ref() {
     let git_ai_repo = open_repo(&repo);
     for (idx, &sha) in rebased_commits.iter().enumerate() {
         assert!(
-            show_authorship_note(&git_ai_repo, sha).is_some(),
+            read_note(&git_ai_repo, sha).is_some(),
             "post-rebase: rebased commit {} (index {}) should have authorship note",
             sha,
             idx

--- a/tests/integration/blame_comprehensive.rs
+++ b/tests/integration/blame_comprehensive.rs
@@ -24,7 +24,7 @@ use git_ai::authorship::authorship_log_serialization::{
 };
 use git_ai::authorship::working_log::AgentId;
 use git_ai::commands::blame::GitAiBlameOptions;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use git_ai::git::repository as GitAiRepository;
 
 // =============================================================================
@@ -692,7 +692,7 @@ fn test_blame_ai_authorship_hunk_splitting() {
     let note_content = authorship_log.serialize_to_string().unwrap();
     let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("Failed to find repository");
-    notes_add(&gitai_repo, &commit_sha, &note_content).unwrap();
+    write_note(&gitai_repo, &commit_sha, &note_content).unwrap();
 
     // Get hunks with split_hunks_by_ai_author enabled
     let options = GitAiBlameOptions {
@@ -750,7 +750,7 @@ fn test_blame_ai_authorship_no_splitting() {
     let note_content = authorship_log.serialize_to_string().unwrap();
     let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("Failed to find repository");
-    notes_add(&gitai_repo, &commit_sha, &note_content).unwrap();
+    write_note(&gitai_repo, &commit_sha, &note_content).unwrap();
 
     let options = GitAiBlameOptions {
         split_hunks_by_ai_author: false,

--- a/tests/integration/blame_flags.rs
+++ b/tests/integration/blame_flags.rs
@@ -6,7 +6,7 @@ use git_ai::authorship::authorship_log_serialization::{
 };
 use git_ai::authorship::working_log::AgentId;
 use git_ai::commands::blame::GitAiBlameOptions;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use git_ai::git::repository as GitAiRepository;
 
 // Helper function to extract author names from blame output
@@ -1450,7 +1450,7 @@ fn test_blame_ai_human_author() {
     let note_content = authorship_log.serialize_to_string().unwrap();
     let gitai_repo = GitAiRepository::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("Failed to find repository");
-    notes_add(&gitai_repo, &initial_sha, &note_content).unwrap();
+    write_note(&gitai_repo, &initial_sha, &note_content).unwrap();
 
     // Call blame_hunks on the file
     let options = GitAiBlameOptions::default();

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -3,7 +3,7 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log::PromptRecord;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::working_log::AgentId;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -49,7 +49,7 @@ fn test_single_commit_cherry_pick() {
 
     // Verify prompt records have correct stats
     let head_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
-    let log = git_ai::git::refs::get_reference_as_authorship_log_v3(
+    let log = git_ai::git::notes_api::read_authorship_v3(
         &git_ai::git::find_repository_in_path(repo.path().to_str().unwrap()).unwrap(),
         &head_commit,
     )
@@ -169,7 +169,7 @@ fn test_cherry_pick_preserves_prompt_only_commit_note_metadata() {
         .expect("serialize mutated source note");
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(
+    write_note(
         &git_ai_repo,
         &source_commit.commit_sha,
         &mutated_source_note,
@@ -259,7 +259,7 @@ fn test_multiple_commits_cherry_pick() {
 
     // Verify session records exist
     let head_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
-    let log = git_ai::git::refs::get_reference_as_authorship_log_v3(
+    let log = git_ai::git::notes_api::read_authorship_v3(
         &git_ai::git::find_repository_in_path(repo.path().to_str().unwrap()).unwrap(),
         &head_commit,
     )
@@ -461,7 +461,7 @@ fn test_cherry_pick_multiple_ai_sessions() {
 
     // Verify session records exist
     let head_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
-    let log = git_ai::git::refs::get_reference_as_authorship_log_v3(
+    let log = git_ai::git::notes_api::read_authorship_v3(
         &git_ai::git::find_repository_in_path(repo.path().to_str().unwrap()).unwrap(),
         &head_commit,
     )

--- a/tests/integration/ci_fork_notes.rs
+++ b/tests/integration/ci_fork_notes.rs
@@ -2,8 +2,8 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::ci::ci_context::{CiContext, CiEvent, CiRunResult};
-use git_ai::git::notes_api::read_authorship_v3 as get_reference_as_authorship_log_v3;
-use git_ai::git::refs::{notes_add, show_authorship_note};
+use git_ai::git::notes_api::read_authorship_v3;
+use git_ai::git::notes_api::{read_note, write_note};
 use git_ai::git::repository as GitAiRepository;
 use std::fs;
 
@@ -66,7 +66,7 @@ fn test_ci_fork_squash_merge() {
     let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
         .expect("Failed to find fork repository");
     assert!(
-        get_reference_as_authorship_log_v3(&fork_repo, &fork_head_sha).is_ok(),
+        read_authorship_v3(&fork_repo, &fork_head_sha).is_ok(),
         "Fork commit should have authorship notes"
     );
 
@@ -178,7 +178,7 @@ fn test_ci_fork_merge_commit() {
     let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
         .expect("Failed to find fork repository");
     assert!(
-        get_reference_as_authorship_log_v3(&fork_repo, &fork_head_sha).is_ok(),
+        read_authorship_v3(&fork_repo, &fork_head_sha).is_ok(),
         "Fork commit should have authorship notes"
     );
 
@@ -237,7 +237,7 @@ fn test_ci_fork_merge_commit() {
     let upstream_repo2 =
         GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
             .expect("Failed to find upstream repository");
-    let authorship_log = get_reference_as_authorship_log_v3(&upstream_repo2, &fork_head_sha);
+    let authorship_log = read_authorship_v3(&upstream_repo2, &fork_head_sha);
     assert!(
         authorship_log.is_ok(),
         "Fork commit's authorship should be accessible in upstream after CI run"
@@ -299,11 +299,11 @@ function forkFeature() {
     let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
         .expect("Failed to find fork repository");
     assert!(
-        get_reference_as_authorship_log_v3(&fork_repo, &ai_commit_sha).is_ok(),
+        read_authorship_v3(&fork_repo, &ai_commit_sha).is_ok(),
         "first fork commit should have authorship notes"
     );
     assert!(
-        show_authorship_note(&fork_repo, &fork_head_sha).is_none(),
+        read_note(&fork_repo, &fork_head_sha).is_none(),
         "raw git head commit should not have an authorship note"
     );
 
@@ -355,11 +355,11 @@ function forkFeature() {
         GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
             .expect("Failed to find upstream repository");
     assert!(
-        get_reference_as_authorship_log_v3(&upstream_repo_after, &ai_commit_sha).is_ok(),
+        read_authorship_v3(&upstream_repo_after, &ai_commit_sha).is_ok(),
         "non-head PR commit authorship should be preserved"
     );
     assert!(
-        show_authorship_note(&upstream_repo_after, &fork_head_sha).is_none(),
+        read_note(&upstream_repo_after, &fork_head_sha).is_none(),
         "head commit should remain without a note"
     );
 }
@@ -477,7 +477,7 @@ fn test_ci_fork_notes_ignores_notes_outside_pr_commit_range() {
 
     let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
         .expect("Failed to find fork repository");
-    notes_add(&fork_repo, &base_sha, "malicious note for upstream base")
+    write_note(&fork_repo, &base_sha, "malicious note for upstream base")
         .expect("add malicious fork note");
 
     let mut fork_file = fork.filename("feature.js");
@@ -537,11 +537,11 @@ fn test_ci_fork_notes_ignores_notes_outside_pr_commit_range() {
         GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
             .expect("Failed to find upstream repository");
     assert!(
-        show_authorship_note(&upstream_repo_after, &base_sha).is_none(),
+        read_note(&upstream_repo_after, &base_sha).is_none(),
         "malicious fork note for base commit must not be imported"
     );
     assert!(
-        get_reference_as_authorship_log_v3(&upstream_repo_after, &merge_sha).is_ok(),
+        read_authorship_v3(&upstream_repo_after, &merge_sha).is_ok(),
         "squash commit should still receive rewritten authorship from PR commit notes"
     );
 }
@@ -795,7 +795,7 @@ fn test_ci_fork_squash_merge_multiple_commits() {
     let upstream_repo2 =
         GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
             .expect("Failed to find upstream repository");
-    let authorship_log = get_reference_as_authorship_log_v3(&upstream_repo2, &merge_sha);
+    let authorship_log = read_authorship_v3(&upstream_repo2, &merge_sha);
     assert!(
         authorship_log.is_ok(),
         "Squash commit should have authorship log from fork notes"
@@ -834,7 +834,7 @@ fn test_ci_local_merge_can_use_preloaded_fork_notes_ref() {
 
     let fork_repo = GitAiRepository::find_repository_in_path(fork.path().to_str().unwrap())
         .expect("Failed to find fork repository");
-    notes_add(
+    write_note(
         &fork_repo,
         &base_sha,
         "malicious note outside the PR commit set",
@@ -912,11 +912,11 @@ fn test_ci_local_merge_can_use_preloaded_fork_notes_ref() {
     let upstream_repo = GitAiRepository::find_repository_in_path(upstream.path().to_str().unwrap())
         .expect("Failed to find upstream repository");
     assert!(
-        show_authorship_note(&upstream_repo, &base_sha).is_none(),
+        read_note(&upstream_repo, &base_sha).is_none(),
         "local CI must not import unrelated notes from the preloaded fork ref"
     );
     assert!(
-        get_reference_as_authorship_log_v3(&upstream_repo, &merge_sha).is_ok(),
+        read_authorship_v3(&upstream_repo, &merge_sha).is_ok(),
         "local CI should rewrite authorship from preloaded fork notes"
     );
 }

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -1,7 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use git_ai::git::repository as GitAiRepository;
 
 fn direct_test_repo() -> TestRepo {
@@ -306,7 +306,7 @@ fn test_ci_local_sync_skips_when_current_rebased_commit_already_has_note() {
         GitAiRepository::find_repository_in_path(repo.path().to_str().expect("repo path"))
             .expect("git-ai repo");
     let existing_note = "client-side-note-that-ci-must-not-overwrite";
-    notes_add(&gitai_repo, &current_head_sha, existing_note).expect("add existing current note");
+    write_note(&gitai_repo, &current_head_sha, existing_note).expect("add existing current note");
 
     let output = repo
         .git_ai(&[

--- a/tests/integration/prompt_utils_unit.rs
+++ b/tests/integration/prompt_utils_unit.rs
@@ -2,7 +2,7 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::prompt_utils::{
     find_prompt, find_prompt_in_commit, find_prompt_in_history,
 };
-use git_ai::git::refs::get_authorship;
+use git_ai::git::notes_api::read_authorship;
 use git_ai::git::repository::find_repository_in_path;
 
 // mock_ai preset does not produce transcript/prompt records — these tests
@@ -27,7 +27,7 @@ fn test_find_prompt_in_commit_integration() {
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
 
     // Get authorship log from the commit
-    let authorship = get_authorship(&gitai_repo, &head_sha).unwrap();
+    let authorship = read_authorship(&gitai_repo, &head_sha).unwrap();
     let prompt_id = authorship.metadata.prompts.keys().next().unwrap().clone();
 
     // Test finding the prompt
@@ -98,7 +98,7 @@ fn test_find_prompt_in_history_basic() {
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
 
     // Get authorship log from the commit
-    let authorship = get_authorship(&gitai_repo, &head_sha).unwrap();
+    let authorship = read_authorship(&gitai_repo, &head_sha).unwrap();
     let prompt_id = authorship
         .metadata
         .prompts
@@ -135,7 +135,7 @@ fn test_find_prompt_in_history_with_offset() {
         .trim()
         .to_string();
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
-    let authorship = get_authorship(&gitai_repo, &head_sha).unwrap();
+    let authorship = read_authorship(&gitai_repo, &head_sha).unwrap();
     let prompt_id = authorship
         .metadata
         .prompts
@@ -197,7 +197,7 @@ fn test_find_prompt_delegates_to_commit() {
         .trim()
         .to_string();
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
-    let authorship = get_authorship(&gitai_repo, &head_sha).unwrap();
+    let authorship = read_authorship(&gitai_repo, &head_sha).unwrap();
     let prompt_id = authorship
         .metadata
         .prompts
@@ -231,7 +231,7 @@ fn test_find_prompt_delegates_to_history() {
         .trim()
         .to_string();
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
-    let authorship = get_authorship(&gitai_repo, &head_sha).unwrap();
+    let authorship = read_authorship(&gitai_repo, &head_sha).unwrap();
     let prompt_id = authorship
         .metadata
         .prompts

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -3,7 +3,7 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log::PromptRecord;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::working_log::AgentId;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use std::collections::HashMap;
 
 /// Test simple rebase with no conflicts where trees are identical - multiple commits
@@ -390,7 +390,7 @@ fn test_rebase_preserves_prompt_only_commit_note_metadata() {
         .expect("serialize mutated source note");
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &prod_commit.commit_sha, &mutated_source_note)
+    write_note(&git_ai_repo, &prod_commit.commit_sha, &mutated_source_note)
         .expect("overwrite source note with prompt-only metadata");
 
     repo.git(&["rebase", "dev"]).unwrap();

--- a/tests/integration/refs_unit.rs
+++ b/tests/integration/refs_unit.rs
@@ -2,12 +2,15 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::error::GitAiError;
 use git_ai::git::notes_api;
+use git_ai::git::notes_api::{read_authorship_v3, read_note, write_note};
+use git_ai::git::refs::git_backend_for_tests::{
+    commits_with_authorship_notes, get_commits_with_notes_from_list, grep_ai_notes,
+    note_blob_oids_for_commits, notes_add_batch, notes_add_blob_batch,
+};
 use git_ai::git::refs::{
-    AI_AUTHORSHIP_FORK_TRACKING_REF, CommitAuthorship, commits_with_authorship_notes,
-    copy_missing_notes_for_commits_from_ref, copy_ref, get_commits_with_notes_from_list,
-    get_reference_as_authorship_log_v3, get_reference_as_working_log, grep_ai_notes,
-    merge_notes_from_ref, note_blob_oids_for_commits, note_blob_oids_for_commits_from_ref,
-    notes_add, notes_add_batch, notes_add_blob_batch, ref_exists, show_authorship_note,
+    AI_AUTHORSHIP_FORK_TRACKING_REF, CommitAuthorship, copy_missing_notes_for_commits_from_ref,
+    copy_ref, get_reference_as_working_log, merge_notes_from_ref,
+    note_blob_oids_for_commits_from_ref, ref_exists,
 };
 use git_ai::git::repository::{exec_git, exec_git_stdin, find_repository_in_path};
 use std::fs;
@@ -61,18 +64,17 @@ fn test_notes_add_and_show_authorship_note() {
     let note_content = "This is a test authorship note with some random content!";
 
     // Add the authorship note (force overwrite since stage_all_and_commit may create one)
-    notes_add(&gitai_repo, &commit_sha, note_content).expect("Failed to add authorship note");
+    write_note(&gitai_repo, &commit_sha, note_content).expect("Failed to add authorship note");
 
     // Read the note back
     let retrieved_content =
-        show_authorship_note(&gitai_repo, &commit_sha).expect("Failed to retrieve authorship note");
+        read_note(&gitai_repo, &commit_sha).expect("Failed to retrieve authorship note");
 
     // Assert the content matches exactly
     assert_eq!(retrieved_content, note_content);
 
     // Test that non-existent commit returns None
-    let non_existent_content =
-        show_authorship_note(&gitai_repo, "0000000000000000000000000000000000000000");
+    let non_existent_content = read_note(&gitai_repo, "0000000000000000000000000000000000000000");
     assert!(non_existent_content.is_none());
 }
 
@@ -95,8 +97,8 @@ fn test_notes_add_batch_writes_multiple_notes() {
 
     notes_add_batch(&gitai_repo, &entries).expect("batch notes add");
 
-    let note_a = show_authorship_note(&gitai_repo, &commit_a).expect("note A");
-    let note_b = show_authorship_note(&gitai_repo, &commit_b).expect("note B");
+    let note_a = read_note(&gitai_repo, &commit_a).expect("note A");
+    let note_b = read_note(&gitai_repo, &commit_b).expect("note B");
     assert!(note_a.contains("\"note\":\"a\""));
     assert!(note_b.contains("\"note\":\"b\""));
 }
@@ -116,7 +118,7 @@ fn test_notes_add_blob_batch_reuses_existing_note_blob() {
     let mut log = AuthorshipLog::new();
     log.metadata.base_commit_sha = commit_a.clone();
     let note_content = log.serialize_to_string().expect("serialize authorship log");
-    notes_add(&gitai_repo, &commit_a, &note_content).expect("add note A");
+    write_note(&gitai_repo, &commit_a, &note_content).expect("add note A");
 
     let blob_oids = note_blob_oids_for_commits(&gitai_repo, std::slice::from_ref(&commit_a))
         .expect("resolve note blob oid");
@@ -129,11 +131,10 @@ fn test_notes_add_blob_batch_reuses_existing_note_blob() {
     notes_add_blob_batch(&gitai_repo, std::slice::from_ref(&blob_entry))
         .expect("batch add blob-backed note");
 
-    let raw_note_b = show_authorship_note(&gitai_repo, &commit_b).expect("note B");
+    let raw_note_b = read_note(&gitai_repo, &commit_b).expect("note B");
     assert_eq!(raw_note_b, note_content);
 
-    let parsed_note_b =
-        get_reference_as_authorship_log_v3(&gitai_repo, &commit_b).expect("parse B");
+    let parsed_note_b = read_authorship_v3(&gitai_repo, &commit_b).expect("parse B");
     assert_eq!(parsed_note_b.metadata.base_commit_sha, commit_b);
 }
 
@@ -184,11 +185,11 @@ fn test_copy_missing_notes_for_commits_from_ref_copies_only_requested_commits() 
 
     assert_eq!(copied, 1);
     assert_eq!(
-        show_authorship_note(&gitai_repo, &commit_a).as_deref(),
+        read_note(&gitai_repo, &commit_a).as_deref(),
         Some("fork-note-a")
     );
     assert!(
-        show_authorship_note(&gitai_repo, &commit_b).is_none(),
+        read_note(&gitai_repo, &commit_b).is_none(),
         "note for unrequested commit must not be copied"
     );
 }
@@ -215,7 +216,7 @@ fn test_copy_missing_notes_for_commits_from_ref_keeps_existing_local_note() {
     ]);
     exec_git(&args).expect("add source note");
 
-    notes_add(&gitai_repo, &commit_a, "local-note").expect("add local note");
+    write_note(&gitai_repo, &commit_a, "local-note").expect("add local note");
 
     let copied = copy_missing_notes_for_commits_from_ref(
         &gitai_repo,
@@ -226,7 +227,7 @@ fn test_copy_missing_notes_for_commits_from_ref_keeps_existing_local_note() {
 
     assert_eq!(copied, 0);
     assert_eq!(
-        show_authorship_note(&gitai_repo, &commit_a).as_deref(),
+        read_note(&gitai_repo, &commit_a).as_deref(),
         Some("local-note")
     );
 }
@@ -288,13 +289,13 @@ fn test_merge_notes_from_ref() {
     exec_git(&args).expect("add note C on test ref");
 
     // Verify initial state - commit C should not have note on refs/notes/ai
-    let initial_note_c = show_authorship_note(&gitai_repo, &commit_c);
+    let initial_note_c = read_note(&gitai_repo, &commit_c);
 
     // Merge notes from refs/notes/test into refs/notes/ai
     merge_notes_from_ref(&gitai_repo, "refs/notes/test").expect("merge notes");
 
     // After merge, commit C should have a note on refs/notes/ai
-    let final_note_c = show_authorship_note(&gitai_repo, &commit_c);
+    let final_note_c = read_note(&gitai_repo, &commit_c);
 
     // If initially had no note, should now have one. If it had one, should still have one.
     assert!(final_note_c.is_some() || initial_note_c.is_some());
@@ -310,7 +311,7 @@ fn test_copy_ref() {
     let commit_sha = head_sha(&repo);
 
     let note_content = "{\"test\":\"note\"}";
-    notes_add(&gitai_repo, &commit_sha, note_content).expect("add note");
+    write_note(&gitai_repo, &commit_sha, note_content).expect("add note");
 
     // refs/notes/ai should exist
     assert!(ref_exists(&gitai_repo, "refs/notes/ai"));
@@ -326,7 +327,7 @@ fn test_copy_ref() {
     assert!(ref_exists(&gitai_repo, "refs/notes/ai-backup"));
 
     // Verify content is accessible from both refs
-    let note_from_ai = show_authorship_note(&gitai_repo, &commit_sha).expect("note from ai");
+    let note_from_ai = read_note(&gitai_repo, &commit_sha).expect("note from ai");
 
     // Read from backup ref
     let mut args = gitai_repo.global_args_for_exec();
@@ -354,7 +355,7 @@ fn test_grep_ai_notes_single_match() {
     let commit_sha = head_sha(&repo);
 
     let note = "{\"tool\":\"cursor\",\"model\":\"claude-3-sonnet\"}";
-    notes_add(&gitai_repo, &commit_sha, note).expect("add note");
+    write_note(&gitai_repo, &commit_sha, note).expect("add note");
 
     // Search for "cursor" should find the commit
     let results = grep_ai_notes(&gitai_repo, "cursor").expect("grep");
@@ -380,9 +381,9 @@ fn test_grep_ai_notes_multiple_matches() {
     let commit_c = head_sha(&repo);
 
     // Add notes with "cursor" to all three
-    notes_add(&gitai_repo, &commit_a, "{\"tool\":\"cursor\"}").expect("add note A");
-    notes_add(&gitai_repo, &commit_b, "{\"tool\":\"cursor\"}").expect("add note B");
-    notes_add(&gitai_repo, &commit_c, "{\"tool\":\"cursor\"}").expect("add note C");
+    write_note(&gitai_repo, &commit_a, "{\"tool\":\"cursor\"}").expect("add note A");
+    write_note(&gitai_repo, &commit_b, "{\"tool\":\"cursor\"}").expect("add note B");
+    write_note(&gitai_repo, &commit_c, "{\"tool\":\"cursor\"}").expect("add note C");
 
     // Search should find all three, sorted by commit date (newest first)
     let results = grep_ai_notes(&gitai_repo, "cursor").expect("grep");
@@ -418,7 +419,7 @@ fn test_grep_ai_notes_no_match() {
     let commit_sha = head_sha(&repo);
 
     let note = "{\"tool\":\"cursor\"}";
-    notes_add(&gitai_repo, &commit_sha, note).expect("add note");
+    write_note(&gitai_repo, &commit_sha, note).expect("add note");
 
     // Search for non-existent pattern
     let results = grep_ai_notes(&gitai_repo, "vscode");
@@ -598,7 +599,7 @@ fn test_commits_with_authorship_notes() {
 
     // Both commits may already have notes from stage_all_and_commit
     // Add a custom note to A to ensure it has one
-    notes_add(&gitai_repo, &commit_a, "{\"test\":\"note\"}").expect("add note");
+    write_note(&gitai_repo, &commit_a, "{\"test\":\"note\"}").expect("add note");
 
     let commits = vec![commit_a.clone(), commit_b.clone()];
     let result = commits_with_authorship_notes(&gitai_repo, &commits).expect("check notes");
@@ -624,7 +625,7 @@ fn test_get_reference_as_working_log() {
 
     // Add a working log format note
     let working_log_json = "[]";
-    notes_add(&gitai_repo, &commit_sha, working_log_json).expect("add note");
+    write_note(&gitai_repo, &commit_sha, working_log_json).expect("add note");
 
     let result = get_reference_as_working_log(&gitai_repo, &commit_sha).expect("get working log");
     assert_eq!(result.len(), 0); // Empty array
@@ -644,10 +645,10 @@ fn test_get_reference_as_authorship_log_v3_version_mismatch() {
     log.metadata.base_commit_sha = commit_sha.clone();
 
     let note_content = log.serialize_to_string().expect("serialize");
-    notes_add(&gitai_repo, &commit_sha, &note_content).expect("add note");
+    write_note(&gitai_repo, &commit_sha, &note_content).expect("add note");
 
     // Should fail with version mismatch error
-    let result = get_reference_as_authorship_log_v3(&gitai_repo, &commit_sha);
+    let result = read_authorship_v3(&gitai_repo, &commit_sha);
     assert!(result.is_err());
 
     if let Err(GitAiError::Generic(msg)) = result {

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -3143,11 +3143,11 @@ impl TestRepo {
                 // In daemon mode, the authorship note may not be immediately
                 // visible after the session completes due to filesystem flush
                 // timing. Retry briefly before failing.
-                let mut content = git_ai::git::refs::show_authorship_note(&repo, &head_commit);
+                let mut content = git_ai::git::notes_api::read_note(&repo, &head_commit);
                 if content.is_none() {
                     for _ in 0..10 {
                         thread::sleep(Duration::from_millis(50));
-                        content = git_ai::git::refs::show_authorship_note(&repo, &head_commit);
+                        content = git_ai::git::notes_api::read_note(&repo, &head_commit);
                         if content.is_some() {
                             break;
                         }

--- a/tests/integration/sessions_cutover.rs
+++ b/tests/integration/sessions_cutover.rs
@@ -2627,3 +2627,129 @@ fn test_diff_json_stats_with_old_format_note_only() {
         "sessions should be empty for old-format-only commit"
     );
 }
+
+// Regression: under the HTTP notes backend (notes live in the local notes-db,
+// NOT in refs/notes/ai), amending a commit must preserve the sessions
+// metadata on the rebuilt note. The amend pipeline re-reads the original note
+// and session history through refs/notes/ai-only helpers
+// (`refs::get_reference_as_authorship_log_v3`, `refs::grep_ai_notes`), which
+// find nothing under the HTTP backend — so the amended note keeps its s_::t_
+// attestation hashes but silently loses `metadata.sessions`, and downstream
+// consumers bucket every AI line as tool=unknown.
+#[test]
+fn test_amend_preserves_sessions_under_http_notes_backend() {
+    use git_ai::config::{ConfigPatch, NotesBackendConfig, NotesBackendKind};
+    use git_ai::notes::db::NotesDatabase;
+
+    // The daemon owns note writes and the amend rebuild, so the DAEMON must run
+    // with the HTTP backend. The test-home config.json writer does not cover
+    // notes_backend and the daemon caches config at startup, so pass the patch
+    // via env at daemon spawn.
+    let daemon_patch = ConfigPatch {
+        exclude_prompts_in_repositories: Some(vec![]),
+        prompt_storage: Some("notes".to_string()),
+        notes_backend: Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        }),
+        ..Default::default()
+    };
+    let daemon_patch_json =
+        serde_json::to_string(&daemon_patch).expect("serialize daemon config patch");
+    let mut repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_CONFIG_PATCH", daemon_patch_json.as_str())]);
+    // CLI invocations (checkpoint, blame) should use the HTTP backend too.
+    repo.patch_git_ai_config(|patch| {
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        });
+    });
+
+    // Poll the notes-db for a commit's note: post-commit note writes land in the
+    // daemon's notes-db queue (never refs/notes/ai), so the harness's usual
+    // "note visible in refs/notes/ai" commit assertion cannot be used here.
+    let notes_db_path = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("notes-db");
+    let read_note_from_db = |sha: &str| -> Option<String> {
+        for _ in 0..100 {
+            if let Ok(db) = NotesDatabase::open_at_path(&notes_db_path)
+                && let Ok(Some(content)) = db.get_note(sha)
+            {
+                return Some(content);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        None
+    };
+
+    let file_path = repo.path().join("http_amend.txt");
+    fs::write(&file_path, "Human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "http_amend.txt"])
+        .unwrap();
+    fs::write(&file_path, "Human line\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "http_amend.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.git(&["commit", "-m", "AI commit"]).unwrap();
+    repo.sync_daemon();
+    let original_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    let original_note =
+        read_note_from_db(&original_sha).expect("original commit should have a note in notes-db");
+    // Under the HTTP backend the note must be in notes-db, not refs/notes/ai.
+    assert!(
+        repo.read_authorship_note(&original_sha).is_none(),
+        "HTTP backend should not write to refs/notes/ai"
+    );
+    let original_log =
+        AuthorshipLog::deserialize_from_string(&original_note).expect("parse original note");
+    assert!(
+        !original_log.metadata.sessions.is_empty(),
+        "original note should carry sessions metadata"
+    );
+
+    // Amend the commit message only — the attributed content is unchanged, so
+    // the rebuilt note must still attest the AI line to the same session.
+    repo.git(&["commit", "--amend", "-m", "Amended commit"])
+        .unwrap();
+    repo.sync_daemon();
+    let amended_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(amended_sha, original_sha, "amend should rewrite HEAD");
+
+    let amended_note =
+        read_note_from_db(&amended_sha).expect("amended commit should have a note in notes-db");
+    let amended_log =
+        AuthorshipLog::deserialize_from_string(&amended_note).expect("parse amended note");
+
+    // The AI line's attestation must still use the session format...
+    let has_session_attestation = amended_log
+        .attestations
+        .iter()
+        .flat_map(|fa| fa.entries.iter())
+        .any(|entry| entry.hash.starts_with("s_"));
+    assert!(
+        has_session_attestation,
+        "amended note should still attest AI lines to a session hash:\n{}",
+        amended_note
+    );
+
+    // ...and the sessions map those hashes resolve through must survive the amend.
+    assert!(
+        !amended_log.metadata.sessions.is_empty(),
+        "amended note lost metadata.sessions — session attestations no longer resolve to a tool:\n{}",
+        amended_note
+    );
+
+    // The surviving record must be the same session as the original note.
+    for session_id in original_log.metadata.sessions.keys() {
+        assert!(
+            amended_log.metadata.sessions.contains_key(session_id),
+            "session {} from the original note is missing after amend",
+            session_id
+        );
+    }
+}

--- a/tests/integration/sessions_cutover.rs
+++ b/tests/integration/sessions_cutover.rs
@@ -10,7 +10,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use serde_json::Value;
 use std::fs;
 
@@ -53,7 +53,7 @@ fn test_old_format_note_can_be_attached_and_read() {
     // Attach old-format note
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, base_sha, &old_note).expect("add old-format note");
+    write_note(&git_ai_repo, base_sha, &old_note).expect("add old-format note");
 
     // Verify old format note is present and reads correctly
     let read_note = repo
@@ -155,7 +155,7 @@ fn test_mixed_format_note_with_both_prompts_and_sessions() {
     // Attach mixed-format note
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &mixed_note).expect("add mixed-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &mixed_note).expect("add mixed-format note");
 
     // Read and verify the note
     let read_note = repo
@@ -241,7 +241,7 @@ fn test_rebase_chain_with_old_and_new_format_notes() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit_a.commit_sha, &old_note_a).expect("add old-format note A");
+    write_note(&git_ai_repo, &commit_a.commit_sha, &old_note_a).expect("add old-format note A");
 
     // Commit B with AI content (will use new format naturally)
     let mut file_b = repo.filename("file_b.txt");
@@ -353,7 +353,7 @@ fn test_cherry_pick_old_format_note_with_ai_lines_preserved() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &source_commit.commit_sha, &old_note).expect("add old-format note");
+    write_note(&git_ai_repo, &source_commit.commit_sha, &old_note).expect("add old-format note");
 
     // Go back to main and cherry-pick
     repo.git(&["checkout", &default_branch]).unwrap();
@@ -474,7 +474,7 @@ fn test_old_format_note_roundtrips_without_corruption() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &ai_commit.commit_sha, &old_note).expect("add old-format note");
+    write_note(&git_ai_repo, &ai_commit.commit_sha, &old_note).expect("add old-format note");
 
     // Read it back
     let note_v1 = repo
@@ -575,7 +575,7 @@ fn test_reset_preserves_old_format_notes_in_working_log() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("add old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("add old-format note");
 
     // Reset --soft to un-commit but keep changes staged
     repo.git(&["reset", "--soft", "HEAD~1"]).unwrap();
@@ -698,7 +698,7 @@ fn test_amend_old_prompts_commit_with_new_session_checkpoints() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 3: Make new edits and checkpoint with new-format (mock_ai produces trace_id)
     let edited = "Human line 1\nAI old line\nAI new line\n";
@@ -1006,7 +1006,7 @@ fn test_reset_soft_old_note_then_new_session_checkpoints() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 4: Reset --soft HEAD~1 (uncommit, triggers working log reconstruction with old prompts)
     repo.git(&["reset", "--soft", "HEAD~1"]).unwrap();
@@ -1116,7 +1116,7 @@ fn test_squash_merge_mixed_format_commits() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit_a.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit_a.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 4: Commit C2 with AI content using standard helpers (produces new-format/sessions)
     let mut file_b = repo.filename("feature_b.txt");
@@ -1334,7 +1334,8 @@ fn test_rebase_conflict_old_note_ai_resolves_with_sessions() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &feature_commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &feature_commit.commit_sha, &old_note)
+        .expect("attach old-format note");
 
     // Step 3: Go back to main, make conflicting change
     repo.git(&["checkout", &default_branch]).unwrap();
@@ -1415,7 +1416,7 @@ fn test_show_prompt_finds_old_format_prompt_by_id() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // show-prompt with --commit should find the old-format prompt
     let output = repo
@@ -1464,7 +1465,7 @@ fn test_show_prompt_finds_old_format_prompt_in_history() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // show-prompt without --commit should search history and find it
     let output = repo
@@ -1519,7 +1520,7 @@ fn test_stats_json_works_with_old_format_notes() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Run git-ai stats --json — should not crash on old-format notes
     let output = repo
@@ -1643,7 +1644,7 @@ fn test_diff_json_all_prompts_includes_old_format_prompts() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Run git-ai diff --json --all-prompts
     let output = repo
@@ -1714,7 +1715,7 @@ fn test_amend_old_prompts_delete_ai_line_then_add_new_session_line() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 3: Delete the old AI line and add a new one with new-format checkpoint
     let edited = "Human line\nNew session AI line\n";
@@ -1829,7 +1830,7 @@ fn test_amend_old_prompts_keep_old_line_add_new_session_same_file() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 3: Add a new line at the end (keep existing content) with new-format checkpoint
     let edited = "Human line\nOld AI line\nNew session AI line\n";
@@ -1943,7 +1944,7 @@ fn test_multiple_amends_mixed_format_accumulation() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 3: First amend - add new AI line
     let edit1 = "Line 1\nOld AI line\nFirst session line\n";
@@ -2058,7 +2059,7 @@ fn test_initial_from_old_note_plus_human_and_session_edits() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &ai_commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &ai_commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 4: Reset --soft to bring content back to working tree
     repo.git(&["reset", "--soft", "HEAD~1"]).unwrap();
@@ -2165,7 +2166,7 @@ fn test_amend_old_prompts_different_file_gets_session_edits() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 3: Create file_b with new session AI content (different file, not in original commit)
     let content_b = "New session AI line B\n";
@@ -2269,7 +2270,7 @@ fn test_status_counts_ai_lines_from_old_format_initial() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &ai_commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &ai_commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 4: Reset --soft to bring content into working log with old-format INITIAL
     repo.git(&["reset", "--soft", "HEAD~1"]).unwrap();
@@ -2340,7 +2341,7 @@ fn test_diff_json_mixed_format_commit_separates_prompts_and_sessions() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 4: Amend with new-format AI content
     fs::write(&file_path, "base line\nold ai line\nnew ai line\n").unwrap();
@@ -2457,7 +2458,7 @@ fn test_diff_json_history_with_mixed_old_and_new_format_commits() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &old_commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &old_commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Step 3: New-format AI commit
     fs::write(&file_path, "base\nold ai line\nnew session line\n").unwrap();
@@ -2576,7 +2577,7 @@ fn test_diff_json_stats_with_old_format_note_only() {
     );
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
+    write_note(&git_ai_repo, &commit.commit_sha, &old_note).expect("attach old-format note");
 
     // Run diff --json --include-stats
     let output = repo

--- a/tests/integration/show_prompt.rs
+++ b/tests/integration/show_prompt.rs
@@ -1,6 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
-use git_ai::git::refs::notes_add;
+use git_ai::git::notes_api::write_note;
 use serde_json::Value;
 
 // Local helper mirroring the CLI arg vector used by main
@@ -218,13 +218,13 @@ fn show_prompt_commit_flag_scopes_to_requested_commit() {
 
     let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
         .expect("find repository");
-    notes_add(
+    write_note(
         &git_ai_repo,
         &first_commit.commit_sha,
         &note(&first_commit.commit_sha, 5),
     )
     .expect("attach note to first commit");
-    notes_add(
+    write_note(
         &git_ai_repo,
         &second_commit.commit_sha,
         &note(&second_commit.commit_sha, 99),


### PR DESCRIPTION
Following up on #1887, this PR finds and fixes all other locations throughout the codebase that use refs instead of notes_api. It also uses the original names of functions instead of renaming them to avoid bugs caused by callers not knowing which version of a function they're calling when they don't read the imports.

This is a defensive change to avoid future bugs; #1887 is the one that fixes the known bug.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->