### PR TITLE
Fetch missing source notes from the HTTP backend before the git refs fetch

### DIFF
--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -381,7 +381,6 @@ pub fn materialize_notes_for_display(repo: &Repository, limit: usize) -> Result<
 /// This function is a best-effort operation: errors are logged but not propagated
 /// (callers should treat failure as a cache miss, not a hard error).
 pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitAiError> {
-    use crate::api::client::{ApiClient, ApiContext};
     use crate::git::repository::exec_git;
 
     // 1. Walk recent history. Prefer the remote's default branch; fall back to HEAD.
@@ -431,27 +430,7 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
     }
 
     // 2. Filter out SHAs already in notes-db.
-    let already_cached: std::collections::HashSet<String> = {
-        match crate::notes::db::NotesDatabase::global() {
-            Ok(db) => match db.lock() {
-                Ok(lock) => {
-                    let refs: Vec<&str> = all_shas.iter().map(|s| s.as_str()).collect();
-                    lock.get_notes(&refs)
-                        .unwrap_or_default()
-                        .into_keys()
-                        .collect()
-                }
-                Err(e) => {
-                    tracing::warn!("warm_cache_for_remote: DB lock poisoned: {}", e);
-                    std::collections::HashSet::new()
-                }
-            },
-            Err(e) => {
-                tracing::warn!("warm_cache_for_remote: failed to open notes-db: {}", e);
-                std::collections::HashSet::new()
-            }
-        }
-    };
+    let already_cached = cached_note_shas(&all_shas);
 
     let uncached: Vec<String> = all_shas
         .into_iter()
@@ -474,15 +453,78 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
         uncached.len()
     );
 
