### PR TITLE
Preserve attribution across commit-time line reordering

### DIFF
--- a/src/authorship/attribution_tracker.rs
+++ b/src/authorship/attribution_tracker.rs
@@ -284,6 +284,15 @@ impl AttributionTracker {
         }
     }
 
+    /// Create a tracker that recognizes moves down to the specified number of lines.
+    pub(crate) fn with_move_lines_threshold(move_lines_threshold: usize) -> Self {
+        AttributionTracker {
+            config: AttributionConfig {
+                move_lines_threshold,
+            },
+        }
+    }
+
     /// Create a new attribution tracker with custom configuration
     #[allow(dead_code)]
     pub fn with_config(config: AttributionConfig) -> Self {

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1528,6 +1528,25 @@ fn line_sequence_contains(needle: &str, haystack: &str) -> bool {
     false
 }
 
+fn same_line_multiset(a: &str, b: &str) -> bool {
+    let normalized_a = normalize_line_endings(a);
+    let normalized_b = normalize_line_endings(b);
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for line in split_lines_preserving_terminators(&normalized_a) {
+        *counts.entry(line).or_default() += 1;
+    }
+    for line in split_lines_preserving_terminators(&normalized_b) {
+        let Some(count) = counts.get_mut(line) else {
+            return false;
+        };
+        *count -= 1;
+        if *count == 0 {
+            counts.remove(line);
+        }
+    }
+    counts.is_empty()
+}
+
 /// Pure carryover reconciliation given already-fetched contents (no git ops).
 /// `parent_content` is the file at the parent commit ("" if absent / initial).
 fn merged_carryover_content_pure(
@@ -1548,6 +1567,14 @@ fn merged_carryover_content_pure(
         return observed_content.to_string();
     }
     if content_eq_ignoring_line_endings(observed_content, parent_content) {
+        return committed_content.to_string();
+    }
+    // A formatter can reorder the checkpointed lines before the index is
+    // committed. A three-way merge treats the two insertion positions as
+    // independent and duplicates the moved lines in the carryover snapshot.
+    // Check this only after the one-sided cases so a real uncommitted reorder
+    // is retained when the committed side is unchanged from the parent.
+    if same_line_multiset(committed_content, observed_content) {
         return committed_content.to_string();
     }
     carryover_merge_content(parent_content, committed_content, observed_content)
@@ -2268,7 +2295,7 @@ impl VirtualAttributions {
         unstaged_hunks.retain(|_, ranges| !ranges.is_empty());
 
         // Process each file
-        for (file_path, (_, line_attrs)) in &self.attributions {
+        for (file_path, (char_attrs, line_attrs)) in &self.attributions {
             if line_attrs.is_empty() {
                 continue;
             }
@@ -2298,9 +2325,29 @@ impl VirtualAttributions {
                             file_path
                         ))
                     })?;
-                let shift_hunks = diff_hunks_between_contents(observed_content, carryover_content);
-                rebased_line_attrs =
-                    apply_hunk_shifts_to_line_attributions(line_attrs, &shift_hunks);
+                if !content_eq_ignoring_line_endings(observed_content, carryover_content)
+                    && same_line_multiset(observed_content, carryover_content)
+                {
+                    // Since the carryover snapshot adopted a formatter's ordering,
+                    // move each checkpoint attribution to that line's committed
+                    // position. Import sorters commonly move one line at a time.
+                    let tracker =
+                        crate::authorship::attribution_tracker::AttributionTracker::with_move_lines_threshold(1);
+                    let rebased_char_attrs = transform_attributions_to_final(
+                        &tracker,
+                        observed_content,
+                        char_attrs,
+                        carryover_content,
+                        self.ts,
+                    )?;
+                    rebased_line_attrs =
+                        attributions_to_line_attributions(&rebased_char_attrs, carryover_content);
+                } else {
+                    let shift_hunks =
+                        diff_hunks_between_contents(observed_content, carryover_content);
+                    rebased_line_attrs =
+                        apply_hunk_shifts_to_line_attributions(line_attrs, &shift_hunks);
+                }
                 &rebased_line_attrs
             } else {
                 line_attrs
@@ -3687,6 +3734,34 @@ mod tests {
             committed
         );
         assert!(diff_hunks_between_contents(observed, committed).is_empty());
+    }
+
+    #[test]
+    fn carryover_merge_uses_committed_order_for_the_same_lines() {
+        let parent = "import m\nimport n\n";
+        let committed = "import a\nimport b\nimport m\nimport n\n";
+        let observed = "import m\nimport n\nimport a\nimport b\n";
+
+        assert_eq!(
+            merged_carryover_content_pure(parent, committed, observed),
+            committed
+        );
+    }
+
+    #[test]
+    fn carryover_merge_retains_observed_only_reordering() {
+        let parent = "import a\nimport b\n";
+        let observed = "import b\nimport a\n";
+
+        assert_eq!(
+            merged_carryover_content_pure(parent, parent, observed),
+            observed
+        );
+    }
+
+    #[test]
+    fn line_multiset_comparison_counts_duplicate_lines() {
+        assert!(!same_line_multiset("duplicate\nduplicate\n", "duplicate\n"));
     }
 
     #[test]

--- a/tests/integration/daemon_commit_carryover.rs
+++ b/tests/integration/daemon_commit_carryover.rs
@@ -160,3 +160,71 @@ fn test_autocrlf_worktree_preserves_ai_attribution_after_commit() {
     assert_eq!(stats.ai_accepted, 3);
     assert_eq!(stats.unknown_additions, 0);
 }
+
+#[test]
+fn test_commit_time_import_reordering_preserves_ai_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("consumer.js");
+    let mut file = repo.filename("consumer.js");
+    fs::write(
+        &file_path,
+        "const base = 0;\nimport m1 from 'm1';\nimport n1 from 'n1';\nimport o1 from 'o1';\nimport p1 from 'p1';\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("baseline").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "const base = 0;".unattributed_human(),
+        "import m1 from 'm1';".unattributed_human(),
+        "import n1 from 'n1';".unattributed_human(),
+        "import o1 from 'o1';".unattributed_human(),
+        "import p1 from 'p1';".unattributed_human(),
+    ]);
+
+    repo.git_ai(&["checkpoint", "human", "consumer.js"])
+        .unwrap();
+    fs::write(
+        &file_path,
+        "const base = 0;\nimport m1 from 'm1';\nimport n1 from 'n1';\nimport o1 from 'o1';\nimport p1 from 'p1';\nimport d1 from 'd1';\nimport b1 from 'b1';\nimport a1 from 'a1';\nimport c1 from 'c1';\n",
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "consumer.js"])
+        .unwrap();
+
+    let status: serde_json::Value =
+        serde_json::from_str(&repo.git_ai(&["status", "--json"]).unwrap()).unwrap();
+    assert_eq!(status["stats"]["ai_additions"], 4);
+    assert_eq!(status["stats"]["unknown_additions"], 0);
+
+    // Simulate an import sorter running after the AI checkpoint but before the
+    // index snapshot is committed.
+    fs::write(
+        &file_path,
+        "const base = 0;\nimport a1 from 'a1';\nimport b1 from 'b1';\nimport c1 from 'c1';\nimport d1 from 'd1';\nimport m1 from 'm1';\nimport n1 from 'n1';\nimport o1 from 'o1';\nimport p1 from 'p1';\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("AI imports sorted before commit")
+        .unwrap();
+
+    file.assert_committed_lines(crate::lines![
+        "const base = 0;".unattributed_human(),
+        "import a1 from 'a1';".ai(),
+        "import b1 from 'b1';".ai(),
+        "import c1 from 'c1';".ai(),
+        "import d1 from 'd1';".ai(),
+        "import m1 from 'm1';".unattributed_human(),
+        "import n1 from 'n1';".unattributed_human(),
+        "import o1 from 'o1';".unattributed_human(),
+        "import p1 from 'p1';".unattributed_human(),
+    ]);
+
+    let stats = repo.stats().unwrap();
+    assert_eq!(stats.git_diff_added_lines, 4);
+    assert_eq!(stats.ai_additions, 4);
+    assert_eq!(stats.unknown_additions, 0);
+
+    let initial = repo.current_working_logs().read_initial_attributions();
+    assert!(
+        initial.files.is_empty(),
+        "clean commit left phantom INITIAL attribution: {initial:#?}"
+    );
+}


### PR DESCRIPTION
Fixes #1845

## Summary

- treat checkpoint and committed snapshots containing the same line multiset as a commit-time reorder instead of three-way merging both insertion positions
- rebase checkpoint attribution through single-line moves so import sorters preserve ownership
- retain genuine observed-only reorderings when the committed side is unchanged

## Root cause

When a formatter or import sorter reordered AI-added lines after the AI checkpoint but before commit, carryover reconciliation treated the old and new insertion positions as independent changes. The synthetic carryover snapshot duplicated the moved lines. Attribution followed those duplicate ghost lines into `INITIAL`, leaving the actual committed lines untracked even though the referenced blob still existed.

This is platform-independent and reproduces the macOS reports without requiring pre-v1.6 data or CRLF conversion.

## Test coverage

- added a `TestRepo` integration regression covering scrambled AI imports sorted before commit
- verifies pre-commit status reports 4 AI / 0 unknown
- verifies committed blame and stats remain 4 AI / 0 unknown
- verifies a clean commit leaves no phantom `INITIAL` attribution
- added unit coverage for duplicate lines and observed-only reorder carryover

## Validation

- `task test`
- `task lint`
- `task fmt`
- `task build`