### PR TITLE
Ignore empty nested .git directories

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8675,6 +8675,7 @@ mod tests {
         std::fs::create_dir_all(head_log.parent().unwrap()).unwrap();
         std::fs::create_dir_all(stash_log.parent().unwrap()).unwrap();
         std::fs::create_dir_all(branch_log.parent().unwrap()).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
         let old_head_reflog = b"old HEAD reflog entry\n";
         let old_reflog = b"old stash reflog entry\n";
         let old_branch_reflog = b"old branch reflog entry\n";

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -3643,6 +3643,13 @@ mod tests {
     const F: &str = "6666666666666666666666666666666666666666";
     const G: &str = "7777777777777777777777777777777777777777";
 
+    fn create_git_dir(worktree: &Path) -> PathBuf {
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        git_dir
+    }
+
     #[test]
     fn commit_subject_matches_git_reflog_trailing_whitespace_cleanup() {
         assert_eq!(commit_subject("subject \t"), Some("subject".to_string()));
@@ -3757,7 +3764,7 @@ mod tests {
         // silently lost.
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -3811,7 +3818,7 @@ mod tests {
         // branch transition is then never found.
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let reference = "refs/heads/feature";
         let head_log = git_dir.join("logs/HEAD");
         let branch_log = git_dir.join("logs").join(reference);
@@ -3867,7 +3874,7 @@ mod tests {
         // match — this commit's own entry. The commit keeps its attribution.
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -3926,7 +3933,7 @@ mod tests {
         // entry. The hint must be honored, not ignored.
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -3982,7 +3989,7 @@ mod tests {
         // than the older untraced duplicate.
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -4030,7 +4037,7 @@ mod tests {
     fn amend_without_message_does_not_match_plain_commit_reflog_entry() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -4062,7 +4069,7 @@ mod tests {
     fn commit_with_exact_reflog_message_ignores_stale_daemon_head() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -4100,7 +4107,7 @@ mod tests {
     fn commit_reflog_boundary_skips_untraced_duplicate_message() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -4138,7 +4145,7 @@ mod tests {
     fn first_observed_head_boundary_skips_prior_reset_history() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -4173,7 +4180,7 @@ mod tests {
     fn reset_late_reflog_offset_uses_command_message_not_stale_state() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -4240,7 +4247,7 @@ mod tests {
     fn direct_branch_update_ref_uses_argv_transition_when_reflog_cursor_starts_too_late() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let reference = "refs/heads/feature";
         fs::create_dir_all(git_dir.join("logs").join("refs/heads")).unwrap();
         fs::create_dir_all(git_dir.join("logs")).unwrap();
@@ -4285,7 +4292,7 @@ mod tests {
     fn direct_branch_update_ref_does_not_treat_stale_head_reflog_match_as_current_head_move() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let reference = "refs/heads/feature";
         fs::create_dir_all(git_dir.join("logs").join("refs/heads")).unwrap();
         fs::create_dir_all(git_dir.join("logs")).unwrap();
@@ -4354,7 +4361,7 @@ mod tests {
     fn direct_branch_update_ref_consumes_head_mirror_before_later_unstructured_update_ref() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let reference = "refs/heads/feature";
         append_reflog(&git_dir, reference, &[(A, B, "")]);
         append_reflog(&git_dir, "HEAD", &[(A, B, "")]);
@@ -4398,7 +4405,7 @@ mod tests {
     fn direct_head_update_ref_uses_argv_and_late_cursor_branch_mirror_once() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let reference = "refs/heads/feature";
         append_reflog(&git_dir, reference, &[(A, B, "")]);
         append_reflog(&git_dir, "HEAD", &[(A, B, "")]);
@@ -4454,7 +4461,7 @@ mod tests {
     fn direct_head_update_ref_uses_known_worktree_branch_when_other_branch_matches_same_second() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let current = "refs/heads/main";
         let other = "refs/heads/other";
         append_reflog(&git_dir, current, &[(A, B, "")]);
@@ -4513,7 +4520,7 @@ mod tests {
     fn direct_head_update_ref_without_known_branch_does_not_guess_ambiguous_branch_mirror() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         append_reflog(&git_dir, "refs/heads/main", &[(A, B, "")]);
         append_reflog(&git_dir, "refs/heads/other", &[(A, B, "")]);
         append_reflog(&git_dir, "HEAD", &[(A, B, "")]);
@@ -4539,7 +4546,7 @@ mod tests {
     fn direct_branch_update_ref_does_not_attach_head_when_state_names_different_branch() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let current = "refs/heads/main";
         let updated = "refs/heads/feature";
         append_reflog(&git_dir, updated, &[(A, B, "")]);
@@ -4649,7 +4656,7 @@ mod tests {
     fn rebase_span_stops_at_new_rebase_start_before_finish() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -4689,7 +4696,7 @@ mod tests {
     fn rebase_span_continuation_skips_stale_abort_before_selected_start() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         let branch_log = git_dir.join("logs/refs/heads/feature");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
@@ -4939,7 +4946,7 @@ mod tests {
     fn rebase_does_not_consume_adjacent_checkout_head_entry() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -4988,7 +4995,7 @@ mod tests {
     fn failed_explicit_branch_rebase_consumes_noop_start_marker_before_continue() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -5064,7 +5071,7 @@ mod tests {
     fn cold_rebase_late_ingress_offset_still_recovers_start_and_branch_finish() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
 
         let start_line = format!(
@@ -5130,7 +5137,7 @@ mod tests {
     fn cold_rebase_true_boundary_does_not_replay_older_rebase_span() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
 
         let old_start = format!(
@@ -5214,7 +5221,7 @@ mod tests {
     fn rebase_span_stops_before_later_rebase_after_checkout() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -5270,7 +5277,7 @@ mod tests {
     fn rebase_does_not_attach_unrelated_branch_with_same_new_tip() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
         append_reflog(
             &git_dir,
@@ -5323,7 +5330,7 @@ mod tests {
     fn rebase_prefers_start_entry_when_expected_state_matches_pick() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -5376,7 +5383,7 @@ mod tests {
     fn cherry_pick_span_starts_at_first_pick_when_expected_state_matches_second_pick() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -5420,7 +5427,7 @@ mod tests {
     fn revert_span_starts_at_first_revert_when_expected_state_matches_second_revert() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs")).unwrap();
         append_reflog(
             &git_dir,
@@ -5473,7 +5480,7 @@ mod tests {
     fn pull_rebase_span_starts_at_start_entry_when_expected_state_matches_pick() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
         append_reflog(
             &git_dir,
@@ -5542,7 +5549,7 @@ mod tests {
     fn cold_pull_rebase_late_ingress_offset_still_recovers_start_and_branch_finish() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
 
         let start_line = format!(
@@ -5609,7 +5616,7 @@ mod tests {
     fn cold_pull_rebase_true_boundary_does_not_replay_older_pull_span() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         fs::create_dir_all(git_dir.join("logs/refs/heads")).unwrap();
 
         let old_start = format!(

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -1216,6 +1216,12 @@ mod tests {
         })
     }
 
+    fn create_git_dir(worktree: &Path) {
+        let git_dir = worktree.join(".git");
+        fs::create_dir_all(&git_dir).expect("create git dir");
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+    }
+
     #[test]
     fn payload_timestamp_prefers_stock_trace2_rfc3339_time_over_relative_t_abs() {
         let payload = serde_json::json!({
@@ -1398,7 +1404,7 @@ mod tests {
         let backend = Arc::new(MockBackend::default());
         let temp = tempfile::tempdir().expect("create tempdir");
         let worktree = temp.path().join("repo");
-        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        create_git_dir(&worktree);
         backend.set_alias(worktree.to_str().expect("utf8 worktree"), "ci", "commit");
         let mut normalizer = TraceNormalizer::new(backend);
 
@@ -1432,7 +1438,7 @@ mod tests {
         let backend = Arc::new(MockBackend::default());
         let temp = tempfile::tempdir().expect("create tempdir");
         let worktree = temp.path().join("repo");
-        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        create_git_dir(&worktree);
         backend.set_alias(
             worktree.to_str().expect("utf8 worktree"),
             "up",
@@ -1491,7 +1497,7 @@ mod tests {
         let backend = Arc::new(MockBackend::default());
         let temp = tempfile::tempdir().expect("create tempdir");
         let worktree = temp.path().join("repo");
-        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        create_git_dir(&worktree);
         backend.set_alias(
             worktree.to_str().expect("utf8 worktree"),
             "up",
@@ -1538,7 +1544,7 @@ mod tests {
         let backend = Arc::new(MockBackend::default());
         let temp = tempfile::tempdir().expect("create tempdir");
         let worktree = temp.path().join("repo");
-        fs::create_dir_all(worktree.join(".git")).expect("create git dir");
+        create_git_dir(&worktree);
         let mut normalizer = TraceNormalizer::new(backend);
 
         let start = serde_json::json!({
@@ -1754,7 +1760,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("create tempdir");
         let outer = temp.path().join("outer");
         let clone_dir = outer.join("nested").join("relative-clone");
-        fs::create_dir_all(clone_dir.join(".git")).expect("create clone git dir");
+        create_git_dir(&clone_dir);
 
         let start = serde_json::json!({
             "event":"start",
@@ -1828,7 +1834,7 @@ mod tests {
         assert!(normalizer.ingest_payload(&cmd_name).unwrap().is_none());
 
         // Simulate repo discoverability only once clone is about to exit.
-        fs::create_dir_all(clone_dir.join(".git")).expect("create clone git dir");
+        create_git_dir(&clone_dir);
 
         assert!(normalizer.ingest_payload(&exit).unwrap().is_none());
         let cmd = normalizer
@@ -1847,8 +1853,8 @@ mod tests {
         let temp = tempfile::tempdir().expect("create tempdir");
         let source_repo = temp.path().join("source-repo");
         let cloned_repo = temp.path().join("cloned-repo");
-        fs::create_dir_all(source_repo.join(".git")).expect("create source git dir");
-        fs::create_dir_all(cloned_repo.join(".git")).expect("create cloned git dir");
+        create_git_dir(&source_repo);
+        create_git_dir(&cloned_repo);
 
         let start = serde_json::json!({
             "event":"start",
@@ -1899,7 +1905,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("create tempdir");
         let cwd = temp.path().join("projects"); // non-repo CWD
         let clone_dest = cwd.join("testing-git"); // the clone destination
-        fs::create_dir_all(clone_dest.join(".git")).expect("create clone git dir");
+        create_git_dir(&clone_dest);
 
         let root_sid = "20260327T000000.000000Z-Hdeadbeef-P00010000";
         let child_sid = format!("{}/20260327T000000.000001Z-Hdeadbeef-P00010001", root_sid);
@@ -1993,8 +1999,8 @@ mod tests {
         let temp = tempfile::tempdir().expect("create tempdir");
         let repo_a = temp.path().join("repo-a");
         let repo_b = temp.path().join("repo-b");
-        fs::create_dir_all(repo_a.join(".git")).expect("create repo-a git dir");
-        fs::create_dir_all(repo_b.join(".git")).expect("create repo-b git dir");
+        create_git_dir(&repo_a);
+        create_git_dir(&repo_b);
 
         let start_a = serde_json::json!({
             "event":"start",
@@ -2115,7 +2121,7 @@ mod tests {
         let mut normalizer = TraceNormalizer::new(backend);
         let temp = tempfile::tempdir().expect("create tempdir");
         let repo = temp.path().join("repo");
-        fs::create_dir_all(repo.join(".git")).expect("create git dir");
+        create_git_dir(&repo);
 
         let start = serde_json::json!({
             "event":"start",

--- a/src/git/repo_state.rs
+++ b/src/git/repo_state.rs
@@ -12,11 +12,19 @@ pub struct HeadState {
     pub detached: bool,
 }
 
+/// Check the minimal required marker for a directory-form Git repository.
+///
+/// Using `HEAD` instead of the directory itself rejects empty `.git`
+/// placeholders without adding a filesystem lookup to normal discovery.
+pub fn is_valid_git_dir(path: &Path) -> bool {
+    path.join("HEAD").is_file()
+}
+
 pub fn worktree_root_for_path(path: &Path) -> Option<PathBuf> {
     let mut current = Some(path);
     while let Some(candidate) = current {
         let dot_git = candidate.join(".git");
-        if dot_git.is_dir() || dot_git.is_file() {
+        if is_valid_git_dir(&dot_git) || dot_git.is_file() {
             return Some(candidate.to_path_buf());
         }
         current = candidate.parent();

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use crate::error::GitAiError;
 use crate::git::repo_state::{
-    common_dir_for_git_dir, git_dir_for_worktree, worktree_root_for_path,
+    common_dir_for_git_dir, git_dir_for_worktree, is_valid_git_dir, worktree_root_for_path,
 };
 use crate::git::repo_storage::RepoStorage;
 use crate::git::status::MAX_PATHSPEC_ARGS;
@@ -2172,7 +2172,7 @@ fn discover_repository_paths_no_git_exec(
     };
 
     if start.file_name().and_then(|name| name.to_str()) == Some(".git") {
-        if start.is_dir() {
+        if is_valid_git_dir(&start) {
             let workdir = start.parent().ok_or_else(|| {
                 GitAiError::Generic(format!(
                     "Git directory has no parent workdir: {}",
@@ -2480,8 +2480,8 @@ fn has_intervening_git_dir(file_path: &Path, workdir: &Path) -> bool {
             break;
         }
         let potential_git = workdir.join(parent).join(".git");
-        if potential_git.is_dir() {
-            // A .git directory always indicates a separate independent repo.
+        if is_valid_git_dir(&potential_git) {
+            // A valid .git directory indicates a separate independent repo.
             return true;
         }
         if potential_git.is_file() {
@@ -2576,10 +2576,15 @@ pub fn find_repository_for_file(
 
         // Check for .git directory or file (file for submodules/worktrees)
         let git_path = dir.join(".git");
-        if git_path.exists() {
+        let git_path_metadata = std::fs::metadata(&git_path).ok();
+        let git_path_is_file = git_path_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.is_file());
+        let git_path_is_dir = git_path_metadata.is_some_and(|metadata| metadata.is_dir());
+        if git_path_is_file || (git_path_is_dir && is_valid_git_dir(&git_path)) {
             // Found a .git - but we need to check if this is a submodule
             // Submodules have a .git file (not directory) that points to the parent's .git/modules
-            if git_path.is_file() {
+            if git_path_is_file {
                 // This is a submodule - read the file to check if it points to modules/
                 if let Ok(content) = std::fs::read_to_string(&git_path)
                     && content.contains("gitdir:")

--- a/tests/integration/issue_1415_empty_git_dir.rs
+++ b/tests/integration/issue_1415_empty_git_dir.rs
@@ -1,0 +1,34 @@
+use std::fs;
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+
+#[test]
+fn test_empty_nested_git_dir_does_not_shadow_parent_repository() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("nested/example.md");
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::write(&file_path, "Existing line\n").unwrap();
+
+    repo.git(&["add", "nested/example.md"]).unwrap();
+    repo.commit("Initial commit").unwrap();
+
+    let mut file = repo.filename("nested/example.md");
+    file.assert_committed_lines(crate::lines!["Existing line".unattributed_human()]);
+
+    fs::create_dir(file_path.parent().unwrap().join(".git")).unwrap();
+
+    repo.git_ai(&["checkpoint", "human", "nested/example.md"])
+        .unwrap();
+    fs::write(&file_path, "Existing line\nAI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "nested/example.md"])
+        .unwrap();
+
+    repo.git(&["add", "nested/example.md"]).unwrap();
+    repo.commit("Add AI line").unwrap();
+
+    file.assert_committed_lines(crate::lines![
+        "Existing line".unattributed_human(),
+        "AI line".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -81,6 +81,7 @@ mod install_hooks_comprehensive;
 mod internal_machine_commands;
 mod internal_spawn_safety;
 mod issue_1204_multi_agent;
+mod issue_1415_empty_git_dir;
 mod jetbrains_download;
 mod jetbrains_ide_types;
 mod log;


### PR DESCRIPTION
Fixes #1415

## Summary
- require a HEAD marker before treating a directory-form .git entry as a repository
- reuse the validation for no-exec discovery and nested repository boundaries without adding Git subprocesses or extra normal-path filesystem lookups
- update synthetic daemon test fixtures to model valid Git directories

## Test coverage
- add a TestRepo regression covering pre/post AI checkpoints beneath an empty nested .git directory
- task test
- task lint
- task fmt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->