### PR TITLE
Fix stash apply fail causing lost notes

### DIFF
--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -666,9 +666,17 @@ fn reconstruct_stash_applied_contents(
             &worktree_path,
             true,
         )?;
+        // `-f` (force) is required: on case-insensitive filesystems (macOS/Windows)
+        // a tree with case-colliding paths (e.g. `README.md` and `readme.md`) makes
+        // `checkout-index -a` fail with "already exists, no checkout" for the second
+        // entry. This is a throwaway scratch worktree, so last-casing-wins is harmless.
         run_isolated_git(
             repo,
-            vec!["checkout-index".to_string(), "-a".to_string()],
+            vec![
+                "checkout-index".to_string(),
+                "-a".to_string(),
+                "-f".to_string(),
+            ],
             &index_path,
             &worktree_path,
             true,

--- a/tests/integration/stash_attribution.rs
+++ b/tests/integration/stash_attribution.rs
@@ -1283,6 +1283,69 @@ fn test_stash_apply_shift_uses_final_commit_tree_after_later_edit() {
     ]);
 }
 
+/// Regression: on case-insensitive filesystems (macOS/Windows), the shift-path
+/// reconstruction (`reconstruct_stash_applied_contents`) checked out the target
+/// tree with `checkout-index -a` (no `-f`). If that tree contained a case-colliding
+/// pair (e.g. `README.md` and `readme.md`), git aborted the second checkout with
+/// "already exists, no checkout" (exit 1), and `require_success` zeroed out the
+/// entire stash attribution restore -- silently dropping the AI note.
+#[test]
+fn test_stash_apply_shift_survives_case_colliding_target_tree() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+
+    fs::write(&file_path, "root\nanchor\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+
+    // Stash an AI change against the current base.
+    fs::write(&file_path, "root\nAI stashed\nanchor\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "example.txt"])
+        .unwrap();
+    repo.git(&["stash", "push", "-m", "ai stash"])
+        .expect("stash should succeed");
+
+    // Advance HEAD (so base_commit != current_head => shift path) and give the
+    // target tree a case-colliding pair via plumbing. The working tree can't hold
+    // both casings on a case-insensitive FS, so build the extra index entry from
+    // the existing README blob and commit it.
+    let mut readme = repo.filename("README.md");
+    readme.set_contents(vec!["# Test Repo".to_string()]);
+    repo.stage_all_and_commit("add README").unwrap();
+
+    let readme_blob = repo
+        .git_og(&["rev-parse", "HEAD:README.md"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git_og(&[
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        &format!("100644,{readme_blob},readme.md"),
+    ])
+    .unwrap();
+    repo.git_og(&["commit", "-m", "add case-colliding readme.md"])
+        .unwrap();
+
+    // Apply the stash onto the new HEAD and commit.
+    repo.git(&["stash", "apply"])
+        .expect("stash apply should succeed");
+    repo.git(&["add", "example.txt"]).unwrap();
+    let commit = repo.commit("apply stash onto case-colliding tree").unwrap();
+
+    // The AI attribution must survive despite the case-colliding target tree.
+    let mut file = repo.filename("example.txt");
+    file.assert_committed_lines(crate::lines![
+        "root".unattributed_human(),
+        "AI stashed".ai(),
+        "anchor".unattributed_human(),
+    ]);
+    assert!(
+        !commit.authorship_log.metadata.sessions.is_empty(),
+        "Expected sessions in authorship log - stash attribution lost on case-colliding target tree"
+    );
+}
+
 #[test]
 fn test_repeated_stash_pop_does_not_duplicate_checkpoints() {
     let repo = TestRepo::new();


### PR DESCRIPTION
Original problem: stash-pop attribution restore crashed on a case-colliding file (`README.md` + `readme.md` both tracked). Regression test reproduces exactly the case observed.

`-f` should be harmless here because the checkout-index is run against an isolated throwaway scratch dir rather than the user's actual copy.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->