### PR TITLE
Wait for recent commit stats attribution

### DIFF
--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -2,9 +2,17 @@ use crate::authorship::authorship_log::LineRange;
 use crate::authorship::ignore::{build_ignore_matcher, should_ignore_file_with_matcher};
 use crate::error::GitAiError;
 use crate::git::notes_api::read_authorship;
-use crate::git::repository::Repository;
+use crate::git::repository::{Repository, exec_git};
+use crate::mdm::spinner::Spinner;
+use crate::utils::is_interactive_terminal;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const RECENT_COMMIT_WINDOW: Duration = Duration::from_secs(60);
+const AUTHORSHIP_NOTE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const AUTHORSHIP_NOTE_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const WAIT_MESSAGE: &str = "Waiting for git-ai to process this commit";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ToolModelHeadlineStats {
@@ -65,7 +73,13 @@ pub fn stats_command(
         refname
     );
 
-    let stats = stats_for_commit_stats(repo, &target, ignore_patterns)?;
+    let authorship_log = wait_for_recent_authorship(repo, &target)?;
+    let stats = stats_for_commit_stats_with_authorship(
+        repo,
+        &target,
+        ignore_patterns,
+        authorship_log.as_ref(),
+    )?;
 
     if json {
         let json_str = serde_json::to_string(&stats)?;
@@ -75,6 +89,72 @@ pub fn stats_command(
     }
 
     Ok(())
+}
+
+fn wait_for_recent_authorship(
+    repo: &Repository,
+    commit_sha: &str,
+) -> Result<Option<crate::authorship::authorship_log_serialization::AuthorshipLog>, GitAiError> {
+    if let Some(authorship_log) = read_authorship(repo, commit_sha) {
+        return Ok(Some(authorship_log));
+    }
+
+    let commit_timestamp = commit_timestamp(repo, commit_sha)?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| {
+            GitAiError::Generic(format!("System clock is before Unix epoch: {error}"))
+        })?
+        .as_secs();
+    if now.abs_diff(commit_timestamp) > RECENT_COMMIT_WINDOW.as_secs() {
+        return Ok(None);
+    }
+
+    let force_tty = std::env::var_os("GIT_AI_TEST_FORCE_TTY").is_some();
+    let spinner = if force_tty {
+        // Indicatif intentionally hides itself when stderr is captured. Keep the
+        // existing test-only TTY override useful for subprocess assertions.
+        eprintln!("{WAIT_MESSAGE}");
+        None
+    } else {
+        is_interactive_terminal().then(|| Spinner::new(WAIT_MESSAGE))
+    };
+    let started = Instant::now();
+    let authorship_log = loop {
+        let remaining = AUTHORSHIP_NOTE_WAIT_TIMEOUT.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break None;
+        }
+        std::thread::sleep(AUTHORSHIP_NOTE_POLL_INTERVAL.min(remaining));
+        if let Some(authorship_log) = read_authorship(repo, commit_sha) {
+            break Some(authorship_log);
+        }
+    };
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+
+    Ok(authorship_log)
+}
+
+fn commit_timestamp(repo: &Repository, commit_sha: &str) -> Result<u64, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "show".to_string(),
+        "-s".to_string(),
+        "--no-notes".to_string(),
+        "--format=%ct".to_string(),
+        commit_sha.to_string(),
+    ]);
+    let output = exec_git(&args)?;
+    String::from_utf8(output.stdout)?
+        .trim()
+        .parse()
+        .map_err(|error| {
+            GitAiError::Generic(format!(
+                "Invalid commit timestamp for {commit_sha}: {error}"
+            ))
+        })
 }
 
 pub fn write_stats_to_terminal(stats: &CommitStats, is_interactive: bool) -> String {

--- a/src/mdm/spinner.rs
+++ b/src/mdm/spinner.rs
@@ -24,6 +24,10 @@ impl Spinner {
         // Spinner starts automatically when created
     }
 
+    pub fn finish_and_clear(&self) {
+        self.pb.finish_and_clear();
+    }
+
     #[allow(dead_code)]
     pub fn update_message(&self, message: &str) {
         self.pb.set_message(message.to_string());

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -2505,6 +2505,31 @@ impl TestRepo {
         self.git_ai_with_env_inner(args, envs, false)
     }
 
+    pub fn git_ai_command_without_pre_sync_for_test(
+        &self,
+        args: &[&str],
+        envs: &[(&str, &str)],
+    ) -> Command {
+        let binary_path = get_binary_path();
+        let normalized_args = normalize_test_git_ai_checkpoint_args(args);
+
+        let mut command = Command::new(binary_path);
+        command.args(&normalized_args).current_dir(&self.path);
+        self.configure_git_ai_env(&mut command);
+
+        if let Some(patch) = &self.config_patch
+            && let Ok(patch_json) = serde_json::to_string(patch)
+        {
+            command.env("GIT_AI_TEST_CONFIG_PATCH", patch_json);
+        }
+
+        for (key, value) in envs {
+            command.env(key, value);
+        }
+
+        command
+    }
+
     pub fn git(&self, args: &[&str]) -> Result<String, String> {
         self.git_with_env(args, &[], None)
     }
@@ -2908,28 +2933,7 @@ impl TestRepo {
 
         let is_checkpoint = git_ai_primary_command(args) == Some("checkpoint");
 
-        let binary_path = get_binary_path();
-        let normalized_args = normalize_test_git_ai_checkpoint_args(args);
-
-        let mut command = Command::new(binary_path);
-        command.args(&normalized_args).current_dir(&self.path);
-        self.configure_git_ai_env(&mut command);
-
-        // Add config patch as environment variable if present
-        if let Some(patch) = &self.config_patch
-            && let Ok(patch_json) = serde_json::to_string(patch)
-        {
-            command.env("GIT_AI_TEST_CONFIG_PATCH", patch_json);
-        }
-
-        // Add test database path for isolation
-        command.env("GIT_AI_TEST_DB_PATH", self.test_db_path.to_str().unwrap());
-        command.env("GITAI_TEST_DB_PATH", self.test_db_path.to_str().unwrap());
-
-        // Add custom environment variables
-        for (key, value) in envs {
-            command.env(key, value);
-        }
+        let mut command = self.git_ai_command_without_pre_sync_for_test(args, envs);
 
         let output = run_command_output(&mut command, &format!("git-ai {:?}", args))?;
 

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -3,10 +3,12 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::stats::CommitStats;
 use insta::assert_debug_snapshot;
 use std::fs;
+use std::io::{BufRead, BufReader};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 /// Extract the first complete JSON object from mixed stdout/stderr output.
 fn extract_json_object(output: &str) -> String {
@@ -19,6 +21,145 @@ fn stats_from_args(repo: &TestRepo, args: &[&str]) -> CommitStats {
     let raw = repo.git_ai(args).expect("git-ai stats should succeed");
     let json = extract_json_object(&raw);
     serde_json::from_str(&json).expect("valid stats json")
+}
+
+fn stats_while_restoring_authorship_note(
+    repo: &TestRepo,
+    commit_sha: &str,
+    args: &[&str],
+) -> String {
+    let note = repo
+        .read_authorship_note(commit_sha)
+        .expect("commit should start with an authorship note");
+    repo.git_og(&["notes", "--ref=ai", "remove", commit_sha])
+        .expect("authorship note should be removable");
+
+    let mut command =
+        repo.git_ai_command_without_pre_sync_for_test(args, &[("GIT_AI_TEST_FORCE_TTY", "1")]);
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("stats should start");
+    let mut waiting_message = String::new();
+    BufReader::new(child.stderr.take().expect("stats stderr should be piped"))
+        .read_line(&mut waiting_message)
+        .expect("stats should write its waiting indicator");
+    assert!(
+        waiting_message.contains("Waiting for git-ai to process this commit"),
+        "interactive stats should show a waiting indicator, got:\n{waiting_message}"
+    );
+
+    repo.git_og(&["notes", "--ref=ai", "add", "-f", "-m", &note, commit_sha])
+        .expect("authorship note should be restorable");
+
+    let output = child.wait_with_output().expect("stats should finish");
+    assert!(
+        output.status.success(),
+        "stats failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        waiting_message
+    )
+}
+
+#[test]
+fn test_stats_default_waits_for_recent_commit_authorship_note() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("recent-default.txt");
+    file.set_contents(crate::lines!["AI line".ai()]);
+    let commit = repo.stage_all_and_commit("recent AI commit").unwrap();
+    let started = Instant::now();
+    let output =
+        stats_while_restoring_authorship_note(&repo, &commit.commit_sha, &["stats", "--json"]);
+
+    assert!(
+        started.elapsed() >= Duration::from_millis(100),
+        "stats returned before the delayed note was restored"
+    );
+    assert!(
+        output.contains("Waiting for git-ai to process this commit"),
+        "interactive stats should show a waiting indicator, got:\n{output}"
+    );
+    let stats: CommitStats = serde_json::from_str(&extract_json_object(&output)).unwrap();
+    assert_eq!(stats.ai_additions, 1);
+    assert_eq!(stats.unknown_additions, 0);
+}
+
+#[test]
+fn test_stats_single_rev_waits_for_recent_commit_authorship_note() {
+    let repo = TestRepo::new();
+    let mut file = repo.filename("recent-rev.txt");
+    file.set_contents(crate::lines!["AI line".ai()]);
+    let commit = repo.stage_all_and_commit("recent AI commit").unwrap();
+    let started = Instant::now();
+    let output = stats_while_restoring_authorship_note(
+        &repo,
+        &commit.commit_sha,
+        &["stats", &commit.commit_sha, "--json"],
+    );
+
+    assert!(
+        started.elapsed() >= Duration::from_millis(100),
+        "stats <rev> returned before the delayed note was restored"
+    );
+    let stats: CommitStats = serde_json::from_str(&extract_json_object(&output)).unwrap();
+    assert_eq!(stats.ai_additions, 1);
+    assert_eq!(stats.unknown_additions, 0);
+}
+
+#[test]
+fn test_stats_does_not_wait_for_old_commit_without_authorship_note() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("old.txt"), "old line\n").unwrap();
+    repo.git_og(&["add", "old.txt"]).unwrap();
+    repo.git_og_with_env(
+        &["commit", "-m", "old commit"],
+        &[
+            ("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z"),
+            ("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z"),
+        ],
+    )
+    .unwrap();
+
+    let started = Instant::now();
+    repo.git_ai_with_env_without_pre_sync_for_test(&["stats", "--json"], &[])
+        .expect("stats should work without an authorship note");
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "stats should not wait for an old commit"
+    );
+}
+
+#[test]
+fn test_stats_range_does_not_wait_for_missing_authorship_note() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("range-wait.txt"), "first\n").unwrap();
+    repo.git_og(&["add", "range-wait.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "first raw commit"]).unwrap();
+    let first = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+
+    fs::write(repo.path().join("range-wait.txt"), "first\nsecond\n").unwrap();
+    repo.git_og(&["add", "range-wait.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "second raw commit"]).unwrap();
+    let second = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+    let range = format!("{}..{}", first.trim(), second.trim());
+
+    let started = Instant::now();
+    let output = repo
+        .git_ai_with_env_without_pre_sync_for_test(
+            &["stats", &range, "--json"],
+            &[("GIT_AI_TEST_FORCE_TTY", "1")],
+        )
+        .expect("stats range should work without authorship notes");
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "stats range should not wait for a missing note"
+    );
+    assert!(!output.contains("Waiting for git-ai to process this commit"));
 }
 
 fn run_git(cwd: &Path, args: &[&str]) {


### PR DESCRIPTION
## Summary

- wait up to five seconds for authorship on commits created within the last 60 seconds
- show an interactive spinner while `git-ai stats` waits
- limit waiting to default and single-revision stats; ranges remain immediate

## Why

Trace2 processing is asynchronous, so `git-ai stats` can run immediately after a commit and read stats before the daemon saves the authorship note. The command now gives recent commits a bounded window to finish processing before calculating attribution.

## Validation

- `task fmt`
- `task lint`
- `task build`
- `task test`
- focused `stats::test_stats_` integration tests