### PR TITLE
Ignore Gemini internal file hooks

### DIFF
--- a/src/commands/checkpoint_agent/presets/gemini.rs
+++ b/src/commands/checkpoint_agent/presets/gemini.rs
@@ -7,6 +7,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::authorship::working_log::AgentId;
 use crate::commands::checkpoint_agent::bash_tool::{self, Agent, ToolClass};
 use crate::error::GitAiError;
+use crate::mdm::utils::gemini_config_dir;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -27,6 +28,9 @@ impl AgentPreset for GeminiPreset {
         let is_bash = tool_name
             .map(|n| bash_tool::classify_tool(Agent::Gemini, n) == ToolClass::Bash)
             .unwrap_or(false);
+        let mut file_paths = parse::file_paths_from_tool_input(&data, cwd);
+        let internal_tmp_dir = gemini_config_dir().join("tmp");
+        file_paths.retain(|path| !path.starts_with(&internal_tmp_dir));
 
         let context = PresetContext {
             agent_id: AgentId {
@@ -67,7 +71,7 @@ impl AgentPreset for GeminiPreset {
             }),
             (true, false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
                 context,
-                file_paths: parse::file_paths_from_tool_input(&data, cwd),
+                file_paths,
                 dirty_files: None,
                 tool_use_id: Some(tool_use_id.to_string()),
             }),
@@ -79,7 +83,7 @@ impl AgentPreset for GeminiPreset {
             }),
             (false, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {
                 context,
-                file_paths: parse::file_paths_from_tool_input(&data, cwd),
+                file_paths,
                 dirty_files: None,
                 stream_source,
                 tool_use_id: Some(tool_use_id.to_string()),

--- a/tests/integration/gemini.rs
+++ b/tests/integration/gemini.rs
@@ -357,6 +357,59 @@ fn test_gemini_e2e_human_checkpoint() {
 }
 
 #[test]
+fn test_issue_1951_gemini_ignores_internal_files() {
+    let repo = TestRepo::new();
+    let tracked_path = repo.path().join("tracked.txt");
+    fs::write(&tracked_path, "tracked\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let mut tracked_file = repo.filename("tracked.txt");
+    tracked_file.assert_committed_lines(crate::lines!["tracked".unattributed_human()]);
+
+    let gemini_home = tempfile::tempdir().unwrap();
+    let internal_path = gemini_home
+        .path()
+        .join(".gemini/tmp/project/memory/skills/example/SKILL.md");
+    fs::create_dir_all(internal_path.parent().unwrap()).unwrap();
+    fs::write(&internal_path, "internal memory\n").unwrap();
+
+    for hook_event_name in ["BeforeTool", "AfterTool"] {
+        let hook_input = json!({
+            "session_id": "gemini-internal-file-session",
+            "cwd": repo.canonical_path().to_string_lossy().to_string(),
+            "hook_event_name": hook_event_name,
+            "tool_name": "write_file",
+            "tool_input": {
+                "file_path": internal_path.to_string_lossy().to_string()
+            },
+            "transcript_path": fixture_path("gemini-session-simple.jsonl")
+                .to_string_lossy()
+                .to_string(),
+        })
+        .to_string();
+
+        let output = repo
+            .git_ai_with_env(
+                &["checkpoint", "gemini", "--hook-input", &hook_input],
+                &[("GEMINI_CLI_HOME", gemini_home.path().to_str().unwrap())],
+            )
+            .unwrap();
+        assert!(
+            output.is_empty(),
+            "Gemini internal file hooks should be ignored silently, got: {output}"
+        );
+    }
+
+    assert!(
+        repo.current_working_logs()
+            .all_ai_touched_files()
+            .unwrap_or_default()
+            .is_empty(),
+        "Gemini internal files should not create repository checkpoints"
+    );
+}
+
+#[test]
 fn test_gemini_e2e_multiple_tool_calls() {
     let repo = TestRepo::new();
     let fixture_path_str = fixture_path("gemini-session-simple.jsonl")
@@ -546,6 +599,7 @@ crate::reuse_tests_in_worktree!(
     test_gemini_preset_handles_missing_file,
     test_gemini_e2e_with_attribution,
     test_gemini_e2e_human_checkpoint,
+    test_issue_1951_gemini_ignores_internal_files,
     test_gemini_e2e_multiple_tool_calls,
     test_gemini_e2e_with_resync,
     test_gemini_e2e_partial_staging,


### PR DESCRIPTION
Fixes #1951

## Summary
- ignore Gemini file-edit hooks targeting its configured `.gemini/tmp` storage
- keep normal repository and cross-repository Gemini edits eligible for attribution
- cover both before- and after-tool hooks in repository and linked-worktree variants

## Root cause
Gemini auto-memory operations use normal file tools for files under `.gemini/tmp`. The preset forwarded those paths to checkpoint repository discovery, which printed an error because the internal files are outside a Git repository.

## Validation
- `task test`
- `task lint`
- `task fmt`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->