### PR TITLE
Publish PKGs for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -876,7 +876,12 @@ jobs:
   publish-pkg:
     name: Publish macOS PKG installers
     needs: [create-release, package-pkg, test-pkg, build]
-    if: inputs.dry_run != true && needs.create-release.result == 'success' && needs.package-pkg.result == 'success' && needs.test-pkg.result == 'success'
+    if: >-
+      !cancelled() &&
+      inputs.dry_run != true &&
+      needs.create-release.result == 'success' &&
+      needs.package-pkg.result == 'success' &&
+      needs.test-pkg.result == 'success'
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
## Summary

- add an explicit `!cancelled()` status check to the `publish-pkg` job
- attach notarized and tested PKGs to non-production prereleases
- preserve dry-run skipping, production approval, cancellation, and prerequisite failure behavior

## Root cause

The non-production approval job is intentionally skipped. Because `publish-pkg` did not use an explicit status-check function, GitHub applied its implicit `success()` check and skipped PKG publication even though `create-release`, `package-pkg`, and `test-pkg` all succeeded.

This matches the condition pattern already used by the upstream release jobs.

Observed in release run: https://github.com/git-ai-project/git-ai/actions/runs/29885838021

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- `task fmt`
- `task lint`