### PR TITLE
Recover attribution from sandboxed checkpoints

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -8,7 +8,7 @@ use crate::daemon::bash_history_db::{BashCheckpointCall, distance_to_call_window
 use crate::error::GitAiError;
 use crate::git::repo_state::worktree_root_for_path;
 use crate::git::repository::{Repository, exec_git};
-use crate::metrics::db::SessionEventRecoveryCandidate;
+use crate::metrics::db::{AttributionRecoveryCandidate, AttributionRecoveryCandidateSource};
 use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded};
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -18,7 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASH_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
 const BASH_RECOVERY_COARSE_TIMESTAMP_NS: u128 = 1_000_000_000;
-pub(crate) const SESSION_EVENT_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
+pub(crate) const METRIC_RECOVERY_WINDOW_NS: u128 = 3_000_000_000;
 const EDGE_EXTENSION_MAX_LINES: usize = 3;
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
@@ -242,7 +242,7 @@ pub(crate) fn recover_attribution(
         before_external_recovery(&unknown_after_edges);
     }
 
-    recover_session_event_mtime(
+    recover_metric_mtime(
         repo,
         parent_sha,
         commit_sha,
@@ -264,7 +264,7 @@ pub(crate) fn recover_attribution(
     Ok(())
 }
 
-pub(crate) fn matching_session_event_candidate_exists(
+pub(crate) fn matching_metric_recovery_candidate_exists(
     timestamps_ns: &[u128],
     target_repo_url: &str,
 ) -> Result<bool, GitAiError> {
@@ -274,16 +274,19 @@ pub(crate) fn matching_session_event_candidate_exists(
 
     let candidates = match crate::metrics::db::MetricsDatabase::global() {
         Ok(db) => match db.lock() {
-            Ok(db) => db.session_event_candidates_near_timestamps(
+            Ok(db) => db.attribution_recovery_candidates_near_timestamps(
                 timestamps_ns,
-                SESSION_EVENT_RECOVERY_WINDOW_NS,
+                METRIC_RECOVERY_WINDOW_NS,
             )?,
             Err(_) => Vec::new(),
         },
         Err(_) => Vec::new(),
     };
 
-    Ok(select_best_session_event_candidate(&candidates, timestamps_ns, target_repo_url).is_some())
+    Ok(
+        select_best_metric_recovery_candidate(&candidates, timestamps_ns, target_repo_url)
+            .is_some(),
+    )
 }
 
 fn recover_bash_mtime(
@@ -401,7 +404,7 @@ fn recover_bash_mtime(
     Ok(())
 }
 
-fn recover_session_event_mtime(
+fn recover_metric_mtime(
     repo: &Repository,
     parent_sha: &str,
     commit_sha: &str,
@@ -437,9 +440,9 @@ fn recover_session_event_mtime(
 
     let candidates = match crate::metrics::db::MetricsDatabase::global() {
         Ok(db) => match db.lock() {
-            Ok(db) => db.session_event_candidates_near_timestamps(
+            Ok(db) => db.attribution_recovery_candidates_near_timestamps(
                 &all_timestamps,
-                SESSION_EVENT_RECOVERY_WINDOW_NS,
+                METRIC_RECOVERY_WINDOW_NS,
             )?,
             Err(_) => Vec::new(),
         },
@@ -457,23 +460,37 @@ fn recover_session_event_mtime(
             continue;
         };
         let Some(selection) =
-            select_best_session_event_candidate(&candidates, timestamps, &target_repo_url)
+            select_best_metric_recovery_candidate(&candidates, timestamps, &target_repo_url)
         else {
             continue;
         };
-        if selection.distance_ns > SESSION_EVENT_RECOVERY_WINDOW_NS {
+        if selection.distance_ns > METRIC_RECOVERY_WINDOW_NS {
             continue;
         }
 
         let candidate = selection.candidate;
         let trace_id = generate_trace_id();
         let author_id = format!("{}::{}", candidate.session_id, trace_id);
-        insert_session_event_record(authorship_log, candidate, human_author);
+        insert_metric_recovery_session_record(authorship_log, candidate, human_author);
         add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
 
-        let selected_model = session_event_model(candidate);
+        let selected_model = metric_recovery_model(candidate);
+        let (solver, edit_kind, checkpoint_type) = match candidate.source {
+            AttributionRecoveryCandidateSource::SessionEvent => (
+                "session_event_mtime",
+                "attribution_recovery_session_event",
+                "recovered_session_event_mtime",
+            ),
+            AttributionRecoveryCandidateSource::SandboxedBashCheckpoint
+            | AttributionRecoveryCandidateSource::SandboxedFileEditCheckpoint => (
+                "sandboxed_checkpoint_mtime",
+                "attribution_recovery_sandboxed_checkpoint",
+                "recovered_sandboxed_checkpoint_mtime",
+            ),
+        };
         let metadata = json!({
-            "solver": "session_event_mtime",
+            "solver": solver,
+            "candidate_source": recovery_candidate_source_name(candidate.source),
             "file_path": file_path.as_str(),
             "unknown_lines": &unknown_lines,
             "file_timestamps_ns": timestamps,
@@ -487,7 +504,7 @@ fn recover_session_event_mtime(
             "selected_repo_url": candidate.repo_url.as_deref(),
             "target_repo_url": target_repo_url.as_str(),
             "distance_ns": selection.distance_ns,
-            "window_ns": SESSION_EVENT_RECOVERY_WINDOW_NS,
+            "window_ns": METRIC_RECOVERY_WINDOW_NS,
             "selection_tier": selection.tier.as_str(),
             "candidate_count": candidates.len(),
         });
@@ -503,8 +520,8 @@ fn recover_session_event_mtime(
             model: &selected_model,
             external_session_id: &candidate.external_session_id,
             external_tool_use_id: candidate.external_tool_use_id.as_deref(),
-            edit_kind: "attribution_recovery_session_event",
-            checkpoint_type: "recovered_session_event_mtime",
+            edit_kind,
+            checkpoint_type,
             recovered_line_count: unknown_lines.len() as u32,
             metadata,
             event_ts: Some(candidate.event_ts),
@@ -927,7 +944,7 @@ impl CommitMetadataMetricRepoTier {
 }
 
 fn commit_metadata_metric_repo_tier(
-    candidate: &SessionEventRecoveryCandidate,
+    candidate: &AttributionRecoveryCandidate,
     target_repo_url: Option<&str>,
 ) -> Option<CommitMetadataMetricRepoTier> {
     match (target_repo_url, candidate.repo_url.as_deref()) {
@@ -960,9 +977,9 @@ fn select_nearest_commit_metadata_metric_session(
 
     let candidates = match crate::metrics::db::MetricsDatabase::global() {
         Ok(db) => match db.lock() {
-            Ok(db) => db.session_event_candidates_near_timestamps(
+            Ok(db) => db.attribution_recovery_candidates_near_timestamps(
                 latest_timestamps,
-                SESSION_EVENT_RECOVERY_WINDOW_NS,
+                METRIC_RECOVERY_WINDOW_NS,
             )?,
             Err(_) => Vec::new(),
         },
@@ -977,6 +994,9 @@ fn select_nearest_commit_metadata_metric_session(
         CommitMetadataSessionSelection,
     )> = None;
     for candidate in &candidates {
+        if candidate.source != AttributionRecoveryCandidateSource::SessionEvent {
+            continue;
+        }
         let Some((detection_index, _)) = detections
             .iter()
             .enumerate()
@@ -984,10 +1004,10 @@ fn select_nearest_commit_metadata_metric_session(
         else {
             continue;
         };
-        let Some(distance_ns) = session_event_distance(candidate, latest_timestamps) else {
+        let Some(distance_ns) = metric_recovery_distance(candidate, latest_timestamps) else {
             continue;
         };
-        if distance_ns > SESSION_EVENT_RECOVERY_WINDOW_NS {
+        if distance_ns > METRIC_RECOVERY_WINDOW_NS {
             continue;
         }
         let Some(repo_tier) = commit_metadata_metric_repo_tier(candidate, target_repo_url) else {
@@ -1067,7 +1087,7 @@ fn select_latest_commit_metadata_metric_session(
 }
 
 fn commit_metadata_selection_from_metric_candidate(
-    candidate: &SessionEventRecoveryCandidate,
+    candidate: &AttributionRecoveryCandidate,
     tier: &'static str,
     distance_ns: Option<u128>,
 ) -> CommitMetadataSessionSelection {
@@ -1076,7 +1096,7 @@ fn commit_metadata_selection_from_metric_candidate(
         agent_id: AgentId {
             tool: candidate.tool.clone(),
             id: candidate.external_session_id.clone(),
-            model: session_event_model(candidate),
+            model: metric_recovery_model(candidate),
         },
         tier,
         metric_row_id: Some(candidate.row_id),
@@ -1323,16 +1343,16 @@ fn bash_candidate_session_id(candidate: &BashCheckpointCall) -> String {
     generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool)
 }
 
-fn select_best_session_event_candidate<'a>(
-    candidates: &'a [SessionEventRecoveryCandidate],
+fn select_best_metric_recovery_candidate<'a>(
+    candidates: &'a [AttributionRecoveryCandidate],
     timestamps: &[u128],
     target_repo_url: &str,
-) -> Option<SessionEventCandidateSelection<'a>> {
+) -> Option<MetricRecoveryCandidateSelection<'a>> {
     let matching_candidates = candidates
         .iter()
         .filter_map(|candidate| {
-            let distance_ns = session_event_distance(candidate, timestamps)?;
-            if distance_ns > SESSION_EVENT_RECOVERY_WINDOW_NS {
+            let distance_ns = metric_recovery_distance(candidate, timestamps)?;
+            if distance_ns > METRIC_RECOVERY_WINDOW_NS {
                 return None;
             }
             Some((candidate, distance_ns))
@@ -1345,8 +1365,8 @@ fn select_best_session_event_candidate<'a>(
     matching_candidates
         .into_iter()
         .filter_map(|(candidate, distance_ns)| {
-            let tier = session_event_candidate_tier(candidate, target_repo_url)?;
-            Some(SessionEventCandidateSelection {
+            let tier = metric_recovery_candidate_tier(candidate, target_repo_url)?;
+            Some(MetricRecoveryCandidateSelection {
                 candidate,
                 distance_ns,
                 tier,
@@ -1361,18 +1381,18 @@ fn select_best_session_event_candidate<'a>(
         })
 }
 
-struct SessionEventCandidateSelection<'a> {
-    candidate: &'a SessionEventRecoveryCandidate,
+struct MetricRecoveryCandidateSelection<'a> {
+    candidate: &'a AttributionRecoveryCandidate,
     distance_ns: u128,
-    tier: SessionEventCandidateTier,
+    tier: MetricRecoveryCandidateTier,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SessionEventCandidateTier {
+enum MetricRecoveryCandidateTier {
     SameRepoUrl,
 }
 
-impl SessionEventCandidateTier {
+impl MetricRecoveryCandidateTier {
     fn score(self) -> u8 {
         match self {
             Self::SameRepoUrl => 0,
@@ -1386,16 +1406,16 @@ impl SessionEventCandidateTier {
     }
 }
 
-fn session_event_candidate_tier(
-    candidate: &SessionEventRecoveryCandidate,
+fn metric_recovery_candidate_tier(
+    candidate: &AttributionRecoveryCandidate,
     target_repo_url: &str,
-) -> Option<SessionEventCandidateTier> {
+) -> Option<MetricRecoveryCandidateTier> {
     (candidate.repo_url.as_deref() == Some(target_repo_url))
-        .then_some(SessionEventCandidateTier::SameRepoUrl)
+        .then_some(MetricRecoveryCandidateTier::SameRepoUrl)
 }
 
-fn session_event_distance(
-    candidate: &SessionEventRecoveryCandidate,
+fn metric_recovery_distance(
+    candidate: &AttributionRecoveryCandidate,
     timestamps: &[u128],
 ) -> Option<u128> {
     timestamps
@@ -1478,9 +1498,9 @@ fn insert_session_record(
         });
 }
 
-fn insert_session_event_record(
+fn insert_metric_recovery_session_record(
     authorship_log: &mut AuthorshipLog,
-    candidate: &SessionEventRecoveryCandidate,
+    candidate: &AttributionRecoveryCandidate,
     human_author: &str,
 ) {
     authorship_log
@@ -1491,19 +1511,29 @@ fn insert_session_event_record(
             agent_id: AgentId {
                 tool: candidate.tool.clone(),
                 id: candidate.external_session_id.clone(),
-                model: session_event_model(candidate),
+                model: metric_recovery_model(candidate),
             },
             human_author: Some(human_author.to_string()),
             custom_attributes: None,
         });
 }
 
-fn session_event_model(candidate: &SessionEventRecoveryCandidate) -> String {
+fn metric_recovery_model(candidate: &AttributionRecoveryCandidate) -> String {
     candidate
         .model
         .clone()
         .filter(|model| !model.is_empty())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn recovery_candidate_source_name(source: AttributionRecoveryCandidateSource) -> &'static str {
+    match source {
+        AttributionRecoveryCandidateSource::SessionEvent => "session_event",
+        AttributionRecoveryCandidateSource::SandboxedBashCheckpoint => "sandboxed_bash_checkpoint",
+        AttributionRecoveryCandidateSource::SandboxedFileEditCheckpoint => {
+            "sandboxed_file_edit_checkpoint"
+        }
+    }
 }
 
 fn unknown_lines_by_file(
@@ -1821,8 +1851,8 @@ mod tests {
         external_session_id: &str,
         event_ts: u32,
         repo_url: Option<&str>,
-    ) -> crate::metrics::db::SessionEventRecoveryCandidate {
-        crate::metrics::db::SessionEventRecoveryCandidate {
+    ) -> crate::metrics::db::AttributionRecoveryCandidate {
+        crate::metrics::db::AttributionRecoveryCandidate {
             row_id,
             event_ts,
             session_id: session_id.to_string(),
@@ -1832,6 +1862,7 @@ mod tests {
             external_session_id: external_session_id.to_string(),
             external_tool_use_id: Some(format!("tool-use-{row_id}")),
             repo_url: repo_url.map(ToString::to_string),
+            source: crate::metrics::db::AttributionRecoveryCandidateSource::SessionEvent,
         }
     }
 
@@ -1998,7 +2029,7 @@ mod tests {
             ),
         ];
 
-        let selection = select_best_session_event_candidate(
+        let selection = select_best_metric_recovery_candidate(
             &candidates,
             &[timestamp_ns],
             "https://github.com/acme/repo",
@@ -2006,7 +2037,7 @@ mod tests {
         .expect("expected session-event candidate");
 
         assert_eq!(selection.candidate.session_id, "s_matching_repo");
-        assert_eq!(selection.tier, SessionEventCandidateTier::SameRepoUrl);
+        assert_eq!(selection.tier, MetricRecoveryCandidateTier::SameRepoUrl);
     }
 
     #[test]
@@ -2020,7 +2051,7 @@ mod tests {
             None,
         )];
 
-        let selection = select_best_session_event_candidate(
+        let selection = select_best_metric_recovery_candidate(
             &candidates,
             &[timestamp_ns],
             "https://github.com/acme/repo",
@@ -2044,7 +2075,7 @@ mod tests {
             Some("https://github.com/acme/repo"),
         )];
 
-        let selection = select_best_session_event_candidate(
+        let selection = select_best_metric_recovery_candidate(
             &candidates,
             &[timestamp_ns],
             "https://github.com/acme/repo",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2684,7 +2684,7 @@ impl ActorDaemonCoordinator {
         completion
     }
 
-    fn wait_for_session_event_recovery_candidate(
+    fn wait_for_metric_recovery_candidate(
         &self,
         repo: &Repository,
         commit_sha: &str,
@@ -2749,12 +2749,12 @@ impl ActorDaemonCoordinator {
         };
 
         let has_candidate = || {
-            crate::authorship::attribution_recovery::matching_session_event_candidate_exists(
+            crate::authorship::attribution_recovery::matching_metric_recovery_candidate_exists(
                 &timestamps,
                 &target_repo_url,
             )
             .unwrap_or_else(|error| {
-                tracing::debug!(%error, "failed checking session-event recovery candidates");
+                tracing::debug!(%error, "failed checking metric recovery candidates");
                 false
             })
         };
@@ -5536,7 +5536,7 @@ impl ActorDaemonCoordinator {
                             )
                             .await;
                             let recovery_preflight = |unknown_by_file: &crate::authorship::attribution_recovery::UnknownLinesByFile| {
-                                self.wait_for_session_event_recovery_candidate(
+                                self.wait_for_metric_recovery_candidate(
                                     &repo,
                                     new_head,
                                     recovery_file_timestamps.as_ref(),
@@ -5599,7 +5599,7 @@ impl ActorDaemonCoordinator {
                             )
                             .await;
                             let recovery_preflight = |unknown_by_file: &crate::authorship::attribution_recovery::UnknownLinesByFile| {
-                                self.wait_for_session_event_recovery_candidate(
+                                self.wait_for_metric_recovery_candidate(
                                     &repo,
                                     new_head,
                                     recovery_file_timestamps.as_ref(),

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -112,8 +112,15 @@ pub struct MetricHistoryRecord {
     pub event: MetricEvent,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttributionRecoveryCandidateSource {
+    SessionEvent,
+    SandboxedBashCheckpoint,
+    SandboxedFileEditCheckpoint,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SessionEventRecoveryCandidate {
+pub(crate) struct AttributionRecoveryCandidate {
     pub row_id: i64,
     pub event_ts: u32,
     pub session_id: String,
@@ -123,6 +130,7 @@ pub(crate) struct SessionEventRecoveryCandidate {
     pub external_session_id: String,
     pub external_tool_use_id: Option<String>,
     pub repo_url: Option<String>,
+    pub source: AttributionRecoveryCandidateSource,
 }
 
 /// Point-in-time status summary for local metric delivery.
@@ -994,11 +1002,11 @@ impl MetricsDatabase {
         Ok(records)
     }
 
-    pub(crate) fn session_event_candidates_near_timestamps(
+    pub(crate) fn attribution_recovery_candidates_near_timestamps(
         &self,
         timestamps_ns: &[u128],
         window_ns: u128,
-    ) -> Result<Vec<SessionEventRecoveryCandidate>, GitAiError> {
+    ) -> Result<Vec<AttributionRecoveryCandidate>, GitAiError> {
         if timestamps_ns.is_empty() {
             return Ok(Vec::new());
         }
@@ -1014,6 +1022,7 @@ impl MetricsDatabase {
             SELECT
                 id,
                 event_json,
+                event_kind,
                 event_ts,
                 session_id,
                 trace_id,
@@ -1021,9 +1030,9 @@ impl MetricsDatabase {
                 external_session_id,
                 external_tool_use_id
             FROM metrics
-            WHERE event_kind = ?1
-              AND event_ts >= ?2
-              AND event_ts <= ?3
+            WHERE event_kind IN (?1, ?2)
+              AND event_ts >= ?3
+              AND event_ts <= ?4
               AND session_id IS NOT NULL
               AND session_id != ''
               AND tool IS NOT NULL
@@ -1037,6 +1046,7 @@ impl MetricsDatabase {
         let rows = stmt.query_map(
             params![
                 MetricEventId::SessionEvent as i64,
+                MetricEventId::Checkpoint as i64,
                 min_event_ts as i64,
                 max_event_ts as i64
             ],
@@ -1045,11 +1055,12 @@ impl MetricsDatabase {
                     row.get::<_, i64>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, i64>(2)?,
-                    row.get::<_, String>(3)?,
-                    row.get::<_, Option<String>>(4)?,
-                    row.get::<_, String>(5)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, Option<String>>(5)?,
                     row.get::<_, String>(6)?,
-                    row.get::<_, Option<String>>(7)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, Option<String>>(8)?,
                 ))
             },
         )?;
@@ -1059,6 +1070,7 @@ impl MetricsDatabase {
             let (
                 row_id,
                 event_json,
+                event_kind,
                 event_ts,
                 session_id,
                 trace_id,
@@ -1069,6 +1081,11 @@ impl MetricsDatabase {
             if event_ts < 0 || event_ts > u32::MAX as i64 {
                 continue;
             }
+            let Some((source, repo_url, model)) =
+                parse_attribution_recovery_candidate(&event_json, event_kind)
+            else {
+                continue;
+            };
             let event_ts = event_ts as u32;
             if min_distance_to_event_ts(timestamps_ns, event_ts)
                 .is_none_or(|distance| distance > window_ns)
@@ -1076,8 +1093,7 @@ impl MetricsDatabase {
                 continue;
             }
 
-            let (repo_url, model) = recovery_attrs_from_event_json(&event_json);
-            candidates.push(SessionEventRecoveryCandidate {
+            candidates.push(AttributionRecoveryCandidate {
                 row_id,
                 event_ts,
                 session_id,
@@ -1087,6 +1103,7 @@ impl MetricsDatabase {
                 external_session_id,
                 external_tool_use_id,
                 repo_url,
+                source,
             });
         }
 
@@ -1096,7 +1113,7 @@ impl MetricsDatabase {
     pub(crate) fn latest_session_event_candidates_for_tools(
         &self,
         tools: &[&str],
-    ) -> Result<Vec<SessionEventRecoveryCandidate>, GitAiError> {
+    ) -> Result<Vec<AttributionRecoveryCandidate>, GitAiError> {
         if tools.is_empty() {
             return Ok(Vec::new());
         }
@@ -1172,7 +1189,7 @@ impl MetricsDatabase {
             }
 
             let (repo_url, model) = recovery_attrs_from_event_json(&event_json);
-            candidates.push(SessionEventRecoveryCandidate {
+            candidates.push(AttributionRecoveryCandidate {
                 row_id,
                 event_ts: event_ts as u32,
                 session_id,
@@ -1182,6 +1199,7 @@ impl MetricsDatabase {
                 external_session_id,
                 external_tool_use_id,
                 repo_url,
+                source: AttributionRecoveryCandidateSource::SessionEvent,
             });
         }
 
@@ -1391,6 +1409,60 @@ fn recovery_attrs_from_event_json(event_json: &str) -> (Option<String>, Option<S
         sparse_object_string(attrs, attr_pos::REPO_URL),
         sparse_object_string(attrs, attr_pos::MODEL),
     )
+}
+
+fn parse_attribution_recovery_candidate(
+    event_json: &str,
+    event_kind: i64,
+) -> Option<(
+    AttributionRecoveryCandidateSource,
+    Option<String>,
+    Option<String>,
+)> {
+    let value = serde_json::from_str::<Value>(event_json).ok()?;
+    let attrs = value.get("a").and_then(Value::as_object);
+    let repo_url = sparse_object_string(attrs, attr_pos::REPO_URL);
+    let model = sparse_object_string(attrs, attr_pos::MODEL);
+
+    if event_kind == MetricEventId::SessionEvent as i64 {
+        return Some((
+            AttributionRecoveryCandidateSource::SessionEvent,
+            repo_url,
+            model,
+        ));
+    }
+    if event_kind != MetricEventId::Checkpoint as i64 {
+        return None;
+    }
+
+    let values = value.get("v").and_then(Value::as_object);
+    if sparse_object_string(values, checkpoint_pos::KIND).as_deref() != Some("ai_agent")
+        || sparse_object_string(values, checkpoint_pos::CHECKPOINT_TYPE).as_deref()
+            != Some("sandboxed_fallback")
+    {
+        return None;
+    }
+    let phase = sparse_object_string(values, checkpoint_pos::ATTRIBUTION_RECOVERY_METADATA)
+        .and_then(|metadata| serde_json::from_str::<Value>(&metadata).ok())
+        .and_then(|metadata| {
+            metadata
+                .get("phase")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+    let source = match (
+        sparse_object_string(values, checkpoint_pos::EDIT_KIND).as_deref(),
+        phase.as_deref(),
+    ) {
+        (Some("bash_sandboxed"), Some("pre" | "post")) => {
+            AttributionRecoveryCandidateSource::SandboxedBashCheckpoint
+        }
+        (Some("file_edit_sandboxed"), Some("post")) => {
+            AttributionRecoveryCandidateSource::SandboxedFileEditCheckpoint
+        }
+        _ => return None,
+    };
+    Some((source, repo_url, model))
 }
 
 fn metric_row_is_older_than_cutoff(
@@ -2170,8 +2242,41 @@ mod tests {
         )
     }
 
+    fn sandboxed_checkpoint_json(
+        ts: u32,
+        session_id: &str,
+        edit_kind: &str,
+        phase: &str,
+        file_path: Option<&str>,
+    ) -> String {
+        use crate::metrics::{CheckpointValues, EventAttributes, PosEncoded};
+
+        let mut values = CheckpointValues::new()
+            .checkpoint_ts(ts.into())
+            .kind("ai_agent")
+            .edit_kind(edit_kind)
+            .checkpoint_type("sandboxed_fallback")
+            .attribution_recovery_metadata(serde_json::json!({ "phase": phase }).to_string());
+        if let Some(file_path) = file_path {
+            values = values.file_path(file_path);
+        }
+        let attrs = EventAttributes::with_version("test")
+            .repo_url("https://github.com/acme/repo")
+            .tool("codex")
+            .model("gpt-5")
+            .external_session_id(format!("external-{session_id}"))
+            .session_id(session_id)
+            .trace_id(format!("trace-{session_id}"));
+        serde_json::to_string(&MetricEvent::from_values_with_timestamp(
+            values,
+            attrs.to_sparse(),
+            Some(ts),
+        ))
+        .unwrap()
+    }
+
     #[test]
-    fn test_session_event_candidates_near_timestamps_filters_kind_and_window() {
+    fn test_attribution_recovery_candidates_near_timestamps_filters_kind_and_window() {
         let (mut db, _temp_dir) = create_test_db();
         let base_ts = seconds_ago(60);
         let events = vec![
@@ -2202,7 +2307,7 @@ mod tests {
 
         let timestamp_ns = (base_ts as u128 * 1_000_000_000) + 500_000_000;
         let candidates = db
-            .session_event_candidates_near_timestamps(&[timestamp_ns], 3_000_000_000)
+            .attribution_recovery_candidates_near_timestamps(&[timestamp_ns], 3_000_000_000)
             .unwrap();
 
         assert_eq!(candidates.len(), 1);
@@ -2226,7 +2331,7 @@ mod tests {
 
         let timestamp_ns = base_ts as u128 * NS_PER_SECOND + 3_500_000_000;
         let candidates = db
-            .session_event_candidates_near_timestamps(&[timestamp_ns], 3_000_000_000)
+            .attribution_recovery_candidates_near_timestamps(&[timestamp_ns], 3_000_000_000)
             .unwrap();
 
         assert_eq!(candidates.len(), 1);
@@ -2258,7 +2363,7 @@ mod tests {
 
         let timestamp_ns = ts as u128 * 1_000_000_000;
         let candidates = db
-            .session_event_candidates_near_timestamps(&[timestamp_ns], 3_000_000_000)
+            .attribution_recovery_candidates_near_timestamps(&[timestamp_ns], 3_000_000_000)
             .unwrap();
 
         assert_eq!(candidates.len(), 1);
@@ -2278,6 +2383,48 @@ mod tests {
         assert_eq!(
             candidate.repo_url.as_deref(),
             Some("https://github.com/acme/repo")
+        );
+    }
+
+    #[test]
+    fn test_recovery_candidates_include_eligible_sandboxed_checkpoints() {
+        let (mut db, _temp_dir) = create_test_db();
+        let ts = seconds_ago(30);
+        db.insert_events(&[
+            sandboxed_checkpoint_json(ts, "bash-pre", "bash_sandboxed", "pre", None),
+            sandboxed_checkpoint_json(
+                ts,
+                "file-post",
+                "file_edit_sandboxed",
+                "post",
+                Some("src/lib.rs"),
+            ),
+            sandboxed_checkpoint_json(
+                ts,
+                "file-pre",
+                "file_edit_sandboxed",
+                "pre",
+                Some("src/ignored.rs"),
+            ),
+            sandboxed_checkpoint_json(ts, "other", "file_edit", "post", Some("src/other.rs")),
+        ])
+        .unwrap();
+
+        let candidates = db
+            .attribution_recovery_candidates_near_timestamps(
+                &[ts as u128 * NS_PER_SECOND],
+                3 * NS_PER_SECOND,
+            )
+            .unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            candidates[0].source,
+            AttributionRecoveryCandidateSource::SandboxedBashCheckpoint
+        );
+        assert_eq!(
+            candidates[1].source,
+            AttributionRecoveryCandidateSource::SandboxedFileEditCheckpoint
         );
     }
 

--- a/tests/integration/sandboxed_checkpoints.rs
+++ b/tests/integration/sandboxed_checkpoints.rs
@@ -1,6 +1,8 @@
+use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use git_ai::metrics::db::MetricsDatabase;
-use git_ai::metrics::{CheckpointValues, PosEncoded};
+use git_ai::metrics::types::MetricEventId;
+use git_ai::metrics::{CheckpointValues, MetricEvent, PosEncoded};
 use git_ai::sandboxed_checkpoints::{
     SandboxedCheckpointKind, SandboxedCheckpointPhase, SandboxedCheckpointRecord,
 };
@@ -35,6 +37,37 @@ fn checkpoint_files(dir: &Path) -> Vec<std::path::PathBuf> {
         .collect::<Vec<_>>();
     paths.sort();
     paths
+}
+
+fn wait_for_checkpoint_metrics(
+    metrics_path: &Path,
+    edit_kind: &str,
+    expected_count: usize,
+) -> Vec<MetricEvent> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let db = MetricsDatabase::open_at_path(metrics_path).unwrap();
+        let records = db
+            .get_metric_history(0, None, &[MetricEventId::Checkpoint as u16])
+            .unwrap();
+        let events = records
+            .into_iter()
+            .map(|record| record.event)
+            .filter(|event| {
+                let values = CheckpointValues::from_sparse(&event.values);
+                values.edit_kind.as_ref().and_then(|value| value.as_deref()) == Some(edit_kind)
+            })
+            .collect::<Vec<_>>();
+        if events.len() >= expected_count {
+            return events;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected {expected_count} {edit_kind} checkpoint metrics, found {}",
+            events.len()
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[test]
@@ -144,23 +177,10 @@ fn daemon_imports_sandboxed_checkpoint_into_metrics_database() {
     )
     .unwrap();
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let event = loop {
-        let db = MetricsDatabase::open_at_path(&metrics_path).unwrap();
-        let records = db.get_metric_history(0, None, &[4]).unwrap();
-        if let Some(record) = records.into_iter().find(|record| {
-            let values = CheckpointValues::from_sparse(&record.event.values);
-            values.edit_kind.as_ref().and_then(|value| value.as_deref())
-                == Some("file_edit_sandboxed")
-        }) {
-            break record.event;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "daemon did not import checkpoint"
-        );
-        thread::sleep(Duration::from_millis(25));
-    };
+    let event = wait_for_checkpoint_metrics(&metrics_path, "file_edit_sandboxed", 1)
+        .into_iter()
+        .next()
+        .unwrap();
 
     let values = CheckpointValues::from_sparse(&event.values);
     assert_eq!(
@@ -190,5 +210,148 @@ fn daemon_imports_sandboxed_checkpoint_into_metrics_database() {
     assert!(
         checkpoint_files(spool.path()).is_empty(),
         "a healthy daemon should use the normal checkpoint flow"
+    );
+}
+
+#[test]
+fn sandboxed_file_edit_checkpoint_recovers_ai_attribution() {
+    let spool = tempfile::tempdir().unwrap();
+    let metrics = tempfile::tempdir().unwrap();
+    let metrics_path = metrics.path().join("metrics.db");
+    let metrics_path_string = metrics_path.to_string_lossy().to_string();
+    let spool_path_string = spool.path().to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[
+        (
+            "GIT_AI_TEST_SANDBOX_CHECKPOINT_DIR",
+            spool_path_string.as_str(),
+        ),
+        ("GIT_AI_TEST_SANDBOX_CHECKPOINT_POLL_MS", "10"),
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_path_string.as_str()),
+    ]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/sandboxed-file-recovery.git",
+    ])
+    .unwrap();
+
+    let file_path = repo.path().join("generated.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    fs::write(&file_path, "base\nAI file edit\n").unwrap();
+
+    let hook_input = codex_hook_input(&repo, "sandboxed-file-session");
+    repo.git_ai_with_env(
+        &["checkpoint", "codex", "--hook-input", &hook_input],
+        &[
+            ("CODEX_SANDBOX", "1"),
+            (
+                "GIT_AI_TEST_SANDBOX_CHECKPOINT_DIR",
+                spool_path_string.as_str(),
+            ),
+        ],
+    )
+    .unwrap();
+    wait_for_checkpoint_metrics(&metrics_path, "file_edit_sandboxed", 1);
+
+    let commit = repo.stage_all_and_commit("Sandboxed file edit").unwrap();
+    let mut file = repo.filename("generated.txt");
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI file edit".ai(),
+    ]);
+    assert!(
+        commit
+            .authorship_log
+            .metadata
+            .sessions
+            .values()
+            .any(|session| {
+                session.agent_id.tool == "codex" && session.agent_id.id == "sandboxed-file-session"
+            })
+    );
+    wait_for_checkpoint_metrics(
+        &metrics_path,
+        "attribution_recovery_sandboxed_checkpoint",
+        1,
+    );
+}
+
+#[test]
+fn sandboxed_bash_checkpoints_recover_ai_attribution() {
+    let spool = tempfile::tempdir().unwrap();
+    let metrics = tempfile::tempdir().unwrap();
+    let metrics_path = metrics.path().join("metrics.db");
+    let metrics_path_string = metrics_path.to_string_lossy().to_string();
+    let spool_path_string = spool.path().to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[
+        (
+            "GIT_AI_TEST_SANDBOX_CHECKPOINT_DIR",
+            spool_path_string.as_str(),
+        ),
+        ("GIT_AI_TEST_SANDBOX_CHECKPOINT_POLL_MS", "10"),
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_path_string.as_str()),
+    ]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/sandboxed-bash-recovery.git",
+    ])
+    .unwrap();
+
+    let file_path = repo.path().join("generated.txt");
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    for hook_event_name in ["PreToolUse", "PostToolUse"] {
+        if hook_event_name == "PostToolUse" {
+            fs::write(&file_path, "base\nAI bash edit\n").unwrap();
+        }
+        let hook_input = json!({
+            "session_id": "sandboxed-bash-session",
+            "cwd": repo.canonical_path(),
+            "hook_event_name": hook_event_name,
+            "tool_name": "shell_command",
+            "tool_use_id": "bash-tool-use-1",
+            "model": "gpt-5",
+            "tool_input": { "command": "printf 'AI bash edit\\n' >> generated.txt" }
+        })
+        .to_string();
+        repo.git_ai_with_env(
+            &["checkpoint", "codex", "--hook-input", &hook_input],
+            &[
+                ("CODEX_SANDBOX", "1"),
+                (
+                    "GIT_AI_TEST_SANDBOX_CHECKPOINT_DIR",
+                    spool_path_string.as_str(),
+                ),
+            ],
+        )
+        .unwrap();
+    }
+    wait_for_checkpoint_metrics(&metrics_path, "bash_sandboxed", 2);
+
+    let commit = repo.stage_all_and_commit("Sandboxed bash edit").unwrap();
+    let mut file = repo.filename("generated.txt");
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI bash edit".ai(),
+    ]);
+    assert!(
+        commit
+            .authorship_log
+            .metadata
+            .sessions
+            .values()
+            .any(|session| {
+                session.agent_id.tool == "codex" && session.agent_id.id == "sandboxed-bash-session"
+            })
+    );
+    wait_for_checkpoint_metrics(
+        &metrics_path,
+        "attribution_recovery_sandboxed_checkpoint",
+        1,
     );
 }


### PR DESCRIPTION
## Summary

- Treat imported sandboxed Bash and post-file-edit checkpoint metrics as candidates in the existing repo-and-mtime attribution recovery flow.
- Preserve the shared candidate ranking and session attribution logic while keeping commit-metadata recovery restricted to session events.
- Add TestRepo E2Es proving both sandboxed file edits and Bash edits are marked as likely AI code after commit.

## Testing

- `task build`
- `task fmt`
- `task lint`
- `task test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->