### PR TITLE
Bound range-diff squash fabrication in rewrite mapping derivation

### DIFF
--- a/scripts/repro/daemon-restack-undo-mapping-bomb/README.md
+++ b/scripts/repro/daemon-restack-undo-mapping-bomb/README.md
@@ -1,0 +1,167 @@
+# Repro: daemon memory blowup on restack undo (range-diff mapping bomb)
+
+Minimal, fully synthetic reproduction of a production incident where the git-ai
+daemon reached ~30 GB RSS (and made every git command crawl via machine-wide
+memory pressure) while processing the rewrite-attribution side effect of a
+**restack undo** — moving a branch from its rebased tip back to the pre-rebase
+tip, which is exactly what Graphite runs (`git reset --keep <old-tip>`) when a
+restack is undone or aborted.
+
+This fires **despite** the streaming diff-tree fix ("Fix high memory usage on
+large rebases", `b0efde3fb`, shipped in v1.6.15). That fix stopped buffering
+the raw patch text; this bug is the *parsed* structures, multiplied by an
+unbounded mapping count.
+
+Everything here is isolated: the script creates a brand-new temp repo, a fake
+`$HOME`, and a **per-run daemon** wired via trace2 sockets (the same wiring the
+integration-test harness uses). Nothing is installed system-wide and nothing
+touches your real `~/.git-ai`.
+
+## Root cause
+
+A non-hard `git reset` to a non-ancestor (the daemon's Reset handling in
+`src/daemon.rs`, non-fast-forward arm) raises
+`RewriteEvent::NonFastForward { old_tip: rebased_tip, new_tip: orig_tip }`,
+which flows into `handle_non_fast_forward_rewrite_with_operation`
+(`src/authorship/rewrite.rs:445`):
+
+1. `derive_mappings_from_range_diff` (`rewrite.rs:901`) runs
+   `git range-diff <merge-base>..<rebased-tip> <merge-base>..<orig-tip>`
+   (`run_range_diff`, `rewrite.rs:987`). For a restack undo the merge base is
+   the branch's **fork point**, so the left range contains **every trunk
+   commit landed since the branch forked** — thousands on a busy monorepo.
+   None of them match the right range, so each is emitted as an unmatched `<`
+   line, and `parse_range_diff_output` (`rewrite.rs:1008`) maps **every one**
+   of them to a commit of the new range (`previous_new_sha` / the
+   `pending_dropped` drain, `rewrite.rs:1031-1055`). Mapping count is
+   unbounded: ~= trunk commits since fork.
+2. `shift_authorship_notes_with_existing_mode` (`rewrite.rs:720`) batch-reads
+   the notes for all mapping endpoints (`read_notes_batch`, `rewrite.rs:738`)
+   and queues a **full-root-tree diff pair per mapping whose source commit has
+   a note** (`rewrite.rs:752-787`). On the Robinhood fleet effectively every
+   trunk commit has an authorship note, so ~every bogus mapping becomes a diff
+   pair — plus its parsed `AuthorshipLog` held in `pending`.
+3. `compute_diff_trees_batch` (`rewrite.rs:1231`) streams one
+   `git diff-tree --stdin -p -U0 -M -r` over all pairs. The raw text is no
+   longer buffered, **but** each pair still materializes a `DiffTreeResult`
+   (`rewrite.rs:34`): `added_lines_by_file` holds **one `u32` per `+` line**
+   and `hunks_by_file` one 16-byte `DiffHunk` per hunk
+   (`DiffTreeChunkParser`, `rewrite.rs:1321`), all collected into
+   `Vec<DiffTreeResult>` — alive until every pair is parsed and shifted.
+
+The blowup: each pair diffs a **trunk commit's tree against the original
+branch tip's tree**, i.e. it *reverses the entire trunk delta*. Every line the
+trunk modified since the fork point comes back as a `+` line (its pre-fork
+content), so:
+
+```
+daemon RSS  ≈  (trunk commits since fork)  ×  (lines modified on trunk)  ×  ~12 B
+```
+
+Both factors are unbounded and multiplicative. A monorepo branch forked a few
+weeks back easily has thousands of trunk commits × millions of modified lines
+— tens of GB. On top of the memory, `-U0 -M` diff generation across thousands
+of full-tree pairs is what burns the CPU/wall-clock (the raw patch text
+streamed through the parser is `pairs × trunk-delta bytes`, even though it is
+no longer held).
+
+Note `git reset --hard` does **not** reproduce this: the daemon's
+`ResetKind::Hard` arm only deletes the working log. The rewrite path fires for
+the non-hard kinds — and `--keep` is what Graphite uses.
+
+## Running it
+
+```bash
+task build   # produces target/debug/git-ai (or pass GIT_AI_BIN=...)
+./scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh              # default scale
+SCALE=small ./scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh  # quick sanity
+SCALE=large ./scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh  # multi-GB peak
+```
+
+What the script does:
+
+1. `git init` a temp repo; seed commit with `BASE_FILES × LINES_PER_FILE`
+   lines of pre-fork content.
+2. Create a `feature` branch with `STACK_COMMITS` commits, each preceded by
+   `git-ai checkpoint mock_ai <file>` so the daemon writes real authorship
+   notes. Waits until all notes exist.
+3. Advance `main` by `TRUNK_COMMITS` commits; the first one rewrites **every
+   line** of the pre-fork files (the trunk delta), the rest are cheap. Attach
+   an authorship note to **every** trunk commit (reusing a real note blob) —
+   modeling the org-wide notes fleet, where virtually every commit has one.
+4. `git rebase main` on the feature branch (traced → daemon) — the *cheap*
+   direction; waits for note migration to finish.
+5. **The trigger:** `git reset --keep <orig-tip>` (traced → daemon), i.e. the
+   restack undo. Samples daemon RSS (and child git processes) every 200 ms.
+6. Waits for the batched notes write that ends the shift, then prints peak
+   RSS, the mapping count straight from the daemon's debug log
+   (`shift_authorship_notes: N mappings`), the unmatched-commit count from the
+   same range-diff the daemon ran, and one pair's `+`-line/byte counts as
+   ground truth.
+
+### Knobs
+
+| Env var | Meaning |
+|---|---|
+| `STACK_COMMITS` | feature-branch commits with real AI notes (default 4) |
+| `TRUNK_COMMITS` | trunk commits after the fork; each gets a note and becomes one bogus mapping = one full-root-tree diff pair |
+| `BASE_FILES` | pre-fork files the first trunk commit rewrites |
+| `LINES_PER_FILE` | lines per pre-fork file; per-pair `+` lines = `BASE_FILES × LINES_PER_FILE` |
+| `PROCESS_TIMEOUT_SECS` | max wait for daemon processing (default 1800) |
+| `KEEP=1` | keep the temp workdir (repo, daemon stderr log, raw RSS samples) |
+| `GIT_AI_BIN` | git-ai binary to use (default `target/debug/git-ai`) |
+
+Expected: mappings ≈ `TRUNK_COMMITS`; parsed-structure memory ≈
+`TRUNK_COMMITS × BASE_FILES × LINES_PER_FILE × ~12 B`; bytes streamed through
+the parser ≈ `TRUNK_COMMITS ×` (one pair's raw diff bytes).
+
+## Measured results
+
+Measured on an M-series MacBook Pro (48 GB), macOS, debug build of git-ai
+(post-streaming-fix, branch `andrew/best-effort-source-note-fetch`). "Peak" is
+daemon RSS sampled at 200 ms during rewrite processing; baseline is daemon RSS
+immediately before the reset. Mapping counts are read from the daemon's own
+debug log (`shift_authorship_notes: N mappings`).
+
+| | `SCALE=small` | `SCALE=default` |
+|---|---|---|
+| trunk commits since fork | 150 | 600 |
+| trunk delta (`+` lines per pair) | 10,160 | 80,160 |
+| **mappings derived by the daemon** | **154** | **604** |
+| raw diff streamed through parser | 263 MB | 8,385 MB |
+| daemon RSS baseline | 26 MB | 28 MB |
+| daemon RSS peak | 36 MB | 234 MB |
+| daemon RSS delta | **+9 MB** | **+206 MB** |
+| rewrite processing wall time | 7 s | 33 s |
+| RSS delta per `+` line per pair | ~6 B | ~4.3 B |
+
+Two things worth noting:
+
+- The stack is 4 commits in both runs. The 150/600 extra mappings are pure
+  fabrication by `parse_range_diff_output` — the daemon literally logs
+  `shift_authorship_notes: 604 mappings` for a 4-commit branch move.
+- The RSS delta tracks `mappings × per-pair '+' lines × ~4–6 B` (the
+  `Vec<u32>` in `added_lines_by_file`, plus map/allocator overhead), while the
+  *streamed* raw text (8.4 GB at default scale) no longer shows up in RSS —
+  i.e. the streaming fix works, and the residual growth is exactly the parsed
+  accumulation.
+
+Extrapolation to the production incident (v1.6.15, rh monorepo): a stack
+forked weeks earlier easily faces ~3,000 trunk commits × ~2 M lines modified
+on trunk; at ~4–6 B per line per pair that is **24–36 GB of daemon RSS** —
+matching the observed ~30 GB — with the `-U0 -M` diff generation over
+thousands of full-tree pairs supplying the multi-minute-to-hours runtime and
+the machine-wide memory pressure that makes ordinary git commands take 30+
+seconds.
+
+## Fix directions
+
+The two factors need independent bounds:
+
+- **Clamp mapping derivation**: unmatched `<` commits mapped to
+  `previous_new_sha` should be bounded (or dropped entirely when the
+  unmatched count dwarfs the new range — a restack undo is not a squash of
+  3000 trunk commits into a 4-commit stack).
+- **Bound the per-batch parsed accumulation**: process diff pairs in bounded
+  chunks and drop each `DiffTreeResult` after its shift is applied, instead
+  of materializing all pairs before applying any.

--- a/scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh
+++ b/scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+#
+# Reproduces the git-ai daemon memory blowup on a "restack undo" — moving a
+# branch ref from a rebased tip back to its pre-rebase tip via
+# `git reset --keep <old-tip>` (exactly what Graphite runs when undoing /
+# aborting a restack). NOTE: `reset --hard` does NOT reproduce this — the
+# daemon's ResetKind::Hard arm only deletes the working log; the non-fast-
+# forward rewrite path fires for the non-hard reset kinds (daemon.rs Reset
+# handling).
+#
+# This fires DESPITE the streaming diff-tree fix ("Fix high memory usage on
+# large rebases"): the raw patch text is no longer buffered, but the daemon
+# still materializes one parsed DiffTreeResult per mapping, and the mapping
+# count is unbounded (see README.md in this directory):
+#
+#   parse_range_diff_output (src/authorship/rewrite.rs) maps EVERY unmatched
+#   `<` commit in the range-diff to a commit of the new range. For a restack
+#   undo, the old range (merge-base..rebased-tip) contains every trunk commit
+#   since the branch forked — thousands on a busy monorepo — and on a fleet
+#   where every commit has an authorship note, each one becomes a
+#   (trunk_commit, stack_commit) full-root-tree diff pair. Each pair's diff
+#   REVERSES the whole trunk delta, so its '+' lines are the pre-fork content
+#   of every line the trunk modified, and the parsed per-pair structures
+#   (added_lines_by_file: one u32 per '+' line) accumulate:
+#
+#     daemon RSS  ~=  (trunk commits since fork) x (lines modified on trunk) x ~12B
+#
+# This script builds a fully synthetic repo, drives a real rebase + reset
+# through an ISOLATED per-run daemon (same wiring as the integration-test
+# harness; nothing installed system-wide), samples daemon RSS during rewrite
+# processing, and prints the peak alongside ground-truth mapping count and
+# per-pair diff size.
+#
+# Usage:
+#   ./repro.sh                 # default scale (several-hundred-MB peak, a few minutes)
+#   SCALE=small ./repro.sh     # quick sanity run (~2 min)
+#   SCALE=large ./repro.sh     # multi-GB peak (long runtime)
+#   TRUNK_COMMITS=600 BASE_FILES=80 LINES_PER_FILE=1000 ./repro.sh   # custom
+#
+# Knobs (env vars):
+#   STACK_COMMITS    feature-branch commits with real AI authorship notes
+#   TRUNK_COMMITS    commits on main after the fork; EVERY one gets an
+#                    authorship note (models an org-wide notes fleet) and each
+#                    becomes one bogus mapping = one full-root-tree diff pair
+#   BASE_FILES       pre-fork files that the first trunk commit rewrites
+#   LINES_PER_FILE   lines per pre-fork file; every line is modified on trunk,
+#                    so per-pair '+' lines = BASE_FILES * LINES_PER_FILE
+#   PROCESS_TIMEOUT_SECS  how long to wait for the daemon to finish (default 1800)
+#   KEEP=1           keep the temp workdir + daemon logs
+#   GIT_AI_BIN       path to a git-ai binary (default: <repo>/target/debug/git-ai)
+#
+# Expected mappings            ~= TRUNK_COMMITS (+ STACK_COMMITS real ones)
+# Expected per-pair '+' lines  ~= BASE_FILES * LINES_PER_FILE
+# Expected daemon RSS delta    ~= mappings * plus_lines * ~12B
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Knobs
+# ---------------------------------------------------------------------------
+SCALE="${SCALE:-default}"
+case "$SCALE" in
+  small)
+    STACK_COMMITS="${STACK_COMMITS:-4}"
+    TRUNK_COMMITS="${TRUNK_COMMITS:-150}"
+    BASE_FILES="${BASE_FILES:-25}"
+    LINES_PER_FILE="${LINES_PER_FILE:-400}"
+    ;;
+  default)
+    STACK_COMMITS="${STACK_COMMITS:-4}"
+    TRUNK_COMMITS="${TRUNK_COMMITS:-600}"
+    BASE_FILES="${BASE_FILES:-80}"
+    LINES_PER_FILE="${LINES_PER_FILE:-1000}"
+    ;;
+  large)
+    STACK_COMMITS="${STACK_COMMITS:-4}"
+    TRUNK_COMMITS="${TRUNK_COMMITS:-1200}"
+    BASE_FILES="${BASE_FILES:-100}"
+    LINES_PER_FILE="${LINES_PER_FILE:-1500}"
+    ;;
+  *) echo "Unknown SCALE=$SCALE (small|default|large)"; exit 1 ;;
+esac
+PROCESS_TIMEOUT_SECS="${PROCESS_TIMEOUT_SECS:-1800}"
+KEEP="${KEEP:-0}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+GIT_AI_BIN="${GIT_AI_BIN:-$REPO_ROOT/target/debug/git-ai}"
+
+if [[ ! -x "$GIT_AI_BIN" ]]; then
+  echo "error: git-ai binary not found at $GIT_AI_BIN — run 'task build' first (or set GIT_AI_BIN)" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Sanitize PATH: drop any dir whose `git` is actually a git-ai wrapper, so the
+# repro never talks to a system-installed git-ai (mirrors the test harness).
+# ---------------------------------------------------------------------------
+sanitize_path() {
+  local out="" dir gitp
+  local IFS=':'
+  for dir in $PATH; do
+    gitp="$dir/git"
+    if [[ -f "$gitp" || -L "$gitp" ]]; then
+      if [[ -L "$gitp" ]] && readlink "$gitp" | grep -q "git-ai"; then continue; fi
+      if grep -q "git-ai" "$gitp" 2>/dev/null; then continue; fi
+      local canon
+      canon="$(cd "$(dirname "$gitp")" 2>/dev/null && pwd -P)/$(basename "$gitp")" || canon="$gitp"
+      if [[ "$canon" == *git-ai* ]]; then continue; fi
+    fi
+    out="${out:+$out:}$dir"
+  done
+  printf '%s' "$out"
+}
+SAFE_PATH="$(sanitize_path)"
+
+# ---------------------------------------------------------------------------
+# Isolated workspace: repo + fake HOME + per-run daemon sockets
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/git-ai-bomb.XXXXXX")"
+HOME_DIR="$WORK/home"
+REPO="$WORK/repo"
+SOCK_DIR="$WORK/s"
+CONTROL_SOCK="$SOCK_DIR/c.sock"
+TRACE_SOCK="$SOCK_DIR/t.sock"
+TEST_DB="$WORK/git-ai-test-db"
+RSS_LOG="$WORK/rss.log"
+DAEMON_LOG="$WORK/daemon.stderr.log"
+mkdir -p "$HOME_DIR/.git-ai" "$REPO" "$SOCK_DIR"
+
+if (( ${#TRACE_SOCK} >= 100 )); then
+  echo "error: socket path too long for AF_UNIX: $TRACE_SOCK" >&2
+  exit 1
+fi
+
+cat > "$HOME_DIR/.gitconfig" <<'EOF'
+[user]
+	name = Repro User
+	email = repro@example.com
+[init]
+	defaultBranch = main
+[gc]
+	auto = 0
+[advice]
+	detachedHead = false
+EOF
+# Keep the isolated git-ai fully offline / defaults (local git_notes backend).
+cat > "$HOME_DIR/.git-ai/config.json" <<'EOF'
+{
+  "telemetry_oss": "off",
+  "disable_version_checks": true,
+  "disable_auto_updates": true
+}
+EOF
+
+COMMON_ENV=(
+  "PATH=$SAFE_PATH"
+  "HOME=$HOME_DIR"
+  "GIT_CONFIG_GLOBAL=$HOME_DIR/.gitconfig"
+  "GIT_CONFIG_NOSYSTEM=1"
+  "XDG_CONFIG_HOME=$HOME_DIR/.config"
+)
+DAEMON_ENV=(
+  "GIT_AI_DAEMON_HOME=$HOME_DIR"
+  "GIT_AI_DAEMON_CONTROL_SOCKET=$CONTROL_SOCK"
+  "GIT_AI_DAEMON_TRACE_SOCKET=$TRACE_SOCK"
+  "GIT_AI_TEST_DB_PATH=$TEST_DB"
+  "GITAI_TEST_DB_PATH=$TEST_DB"
+)
+
+# Real git wired to the per-run daemon via trace2 (exactly how production learns
+# about git commands — git-ai does NOT wrap git).
+tgit() {
+  env "${COMMON_ENV[@]}" \
+    "GIT_TRACE2_EVENT=af_unix:stream:$TRACE_SOCK" \
+    "GIT_TRACE2_EVENT_NESTING=10" \
+    git -C "$REPO" "$@"
+}
+# git without trace2 (setup plumbing we don't want the daemon to see/process).
+qgit() {
+  env "${COMMON_ENV[@]}" git -C "$REPO" "$@"
+}
+gai() {
+  (cd "$REPO" && env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "$GIT_AI_BIN" "$@")
+}
+
+DAEMON_PID=""
+SAMPLER_PID=""
+cleanup() {
+  [[ -n "$SAMPLER_PID" ]] && kill "$SAMPLER_PID" 2>/dev/null || true
+  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    for _ in $(seq 1 20); do kill -0 "$DAEMON_PID" 2>/dev/null || break; sleep 0.1; done
+    kill -9 "$DAEMON_PID" 2>/dev/null || true
+  fi
+  if [[ "$KEEP" == "1" ]]; then
+    echo "[repro] KEEP=1 — workdir preserved at: $WORK"
+  else
+    rm -rf "$WORK"
+  fi
+}
+trap cleanup EXIT
+
+log() { printf '[repro] %s\n' "$*"; }
+
+PLUS_LINES_PER_PAIR=$(( BASE_FILES * LINES_PER_FILE ))
+log "workdir: $WORK"
+log "scale: SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_COMMITS=$TRUNK_COMMITS BASE_FILES=$BASE_FILES LINES_PER_FILE=$LINES_PER_FILE"
+log "expected: ~$TRUNK_COMMITS bogus mappings x ~$PLUS_LINES_PER_PAIR '+' lines/pair -> parsed structures ~$(( TRUNK_COMMITS * PLUS_LINES_PER_PAIR * 12 / 1048576 )) MB"
+
+# ---------------------------------------------------------------------------
+# Start the isolated daemon (GIT_AI_DEBUG=1 so the daemon log records
+# "shift_authorship_notes: N mappings" — direct proof of the mapping bomb).
+# ---------------------------------------------------------------------------
+env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "GIT_AI_DEBUG=1" "$GIT_AI_BIN" bg run >/dev/null 2>>"$DAEMON_LOG" &
+DAEMON_PID=$!
+log "daemon pid: $DAEMON_PID"
+for i in $(seq 1 100); do
+  [[ -S "$TRACE_SOCK" && -S "$CONTROL_SOCK" ]] && break
+  kill -0 "$DAEMON_PID" 2>/dev/null || { echo "daemon died at startup; log tail:"; tail -20 "$DAEMON_LOG"; exit 1; }
+  sleep 0.1
+done
+[[ -S "$TRACE_SOCK" ]] || { echo "daemon sockets never appeared"; exit 1; }
+log "daemon sockets ready"
+
+# ---------------------------------------------------------------------------
+# Build the synthetic repo
+# ---------------------------------------------------------------------------
+gen_file() { # path lines salt
+  awk -v n="$2" -v salt="$3" 'BEGIN {
+    for (i = 1; i <= n; i++)
+      printf "line %06d of %s :: 0123456789abcdefghijklmnopqrstuvwxyz-payload-%06d\n", i, salt, i * 7
+  }' > "$1"
+}
+
+qgit init -q -b main .
+
+# Seed commit: the pre-fork content the trunk will later rewrite. The restack
+# undo diffs (trunk commit -> original stack commit), which RESTORES this
+# content — that reversal is the '+' payload parsed into memory per pair.
+mkdir -p "$REPO/src"
+for i in $(seq 1 "$BASE_FILES"); do
+  gen_file "$REPO/src/module_$(printf '%03d' "$i").txt" "$LINES_PER_FILE" "module_$i"
+done
+echo "seed" > "$REPO/README.md"
+qgit add -A
+qgit commit -qm "seed"
+FORK_POINT="$(qgit rev-parse HEAD)"
+log "seed commit done ($BASE_FILES files x $LINES_PER_FILE lines)"
+
+# Feature branch: STACK_COMMITS commits with real AI authorship notes
+# (mock_ai checkpoint before commit => daemon writes an authorship note).
+qgit checkout -qb feature
+for i in $(seq 1 "$STACK_COMMITS"); do
+  f="feature_$(printf '%03d' "$i").txt"
+  gen_file "$REPO/$f" 40 "feature_$i"
+  gai checkpoint mock_ai "$f" >/dev/null
+  tgit add "$f"
+  tgit commit -qm "AI feature $i"
+done
+ORIG_TIP="$(qgit rev-parse feature)"
+log "created $STACK_COMMITS feature commits (waiting for authorship notes...)"
+
+ORIG_COMMITS_FILE="$WORK/orig_commits.txt"
+qgit rev-list --reverse "$FORK_POINT..feature" > "$ORIG_COMMITS_FILE"
+
+notes_hit_count() { # file-with-shas
+  local list
+  list="$(qgit notes --ref=ai list 2>/dev/null | awk '{print $2}')" || true
+  [[ -z "$list" ]] && { echo 0; return; }
+  grep -cFf <(printf '%s\n' "$list") "$1" || true
+}
+
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  n="$(notes_hit_count "$ORIG_COMMITS_FILE")"
+  (( n >= STACK_COMMITS )) && break
+  if (( $(date +%s) > deadline )); then
+    echo "error: only $n/$STACK_COMMITS feature commits got authorship notes in 300s" >&2
+    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+log "all $STACK_COMMITS feature commits have authorship notes (refs/notes/ai)"
+
+# Trunk advance: first commit rewrites EVERY line of every pre-fork file (the
+# large delta), then TRUNK_COMMITS-1 cheap commits. Untraced — pure setup.
+qgit checkout -q main
+for i in $(seq 1 "$BASE_FILES"); do
+  f="$REPO/src/module_$(printf '%03d' "$i").txt"
+  awk '{ print $0 " [rewritten-on-trunk]" }' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+done
+qgit add -A
+qgit commit -qm "trunk 1: rewrite all base files"
+for i in $(seq 2 "$TRUNK_COMMITS"); do
+  echo "tick $i" >> "$REPO/counter.txt"
+  qgit add counter.txt
+  qgit commit -qm "trunk $i"
+done
+log "trunk advanced by $TRUNK_COMMITS commits (delta: every line of $BASE_FILES x $LINES_PER_FILE rewritten)"
+
+# Give every trunk commit an authorship note (org-wide notes fleet: on the
+# real deployment virtually every trunk commit has one). Reuse the blob of a
+# real note — content just has to be a parseable AuthorshipLog for the mapping
+# to be queued as a diff pair (rewrite.rs pair queuing). Use stack commit #2's
+# note: the bogus trunk mappings all target stack commit #1 (pending_dropped ->
+# first matched pair), and merging a feature_002 attestation into commit #1's
+# note guarantees its content changes — which is our completion signal.
+NOTE_DONOR="$(sed -n 2p "$ORIG_COMMITS_FILE")"
+NOTE_BLOB="$(qgit notes --ref=ai list "$NOTE_DONOR" 2>/dev/null || qgit notes --ref=ai list | head -1 | awk '{print $1}')"
+[[ -n "$NOTE_BLOB" ]] || { echo "error: no authorship note blob found to reuse" >&2; exit 1; }
+TRUNK_COMMITS_FILE="$WORK/trunk_commits.txt"
+qgit rev-list "$FORK_POINT..main" > "$TRUNK_COMMITS_FILE"
+while read -r sha; do
+  qgit notes --ref=ai add -f -C "$NOTE_BLOB" "$sha" 2>/dev/null
+done < "$TRUNK_COMMITS_FILE"
+log "attached authorship notes to all $TRUNK_COMMITS trunk commits"
+
+# The setup restack: rebase feature onto the advanced trunk (traced). This is
+# the CHEAP direction — the range-diff old range is just the stack.
+qgit checkout -q feature
+log "running: git rebase main (traced -> daemon)"
+tgit rebase main >/dev/null
+REBASED_TIP="$(qgit rev-parse feature)"
+
+REBASED_COMMITS_FILE="$WORK/rebased_commits.txt"
+qgit rev-list --reverse "main..feature" > "$REBASED_COMMITS_FILE"
+
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  n="$(notes_hit_count "$REBASED_COMMITS_FILE")"
+  (( n >= STACK_COMMITS )) && break
+  if (( $(date +%s) > deadline )); then
+    echo "error: only $n/$STACK_COMMITS rebased commits got migrated notes in 300s" >&2
+    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+log "rebase note migration complete (notes on all $STACK_COMMITS rebased commits)"
+sleep 2  # let the daemon fully quiesce before baselining
+
+NOTES_REF_BEFORE="$(qgit rev-parse refs/notes/ai)"
+DAEMON_LOG_LINES_BEFORE="$(wc -l < "$DAEMON_LOG" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+# RSS sampler for the daemon (+ its direct children, i.e. the spawned
+# `git diff-tree` / `git range-diff`). Columns: epoch daemon_rss_kb children_rss_kb
+# ---------------------------------------------------------------------------
+(
+  while kill -0 "$DAEMON_PID" 2>/dev/null; do
+    ps -axo pid=,ppid=,rss= | awk -v d="$DAEMON_PID" -v t="$(date +%s)" '
+      $1 == d { drss = $3 } $2 == d { crss += $3 }
+      END { printf "%s %d %d\n", t, drss, crss }' >> "$RSS_LOG"
+    sleep 0.2
+  done
+) &
+SAMPLER_PID=$!
+
+BASELINE_KB="$(ps -o rss= -p "$DAEMON_PID" | tr -d ' ')"
+log "daemon baseline RSS: $(( BASELINE_KB / 1024 )) MB"
+
+# ---------------------------------------------------------------------------
+# THE TRIGGER: undo the restack — move the branch from the rebased tip back
+# to the original tip with `reset --keep`, exactly like gt's restack undo.
+# (`reset --hard` would NOT fire the rewrite path — see header comment.)
+# ---------------------------------------------------------------------------
+log "running: git reset --keep $ORIG_TIP (traced -> daemon)"
+RESET_START=$(date +%s)
+tgit reset --keep "$ORIG_TIP" >/dev/null
+RESET_END=$(date +%s)
+log "git reset finished in $(( RESET_END - RESET_START ))s; daemon now processes the rewrite asynchronously"
+
+# Completion: the shift ends with ONE batched notes write, so refs/notes/ai
+# moving is the "done" signal.
+deadline=$(( $(date +%s) + PROCESS_TIMEOUT_SECS ))
+while :; do
+  now="$(qgit rev-parse refs/notes/ai)"
+  if [[ "$now" != "$NOTES_REF_BEFORE" ]]; then
+    DONE_TS=$(date +%s)
+    break
+  fi
+  if (( $(date +%s) > deadline )); then
+    echo "error: rewrite processing incomplete after ${PROCESS_TIMEOUT_SECS}s (refs/notes/ai unchanged)" >&2
+    echo "daemon log tail:"; tail -40 "$DAEMON_LOG"
+    exit 1
+  fi
+  sleep 0.5
+done
+PROCESS_SECS=$(( DONE_TS - RESET_END ))
+log "rewrite processing complete: refs/notes/ai rewritten ($PROCESS_SECS s after reset exit)"
+
+# Let RSS settle a moment, then stop sampling.
+sleep 2
+kill "$SAMPLER_PID" 2>/dev/null || true
+wait "$SAMPLER_PID" 2>/dev/null || true
+SAMPLER_PID=""
+
+# ---------------------------------------------------------------------------
+# Ground truth
+# ---------------------------------------------------------------------------
+# Mapping count as the daemon derived it (debug log), if present.
+MAPPINGS_LOGGED="$(tail -n "+$(( DAEMON_LOG_LINES_BEFORE + 1 ))" "$DAEMON_LOG" \
+  | grep -o 'shift_authorship_notes: [0-9]* mappings' | grep -o '[0-9]*' | sort -n | tail -1 || true)"
+# Unmatched `<` commits in the same range-diff the daemon ran.
+RANGE_DIFF_DROPPED="$(qgit range-diff --no-color --no-abbrev -s --creation-factor=100 \
+  "$FORK_POINT..$REBASED_TIP" "$FORK_POINT..$ORIG_TIP" | grep -c '<' || true)"
+# One pair's diff, same flags as compute_diff_tree_stdin: '+' lines are what
+# the parser keeps (one u32 per line), bytes are what gets streamed per pair.
+PAIR_STATS="$(qgit diff-tree -p -U0 -M --no-color -r "$(head -1 "$TRUNK_COMMITS_FILE")" "$ORIG_TIP" \
+  | awk '/^\+/ && !/^\+\+\+/ { plus++ } { bytes += length($0) + 1 } END { printf "%d %d", plus, bytes }')"
+PAIR_PLUS_LINES="$(cut -d' ' -f1 <<<"$PAIR_STATS")"
+PAIR_BYTES="$(cut -d' ' -f2 <<<"$PAIR_STATS")"
+
+PEAK_KB="$(awk 'BEGIN{m=0} {if ($2>m) m=$2} END{print m}' "$RSS_LOG")"
+PEAK_CHILD_KB="$(awk 'BEGIN{m=0} {if ($3>m) m=$3} END{print m}' "$RSS_LOG")"
+
+echo
+echo "================================ RESULTS ================================"
+echo "knobs:                  SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_COMMITS=$TRUNK_COMMITS BASE_FILES=$BASE_FILES LINES_PER_FILE=$LINES_PER_FILE"
+echo "mappings (daemon log):  ${MAPPINGS_LOGGED:-n/a} (range-diff '<' commits: $RANGE_DIFF_DROPPED)"
+echo "per-pair diff:          $PAIR_PLUS_LINES '+' lines, $(( PAIR_BYTES / 1048576 )) MB raw"
+echo "streamed total:         ~$(( PAIR_BYTES * TRUNK_COMMITS / 1048576 )) MB through the parser (not buffered)"
+echo "daemon RSS baseline:    $(( BASELINE_KB / 1024 )) MB"
+echo "daemon RSS peak:        $(( PEAK_KB / 1024 )) MB  (delta +$(( (PEAK_KB - BASELINE_KB) / 1024 )) MB)"
+echo "peak child git RSS:     $(( PEAK_CHILD_KB / 1024 )) MB  (git diff-tree/range-diff spawned by daemon)"
+echo "rewrite processing:     ${PROCESS_SECS}s (reset exit -> batched notes write)"
+echo "========================================================================="

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -933,6 +933,32 @@ fn derive_mappings_from_range_diff(
         }
         _ => &base,
     };
+    // A genuine rebase replays a branch's own commits, so both range-diff
+    // sides stay small. A huge side means this ref move is not a rebase of
+    // the branch's work — typically a stale branch being moved onto a much
+    // newer base, where (with no usable onto hint) the new side spans the
+    // entire upstream divergence. `git range-diff` computes a full diff for
+    // every commit on both sides plus an N×M matching matrix, which has
+    // produced 30+ GB git child processes on large monorepos and taken the
+    // daemon down with them. Skip mapping derivation instead: a range that
+    // size has nothing meaningful to map.
+    let limit = range_diff_commit_limit();
+    let old_count = range_commit_count(repo, &base, old_tip);
+    let new_count = range_commit_count(repo, onto, new_tip);
+    let within_limit =
+        matches!((old_count, new_count), (Some(o), Some(n)) if o <= limit && n <= limit);
+    if !within_limit {
+        tracing::warn!(
+            old_tip = %old_tip,
+            new_tip = %new_tip,
+            old_count = ?old_count,
+            new_count = ?new_count,
+            limit,
+            "skipping range-diff mapping derivation: range too large to be a rebase"
+        );
+        return Ok(Vec::new());
+    }
+
     let range_diff_output = run_range_diff(repo, &base, old_tip, onto, new_tip)?;
     let mut mappings = parse_range_diff_output(&range_diff_output);
 
@@ -987,6 +1013,36 @@ pub(crate) fn list_commits_in_range(repo: &Repository, base: &str, tip: &str) ->
         .unwrap_or_default()
 }
 
