### PR TITLE
fix(ci): keep CodeQL action versions aligned

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,5 +37,9 @@ updates:
     target-branch: "main"
     schedule:
       interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
     commit-message:
       prefix: "chore(ci)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}


### PR DESCRIPTION
## What changed

- pin `github/codeql-action/init` to the same 4.37.1 commit as `analyze`
- group all `github/codeql-action/*` Dependabot updates so multi-step CodeQL upgrades stay synchronized

## Root cause

Dependabot updated only `github/codeql-action/analyze` from 4.36.1 to 4.37.1. The workflow still initialized CodeQL with 4.36.1, so analysis failed with:

> Loaded a configuration file for version '4.36.1', but running version '4.37.1'

This restores CodeQL scanning for every language matrix leg and prevents the same partial-update failure on future version bumps.

## Validation

- `task fmt`
- `task lint`
- `actionlint .github/workflows/codeql.yml`
- YAML parse validation for both changed files
- CodeQL init/analyze SHA consistency check