### PR TITLE
Require global Git config access for daemon startup

### DIFF
--- a/scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py
+++ b/scripts/benchmarks/git/benchmark_nasty_modes_vs_main.py
@@ -201,9 +201,12 @@ def setup_variant_runtime(
     if variant.mode == "wrapper":
         create_link_or_copy(variant.binary, wrapper_git)
 
+    global_git_config = home_dir / ".gitconfig"
+    global_git_config.touch()
+
     env = dict(os.environ)
     env["HOME"] = str(home_dir)
-    env["GIT_CONFIG_GLOBAL"] = str(home_dir / ".gitconfig")
+    env["GIT_CONFIG_GLOBAL"] = str(global_git_config)
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GIT_AI_DEBUG"] = "0"
     env["GIT_AI_DEBUG_PERFORMANCE"] = "0"

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -17,12 +17,18 @@ pub(crate) fn sandbox_restriction() -> Option<SandboxRestriction> {
 }
 
 pub(crate) fn ensure_daemon_start_allowed() -> Result<(), String> {
-    let Some(restriction) = sandbox_restriction() else {
-        return Ok(());
-    };
+    if let Some(restriction) = sandbox_restriction() {
+        return Err(format!(
+            "cannot start the daemon inside the {} sandbox ({} is set)",
+            restriction.name, restriction.env_var
+        ));
+    }
 
-    Err(format!(
-        "cannot start the daemon inside the {} sandbox ({} is set)",
-        restriction.name, restriction.env_var
-    ))
+    crate::git::repository::exec_git(&[
+        "config".to_string(),
+        "--global".to_string(),
+        "--list".to_string(),
+    ])
+    .map(|_| ())
+    .map_err(|error| format!("cannot read global Git config: {error}"))
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -978,6 +978,94 @@ fn daemon_refuses_to_start_in_sandbox() {
 }
 
 #[test]
+#[serial]
+fn daemon_refuses_to_start_without_git_config_access() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let git_config_path = repo.test_home_path().join(".gitconfig");
+    fs::remove_file(&git_config_path).expect("failed to remove readable test Git config");
+    fs::create_dir(&git_config_path).expect("failed to make test git config unreadable");
+
+    for subcommand in ["start", "run"] {
+        let output = bg_command(&repo, subcommand, &[]);
+        if output.status.success() {
+            let _ = send_control_request(
+                &daemon_control_socket_path(&repo),
+                &ControlRequest::Shutdown,
+            );
+        }
+
+        assert!(
+            !output.status.success(),
+            "daemon {subcommand} should fail without git config access"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("cannot read global Git config"),
+            "daemon {subcommand} should explain the Git config failure: {stderr}"
+        );
+    }
+
+    assert!(
+        send_control_request_with_timeout(
+            &daemon_control_socket_path(&repo),
+            &ControlRequest::Ping,
+            DAEMON_TEST_PROBE_TIMEOUT,
+        )
+        .is_err(),
+        "daemon control socket should not be available"
+    );
+    assert!(
+        local_socket_connects_with_timeout(
+            &daemon_trace_socket_path(&repo),
+            DAEMON_TEST_PROBE_TIMEOUT,
+        )
+        .is_err(),
+        "daemon trace socket should not be available"
+    );
+}
+
+#[test]
+#[serial]
+fn daemon_refuses_to_start_without_a_global_git_config() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    fs::remove_file(repo.test_home_path().join(".gitconfig"))
+        .expect("failed to remove test global Git config");
+
+    let output = bg_command(&repo, "start", &[]);
+    assert!(
+        !output.status.success(),
+        "daemon start should require a global Git config"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot read global Git config"),
+        "daemon start should explain the Git config failure: {stderr}"
+    );
+}
+
+#[test]
+#[serial]
+fn daemon_start_only_requires_global_git_config_access() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let local_config_path = repo.path().join(".git").join("config");
+    fs::remove_file(&local_config_path).expect("failed to remove local Git config");
+    fs::create_dir(&local_config_path).expect("failed to make local Git config unreadable");
+
+    let output = bg_command(&repo, "start", &[]);
+    assert!(
+        output.status.success(),
+        "daemon start should ignore an unreadable local Git config: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    send_control_request(
+        &daemon_control_socket_path(&repo),
+        &ControlRequest::Shutdown,
+    )
+    .expect("daemon should be available for shutdown");
+}
+
+#[test]
 #[should_panic(expected = "pending daemon sync work")]
 fn dedicated_daemon_restart_rejects_pending_traced_command_for_test() {
     let mut repo = TestRepo::new_dedicated_daemon();

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -187,6 +187,7 @@ impl DaemonProcess {
         test_db_path: &Path,
         extra_env: &[(&str, &str)],
     ) -> Self {
+        ensure_test_global_git_config(test_home);
         let control_socket_path = Self::control_socket_path_for_home(test_home);
         let trace_socket_path = Self::trace_socket_path_for_home(test_home);
         let stderr_log_path = test_home
@@ -547,6 +548,15 @@ fn configure_test_home_env(command: &mut Command, test_home: &Path) {
         command.env("USERPROFILE", test_home);
         command.env("APPDATA", test_home.join("AppData").join("Roaming"));
         command.env("LOCALAPPDATA", test_home.join("AppData").join("Local"));
+    }
+}
+
+fn ensure_test_global_git_config(test_home: &Path) {
+    fs::create_dir_all(test_home).expect("failed to create test HOME");
+    let global_git_config_path = test_home.join(".gitconfig");
+    if !global_git_config_path.exists() {
+        fs::write(&global_git_config_path, "")
+            .expect("failed to write empty test global Git config");
     }
 }
 
@@ -1267,6 +1277,7 @@ impl TestRepo {
             );
         }
 
+        ensure_test_global_git_config(home);
         let config_dir = home.join(".git-ai");
         fs::create_dir_all(&config_dir).expect("failed to create test HOME config directory");
         let config_path = config_dir.join("config.json");


### PR DESCRIPTION
## Summary

Require daemon startup to have a readable global Git configuration.

- Validate only global config with one bounded `git config --global --list` invocation.
- Do not inspect repository-local config.
- Reject startup when the global config is absent, inaccessible, or invalid.
- Keep the probe outside trace2 ingestion and reuse the existing trace2-disabled Git execution helper.

## Why use Git directly

Git is the source of truth for config path resolution, parsing, and include behavior. A gix preflight added complexity without improving the intended contract: the daemon requires the global config to exist and be readable. The probe runs once at daemon startup, never on the latency-sensitive ingestion path, and has a fixed process bound.

## Tests and fixtures

Strict TDD coverage demonstrates that:

- an inaccessible global config rejects both `daemon start` and `daemon run`;
- an absent global config rejects startup;
- an inaccessible repository-local config does not block startup.

Isolated `TestRepo` homes contain an empty global config by default, matching the installed-product prerequisite; negative tests explicitly remove or replace it. The nasty benchmark fixture likewise creates the `GIT_CONFIG_GLOBAL` file before starting its isolated daemon.

Validated with:

- `task test TEST_FILTER=git_config`
- focused benchmark daemon-start smoke
- `task fmt`
- `task lint`
- `task test`