+/// Default upper bound on commits per range-diff side. A genuine rebase
+/// replays a branch's own commits, so both sides stay far below this;
+/// ranges beyond it come from stale-branch syncs and similar non-rebase
+/// ref moves where mapping derivation is meaningless and the spawned
+/// `git range-diff` becomes pathologically expensive.
+const MAX_RANGE_DIFF_COMMITS: u64 = 1000;
+
+fn range_diff_commit_limit() -> u64 {
+    std::env::var("GIT_AI_RANGE_DIFF_COMMIT_LIMIT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(MAX_RANGE_DIFF_COMMITS)
+}
+
+/// Number of commits in `base..tip`, via a single `rev-list --count` spawn.
+/// `None` when the range cannot be resolved.
+fn range_commit_count(repo: &Repository, base: &str, tip: &str) -> Option<u64> {
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "rev-list".to_string(),
+        "--count".to_string(),
+        format!("{}..{}", base, tip),
+    ]);
+    let output = exec_git_allow_nonzero(&args).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
 fn run_range_diff(
     repo: &Repository,
     old_base: &str,
@@ -1008,8 +1064,28 @@ fn run_range_diff(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Bounds on range-diff `<` (dropped) commits that may be folded into
+/// neighboring kept commits as squash mappings. A real squash folds a
+/// handful of commits into an adjacent kept one; when the dropped count
+/// dwarfs the matched pairs, the two ranges are not versions of the same
+/// branch — typically a restack undo (`git reset --keep <pre-rebase-tip>`),
+/// where the old range contains every trunk commit since the branch's fork
+/// point. Folding those would fabricate one full-root-tree diff pair per
+/// trunk commit and reverse the entire trunk delta per pair — the daemon
+/// memory bomb reproduced in `scripts/repro/daemon-restack-undo-mapping-bomb`
+/// (~30 GB RSS observed in production on a large monorepo).
+const MAX_SQUASH_FANIN_PER_MATCH: usize = 8;
+const MAX_SQUASH_FANIN_FLOOR: usize = 64;
+
+fn squash_fanin_limit(matched_count: usize) -> usize {
+    MAX_SQUASH_FANIN_FLOOR.max(matched_count.saturating_mul(MAX_SQUASH_FANIN_PER_MATCH))
+}
+
 fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
-    let mut mappings = Vec::new();
+    // (old, new, fabricated): `fabricated` marks squash mappings synthesized
+    // for dropped (`<`) commits, as opposed to `=`/`!` matched pairs.
+    let mut entries: Vec<(String, String, bool)> = Vec::new();
+    let mut matched_count = 0usize;
     let mut pending_dropped: Vec<String> = Vec::new();
     let mut previous_new_sha: Option<String> = None;
 
@@ -1035,7 +1111,7 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
                 // Dropped commit (squashed into a later commit)
                 if !old_sha.chars().all(|c| c == '0') {
                     if let Some(new_sha) = previous_new_sha.as_ref() {
-                        mappings.push((old_sha, new_sha.clone()));
+                        entries.push((old_sha, new_sha.clone(), true));
                     } else {
                         pending_dropped.push(old_sha);
                     }
@@ -1052,10 +1128,11 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
                 }
                 // Map any preceding dropped commits to this new commit (squash)
                 for dropped in pending_dropped.drain(..) {
-                    mappings.push((dropped, new_sha.clone()));
+                    entries.push((dropped, new_sha.clone(), true));
                 }
                 previous_new_sha = Some(new_sha.clone());
-                mappings.push((old_sha, new_sha));
+                entries.push((old_sha, new_sha, false));
+                matched_count += 1;
             }
             _ => {
                 // '>' (new commit) or other — skip
@@ -1064,7 +1141,23 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
         }
     }
 
