### PR TITLE
fix: preserve attribution across autocrlf commits

### DIFF
--- a/src/authorship/imara_diff_utils.rs
+++ b/src/authorship/imara_diff_utils.rs
@@ -258,10 +258,41 @@ pub fn compute_line_changes<'a>(old: &'a str, new: &'a str) -> Vec<LineChange<'a
 /// index alignment between normalized diff hunks and original line arrays in
 /// `compute_line_changes`.
 pub(crate) fn normalize_line_endings(s: &str) -> std::borrow::Cow<'_, str> {
-    if !s.contains('\r') {
+    if !s.contains("\r\n") {
         return std::borrow::Cow::Borrowed(s);
     }
     std::borrow::Cow::Owned(s.replace("\r\n", "\n"))
+}
+
+/// Compare two strings while treating CRLF and LF line endings as equivalent.
+pub(crate) fn content_eq_ignoring_line_endings(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+
+    fn next_normalized_byte(bytes: &[u8], index: &mut usize) -> Option<u8> {
+        let byte = *bytes.get(*index)?;
+        *index += 1;
+        if byte == b'\r' && bytes.get(*index) == Some(&b'\n') {
+            *index += 1;
+            Some(b'\n')
+        } else {
+            Some(byte)
+        }
+    }
+
+    let mut a_index = 0;
+    let mut b_index = 0;
+    loop {
+        match (
+            next_normalized_byte(a.as_bytes(), &mut a_index),
+            next_normalized_byte(b.as_bytes(), &mut b_index),
+        ) {
+            (Some(a_byte), Some(b_byte)) if a_byte == b_byte => {}
+            (None, None) => return true,
+            _ => return false,
+        }
+    }
 }
 
 /// Splits a string into lines, preserving line terminators.
