### PR TITLE
Target repository for PKG upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -917,4 +917,8 @@ jobs:
             RELEASE_TAG="${BASE_VERSION}-next-${SHORT_SHA}"
           fi
 
-          gh release upload "$RELEASE_TAG" release/git-ai-macos-*.pkg release/PKG-SHA256SUMS --clobber
+          gh release upload "$RELEASE_TAG" \
+            release/git-ai-macos-*.pkg \
+            release/PKG-SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber


### PR DESCRIPTION
## Summary

- pass `GITHUB_REPOSITORY` explicitly to `gh release upload`
- allow the no-checkout `publish-pkg` job to attach notarized PKGs and checksums
- preserve the existing prerelease and production tag selection

## Root cause

The PKG publication job intentionally downloads artifacts without checking out the repository. The GitHub CLI therefore had no Git remote from which to infer the target repository and failed with `fatal: not a git repository`.

Observed in release run: https://github.com/git-ai-project/git-ai/actions/runs/29892147013/job/88835566598

## Validation

- parsed `.github/workflows/release.yml` with Ruby YAML
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- verified explicit repository resolution from outside Git context with `gh release view --repo git-ai-project/git-ai`
- `task fmt`
- `task lint`