### PR TITLE
fix: support Codex exec checkpoints

### DIFF
--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -354,7 +354,7 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             let tool_name = normalize_tool_name(tool_name);
             match tool_name {
                 "apply_patch" => ToolClass::FileEdit,
-                "Bash" | "exec_command" | "shell" | "shell_command" => ToolClass::Bash,
+                "Bash" | "exec" | "exec_command" | "shell" | "shell_command" => ToolClass::Bash,
                 "multi_tool_use.parallel" => ToolClass::Bash,
                 _ => ToolClass::Skip,
             }
@@ -1550,6 +1550,7 @@ mod tests {
             ToolClass::FileEdit
         );
         assert_eq!(classify_tool(Agent::Codex, "Bash"), ToolClass::Bash);
+        assert_eq!(classify_tool(Agent::Codex, "exec"), ToolClass::Bash);
         assert_eq!(classify_tool(Agent::Codex, "exec_command"), ToolClass::Bash);
         // The parallel tool wrapper must be routed through the bash/stat-diff path.
         assert_eq!(

--- a/src/commands/checkpoint_agent/presets/codex.rs
+++ b/src/commands/checkpoint_agent/presets/codex.rs
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_codex_shell_tool_variants_treated_as_bash() {
-        for tool_name in &["exec_command", "shell", "shell_command"] {
+        for tool_name in &["exec", "exec_command", "shell", "shell_command"] {
             let input = json!({
                 "cwd": "/home/user/project",
                 "hook_event_name": "PostToolUse",

--- a/tests/integration/bash_tool_conformance.rs
+++ b/tests/integration/bash_tool_conformance.rs
@@ -627,6 +627,7 @@ fn test_classify_tool_opencode() {
 #[test]
 fn test_classify_tool_codex() {
     assert_eq!(classify_tool(Agent::Codex, "Bash"), ToolClass::Bash);
+    assert_eq!(classify_tool(Agent::Codex, "exec"), ToolClass::Bash);
     assert_eq!(
         classify_tool(Agent::Codex, "apply_patch"),
         ToolClass::FileEdit

--- a/tests/integration/codex.rs
+++ b/tests/integration/codex.rs
@@ -1346,6 +1346,81 @@ fn test_codex_e2e_namespaced_exec_command_bash_full_cycle() {
 }
 
 #[test]
+fn test_codex_e2e_exec_bash_full_cycle() {
+    use crate::repos::test_repo::TestRepo;
+
+    let mut repo = TestRepo::new();
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("app.py");
+    fs::write(&file_path, "print('hello')\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut tracked_file = repo.filename("app.py");
+    tracked_file.assert_committed_lines(crate::lines!["print('hello')".unattributed_human(),]);
+
+    let simple_fixture = fixture_path("codex-session-simple.jsonl");
+    let transcript_path = repo_root.join("codex-exec.jsonl");
+    fs::copy(&simple_fixture, &transcript_path).unwrap();
+
+    let pre_hook_input = json!({
+        "session_id": "codex-exec-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "exec",
+        "tool_use_id": "exec-1",
+        "tool_input": {
+            "command": "sed -i '' 's/hello/world/' app.py"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &pre_hook_input])
+        .expect("exec pre-hook should succeed");
+
+    fs::write(&file_path, "print('world')\nprint('from codex')\n").unwrap();
+
+    let post_hook_input = json!({
+        "session_id": "codex-exec-session",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "tool_name": "exec",
+        "tool_use_id": "exec-1",
+        "tool_input": {
+            "command": "sed -i '' 's/hello/world/' app.py"
+        },
+        "transcript_path": transcript_path.to_string_lossy().to_string()
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &post_hook_input])
+        .expect("exec post-hook should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Codex exec edit")
+        .expect("commit should succeed");
+
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("session record should exist");
+
+    assert_eq!(session.agent_id.tool, "codex");
+    assert_eq!(session.agent_id.id, "codex-exec-session");
+
+    tracked_file.assert_lines_and_blame(crate::lines![
+        "print('world')".ai(),
+        "print('from codex')".ai(),
+    ]);
+}
+
+#[test]
 fn test_codex_e2e_multi_tool_use_parallel_wrapper() {
     use crate::repos::test_repo::TestRepo;
 
@@ -1455,5 +1530,6 @@ crate::reuse_tests_in_worktree!(
     test_codex_e2e_apply_patch_preserves_human_lines,
     test_codex_e2e_namespaced_apply_patch_file_edit_full_cycle,
     test_codex_e2e_namespaced_exec_command_bash_full_cycle,
+    test_codex_e2e_exec_bash_full_cycle,
     test_codex_e2e_multi_tool_use_parallel_wrapper,
 );


### PR DESCRIPTION
## Summary

- recognize Codex's newer `exec` tool name as a shell tool while preserving the existing `exec_command` aliases
- route `exec` pre/post hooks through the existing bash stat-diff checkpoint path
- add classifier, preset, and end-to-end `TestRepo` coverage for line attribution from an `exec` edit

## Root cause

Newer Codex rollouts emit custom tool calls named `exec`. The Codex classifier accepted `exec_command`, `Bash`, `shell`, and `shell_command`, but not `exec`, so git-ai treated those hook payloads as unsupported and skipped the checkpoint flow. Edits made through `exec` could therefore land without Codex attribution.

## User impact

Codex shell edits emitted under the `exec` name now produce the same checkpoints and authorship metadata as the older `exec_command` path.

## Validation

- reproduced before the fix with `test_codex_e2e_exec_bash_full_cycle`: both repository variants committed without a Codex session record
- `task test TEST_FILTER=test_codex_e2e_exec_bash_full_cycle`
- `task test TEST_FILTER=test_codex_shell_tool_variants_treated_as_bash`
- `task test TEST_FILTER=test_classify_tool_codex`
- `task test TEST_FILTER=test_tool_classification_codex_namespaced`
- `task fmt`
- `task lint`
- `task test`: all 2,060 library tests passed and 3,215 integration tests passed; one unrelated notes-backend test failed and was confirmed to fail identically on a detached `origin/main` worktree
