### PR TITLE
Start package daemon at login

### DIFF
--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -39,6 +39,8 @@ OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$
 rm -rf "$WORK_DIR"
 mkdir -p "$SCRIPTS" "$(dirname "$OUTPUT_ABS")"
 install -m 0755 "$BINARY" "$SCRIPTS/git-ai"
+install -m 0755 "$ROOT/packaging/macos/launchagents/git-ai-daemon-launcher" "$SCRIPTS/git-ai-daemon-launcher"
+install -m 0644 "$ROOT/packaging/macos/launchagents/com.git-ai.daemon.plist" "$SCRIPTS/com.git-ai.daemon.plist"
 install -m 0755 "$ROOT/packaging/macos/scripts/preinstall" "$SCRIPTS/preinstall"
 install -m 0755 "$ROOT/packaging/macos/scripts/postinstall" "$SCRIPTS/postinstall"
 xattr -cr "$SCRIPTS" 2>/dev/null || true

--- a/packaging/macos/launchagents/com.git-ai.daemon.plist
+++ b/packaging/macos/launchagents/com.git-ai.daemon.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.git-ai.daemon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>exec "$HOME/.git-ai/bin/git-ai-daemon-launcher"</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>

--- a/packaging/macos/launchagents/git-ai-daemon-launcher
+++ b/packaging/macos/launchagents/git-ai-daemon-launcher
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+: "${HOME:?HOME is required}"
+exec "$HOME/.git-ai/bin/git-ai" bg run

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -8,6 +8,8 @@ fail() {
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
 SOURCE_BINARY="$SCRIPT_DIR/git-ai"
+SOURCE_LAUNCHER="$SCRIPT_DIR/git-ai-daemon-launcher"
+SOURCE_PLIST="$SCRIPT_DIR/com.git-ai.daemon.plist"
 CONSOLE_USER="$(/usr/bin/stat -f%Su /dev/console)"
 
 case "$CONSOLE_USER" in
@@ -17,6 +19,8 @@ case "$CONSOLE_USER" in
 esac
 
 [ -x "$SOURCE_BINARY" ] || fail "bundled git-ai binary is missing"
+[ -x "$SOURCE_LAUNCHER" ] || fail "bundled daemon launcher is missing"
+[ -f "$SOURCE_PLIST" ] || fail "bundled LaunchAgent is missing"
 /usr/bin/id "$CONSOLE_USER" >/dev/null 2>&1 || fail "console user $CONSOLE_USER does not exist"
 
 USER_HOME="$(/usr/bin/dscl . -read "/Users/$CONSOLE_USER" NFSHomeDirectory | /usr/bin/awk 'NR == 1 { print $2 }')"
@@ -29,11 +33,16 @@ USER_GROUP="$(/usr/bin/id -gn "$CONSOLE_USER")"
 GIT_AI_HOME="$USER_HOME/.git-ai"
 GIT_AI_BIN_DIR="$GIT_AI_HOME/bin"
 GIT_AI_BIN="$GIT_AI_BIN_DIR/git-ai"
+GIT_AI_LAUNCHER="$GIT_AI_BIN_DIR/git-ai-daemon-launcher"
+LAUNCH_AGENTS_DIR="$USER_HOME/Library/LaunchAgents"
 
 /usr/bin/install -d -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$GIT_AI_HOME"
 /usr/bin/install -d -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$GIT_AI_BIN_DIR"
+/usr/bin/install -d -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$LAUNCH_AGENTS_DIR"
 /usr/sbin/chown "$CONSOLE_USER:$USER_GROUP" "$GIT_AI_HOME" "$GIT_AI_BIN_DIR"
 /usr/bin/install -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$SOURCE_BINARY" "$GIT_AI_BIN"
+/usr/bin/install -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$SOURCE_LAUNCHER" "$GIT_AI_LAUNCHER"
+/usr/bin/install -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0644 "$SOURCE_PLIST" "$LAUNCH_AGENTS_DIR/com.git-ai.daemon.plist"
 /usr/bin/su - "$CONSOLE_USER" -c "\"$GIT_AI_BIN\" install-hooks"
 
 exit 0

--- a/packaging/windows/build-msi.ps1
+++ b/packaging/windows/build-msi.ps1
@@ -16,6 +16,7 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
 $wxsPath = Join-Path $PSScriptRoot 'git-ai.wxs'
 $stageDir = Join-Path $repoRoot "target\package\msi-$Architecture"
 $stagedExe = Join-Path $stageDir 'git-ai.exe'
+$stagedLoginLauncher = Join-Path $stageDir 'git-ai-login.cmd'
 $outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
 $outputDir = [System.IO.Path]::GetDirectoryName($outputFullPath)
 $upgradeCode = '4B6D731B-CB6B-48F2-8A0A-A4344C91E1E0'
@@ -23,6 +24,7 @@ $upgradeCode = '4B6D731B-CB6B-48F2-8A0A-A4344C91E1E0'
 New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
 New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
 Copy-Item -Force -LiteralPath $BinaryPath -Destination $stagedExe
+Copy-Item -Force -LiteralPath (Join-Path $PSScriptRoot 'git-ai-login.cmd') -Destination $stagedLoginLauncher
 
 $wixVersion = '7.0.0'
 $wixUtilExtension = 'WixToolset.Util.wixext/7.0.0'
@@ -47,6 +49,7 @@ $platform = if ($Architecture -eq 'arm64') { 'arm64' } else { 'x64' }
     -arch $platform `
     -d "ProductVersion=$Version" `
     -d "GitAiExe=$stagedExe" `
+    -d "GitAiLoginLauncher=$stagedLoginLauncher" `
     -d "UpgradeCode={$upgradeCode}" `
     -o $outputFullPath
 

--- a/packaging/windows/git-ai-login.cmd
+++ b/packaging/windows/git-ai-login.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+
+set "GIT_AI_USER_BINARY=%USERPROFILE%\.git-ai\bin\git-ai.exe"
+if exist "%GIT_AI_USER_BINARY%" (
+  "%GIT_AI_USER_BINARY%" bg start
+  exit /b %ERRORLEVEL%
+)
+
+"%~dp0git-ai.exe" bg start

--- a/packaging/windows/git-ai.wxs
+++ b/packaging/windows/git-ai.wxs
@@ -24,6 +24,7 @@
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="GitAiExeComponent" Guid="{95D3C11E-6881-43AB-9E5B-4462AA59E0E2}">
         <File Id="GitAiExe" Source="$(var.GitAiExe)" Name="git-ai.exe" KeyPath="yes" />
+        <File Id="GitAiLoginLauncher" Source="$(var.GitAiLoginLauncher)" Name="git-ai-login.cmd" />
         <Environment
           Id="GitAiPath"
           Name="PATH"
@@ -32,6 +33,13 @@
           Part="first"
           System="no"
           Action="set" />
+        <RegistryValue
+          Id="GitAiRunAtLogin"
+          Root="HKCU"
+          Key="Software\Microsoft\Windows\CurrentVersion\Run"
+          Name="Git AI"
+          Value="&quot;[INSTALLFOLDER]git-ai-login.cmd&quot;"
+          Type="string" />
       </Component>
     </ComponentGroup>
 

--- a/tests/package_login_startup.rs
+++ b/tests/package_login_startup.rs
@@ -1,0 +1,41 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+#[test]
+fn macos_pkg_installs_a_user_session_launch_agent() {
+    let build_pkg = read("packaging/macos/build-pkg.sh");
+    let postinstall = read("packaging/macos/scripts/postinstall");
+
+    assert!(build_pkg.contains("$SCRIPTS/git-ai-daemon-launcher"));
+    assert!(build_pkg.contains("$SCRIPTS/com.git-ai.daemon.plist"));
+    assert!(postinstall.contains("$USER_HOME/Library/LaunchAgents"));
+    assert!(postinstall.contains("$GIT_AI_BIN_DIR/git-ai-daemon-launcher"));
+
+    let plist = read("packaging/macos/launchagents/com.git-ai.daemon.plist");
+    assert!(plist.contains("<string>com.git-ai.daemon</string>"));
+    assert!(plist.contains("<key>RunAtLoad</key>"));
+    assert!(plist.contains("$HOME/.git-ai/bin/git-ai-daemon-launcher"));
+
+    let launcher = read("packaging/macos/launchagents/git-ai-daemon-launcher");
+    assert!(launcher.contains("$HOME/.git-ai/bin/git-ai"));
+    assert!(!launcher.contains("/opt/git-ai"));
+}
+
+#[test]
+fn windows_msi_registers_login_startup_per_user() {
+    let wix = read("packaging/windows/git-ai.wxs");
+
+    assert!(wix.contains("File Id=\"GitAiLoginLauncher\""));
+    assert!(wix.contains("Root=\"HKCU\""));
+    assert!(wix.contains("Key=\"Software\\Microsoft\\Windows\\CurrentVersion\\Run\""));
+    assert!(!wix.contains("Root=\"HKLM\""));
+    assert!(wix.contains("Value=\"&quot;[INSTALLFOLDER]git-ai-login.cmd&quot;\""));
+
+    let launcher = read("packaging/windows/git-ai-login.cmd");
+    assert!(launcher.contains("%USERPROFILE%\\.git-ai\\bin\\git-ai.exe"));
+    assert!(launcher.contains("\"%GIT_AI_USER_BINARY%\" bg start"));
+    assert!(launcher.contains("\"%~dp0git-ai.exe\" bg start"));
+}


### PR DESCRIPTION
## Summary

- start the packaged daemon when each user logs in on Windows and macOS
- install per-user launchers that prefer the user-managed runtime
- cover both package startup integrations with focused tests

## Restack provenance

Restacks #1716 as layer 6 on top of the clean installer stack (#1882–#1886). Every non-overlapping diff byte is identical to #1716 (SHA-256: `9abc9a4c1e5f31b07d1818dc179c308810d1163397de94ef3da37fb31d9b4191`). The sole redundant old addition, `-acceptEula wix7`, is already present in #1886 together with the WiX v7 pin and is intentionally not duplicated. Commit authorship remains Siddhant Khare.

## Validation

- `task fmt`
- `task lint`
- `task test CARGO_TEST_ARGS="--test package_login_startup"`