### PR TITLE
Fix note not writing when precommit hook changes commit name

### DIFF
--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -465,7 +465,39 @@ impl RefCursor {
             .head_expected_transition(cmd, state)
             .without_old_oid_constraint()
             .with_reflog_messages(commit_reflog_messages(&args, amend));
-        self.consume_head_transition_for_command(cmd, state, prefixes, expected)
+        let Some(entry) = self.find_commit_head_entry(cmd, prefixes, expected)? else {
+            return Ok(());
+        };
+
+        self.consume_head_entry_for_command(cmd, entry)
+    }
+
+    fn find_commit_head_entry(
+        &mut self,
+        cmd: &NormalizedCommand,
+        message_prefixes: &[&str],
+        expected: ExpectedTransition,
+    ) -> Result<Option<CursorEntry>, GitAiError> {
+        // Prefer the exact argv-derived reflog message when possible: it is the
+        // strongest discriminator for untraced duplicate commit entries. A
+        // commit-msg hook can rewrite the subject after argv is fixed, though, and
+        // git records that final subject in the reflog. In that case fall back to a
+        // command-window match below instead of dropping the HEAD transition.
+        if let Some(entry) =
+            self.find_head_entry(cmd.worktree.as_deref(), message_prefixes, expected.clone())?
+        {
+            return Ok(Some(entry));
+        }
+
+        if expected.messages.is_empty() {
+            return Ok(None);
+        }
+
+        self.find_head_entry_in_command_window(
+            cmd,
+            message_prefixes,
+            expected.without_reflog_message_constraint(),
+        )
     }
 
     fn enrich_cherry_pick(
@@ -1353,6 +1385,43 @@ impl RefCursor {
         }
 
         Ok(latest_before_hint)
+    }
+
+    fn find_head_entry_in_command_window(
+        &mut self,
+        cmd: &NormalizedCommand,
+        message_prefixes: &[&str],
+        expected: ExpectedTransition,
+    ) -> Result<Option<CursorEntry>, GitAiError> {
+        let Some(worktree) = cmd.worktree.as_deref() else {
+            return Ok(None);
+        };
+        let Some(git_dir) = git_dir_for_worktree(worktree) else {
+            return Ok(None);
+        };
+        let key = head_key(&git_dir);
+        let path = git_dir.join("logs").join("HEAD");
+        let start = self.reflog_start_offset(&key, &path)?;
+        let command_window = reflog_timestamp_window(cmd);
+        let candidates = read_reflog_entries(key.clone(), &path, "HEAD", start)?
+            .into_iter()
+            .filter(|entry| {
+                !self.entry_consumed(entry)
+                    && expected.matches(entry)
+                    && message_matches(&entry.message, message_prefixes)
+                    && entry
+                        .timestamp_secs
+                        .is_some_and(|timestamp| command_window.contains(timestamp))
+            })
+            .collect::<Vec<_>>();
+
+        if self.command_start_hints.contains_key(&key) {
+            return Ok(self.select_candidate_with_hint(&key, candidates));
+        }
+        Ok(match candidates.as_slice() {
+            [entry] => Some(entry.clone()),
+            _ => None,
+        })
     }
 
     fn find_head_entry(
@@ -2245,6 +2314,11 @@ fn current_worktree_branch_ref<'a>(
 impl ExpectedTransition {
     fn with_reflog_messages(mut self, messages: HashSet<String>) -> Self {
         self.messages = messages;
+        self
+    }
+
+    fn without_reflog_message_constraint(mut self) -> Self {
+        self.messages.clear();
         self
     }
 
@@ -4023,6 +4097,84 @@ mod tests {
                 new: D.to_string(),
             }],
             "late ingress hint must select the traced duplicate-message commit"
+        );
+    }
+
+    #[test]
+    fn commit_reflog_subject_rewritten_by_hook_falls_back_to_hinted_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        let head_log = git_dir.join("logs/HEAD");
+        fs::create_dir_all(head_log.parent().unwrap()).unwrap();
+
+        let base_line =
+            format!("{A} {B} Test User <test@example.com> 0 +0000\tcommit: traced base\n");
+        let untraced_line =
+            format!("{B} {C} Test User <test@example.com> 0 +0000\tcommit: untraced\n");
+        let hooked_line =
+            format!("{C} {D} Test User <test@example.com> 0 +0000\tcommit: hooked: raw subject\n");
+        let in_order_offset = base_line.len() as u64;
+        let hint_offset = (base_line.len() + untraced_line.len()) as u64;
+        fs::write(
+            &head_log,
+            format!("{base_line}{untraced_line}{hooked_line}"),
+        )
+        .unwrap();
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let mut state = family_state(&family);
+        state.refs.insert("HEAD".to_string(), B.to_string());
+        let mut cursor = RefCursor::new(family.clone());
+        cursor
+            .initialize_reflog_cursor(&head_key(&git_dir), in_order_offset)
+            .unwrap();
+
+        let mut cmd =
+            command_with_worktree(&family, Some(worktree), &["commit", "-m", "raw subject"]);
+        cmd.reflog_start_offsets
+            .insert(head_key(&git_dir), hint_offset);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert_eq!(
+            cmd.ref_changes,
+            vec![RefChange {
+                reference: "HEAD".to_string(),
+                old: C.to_string(),
+                new: D.to_string(),
+            }],
+            "commit-msg hooks may rewrite the final subject used by git's reflog"
+        );
+    }
+
+    #[test]
+    fn commit_reflog_subject_rewrite_fallback_does_not_guess_without_hint() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = worktree.join(".git");
+        let head_log = git_dir.join("logs/HEAD");
+        fs::create_dir_all(head_log.parent().unwrap()).unwrap();
+
+        append_reflog(
+            &git_dir,
+            "HEAD",
+            &[
+                (A, B, "commit: untraced"),
+                (B, C, "commit: hooked: raw subject"),
+            ],
+        );
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let state = family_state(&family);
+        let mut cursor = RefCursor::new(family.clone());
+        let mut cmd =
+            command_with_worktree(&family, Some(worktree), &["commit", "-m", "raw subject"]);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert!(
+            cmd.ref_changes.is_empty(),
+            "without an exact message or command-start hint, multiple commit entries are ambiguous"
         );
     }
 

