### PR TITLE
Fix attribution debug self-check timeouts

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -385,7 +385,11 @@ where
     authorship_log = transform(authorship_log)?;
     authorship_log.metadata.base_commit_sha = commit_sha.clone();
 
-    if options.recover_attribution {
+    let is_debug_self_check = repo.workdir().is_ok_and(|workdir| {
+        crate::diagnostic_sentinels::path_is_in_debug_self_check_root(&workdir)
+    });
+    // Synthetic self-check commits already provide explicit attribution for every line.
+    if options.recover_attribution && !is_debug_self_check {
         let recovery_hunks = recovery_committed_hunks(
             repo,
             &parent_sha,

--- a/src/commands/debug.rs
+++ b/src/commands/debug.rs
@@ -551,33 +551,18 @@ fn collect_git_diagnostics(
             })
             .collect()
     };
-    let attribution_handles: Vec<_> = targets
-        .clone()
-        .into_iter()
+    let attributions: Vec<_> = targets
+        .iter()
         .map(|target| {
             let label = target.label.clone();
             debug_progress(format!("starting attribution self-check for {}", label));
-            std::thread::spawn(move || {
-                let result = crate::diagnostics::run_attribution_self_check(&target);
-                debug_progress(format!(
-                    "attribution self-check for {} {}",
-                    label,
-                    result.status.as_str()
-                ));
-                result
-            })
-        })
-        .collect();
-    let attributions: Vec<_> = attribution_handles
-        .into_iter()
-        .map(|handle| {
-            handle.join().unwrap_or_else(|_| {
-                DiagnosticCheckResult::failed(
-                    "attribution self-check failed",
-                    vec!["attribution self-check worker panicked".to_string()],
-                    Vec::new(),
-                )
-            })
+            let result = crate::diagnostics::run_attribution_self_check(target);
+            debug_progress(format!(
+                "attribution self-check for {} {}",
+                label,
+                result.status.as_str()
+            ));
+            result
         })
         .collect();
     // Trace2 file checks temporarily rewrite global git config, so they must remain serialized.

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -48,7 +48,7 @@ const AGENT_USAGE_MIN_INTERVAL_SECS: u64 = 150;
 const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 1;
 
 #[cfg(not(any(test, feature = "test-support")))]
-pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
+fn should_emit_real_agent_usage(agent_id: &AgentId) -> bool {
     let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
     let now_ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -68,8 +68,12 @@ pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
 }
 
 #[cfg(any(test, feature = "test-support"))]
-pub(crate) fn should_emit_agent_usage(_agent_id: &AgentId) -> bool {
+fn should_emit_real_agent_usage(_agent_id: &AgentId) -> bool {
     false
+}
+
+pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
+    agent_id.tool != "mock_ai" && should_emit_real_agent_usage(agent_id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1112,4 +1116,20 @@ fn compute_line_stats(
     }
 
     Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_ai_skips_agent_usage_throttle() {
+        let agent_id = AgentId {
+            tool: "mock_ai".to_string(),
+            id: "debug-self-check".to_string(),
+            model: "unknown".to_string(),
+        };
+
+        assert!(!should_emit_agent_usage(&agent_id));
+    }
 }

--- a/src/diagnostic_sentinels.rs
+++ b/src/diagnostic_sentinels.rs
@@ -13,10 +13,14 @@ pub fn is_debug_self_check_remote_url(url: &str) -> bool {
 }
 
 pub fn debug_self_check_root() -> PathBuf {
-    crate::mdm::utils::home_dir()
-        .join(".git-ai")
-        .join("internal")
-        .join(DEBUG_SELF_CHECK_DIR_NAME)
+    crate::daemon::DaemonConfig::from_env_or_default_paths()
+        .map(|config| config.internal_dir.join(DEBUG_SELF_CHECK_DIR_NAME))
+        .unwrap_or_else(|_| {
+            crate::mdm::utils::home_dir()
+                .join(".git-ai")
+                .join("internal")
+                .join(DEBUG_SELF_CHECK_DIR_NAME)
+        })
 }
 
 pub fn path_is_in_debug_self_check_root(path: &Path) -> bool {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -414,7 +414,11 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         .trim()
         .to_string();
 
-        let mut details = poll_self_check_attribution(&repo_path, &commit_sha, deadline)?;
+        // Attribution is produced asynchronously after the commit. Give that
+        // phase its own bounded budget instead of sharing the setup deadline.
+        let attribution_deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
+        let mut details =
+            poll_self_check_attribution(&repo_path, &commit_sha, attribution_deadline)?;
         details.insert(0, format!("repo: {}", repo_path.display()));
         details.insert(1, format!("commit: {}", commit_sha));
         details.insert(

--- a/tests/integration/debug_diagnostics.rs
+++ b/tests/integration/debug_diagnostics.rs
@@ -1,0 +1,50 @@
+use crate::repos::test_repo::TestRepo;
+use git_ai::{daemon::DaemonConfig, diagnostic_sentinels::DEBUG_SELF_CHECK_DIR_NAME};
+
+#[test]
+fn attribution_self_checks_do_not_timeout() {
+    let repo = TestRepo::new();
+    let trace2_target =
+        DaemonConfig::trace2_event_target_for_path(&repo.daemon_trace_socket_path());
+
+    let report = repo
+        .git_ai_with_env(
+            &["debug", "--skip-trace2-checks"],
+            &[
+                ("GIT_TRACE2_EVENT", trace2_target.as_str()),
+                ("GIT_TRACE2_EVENT_NESTING", "0"),
+            ],
+        )
+        .expect("git-ai debug should complete");
+
+    let passed_checks = report
+        .lines()
+        .filter(|line| line.contains("Attribution self-check: passed"))
+        .count();
+    assert_eq!(
+        passed_checks, 2,
+        "configured and terminal git attribution checks should pass:\n{report}"
+    );
+    let daemon_self_check_root = repo
+        .daemon_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join(DEBUG_SELF_CHECK_DIR_NAME);
+    let expected_repo_prefix = format!("    repo: {}", daemon_self_check_root.display());
+    assert_eq!(
+        report.matches(&expected_repo_prefix).count(),
+        2,
+        "both self-check repositories should use the active daemon home:\n{report}"
+    );
+    for expected_line in [
+        "line 1: untracked (expected untracked",
+        "line 2: known_human (expected known_human",
+        "line 3: ai (expected ai",
+    ] {
+        assert_eq!(
+            report.matches(expected_line).count(),
+            2,
+            "both attribution checks should validate {expected_line}:\n{report}"
+        );
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -52,6 +52,7 @@ mod continue_cli;
 mod cross_repo_cwd_attribution;
 mod cursor;
 mod daemon_commit_carryover;
+mod debug_diagnostics;
 mod diff;
 mod diff_comprehensive;
 mod diff_ignore_binary;


### PR DESCRIPTION
## Summary

- give asynchronous attribution polling a fresh bounded deadline after the synthetic commit
- run the configured and terminal Git self-checks sequentially to avoid daemon-side contention
- resolve self-check repositories from the active daemon home so every process recognizes them consistently
- skip session-event recovery and agent-usage throttling for synthetic `git-ai debug` checkpoints
- add a `TestRepo` regression that validates the daemon-home path, both self-check targets, and every expected attribution class

## Root cause

The attribution self-check shared its three-second deadline between repository setup, three checkpoints, commit processing, and result polling. A new two-second post-commit session-event recovery preflight consumed most of that budget, while the two self-check repositories competed concurrently. In installed debug builds, the synthetic `mock_ai` checkpoint also opened the production metrics throttle database even though mock metrics are discarded.

The remaining Windows failure exposed a split-home bug in the test harness: the debug subprocess created repositories beneath its isolated process home, while the shared daemon determined the self-check root from `GIT_AI_DAEMON_HOME`. Because those paths differed, the daemon did not recognize the repositories as synthetic and still ran the recovery path. Windows latency then exhausted the fresh polling deadline.

## Impact

`git-ai debug` now waits for attribution with its own bounded budget, creates diagnostic repositories beneath the active daemon's internal directory, and avoids production-only recovery and telemetry work that cannot affect the synthetic result. Normal checkpoint, recovery, and trace2 ingestion behavior is unchanged.

## Validation

- `task test TEST_FILTER=attribution_self_checks_do_not_timeout`
- `task test`
- `task build`
- `task lint`
- `task fmt`
- `task dev`
- installed `git-ai debug` smoke test: both attribution self-checks passed with untracked, known-human, and AI lines correctly classified