### PR TITLE
Fix high memory usage on large rebases

### DIFF
--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -6,7 +6,9 @@ use crate::config::Config;
 use crate::error::GitAiError;
 use crate::git::notes_api;
 use crate::git::repo_state::is_valid_git_oid;
-use crate::git::repository::{Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin};
+use crate::git::repository::{
+    Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin_streaming,
+};
 
 const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
@@ -28,7 +30,7 @@ pub enum RewriteEvent {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct DiffTreeResult {
     pub hunks_by_file: HashMap<String, Vec<DiffHunk>>,
     pub added_lines_by_file: HashMap<String, Vec<u32>>,
@@ -325,9 +327,8 @@ fn tree_for_commit<'a>(
 fn build_diff_tree_stdin(
     pairs: &[(String, String)],
     sha_to_tree: &HashMap<String, String>,
-) -> Result<(String, Vec<(String, String)>), GitAiError> {
+) -> Result<String, GitAiError> {
     let mut stdin_data = String::new();
-    let mut tree_pair_keys: Vec<(String, String)> = Vec::with_capacity(pairs.len());
     for (src, dst) in pairs {
         let src_tree = tree_for_commit(sha_to_tree, src)?;
         let dst_tree = tree_for_commit(sha_to_tree, dst)?;
@@ -335,26 +336,14 @@ fn build_diff_tree_stdin(
         stdin_data.push(' ');
         stdin_data.push_str(dst_tree);
         stdin_data.push('\n');
-        tree_pair_keys.push((src_tree.to_string(), dst_tree.to_string()));
     }
-    Ok((stdin_data, tree_pair_keys))
-}
-
-fn parse_batched_diff_tree_output_for_owned_keys(
-    output: &str,
-    tree_pair_keys: &[(String, String)],
-) -> Result<Vec<DiffTreeResult>, GitAiError> {
-    let key_refs: Vec<(&str, &str)> = tree_pair_keys
-        .iter()
-        .map(|(src, dst)| (src.as_str(), dst.as_str()))
-        .collect();
-    parse_batched_diff_tree_output(output, &key_refs)
+    Ok(stdin_data)
 }
 
 fn compute_diff_tree_stdin(
     repo: &Repository,
     stdin_data: String,
-    tree_pair_keys: Vec<(String, String)>,
+    pair_count: usize,
 ) -> Result<Vec<DiffTreeResult>, GitAiError> {
     // Single git diff-tree --stdin call.
     //
@@ -377,11 +366,15 @@ fn compute_diff_tree_stdin(
         "-r".to_string(),
     ]);
 
-    let output = exec_git_stdin(&args, stdin_data.as_bytes())?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Parse output: each pair's result starts with a "tree1 tree2\n" separator line
-    parse_batched_diff_tree_output_for_owned_keys(&stdout, &tree_pair_keys)
+    // Stream the output line-by-line into the parser instead of buffering it:
+    // after a rebase across a large trunk delta, every pair's root-tree diff
+    // contains that whole delta, so the batched output is
+    // (trunk delta bytes) x (pair count) and buffering it has driven the
+    // daemon to multi-GB RSS. The parsed hunk/line structures are a small
+    // fraction of the raw patch text.
+    let mut parser = BatchedDiffTreeParser::new(pair_count);
+    exec_git_stdin_streaming(&args, stdin_data.as_bytes(), |line| parser.feed_line(line))?;
+    Ok(parser.finish())
 }
 
 pub fn handle_rewrite_event(repo: &Repository, event: RewriteEvent) -> Result<(), GitAiError> {
@@ -1245,50 +1238,71 @@ pub(crate) fn compute_diff_trees_batch(
 
     let unique_shas = unique_pair_shas(pairs);
     let sha_to_tree = resolve_tree_shas(repo, &unique_shas)?;
-    let (stdin_data, tree_pair_keys) = build_diff_tree_stdin(pairs, &sha_to_tree)?;
-    compute_diff_tree_stdin(repo, stdin_data, tree_pair_keys)
+    let stdin_data = build_diff_tree_stdin(pairs, &sha_to_tree)?;
+    compute_diff_tree_stdin(repo, stdin_data, pairs.len())
 }
 
-/// Parse the output of `git diff-tree --stdin` which produces multiple results
-/// separated by "tree1 tree2" header lines.
-fn parse_batched_diff_tree_output(
-    output: &str,
-    tree_pair_keys: &[(&str, &str)],
-) -> Result<Vec<DiffTreeResult>, GitAiError> {
-    let mut results: Vec<DiffTreeResult> = Vec::with_capacity(tree_pair_keys.len());
-    let mut current_chunk = String::new();
-    let mut seen_first_header = false;
+/// Incremental parser for the output of `git diff-tree --stdin`, which
+/// produces one patch per tree pair, each preceded by a "tree1 tree2"
+/// separator line. Results are positional: the Nth separator starts the Nth
+/// pair's patch. Fed one line at a time so callers can stream arbitrarily
+/// large diff output without holding the raw patch text in memory.
+struct BatchedDiffTreeParser {
+    expected_pairs: usize,
+    results: Vec<DiffTreeResult>,
+    current: DiffTreeChunkParser,
+    seen_first_header: bool,
+}
 
-    for line in output.lines() {
-        // Separator lines are exactly "tree_sha1 tree_sha2" (two 40-char hex SHAs separated by space)
-        if is_tree_pair_separator(line) {
-            if seen_first_header {
-                results.push(parse_diff_tree_output(&current_chunk));
-                current_chunk.clear();
-            }
-            seen_first_header = true;
-        } else if seen_first_header {
-            current_chunk.push_str(line);
-            current_chunk.push('\n');
+impl BatchedDiffTreeParser {
+    fn new(expected_pairs: usize) -> Self {
+        Self {
+            expected_pairs,
+            results: Vec::with_capacity(expected_pairs),
+            current: DiffTreeChunkParser::default(),
+            seen_first_header: false,
         }
     }
 
-    // Push final chunk
-    if seen_first_header {
-        results.push(parse_diff_tree_output(&current_chunk));
+    fn feed_line(&mut self, line: &str) {
+        // Separator lines are exactly "tree_sha1 tree_sha2" (two OIDs separated by a space)
+        if is_tree_pair_separator(line) {
+            if self.seen_first_header {
+                let chunk = std::mem::take(&mut self.current);
+                self.results.push(chunk.finish());
+            }
+            self.seen_first_header = true;
+        } else if self.seen_first_header {
+            self.current.feed_line(line);
+        }
     }
 
-    // If git produced fewer results than pairs, pad with empty results
-    // (happens when trees are identical — no separator line emitted)
-    while results.len() < tree_pair_keys.len() {
-        results.push(DiffTreeResult {
-            hunks_by_file: HashMap::new(),
-            added_lines_by_file: HashMap::new(),
-            renames: Vec::new(),
-        });
-    }
+    fn finish(mut self) -> Vec<DiffTreeResult> {
+        // Push final chunk
+        if self.seen_first_header {
+            self.results.push(self.current.finish());
+        }
 
-    Ok(results)
+        // If git produced fewer results than pairs, pad with empty results
+        // (happens when trees are identical — no separator line emitted)
+        while self.results.len() < self.expected_pairs {
+            self.results.push(DiffTreeResult::default());
+        }
+
+        self.results
+    }
+}
+
+/// Parse the output of `git diff-tree --stdin` provided as a single string.
+/// Thin wrapper over `BatchedDiffTreeParser` (which the streaming path feeds
+/// directly).
+#[cfg(test)]
+fn parse_batched_diff_tree_output(output: &str, expected_pairs: usize) -> Vec<DiffTreeResult> {
+    let mut parser = BatchedDiffTreeParser::new(expected_pairs);
+    for line in output.lines() {
+        parser.feed_line(line);
+    }
+    parser.finish()
 }
 
 fn is_tree_pair_separator(line: &str) -> bool {
@@ -1302,37 +1316,44 @@ fn is_tree_pair_separator(line: &str) -> bool {
     is_valid_git_oid(old) && is_valid_git_oid(new)
 }
 
-fn parse_diff_tree_output(output: &str) -> DiffTreeResult {
-    let mut hunks_by_file: HashMap<String, Vec<DiffHunk>> = HashMap::new();
-    let mut added_lines_by_file: HashMap<String, Vec<u32>> = HashMap::new();
-    let mut renames: Vec<(String, String)> = Vec::new();
-    let mut current_file: Option<String> = None;
-    let mut current_rename_from: Option<String> = None;
-    let mut active_hunk_new_line: Option<u32> = None;
+/// Incremental parser for a single tree pair's diff-tree patch.
+#[derive(Default)]
+struct DiffTreeChunkParser {
+    hunks_by_file: HashMap<String, Vec<DiffHunk>>,
+    added_lines_by_file: HashMap<String, Vec<u32>>,
+    renames: Vec<(String, String)>,
+    current_file: Option<String>,
+    current_rename_from: Option<String>,
+    active_hunk_new_line: Option<u32>,
+}
 
-    for line in output.lines() {
+impl DiffTreeChunkParser {
+    fn feed_line(&mut self, line: &str) {
         if let Some(rest) = line.strip_prefix("diff --git ") {
             // Extract the b/ path from "a/old b/new"
-            current_file = extract_b_path(rest);
-            current_rename_from = None;
-            active_hunk_new_line = None;
+            self.current_file = extract_b_path(rest);
+            self.current_rename_from = None;
+            self.active_hunk_new_line = None;
         } else if let Some(from_path) = line.strip_prefix("rename from ") {
-            current_rename_from = Some(from_path.to_string());
-            active_hunk_new_line = None;
+            self.current_rename_from = Some(from_path.to_string());
+            self.active_hunk_new_line = None;
         } else if let Some(to_path) = line.strip_prefix("rename to ") {
-            if let Some(from_path) = current_rename_from.take() {
-                renames.push((from_path, to_path.to_string()));
+            if let Some(from_path) = self.current_rename_from.take() {
+                self.renames.push((from_path, to_path.to_string()));
             }
         } else if line.starts_with("@@")
-            && let Some(ref file) = current_file
+            && let Some(ref file) = self.current_file
             && let Some(hunk) = parse_hunk_header(line)
         {
-            active_hunk_new_line = Some(hunk.new_start);
-            hunks_by_file.entry(file.clone()).or_default().push(hunk);
-        } else if let Some(new_line) = active_hunk_new_line.as_mut() {
+            self.active_hunk_new_line = Some(hunk.new_start);
+            self.hunks_by_file
+                .entry(file.clone())
+                .or_default()
+                .push(hunk);
+        } else if let Some(new_line) = self.active_hunk_new_line.as_mut() {
             if line.starts_with('+') {
-                if let Some(ref file) = current_file {
-                    added_lines_by_file
+                if let Some(ref file) = self.current_file {
+                    self.added_lines_by_file
                         .entry(file.clone())
                         .or_default()
                         .push(*new_line);
@@ -1347,16 +1368,27 @@ fn parse_diff_tree_output(output: &str) -> DiffTreeResult {
         }
     }
 
-    for lines in added_lines_by_file.values_mut() {
-        lines.sort_unstable();
-        lines.dedup();
-    }
+    fn finish(mut self) -> DiffTreeResult {
+        for lines in self.added_lines_by_file.values_mut() {
+            lines.sort_unstable();
+            lines.dedup();
+        }
 
-    DiffTreeResult {
-        hunks_by_file,
-        added_lines_by_file,
-        renames,
+        DiffTreeResult {
+            hunks_by_file: self.hunks_by_file,
+            added_lines_by_file: self.added_lines_by_file,
+            renames: self.renames,
+        }
     }
+}
+
+#[cfg(test)]
+fn parse_diff_tree_output(output: &str) -> DiffTreeResult {
+    let mut parser = DiffTreeChunkParser::default();
+    for line in output.lines() {
+        parser.feed_line(line);
+    }
+    parser.finish()
 }
 
 fn extract_b_path(diff_header: &str) -> Option<String> {
@@ -1755,11 +1787,7 @@ index a29bdeb..c0d0fb4 100644
 @@ -1,0 +2 @@ line1
 +line2
 ";
-        let keys = [(
-            "1778ed95466977076f4e5908e6500789be732d2e",
-            "471b7bbf5998ffa15a81b17ee9f6854a357a2a6a",
-        )];
-        let results = parse_batched_diff_tree_output(output, &keys).unwrap();
+        let results = parse_batched_diff_tree_output(output, 1);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].hunks_by_file.len(), 1);
         assert_eq!(results[0].hunks_by_file["f.txt"][0].new_count, 1);
@@ -1783,17 +1811,7 @@ index eee..fff 100644
 @@ -5,2 +5,3 @@
 +new line
 ";
-        let keys = [
-            (
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            ),
-            (
-                "cccccccccccccccccccccccccccccccccccccccc",
-                "dddddddddddddddddddddddddddddddddddddddd",
-            ),
-        ];
-        let results = parse_batched_diff_tree_output(output, &keys).unwrap();
+        let results = parse_batched_diff_tree_output(output, 2);
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].hunks_by_file.len(), 1);
         assert!(results[0].hunks_by_file.contains_key("f.txt"));
@@ -1806,11 +1824,7 @@ index eee..fff 100644
         let output = "\
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ";
-        let keys = [(
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )];
-        let results = parse_batched_diff_tree_output(output, &keys).unwrap();
+        let results = parse_batched_diff_tree_output(output, 1);
         assert_eq!(results.len(), 1);
         assert!(results[0].hunks_by_file.is_empty());
         assert!(results[0].renames.is_empty());
@@ -1829,21 +1843,7 @@ diff --git a/g.txt b/g.txt
 @@ -3,1 +3,2 @@
 +y
 ";
-        let keys = [
-            (
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            ),
-            (
-                "cccccccccccccccccccccccccccccccccccccccc",
-                "cccccccccccccccccccccccccccccccccccccccc",
-            ),
-            (
-                "dddddddddddddddddddddddddddddddddddddddd",
-                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-            ),
-        ];
-        let results = parse_batched_diff_tree_output(output, &keys).unwrap();
+        let results = parse_batched_diff_tree_output(output, 3);
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].hunks_by_file.len(), 1);
         assert!(results[1].hunks_by_file.is_empty());
@@ -1852,7 +1852,49 @@ diff --git a/g.txt b/g.txt
 
     #[test]
     fn test_parse_batched_diff_tree_output_empty() {
-        let results = parse_batched_diff_tree_output("", &[]).unwrap();
+        let results = parse_batched_diff_tree_output("", 0);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_batched_diff_tree_parser_streams_line_by_line() {
+        // The streaming exec path feeds the parser one line at a time (without
+        // trailing newlines); the result must match parsing the whole output.
+        let output = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+diff --git a/src/old.rs b/src/new.rs
+similarity index 90%
+rename from src/old.rs
+rename to src/new.rs
+index abc123..def456 100644
+--- a/src/old.rs
++++ b/src/new.rs
+@@ -5,2 +5,3 @@ fn bar()
++new line
+cccccccccccccccccccccccccccccccccccccccc dddddddddddddddddddddddddddddddddddddddd
+diff --git a/g.txt b/g.txt
+index eee..fff 100644
+--- a/g.txt
++++ b/g.txt
+@@ -10,0 +11,2 @@
++line1
++line2
+";
+        // Pad expected_pairs beyond what git emitted (identical trees case).
+        let mut parser = BatchedDiffTreeParser::new(3);
+        for line in output.lines() {
+            parser.feed_line(line);
+        }
+        let streamed = parser.finish();
+
+        assert_eq!(streamed, parse_batched_diff_tree_output(output, 3));
+        assert_eq!(streamed.len(), 3);
+        assert_eq!(
+            streamed[0].renames,
+            vec![("src/old.rs".to_string(), "src/new.rs".to_string())]
+        );
+        assert_eq!(streamed[0].added_lines_by_file["src/new.rs"], vec![5]);
+        assert_eq!(streamed[1].added_lines_by_file["g.txt"], vec![11, 12]);
+        assert_eq!(streamed[2], DiffTreeResult::default());
     }
 }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2833,18 +2833,20 @@ pub fn exec_git_stdin(args: &[String], stdin_data: &[u8]) -> Result<Output, GitA
     exec_git_stdin_with_profile(args, stdin_data, InternalGitProfile::General)
 }
 
-/// Helper to execute a git command with data provided on stdin and an explicit profile.
-pub fn exec_git_stdin_with_profile(
-    args: &[String],
+/// Spawn a fully-piped git child for `effective_args` and start a thread
+/// writing `stdin_data` to it. Writing stdin in a separate thread avoids
+/// deadlock: if we wrote all stdin before reading stdout, the child's stdout
+/// pipe buffer could fill up, causing the child to block on write, which
+/// prevents it from consuming more stdin, which would block our write_all.
+type StdinWriterHandle = std::thread::JoinHandle<std::io::Result<()>>;
+
+fn spawn_git_stdin_piped(
+    effective_args: &[String],
     stdin_data: &[u8],
-    profile: InternalGitProfile,
-) -> Result<Output, GitAiError> {
-    // TODO Make sure to handle process signals, etc.
-    let effective_args =
-        args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
-    spawn_probe_log(&effective_args);
+) -> Result<(Child, Option<StdinWriterHandle>), GitAiError> {
+    spawn_probe_log(effective_args);
     let mut cmd = Command::new(config::Config::get().git_cmd());
-    cmd.args(&effective_args)
+    cmd.args(effective_args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
@@ -2859,10 +2861,6 @@ pub fn exec_git_stdin_with_profile(
 
     let mut child = cmd.spawn().map_err(GitAiError::IoError)?;
 
-    // Write stdin in a separate thread to avoid deadlock: if we write all stdin
-    // before reading stdout, the child's stdout pipe buffer can fill up, causing
-    // the child to block on write, which prevents it from consuming more stdin,
-    // which blocks our write_all. Writing concurrently avoids this.
     let stdin_handle = child.stdin.take().map(|mut stdin| {
         let data = stdin_data.to_vec();
         std::thread::spawn(move || {
@@ -2870,6 +2868,100 @@ pub fn exec_git_stdin_with_profile(
             stdin.write_all(&data)
         })
     });
+
+    Ok((child, stdin_handle))
+}
+
+/// Like `exec_git_stdin`, but streams the child's stdout to `on_line` one line
+/// at a time instead of buffering the entire output in memory. Use this for
+/// commands whose output can be arbitrarily large (e.g. batched
+/// `diff-tree --stdin -p`), where `wait_with_output()` would hold the full
+/// output (plus a lossy-conversion copy) in memory at once.
+///
+/// Each line is lossily UTF-8 converted individually and passed without its
+/// trailing `\n` (and at most one preceding `\r`), matching `str::lines()`.
+pub fn exec_git_stdin_streaming(
+    args: &[String],
+    stdin_data: &[u8],
+    mut on_line: impl FnMut(&str),
+) -> Result<(), GitAiError> {
+    use std::io::BufRead;
+
+    let effective_args = args_with_internal_git_profile(
+        &args_with_disabled_hooks_if_needed(args),
+        InternalGitProfile::General,
+    );
+    let (mut child, stdin_handle) = spawn_git_stdin_piped(&effective_args, stdin_data)?;
+
+    // Drain stderr concurrently so the child can never block on a full stderr
+    // pipe while we are still reading stdout.
+    let stderr_handle = child.stderr.take().map(|mut stderr| {
+        std::thread::spawn(move || {
+            use std::io::Read;
+            let mut buf = Vec::new();
+            let _ = stderr.read_to_end(&mut buf);
+            buf
+        })
+    });
+
+    let stdout = child.stdout.take().expect("child stdout is piped");
+    let mut reader = std::io::BufReader::new(stdout);
+    let mut buf: Vec<u8> = Vec::new();
+    let read_result = loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) => break Ok(()),
+            Ok(_) => {
+                if buf.last() == Some(&b'\n') {
+                    buf.pop();
+                    if buf.last() == Some(&b'\r') {
+                        buf.pop();
+                    }
+                }
+                on_line(&String::from_utf8_lossy(&buf));
+            }
+            Err(e) => break Err(e),
+        }
+    };
+    if let Err(e) = read_result {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(GitAiError::IoError(e));
+    }
+
+    let status = child.wait().map_err(GitAiError::IoError)?;
+
+    if let Some(handle) = stdin_handle
+        && let Err(e) = handle.join().expect("stdin writer thread panicked")
+        && e.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(GitAiError::IoError(e));
+    }
+
+    if !status.success() {
+        let stderr_bytes = stderr_handle
+            .map(|h| h.join().unwrap_or_default())
+            .unwrap_or_default();
+        return Err(GitAiError::GitCliError {
+            code: status.code(),
+            stderr: String::from_utf8_lossy(&stderr_bytes).to_string(),
+            args: effective_args,
+        });
+    }
+
+    Ok(())
+}
+
+/// Helper to execute a git command with data provided on stdin and an explicit profile.
+pub fn exec_git_stdin_with_profile(
+    args: &[String],
+    stdin_data: &[u8],
+    profile: InternalGitProfile,
+) -> Result<Output, GitAiError> {
+    // TODO Make sure to handle process signals, etc.
+    let effective_args =
+        args_with_internal_git_profile(&args_with_disabled_hooks_if_needed(args), profile);
+    let (child, stdin_handle) = spawn_git_stdin_piped(&effective_args, stdin_data)?;
 
     let output = child.wait_with_output().map_err(GitAiError::IoError)?;
 


### PR DESCRIPTION
When the daemon classifies a completed git rebase as a rewrite, it migrates authorship notes from the old commits to the rebased ones. When there's a big diff, it has to be read into memory and processed all at once. That caused unbounded memory usage and blocked all Git operations in degenerate cases (common in a large monorepo).

This change streams the diff instead of 

<details>
<summary>Here's a repro for the initial problem that's fixed on this branch (not sure the best way to include it in CI):</summary>

```sh
#!/usr/bin/env bash
#
# Reproduces the git-ai daemon memory blowup during rewrite (rebase) attribution.
#
# Root cause (see README.md in this directory):
#   shift_authorship_notes_with_existing_mode (src/authorship/rewrite.rs) queues one
#   (old_commit, new_commit) full-root-tree diff pair per rebased commit that has an
#   authorship note, then compute_diff_tree_stdin runs ONE
#   `git diff-tree --stdin -p -U0 -M -r` over all pairs and buffers the ENTIRE output
#   in memory (exec_git_stdin -> wait_with_output, src/git/repository.rs).
#   After a rebase across a large trunk delta, EVERY pair's tree diff contains the
#   whole trunk delta, so the buffered output is (trunk delta bytes) x (stack size).
#
# This script builds a fully synthetic repo, drives a real `git rebase` through an
# ISOLATED per-run daemon (same wiring as the integration-test harness: trace2 socket
# + isolated HOME; nothing is installed system-wide), samples daemon RSS while the
# daemon processes the rewrite, and prints the peak alongside the raw size of the
# equivalent batched diff-tree output.
#
# Usage:
#   ./repro.sh                 # default scale (~0.5 GB daemon RSS peak, a few minutes)
#   SCALE=small ./repro.sh     # quick sanity run (~75 MB peak, ~2 min)
#   SCALE=large ./repro.sh     # ~2.9 GB daemon RSS peak
#   STACK_COMMITS=24 TRUNK_FILES=200 LINES_PER_FILE=2500 ./repro.sh   # custom
#
# Knobs (env vars):
#   STACK_COMMITS    number of feature-branch commits carrying authorship notes
#   TRUNK_FILES      number of NEW files added on trunk after the branch forked
#   LINES_PER_FILE   lines per trunk file (~73 bytes/line)
#   RENAMED_FILES    pre-fork files renamed+edited on trunk (engages -M rename detection)
#   INVALID_UTF8     1 (default) = plant one non-UTF8 byte in the trunk delta so
#                    String::from_utf8_lossy materializes a FULL second copy of the
#                    buffered diff output (Cow::Owned). 0 = pure-ASCII delta, the
#                    lossy conversion stays borrowed and peak is ~1x instead of ~2x.
#   PROCESS_TIMEOUT_SECS  how long to wait for the daemon to finish (default 1800)
#   KEEP=1           keep the temp workdir + daemon logs
#   GIT_AI_BIN       path to a git-ai binary (default: <repo>/target/debug/git-ai)
#
# Expected per-pair diff bytes ~= TRUNK_FILES * LINES_PER_FILE * 73
# Expected buffered bytes      ~= per-pair * STACK_COMMITS   (x2 with INVALID_UTF8=1)
set -euo pipefail

# ---------------------------------------------------------------------------
# Knobs
# ---------------------------------------------------------------------------
SCALE="${SCALE:-default}"
case "$SCALE" in
  small)
    STACK_COMMITS="${STACK_COMMITS:-8}"
    TRUNK_FILES="${TRUNK_FILES:-40}"
    LINES_PER_FILE="${LINES_PER_FILE:-800}"
    RENAMED_FILES="${RENAMED_FILES:-8}"
    ;;
  default)
    STACK_COMMITS="${STACK_COMMITS:-16}"
    TRUNK_FILES="${TRUNK_FILES:-120}"
    LINES_PER_FILE="${LINES_PER_FILE:-1500}"
    RENAMED_FILES="${RENAMED_FILES:-16}"
    ;;
  large)
    STACK_COMMITS="${STACK_COMMITS:-24}"
    TRUNK_FILES="${TRUNK_FILES:-200}"
    LINES_PER_FILE="${LINES_PER_FILE:-2500}"
    RENAMED_FILES="${RENAMED_FILES:-24}"
    ;;
  *) echo "Unknown SCALE=$SCALE (small|default|large)"; exit 1 ;;
esac
INVALID_UTF8="${INVALID_UTF8:-1}"
PROCESS_TIMEOUT_SECS="${PROCESS_TIMEOUT_SECS:-1800}"
KEEP="${KEEP:-0}"

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
GIT_AI_BIN="${GIT_AI_BIN:-$REPO_ROOT/target/debug/git-ai}"

if [[ ! -x "$GIT_AI_BIN" ]]; then
  echo "error: git-ai binary not found at $GIT_AI_BIN — run 'task build' first (or set GIT_AI_BIN)" >&2
  exit 1
fi

# ---------------------------------------------------------------------------
# Sanitize PATH: drop any dir whose `git` is actually a git-ai wrapper, so the
# repro never talks to a system-installed git-ai (mirrors the test harness).
# ---------------------------------------------------------------------------
sanitize_path() {
  local out="" dir gitp
  local IFS=':'
  for dir in $PATH; do
    gitp="$dir/git"
    if [[ -f "$gitp" || -L "$gitp" ]]; then
      if [[ -L "$gitp" ]] && readlink "$gitp" | grep -q "git-ai"; then continue; fi
      if grep -q "git-ai" "$gitp" 2>/dev/null; then continue; fi
      local canon
      canon="$(cd "$(dirname "$gitp")" 2>/dev/null && pwd -P)/$(basename "$gitp")" || canon="$gitp"
      if [[ "$canon" == *git-ai* ]]; then continue; fi
    fi
    out="${out:+$out:}$dir"
  done
  printf '%s' "$out"
}
SAFE_PATH="$(sanitize_path)"

# ---------------------------------------------------------------------------
# Isolated workspace: repo + fake HOME + per-run daemon sockets
# ---------------------------------------------------------------------------
WORK="$(mktemp -d "${TMPDIR:-/tmp}/git-ai-oom.XXXXXX")"
HOME_DIR="$WORK/home"
REPO="$WORK/repo"
SOCK_DIR="$WORK/s"
CONTROL_SOCK="$SOCK_DIR/c.sock"
TRACE_SOCK="$SOCK_DIR/t.sock"
TEST_DB="$WORK/git-ai-test-db"
RSS_LOG="$WORK/rss.log"
DAEMON_LOG="$WORK/daemon.stderr.log"
mkdir -p "$HOME_DIR/.git-ai" "$REPO" "$SOCK_DIR"

if (( ${#TRACE_SOCK} >= 100 )); then
  echo "error: socket path too long for AF_UNIX: $TRACE_SOCK" >&2
  exit 1
fi

cat > "$HOME_DIR/.gitconfig" <<'EOF'
[user]
	name = Repro User
	email = repro@example.com
[init]
	defaultBranch = main
[gc]
	auto = 0
[advice]
	detachedHead = false
EOF
# Keep the isolated git-ai fully offline / defaults (local git_notes backend).
cat > "$HOME_DIR/.git-ai/config.json" <<'EOF'
{
  "telemetry_oss": "off",
  "disable_version_checks": true,
  "disable_auto_updates": true
}
EOF

COMMON_ENV=(
  "PATH=$SAFE_PATH"
  "HOME=$HOME_DIR"
  "GIT_CONFIG_GLOBAL=$HOME_DIR/.gitconfig"
  "GIT_CONFIG_NOSYSTEM=1"
  "XDG_CONFIG_HOME=$HOME_DIR/.config"
)
DAEMON_ENV=(
  "GIT_AI_DAEMON_HOME=$HOME_DIR"
  "GIT_AI_DAEMON_CONTROL_SOCKET=$CONTROL_SOCK"
  "GIT_AI_DAEMON_TRACE_SOCKET=$TRACE_SOCK"
  "GIT_AI_TEST_DB_PATH=$TEST_DB"
  "GITAI_TEST_DB_PATH=$TEST_DB"
)

# Real git wired to the per-run daemon via trace2 (exactly how production learns
# about git commands — git-ai does NOT wrap git).
tgit() {
  env "${COMMON_ENV[@]}" \
    "GIT_TRACE2_EVENT=af_unix:stream:$TRACE_SOCK" \
    "GIT_TRACE2_EVENT_NESTING=10" \
    git -C "$REPO" "$@"
}
# git without trace2 (setup plumbing we don't want the daemon to see/process).
qgit() {
  env "${COMMON_ENV[@]}" git -C "$REPO" "$@"
}
gai() {
  (cd "$REPO" && env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "$GIT_AI_BIN" "$@")
}

DAEMON_PID=""
SAMPLER_PID=""
cleanup() {
  [[ -n "$SAMPLER_PID" ]] && kill "$SAMPLER_PID" 2>/dev/null || true
  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
    kill "$DAEMON_PID" 2>/dev/null || true
    for _ in $(seq 1 20); do kill -0 "$DAEMON_PID" 2>/dev/null || break; sleep 0.1; done
    kill -9 "$DAEMON_PID" 2>/dev/null || true
  fi
  if [[ "$KEEP" == "1" ]]; then
    echo "[repro] KEEP=1 — workdir preserved at: $WORK"
  else
    rm -rf "$WORK"
  fi
}
trap cleanup EXIT

log() { printf '[repro] %s\n' "$*"; }

log "workdir: $WORK"
log "scale: SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_FILES=$TRUNK_FILES LINES_PER_FILE=$LINES_PER_FILE RENAMED_FILES=$RENAMED_FILES INVALID_UTF8=$INVALID_UTF8"
EXPECTED_PER_PAIR=$(( TRUNK_FILES * LINES_PER_FILE * 73 ))
log "expected per-pair diff ~$(( EXPECTED_PER_PAIR / 1048576 )) MB; batched ~$(( EXPECTED_PER_PAIR * STACK_COMMITS / 1048576 )) MB"

# ---------------------------------------------------------------------------
# Start the isolated daemon
# ---------------------------------------------------------------------------
env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "$GIT_AI_BIN" bg run >/dev/null 2>>"$DAEMON_LOG" &
DAEMON_PID=$!
log "daemon pid: $DAEMON_PID"
for i in $(seq 1 100); do
  [[ -S "$TRACE_SOCK" && -S "$CONTROL_SOCK" ]] && break
  kill -0 "$DAEMON_PID" 2>/dev/null || { echo "daemon died at startup; log tail:"; tail -20 "$DAEMON_LOG"; exit 1; }
  sleep 0.1
done
[[ -S "$TRACE_SOCK" ]] || { echo "daemon sockets never appeared"; exit 1; }
log "daemon sockets ready"

# ---------------------------------------------------------------------------
# Build the synthetic repo
# ---------------------------------------------------------------------------
gen_file() { # path lines salt
  awk -v n="$2" -v salt="$3" 'BEGIN {
    for (i = 1; i <= n; i++)
      printf "line %06d of %s :: 0123456789abcdefghijklmnopqrstuvwxyz-payload-%06d\n", i, salt, i * 7
  }' > "$1"
}

qgit init -q -b main .

# Seed commit: files that the trunk will later rename (rename sources must exist
# BEFORE the fork so the old->new root-tree diffs contain the renames).
mkdir -p "$REPO/src"
for i in $(seq 1 "$RENAMED_FILES"); do
  gen_file "$REPO/src/module_$(printf '%03d' "$i").txt" "$LINES_PER_FILE" "module_$i"
done
echo "seed" > "$REPO/README.md"
qgit add -A
qgit commit -qm "seed"
log "seed commit done"

# Feature branch: STACK_COMMITS commits, each with AI-attributed content
# (mock_ai checkpoint before commit => daemon writes an authorship note).
qgit checkout -qb feature
for i in $(seq 1 "$STACK_COMMITS"); do
  f="feature_$(printf '%03d' "$i").txt"
  gen_file "$REPO/$f" 40 "feature_$i"
  gai checkpoint mock_ai "$f" >/dev/null
  tgit add "$f"
  tgit commit -qm "AI feature $i"
done
log "created $STACK_COMMITS feature commits (waiting for authorship notes...)"

OLD_COMMITS_FILE="$WORK/old_commits.txt"
tgit rev-list --reverse main..feature > "$OLD_COMMITS_FILE"

notes_hit_count() { # file-with-shas
  local list
  list="$(qgit notes --ref=ai list 2>/dev/null | awk '{print $2}')" || true
  [[ -z "$list" ]] && { echo 0; return; }
  grep -cFf <(printf '%s\n' "$list") "$1" || true
}

deadline=$(( $(date +%s) + 300 ))
while :; do
  n="$(notes_hit_count "$OLD_COMMITS_FILE")"
  (( n >= STACK_COMMITS )) && break
  if (( $(date +%s) > deadline )); then
    echo "error: only $n/$STACK_COMMITS feature commits got authorship notes in 300s" >&2
    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
    exit 1
  fi
  sleep 1
done
log "all $STACK_COMMITS feature commits have authorship notes (refs/notes/ai)"

# Trunk advance: the large delta the branch is stale against.
qgit checkout -q main
mkdir -p "$REPO/src/core" "$REPO/trunk"
for i in $(seq 1 "$RENAMED_FILES"); do
  src="src/module_$(printf '%03d' "$i").txt"
  dst="src/core/module_$(printf '%03d' "$i").txt"
  qgit mv "$src" "$dst"
  # Edit every 20th line: keeps >50% similarity (rename detected) but forces -M
  # to do content comparison and produces many small hunks.
  awk 'NR % 20 == 0 { print $0 " [edited-on-trunk]"; next } { print }' \
    "$REPO/$dst" > "$REPO/$dst.tmp" && mv "$REPO/$dst.tmp" "$REPO/$dst"
done
for i in $(seq 1 "$TRUNK_FILES"); do
  gen_file "$REPO/trunk/file_$(printf '%04d' "$i").txt" "$LINES_PER_FILE" "trunk_$i"
done
if [[ "$INVALID_UTF8" == "1" ]]; then
  # One stray non-UTF8 byte anywhere in the batched diff output flips
  # String::from_utf8_lossy from Cow::Borrowed (free) to Cow::Owned — a full
  # second copy of the entire buffered output. Production diffs hit this
  # routinely (latin-1 text, mixed encodings).
  printf 'non-utf8 marker: \xff\nrest of file is plain text\n' > "$REPO/trunk/encoding_probe.txt"
fi
qgit add -A
qgit commit -qm "trunk advance: $TRUNK_FILES new files, $RENAMED_FILES renames"
log "trunk advanced ($(qgit diff --shortstat main~1 main | sed 's/^ //'))"

# ---------------------------------------------------------------------------
# RSS sampler for the daemon (+ its direct children, i.e. the spawned
# `git diff-tree`). Columns: epoch daemon_rss_kb children_rss_kb
# ---------------------------------------------------------------------------
(
  while kill -0 "$DAEMON_PID" 2>/dev/null; do
    ps -axo pid=,ppid=,rss= | awk -v d="$DAEMON_PID" -v t="$(date +%s)" '
      $1 == d { drss = $3 } $2 == d { crss += $3 }
      END { printf "%s %d %d\n", t, drss, crss }' >> "$RSS_LOG"
    sleep 0.2
  done
) &
SAMPLER_PID=$!

BASELINE_KB="$(ps -o rss= -p "$DAEMON_PID" | tr -d ' ')"
log "daemon baseline RSS: $(( BASELINE_KB / 1024 )) MB"

# ---------------------------------------------------------------------------
# The trigger: rebase the stale feature stack onto the advanced trunk.
# ---------------------------------------------------------------------------
qgit checkout -q feature
log "running: git rebase main (traced -> daemon)"
REBASE_START=$(date +%s)
tgit rebase main >/dev/null
REBASE_END=$(date +%s)
log "git rebase finished in $(( REBASE_END - REBASE_START ))s; daemon now processes the rewrite asynchronously"

NEW_COMMITS_FILE="$WORK/new_commits.txt"
tgit rev-list --reverse main..feature > "$NEW_COMMITS_FILE"

deadline=$(( $(date +%s) + PROCESS_TIMEOUT_SECS ))
while :; do
  n="$(notes_hit_count "$NEW_COMMITS_FILE")"
  if (( n >= STACK_COMMITS )); then
    DONE_TS=$(date +%s)
    break
  fi
  if (( $(date +%s) > deadline )); then
    echo "error: rewrite processing incomplete after ${PROCESS_TIMEOUT_SECS}s ($n/$STACK_COMMITS rebased commits have notes)" >&2
    echo "daemon log tail:"; tail -40 "$DAEMON_LOG"
    exit 1
  fi
  sleep 1
done
PROCESS_SECS=$(( DONE_TS - REBASE_END ))
log "rewrite attribution complete: notes migrated onto all $STACK_COMMITS rebased commits ($PROCESS_SECS s after rebase exit)"

# Let RSS settle a moment, then stop sampling.
sleep 2
kill "$SAMPLER_PID" 2>/dev/null || true
wait "$SAMPLER_PID" 2>/dev/null || true
SAMPLER_PID=""

# ---------------------------------------------------------------------------
# Ground truth: size of the exact batched diff-tree output the daemon buffered.
# Same invocation as compute_diff_tree_stdin (src/authorship/rewrite.rs).
# ---------------------------------------------------------------------------
log "measuring ground-truth batched diff-tree output size..."
GT_START=$(date +%s)
DIFF_BYTES="$(paste -d' ' "$OLD_COMMITS_FILE" "$NEW_COMMITS_FILE" \
  | qgit diff-tree --stdin -p -U0 -M --no-color -r | wc -c | tr -d ' ')"
GT_SECS=$(( $(date +%s) - GT_START ))

PEAK_LINE="$(awk 'BEGIN{m=0} {if ($2>m){m=$2; c=$3; t=$1}} END{print m, c, t}' "$RSS_LOG")"
PEAK_KB="$(cut -d' ' -f1 <<<"$PEAK_LINE")"
PEAK_CHILD_KB="$(awk 'BEGIN{m=0} {if ($3>m) m=$3} END{print m}' "$RSS_LOG")"

echo
echo "================================ RESULTS ================================"
echo "knobs:                 SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_FILES=$TRUNK_FILES LINES_PER_FILE=$LINES_PER_FILE RENAMED_FILES=$RENAMED_FILES INVALID_UTF8=$INVALID_UTF8"
echo "daemon RSS baseline:   $(( BASELINE_KB / 1024 )) MB"
echo "daemon RSS peak:       $(( PEAK_KB / 1024 )) MB  (delta +$(( (PEAK_KB - BASELINE_KB) / 1024 )) MB)"
echo "peak child git RSS:    $(( PEAK_CHILD_KB / 1024 )) MB  (git diff-tree -M spawned by daemon)"
echo "batched diff-tree out: $(( DIFF_BYTES / 1048576 )) MB raw ($DIFF_BYTES bytes; ground-truth rerun took ${GT_SECS}s)"
echo "rewrite processing:    ${PROCESS_SECS}s (rebase exit -> notes on all $STACK_COMMITS rebased commits)"
echo "verification:          $(notes_hit_count "$NEW_COMMITS_FILE")/$STACK_COMMITS rebased commits carry refs/notes/ai notes"
echo "========================================================================="

```

</details>

Report:

```
┌────────────────────────────────┬────────┬─────────┬──────────┐
│                                │ small  │ default │  large   │
├────────────────────────────────┼────────┼─────────┼──────────┤
│ batched diff-tree output (raw) │ 20 MB  │ 225 MB  │ 940 MB   │
├────────────────────────────────┼────────┼─────────┼──────────┤
│ RSS delta before               │ +49 MB │ +483 MB │ +2905 MB │
├────────────────────────────────┼────────┼─────────┼──────────┤
│ RSS delta after                │ +3 MB  │ +16 MB  │ +79 MB   │
├────────────────────────────────┼────────┼─────────┼──────────┤
│ notes migrated                 │ 8/8 ✓  │ 16/16 ✓ │ 24/24 ✓  │
└────────────────────────────────┴────────┴─────────┴──────────┘
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->