--- a/tests/integration/commit_msg_hook_rewrite_note_loss.rs
+++ b/tests/integration/commit_msg_hook_rewrite_note_loss.rs
@@ -8,8 +8,11 @@
 //! the raw argv subject, so the real reflog entry is missed and `ref_changes`
 //! remains empty.
 
+#[cfg(unix)]
 use crate::repos::test_file::ExpectedLineExt;
+#[cfg(unix)]
 use crate::repos::test_repo::TestRepo;
+#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/tests/integration/commit_msg_hook_rewrite_note_loss.rs
+++ b/tests/integration/commit_msg_hook_rewrite_note_loss.rs
@@ -1,0 +1,79 @@
+//! Repro for a customer bug: commits that run a hook suite can complete with
+//! an empty `new_head` in the daemon, so no authorship note is written.
+//!
+//! The repro uses a `commit-msg` hook that rewrites the final commit subject.
+//! `git commit -m ...` records the original subject in argv, but git writes the
+//! HEAD reflog message from the hook-rewritten final commit message. git-ai
+//! currently matches commit reflog entries against an exact message built from
+//! the raw argv subject, so the real reflog entry is missed and `ref_changes`
+//! remains empty.
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
+fn install_git_hook(repo: &TestRepo, name: &str, script: &str) {
+    let git_dir = repo.path().join(".git");
+    let hooks_dir = if git_dir.is_file() {
+        let content = fs::read_to_string(&git_dir).expect("read .git file");
+        let real_git_dir = content
+            .trim()
+            .strip_prefix("gitdir: ")
+            .expect("parse gitdir");
+        std::path::PathBuf::from(real_git_dir).join("hooks")
+    } else {
+        git_dir.join("hooks")
+    };
+    fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+    let hook_path = hooks_dir.join(name);
+    fs::write(&hook_path, script).unwrap_or_else(|_| panic!("write {name} hook"));
+    let mut perms = fs::metadata(&hook_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&hook_path, perms).unwrap_or_else(|_| panic!("chmod {name} hook"));
+}
+
+/// A hook suite can include a `commit-msg` hook that rewrites the final subject.
+/// Git writes the reflog message from the final hook-rewritten commit message,
+/// but git-ai currently builds an exact expected reflog message from the raw
+/// `git commit -m ...` argv. When those differ, the daemon misses the HEAD
+/// reflog entry and logs the commit with empty `new_head`.
+#[cfg(unix)]
+#[test]
+fn commit_msg_hook_rewriting_subject_still_writes_authorship_note() {
+    let repo = TestRepo::new();
+    let app_path = repo.path().join("app.py");
+
+    fs::write(&app_path, "print('start')\n").unwrap();
+    repo.stage_all_and_commit("initial commit").unwrap();
+
+    let mut app = repo.filename("app.py");
+    app.assert_committed_lines(crate::lines!["print('start')".unattributed_human()]);
+
+    install_git_hook(
+        &repo,
+        "commit-msg",
+        "#!/bin/sh\n\
+         msg_file=\"$1\"\n\
+         tmp=\"$msg_file.tmp\"\n\
+         { printf 'hooked: '; cat \"$msg_file\"; } > \"$tmp\"\n\
+         mv \"$tmp\" \"$msg_file\"\n\
+         exit 0\n",
+    );
+
+    fs::write(&app_path, "print('start')\nprint('ai wrote this')\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "app.py"]).unwrap();
+    repo.git(&["add", "app.py"]).unwrap();
+
+    // The actual commit subject becomes "hooked: add AI line", while the raw
+    // argv subject remains "add AI line". The daemon must still learn HEAD's
+    // new OID and write the authorship note.
+    repo.commit("add AI line").unwrap();
+
+    app.assert_committed_lines(crate::lines![
+        "print('start')".unattributed_human(),
+        "print('ai wrote this')".ai(),
+    ]);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -44,6 +44,7 @@ mod cli_parser_rebase_args;
 mod codex;
 mod cold_trace2_repo;
 mod commit_metric_metadata;
+mod commit_msg_hook_rewrite_note_loss;
 mod commit_post_stats_benchmark;
 mod config_cli_coverage;
 mod config_pattern_detection;


### PR DESCRIPTION
Before: if you have a pre-commit hook that renames a commit, that commit does not get a note with attribution written. (Notable symptom: daemon logs reported `op=commit` with empty `new_head`)

After: attempt to resolve the renamed commit using the existing machinery from `update-ref`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->