@@ -509,6 +540,23 @@ mod tests {
     // ====================================================================
     // CRLF / LF normalization tests
     // ====================================================================
+
+    #[test]
+    fn test_normalize_line_endings_does_not_allocate_for_bare_carriage_returns() {
+        let normalized = normalize_line_endings("one\rtwo");
+
+        assert!(matches!(normalized, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn test_content_eq_ignoring_line_endings() {
+        assert!(content_eq_ignoring_line_endings(
+            "one\r\ntwo\nthree\r\n",
+            "one\ntwo\r\nthree\n"
+        ));
+        assert!(!content_eq_ignoring_line_endings("one\rtwo", "one\ntwo"));
+        assert!(!content_eq_ignoring_line_endings("one\n", "two\n"));
+    }
 
     #[test]
     fn test_compute_line_changes_crlf_to_lf_identical_content() {

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -4,6 +4,9 @@ use crate::authorship::attribution_tracker::{
 };
 use crate::authorship::authorship_log::{HumanRecord, LineRange, PromptRecord, SessionRecord};
 use crate::authorship::hunk_shift::{DiffHunk, apply_hunk_shifts_to_line_attributions};
+use crate::authorship::imara_diff_utils::{
+    content_eq_ignoring_line_endings, normalize_line_endings,
+};
 use crate::authorship::working_log::CheckpointKind;
 use crate::commands::blame::{GitAiBlameOptions, OLDEST_AI_BLAME_DATE};
 use crate::error::GitAiError;
@@ -1386,12 +1389,14 @@ fn collect_unstaged_hunks_from_snapshot(
             .cloned()
             .unwrap_or_else(|| committed_content.clone());
 
-        if committed_content == final_content {
+        if content_eq_ignoring_line_endings(&committed_content, &final_content) {
             continue;
         }
 
-        let committed_lines = split_lines_preserving_terminators(&committed_content);
-        let final_lines = split_lines_preserving_terminators(&final_content);
+        let normalized_committed = normalize_line_endings(&committed_content);
+        let normalized_final = normalize_line_endings(&final_content);
+        let committed_lines = split_lines_preserving_terminators(&normalized_committed);
+        let final_lines = split_lines_preserving_terminators(&normalized_final);
         let diff_ops = crate::authorship::imara_diff_utils::capture_diff_slices(
             &committed_lines,
             &final_lines,
@@ -1460,8 +1465,10 @@ fn split_lines_preserving_terminators(s: &str) -> Vec<&str> {
 }
 
 fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
-    let old_lines = split_lines_preserving_terminators(old_content);
-    let new_lines = split_lines_preserving_terminators(new_content);
+    let normalized_old = normalize_line_endings(old_content);
+    let normalized_new = normalize_line_endings(new_content);
+    let old_lines = split_lines_preserving_terminators(&normalized_old);
+    let new_lines = split_lines_preserving_terminators(&normalized_new);
     crate::authorship::imara_diff_utils::capture_diff_slices(&old_lines, &new_lines)
         .into_iter()
         .filter_map(|op| match op {
@@ -1502,13 +1509,15 @@ fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<Diff
 }
 
 fn line_sequence_contains(needle: &str, haystack: &str) -> bool {
-    let needle_lines = split_lines_preserving_terminators(needle);
+    let normalized_needle = normalize_line_endings(needle);
+    let normalized_haystack = normalize_line_endings(haystack);
+    let needle_lines = split_lines_preserving_terminators(&normalized_needle);
     if needle_lines.is_empty() {
         return true;
     }
 
     let mut next_needle = 0;
-    for haystack_line in split_lines_preserving_terminators(haystack) {
+    for haystack_line in split_lines_preserving_terminators(&normalized_haystack) {
         if haystack_line == needle_lines[next_needle] {
             next_needle += 1;
             if next_needle == needle_lines.len() {
@@ -1526,8 +1535,8 @@ fn merged_carryover_content_pure(
     committed_content: &str,
     observed_content: &str,
 ) -> String {
-    if committed_content == observed_content {
-        return observed_content.to_string();
+    if content_eq_ignoring_line_endings(committed_content, observed_content) {
+        return committed_content.to_string();
     }
     if line_sequence_contains(committed_content, observed_content) {
         return observed_content.to_string();
@@ -1535,10 +1544,10 @@ fn merged_carryover_content_pure(
     if line_sequence_contains(observed_content, committed_content) {
         return committed_content.to_string();
     }
-    if committed_content == parent_content {
+    if content_eq_ignoring_line_endings(committed_content, parent_content) {
         return observed_content.to_string();
     }
-    if observed_content == parent_content {
+    if content_eq_ignoring_line_endings(observed_content, parent_content) {
         return committed_content.to_string();
     }
     carryover_merge_content(parent_content, committed_content, observed_content)
@@ -1556,24 +1565,31 @@ fn merged_carryover_content_pure(
 fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> String {
     use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
 
-    if committed == observed {
+    if content_eq_ignoring_line_endings(committed, observed) {
+        return committed.to_string();
+    }
+    if content_eq_ignoring_line_endings(parent, committed) {
         return observed.to_string();
     }
-    if parent == committed {
-        return observed.to_string();
-    }
-    if parent == observed {
+    if content_eq_ignoring_line_endings(parent, observed) {
         return committed.to_string();
     }
 
     let base_lines = split_lines_preserving_terminators(parent);
     let committed_lines = split_lines_preserving_terminators(committed);
     let observed_lines = split_lines_preserving_terminators(observed);
+    let normalized_parent = normalize_line_endings(parent);
+    let normalized_committed = normalize_line_endings(committed);
+    let normalized_observed = normalize_line_endings(observed);
+    let base_cmp_lines = split_lines_preserving_terminators(&normalized_parent);
+    let committed_cmp_lines = split_lines_preserving_terminators(&normalized_committed);
+    let observed_cmp_lines = split_lines_preserving_terminators(&normalized_observed);
 
     // For each side, map every base line index to its aligned index on that
     // side (None if the base line was changed/deleted on that side). Also record
     // each side's content so we can emit it for changed chunks.
-    fn align_to_base(base_len: usize, base: &[&str], side: &[&str]) -> Vec<Option<usize>> {
+    fn align_to_base(base: &[&str], side: &[&str]) -> Vec<Option<usize>> {
+        let base_len = base.len();
         let mut map = vec![None; base_len];
         for op in capture_diff_slices(base, side) {
             if let DiffOp::Equal {
@@ -1590,8 +1606,8 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
         map
     }
 
-    let committed_map = align_to_base(base_lines.len(), &base_lines, &committed_lines);
-    let observed_map = align_to_base(base_lines.len(), &base_lines, &observed_lines);
+    let committed_map = align_to_base(&base_cmp_lines, &committed_cmp_lines);
+    let observed_map = align_to_base(&base_cmp_lines, &observed_cmp_lines);
 
     // A base line is "stable" when both sides keep it aligned (unchanged on
     // both). We walk base lines; runs of stable lines are emitted verbatim,
@@ -1636,7 +1652,9 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
             // Resolve pending region: if both sides inserted differing content,
             // favor observed; else take whichever inserted.
             if !c_pending.is_empty() && !o_pending.is_empty() {
-                if c_pending == o_pending {
+                if committed_cmp_lines[committed_i..c_anchor]
+                    == observed_cmp_lines[observed_i..o_anchor]
+                {
                     result.extend(c_pending);
                 } else {
                     result.extend(o_pending);
@@ -1681,8 +1699,11 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
                 .iter()
                 .map(|s| (*s).to_string())
                 .collect();
-            let committed_changed = committed_chunk != base_chunk;
-            let observed_changed = observed_chunk != base_chunk;
+            let base_cmp_chunk = &base_cmp_lines[chunk_base_start..base_i];
+            let committed_cmp_chunk = &committed_cmp_lines[committed_i..c_anchor];
+            let observed_cmp_chunk = &observed_cmp_lines[observed_i..o_anchor];
+            let committed_changed = committed_cmp_chunk != base_cmp_chunk;
+            let observed_changed = observed_cmp_chunk != base_cmp_chunk;
 
             match (committed_changed, observed_changed) {
                 (true, false) => result.extend(committed_chunk),
@@ -1690,7 +1711,7 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
                 (true, true) => {
                     // Two-sided change → favor observed (matches --theirs),
                     // unless both produced identical content.
-                    if committed_chunk == observed_chunk {
+                    if committed_cmp_chunk == observed_cmp_chunk {
                         result.extend(committed_chunk);
                     } else {
                         result.extend(observed_chunk);
@@ -1714,7 +1735,7 @@ fn carryover_merge_content(parent: &str, committed: &str, observed: &str) -> Str
         .map(|s| (*s).to_string())
         .collect();
     if !c_tail.is_empty() && !o_tail.is_empty() {
-        if c_tail == o_tail {
+        if committed_cmp_lines[committed_i..] == observed_cmp_lines[observed_i..] {
             result.extend(c_tail);
         } else {
             result.extend(o_tail);
@@ -3652,6 +3673,31 @@ mod tests {
         assert_eq!(
             carryover_merge_content(parent, committed, observed),
             "a\nB\n"
+        );
+    }
+
+    #[test]
+    fn carryover_merge_ignores_mixed_eol_when_content_matches_committed() {
+        let parent = "base one\nbase two\n";
+        let committed = "base one\nbase two\nai line\n";
+        let observed = "base one\r\nbase two\r\nai line\n";
+
+        assert_eq!(
+            merged_carryover_content_pure(parent, committed, observed),
+            committed
+        );
+        assert!(diff_hunks_between_contents(observed, committed).is_empty());
+    }
+
+    #[test]
+    fn carryover_merge_does_not_treat_crlf_only_observed_chunk_as_change() {
+        let parent = "a\nb\nc\n";
+        let committed = "A\nb\nC\n";
+        let observed = "a\r\nb\r\nD\r\n";
+
+        assert_eq!(
+            carryover_merge_content(parent, committed, observed),
+            "A\nb\nD\r\n"
         );
     }
 

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -5,7 +5,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 #[cfg(not(any(test, feature = "test-support")))]
 use crate::authorship::authorship_log_serialization::generate_short_hash;
 use crate::authorship::imara_diff_utils::{
-    LineChangeTag, compute_line_changes, normalize_line_endings,
+    LineChangeTag, compute_line_changes, content_eq_ignoring_line_endings,
 };
 use crate::authorship::working_log::CheckpointKind;
 use crate::authorship::working_log::{Checkpoint, WorkingLogEntry};
@@ -524,14 +524,6 @@ fn get_previous_content_from_head(
     }
 }
 
-/// Compare file contents ignoring CRLF/LF differences.
-fn content_eq_normalized(a: &str, b: &str) -> bool {
-    if a == b {
-        return true;
-    }
-    normalize_line_endings(a) == normalize_line_endings(b)
-}
-
 #[doc(hidden)]
 pub fn is_ai_author_id(author_id: &str) -> bool {
     author_id != "human" && !author_id.starts_with("h_")
@@ -621,7 +613,7 @@ fn get_checkpoint_entry_for_file(
             get_previous_content_from_head(&repo, &file_path, head_tree_id.as_ref())
         };
 
-        if content_eq_normalized(&current_content, &previous_content) {
+        if content_eq_ignoring_line_endings(&current_content, &previous_content) {
             return Ok(None);
         }
 
@@ -651,7 +643,7 @@ fn get_checkpoint_entry_for_file(
 
         // Skip if no changes, UNLESS we have INITIAL attributions for this file
         // (in which case we need to create an entry to record those attributions)
-        if content_eq_normalized(&current_content, &previous_content)
+        if content_eq_ignoring_line_endings(&current_content, &previous_content)
             && initial_attrs_for_file.is_empty()
         {
             return Ok(None);
@@ -682,7 +674,7 @@ fn get_checkpoint_entry_for_file(
             let snapshot = initial_snapshot_content
                 .as_deref()
                 .unwrap_or(&previous_content);
-            if content_eq_normalized(snapshot, &current_content) {
+            if content_eq_ignoring_line_endings(snapshot, &current_content) {
                 &previous_content
             } else {
                 snapshot
@@ -743,7 +735,7 @@ fn get_checkpoint_entry_for_file(
 
     // Skip if no changes (but we already checked this earlier, accounting for INITIAL attributions)
     // For files from previous checkpoints, check if content has changed
-    if is_from_checkpoint && content_eq_normalized(&current_content, &previous_content) {
+    if is_from_checkpoint && content_eq_ignoring_line_endings(&current_content, &previous_content) {
         if current_content == previous_content {
             // Byte-identical — truly no change.
             return Ok(None);

--- a/tests/integration/checkpoint_unit.rs
+++ b/tests/integration/checkpoint_unit.rs
@@ -1131,7 +1131,7 @@ fn test_checkpoint_crlf_blob_vs_lf_working_tree_stats_not_inflated() {
 #[test]
 fn test_checkpoint_crlf_blob_vs_lf_working_tree_no_changes_skipped() {
     // When the only difference is CRLF→LF (no actual content change),
-    // the checkpoint should skip the file entirely — content_eq_normalized
+    // the checkpoint should skip the file entirely — normalized comparison
     // detects they're equal and returns None.
     let repo = TestRepo::new();
     let crlf_content = "line1\r\nline2\r\nline3\r\n";
@@ -1161,7 +1161,7 @@ fn test_checkpoint_crlf_blob_vs_lf_working_tree_no_changes_skipped() {
     let checkpoints = working_log.read_all_checkpoints().unwrap();
 
     // The checkpoint may be empty (no entries) or absent entirely,
-    // because content_eq_normalized correctly detected no real change.
+    // because normalized comparison correctly detected no real change.
     if let Some(latest) = checkpoints.last() {
         let test_entry = latest.entries.iter().find(|e| e.file == "test.txt");
         assert!(

--- a/tests/integration/daemon_commit_carryover.rs
+++ b/tests/integration/daemon_commit_carryover.rs
@@ -114,3 +114,49 @@ fn test_checkpointed_carryover_survives_uncheckpointed_append() {
     expected.extend((19..=20).map(|line| format!("line {line}").human()));
     file.assert_lines_and_blame(expected);
 }
+
+#[test]
+fn test_autocrlf_worktree_preserves_ai_attribution_after_commit() {
+    let repo = TestRepo::new();
+    repo.git_og(&["config", "core.autocrlf", "true"]).unwrap();
+
+    let file_path = repo.path().join("s.dart");
+    let mut file = repo.filename("s.dart");
+    fs::write(
+        &file_path,
+        "class A {\n  void a() {}\n  void b() {}\n  void c() {}\n}\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("baseline").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "class A {".unattributed_human(),
+        "  void a() {}".unattributed_human(),
+        "  void b() {}".unattributed_human(),
+        "  void c() {}".unattributed_human(),
+        "}".unattributed_human(),
+    ]);
+
+    fs::write(
+        &file_path,
+        "class A {\r\n  void a() {}\r\n  void b() {}\r\n  void c() {}\r\n  void ai1() {}\r\n  void ai2() {}\r\n  void ai3() {}\r\n}\r\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "s.dart"]).unwrap();
+    repo.stage_all_and_commit("ai adds three methods").unwrap();
+
+    file.assert_committed_lines(crate::lines![
+        "class A {".unattributed_human(),
+        "  void a() {}".unattributed_human(),
+        "  void b() {}".unattributed_human(),
+        "  void c() {}".unattributed_human(),
+        "  void ai1() {}".ai(),
+        "  void ai2() {}".ai(),
+        "  void ai3() {}".ai(),
+        "}".unattributed_human(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(stats.ai_additions, 3);
+    assert_eq!(stats.ai_accepted, 3);
+    assert_eq!(stats.unknown_additions, 0);
+}


### PR DESCRIPTION
## Summary

- treat CRLF and LF as equivalent throughout post-commit virtual attribution and carryover comparisons
- reuse one shared, allocation-free content equality helper while normalizing whole snapshots only when line-based diffing requires it
- add a `TestRepo` end-to-end regression covering `core.autocrlf=true`, committed blame, and `git-ai stats`

## Root cause

The immutable commit snapshot/carryover path introduced in v1.5.9 compared raw snapshot bytes. With `core.autocrlf=true`, the working snapshot contains CRLF while the committed blob contains LF, so identical lines were interpreted as unstaged or conflicting carryover and their AI attribution was lost. The pre-commit status path already handled EOL normalization, which explains the status/stats mismatch.

This fix changes only in-memory comparisons and adds no Git calls, object lookups, file reads, or ingestion-path work. Equality checks use constant auxiliary memory; line-based diff paths allocate at most one normalized string per CRLF-bearing snapshot and otherwise borrow the original content.

## Validation

- `task fmt`
- `task lint`
- `task build`
- `task test`
- focused CRLF, mixed-EOL carryover, and allocation fast-path tests

The exact Ubuntu reproduction fails before this change and reports all three additions as AI-authored after it.