-    // 3. Batch-fetch from the HTTP backend (chunks of 100).
+    // 3+4. Batch-fetch from the HTTP backend and cache as synced rows.
+    fetch_and_cache_notes(&uncached).map(|_| ())
+}
+
+/// Fetch authorship notes for the given commits from the HTTP notes backend
+/// into the local notes-db cache (as already-synced rows), skipping SHAs
+/// already cached. Returns the SHAs newly cached.
+///
+/// Used by rewrite/shift paths when source notes are missing locally: on the
+/// HTTP backend the server — not `refs/notes/ai` — is the source of truth,
+/// and the git refs fetch requires SSH auth that is not available in every
+/// daemon environment.
+///
+/// Best-effort like [`warm_cache_for_remote`]: backend-unconfigured and
+/// unauthenticated states return an empty set rather than an error.
+pub fn warm_cache_for_commits(commit_shas: &[String]) -> Result<Vec<String>, GitAiError> {
+    let already_cached = cached_note_shas(commit_shas);
+    let uncached: Vec<String> = commit_shas
+        .iter()
+        .filter(|sha| !already_cached.contains(sha.as_str()))
+        .cloned()
+        .collect();
+    if uncached.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    tracing::info!(
+        backend = %"http",
+        uncached_commits = uncached.len(),
+        "fetching authorship notes"
+    );
+
+    fetch_and_cache_notes(&uncached)
+}
+
+/// SHAs among `shas` that already have a note in the local notes-db cache.
+fn cached_note_shas(shas: &[String]) -> std::collections::HashSet<String> {
+    match crate::notes::db::NotesDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(lock) => {
+                let refs: Vec<&str> = shas.iter().map(|s| s.as_str()).collect();
+                lock.get_notes(&refs)
+                    .unwrap_or_default()
+                    .into_keys()
+                    .collect()
+            }
+            Err(e) => {
+                tracing::warn!("notes cache lookup: DB lock poisoned: {}", e);
+                std::collections::HashSet::new()
+            }
+        },
+        Err(e) => {
+            tracing::warn!("notes cache lookup: failed to open notes-db: {}", e);
+            std::collections::HashSet::new()
+        }
+    }
+}
+
+/// Batch-fetch notes for `shas` from the HTTP backend (chunks of 100) and
+/// write them into notes-db as already-synced cache rows. Returns the SHAs
+/// cached. Read errors are logged and skipped (best-effort).
+fn fetch_and_cache_notes(shas: &[String]) -> Result<Vec<String>, GitAiError> {
+    use crate::api::client::{ApiClient, ApiContext};
+
     let cfg = crate::config::Config::fresh();
     let backend_url = match cfg.notes_backend_url() {
         Some(url) => url.to_string(),
         None => {
             tracing::debug!(
-                "warm_cache_for_remote: notes_backend.backend_url is not configured; skipping"
+                "notes backend fetch: notes_backend.backend_url is not configured; skipping"
             );
-            return Ok(());
+            return Ok(Vec::new());
         }
     };
     let ctx = ApiContext::new(Some(backend_url));
@@ -490,51 +532,52 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
 
     // Skip when not authenticated (matches daemon flush_notes pattern).
     if !client.is_logged_in() && !client.has_api_key() {
-        tracing::debug!("warm_cache_for_remote: not authenticated; skipping");
-        return Ok(());
+        tracing::debug!("notes backend fetch: not authenticated; skipping");
+        return Ok(Vec::new());
     }
 
-    for chunk in uncached.chunks(100) {
+    let mut cached = Vec::new();
+    for chunk in shas.chunks(100) {
         let sha_refs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
         match client.read_notes(&sha_refs) {
             Ok(response) => {
                 if response.notes.is_empty() {
                     continue;
                 }
-                // 4. Write returned entries as already-synced cache rows.
                 let entries: Vec<(String, String)> = response.notes.into_iter().collect();
                 match crate::notes::db::NotesDatabase::global() {
                     Ok(db) => match db.lock() {
                         Ok(mut lock) => {
                             if let Err(e) = lock.cache_synced_notes(&entries) {
                                 tracing::warn!(
-                                    "warm_cache_for_remote: cache_synced_notes error: {}",
+                                    "notes backend fetch: cache_synced_notes error: {}",
                                     e
                                 );
                             } else {
                                 tracing::debug!(
                                     count = entries.len(),
-                                    "warm_cache_for_remote: cached notes from remote"
+                                    "notes backend fetch: cached notes from backend"
                                 );
+                                cached.extend(entries.into_iter().map(|(sha, _)| sha));
                             }
                         }
                         Err(e) => {
-                            tracing::warn!("warm_cache_for_remote: DB lock poisoned: {}", e);
+                            tracing::warn!("notes backend fetch: DB lock poisoned: {}", e);
                         }
                     },
                     Err(e) => {
-                        tracing::warn!("warm_cache_for_remote: failed to open notes-db: {}", e);
+                        tracing::warn!("notes backend fetch: failed to open notes-db: {}", e);
                     }
                 }
             }
             Err(e) => {
                 // Best-effort: log and continue.
-                tracing::warn!("warm_cache_for_remote: read_notes error: {}", e);
+                tracing::warn!("notes backend fetch: read_notes error: {}", e);
             }
         }
     }
 
-    Ok(())
+    Ok(cached)
 }
 
 // --- HTTP backend helpers (private) ---

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -454,7 +454,8 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
     );
 
     // 3+4. Batch-fetch from the HTTP backend and cache as synced rows.
-    fetch_and_cache_notes(&uncached).map(|_| ())
+    http_fetch_and_cache_notes(&uncached);
+    Ok(())
 }
 
 /// Fetch authorship notes for the given commits from the HTTP notes backend
@@ -485,7 +486,7 @@ pub fn warm_cache_for_commits(commit_shas: &[String]) -> Result<Vec<String>, Git
         "fetching authorship notes"
     );
 
-    fetch_and_cache_notes(&uncached)
+    Ok(http_fetch_and_cache_notes(&uncached).into_keys().collect())
 }
 
 /// SHAs among `shas` that already have a note in the local notes-db cache.
@@ -509,75 +510,6 @@ fn cached_note_shas(shas: &[String]) -> std::collections::HashSet<String> {
             std::collections::HashSet::new()
         }
     }
