### PR TITLE
Preserve metadata after conflicted cherry-picks

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5193,10 +5193,16 @@ impl ActorDaemonCoordinator {
                     let new_commits = cherry_pick_destination_commits(cmd);
                     let is_continue = cherry_pick_command_has_flag(cmd, "--continue");
                     let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
+                    let explicit_source_args = cherry_pick_source_args_for_side_effect(cmd);
+                    // Async processing may run after `--continue` removes CHERRY_PICK_HEAD.
+                    // A single explicit source remains bounded to one batched object lookup.
+                    let can_resolve_without_live_state = explicit_source_args.len() == 1
+                        && !cherry_pick_source_is_range(&explicit_source_args[0]);
                     let mut source_oids = cmd.cherry_pick_source_oids.clone();
                     let mut source_oids_from_daemon_pending = false;
                     if source_oids.is_empty()
-                        && (!new_commits.is_empty()
+                        && (can_resolve_without_live_state
+                            || !new_commits.is_empty()
                             || cherry_pick_state_exists_for_worktree(worktree))
                     {
                         let repo = find_repository_in_path(&worktree.to_string_lossy())?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2469,6 +2469,13 @@ struct PendingSquashMerge {
 }
 
 #[derive(Debug, Clone)]
+struct PendingCherryPickSources {
+    source_oids: Vec<String>,
+    // Async processing could not confirm that Git started a sequencer.
+    speculative: bool,
+}
+
+#[derive(Debug, Clone)]
 struct PendingCherryPickNoCommit {
     source_commits: Vec<String>,
     head: String,
@@ -2517,7 +2524,7 @@ pub struct ActorDaemonCoordinator {
         >,
     >,
     pending_rebase_original_head_by_worktree: Mutex<HashMap<String, (String, Option<String>)>>,
-    pending_cherry_pick_sources_by_worktree: Mutex<HashMap<String, Vec<String>>>,
+    pending_cherry_pick_sources_by_worktree: Mutex<HashMap<String, PendingCherryPickSources>>,
     pending_cherry_pick_no_commit_by_worktree: Mutex<HashMap<String, PendingCherryPickNoCommit>>,
     pending_squash_merge_by_worktree: Mutex<HashMap<String, PendingSquashMerge>>,
     inflight_effects_by_family: Mutex<HashMap<String, usize>>,
@@ -2931,7 +2938,7 @@ impl ActorDaemonCoordinator {
             map.shrink_to_fit();
         }
         if let Ok(mut map) = self.pending_cherry_pick_sources_by_worktree.lock() {
-            map.retain(|_, sources| !sources.is_empty());
+            map.retain(|_, pending| !pending.source_oids.is_empty());
         }
         if let Ok(mut map) = self.pending_squash_merge_by_worktree.lock() {
             map.retain(|_, pending| {
@@ -4481,7 +4488,8 @@ impl ActorDaemonCoordinator {
     fn set_pending_cherry_pick_sources_for_worktree(
         &self,
         worktree: &Path,
-        sources: Vec<String>,
+        source_oids: Vec<String>,
+        speculative: bool,
     ) -> Result<(), GitAiError> {
         let mut map = self
             .pending_cherry_pick_sources_by_worktree
@@ -4490,12 +4498,39 @@ impl ActorDaemonCoordinator {
                 GitAiError::Generic("pending cherry-pick sources map lock poisoned".to_string())
             })?;
         let key = Self::worktree_state_key(worktree);
-        if sources.is_empty() {
+        if source_oids.is_empty() {
             map.remove(&key);
         } else {
-            map.insert(key, sources);
+            map.insert(
+                key,
+                PendingCherryPickSources {
+                    source_oids,
+                    speculative,
+                },
+            );
         }
         Ok(())
+    }
+
+    fn prepare_pending_cherry_pick_sources_for_explicit_command(
+        &self,
+        worktree: &Path,
+    ) -> Result<bool, GitAiError> {
+        let mut map = self
+            .pending_cherry_pick_sources_by_worktree
+            .lock()
+            .map_err(|_| {
+                GitAiError::Generic("pending cherry-pick sources map lock poisoned".to_string())
+            })?;
+        let key = Self::worktree_state_key(worktree);
+        match map.get(&key) {
+            Some(pending) if !pending.speculative => Ok(false),
+            Some(_) => {
+                map.remove(&key);
+                Ok(true)
+            }
+            None => Ok(true),
+        }
     }
 
     fn clear_pending_cherry_pick_sources_for_worktree(
@@ -4524,23 +4559,21 @@ impl ActorDaemonCoordinator {
             })?;
         Ok(map
             .remove(&Self::worktree_state_key(worktree))
+            .map(|pending| pending.source_oids)
             .unwrap_or_default())
     }
 
     fn pending_cherry_pick_sources_for_worktree(
         &self,
         worktree: &Path,
-    ) -> Result<Vec<String>, GitAiError> {
+    ) -> Result<Option<PendingCherryPickSources>, GitAiError> {
         let map = self
             .pending_cherry_pick_sources_by_worktree
             .lock()
             .map_err(|_| {
                 GitAiError::Generic("pending cherry-pick sources map lock poisoned".to_string())
             })?;
-        Ok(map
-            .get(&Self::worktree_state_key(worktree))
-            .cloned()
-            .unwrap_or_default())
+        Ok(map.get(&Self::worktree_state_key(worktree)).cloned())
     }
 
     fn set_pending_cherry_pick_no_commit_for_worktree(
@@ -5194,24 +5227,42 @@ impl ActorDaemonCoordinator {
                     let is_continue = cherry_pick_command_has_flag(cmd, "--continue");
                     let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
                     let explicit_source_args = cherry_pick_source_args_for_side_effect(cmd);
+                    let can_replace_pending = explicit_source_args.is_empty()
+                        || self
+                            .prepare_pending_cherry_pick_sources_for_explicit_command(worktree)?;
+                    let cherry_pick_state_exists = cherry_pick_state_exists_for_worktree(worktree);
+                    let mut source_oids_are_speculative = !explicit_source_args.is_empty()
+                        && new_commits.is_empty()
+                        && !cherry_pick_state_exists;
                     // Async processing may run after `--continue` removes CHERRY_PICK_HEAD.
                     // A single explicit source remains bounded to one batched object lookup.
                     let can_resolve_without_live_state = explicit_source_args.len() == 1
                         && !cherry_pick_source_is_range(&explicit_source_args[0]);
-                    let mut source_oids = cmd.cherry_pick_source_oids.clone();
+                    let mut source_oids = if can_replace_pending {
+                        cmd.cherry_pick_source_oids.clone()
+                    } else {
+                        Vec::new()
+                    };
                     let mut source_oids_from_daemon_pending = false;
-                    if source_oids.is_empty()
+                    if can_replace_pending
+                        && source_oids.is_empty()
                         && (can_resolve_without_live_state
                             || !new_commits.is_empty()
-                            || cherry_pick_state_exists_for_worktree(worktree))
+                            || cherry_pick_state_exists)
                     {
                         let repo = find_repository_in_path(&worktree.to_string_lossy())?;
                         source_oids =
                             resolve_explicit_cherry_pick_sources_for_side_effect(&repo, cmd)?;
                     }
-                    if source_oids.is_empty() && (is_continue || is_skip) {
-                        source_oids = self.pending_cherry_pick_sources_for_worktree(worktree)?;
-                        source_oids_from_daemon_pending = !source_oids.is_empty();
+                    if (is_continue || is_skip)
+                        && let Some(pending) =
+                            self.pending_cherry_pick_sources_for_worktree(worktree)?
+                    {
+                        source_oids_are_speculative = pending.speculative;
+                        if source_oids.is_empty() {
+                            source_oids = pending.source_oids;
+                            source_oids_from_daemon_pending = true;
+                        }
                     }
                     let skipped_sources = usize::from(is_skip && source_oids_from_daemon_pending);
                     let applied_source_oids = source_oids
@@ -5244,7 +5295,11 @@ impl ActorDaemonCoordinator {
                             .skip(consumed_sources.min(source_oids.len()))
                             .cloned()
                             .collect();
-                        self.set_pending_cherry_pick_sources_for_worktree(worktree, remaining)?;
+                        self.set_pending_cherry_pick_sources_for_worktree(
+                            worktree,
+                            remaining,
+                            source_oids_are_speculative,
+                        )?;
                     }
                 }
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5171,6 +5171,19 @@ impl ActorDaemonCoordinator {
             self.detect_and_handle_non_ff_rewrites(cmd)?;
         }
 
+        let terminates_pending_cherry_pick = cmd.primary_command.as_deref() == Some("cherry-pick")
+            && cherry_pick_command_terminates_pending_sequence(cmd);
+        if terminates_pending_cherry_pick {
+            let worktree = cmd.worktree.as_ref().ok_or_else(|| {
+                GitAiError::Generic(format!(
+                    "cherry-pick side-effect state requires worktree sid={}",
+                    cmd.root_sid
+                ))
+            })?;
+            self.clear_pending_cherry_pick_sources_for_worktree(worktree)?;
+            self.clear_pending_cherry_pick_no_commit_for_worktree(worktree)?;
+        }
+
         if cmd.exit_code != 0 {
             let rebase_start = cmd
                 .ref_changes
@@ -5233,10 +5246,7 @@ impl ActorDaemonCoordinator {
                         cmd.root_sid
                     ))
                 })?;
-                if cherry_pick_command_terminates_pending_sequence(cmd) {
-                    self.clear_pending_cherry_pick_sources_for_worktree(worktree)?;
-                    self.clear_pending_cherry_pick_no_commit_for_worktree(worktree)?;
-                } else if cmd.exit_code != 0 {
+                if !terminates_pending_cherry_pick {
                     let new_commits = cherry_pick_destination_commits(cmd);
                     let is_continue = cherry_pick_command_has_flag(cmd, "--continue");
                     let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
@@ -8253,6 +8263,69 @@ mod tests {
             1,
             Vec::new()
         )));
+    }
+
+    #[test]
+    fn successful_cherry_pick_quit_clears_coordinator_pending_state() {
+        const SOURCE: &str = "1111111111111111111111111111111111111111";
+        const HEAD: &str = "2222222222222222222222222222222222222222";
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let coordinator = ActorDaemonCoordinator::new();
+            let worktree = Path::new("/repo");
+            coordinator
+                .set_pending_cherry_pick_sources_for_worktree(
+                    worktree,
+                    vec![SOURCE.to_string()],
+                    false,
+                )
+                .unwrap();
+            coordinator
+                .set_pending_cherry_pick_no_commit_for_worktree(
+                    worktree,
+                    vec![SOURCE.to_string()],
+                    HEAD.to_string(),
+                )
+                .unwrap();
+            let applied = crate::daemon::domain::AppliedCommand {
+                seq: 1,
+                command: test_history_command("cherry-pick", &["--quit"], 0, Vec::new()),
+                analysis: crate::daemon::domain::AnalysisResult {
+                    class: crate::daemon::domain::CommandClass::HistoryRewrite,
+                    // Keep unrelated non-FF detection inert while exercising the
+                    // side-effect coordinator with a successful terminal control.
+                    events: vec![crate::daemon::domain::SemanticEvent::CherryPickComplete {
+                        original_head: String::new(),
+                        new_head: String::new(),
+                        source_commits: Vec::new(),
+                        new_commits: Vec::new(),
+                    }],
+                    confidence: crate::daemon::domain::Confidence::High,
+                },
+            };
+
+            coordinator
+                .maybe_apply_side_effects_for_applied_command(None, &applied, &mut HashMap::new())
+                .await
+                .unwrap();
+
+            assert!(
+                coordinator
+                    .pending_cherry_pick_sources_for_worktree(worktree)
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(
+                coordinator
+                    .take_pending_cherry_pick_no_commit_for_worktree(worktree)
+                    .unwrap()
+                    .is_none()
+            );
+        });
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1597,6 +1597,16 @@ fn cherry_pick_command_has_flag(
     parsed.command_args.iter().any(|arg| arg == flag)
 }
 
+fn cherry_pick_command_terminates_pending_sequence(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> bool {
+    cherry_pick_command_has_flag(cmd, "--abort")
+        || cherry_pick_command_has_flag(cmd, "--quit")
+        || (cmd.exit_code == 0
+            && cherry_pick_command_has_flag(cmd, "--skip")
+            && cherry_pick_destination_commits(cmd).is_empty())
+}
+
 fn cherry_pick_source_args_from_command_args(args: &[String]) -> Vec<&str> {
     let mut sources = Vec::new();
     let mut idx = 0usize;
@@ -1642,6 +1652,10 @@ fn cherry_pick_source_args_from_command_args(args: &[String]) -> Vec<&str> {
 
 fn cherry_pick_source_is_range(source: &str) -> bool {
     source.contains("..")
+}
+
+fn cherry_pick_source_is_immutable_oid(source: &str) -> bool {
+    (4..=64).contains(&source.len()) && source.chars().all(|ch| ch.is_ascii_hexdigit())
 }
 
 fn cherry_pick_range_has_omitted_side(source: &str) -> bool {
@@ -2471,7 +2485,7 @@ struct PendingSquashMerge {
 #[derive(Debug, Clone)]
 struct PendingCherryPickSources {
     source_oids: Vec<String>,
-    // Async processing could not confirm that Git started a sequencer.
+    // No command-bounded ref transition proved that Git started this sequence.
     speculative: bool,
 }
 
@@ -5219,7 +5233,7 @@ impl ActorDaemonCoordinator {
                         cmd.root_sid
                     ))
                 })?;
-                if cmd.invoked_args.iter().any(|arg| arg == "--abort") {
+                if cherry_pick_command_terminates_pending_sequence(cmd) {
                     self.clear_pending_cherry_pick_sources_for_worktree(worktree)?;
                     self.clear_pending_cherry_pick_no_commit_for_worktree(worktree)?;
                 } else if cmd.exit_code != 0 {
@@ -5231,13 +5245,13 @@ impl ActorDaemonCoordinator {
                         || self
                             .prepare_pending_cherry_pick_sources_for_explicit_command(worktree)?;
                     let cherry_pick_state_exists = cherry_pick_state_exists_for_worktree(worktree);
-                    let mut source_oids_are_speculative = !explicit_source_args.is_empty()
-                        && new_commits.is_empty()
-                        && !cherry_pick_state_exists;
-                    // Async processing may run after `--continue` removes CHERRY_PICK_HEAD.
-                    // A single explicit source remains bounded to one batched object lookup.
+                    // Only a command-bounded HEAD transition proves that this failed
+                    // command started a sequence. Sources recovered without one remain
+                    // replaceable by the next explicit cherry-pick.
+                    let mut source_oids_are_speculative =
+                        !explicit_source_args.is_empty() && new_commits.is_empty();
                     let can_resolve_without_live_state = explicit_source_args.len() == 1
-                        && !cherry_pick_source_is_range(&explicit_source_args[0]);
+                        && cherry_pick_source_is_immutable_oid(&explicit_source_args[0]);
                     let mut source_oids = if can_replace_pending {
                         cmd.cherry_pick_source_oids.clone()
                     } else {
@@ -8195,6 +8209,53 @@ mod tests {
     }
 
     #[test]
+    fn delayed_cherry_pick_lookup_accepts_only_immutable_oid_sources() {
+        assert!(cherry_pick_source_is_immutable_oid("0123abc"));
+        assert!(cherry_pick_source_is_immutable_oid(
+            "0123456789abcdef0123456789abcdef01234567"
+        ));
+        assert!(!cherry_pick_source_is_immutable_oid("HEAD~1"));
+        assert!(!cherry_pick_source_is_immutable_oid("topic"));
+        assert!(!cherry_pick_source_is_immutable_oid("0123abc..4567def"));
+    }
+
+    #[test]
+    fn terminal_cherry_pick_controls_clear_pending_sources() {
+        const OLD: &str = "1111111111111111111111111111111111111111";
+        const NEW: &str = "2222222222222222222222222222222222222222";
+        let command =
+            |args: &[&str], exit_code: i32, ref_changes: Vec<crate::daemon::domain::RefChange>| {
+                test_history_command("cherry-pick", args, exit_code, ref_changes)
+            };
+
+        assert!(cherry_pick_command_terminates_pending_sequence(&command(
+            &["--abort"],
+            0,
+            Vec::new()
+        )));
+        assert!(cherry_pick_command_terminates_pending_sequence(&command(
+            &["--quit"],
+            0,
+            Vec::new()
+        )));
+        assert!(cherry_pick_command_terminates_pending_sequence(&command(
+            &["--skip"],
+            0,
+            Vec::new()
+        )));
+        assert!(!cherry_pick_command_terminates_pending_sequence(&command(
+            &["--skip"],
+            0,
+            vec![ref_change("HEAD", OLD, NEW)]
+        )));
+        assert!(!cherry_pick_command_terminates_pending_sequence(&command(
+            &["--skip"],
+            1,
+            Vec::new()
+        )));
+    }
+
+    #[test]
     fn checkpoint_requests_use_long_timeout_in_ci_or_test_env() {
         assert_eq!(
             checkpoint_control_response_timeout(&sample_checkpoint_request(), true),
@@ -8249,8 +8310,10 @@ mod tests {
         );
     }
 
-    fn test_rebase_command(
+    fn test_history_command(
+        command: &str,
         invoked_args: &[&str],
+        exit_code: i32,
         ref_changes: Vec<crate::daemon::domain::RefChange>,
     ) -> crate::daemon::domain::NormalizedCommand {
         crate::daemon::domain::NormalizedCommand {
@@ -8259,17 +8322,17 @@ mod tests {
             )),
             family_key: Some(crate::daemon::domain::FamilyKey("/repo/.git".to_string())),
             worktree: Some(PathBuf::from("/repo")),
-            root_sid: "rebase-test".to_string(),
+            root_sid: format!("{command}-test"),
             raw_argv: std::iter::once("git")
-                .chain(std::iter::once("rebase"))
+                .chain(std::iter::once(command))
                 .chain(invoked_args.iter().copied())
                 .map(str::to_string)
                 .collect(),
-            primary_command: Some("rebase".to_string()),
-            invoked_command: Some("rebase".to_string()),
+            primary_command: Some(command.to_string()),
+            invoked_command: Some(command.to_string()),
             invoked_args: invoked_args.iter().map(|arg| (*arg).to_string()).collect(),
             observed_child_commands: Vec::new(),
-            exit_code: 0,
+            exit_code,
             started_at_ns: 1,
             finished_at_ns: 2,
             reflog_start_offsets: HashMap::new(),
@@ -8279,6 +8342,13 @@ mod tests {
             ref_changes,
             confidence: crate::daemon::domain::Confidence::High,
         }
+    }
+
+    fn test_rebase_command(
+        invoked_args: &[&str],
+        ref_changes: Vec<crate::daemon::domain::RefChange>,
+    ) -> crate::daemon::domain::NormalizedCommand {
+        test_history_command("rebase", invoked_args, 0, ref_changes)
     }
 
     fn ref_change(reference: &str, old: &str, new: &str) -> crate::daemon::domain::RefChange {

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2288,6 +2288,126 @@ fn daemon_late_cherry_pick_trace_uses_actual_destination_not_stale_commit_entry(
 }
 
 #[test]
+fn daemon_delayed_conflicted_cherry_pick_preserves_source_session_metadata() {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    let mut file = repo.filename("conflict.txt");
+    file.set_contents(lines!["shared".human(), "base".human(), "tail".human(),]);
+    repo.stage_all_and_commit("base")
+        .expect("base commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "base".human(), "tail".human(),]);
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "source"])
+        .expect("checkout source should succeed");
+    file.replace_at(1, "source".ai());
+    let source_commit = repo
+        .stage_all_and_commit("AI source change")
+        .expect("source commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "source".ai(), "tail".human(),]);
+
+    repo.git(&["checkout", &default_branch])
+        .expect("checkout default branch should succeed");
+    file.replace_at(1, "main".human());
+    repo.stage_all_and_commit("main conflict")
+        .expect("main conflict commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "main".human(), "tail".human(),]);
+    drop(file);
+
+    repo.restart_dedicated_daemon_for_test();
+    let source_short_sha = &source_commit.commit_sha[..7];
+    let cherry_pick = repo.git_og(&["cherry-pick", source_short_sha]);
+    assert!(cherry_pick.is_err(), "cherry-pick should conflict");
+    fs::write(
+        repo.path().join("conflict.txt"),
+        "shared\nmain\nsource\ntail\n",
+    )
+    .expect("write conflict resolution");
+    repo.git_og(&["add", "conflict.txt"])
+        .expect("stage conflict resolution");
+    repo.git_og_with_env(&["cherry-pick", "--continue"], &[("GIT_EDITOR", "true")])
+        .expect("cherry-pick continue should succeed");
+    let picked_commit = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .expect("resolve cherry-picked commit")
+        .trim()
+        .to_string();
+
+    let failed_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let continue_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let failed_session_arg = format!("git-ai.testSyncSession={failed_session}");
+    let continue_session_arg = format!("git-ai.testSyncSession={continue_session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "delayed-conflicted-cherry-pick",
+                "argv": ["git", "-c", failed_session_arg, "-C", worktree, "cherry-pick", source_short_sha],
+                "time_ns": 1_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "delayed-conflicted-cherry-pick",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 1_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "delayed-conflicted-cherry-pick",
+                "code": 1,
+                "time_ns": 1_100u64,
+            }),
+            trace_atexit_frame("delayed-conflicted-cherry-pick", 1, 1_101u64),
+            json!({
+                "event": "start",
+                "sid": "delayed-cherry-pick-continue",
+                "argv": ["git", "-c", continue_session_arg, "-C", worktree, "cherry-pick", "--continue"],
+                "time_ns": 2_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "delayed-cherry-pick-continue",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 2_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "delayed-cherry-pick-continue",
+                "code": 0,
+                "time_ns": 2_100u64,
+            }),
+            trace_atexit_frame("delayed-cherry-pick-continue", 0, 2_101u64),
+        ],
+    );
+    repo.sync_daemon_external_completion_sessions(&[failed_session, continue_session]);
+
+    let mut file = repo.filename("conflict.txt");
+    file.assert_lines_and_blame(lines![
+        "shared".human(),
+        "main".human(),
+        "source".ai(),
+        "tail".human(),
+    ]);
+    let stats = repo.stats().expect("read cherry-pick stats");
+    let tool_model = stats
+        .tool_model_breakdown
+        .get("mock_ai::unknown")
+        .expect("conflicted cherry-pick should preserve source session metadata");
+    assert_eq!(tool_model.ai_additions, 1);
+    assert_eq!(tool_model.ai_accepted, 1);
+    assert!(
+        repo.read_authorship_note(&picked_commit).is_some(),
+        "cherry-picked commit should receive an authorship note"
+    );
+}
+
+#[test]
 fn daemon_failed_rebase_does_not_consume_later_skip_reflog_entry() {
     let repo = TestRepo::new_dedicated_daemon();
     let trace_socket = daemon_trace_socket_path(&repo);

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2408,6 +2408,161 @@ fn daemon_delayed_conflicted_cherry_pick_preserves_source_session_metadata() {
 }
 
 #[test]
+fn daemon_failed_cherry_pick_source_does_not_leak_into_later_range_conflict() {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    let mut file = repo.filename("conflict.txt");
+    file.set_contents(lines!["shared".human(), "base".human(), "tail".human(),]);
+    let base_commit = repo
+        .stage_all_and_commit("base")
+        .expect("base commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "base".human(), "tail".human(),]);
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "stale-source"])
+        .expect("checkout stale source should succeed");
+    file.replace_at(1, "source".ai());
+    let stale_source = repo
+        .stage_all_and_commit("AI stale source")
+        .expect("stale source commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "source".ai(), "tail".human(),]);
+
+    repo.git(&["checkout", &default_branch])
+        .expect("checkout default branch should succeed");
+    repo.git(&["checkout", "-b", "range-source"])
+        .expect("checkout range source should succeed");
+    file.replace_at(1, "source".human());
+    let range_source = repo
+        .stage_all_and_commit("Human range source")
+        .expect("range source commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "source".human(), "tail".human(),]);
+
+    repo.git(&["checkout", &default_branch])
+        .expect("checkout default branch should succeed");
+    file.replace_at(1, "main".human());
+    repo.stage_all_and_commit("main conflict")
+        .expect("main conflict commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "main".human(), "tail".human(),]);
+    drop(file);
+
+    repo.restart_dedicated_daemon_for_test();
+    fs::write(repo.path().join("conflict.txt"), "shared\ndirty\ntail\n")
+        .expect("write dirty working tree");
+    let stale_short_sha = &stale_source.commit_sha[..7];
+    let dirty_failure = repo.git_og(&["cherry-pick", stale_short_sha]);
+    assert!(
+        dirty_failure.is_err(),
+        "cherry-pick should fail before starting a sequencer"
+    );
+    repo.git_og(&["checkout", "--", "conflict.txt"])
+        .expect("restore main contents");
+
+    let source_range = format!("{}..{}", base_commit.commit_sha, range_source.commit_sha);
+    let range_cherry_pick = repo.git_og(&["cherry-pick", &source_range]);
+    assert!(
+        range_cherry_pick.is_err(),
+        "range cherry-pick should conflict"
+    );
+    fs::write(
+        repo.path().join("conflict.txt"),
+        "shared\nmain\nsource\ntail\n",
+    )
+    .expect("write conflict resolution");
+    repo.git_og(&["add", "conflict.txt"])
+        .expect("stage conflict resolution");
+    repo.git_og_with_env(&["cherry-pick", "--continue"], &[("GIT_EDITOR", "true")])
+        .expect("cherry-pick continue should succeed");
+
+    let dirty_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let range_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let continue_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let dirty_session_arg = format!("git-ai.testSyncSession={dirty_session}");
+    let range_session_arg = format!("git-ai.testSyncSession={range_session}");
+    let continue_session_arg = format!("git-ai.testSyncSession={continue_session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "failed-dirty-cherry-pick",
+                "argv": ["git", "-c", dirty_session_arg, "-C", worktree, "cherry-pick", stale_short_sha],
+                "time_ns": 1_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "failed-dirty-cherry-pick",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 1_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "failed-dirty-cherry-pick",
+                "code": 1,
+                "time_ns": 1_100u64,
+            }),
+            trace_atexit_frame("failed-dirty-cherry-pick", 1, 1_101u64),
+            json!({
+                "event": "start",
+                "sid": "delayed-range-cherry-pick",
+                "argv": ["git", "-c", range_session_arg, "-C", worktree, "cherry-pick", source_range],
+                "time_ns": 2_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "delayed-range-cherry-pick",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 2_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "delayed-range-cherry-pick",
+                "code": 1,
+                "time_ns": 2_100u64,
+            }),
+            trace_atexit_frame("delayed-range-cherry-pick", 1, 2_101u64),
+            json!({
+                "event": "start",
+                "sid": "delayed-range-cherry-pick-continue",
+                "argv": ["git", "-c", continue_session_arg, "-C", worktree, "cherry-pick", "--continue"],
+                "time_ns": 3_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "delayed-range-cherry-pick-continue",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 3_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "delayed-range-cherry-pick-continue",
+                "code": 0,
+                "time_ns": 3_100u64,
+            }),
+            trace_atexit_frame("delayed-range-cherry-pick-continue", 0, 3_101u64),
+        ],
+    );
+    repo.sync_daemon_external_completion_sessions(&[
+        dirty_session,
+        range_session,
+        continue_session,
+    ]);
+
+    let mut file = repo.filename("conflict.txt");
+    file.assert_lines_and_blame(lines![
+        "shared".human(),
+        "main".human(),
+        "source".unattributed_human(),
+        "tail".human(),
+    ]);
+}
+
+#[test]
 fn daemon_failed_rebase_does_not_consume_later_skip_reflog_entry() {
     let repo = TestRepo::new_dedicated_daemon();
     let trace_socket = daemon_trace_socket_path(&repo);

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2571,10 +2571,7 @@ fn daemon_failed_cherry_pick_source_does_not_leak_into_later_range_conflict() {
 
 #[test]
 fn daemon_cherry_pick_quit_clears_pending_source() {
-    let mut repo = TestRepo::new_dedicated_daemon();
-    let trace_socket = daemon_trace_socket_path(&repo);
-    let worktree = repo_workdir_string(&repo);
-    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+    let repo = TestRepo::new_dedicated_daemon();
 
     let mut file = repo.filename("conflict.txt");
     file.set_contents(lines!["shared".human(), "base".human(), "tail".human(),]);
@@ -2586,11 +2583,20 @@ fn daemon_cherry_pick_quit_clears_pending_source() {
 
     repo.git(&["checkout", "-b", "stale-source"])
         .expect("checkout stale source should succeed");
+    let mut sequence_file = repo.filename("sequence.txt");
+    sequence_file.set_contents(lines!["first source".human()]);
+    let first_source = repo
+        .stage_all_and_commit("First sequence source")
+        .expect("first sequence source commit should succeed");
+    sequence_file.assert_lines_and_blame(lines!["first source".human()]);
+    file.assert_lines_and_blame(lines!["shared".human(), "base".human(), "tail".human(),]);
+
     file.replace_at(1, "source".ai());
     let stale_source = repo
         .stage_all_and_commit("AI stale source")
         .expect("stale source commit should succeed");
     file.assert_lines_and_blame(lines!["shared".human(), "source".ai(), "tail".human(),]);
+    sequence_file.assert_lines_and_blame(lines!["first source".human()]);
 
     repo.git(&["checkout", &default_branch])
         .expect("checkout default branch should succeed");
@@ -2610,139 +2616,38 @@ fn daemon_cherry_pick_quit_clears_pending_source() {
     file.assert_lines_and_blame(lines!["shared".human(), "main".human(), "tail".human(),]);
     drop(file);
 
-    repo.restart_dedicated_daemon_for_test();
     let stale_short_sha = &stale_source.commit_sha[..7];
-    let stale_cherry_pick = repo.git_og(&["cherry-pick", stale_short_sha]);
+    let stale_cherry_pick = repo.git(&["cherry-pick", &first_source.commit_sha, stale_short_sha]);
     assert!(stale_cherry_pick.is_err(), "cherry-pick should conflict");
+    repo.sync_daemon();
 
-    let stale_session = repos::test_repo::new_daemon_test_sync_session_id();
-    let stale_session_arg = format!("git-ai.testSyncSession={stale_session}");
-    send_trace_frames(
-        &trace_socket,
-        &[
-            json!({
-                "event": "start",
-                "sid": "stale-conflicted-cherry-pick",
-                "argv": ["git", "-c", stale_session_arg, "-C", worktree, "cherry-pick", stale_short_sha],
-                "time_ns": 1_000u64,
-            }),
-            json!({
-                "event": "def_repo",
-                "sid": "stale-conflicted-cherry-pick",
-                "worktree": worktree,
-                "repo": git_dir,
-                "time_ns": 1_001u64,
-            }),
-            json!({
-                "event": "exit",
-                "sid": "stale-conflicted-cherry-pick",
-                "code": 1,
-                "time_ns": 1_100u64,
-            }),
-            trace_atexit_frame("stale-conflicted-cherry-pick", 1, 1_101u64),
-        ],
-    );
-    repo.sync_daemon_external_completion_sessions(&[stale_session]);
-
-    repo.git_og(&["cherry-pick", "--quit"])
+    repo.git(&["cherry-pick", "--quit"])
         .expect("cherry-pick quit should succeed");
-    let quit_session = repos::test_repo::new_daemon_test_sync_session_id();
-    let quit_session_arg = format!("git-ai.testSyncSession={quit_session}");
-    send_trace_frames(
-        &trace_socket,
-        &[
-            json!({
-                "event": "start",
-                "sid": "cherry-pick-quit",
-                "argv": ["git", "-c", quit_session_arg, "-C", worktree, "cherry-pick", "--quit"],
-                "time_ns": 2_000u64,
-            }),
-            json!({
-                "event": "def_repo",
-                "sid": "cherry-pick-quit",
-                "worktree": worktree,
-                "repo": git_dir,
-                "time_ns": 2_001u64,
-            }),
-            json!({
-                "event": "exit",
-                "sid": "cherry-pick-quit",
-                "code": 0,
-                "time_ns": 2_100u64,
-            }),
-            trace_atexit_frame("cherry-pick-quit", 0, 2_101u64),
-        ],
-    );
-    repo.sync_daemon_external_completion_sessions(&[quit_session]);
+    repo.sync_daemon();
     repo.git_og(&["reset", "--hard", "HEAD"])
         .expect("discard abandoned conflict");
 
     let source_range = format!("{}..{}", base_commit.commit_sha, range_source.commit_sha);
-    let range_cherry_pick = repo.git_og(&["cherry-pick", &source_range]);
+    let range_cherry_pick = repo.git(&["cherry-pick", &source_range]);
     assert!(
         range_cherry_pick.is_err(),
         "range cherry-pick should conflict"
     );
+    repo.sync_daemon();
     fs::write(
         repo.path().join("conflict.txt"),
         "shared\nmain\nsource\ntail\n",
     )
     .expect("write conflict resolution");
-    repo.git_og(&["add", "conflict.txt"])
+    repo.git(&["add", "conflict.txt"])
         .expect("stage conflict resolution");
-    repo.git_og_with_env(&["cherry-pick", "--continue"], &[("GIT_EDITOR", "true")])
-        .expect("cherry-pick continue should succeed");
-
-    let range_session = repos::test_repo::new_daemon_test_sync_session_id();
-    let continue_session = repos::test_repo::new_daemon_test_sync_session_id();
-    let range_session_arg = format!("git-ai.testSyncSession={range_session}");
-    let continue_session_arg = format!("git-ai.testSyncSession={continue_session}");
-    send_trace_frames(
-        &trace_socket,
-        &[
-            json!({
-                "event": "start",
-                "sid": "range-cherry-pick-after-quit",
-                "argv": ["git", "-c", range_session_arg, "-C", worktree, "cherry-pick", source_range],
-                "time_ns": 3_000u64,
-            }),
-            json!({
-                "event": "def_repo",
-                "sid": "range-cherry-pick-after-quit",
-                "worktree": worktree,
-                "repo": git_dir,
-                "time_ns": 3_001u64,
-            }),
-            json!({
-                "event": "exit",
-                "sid": "range-cherry-pick-after-quit",
-                "code": 1,
-                "time_ns": 3_100u64,
-            }),
-            trace_atexit_frame("range-cherry-pick-after-quit", 1, 3_101u64),
-            json!({
-                "event": "start",
-                "sid": "range-cherry-pick-continue-after-quit",
-                "argv": ["git", "-c", continue_session_arg, "-C", worktree, "cherry-pick", "--continue"],
-                "time_ns": 4_000u64,
-            }),
-            json!({
-                "event": "def_repo",
-                "sid": "range-cherry-pick-continue-after-quit",
-                "worktree": worktree,
-                "repo": git_dir,
-                "time_ns": 4_001u64,
-            }),
-            json!({
-                "event": "exit",
-                "sid": "range-cherry-pick-continue-after-quit",
-                "code": 0,
-                "time_ns": 4_100u64,
-            }),
-            trace_atexit_frame("range-cherry-pick-continue-after-quit", 0, 4_101u64),
-        ],
-    );
-    repo.sync_daemon_external_completion_sessions(&[range_session, continue_session]);
+    repo.git_with_env(
+        &["cherry-pick", "--continue"],
+        &[("GIT_EDITOR", "true")],
+        None,
+    )
+    .expect("cherry-pick continue should succeed");
+    repo.sync_daemon();
 
     let mut file = repo.filename("conflict.txt");
     file.assert_lines_and_blame(lines![

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2466,22 +2466,12 @@ fn daemon_failed_cherry_pick_source_does_not_leak_into_later_range_conflict() {
         range_cherry_pick.is_err(),
         "range cherry-pick should conflict"
     );
-    fs::write(
-        repo.path().join("conflict.txt"),
-        "shared\nmain\nsource\ntail\n",
-    )
-    .expect("write conflict resolution");
-    repo.git_og(&["add", "conflict.txt"])
-        .expect("stage conflict resolution");
-    repo.git_og_with_env(&["cherry-pick", "--continue"], &[("GIT_EDITOR", "true")])
-        .expect("cherry-pick continue should succeed");
 
+    // Process the earlier dirty-tree failure while the later range conflict is
+    // still live. Async side effects must not mistake the range sequencer for
+    // evidence that the dirty-tree command started a cherry-pick.
     let dirty_session = repos::test_repo::new_daemon_test_sync_session_id();
-    let range_session = repos::test_repo::new_daemon_test_sync_session_id();
-    let continue_session = repos::test_repo::new_daemon_test_sync_session_id();
     let dirty_session_arg = format!("git-ai.testSyncSession={dirty_session}");
-    let range_session_arg = format!("git-ai.testSyncSession={range_session}");
-    let continue_session_arg = format!("git-ai.testSyncSession={continue_session}");
     send_trace_frames(
         &trace_socket,
         &[
@@ -2505,6 +2495,27 @@ fn daemon_failed_cherry_pick_source_does_not_leak_into_later_range_conflict() {
                 "time_ns": 1_100u64,
             }),
             trace_atexit_frame("failed-dirty-cherry-pick", 1, 1_101u64),
+        ],
+    );
+    repo.sync_daemon_external_completion_sessions(&[dirty_session]);
+
+    fs::write(
+        repo.path().join("conflict.txt"),
+        "shared\nmain\nsource\ntail\n",
+    )
+    .expect("write conflict resolution");
+    repo.git_og(&["add", "conflict.txt"])
+        .expect("stage conflict resolution");
+    repo.git_og_with_env(&["cherry-pick", "--continue"], &[("GIT_EDITOR", "true")])
+        .expect("cherry-pick continue should succeed");
+
+    let range_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let continue_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let range_session_arg = format!("git-ai.testSyncSession={range_session}");
+    let continue_session_arg = format!("git-ai.testSyncSession={continue_session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
             json!({
                 "event": "start",
                 "sid": "delayed-range-cherry-pick",
@@ -2547,11 +2558,191 @@ fn daemon_failed_cherry_pick_source_does_not_leak_into_later_range_conflict() {
             trace_atexit_frame("delayed-range-cherry-pick-continue", 0, 3_101u64),
         ],
     );
-    repo.sync_daemon_external_completion_sessions(&[
-        dirty_session,
-        range_session,
-        continue_session,
+    repo.sync_daemon_external_completion_sessions(&[range_session, continue_session]);
+
+    let mut file = repo.filename("conflict.txt");
+    file.assert_lines_and_blame(lines![
+        "shared".human(),
+        "main".human(),
+        "source".unattributed_human(),
+        "tail".human(),
     ]);
+}
+
+#[test]
+fn daemon_cherry_pick_quit_clears_pending_source() {
+    let mut repo = TestRepo::new_dedicated_daemon();
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    let mut file = repo.filename("conflict.txt");
+    file.set_contents(lines!["shared".human(), "base".human(), "tail".human(),]);
+    let base_commit = repo
+        .stage_all_and_commit("base")
+        .expect("base commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "base".human(), "tail".human(),]);
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "stale-source"])
+        .expect("checkout stale source should succeed");
+    file.replace_at(1, "source".ai());
+    let stale_source = repo
+        .stage_all_and_commit("AI stale source")
+        .expect("stale source commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "source".ai(), "tail".human(),]);
+
+    repo.git(&["checkout", &default_branch])
+        .expect("checkout default branch should succeed");
+    repo.git(&["checkout", "-b", "range-source"])
+        .expect("checkout range source should succeed");
+    file.replace_at(1, "source".human());
+    let range_source = repo
+        .stage_all_and_commit("Human range source")
+        .expect("range source commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "source".human(), "tail".human(),]);
+
+    repo.git(&["checkout", &default_branch])
+        .expect("checkout default branch should succeed");
+    file.replace_at(1, "main".human());
+    repo.stage_all_and_commit("main conflict")
+        .expect("main conflict commit should succeed");
+    file.assert_lines_and_blame(lines!["shared".human(), "main".human(), "tail".human(),]);
+    drop(file);
+
+    repo.restart_dedicated_daemon_for_test();
+    let stale_short_sha = &stale_source.commit_sha[..7];
+    let stale_cherry_pick = repo.git_og(&["cherry-pick", stale_short_sha]);
+    assert!(stale_cherry_pick.is_err(), "cherry-pick should conflict");
+
+    let stale_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let stale_session_arg = format!("git-ai.testSyncSession={stale_session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "stale-conflicted-cherry-pick",
+                "argv": ["git", "-c", stale_session_arg, "-C", worktree, "cherry-pick", stale_short_sha],
+                "time_ns": 1_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "stale-conflicted-cherry-pick",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 1_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "stale-conflicted-cherry-pick",
+                "code": 1,
+                "time_ns": 1_100u64,
+            }),
+            trace_atexit_frame("stale-conflicted-cherry-pick", 1, 1_101u64),
+        ],
+    );
+    repo.sync_daemon_external_completion_sessions(&[stale_session]);
+
+    repo.git_og(&["cherry-pick", "--quit"])
+        .expect("cherry-pick quit should succeed");
+    let quit_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let quit_session_arg = format!("git-ai.testSyncSession={quit_session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "cherry-pick-quit",
+                "argv": ["git", "-c", quit_session_arg, "-C", worktree, "cherry-pick", "--quit"],
+                "time_ns": 2_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "cherry-pick-quit",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 2_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "cherry-pick-quit",
+                "code": 0,
+                "time_ns": 2_100u64,
+            }),
+            trace_atexit_frame("cherry-pick-quit", 0, 2_101u64),
+        ],
+    );
+    repo.sync_daemon_external_completion_sessions(&[quit_session]);
+    repo.git_og(&["reset", "--hard", "HEAD"])
+        .expect("discard abandoned conflict");
+
+    let source_range = format!("{}..{}", base_commit.commit_sha, range_source.commit_sha);
+    let range_cherry_pick = repo.git_og(&["cherry-pick", &source_range]);
+    assert!(
+        range_cherry_pick.is_err(),
+        "range cherry-pick should conflict"
+    );
+    fs::write(
+        repo.path().join("conflict.txt"),
+        "shared\nmain\nsource\ntail\n",
+    )
+    .expect("write conflict resolution");
+    repo.git_og(&["add", "conflict.txt"])
+        .expect("stage conflict resolution");
+    repo.git_og_with_env(&["cherry-pick", "--continue"], &[("GIT_EDITOR", "true")])
+        .expect("cherry-pick continue should succeed");
+
+    let range_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let continue_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let range_session_arg = format!("git-ai.testSyncSession={range_session}");
+    let continue_session_arg = format!("git-ai.testSyncSession={continue_session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "range-cherry-pick-after-quit",
+                "argv": ["git", "-c", range_session_arg, "-C", worktree, "cherry-pick", source_range],
+                "time_ns": 3_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "range-cherry-pick-after-quit",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 3_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "range-cherry-pick-after-quit",
+                "code": 1,
+                "time_ns": 3_100u64,
+            }),
+            trace_atexit_frame("range-cherry-pick-after-quit", 1, 3_101u64),
+            json!({
+                "event": "start",
+                "sid": "range-cherry-pick-continue-after-quit",
+                "argv": ["git", "-c", continue_session_arg, "-C", worktree, "cherry-pick", "--continue"],
+                "time_ns": 4_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "range-cherry-pick-continue-after-quit",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 4_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "range-cherry-pick-continue-after-quit",
+                "code": 0,
+                "time_ns": 4_100u64,
+            }),
+            trace_atexit_frame("range-cherry-pick-continue-after-quit", 0, 4_101u64),
+        ],
+    );
+    repo.sync_daemon_external_completion_sessions(&[range_session, continue_session]);
 
     let mut file = repo.filename("conflict.txt");
     file.assert_lines_and_blame(lines![

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -332,6 +332,14 @@ fn test_cherry_pick_with_conflict_and_continue() {
         "AI_FEATURE_VERSION".ai(),
         "Line 3".human(),
     ]);
+
+    let stats = repo.stats().unwrap();
+    let tool_model = stats
+        .tool_model_breakdown
+        .get("mock_ai::unknown")
+        .expect("conflicted cherry-pick should preserve source session metadata");
+    assert_eq!(tool_model.ai_additions, 1);
+    assert_eq!(tool_model.ai_accepted, 1);
 }
 
 /// Test cherry-pick --abort


### PR DESCRIPTION
Fixes #1385

## Summary

- Recover a single explicit cherry-pick source after delayed async processing while limiting post-sequence lookup to literal hexadecimal object IDs.
- Treat failed picks without command-bounded HEAD progress as speculative, so a queued dirty-tree failure cannot block a later real conflict from replacing its source.
- Clear pending cherry-pick sources on abort, quit, and terminal successful skip controls.
- Preserve the existing bounded fallback for active conflicts whose refs are absent from the daemon snapshot.

## Test coverage

- Added delayed trace2 conflict/continue coverage with a short source SHA.
- Added a queued dirty-tree failure regression processed while a later range conflict is live.
- Added a quit-abandoned conflict regression and unit coverage for immutable source lookup plus terminal controls.
- Ran task test, task lint, and task fmt.