### PR TITLE
Refuse daemon startup in agent sandboxes

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -3,6 +3,7 @@ use crate::daemon::{
     ControlRequest, DaemonConfig, local_socket_connects_with_timeout, read_daemon_pid,
     remove_stale_daemon_files, send_control_request, send_control_request_with_timeout,
 };
+use crate::sandbox::ensure_daemon_start_allowed;
 use crate::utils::LockFile;
 #[cfg(windows)]
 use crate::utils::{CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
@@ -106,6 +107,8 @@ fn ensure_daemon_running_attached(timeout: Duration) -> Result<DaemonConfig, Str
         return Ok(config);
     }
 
+    ensure_daemon_start_allowed()?;
+
     remove_stale_daemon_files(&config);
 
     if daemon_startup_is_blocked(&config) {
@@ -177,6 +180,7 @@ fn handle_run(args: &[String]) -> Result<(), String> {
     if has_flag(args, "--mode") {
         return Err("--mode is no longer supported; daemon always runs in write mode".to_string());
     }
+    ensure_daemon_start_allowed()?;
     let config = daemon_config_from_env_or_default_paths()?;
     let runtime_dir = daemon_runtime_dir(&config)?;
     std::env::set_current_dir(&runtime_dir).map_err(|e| {
@@ -309,6 +313,8 @@ fn start_daemon_detached_with_config(
     if daemon_is_up(&config) {
         return Ok(config);
     }
+
+    ensure_daemon_start_allowed()?;
 
     remove_stale_daemon_files(&config);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod notes;
 pub mod observability;
 pub mod process_timeout;
 pub mod repo_url;
+pub(crate) mod sandbox;
 pub mod sqlite;
 pub mod streams;
 pub mod tokio_runtime;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,28 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SandboxRestriction {
+    pub(crate) env_var: &'static str,
+    pub(crate) name: &'static str,
+}
+
+pub(crate) fn sandbox_restriction() -> Option<SandboxRestriction> {
+    [
+        ("CURSOR_SANDBOX", "Cursor"),
+        ("SANDBOX_RUNTIME", "Claude Code"),
+        ("CODEX_SANDBOX", "Codex"),
+        ("CODEX_SANDBOX_NETWORK_DISABLED", "Codex"),
+    ]
+    .into_iter()
+    .find(|(env_var, _)| std::env::var_os(env_var).is_some())
+    .map(|(env_var, name)| SandboxRestriction { env_var, name })
+}
+
+pub(crate) fn ensure_daemon_start_allowed() -> Result<(), String> {
+    let Some(restriction) = sandbox_restriction() else {
+        return Ok(());
+    };
+
+    Err(format!(
+        "cannot start the daemon inside the {} sandbox ({} is set)",
+        restriction.name, restriction.env_var
+    ))
+}

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -10,7 +10,6 @@ use git_ai::commands::checkpoint_agent::orchestrator::{
 use git_ai::config::{NotesBackendConfig, NotesBackendKind};
 #[cfg(not(windows))]
 use git_ai::daemon::checkpoint::PreparedPathRole;
-#[cfg(not(windows))]
 use git_ai::daemon::send_control_request_with_timeout;
 use git_ai::daemon::{
     ControlRequest, DaemonConfig, DaemonLock, local_socket_connects_with_timeout,
@@ -914,6 +913,57 @@ fn daemon_start_spawns_detached_run_process() {
         &daemon_control_socket_path(&repo),
         &ControlRequest::Shutdown,
     );
+}
+
+#[test]
+#[serial]
+fn daemon_refuses_to_start_in_sandbox() {
+    for (env_var, sandbox) in [
+        ("CURSOR_SANDBOX", "Cursor"),
+        ("SANDBOX_RUNTIME", "Claude Code"),
+        ("CODEX_SANDBOX", "Codex"),
+        ("CODEX_SANDBOX_NETWORK_DISABLED", "Codex"),
+    ] {
+        let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+
+        for subcommand in ["start", "run"] {
+            let output = bg_command_with_env(&repo, subcommand, &[], &[(env_var, "1")]);
+            if output.status.success() {
+                let _ = send_control_request(
+                    &daemon_control_socket_path(&repo),
+                    &ControlRequest::Shutdown,
+                );
+            }
+
+            assert!(
+                !output.status.success(),
+                "daemon {subcommand} should fail in the {sandbox} sandbox"
+            );
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                stderr.contains(&format!("{sandbox} sandbox")) && stderr.contains(env_var),
+                "daemon {subcommand} should explain the sandbox refusal: {stderr}"
+            );
+        }
+
+        assert!(
+            send_control_request_with_timeout(
+                &daemon_control_socket_path(&repo),
+                &ControlRequest::Ping,
+                DAEMON_TEST_PROBE_TIMEOUT,
+            )
+            .is_err(),
+            "daemon control socket should not be available"
+        );
+        assert!(
+            local_socket_connects_with_timeout(
+                &daemon_trace_socket_path(&repo),
+                DAEMON_TEST_PROBE_TIMEOUT,
+            )
+            .is_err(),
+            "daemon trace socket should not be available"
+        );
+    }
 }
 
 #[test]
@@ -4522,6 +4572,15 @@ fn daemon_memory_does_not_grow_unbounded_under_trace_load() {
 }
 
 fn bg_command(repo: &TestRepo, subcommand: &str, extra_args: &[&str]) -> Output {
+    bg_command_with_env(repo, subcommand, extra_args, &[])
+}
+
+fn bg_command_with_env(
+    repo: &TestRepo,
+    subcommand: &str,
+    extra_args: &[&str],
+    env: &[(&str, &str)],
+) -> Output {
     let daemon_home = repo.daemon_home_path();
     let control_socket_path = daemon_control_socket_path(repo);
     let trace_socket_path = daemon_trace_socket_path(repo);
@@ -4534,6 +4593,9 @@ fn bg_command(repo: &TestRepo, subcommand: &str, extra_args: &[&str]) -> Output 
         .current_dir(repo.path())
         .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
         .env("GITAI_TEST_DB_PATH", repo.test_db_path());
+    for (key, value) in env {
+        command.env(key, value);
+    }
     configure_test_home_env(&mut command, repo.test_home_path());
     configure_test_daemon_env(
         &mut command,


### PR DESCRIPTION
## Summary

- add a centralized daemon startup policy guard for Cursor, Claude Code, and Codex sandboxes
- reject `CURSOR_SANDBOX`, `SANDBOX_RUNTIME`, `CODEX_SANDBOX`, and `CODEX_SANDBOX_NETWORK_DISABLED` when any variable is present
- apply the guard to direct runs and attached or detached startup paths so every platform reports the refusal immediately
- identify the triggering environment variable and sandbox provider in the error

## Why

The daemon must not inherit an agent sandbox environment. Keeping the checks in one small startup-policy function makes the current behavior explicit and provides a simple extension point for additional sandbox rules.

## Validation

- `task test TEST_FILTER=daemon_refuses_to_start_in_sandbox`
- `task fmt`
- `task lint`
- `task test`

The expanded regression was added first and failed on `SANDBOX_RUNTIME` before the implementation was updated. It covers both `bg start` and `bg run`, provider-specific stderr, and absence of daemon control and trace endpoints.