-}
-
-/// Batch-fetch notes for `shas` from the HTTP backend (chunks of 100) and
-/// write them into notes-db as already-synced cache rows. Returns the SHAs
-/// cached. Read errors are logged and skipped (best-effort).
-fn fetch_and_cache_notes(shas: &[String]) -> Result<Vec<String>, GitAiError> {
-    use crate::api::client::{ApiClient, ApiContext};
-
-    let cfg = crate::config::Config::fresh();
-    let backend_url = match cfg.notes_backend_url() {
-        Some(url) => url.to_string(),
-        None => {
-            tracing::debug!(
-                "notes backend fetch: notes_backend.backend_url is not configured; skipping"
-            );
-            return Ok(Vec::new());
-        }
-    };
-    let ctx = ApiContext::new(Some(backend_url));
-    let client = ApiClient::new(ctx);
-
-    // Skip when not authenticated (matches daemon flush_notes pattern).
-    if !client.is_logged_in() && !client.has_api_key() {
-        tracing::debug!("notes backend fetch: not authenticated; skipping");
-        return Ok(Vec::new());
-    }
-
-    let mut cached = Vec::new();
-    for chunk in shas.chunks(100) {
-        let sha_refs: Vec<&str> = chunk.iter().map(|s| s.as_str()).collect();
-        match client.read_notes(&sha_refs) {
-            Ok(response) => {
-                if response.notes.is_empty() {
-                    continue;
-                }
-                let entries: Vec<(String, String)> = response.notes.into_iter().collect();
-                match crate::notes::db::NotesDatabase::global() {
-                    Ok(db) => match db.lock() {
-                        Ok(mut lock) => {
-                            if let Err(e) = lock.cache_synced_notes(&entries) {
-                                tracing::warn!(
-                                    "notes backend fetch: cache_synced_notes error: {}",
-                                    e
-                                );
-                            } else {
-                                tracing::debug!(
-                                    count = entries.len(),
-                                    "notes backend fetch: cached notes from backend"
-                                );
-                                cached.extend(entries.into_iter().map(|(sha, _)| sha));
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!("notes backend fetch: DB lock poisoned: {}", e);
-                        }
-                    },
-                    Err(e) => {
-                        tracing::warn!("notes backend fetch: failed to open notes-db: {}", e);
-                    }
-                }
-            }
-            Err(e) => {
-                // Best-effort: log and continue.
-                tracing::warn!("notes backend fetch: read_notes error: {}", e);
-            }
-        }
-    }
-
-    Ok(cached)
 }
 
 // --- HTTP backend helpers (private) ---

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -596,8 +596,9 @@ mod tests {
         let tmp_db = NamedTempFile::new().expect("tmp notes-db");
 
         let repo = TmpRepo::new().expect("TmpRepo::new");
-        repo.write_file("src.txt", "content", false).expect("write");
-        let sha = repo.commit_all("source commit").expect("commit");
+        repo.write_file("src.txt", "missing content", false)
+            .expect("write");
+        let sha = repo.commit_all("missing source commit").expect("commit");
         repo.git_command(&["remote", "add", "origin", "/nonexistent/git-ai-test-remote"])
             .expect("remote add");
 

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -566,7 +566,7 @@ mod tests {
 
         set_http_backend_env(tmp_db.path().to_str().unwrap(), &server.url());
 
-        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), &[sha.clone()]);
+        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), std::slice::from_ref(&sha));
 
         // The note must now be in the local cache as an already-synced row.
         let cached = {
@@ -613,7 +613,7 @@ mod tests {
             .create();
 
         set_http_backend_env(tmp_db.path().to_str().unwrap(), &server.url());
-        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), &[sha.clone()]);
+        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), std::slice::from_ref(&sha));
         clear_http_backend_env();
 
         let err = result.expect_err("missing everywhere should still be an error");

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -136,6 +136,28 @@ pub fn fetch_missing_notes_for_commits(
         return Ok(());
     }
 