-    mappings
+    let squash_count = entries.len() - matched_count;
+    let limit = squash_fanin_limit(matched_count);
+    if squash_count > limit {
+        tracing::warn!(
+            dropped = squash_count,
+            matched = matched_count,
+            limit,
+            "range-diff dropped-commit count dwarfs the matched pairs; \
+             skipping squash mappings (the ranges are not two versions of one branch)"
+        );
+        entries.retain(|(_, _, fabricated)| !fabricated);
+    }
+
+    entries
+        .into_iter()
+        .map(|(old_sha, new_sha, _)| (old_sha, new_sha))
+        .collect()
 }
 
 /// Find the first maximal ASCII-hex run in `s` whose length is a valid git OID
@@ -1405,6 +1498,191 @@ fn extract_b_path(diff_header: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: `run_range_diff` was invoked with unbounded ranges. When a
+    /// stale branch is moved onto a much newer base (update-ref / branch
+    /// sync), the new side of the range spans the entire upstream divergence,
+    /// and the spawned `git range-diff` computes a full diff per commit on
+    /// both sides plus an N×M matching matrix — observed ballooning past
+    /// 30 GB on a large monorepo and crashing the daemon with it. Above the
+    /// commit limit, mapping derivation must skip instead of spawning
+    /// range-diff.
+    #[test]
+    fn derive_mappings_skips_when_range_exceeds_commit_limit() {
+        use crate::git::test_utils::TmpRepo;
+
+        let repo = TmpRepo::new().unwrap();
+        repo.write_file("base.txt", "base\n", false).unwrap();
+        repo.commit_all("base").unwrap();
+
+        // Branch with one real commit.
+        repo.create_branch("feature").unwrap();
+        repo.switch_branch("feature").unwrap();
+        repo.write_file("feature.txt", "feature\n", false).unwrap();
+        let old_tip = repo.commit_all("feature work").unwrap();
+
+        // "Upstream" advances by many commits, then replays the feature
+        // commit — the shape of a stale branch landing on a much newer base.
+        repo.switch_branch("main").unwrap();
+        for i in 0..12 {
+            repo.write_file("upstream.txt", &format!("v{i}\n"), false)
+                .unwrap();
+            repo.commit_all(&format!("upstream {i}")).unwrap();
+        }
+        repo.git_command(&["cherry-pick", &old_tip]).unwrap();
+        let new_tip = repo
+            .git_command(&["rev-parse", "HEAD"])
+            .unwrap()
+            .trim()
+            .to_string();
+
+        // Control: within the limit the replayed commit is mapped.
+        let mappings =
+            derive_mappings_from_range_diff(repo.gitai_repo(), &old_tip, &new_tip, None).unwrap();
+        assert!(
+            mappings.iter().any(|(old, _)| old == &old_tip),
+            "control: mapping should be derived for small ranges: {:?}",
+            mappings
+        );
+
+        // Above the limit, derivation must skip entirely.
+        // Safety: test-only env var manipulation.
+        unsafe { std::env::set_var("GIT_AI_RANGE_DIFF_COMMIT_LIMIT", "5") };
+        let mappings = derive_mappings_from_range_diff(repo.gitai_repo(), &old_tip, &new_tip, None);
+        unsafe { std::env::remove_var("GIT_AI_RANGE_DIFF_COMMIT_LIMIT") };
+        assert_eq!(
+            mappings.unwrap(),
+            Vec::new(),
+            "oversized ranges must skip range-diff mapping derivation"
+        );
+    }
+
+    fn sha(i: usize) -> String {
+        format!("{:040x}", i + 1)
+    }
+
+    fn matched_line(old: &str, new: &str) -> String {
+        format!(" 1:  {old} = 1:  {new} subject\n")
+    }
+
+    fn dropped_line(old: &str) -> String {
+        format!(" 2:  {old} < -:  ------------ subject\n")
+    }
+
+    /// A genuine squash keeps its fabricated dropped→kept mappings.
+    #[test]
+    fn parse_range_diff_keeps_proportionate_squash_mappings() {
+        let old_a = sha(1);
+        let old_b = sha(2);
+        let old_c = sha(3);
+        let new_a = sha(100);
+        let output = format!(
+            "{}{}{}",
+            dropped_line(&old_a),
+            dropped_line(&old_b),
+            matched_line(&old_c, &new_a),
+        );
+        let mappings = parse_range_diff_output(&output);
+        assert_eq!(
+            mappings,
+            vec![
+                (old_a, new_a.clone()),
+                (old_b, new_a.clone()),
+                (old_c, new_a),
+            ]
+        );
+    }
+
+    /// Regression (restack-undo mapping bomb): when the dropped-commit count
+    /// dwarfs the matched pairs, the ranges are not two versions of one
+    /// branch — mapping every dropped commit fabricates one full-root-tree
+    /// diff pair per trunk commit and blew the daemon past 30 GB RSS on a
+    /// large monorepo. The fabricated mappings must be dropped wholesale
+    /// while the matched pairs survive.
+    #[test]
+    fn parse_range_diff_drops_disproportionate_squash_mappings() {
+        let matched_old_a = sha(1000);
+        let matched_old_b = sha(1001);
+        let new_a = sha(2000);
+        let new_b = sha(2001);
+        let mut output = String::new();
+        output.push_str(&matched_line(&matched_old_a, &new_a));
+        // 70 "dropped" trunk commits > limit max(64, 2 * 8).
+        for i in 0..70 {
+            output.push_str(&dropped_line(&sha(i)));
+        }
+        output.push_str(&matched_line(&matched_old_b, &new_b));
+
+        let mappings = parse_range_diff_output(&output);
+        assert_eq!(
+            mappings,
+            vec![(matched_old_a, new_a), (matched_old_b, new_b)],
+            "only the matched pairs must survive a disproportionate drop count"
+        );
+    }
+
+    /// End-to-end shape of the production incident, on a real repo: rebase a
+    /// small branch onto an advanced trunk, then undo the restack by moving
+    /// the ref back to the pre-rebase tip (what `gt` does via
+    /// `git reset --keep`). Mapping derivation must return only the
+    /// stack-commit pairs — not one fabricated mapping per trunk commit.
+    #[test]
+    fn derive_mappings_restack_undo_yields_only_stack_mappings() {
+        use crate::git::test_utils::TmpRepo;
+
+        let repo = TmpRepo::new().unwrap();
+        repo.write_file("base.txt", "base\n", false).unwrap();
+        repo.commit_all("base").unwrap();
+
+        repo.create_branch("feature").unwrap();
+        repo.switch_branch("feature").unwrap();
+        repo.write_file("f1.txt", "one\n", false).unwrap();
+        repo.commit_all("stack 1").unwrap();
+        repo.write_file("f2.txt", "two\n", false).unwrap();
+        let orig_tip = repo.commit_all("stack 2").unwrap();
+
+        // Trunk advances by more commits than the squash fan-in limit.
+        repo.switch_branch("main").unwrap();
+        for i in 0..70 {
+            repo.write_file("trunk.txt", &format!("tick {i}\n"), false)
+                .unwrap();
+            repo.commit_all(&format!("trunk {i}")).unwrap();
+        }
+
+        // Restack, then capture the rebased tip and its commits.
+        repo.switch_branch("feature").unwrap();
+        repo.git_command(&["rebase", "main"]).unwrap();
+        let rebased_tip = repo
+            .git_command(&["rev-parse", "HEAD"])
+            .unwrap()
+            .trim()
+            .to_string();
+        let rebased_commits: Vec<String> = repo
+            .git_command(&["rev-list", "main..HEAD"])
+            .unwrap()
+            .lines()
+            .map(|l| l.trim().to_string())
+            .collect();
+
+        // The undo direction: old tip = rebased tip, new tip = original tip.
+        let mappings =
+            derive_mappings_from_range_diff(repo.gitai_repo(), &rebased_tip, &orig_tip, None)
+                .unwrap();
+
+        assert_eq!(
+            mappings.len(),
+            2,
+            "restack undo must map only the stack commits: {:?}",
+            mappings
+        );
+        for (old, _) in &mappings {
+            assert!(
+                rebased_commits.contains(old),
+                "mapping source {} is not a stack commit (trunk commit leaked in)",
+                old
+            );
+        }
+    }
 
     #[test]
     fn metric_commits_from_mappings_groups_squashed_sources() {


### PR DESCRIPTION
## Problem

A **restack undo** — `git reset --keep <pre-rebase-tip>`, exactly what Graphite runs when a restack is undone or aborted — drives the daemon's non-fast-forward rewrite handling with `old_tip = rebased tip`, `new_tip = original tip`. The merge base of those two is the branch's **fork point**, so the old side of the range-diff contains **every trunk commit landed since the branch forked** — thousands on a busy monorepo.

`parse_range_diff_output` mapped **every** unmatched `<` commit onto a neighboring kept commit (the squash heuristic, applied without any bound). The daemon literally derives **604 mappings for a 4-commit branch move**. Each fabricated mapping whose source commit carries an authorship note (on a fleet with notes on effectively every commit: all of them) becomes a full-root-tree `-U0 -M` diff pair that **reverses the entire trunk delta**, and the parsed per-pair structures (`added_lines_by_file`: one `u32` per `+` line, plus hunks) accumulate until every pair is processed:

```
daemon RSS ≈ (trunk commits since fork) × (lines modified on trunk) × ~12 B
```

This fires **despite** the streamed-diff fix (#1902 / b0efde3fb) — the raw patch text is streamed, the parsed structures are not. Production incident: **~30 GB RSS** on a large-monorepo deployment, with machine-wide memory pressure making every git command crawl. Fully synthetic, isolated repro with RSS measurements included in this PR under `scripts/repro/daemon-restack-undo-mapping-bomb/` (150 fabricated mappings at SCALE=small; 604 at default, +206 MB RSS from a 28 MB baseline on a debug build).

## Fix

Two independent bounds:

1. **`parse_range_diff_output` drops fabricated squash mappings wholesale when the dropped-commit count dwarfs the matched pairs** (limit: `max(64, 8 × matched)`). A genuine squash folds a handful of commits into an adjacent kept one; thousands of unmatched commits mean the two ranges are not versions of the same branch, and mapping them is meaningless — a restack undo is not a squash of 3,000 trunk commits into a 4-commit stack. Matched (`=`/`!`) pairs always survive, so real note migration is unaffected — and on a restack undo the original tips already hold their notes, so nothing is lost.
2. **`derive_mappings_from_range_diff` skips derivation when either range side exceeds `GIT_AI_RANGE_DIFF_COMMIT_LIMIT` (default 1000) commits** — an outer wall for the `range-diff`/`diff-tree` spawn cost itself. One `git rev-list --count` per side (constant spawns).

Deliberately **not** included (noted as follow-up): chunking `compute_diff_trees_batch` so `DiffTreeResult`s are dropped as applied. With fabrication bounded, pair counts return to real stack sizes and per-pair diffs return to commit-sized deltas, so the accumulation ceases to be the dominant factor.

## Tests

- `parse_range_diff_keeps_proportionate_squash_mappings` — genuine squash fabrication preserved (existing squash tests also still pass).
- `parse_range_diff_drops_disproportionate_squash_mappings` — 70 dropped vs 2 matched: only the matched pairs survive. **Red without the fix.**
- `derive_mappings_restack_undo_yields_only_stack_mappings` — real repo, repro-shaped at small scale: 2-commit branch, 70-commit trunk advance, rebase, then mapping derivation in the undo direction returns exactly the 2 stack mappings with zero trunk leakage. **Red without the fix.**
- `derive_mappings_skips_when_range_exceeds_commit_limit` — the outer wall, env-overridable limit. **Red without the guard.**
- All 36 `authorship::rewrite` unit tests green.

Related: #1902 fixed the raw-text buffering on this same path; #1677 reported the same user-visible symptom from an earlier variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)