### PR TITLE
perf(telemetry): skip client setup when no metrics are pending

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -692,6 +692,21 @@ fn flush_metrics(events: &[MetricEvent]) {
 }
 
 fn flush_pending_metrics() {
+    let retryable_metrics_ready = MetricsDatabase::global()
+        .and_then(|db| {
+            db.lock()
+                .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))
+        })
+        .and_then(|mut db| db.has_retryable_for_upload());
+    match retryable_metrics_ready {
+        Ok(true) => {}
+        Ok(false) => return,
+        Err(e) => {
+            tracing::warn!(%e, "telemetry: failed to inspect pending metrics");
+            return;
+        }
+    }
+
     let context = ApiContext::new(None);
     let api_base_url = context.base_url.clone();
     let client = ApiClient::new(context);

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -759,6 +759,24 @@ impl MetricsDatabase {
         Ok(count as usize)
     }
 
+    /// Return whether at least one metric is currently eligible for upload.
+    ///
+    /// Stale processing locks must be released here, before callers decide
+    /// whether to enter the upload path, so a crashed upload can still recover.
+    pub(crate) fn has_retryable_for_upload(&mut self) -> Result<bool, GitAiError> {
+        let now = current_unix_ts();
+        self.release_stale_processing_locks(now)?;
+        self.conn
+            .query_row(
+                RETRYABLE_METRIC_IDS_SQL,
+                params![now as i64, 1_i64],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map(|id| id.is_some())
+            .map_err(GitAiError::SqliteError)
+    }
+
     /// Summarize local metrics delivery state for user-facing diagnostics.
     pub fn status(&self) -> Result<MetricsStatus, GitAiError> {
         let now = current_unix_ts();
@@ -2598,6 +2616,48 @@ mod tests {
         let second_batch = db.dequeue_pending_batch(1).unwrap();
         assert_eq!(second_batch.len(), 1);
         assert_eq!(second_batch[0].id, first_batch[0].id);
+    }
+
+    #[test]
+    fn test_retryable_upload_readiness_releases_stale_processing_locks() {
+        let (mut db, _temp_dir) = create_test_db();
+        assert!(!db.has_retryable_for_upload().unwrap());
+
+        let ids = db.insert_events(&[event_json(days_ago(1))]).unwrap();
+        assert!(db.has_retryable_for_upload().unwrap());
+
+        db.conn
+            .execute(
+                "UPDATE metrics SET processing_started_at = ?1 WHERE id = ?2",
+                params![unix_now() as i64, ids[0]],
+            )
+            .unwrap();
+        assert!(!db.has_retryable_for_upload().unwrap());
+
+        let stale_started_at = unix_now().saturating_sub(METRIC_PROCESSING_LOCK_TIMEOUT_SECS + 1);
+        db.conn
+            .execute(
+                "UPDATE metrics SET processing_started_at = ?1 WHERE id = ?2",
+                params![stale_started_at as i64, ids[0]],
+            )
+            .unwrap();
+        assert!(db.has_retryable_for_upload().unwrap());
+
+        db.conn
+            .execute(
+                "UPDATE metrics SET next_retry_at = ?1 WHERE id = ?2",
+                params![(unix_now() + 60) as i64, ids[0]],
+            )
+            .unwrap();
+        assert!(!db.has_retryable_for_upload().unwrap());
+
+        db.conn
+            .execute(
+                "UPDATE metrics SET attempts = ?1, next_retry_at = 0 WHERE id = ?2",
+                params![MAX_METRIC_UPLOAD_ATTEMPTS as i64, ids[0]],
+            )
+            .unwrap();
+        assert!(!db.has_retryable_for_upload().unwrap());
     }
 
     #[test]

--- a/tests/integration/metrics_retry_idle.rs
+++ b/tests/integration/metrics_retry_idle.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::db::MetricsDatabase;
 use git_ai::sqlite::open_with_memory_limits;
 use std::fs;
 use std::path::Path;
@@ -90,6 +91,39 @@ fn wait_for_schema_migration(path: &Path) {
         );
         std::thread::sleep(Duration::from_millis(25));
     }
+}
+
+#[test]
+fn idle_metrics_flush_skips_git_identity_lookup() {
+    let spawn_log_dir = tempfile::tempdir().unwrap();
+    let spawn_log_path = spawn_log_dir.path().join("git-spawns.log");
+    let spawn_log = spawn_log_path.to_string_lossy().to_string();
+    let metrics_path = spawn_log_dir.path().join("metrics.db");
+    let metrics_db = metrics_path.to_string_lossy().to_string();
+    MetricsDatabase::open_at_path(&metrics_path).unwrap();
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_KEY", "test-api-key"),
+        ("GIT_AI_API_BASE_URL", "http://127.0.0.1:1"),
+        ("GIT_AI_DAEMON_LOG_UPLOAD", "false"),
+        ("GIT_AI_SPAWN_LOG", spawn_log.as_str()),
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db.as_str()),
+        ("GIT_AI_TRANSCRIPT_STREAMING", "false"),
+    ]);
+
+    // Drain startup work before observing two complete idle flush intervals.
+    repo.sync_daemon();
+    open_with_memory_limits(&metrics_path)
+        .unwrap()
+        .execute("DELETE FROM metrics", [])
+        .unwrap();
+    fs::write(&spawn_log_path, "").unwrap();
+    std::thread::sleep(Duration::from_secs(7));
+
+    let git_spawns = fs::read_to_string(&spawn_log_path).unwrap_or_default();
+    assert!(
+        !git_spawns.lines().any(|command| command == "var"),
+        "idle metrics flush unexpectedly resolved Git identity:\n{git_spawns}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- avoid initializing the telemetry API client when the local queue has no retryable metrics
- preserve retry recovery by releasing stale processing locks before the readiness check
- cover idle behavior with a TestRepo integration test and database edge-case tests

## Why

The metrics worker wakes every three seconds. API client setup resolves the Git committer identity even when no metrics are due for upload. This keeps upload and identity behavior unchanged when work exists while avoiding unnecessary idle subprocess startup across platforms.

## Validation

- CARGO_INCREMENTAL=0 task test
- CARGO_INCREMENTAL=0 task lint
- task fmt