### PR TITLE
Reconcile rebases that completed while the daemon was not observing

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4780,34 +4780,72 @@ impl ActorDaemonCoordinator {
         {
             spans.pop();
         }
-        if spans.is_empty() {
-            return Ok(());
-        }
-
+        // Reflog-only filters first (no git): age, degenerate spans, and a
+        // hard cap (newest kept) so total git work is bounded by a constant
+        // no matter how rebase-heavy the reflog is.
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
+        spans.retain(|span| {
+            span.old_tip != span.new_tip
+                && now_secs.saturating_sub(span.finished_at_secs)
+                    <= crate::daemon::rebase_reconcile::MAX_SPAN_AGE_SECS
+        });
+        if spans.len() > crate::daemon::rebase_reconcile::MAX_RECONCILE_SPANS {
+            spans.drain(..spans.len() - crate::daemon::rebase_reconcile::MAX_RECONCILE_SPANS);
+        }
+        if spans.is_empty() {
+            return Ok(());
+        }
+
         let repo = find_repository_in_path(&worktree.to_string_lossy())?;
 
+        // Batched existence screen: one cat-file --batch-check spawn covers
+        // every tip of every span (never one git spawn per object).
+        let mut tips: Vec<String> = spans
+            .iter()
+            .flat_map(|span| [span.old_tip.clone(), span.new_tip.clone()])
+            .collect();
+        tips.sort();
+        tips.dedup();
+        let existing = match crate::daemon::rebase_reconcile::existing_commits(&repo, &tips) {
+            Ok(existing) => existing,
+            Err(error) => {
+                tracing::warn!(error = %error, "unobserved rebase existence probe failed");
+                return Ok(());
+            }
+        };
+        spans.retain(|span| existing.contains(&span.old_tip) && existing.contains(&span.new_tip));
+
+        // Batched notes screen: the spans' own reflog rows record the commits
+        // each rewrite created, so one commits_with_notes call over their
+        // union drops every span that was already handled — without any
+        // per-span git. Only genuinely stranded candidates (normally zero or
+        // one) reach the precise per-span probe below.
+        let mut rewritten: Vec<String> = spans
+            .iter()
+            .flat_map(|span| span.rewritten_commits.iter().cloned())
+            .collect();
+        rewritten.sort();
+        rewritten.dedup();
+        if !rewritten.is_empty() {
+            let noted = match crate::git::notes_api::commits_with_notes(&repo, &rewritten) {
+                Ok(noted) => noted,
+                Err(error) => {
+                    tracing::warn!(error = %error, "unobserved rebase notes screen failed");
+                    return Ok(());
+                }
+            };
+            spans.retain(|span| {
+                crate::daemon::rebase_reconcile::may_have_stranded_notes(span, &noted)
+            });
+        }
+
         for span in spans {
-            if now_secs.saturating_sub(span.finished_at_secs)
-                > crate::daemon::rebase_reconcile::MAX_SPAN_AGE_SECS
-            {
-                continue;
-            }
-            if span.old_tip == span.new_tip {
-                continue;
-            }
-            if !crate::daemon::rebase_reconcile::commit_exists(&repo, &span.old_tip)
-                || !crate::daemon::rebase_reconcile::commit_exists(&repo, &span.new_tip)
-            {
-                continue;
-            }
-            // Fast-forward "rebases" rewrite nothing.
-            if is_ancestor_commit(&repo, &span.old_tip, &span.new_tip) {
-                continue;
-            }
+            // Precise probe, candidates only: empty sources also screens out
+            // fast-forward "rebases" (nothing reachable from the old tip
+            // alone), so no separate ancestor check is needed.
             match crate::daemon::rebase_reconcile::span_has_stranded_notes(&repo, &span) {
                 Ok(true) => {}
                 Ok(false) => continue,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4723,15 +4723,22 @@ impl ActorDaemonCoordinator {
     /// on the first command that reaches side-effect processing for that
     /// worktree.
     ///
-    /// `exclude_newest_span` must be true when the triggering command is
-    /// itself a completing rebase / pull --rebase: its own span is already in
-    /// the reflog by side-effect time and is owned by the live path
+    /// `command_is_completing_rebase` must be true when the triggering
+    /// command is itself a completing rebase / pull --rebase: if that command
+    /// actually rewrote history, its own span is already in the reflog by
+    /// side-effect time and is owned by the live path
     /// (`detect_and_handle_non_ff_rewrites`), which additionally renames
     /// working logs — something this after-the-fact replay does not attempt.
+    /// The span is identified by matching the command's observed ref
+    /// movement, not by position: an already-up-to-date rebase or a
+    /// fast-forward `pull --rebase` writes no span, and dropping the newest
+    /// span blindly would discard a genuinely stranded one — precisely the
+    /// natural case of a user re-running the same rebase after the blind
+    /// window.
     fn reconcile_unobserved_rebases(
         &self,
         cmd: &crate::daemon::domain::NormalizedCommand,
-        exclude_newest_span: bool,
+        command_is_completing_rebase: bool,
     ) -> Result<(), GitAiError> {
         let worktree = match cmd.worktree.as_ref() {
             Some(w) => w,
@@ -4763,7 +4770,14 @@ impl ActorDaemonCoordinator {
 
         let mut spans =
             crate::daemon::rebase_reconcile::completed_rebase_spans(&head_reflog);
-        if exclude_newest_span {
+        if command_is_completing_rebase
+            && spans.last().is_some_and(|newest| {
+                crate::daemon::rebase_reconcile::span_matches_command_ref_changes(
+                    newest,
+                    &cmd.ref_changes,
+                )
+            })
+        {
             spans.pop();
         }
         if spans.is_empty() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -62,6 +62,7 @@ pub mod domain;
 pub mod family_actor;
 pub mod git_backend;
 pub mod global_actor;
+pub mod rebase_reconcile;
 pub mod reducer;
 pub mod ref_cursor;
 pub mod rewrite_metrics;
@@ -2520,6 +2521,9 @@ pub struct ActorDaemonCoordinator {
     pending_cherry_pick_sources_by_worktree: Mutex<HashMap<String, Vec<String>>>,
     pending_cherry_pick_no_commit_by_worktree: Mutex<HashMap<String, PendingCherryPickNoCommit>>,
     pending_squash_merge_by_worktree: Mutex<HashMap<String, PendingSquashMerge>>,
+    /// Worktrees already scanned for rebases that completed while no daemon
+    /// was observing (reconciliation runs once per worktree per daemon life).
+    reconciled_unobserved_rebase_worktrees: Mutex<HashSet<String>>,
     inflight_effects_by_family: Mutex<HashMap<String, usize>>,
     /// Files with an in-flight AI edit (PreFileEdit received, PostFileEdit not yet completed).
     /// Outer key: family. Inner key: absolute file path string. Value: registration timestamp (nanos).
@@ -2608,6 +2612,7 @@ impl ActorDaemonCoordinator {
             pending_cherry_pick_sources_by_worktree: Mutex::new(HashMap::new()),
             pending_cherry_pick_no_commit_by_worktree: Mutex::new(HashMap::new()),
             pending_squash_merge_by_worktree: Mutex::new(HashMap::new()),
+            reconciled_unobserved_rebase_worktrees: Mutex::new(HashSet::new()),
             inflight_effects_by_family: Mutex::new(HashMap::new()),
             pending_ai_edits_by_family: Mutex::new(HashMap::new()),
             family_sequencers_by_family: Mutex::new(HashMap::new()),
@@ -4711,6 +4716,125 @@ impl ActorDaemonCoordinator {
     }
 
     /// Detects non-fast-forward ref moves and fires handle_rewrite_event.
+    /// Recover rebases that completed while no daemon was observing (daemon
+    /// down, or its trace ingestion broken) and replay them through the
+    /// non-fast-forward shift path so stranded authorship notes reach the
+    /// rewritten commits. Runs at most once per worktree per daemon lifetime,
+    /// on the first command that reaches side-effect processing for that
+    /// worktree.
+    ///
+    /// `exclude_newest_span` must be true when the triggering command is
+    /// itself a completing rebase / pull --rebase: its own span is already in
+    /// the reflog by side-effect time and is owned by the live path
+    /// (`detect_and_handle_non_ff_rewrites`), which additionally renames
+    /// working logs — something this after-the-fact replay does not attempt.
+    fn reconcile_unobserved_rebases(
+        &self,
+        cmd: &crate::daemon::domain::NormalizedCommand,
+        exclude_newest_span: bool,
+    ) -> Result<(), GitAiError> {
+        let worktree = match cmd.worktree.as_ref() {
+            Some(w) => w,
+            None => return Ok(()),
+        };
+        {
+            let mut seen = self
+                .reconciled_unobserved_rebase_worktrees
+                .lock()
+                .map_err(|_| {
+                    GitAiError::Generic(
+                        "reconciled unobserved rebase worktrees lock poisoned".to_string(),
+                    )
+                })?;
+            if !seen.insert(worktree.to_string_lossy().to_string()) {
+                return Ok(());
+            }
+        }
+
+        let head_log_path = match git_dir_for_worktree(worktree) {
+            Some(git_dir) => git_dir.join("logs").join("HEAD"),
+            None => return Ok(()),
+        };
+        let head_reflog = match fs::read_to_string(&head_log_path) {
+            Ok(contents) => contents,
+            // No reflog — nothing could have been missed.
+            Err(_) => return Ok(()),
+        };
+
+        let mut spans =
+            crate::daemon::rebase_reconcile::completed_rebase_spans(&head_reflog);
+        if exclude_newest_span {
+            spans.pop();
+        }
+        if spans.is_empty() {
+            return Ok(());
+        }
+
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+
+        for span in spans {
+            if now_secs.saturating_sub(span.finished_at_secs)
+                > crate::daemon::rebase_reconcile::MAX_SPAN_AGE_SECS
+            {
+                continue;
+            }
+            if span.old_tip == span.new_tip {
+                continue;
+            }
+            if !crate::daemon::rebase_reconcile::commit_exists(&repo, &span.old_tip)
+                || !crate::daemon::rebase_reconcile::commit_exists(&repo, &span.new_tip)
+            {
+                continue;
+            }
+            // Fast-forward "rebases" rewrite nothing.
+            if is_ancestor_commit(&repo, &span.old_tip, &span.new_tip) {
+                continue;
+            }
+            match crate::daemon::rebase_reconcile::span_has_stranded_notes(&repo, &span) {
+                Ok(true) => {}
+                Ok(false) => continue,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        old_tip = %span.old_tip,
+                        new_tip = %span.new_tip,
+                        "unobserved rebase note probe failed"
+                    );
+                    continue;
+                }
+            }
+            tracing::info!(
+                old_tip = %span.old_tip,
+                new_tip = %span.new_tip,
+                onto = %span.onto,
+                finished_at_secs = span.finished_at_secs,
+                repo = %worktree.display(),
+                "reconciling rebase that completed while unobserved"
+            );
+            if let Err(error) =
+                crate::authorship::rewrite::handle_non_fast_forward_rewrite_with_operation(
+                    &repo,
+                    &span.old_tip,
+                    &span.new_tip,
+                    Some(span.onto.as_str()),
+                    crate::authorship::rewrite::RewriteMetricOperation::Rebase,
+                )
+            {
+                tracing::warn!(
+                    error = %error,
+                    old_tip = %span.old_tip,
+                    new_tip = %span.new_tip,
+                    "unobserved rebase reconciliation failed"
+                );
+            }
+        }
+        Ok(())
+    }
+
     fn detect_and_handle_non_ff_rewrites(
         &self,
         cmd: &crate::daemon::domain::NormalizedCommand,
@@ -5120,6 +5244,17 @@ impl ActorDaemonCoordinator {
                 Some("checkout" | "switch" | "branch" | "stash")
             )
         };
+        // Rebases that completed while no daemon was observing left their
+        // notes stranded on the pre-rebase commits (cursor state is in-memory
+        // only, and cold seeding skips pre-daemon reflog history). Replay any
+        // such recent span once per worktree — before the current command's
+        // own non-FF handling, so a chained rebase can find its source notes.
+        if cmd.exit_code == 0
+            && let Err(error) =
+                self.reconcile_unobserved_rebases(cmd, is_completing_rebase || is_pull_rebase)
+        {
+            tracing::warn!(error = %error, "unobserved rebase reconciliation failed");
+        }
         if !skip_non_ff && cmd.exit_code == 0 {
             self.detect_and_handle_non_ff_rewrites(cmd)?;
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4753,7 +4753,7 @@ impl ActorDaemonCoordinator {
                         "reconciled unobserved rebase worktrees lock poisoned".to_string(),
                     )
                 })?;
-            if !seen.insert(worktree.to_string_lossy().to_string()) {
+            if !seen.insert(Self::worktree_state_key(worktree)) {
                 return Ok(());
             }
         }

--- a/src/daemon/rebase_reconcile.rs
+++ b/src/daemon/rebase_reconcile.rs
@@ -12,6 +12,7 @@
 //! merges/skips targets that already have notes, so replaying an
 //! already-handled span is a no-op).
 
+use crate::daemon::domain::RefChange;
 use crate::error::GitAiError;
 use crate::git::notes_api;
 use crate::git::repository::{Repository, exec_git};
@@ -94,6 +95,23 @@ pub(crate) fn completed_rebase_spans(head_reflog: &str) -> Vec<CompletedRebaseSp
         }
     }
     spans
+}
+
+/// True when the span's tips line up with a real ref movement observed for
+/// the current command — i.e. the span was produced by this command and is
+/// owned by the live non-fast-forward path, not left over from an earlier
+/// unobserved rebase. A no-op rebase ("current branch is up to date") writes
+/// no reflog span and observes no movement, and a fast-forward `pull
+/// --rebase` moves HEAD between tips unrelated to a stranded span, so
+/// neither matches.
+pub(crate) fn span_matches_command_ref_changes(
+    span: &CompletedRebaseSpan,
+    ref_changes: &[RefChange],
+) -> bool {
+    ref_changes
+        .iter()
+        .filter(|change| change.old != change.new)
+        .any(|change| change.old == span.old_tip || change.new == span.new_tip)
 }
 
 /// True when the span moved notes-bearing work onto commits that are missing
@@ -232,6 +250,49 @@ mod tests {
         assert_eq!(spans[0].finished_at_secs, 101);
         assert_eq!(spans[1].old_tip, C);
         assert_eq!(spans[1].new_tip, E);
+    }
+
+    fn ref_change(old: &str, new: &str) -> RefChange {
+        RefChange {
+            reference: "HEAD".to_string(),
+            old: old.to_string(),
+            new: new.to_string(),
+        }
+    }
+
+    fn span(old_tip: &str, new_tip: &str) -> CompletedRebaseSpan {
+        CompletedRebaseSpan {
+            old_tip: old_tip.to_string(),
+            new_tip: new_tip.to_string(),
+            onto: C.to_string(),
+            finished_at_secs: 100,
+        }
+    }
+
+    #[test]
+    fn span_matches_command_that_produced_it() {
+        // A live rebase's enriched ref changes start at the span's old tip
+        // and end at its new tip.
+        let changes = [ref_change(A, C), ref_change(C, B)];
+        assert!(span_matches_command_ref_changes(&span(A, B), &changes));
+    }
+
+    #[test]
+    fn stranded_span_does_not_match_noop_or_fast_forward_command() {
+        let stranded = span(A, B);
+        // No-op rebase ("current branch is up to date"): no ref movement.
+        assert!(!span_matches_command_ref_changes(&stranded, &[]));
+        // Degenerate change (old == new) must not count as the span's owner.
+        assert!(!span_matches_command_ref_changes(
+            &stranded,
+            &[ref_change(B, B)]
+        ));
+        // Fast-forward pull --rebase moves HEAD onward from the stranded
+        // span's new tip; neither endpoint pairs with the span.
+        assert!(!span_matches_command_ref_changes(
+            &stranded,
+            &[ref_change(B, D)]
+        ));
     }
 
     #[test]

--- a/src/daemon/rebase_reconcile.rs
+++ b/src/daemon/rebase_reconcile.rs
@@ -15,12 +15,16 @@
 use crate::daemon::domain::RefChange;
 use crate::error::GitAiError;
 use crate::git::notes_api;
-use crate::git::repository::{Repository, exec_git};
+use crate::git::repository::{Repository, exec_git, exec_git_stdin};
+use std::collections::HashSet;
 
 /// Upper bound on reflog entries scanned (from the tail) per worktree.
 pub(crate) const MAX_REFLOG_ENTRIES: usize = 512;
 /// Only spans that finished within this window are reconciled.
 pub(crate) const MAX_SPAN_AGE_SECS: i64 = 14 * 24 * 60 * 60;
+/// Hard cap on spans considered per worktree (newest kept), so the total git
+/// work is bounded by a constant regardless of how rebase-heavy the reflog is.
+pub(crate) const MAX_RECONCILE_SPANS: usize = 8;
 /// Upper bound on commits listed per span side when probing for stranded notes.
 const MAX_SPAN_COMMITS: usize = 100;
 
@@ -34,6 +38,13 @@ pub(crate) struct CompletedRebaseSpan {
     pub(crate) onto: String,
     /// Reflog timestamp (epoch seconds) of the finish entry.
     pub(crate) finished_at_secs: i64,
+    /// Distinct commits the span's own reflog rows record as created by the
+    /// rewrite (`new` of every row after the start, e.g. picks and the
+    /// finish). Free per-span target data — no git spawn needed — used to
+    /// screen out spans whose rewrites are all already noted. May include
+    /// intermediates later superseded within the same rebase; that only
+    /// widens candidacy, and the precise probe rejects false candidates.
+    pub(crate) rewritten_commits: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -71,6 +82,7 @@ pub(crate) fn completed_rebase_spans(head_reflog: &str) -> Vec<CompletedRebaseSp
 
     let mut spans = Vec::new();
     let mut open_start: Option<ReflogEntry> = None;
+    let mut open_rewritten: Vec<String> = Vec::new();
     for line in &lines[tail_start..] {
         let Some(entry) = parse_reflog_entry(line) else {
             continue;
@@ -79,19 +91,29 @@ pub(crate) fn completed_rebase_spans(head_reflog: &str) -> Vec<CompletedRebaseSp
         let is_rebase = entry.message.starts_with("rebase");
         if is_rebase && entry.message.contains("(start)") {
             open_start = Some(entry);
+            open_rewritten.clear();
         } else if is_rebase && entry.message.contains("(finish)") {
             if let Some(start) = open_start.take() {
+                let mut rewritten_commits = std::mem::take(&mut open_rewritten);
+                rewritten_commits.push(entry.new.clone());
+                rewritten_commits.sort();
+                rewritten_commits.dedup();
+                rewritten_commits.retain(|sha| *sha != start.new);
                 spans.push(CompletedRebaseSpan {
                     old_tip: start.old,
                     onto: start.new,
                     new_tip: entry.new,
                     finished_at_secs: entry.timestamp_secs,
+                    rewritten_commits,
                 });
             }
         } else if !is_rebase || entry.message.contains("(abort)") {
             // Any non-rebase HEAD move (or an abort) while a span is open
             // means that rebase never finished as a rewrite of this branch.
             open_start = None;
+            open_rewritten.clear();
+        } else if open_start.is_some() {
+            open_rewritten.push(entry.new.clone());
         }
     }
     spans
@@ -138,14 +160,45 @@ pub(crate) fn span_has_stranded_notes(
     Ok(noted_targets.len() < targets.len())
 }
 
-pub(crate) fn commit_exists(repo: &Repository, sha: &str) -> bool {
+/// Batched existence probe: a single `git cat-file --batch-check` spawn
+/// validates every candidate tip at once (never one spawn per object).
+/// Returns the subset of `shas` that resolve to commits.
+pub(crate) fn existing_commits(
+    repo: &Repository,
+    shas: &[String],
+) -> Result<HashSet<String>, GitAiError> {
+    if shas.is_empty() {
+        return Ok(HashSet::new());
+    }
     let mut args = repo.global_args_for_exec();
-    args.extend([
-        "cat-file".to_string(),
-        "-e".to_string(),
-        format!("{sha}^{{commit}}"),
-    ]);
-    exec_git(&args).is_ok()
+    args.extend(["cat-file".to_string(), "--batch-check".to_string()]);
+    let stdin = shas.join("\n");
+    let output = exec_git_stdin(&args, stdin.as_bytes())?;
+    let mut existing = HashSet::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let mut tokens = line.split_whitespace();
+        if let (Some(oid), Some(kind)) = (tokens.next(), tokens.next())
+            && kind == "commit"
+        {
+            existing.insert(oid.to_string());
+        }
+    }
+    Ok(existing)
+}
+
+/// Cheap screen using only reflog-derived data plus one batched note lookup:
+/// a span whose recorded rewritten commits all already carry notes was either
+/// handled live or reconciled before — it cannot be stranded. Spans with no
+/// recorded rewrites stay candidates so the precise probe can decide.
+pub(crate) fn may_have_stranded_notes(
+    span: &CompletedRebaseSpan,
+    noted_rewritten: &HashSet<String>,
+) -> bool {
+    span.rewritten_commits.is_empty()
+        || span
+            .rewritten_commits
+            .iter()
+            .any(|sha| !noted_rewritten.contains(sha))
 }
 
 fn rev_list_capped(
@@ -199,6 +252,7 @@ mod tests {
                 new_tip: D.to_string(),
                 onto: C.to_string(),
                 finished_at_secs: 202,
+                rewritten_commits: vec![D.to_string()],
             }]
         );
     }
@@ -266,7 +320,21 @@ mod tests {
             new_tip: new_tip.to_string(),
             onto: C.to_string(),
             finished_at_secs: 100,
+            rewritten_commits: vec![new_tip.to_string()],
         }
+    }
+
+    #[test]
+    fn screen_drops_spans_whose_rewrites_are_all_noted() {
+        let noted: HashSet<String> = [B.to_string()].into();
+        // All rewritten commits noted -> already handled, not a candidate.
+        assert!(!may_have_stranded_notes(&span(A, B), &noted));
+        // An unnoted rewritten commit keeps the span a candidate.
+        assert!(may_have_stranded_notes(&span(A, D), &noted));
+        // No recorded rewrites: stay a candidate for the precise probe.
+        let mut bare = span(A, B);
+        bare.rewritten_commits.clear();
+        assert!(may_have_stranded_notes(&bare, &noted));
     }
 
     #[test]

--- a/src/daemon/rebase_reconcile.rs
+++ b/src/daemon/rebase_reconcile.rs
@@ -1,0 +1,246 @@
+//! Reconciliation of rebases that completed while no daemon was observing.
+//!
+//! The live pipeline shifts authorship notes onto rebased commits only when
+//! the daemon observes the rebase (trace2 → `RefCursor` → non-fast-forward
+//! rewrite detection). If a rebase runs while the daemon is down — or while
+//! its trace ingestion is broken — the note stays on the pre-rebase commit
+//! forever: cursor offsets live only in memory, and cold seeding deliberately
+//! treats reflog history from before the first observed command as prior
+//! untraced history. This module closes that gap: recently completed rebase
+//! spans are recovered from the HEAD reflog and any span that stranded notes
+//! is replayed through the normal non-fast-forward shift path (which
+//! merges/skips targets that already have notes, so replaying an
+//! already-handled span is a no-op).
+
+use crate::error::GitAiError;
+use crate::git::notes_api;
+use crate::git::repository::{Repository, exec_git};
+
+/// Upper bound on reflog entries scanned (from the tail) per worktree.
+pub(crate) const MAX_REFLOG_ENTRIES: usize = 512;
+/// Only spans that finished within this window are reconciled.
+pub(crate) const MAX_SPAN_AGE_SECS: i64 = 14 * 24 * 60 * 60;
+/// Upper bound on commits listed per span side when probing for stranded notes.
+const MAX_SPAN_COMMITS: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompletedRebaseSpan {
+    /// HEAD before `rebase (start)` — the pre-rebase tip whose notes may be stranded.
+    pub(crate) old_tip: String,
+    /// HEAD at `rebase (finish)` — the rewritten tip that may be missing notes.
+    pub(crate) new_tip: String,
+    /// The commit checked out by `rebase (start)` (the rebase target / `--onto`).
+    pub(crate) onto: String,
+    /// Reflog timestamp (epoch seconds) of the finish entry.
+    pub(crate) finished_at_secs: i64,
+}
+
+#[derive(Debug)]
+struct ReflogEntry {
+    old: String,
+    new: String,
+    timestamp_secs: i64,
+    message: String,
+}
+
+fn parse_reflog_entry(line: &str) -> Option<ReflogEntry> {
+    let (left, message) = line.split_once('\t')?;
+    let fields: Vec<&str> = left.split_whitespace().collect();
+    // "<old> <new> <ident...> <epoch-secs> <tz>"
+    if fields.len() < 4 {
+        return None;
+    }
+    let timestamp_secs = fields[fields.len() - 2].parse::<i64>().ok()?;
+    Some(ReflogEntry {
+        old: fields[0].to_string(),
+        new: fields[1].to_string(),
+        timestamp_secs,
+        message: message.to_string(),
+    })
+}
+
+/// Parse completed `rebase (start) … rebase (finish)` spans out of a HEAD
+/// reflog, oldest first. Only the last [`MAX_REFLOG_ENTRIES`] entries are
+/// examined. Spans without a finish row are ignored: a conflicted rebase is
+/// still owned by the live path once it continues, and an abort restores the
+/// pre-rebase tip so there is nothing to shift.
+pub(crate) fn completed_rebase_spans(head_reflog: &str) -> Vec<CompletedRebaseSpan> {
+    let lines: Vec<&str> = head_reflog.lines().collect();
+    let tail_start = lines.len().saturating_sub(MAX_REFLOG_ENTRIES);
+
+    let mut spans = Vec::new();
+    let mut open_start: Option<ReflogEntry> = None;
+    for line in &lines[tail_start..] {
+        let Some(entry) = parse_reflog_entry(line) else {
+            continue;
+        };
+        // Covers both "rebase (...)" and legacy "rebase -i (...)" messages.
+        let is_rebase = entry.message.starts_with("rebase");
+        if is_rebase && entry.message.contains("(start)") {
+            open_start = Some(entry);
+        } else if is_rebase && entry.message.contains("(finish)") {
+            if let Some(start) = open_start.take() {
+                spans.push(CompletedRebaseSpan {
+                    old_tip: start.old,
+                    onto: start.new,
+                    new_tip: entry.new,
+                    finished_at_secs: entry.timestamp_secs,
+                });
+            }
+        } else if !is_rebase || entry.message.contains("(abort)") {
+            // Any non-rebase HEAD move (or an abort) while a span is open
+            // means that rebase never finished as a rewrite of this branch.
+            open_start = None;
+        }
+    }
+    spans
+}
+
+/// True when the span moved notes-bearing work onto commits that are missing
+/// notes: at least one source commit (reachable from `old_tip` only) has an
+/// authorship note while at least one target commit (reachable from `new_tip`
+/// only) has none. Keeps reconciliation from re-fetching/re-shifting spans
+/// that were already handled or never carried AI work.
+pub(crate) fn span_has_stranded_notes(
+    repo: &Repository,
+    span: &CompletedRebaseSpan,
+) -> Result<bool, GitAiError> {
+    let sources = rev_list_capped(repo, &span.old_tip, &span.new_tip)?;
+    if sources.is_empty() {
+        return Ok(false);
+    }
+    if notes_api::commits_with_notes(repo, &sources)?.is_empty() {
+        return Ok(false);
+    }
+    let targets = rev_list_capped(repo, &span.new_tip, &span.old_tip)?;
+    if targets.is_empty() {
+        return Ok(false);
+    }
+    let noted_targets = notes_api::commits_with_notes(repo, &targets)?;
+    Ok(noted_targets.len() < targets.len())
+}
+
+pub(crate) fn commit_exists(repo: &Repository, sha: &str) -> bool {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "cat-file".to_string(),
+        "-e".to_string(),
+        format!("{sha}^{{commit}}"),
+    ]);
+    exec_git(&args).is_ok()
+}
+
+fn rev_list_capped(
+    repo: &Repository,
+    include: &str,
+    exclude: &str,
+) -> Result<Vec<String>, GitAiError> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "rev-list".to_string(),
+        format!("--max-count={MAX_SPAN_COMMITS}"),
+        include.to_string(),
+        format!("^{exclude}"),
+    ]);
+    let output = exec_git(&args)?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const C: &str = "cccccccccccccccccccccccccccccccccccccccc";
+    const D: &str = "dddddddddddddddddddddddddddddddddddddddd";
+    const E: &str = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
+    fn entry(old: &str, new: &str, ts: i64, message: &str) -> String {
+        format!("{old} {new} Test User <test@example.com> {ts} +0000\t{message}\n")
+    }
+
+    #[test]
+    fn extracts_completed_span() {
+        let reflog = [
+            entry(A, B, 100, "commit: base"),
+            entry(B, C, 200, "rebase (start): checkout main"),
+            entry(C, D, 201, "rebase (pick): feature work"),
+            entry(D, D, 202, "rebase (finish): returning to refs/heads/feature"),
+        ]
+        .concat();
+        let spans = completed_rebase_spans(&reflog);
+        assert_eq!(
+            spans,
+            vec![CompletedRebaseSpan {
+                old_tip: B.to_string(),
+                new_tip: D.to_string(),
+                onto: C.to_string(),
+                finished_at_secs: 202,
+            }]
+        );
+    }
+
+    #[test]
+    fn ignores_unfinished_and_aborted_spans() {
+        let unfinished = [
+            entry(B, C, 200, "rebase (start): checkout main"),
+            entry(C, D, 201, "rebase (pick): feature work"),
+        ]
+        .concat();
+        assert!(completed_rebase_spans(&unfinished).is_empty());
+
+        let aborted = [
+            entry(B, C, 200, "rebase (start): checkout main"),
+            entry(C, B, 201, "rebase (abort): returning to refs/heads/feature"),
+            entry(B, E, 300, "commit: after abort"),
+        ]
+        .concat();
+        assert!(completed_rebase_spans(&aborted).is_empty());
+    }
+
+    #[test]
+    fn non_rebase_entry_closes_open_span() {
+        // A checkout in the middle of a conflicted rebase abandons the span;
+        // a later stray finish row must not pair with the stale start.
+        let reflog = [
+            entry(B, C, 200, "rebase (start): checkout main"),
+            entry(C, A, 210, "checkout: moving from feature to main"),
+            entry(A, E, 300, "rebase (finish): returning to refs/heads/other"),
+        ]
+        .concat();
+        assert!(completed_rebase_spans(&reflog).is_empty());
+    }
+
+    #[test]
+    fn extracts_multiple_spans_oldest_first() {
+        let reflog = [
+            entry(A, B, 100, "rebase (start): checkout main"),
+            entry(B, C, 101, "rebase (finish): returning to refs/heads/x"),
+            entry(C, C, 150, "commit (amend): tweak"),
+            entry(C, D, 200, "rebase -i (start): checkout main"),
+            entry(D, E, 201, "rebase -i (finish): returning to refs/heads/x"),
+        ]
+        .concat();
+        let spans = completed_rebase_spans(&reflog);
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].new_tip, C);
+        assert_eq!(spans[0].finished_at_secs, 101);
+        assert_eq!(spans[1].old_tip, C);
+        assert_eq!(spans[1].new_tip, E);
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped() {
+        let reflog = format!(
+            "not a reflog line\n{}{}",
+            entry(B, C, 200, "rebase (start): checkout main"),
+            entry(C, D, 201, "rebase (finish): returning to refs/heads/feature"),
+        );
+        assert_eq!(completed_rebase_spans(&reflog).len(), 1);
+    }
+}

