### PR TITLE
fix: sync stats before reading authorship notes

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::io::IsTerminal;
 use std::io::Read;
+use std::time::Duration;
 
 pub fn handle_git_ai(args: &[String]) {
     let perf_entry =
@@ -1025,6 +1026,7 @@ fn handle_stats(args: &[String]) {
     }
 
     let effective_patterns = effective_ignore_patterns(&repo, &ignore_patterns, &[]);
+    sync_daemon_family_before_stats_read(&repo);
 
     // Handle commit range if detected
     if let Some(range) = commit_range {
@@ -1060,6 +1062,43 @@ fn handle_stats(args: &[String]) {
             }
         }
         std::process::exit(1);
+    }
+}
+
+fn sync_daemon_family_before_stats_read(repo: &Repository) {
+    const STATS_DAEMON_SYNC_TIMEOUT: Duration = Duration::from_secs(5);
+
+    let Ok(workdir) = repo.workdir() else {
+        return;
+    };
+
+    let request = ControlRequest::SyncFamily {
+        repo_working_dir: workdir.to_string_lossy().to_string(),
+    };
+
+    let config = match crate::commands::daemon::ensure_daemon_running(Duration::from_secs(2)) {
+        Ok(config) => config,
+        Err(error) => {
+            tracing::debug!(%error, "stats daemon sync unavailable");
+            return;
+        }
+    };
+
+    match crate::daemon::send_control_request_with_timeout(
+        &config.control_socket_path,
+        &request,
+        STATS_DAEMON_SYNC_TIMEOUT,
+    ) {
+        Ok(response) if response.ok => {}
+        Ok(response) => {
+            tracing::debug!(
+                error = response.error.as_deref().unwrap_or("unknown daemon error"),
+                "stats daemon sync failed"
+            );
+        }
+        Err(error) => {
+            tracing::debug!(%error, "stats daemon sync unavailable");
+        }
     }
 }
 

--- a/tests/integration/stats_unit.rs
+++ b/tests/integration/stats_unit.rs
@@ -1,3 +1,4 @@
+use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log::LineRange;
 use git_ai::authorship::authorship_log::PromptRecord;
@@ -58,6 +59,50 @@ fn test_stats_for_simple_ai_commit() {
         stats.git_diff_deleted_lines, 0,
         "Git diff shows 0 deleted lines"
     );
+}
+
+#[test]
+fn test_stats_waits_for_pending_commit_authorship_note() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_SIDE_EFFECT_MS_FOR_COMMAND",
+        "commit=3000",
+    )]);
+    let file_path = repo.path().join("stats_race.txt");
+    let mut file = repo.filename("stats_race.txt");
+
+    std::fs::write(&file_path, "Base line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "stats_race.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    file.assert_committed_lines(lines!["Base line".human()]);
+
+    std::fs::write(
+        &file_path,
+        "Base line\nAI line 1\nAI line 2\nAI line 3\nAI line 4\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "stats_race.txt"])
+        .unwrap();
+    repo.git_without_test_sync_for_test(&["add", "stats_race.txt"], &[])
+        .unwrap();
+    repo.git_without_test_sync_for_test(&["commit", "-m", "Delayed AI commit"], &[])
+        .unwrap();
+
+    let output = repo
+        .git_ai_without_pre_sync_for_test(&["stats", "--json", "HEAD"])
+        .expect("stats should succeed after syncing pending commit side effects");
+    let stats: CommitStats =
+        serde_json::from_str(output.trim()).expect("stats should emit JSON only");
+
+    assert_eq!(stats.ai_additions, 4, "stats output: {output}");
+    assert_eq!(stats.unknown_additions, 0, "stats output: {output}");
+    file.assert_committed_lines(lines![
+        "Base line".human(),
+        "AI line 1".ai(),
+        "AI line 2".ai(),
+        "AI line 3".ai(),
+        "AI line 4".ai(),
+    ]);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1845

## Summary
- wait for pending daemon side effects before `git-ai stats` reads authorship notes
- use the existing family sync control path and its long response timeout
- add a deterministic TestRepo regression covering immediate stats after a delayed AI commit

## Root cause
Commit authorship notes are produced asynchronously from trace2 events. An immediate `git-ai stats` could read the new commit before its note was written, causing correctly checkpointed AI lines to appear as untracked.

## Testing
- `task test TEST_FILTER=test_stats_waits_for_pending_commit_authorship_note`
- `task test`
- `task lint`
- `task fmt`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->