### PR TITLE
Enable VS Code Copilot usage ingestion

### DIFF
--- a/src/mdm/utils.rs
+++ b/src/mdm/utils.rs
@@ -754,8 +754,7 @@ pub fn update_vscode_chat_hook_settings(
 
     let object = root.object_value_or_set();
     let mut changed = false;
-
-    match object.get("chat.useHooks") {
+    let mut enable_setting = |key: &str| match object.get(key) {
         Some(prop) => {
             let should_update = match prop.value() {
                 Some(node) => match node.as_boolean_lit() {
@@ -771,10 +770,13 @@ pub fn update_vscode_chat_hook_settings(
             }
         }
         None => {
-            object.append("chat.useHooks", jsonc_parser::json!(true));
+            object.append(key, jsonc_parser::json!(true));
             changed = true;
         }
-    }
+    };
+
+    enable_setting("chat.useHooks");
+    enable_setting("github.copilot.chat.otel.dbSpanExporter.enabled");
 
     if !changed {
         return Ok(None);
@@ -955,6 +957,7 @@ mod tests {
         let final_content = fs::read_to_string(&settings_path).unwrap();
         assert!(final_content.contains("// keep existing entries"));
         assert!(final_content.contains("\"chat.useHooks\": true"));
+        assert!(final_content.contains("otel.dbSpanExporter.enabled\": true"));
     }
 
     #[test]
@@ -962,7 +965,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let settings_path = temp_dir.path().join("settings.json");
         let initial = r#"{
-    "chat.useHooks": true
+    "chat.useHooks": true,
+    "github.copilot.chat.otel.dbSpanExporter.enabled": true
 }
 "#;
         fs::write(&settings_path, initial).unwrap();


### PR DESCRIPTION
## Summary

- Enable GitHub Copilot Chat's local SQLite OTel span exporter during VS Code integration setup.
- Reuse the existing OTel stream reader for model, token, and cost data.
- Keep Copilot OTel content capture disabled.


Atrribution was showing instantly but then after ~30 minutes, token/cost start to show up after testing this locally

<img width="1498" height="668" alt="image" src="https://github.com/user-attachments/assets/449dc617-70d4-4274-bc58-19d686f31d6a" />


Fixes PD-181