### PR TITLE
Preserve explicit test notes database path

### DIFF
--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -491,10 +491,15 @@ impl DaemonProcess {
 
 fn configure_test_home_env(command: &mut Command, test_home: &Path) {
     command.env("HOME", test_home);
-    command.env(
-        "GIT_AI_TEST_NOTES_DB_PATH",
-        test_home.join(".git-ai").join("internal").join("notes-db"),
-    );
+    if !command
+        .get_envs()
+        .any(|(key, _)| key == std::ffi::OsStr::new("GIT_AI_TEST_NOTES_DB_PATH"))
+    {
+        command.env(
+            "GIT_AI_TEST_NOTES_DB_PATH",
+            test_home.join(".git-ai").join("internal").join("notes-db"),
+        );
+    }
     command.env("GIT_CONFIG_GLOBAL", test_home.join(".gitconfig"));
     // Redirect XDG_CONFIG_HOME so git does not read the real user's
     // $XDG_CONFIG_HOME/git/config (which may contain filter drivers,
@@ -3655,6 +3660,23 @@ mod tests {
             notes_db_path,
             Some(test_home.join(".git-ai").join("internal").join("notes-db"))
         );
+    }
+
+    #[test]
+    fn test_configure_test_home_env_preserves_explicit_notes_database() {
+        let test_home = PathBuf::from("isolated-test-home");
+        let explicit_notes_db = PathBuf::from("explicit-notes-db");
+        let mut command = Command::new("git");
+        command.env("GIT_AI_TEST_NOTES_DB_PATH", &explicit_notes_db);
+
+        configure_test_home_env(&mut command, &test_home);
+
+        let notes_db_path = command
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("GIT_AI_TEST_NOTES_DB_PATH"))
+            .and_then(|(_, value)| value)
+            .map(PathBuf::from);
+        assert_eq!(notes_db_path, Some(explicit_notes_db));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve an explicitly supplied HTTP notes database path in the integration test harness
- retain the isolated per-test-home database default for ordinary test commands
- add a regression test covering explicit environment precedence

## Root cause

The harness applied custom daemon environment variables before configure_test_home_env. The latter unconditionally replaced GIT_AI_TEST_NOTES_DB_PATH, so the HTTP amend test read a different database from the one used by the daemon. This made the same test fail deterministically on Ubuntu, macOS, and Windows after PRs #1900 and #1901 were combined.

The fix is intentionally limited to GIT_AI_TEST_NOTES_DB_PATH. Other HOME, PATH, Git configuration, and platform isolation settings remain authoritative.

## Validation

- task test TEST_FILTER=test_configure_test_home_env_preserves_explicit_notes_database
- task test TEST_FILTER=test_amend_preserves_sessions_under_http_notes_backend
- task test
- task lint
- task fmt