### PR TITLE
test: isolate notes database per test repo

### DIFF
--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -491,6 +491,10 @@ impl DaemonProcess {
 
 fn configure_test_home_env(command: &mut Command, test_home: &Path) {
     command.env("HOME", test_home);
+    command.env(
+        "GIT_AI_TEST_NOTES_DB_PATH",
+        test_home.join(".git-ai").join("internal").join("notes-db"),
+    );
     command.env("GIT_CONFIG_GLOBAL", test_home.join(".gitconfig"));
     // Redirect XDG_CONFIG_HOME so git does not read the real user's
     // $XDG_CONFIG_HOME/git/config (which may contain filter drivers,
@@ -3634,6 +3638,24 @@ pub fn get_binary_path() -> &'static PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_configure_test_home_env_isolates_notes_database() {
+        let test_home = PathBuf::from("isolated-test-home");
+        let mut command = Command::new("git");
+
+        configure_test_home_env(&mut command, &test_home);
+
+        let notes_db_path = command
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("GIT_AI_TEST_NOTES_DB_PATH"))
+            .and_then(|(_, value)| value)
+            .map(PathBuf::from);
+        assert_eq!(
+            notes_db_path,
+            Some(test_home.join(".git-ai").join("internal").join("notes-db"))
+        );
+    }
 
     #[test]
     fn test_normalize_test_git_ai_checkpoint_args_inserts_separator_for_direct_file() {


### PR DESCRIPTION
## Summary

- Give every `TestRepo` subprocess and daemon an explicit per-repo `GIT_AI_TEST_NOTES_DB_PATH`.
- Prevent Windows home-directory resolution from sending HTTP-backend notes to a different database than the test assertion reads.
- Add a focused harness regression test for the isolated notes-db environment.

## Why

Current `main` deterministically fails `sessions_cutover::test_amend_preserves_sessions_under_http_notes_backend` on Windows because the daemon and assertion can resolve different notes-db paths. This test-only change keeps notes storage isolated and fixes the existing CI blocker without changing production behavior.

## Validation

- Red-to-green: `test_configure_test_home_env_isolates_notes_database`
- `task test TEST_FILTER=test_amend_preserves_sessions_under_http_notes_backend`
- `task fmt`
- `task lint`
- `task test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->