### PR TITLE
fix: exclude out-of-hook human edits from new-file AI line count

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -754,14 +754,44 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
         "initial".to_string()
     };
 
-    let (mut authorship_log, initial_attributions, initial_file_contents) = working_va
-        .to_authorship_log_and_initial_working_log(
+    let (mut authorship_log, initial_attributions, initial_file_contents, out_of_hook_human_lines) =
+        working_va.to_authorship_log_and_initial_working_log_with_precomputed_diff(
             repo,
             &parent_sha,
             amended_commit,
             Some(&pathspecs),
             Some(&final_state_snapshot),
+            AuthorshipLogDiffContext::default(),
         )?;
+
+    // Reconciliation can prove that a line in a newly-created file diverged
+    // from the AI checkpoint before amend. Record those lines as human so
+    // later attribution recovery cannot infer AI ownership from neighboring
+    // AI lines.
+    if !out_of_hook_human_lines.is_empty() {
+        let human_hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+            &human_author,
+        );
+        authorship_log
+            .metadata
+            .humans
+            .entry(human_hash.clone())
+            .or_insert_with(|| crate::authorship::authorship_log::HumanRecord {
+                author: human_author.clone(),
+            });
+        for (file_path, lines) in out_of_hook_human_lines {
+            if lines.is_empty() {
+                continue;
+            }
+            let file = authorship_log.get_or_create_file(&file_path);
+            file.add_entry(
+                crate::authorship::authorship_log_serialization::AttestationEntry::new(
+                    human_hash.clone(),
+                    crate::authorship::authorship_log::LineRange::compress_lines(&lines),
+                ),
+            );
+        }
+    }
 
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();
 

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -316,8 +316,8 @@ where
     }
 
     let committed_diff_base = single_commit_diff_base(&parent_sha, &commit_sha);
-    let (mut authorship_log, initial_attributions, initial_file_contents) = working_va
-        .to_authorship_log_and_initial_working_log_with_precomputed_diff(
+    let (mut authorship_log, initial_attributions, initial_file_contents, out_of_hook_human_lines) =
+        working_va.to_authorship_log_and_initial_working_log_with_precomputed_diff(
             repo,
             &parent_sha,
             &commit_sha,
@@ -328,6 +328,35 @@ where
                 fallback_committed_diff_base: Some(&committed_diff_base),
             },
         )?;
+
+    // Reconciliation can prove that a line in a newly-created file diverged
+    // from the AI checkpoint before commit. Record those lines as human so
+    // later attribution recovery cannot infer AI ownership from neighboring
+    // AI lines.
+    if !out_of_hook_human_lines.is_empty() {
+        let human_hash = crate::authorship::authorship_log_serialization::generate_human_short_hash(
+            &human_author,
+        );
+        authorship_log
+            .metadata
+            .humans
+            .entry(human_hash.clone())
+            .or_insert_with(|| crate::authorship::authorship_log::HumanRecord {
+                author: human_author.clone(),
+            });
+        for (file_path, lines) in out_of_hook_human_lines {
+            if lines.is_empty() {
+                continue;
+            }
+            let file = authorship_log.get_or_create_file(&file_path);
+            file.add_entry(
+                crate::authorship::authorship_log_serialization::AttestationEntry::new(
+                    human_hash.clone(),
+                    crate::authorship::authorship_log::LineRange::compress_lines(&lines),
+                ),
+            );
+        }
+    }
 
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -2455,6 +2455,16 @@ impl VirtualAttributions {
                             continue;
                         }
 
+                        // Out-of-hook edits receive human attribution below. Do
+                        // not fill these gaps with AI attribution, even when the
+                        // inserted content duplicates a checkpointed AI line.
+                        if out_of_hook_human_lines
+                            .get(&nfc_file_path)
+                            .is_some_and(|lines| lines.contains(&line))
+                        {
+                            continue;
+                        }
+
                         // Find nearest attributed neighbor before this line
                         let prev = line_to_author.iter().rev().find(|(l, _)| *l < line);
 

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -40,6 +40,13 @@ pub(crate) struct AuthorshipLogDiffContext<'a> {
     pub fallback_committed_diff_base: Option<&'a str>,
 }
 