--- a/tests/integration/cold_trace2_repo.rs
+++ b/tests/integration/cold_trace2_repo.rs
@@ -407,6 +407,49 @@ fn test_rebase_completed_while_unobserved_is_reconciled_on_next_traced_command()
     file.assert_committed_lines(crate::lines!["ai feature".ai()]);
 }
 
+/// Variant of the unobserved-rebase regression above where the first traced
+/// command after the blind window is the user *re-running the same rebase*,
+/// which is now a no-op ("current branch is up to date") and writes no
+/// reflog span. The triggering command being a completing rebase must not
+/// cause the genuinely stranded span to be skipped: the current command's
+/// span is identified by matching its observed ref movement, not by blindly
+/// dropping the newest span.
+#[test]
+fn test_noop_rebase_after_unobserved_rebase_still_reconciles_stranded_note() {
+    let mut repo = cold_repo();
+    raw_commit_file(&repo, "base.txt", "base\n", "raw base");
+    raw_git(&repo, &["branch", "-M", "main"]);
+
+    start_cold_daemon(&mut repo);
+    run_traced_git(&repo, &["checkout", "-b", "feature"]);
+    let old_feature = traced_ai_commit_file(&repo, "feature.txt", "ai feature\n", "ai feature");
+    assert_ai_authorship_note(&repo, &old_feature);
+
+    run_traced_git(&repo, &["checkout", "main"]);
+    raw_commit_file(&repo, "main.txt", "main advance\n", "raw main advance");
+    run_traced_git(&repo, &["checkout", "feature"]);
+
+    // Rebase happens while git-ai observes nothing.
+    raw_git(&repo, &["rebase", "main"]);
+    let rebased = raw_head(&repo);
+    assert_ne!(rebased, old_feature);
+    assert_no_ai_authorship_for_commit(&repo, &rebased);
+
+    // After the daemon restart the user re-runs the same rebase. It is a
+    // no-op and produces no new rebase span, but it IS a completing rebase
+    // command — the stranded span must still be reconciled.
+    repo.restart_dedicated_daemon_for_test();
+    let output = run_traced_git(&repo, &["rebase", "main"]);
+    assert!(
+        output.to_lowercase().contains("up to date"),
+        "re-run rebase should be a no-op, got: {output}"
+    );
+
+    assert_ai_authorship_note(&repo, &rebased);
+    let mut file = repo.filename("feature.txt");
+    file.assert_committed_lines(crate::lines!["ai feature".ai()]);
+}
+
 #[test]
 fn test_cold_repo_first_traced_conflict_rebase_ignores_stale_rebase_reflog_history() {
     let mut repo = TestRepo::new_dedicated_daemon();

--- a/tests/integration/cold_trace2_repo.rs
+++ b/tests/integration/cold_trace2_repo.rs
@@ -361,6 +361,52 @@ fn test_cold_repo_first_traced_rebase_is_processed() {
     assert_no_ai_authorship_for_commit(&repo, &rebased);
 }
 
+/// Regression: a rebase that completed while git-ai observed nothing (daemon
+/// down, or a daemon whose trace ingestion was broken) used to strand the AI
+/// authorship note on the pre-rebase commit forever. `RefCursor` offsets live
+/// only in memory and cold seeding intentionally treats reflog history from
+/// before the first observed command as prior untraced history, so no later
+/// daemon ever replayed the missed span -- the rebased commit stayed
+/// unattributed in blame and on the backend even though the source note
+/// existed the whole time. The daemon must reconcile recently completed
+/// rebase spans from the HEAD reflog when it first observes a command in the
+/// worktree, and shift the stranded notes onto the rewritten commits.
+#[test]
+fn test_rebase_completed_while_unobserved_is_reconciled_on_next_traced_command() {
+    let mut repo = cold_repo();
+    raw_commit_file(&repo, "base.txt", "base\n", "raw base");
+    raw_git(&repo, &["branch", "-M", "main"]);
+
+    // AI-authored commit on a feature branch, observed by a live daemon so
+    // the authorship note is written for the pre-rebase commit.
+    start_cold_daemon(&mut repo);
+    run_traced_git(&repo, &["checkout", "-b", "feature"]);
+    let old_feature = traced_ai_commit_file(&repo, "feature.txt", "ai feature\n", "ai feature");
+    assert_ai_authorship_note(&repo, &old_feature);
+
+    // Advance main so the upcoming rebase is a real rewrite.
+    run_traced_git(&repo, &["checkout", "main"]);
+    raw_commit_file(&repo, "main.txt", "main advance\n", "raw main advance");
+    run_traced_git(&repo, &["checkout", "feature"]);
+
+    // The rebase runs with hooks and trace2 disabled: git-ai sees nothing.
+    // This is the daemon-down / blind-ingestion window.
+    raw_git(&repo, &["rebase", "main"]);
+    let rebased = raw_head(&repo);
+    assert_ne!(rebased, old_feature);
+    assert_no_ai_authorship_for_commit(&repo, &rebased);
+
+    // Restart the daemon so no in-memory state survives the blind window,
+    // then run any traced command in the worktree. Reconciliation must pick
+    // the completed span out of the reflog and shift the note.
+    repo.restart_dedicated_daemon_for_test();
+    run_traced_git(&repo, &["commit", "--allow-empty", "-m", "poke"]);
+
+    assert_ai_authorship_note(&repo, &rebased);
+    let mut file = repo.filename("feature.txt");
+    file.assert_committed_lines(crate::lines!["ai feature".ai()]);
+}
+
 #[test]
 fn test_cold_repo_first_traced_conflict_rebase_ignores_stale_rebase_reflog_history() {
     let mut repo = TestRepo::new_dedicated_daemon();


### PR DESCRIPTION
## Problem

A rebase that runs while no daemon is observing — the daemon is down, restarting, or its trace ingestion is broken — strands the authorship note on the pre-rebase commit **permanently**:

- `RefCursor` offsets live only in memory (`family_actor.rs` spawns a fresh cursor per family per daemon lifetime), so nothing survives a restart.
- Cold seeding intentionally treats reflog history from before the first observed command as *prior untraced history* and never revisits it (`ref_cursor.rs`, `rebase_span_start_containing_offset`).
- `detect_and_handle_non_ff_rewrites` therefore never receives the missed `old_tip → new_tip` pair, `shift_authorship_notes` never runs, and the rewritten commit reads as unattributed forever — even though the source note exists locally and on the backend the whole time.

We hit this in production: a daemon session survived a network-outage crash in a degraded state (transcript sweeps and metrics kept flowing, git-op ingestion was dead), a branch was rebased during that window, and the rebased commit — the only commit on its PR — permanently lost its AI attribution. The pre-rebase commit still carries the full note; nothing ever moved it.

This is adjacent to the pull-rebase cold-cursor hardening documented in `docs/pull-rebase-authorship-loss-analysis-2026-06-21.md`: that work made cold seeding span-aware for the *currently observed* command, but a rebase that completed entirely before the daemon started (or while it was blind) still has no reconciliation path.

## Fix

New module `src/daemon/rebase_reconcile.rs` + a hook in the daemon's side-effect processing:

- On the **first command that reaches side-effect processing for each worktree** (once per worktree per daemon lifetime), parse the tail of that worktree's HEAD reflog (last 512 entries) for completed `rebase (start) … rebase (finish)` spans no older than 14 days.
- For each span, gate on: distinct existing tips, not a fast-forward, and a **stranded-notes probe** — at least one source-side commit has an authorship note while at least one target-side commit lacks one (`notes_api::commits_with_notes` over capped `rev-list`s). Spans that were already handled live, or never carried AI work, are skipped without any network traffic.
- Qualifying spans are replayed through the existing `handle_non_fast_forward_rewrite_with_operation` path (range-diff mapping → fetch missing source notes → `shift_authorship_notes_merging_existing_with_notes`). Merge mode makes the replay idempotent.
- When the triggering command is itself a completing rebase / `pull --rebase`, its own (newest) span is excluded — it stays owned by the live path, which additionally renames working logs.
- Reconciliation failures are logged and never fail the command pipeline.

Known limits (called out in the code): only the triggering worktree's HEAD reflog is scanned, and the replay does not attempt working-log renames for uncommitted state — it restores committed attribution.

## Tests

- 5 unit tests for the reflog span parser (completed span, unfinished/aborted spans ignored, span abandoned by a non-rebase HEAD move, multiple spans, malformed lines).
- Integration regression test `test_rebase_completed_while_unobserved_is_reconciled_on_next_traced_command` in `cold_trace2_repo.rs`, in the spirit of #1889's regression test: AI commit observed live → rebase performed with hooks + trace2 disabled (the blind window) → daemon restarted → any traced command must shift the stranded note onto the rebased commit, verified via the authorship note and `git-ai blame`. **Fails without the fix, passes with it.**
- Full `cold_trace2_repo` module: 34/35 passed with the fix; the one failure (`test_cold_repo_first_traced_conflict_rebase_ignores_stale_rebase_reflog_history`) passes in isolation with the fix and appears load/timing related — still confirming against an unpatched baseline run and will update here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)