+    // On the HTTP notes backend the server — not refs/notes/ai — is the
+    // source of truth: pull the missing source notes straight from it into
+    // the local cache first. The git refs fetch below requires working SSH
+    // auth in the daemon's environment and only helps repos whose notes live
+    // in refs; rewrites were stranding notes whenever that fetch failed
+    // (e.g. `Permission denied (publickey)`) even though the backend held
+    // every source note.
+    if crate::config::Config::fresh().notes_backend_enabled() {
+        let missing_owned: Vec<String> = missing.iter().map(|sha| sha.to_string()).collect();
+        match crate::git::notes_api::warm_cache_for_commits(&missing_owned) {
+            Ok(cached) => {
+                let cached: HashSet<String> = cached.into_iter().collect();
+                if missing_owned.iter().all(|sha| cached.contains(sha)) {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                tracing::debug!("HTTP backend fetch for missing source notes failed: {}", e);
+            }
+        }
+    }
+
     tracing::debug!(
         "Source commits missing notes: {:?}, trying to fetch from remotes",
         missing
@@ -486,6 +508,120 @@ fn build_authorship_push_args(global_args: Vec<String>, remote_name: &str) -> Ve
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn set_http_backend_env(db_path: &str, server_url: &str) {
+        // Safety: test-only env var manipulation, serialized on notes_db_env.
+        unsafe {
+            std::env::set_var("GIT_AI_TEST_NOTES_DB_PATH", db_path);
+            std::env::set_var("GIT_AI_NOTES_BACKEND_KIND", "http");
+            std::env::set_var("GIT_AI_NOTES_BACKEND_URL", server_url);
+            std::env::set_var("GIT_AI_API_KEY", "sync-authorship-test-key");
+        }
+    }
+
+    fn clear_http_backend_env() {
+        unsafe {
+            std::env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
+            std::env::remove_var("GIT_AI_NOTES_BACKEND_KIND");
+            std::env::remove_var("GIT_AI_NOTES_BACKEND_URL");
+            std::env::remove_var("GIT_AI_API_KEY");
+        }
+    }
+
+    /// Regression: a rewrite's missing source notes must be fetched from the
+    /// HTTP notes backend when the git refs fetch cannot succeed (e.g. the
+    /// daemon's environment has no SSH auth to the remote). This path was
+    /// previously refs-fetch-only, so rebases/restacks stranded authorship
+    /// notes with `failed to fetch authorship notes for source commits`
+    /// even though the backend held every source note.
+    #[test]
+    #[serial_test::serial(notes_db_env)]
+    fn fetch_missing_notes_pulls_sources_from_http_backend_when_refs_fetch_fails() {
+        use crate::git::test_utils::TmpRepo;
+        use tempfile::NamedTempFile;
+
+        let tmp_db = NamedTempFile::new().expect("tmp notes-db");
+
+        let repo = TmpRepo::new().expect("TmpRepo::new");
+        repo.write_file("src.txt", "content", false).expect("write");
+        let sha = repo.commit_all("source commit").expect("commit");
+
+        // A remote whose fetch always fails, standing in for broken SSH auth.
+        repo.git_command(&["remote", "add", "origin", "/nonexistent/git-ai-test-remote"])
+            .expect("remote add");
+
+        // The backend holds the note the local cache and refs are missing.
+        let mut server = mockito::Server::new();
+        let notes_json =
+            serde_json::json!({ "notes": { sha.clone(): "server-note-content" } }).to_string();
+        let _mock = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/worker/notes/".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(&notes_json)
+            .create();
+
+        set_http_backend_env(tmp_db.path().to_str().unwrap(), &server.url());
+
+        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), &[sha.clone()]);
+
+        // The note must now be in the local cache as an already-synced row.
+        let cached = {
+            let db = crate::notes::db::NotesDatabase::global().expect("global db");
+            let lock = db.lock().expect("lock");
+            lock.get_note(&sha).expect("get_note")
+        };
+        clear_http_backend_env();
+
+        assert!(
+            result.is_ok(),
+            "fetch_missing_notes_for_commits should succeed via the HTTP backend: {:?}",
+            result
+        );
+        assert_eq!(cached, Some("server-note-content".to_string()));
+    }
+
+    /// The error contract is preserved: when neither the HTTP backend nor
+    /// any remote can produce the missing source notes, the fetch still
+    /// fails loudly with the missing SHAs.
+    #[test]
+    #[serial_test::serial(notes_db_env)]
+    fn fetch_missing_notes_still_errors_when_backend_lacks_note() {
+        use crate::git::test_utils::TmpRepo;
+        use tempfile::NamedTempFile;
+
+        let tmp_db = NamedTempFile::new().expect("tmp notes-db");
+
+        let repo = TmpRepo::new().expect("TmpRepo::new");
+        repo.write_file("src.txt", "content", false).expect("write");
+        let sha = repo.commit_all("source commit").expect("commit");
+        repo.git_command(&["remote", "add", "origin", "/nonexistent/git-ai-test-remote"])
+            .expect("remote add");
+
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/worker/notes/".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"notes": {}}"#)
+            .create();
+
+        set_http_backend_env(tmp_db.path().to_str().unwrap(), &server.url());
+        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), &[sha.clone()]);
+        clear_http_backend_env();
+
+        let err = result.expect_err("missing everywhere should still be an error");
+        assert!(
+            err.to_string().contains(&sha),
+            "error should name the missing sha: {err}"
+        );
+    }
 
     #[test]
     fn authorship_fetch_args_always_disable_hooks() {


### PR DESCRIPTION
## Problem

When a rewrite (rebase/restack/cherry-pick) needs source notes that are not in the local notes-db cache, `fetch_missing_notes_for_commits` has exactly one recovery path: a git refs fetch of `refs/notes/ai` from each remote. On the **HTTP notes backend** that is the wrong tool twice over:

1. the server — not `refs/notes/ai` — is the source of truth, so the refs fetch often has nothing to offer even when the backend holds every note;
2. the fetch needs working SSH auth in the daemon's environment, which is not a given (the daemon's child `git fetch` may not see the user's SSH agent).

Observed at scale in a large deployment: dozens of restacked PRs permanently lost AI attribution because translation aborted with

```
failed to fetch authorship notes for source commits [...]: Git CLI (... fetch ... +refs/notes/ai:refs/notes/ai-remote/origin) failed with exit code 128: git@github.com: Permission denied (publickey).
```

…while the HTTP backend held every single source note. #1887/#1888 made the *presence check* backend-aware (cached sources skip the network), but sources missing from the local cache still funnel into the SSH-only fetch.

## Fix

- New `notes_api::warm_cache_for_commits(shas)`: batch-fetches specific SHAs from the HTTP backend into notes-db as already-synced rows. Shares the fetch/cache core (`fetch_and_cache_notes`) and the cached-SHA filter with `warm_cache_for_remote`, whose behavior and logging are unchanged.
- `fetch_missing_notes_for_commits`: when the HTTP backend is enabled, pull the missing sources from it first; if that covers everything, done — no refs fetch, no SSH. Otherwise fall through to the existing refs fetch and the existing still-missing error contract (unchanged for the git-notes backend).

Constant git cost: zero new git spawns — the backend fetch is one HTTP call per 100 SHAs and a notes-db write.

## Tests

- `fetch_missing_notes_pulls_sources_from_http_backend_when_refs_fetch_fails` — repo with a remote whose fetch always fails (stand-in for broken SSH auth), note available only on a mock backend server: previously returned the stranding error, now succeeds and caches the note as synced. **Red without the fix (verified by disabling the new path), green with it.**
- `fetch_missing_notes_still_errors_when_backend_lacks_note` — when neither the backend nor any remote has the note, the loud failure with the missing SHAs is preserved.
- Existing `warm_cache_for_remote_*` and notes_api cache tests pass unchanged.

Related: #1961 replays rebases that completed while no daemon was observing; its replay funnels through this same fetch, so the two fixes compose — #1961 finds the missed rewrite, this PR lets its note translation succeed without SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