+pub(crate) type AuthorshipLogAndInitialWorkingLog = (
+    crate::authorship::authorship_log_serialization::AuthorshipLog,
+    crate::git::repo_storage::InitialAttributions,
+    HashMap<String, String>,
+    HashMap<String, Vec<u32>>,
+);
+
 impl VirtualAttributions {
     /// Create a new VirtualAttributions for the given base commit with initial pathspecs
     pub async fn new_for_base_commit(
@@ -2010,7 +2017,7 @@ fn build_carryover_snapshot(
     commit_sha: &str,
     pathspecs: Option<&HashSet<String>>,
     observed_snapshot: &HashMap<String, String>,
-) -> Result<HashMap<String, String>, GitAiError> {
+) -> Result<(HashMap<String, String>, HashSet<String>), GitAiError> {
     let file_paths: HashSet<String> = match pathspecs {
         Some(paths) => paths.iter().cloned().collect(),
         None => observed_snapshot.keys().cloned().collect(),
@@ -2029,6 +2036,7 @@ fn build_carryover_snapshot(
     let contents = batch_file_contents(repo, &requests)?;
 
     let mut carryover_snapshot = HashMap::new();
+    let mut new_files = HashSet::new();
     for file_path in file_paths {
         let committed_content = contents
             .get(&(commit_sha.to_string(), file_path.clone()))
@@ -2043,14 +2051,24 @@ fn build_carryover_snapshot(
                     .cloned()
                     .unwrap_or_default()
             };
-            merged_carryover_content_pure(&parent_content, &committed_content, observed_content)
+            // An empty parent has no lines to carry over. For a newly-created
+            // file, the committed content is authoritative: it may include
+            // out-of-hook human edits made after the AI checkpoint. Rebasing
+            // the checkpoint attributions directly onto it drops replaced and
+            // inserted lines instead of retaining their old AI line numbers.
+            if parent_content.is_empty() {
+                new_files.insert(file_path.clone());
+                committed_content
+            } else {
+                merged_carryover_content_pure(&parent_content, &committed_content, observed_content)
+            }
         } else {
             committed_content
         };
         carryover_snapshot.insert(file_path, content);
     }
 
-    Ok(carryover_snapshot)
+    Ok((carryover_snapshot, new_files))
 }
 
 impl VirtualAttributions {
@@ -2074,14 +2092,16 @@ impl VirtualAttributions {
         ),
         GitAiError,
     > {
-        self.to_authorship_log_and_initial_working_log_with_precomputed_diff(
-            repo,
-            parent_sha,
-            commit_sha,
-            pathspecs,
-            final_state_snapshot,
-            AuthorshipLogDiffContext::default(),
-        )
+        let (authorship_log, initial, contents, _) = self
+            .to_authorship_log_and_initial_working_log_with_precomputed_diff(
+                repo,
+                parent_sha,
+                commit_sha,
+                pathspecs,
+                final_state_snapshot,
+                AuthorshipLogDiffContext::default(),
+            )?;
+        Ok((authorship_log, initial, contents))
     }
 
     /// As [`Self::to_authorship_log_and_initial_working_log`], but accepts a
@@ -2101,14 +2121,7 @@ impl VirtualAttributions {
         pathspecs: Option<&HashSet<String>>,
         final_state_snapshot: Option<&HashMap<String, String>>,
         diff_context: AuthorshipLogDiffContext<'_>,
-    ) -> Result<
-        (
-            crate::authorship::authorship_log_serialization::AuthorshipLog,
-            crate::git::repo_storage::InitialAttributions,
-            HashMap<String, String>,
-        ),
-        GitAiError,
-    > {
+    ) -> Result<AuthorshipLogAndInitialWorkingLog, GitAiError> {
         use crate::authorship::authorship_log_serialization::AuthorshipLog;
         use crate::git::repo_storage::InitialAttributions;
         use std::collections::{HashMap as StdHashMap, HashSet};
@@ -2179,17 +2192,19 @@ impl VirtualAttributions {
         } else {
             collect_committed_hunks(repo, fallback_diff_base, commit_sha, effective_pathspecs)?
         };
-        let carryover_snapshot = if let Some(snapshot) = final_state_snapshot {
-            Some(build_carryover_snapshot(
+        let (carryover_snapshot, new_files) = if let Some(snapshot) = final_state_snapshot {
+            let (snapshot, new_files) = build_carryover_snapshot(
                 repo,
                 parent_sha,
                 commit_sha,
                 effective_pathspecs,
                 snapshot,
-            )?)
+            )?;
+            (Some(snapshot), new_files)
         } else {
-            None
+            (None, HashSet::new())
         };
+        let mut out_of_hook_human_lines: StdHashMap<String, Vec<u32>> = StdHashMap::new();
         let (mut unstaged_hunks, pure_insertion_hunks) = if let Some(snapshot) = &carryover_snapshot
         {
             collect_unstaged_hunks_from_snapshot(repo, commit_sha, effective_pathspecs, snapshot)?
@@ -2278,6 +2293,14 @@ impl VirtualAttributions {
                         ))
                     })?;
                 let shift_hunks = diff_hunks_between_contents(observed_content, carryover_content);
+                if new_files.contains(file_path) || new_files.contains(&nfc_file_path) {
+                    let lines = out_of_hook_human_lines
+                        .entry(nfc_file_path.clone())
+                        .or_default();
+                    for hunk in &shift_hunks {
+                        lines.extend(hunk.new_start..hunk.new_start + hunk.new_count);
+                    }
+                }
                 rebased_line_attrs =
                     apply_hunk_shifts_to_line_attributions(line_attrs, &shift_hunks);
                 &rebased_line_attrs
@@ -2398,6 +2421,15 @@ impl VirtualAttributions {
                 let gap_file_lines: Vec<&str> = gap_file_content
                     .map(|c| c.lines().collect())
                     .unwrap_or_default();
+                let committed_gap_file_lines: Vec<&str> = carryover_snapshot
+                    .as_ref()
+                    .and_then(|snapshot| {
+                        snapshot
+                            .get(&nfc_file_path)
+                            .or_else(|| snapshot.get(file_path))
+                    })
+                    .map(|content| content.lines().collect())
+                    .unwrap_or_default();
 
                 // Build content→author map from AI-attributed lines
                 let mut content_to_ai_author: StdHashMap<&str, &str> = StdHashMap::new();
@@ -2429,13 +2461,26 @@ impl VirtualAttributions {
                         // Find nearest attributed neighbor after this line
                         let next = line_to_author.iter().find(|(l, _)| *l > line);
 
+                        // Only fill an attribution gap when the committed line
+                        // still matches the checkpoint-observed content. This
+                        // prevents an out-of-hook edit in a new file from
+                        // inheriting AI attribution just because its neighbors
+                        // are AI-authored.
+                        let gap_matches_observed_content = gap_file_lines
+                            .get((line - 1) as usize)
+                            .zip(committed_gap_file_lines.get((line - 1) as usize))
+                            .is_none_or(|(observed, committed)| observed == committed);
+
                         // Fill if both neighbors exist and are the same AI author
                         if let (Some((_, prev_author)), Some((_, next_author))) = (prev, next)
                             && prev_author == next_author
                             && !prev_author.starts_with("h_")
+                            && gap_matches_observed_content
                         {
                             gap_fills.push((prev_author.to_string(), line));
-                        } else if let Some(&content) = gap_file_lines.get((line - 1) as usize) {
+                        } else if gap_matches_observed_content
+                            && let Some(&content) = gap_file_lines.get((line - 1) as usize)
+                        {
                             // Content-based fallback: if the gap line has the same
                             // content as an AI-attributed line in this file, it's
                             // likely part of the same AI edit (imara_diff matched it
@@ -2672,7 +2717,17 @@ impl VirtualAttributions {
             sessions: initial_sessions,
         };
 
-        Ok((authorship_log, initial_attributions, initial_file_contents))
+        for lines in out_of_hook_human_lines.values_mut() {
+            lines.sort_unstable();
+            lines.dedup();
+        }
+
+        Ok((
+            authorship_log,
+            initial_attributions,
+            initial_file_contents,
+            out_of_hook_human_lines,
+        ))
     }
 
     /// Convert VirtualAttributions to AuthorshipLog only (index-only mode)

--- a/tests/integration/attribution_tracker_comprehensive.rs
+++ b/tests/integration/attribution_tracker_comprehensive.rs
@@ -1074,6 +1074,41 @@ fn test_new_file_out_of_hook_human_edits_are_not_counted_as_ai() {
 }
 
 #[test]
+fn test_amend_new_file_out_of_hook_human_edits_are_not_counted_as_ai() {
+    let repo = TestRepo::new_with_daemon_env(&[("CLAUDE_CODE_REMOTE", "true")]);
+
+    let mut initial = repo.filename("initial.txt");
+    initial.set_contents(crate::lines!["Initial human line".human()]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let file_path = repo.path().join("new-file.txt");
+    fs::write(
+        &file_path,
+        "AI line 1\nAI line 2\nAI line 3\nAI line 4\nAI line 5\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "new-file.txt"])
+        .unwrap();
+
+    fs::write(
+        &file_path,
+        "AI line 1\nAI line 2\nHuman replacement\nAI line 4\nAI line 5\n",
+    )
+    .unwrap();
+    repo.git(&["add", "new-file.txt"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"]).unwrap();
+
+    let mut file = repo.filename("new-file.txt");
+    file.assert_committed_lines(crate::lines![
+        "AI line 1".ai(),
+        "AI line 2".ai(),
+        "Human replacement".human(),
+        "AI line 4".ai(),
+        "AI line 5".ai(),
+    ]);
+}
+
+#[test]
 fn test_attribution_through_multiple_commits() {
     // Test attribution preservation through multiple commits
     let repo = TestRepo::new();

--- a/tests/integration/attribution_tracker_comprehensive.rs
+++ b/tests/integration/attribution_tracker_comprehensive.rs
@@ -20,6 +20,7 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::attribution_tracker::{
     Attribution, AttributionConfig, AttributionTracker, INITIAL_ATTRIBUTION_TS, LineAttribution,
 };
+use std::fs;
 
 // =============================================================================
 // Basic Attribution Tests - Core functionality
@@ -1029,6 +1030,47 @@ fn test_attribution_through_commit() {
 
     let result = repo.stage_all_and_commit("Second commit");
     assert!(result.is_ok());
+}
+
+#[test]
+fn test_new_file_out_of_hook_human_edits_are_not_counted_as_ai() {
+    let repo = TestRepo::new_with_daemon_env(&[("CLAUDE_CODE_REMOTE", "true")]);
+
+    let mut initial = repo.filename("initial.txt");
+    initial.set_contents(crate::lines!["Initial human line".human()]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let file_path = repo.path().join("new-file.txt");
+    fs::write(
+        &file_path,
+        "AI line 1\nAI line 2\nAI line 3\nAI line 4\nAI line 5\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "new-file.txt"])
+        .unwrap();
+
+    // Simulate an editor without the git-ai hook changing an AI line before commit.
+    fs::write(
+        &file_path,
+        "AI line 1\nAI line 2\nHuman replacement\nAI line 4\nAI line 5\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("Add new file with an out-of-hook edit")
+        .unwrap();
+
+    let mut file = repo.filename("new-file.txt");
+    file.assert_committed_lines(crate::lines![
+        "AI line 1".ai(),
+        "AI line 2".ai(),
+        "Human replacement".human(),
+        "AI line 4".ai(),
+        "AI line 5".ai(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(stats.ai_additions, 4);
+    assert_eq!(stats.human_additions, 1);
+    assert_eq!(stats.git_diff_added_lines, 5);
 }
 
 #[test]

--- a/tests/integration/attribution_tracker_comprehensive.rs
+++ b/tests/integration/attribution_tracker_comprehensive.rs
@@ -1074,6 +1074,33 @@ fn test_new_file_out_of_hook_human_edits_are_not_counted_as_ai() {
 }
 
 #[test]
+fn test_new_file_out_of_hook_duplicate_line_is_not_counted_as_ai() {
+    let repo = TestRepo::new_with_daemon_env(&[("CLAUDE_CODE_REMOTE", "true")]);
+
+    let mut initial = repo.filename("initial.txt");
+    initial.set_contents(crate::lines!["Initial human line".human()]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let file_path = repo.path().join("new-file.txt");
+    fs::write(&file_path, "A\nB\nC\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "new-file.txt"])
+        .unwrap();
+
+    // The unhooked insertion duplicates the following AI-checkpointed line.
+    fs::write(&file_path, "A\nB\nB\nC\n").unwrap();
+    repo.stage_all_and_commit("Add new file with duplicate out-of-hook edit")
+        .unwrap();
+
+    let mut file = repo.filename("new-file.txt");
+    file.assert_committed_lines(crate::lines!["A".ai(), "B".ai(), "B".human(), "C".ai(),]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(stats.ai_additions, 3);
+    assert_eq!(stats.human_additions, 1);
+    assert_eq!(stats.git_diff_added_lines, 4);
+}
+
+#[test]
 fn test_amend_new_file_out_of_hook_human_edits_are_not_counted_as_ai() {
     let repo = TestRepo::new_with_daemon_env(&[("CLAUDE_CODE_REMOTE", "true")]);
 


### PR DESCRIPTION
## Summary

`git ai stats --json` over-counted AI lines for a brand-new file when a human edited some of its lines outside the git-ai hook (a plain editor with no extension). After commit, those human edits were absorbed into the AI total, because new-file line attribution trusted the AI attestation's line ranges by line number and never checked that the committed content still matched what the AI actually wrote.

## Why this matters

Two users reported the same class of bug on #1627: FisherChen saw the AI count equal "AI new-file additions + human edit lines", and gokulsignals independently reported broken commit-time attribution for AI-generated code. For a tool whose whole purpose is attributing authorship between human and AI, silently crediting human edits to the AI undermines the core statistic. The pre-commit `git ai status` path already reported the split correctly; only the post-commit reconciliation was wrong, so this leaves that path untouched.

## Testing

The fix makes new-file attribution content-aware: at reconciliation time, committed lines whose content diverges from the AI-attested content are demoted to human, so out-of-hook edits are excluded from the AI count. The same demotion is applied on the normal commit path, the `git commit --amend` path, and the gap-filling path, so a human insertion that happens to duplicate an adjacent AI line is not double-counted as both AI and human.

- `cargo build` passes and `cargo fmt --check` is clean
- The attribution test suite passes (159 tests), with new regression cases for the out-of-hook human edit, the amend variant, and the duplicate-line insertion

Closes #1627

AI was used for assistance.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->