### PR TITLE
Report AI stats for conflict merges

### DIFF
--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -1,12 +1,14 @@
 use crate::authorship::authorship_log::LineRange;
+use crate::authorship::authorship_log_serialization::AuthorshipLog;
+use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
 use crate::authorship::ignore::{build_ignore_matcher, should_ignore_file_with_matcher};
 use crate::error::GitAiError;
 use crate::git::notes_api::read_authorship;
-use crate::git::repository::{Repository, exec_git};
+use crate::git::repository::{Repository, batch_read_paths_at_treeishes, exec_git};
 use crate::mdm::spinner::Spinner;
 use crate::utils::is_interactive_terminal;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const RECENT_COMMIT_WINDOW: Duration = Duration::from_secs(60);
@@ -477,14 +479,18 @@ pub fn stats_for_commit_stats_with_authorship(
     let commit_obj = repo.revparse_single(commit_sha)?.peel_to_commit()?;
     let parent_count = commit_obj.parent_count()?;
 
-    if parent_count > 1 {
-        return stats_for_commit_stats_from_hunks(
+    if parent_count == 2 {
+        return stats_for_two_parent_merge_commit(
             repo,
             commit_sha,
+            &commit_obj.parent(0)?.id(),
+            &commit_obj.parent(1)?.id(),
             ignore_patterns,
-            &[],
-            authorship_log,
         );
+    }
+
+    if parent_count > 2 {
+        return Ok(CommitStats::default());
     }
 
     let parent_sha = if parent_count == 0 {
@@ -500,6 +506,101 @@ pub fn stats_for_commit_stats_with_authorship(
         ignore_patterns,
         authorship_log,
     )
+}
+
+/// Calculate on-demand stats for a two-parent merge without counting every
+/// change brought in by the merged branch.
+///
+/// Git's combined diff identifies files that differ from both parents. Within
+/// that bounded file set, stats use the normal first-parent diff and project
+/// the second parent's attestations onto the merge result. Content reads are
+/// batched so the number of Git subprocesses does not grow with the file count.
+fn stats_for_two_parent_merge_commit(
+    repo: &Repository,
+    commit_sha: &str,
+    first_parent: &str,
+    second_parent: &str,
+    ignore_patterns: &[String],
+) -> Result<CommitStats, GitAiError> {
+    use crate::commands::diff::get_diff_with_line_numbers;
+
+    let combined_files = repo.list_combined_diff_files(commit_sha)?;
+    if combined_files.is_empty() {
+        return Ok(CommitStats::default());
+    }
+
+    let mut hunks = get_diff_with_line_numbers(repo, first_parent, commit_sha)?;
+    hunks.retain(|hunk| combined_files.contains(&hunk.file_path));
+    if hunks.is_empty() {
+        return Ok(CommitStats::default());
+    }
+
+    let projected_authorship =
+        project_parent_authorship_to_merge(repo, second_parent, commit_sha, &combined_files)?;
+
+    Ok(stats_for_commit_stats_from_hunks_with_merge_flag(
+        ignore_patterns,
+        &hunks,
+        projected_authorship.as_ref(),
+        false,
+    ))
+}
+
+fn project_parent_authorship_to_merge(
+    repo: &Repository,
+    parent_sha: &str,
+    merge_sha: &str,
+    combined_files: &HashSet<String>,
+) -> Result<Option<AuthorshipLog>, GitAiError> {
+    let Some(parent_log) = read_authorship(repo, parent_sha) else {
+        return Ok(None);
+    };
+
+    let parent_attestations = parent_log
+        .attestations
+        .iter()
+        .filter(|attestation| combined_files.contains(&attestation.file_path))
+        .collect::<Vec<_>>();
+    if parent_attestations.is_empty() {
+        return Ok(None);
+    }
+
+    let requests = parent_attestations
+        .iter()
+        .flat_map(|attestation| {
+            [
+                (parent_sha.to_string(), attestation.file_path.clone()),
+                (merge_sha.to_string(), attestation.file_path.clone()),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let contents = batch_read_paths_at_treeishes(repo, &requests)?;
+
+    let mut projected = AuthorshipLog::new();
+    projected.metadata = parent_log.metadata.clone();
+    projected.metadata.base_commit_sha = merge_sha.to_string();
+
+    for parent_attestation in parent_attestations {
+        let parent_key = (parent_sha.to_string(), parent_attestation.file_path.clone());
+        let merge_key = (merge_sha.to_string(), parent_attestation.file_path.clone());
+        let (Some(parent_content), Some(merge_content)) =
+            (contents.get(&parent_key), contents.get(&merge_key))
+        else {
+            continue;
+        };
+
+        let shifts = crate::authorship::virtual_attribution::diff_hunks_between_contents(
+            parent_content,
+            merge_content,
+        );
+        if let Some(attestation) =
+            apply_hunk_shifts_to_file_attestation(parent_attestation, &shifts)
+        {
+            projected.attestations.push(attestation);
+        }
+    }
+
+    Ok(Some(projected))
 }
 
 pub fn stats_for_commit_stats_with_parent_and_authorship(

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1464,7 +1464,7 @@ fn split_lines_preserving_terminators(s: &str) -> Vec<&str> {
     lines
 }
 
-fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
+pub(crate) fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
     let normalized_old = normalize_line_endings(old_content);
     let normalized_new = normalize_line_endings(new_content);
     let old_lines = split_lines_preserving_terminators(&normalized_old);

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1763,6 +1763,36 @@ impl Repository {
         Ok(files)
     }
 
+    /// List files present in a merge commit's combined diff.
+    ///
+    /// Unlike a first-parent diff, this excludes changes that were merely
+    /// brought in by the merged branch. The single `diff-tree` invocation keeps
+    /// the Git process count constant regardless of how many files were merged.
+    pub fn list_combined_diff_files(
+        &self,
+        commit_sha: &str,
+    ) -> Result<HashSet<String>, GitAiError> {
+        let mut args = self.global_args_for_exec();
+        args.extend([
+            "diff-tree".to_string(),
+            "--cc".to_string(),
+            "--no-commit-id".to_string(),
+            "--name-only".to_string(),
+            "-r".to_string(),
+            "-z".to_string(),
+            commit_sha.to_string(),
+        ]);
+
+        let output = exec_git_with_profile(&args, InternalGitProfile::RawDiffParse)?;
+        Ok(output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .filter_map(|path| String::from_utf8(path.to_vec()).ok())
+            .map(|path| path.nfc().collect())
+            .collect())
+    }
+
     /// Get added line ranges from git diff between two commits
     /// Returns a HashMap of file paths to vectors of added line numbers
     ///

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -905,6 +905,93 @@ fn test_stats_ignores_renamed_files() {
     assert_eq!(stats.human_additions, 0);
 }
 
+/// Regression test for https://github.com/git-ai-project/git-ai/issues/910.
+///
+/// Both branches add an AI-authored line at the same location. An AI agent then
+/// resolves the conflict by keeping both lines. The merge introduces exactly
+/// one AI-authored line relative to its first parent, so commit stats must not
+/// classify it as human or suppress the merge stats entirely.
+#[test]
+fn test_stats_ai_resolved_merge_conflict() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("conflict.txt");
+    let mut file = repo.filename("conflict.txt");
+
+    fs::write(&file_path, "header\nfooter\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    file.assert_committed_lines(crate::lines!["header".human(), "footer".human()]);
+
+    let default_branch = repo.current_branch();
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    repo.git_ai(&["checkpoint", "human", "conflict.txt"])
+        .unwrap();
+    fs::write(&file_path, "header\nfeature line\nfooter\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "conflict.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Add feature line").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "header".human(),
+        "feature line".ai(),
+        "footer".human(),
+    ]);
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git_ai(&["checkpoint", "human", "conflict.txt"])
+        .unwrap();
+    fs::write(&file_path, "header\nmain line\nfooter\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "conflict.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Add main line").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "header".human(),
+        "main line".ai(),
+        "footer".human(),
+    ]);
+
+    let merge_result = repo.git(&["merge", "feature"]);
+    assert!(
+        merge_result.is_err(),
+        "merge should require conflict resolution"
+    );
+
+    // Match an agent's real pre/post edit flow: first snapshot the conflicted
+    // file, then attribute the resolved contents to the AI checkpoint.
+    repo.git_ai(&["checkpoint", "human", "conflict.txt"])
+        .unwrap();
+    fs::write(&file_path, "header\nmain line\nfeature line\nfooter\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "conflict.txt"])
+        .unwrap();
+    repo.git(&["add", "conflict.txt"]).unwrap();
+    repo.commit("Resolve merge conflict with AI").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "header".human(),
+        "main line".ai(),
+        "feature line".ai(),
+        "footer".human(),
+    ]);
+
+    // The blame-backed diff path already attributes the first-parent addition
+    // correctly. Commit stats should agree with it.
+    let diff_json: serde_json::Value = serde_json::from_str(
+        repo.git_ai(&["diff", "HEAD", "--json", "--include-stats"])
+            .unwrap()
+            .trim(),
+    )
+    .unwrap();
+    assert_eq!(diff_json["commit_stats"]["git_lines_added"], 1);
+    assert_eq!(diff_json["commit_stats"]["ai_lines_added"], 1);
+
+    let stats = stats_from_args(&repo, &["stats", "HEAD", "--json"]);
+    assert_eq!(stats.git_diff_added_lines, 1);
+    assert_eq!(stats.git_diff_deleted_lines, 0);
+    assert_eq!(stats.ai_additions, 1);
+    assert_eq!(stats.ai_accepted, 1);
+    assert_eq!(stats.human_additions, 0);
+    assert_eq!(stats.unknown_additions, 0);
+}
+
 crate::reuse_tests_in_worktree!(
     test_authorship_log_stats,
     test_stats_cli_range,
@@ -925,4 +1012,5 @@ crate::reuse_tests_in_worktree!(
     test_stats_range_uses_default_ignores,
     test_post_commit_large_ignored_files_do_not_trigger_skip_warning,
     test_stats_ignores_renamed_files,
+    test_stats_ai_resolved_merge_conflict,
 );

--- a/tests/integration/stats_unit.rs
+++ b/tests/integration/stats_unit.rs
@@ -589,8 +589,12 @@ fn test_stats_for_merge_commit_skips_ai_acceptance() {
     let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let stats = stats_for_commit_stats(&gitai_repo, &merge_sha, &[]).unwrap();
 
+    assert_eq!(stats.git_diff_added_lines, 0);
+    assert_eq!(stats.git_diff_deleted_lines, 0);
     assert_eq!(stats.ai_accepted, 0);
     assert_eq!(stats.ai_additions, 0);
+    assert_eq!(stats.human_additions, 0);
+    assert_eq!(stats.unknown_additions, 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #910

## Summary

- report first-parent stats only for files present in a two-parent merge combined diff
- project second-parent attestations onto the merge result using batched content reads and existing in-memory hunk shifting
- preserve zero stats for clean merges so incoming branch history is not inflated
- keep the implementation out of the trace2 ingestion path with a Git process count that does not scale with files or commits

## Test coverage

- added a TestRepo regression reproducing adjacent AI additions, conflict resolution, correct blame/diff attribution, and the formerly suppressed stats result
- strengthened the clean-merge regression to assert every stats field remains zero
- ran task test, task lint, and task fmt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->