### PR TITLE
fix(daemon): suppress unnecessary agent checkpoint traffic

### DIFF
--- a/src/commands/checkpoint_agent/presets/claude.rs
+++ b/src/commands/checkpoint_agent/presets/claude.rs
@@ -48,9 +48,16 @@ impl AgentPreset for ClaudePreset {
             ));
         }
 
+        let tool_class = parse::optional_str_multi(&data, &["tool_name", "toolName"])
+            .map(|name| bash_tool::classify_tool(Agent::Claude, name))
+            // Preserve legacy Claude payloads that predate tool_name.
+            .unwrap_or(ToolClass::FileEdit);
+        if tool_class == ToolClass::Skip {
+            return Ok(Vec::new());
+        }
+
         let cwd = parse::required_str(&data, "cwd")?;
         let transcript_path = parse::required_str(&data, "transcript_path")?;
-
         let session_id = parse::optional_str(&data, "session_id")
             .map(|s| s.to_string())
             .unwrap_or_else(|| {
@@ -58,13 +65,10 @@ impl AgentPreset for ClaudePreset {
                     .unwrap_or_else(|_| "unknown".to_string())
             });
 
-        let tool_name = parse::optional_str_multi(&data, &["tool_name", "toolName"]);
         let hook_event = parse::optional_str_multi(&data, &["hook_event_name", "hookEventName"]);
         let tool_use_id = parse::str_or_default_multi(&data, &["tool_use_id", "toolUseId"], "bash");
 
-        let is_bash = tool_name
-            .map(|n| bash_tool::classify_tool(Agent::Claude, n) == ToolClass::Bash)
-            .unwrap_or(false);
+        let is_bash = tool_class == ToolClass::Bash;
 
         let context = PresetContext {
             agent_id: AgentId {
@@ -217,6 +221,59 @@ mod tests {
                 assert_eq!(e.tool_use_id, "tu-1");
             }
             _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_claude_ignores_read_only_and_unsupported_tools() {
+        for hook_event in ["PreToolUse", "PostToolUse"] {
+            for tool_name in ["Read", "Glob", "Grep", "Task", "UnknownTool"] {
+                let input = json!({
+                    "hook_event_name": hook_event,
+                    "tool_name": tool_name,
+                    "transcript_path": "/does/not/exist.jsonl"
+                })
+                .to_string();
+
+                let events = ClaudePreset.parse(&input, "t_test123456789a").unwrap();
+                assert!(
+                    events.is_empty(),
+                    "{hook_event} {tool_name} unexpectedly produced events"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ignored_claude_hook_produces_no_checkpoint_requests() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "transcript_path": "/does/not/exist.jsonl"
+        })
+        .to_string();
+
+        let requests = crate::commands::checkpoint_agent::orchestrator::execute_preset_checkpoint(
+            "claude", &input,
+        )
+        .unwrap();
+        assert!(requests.is_empty());
+    }
+
+    #[test]
+    fn test_claude_preserves_all_mutating_file_tools() {
+        for tool_name in ["Write", "Edit", "MultiEdit"] {
+            let pre = make_claude_hook_input("PreToolUse", tool_name);
+            assert!(matches!(
+                ClaudePreset.parse(&pre, "t_test123456789a").unwrap()[..],
+                [ParsedHookEvent::PreFileEdit(_)]
+            ));
+
+            let post = make_claude_hook_input("PostToolUse", tool_name);
+            assert!(matches!(
+                ClaudePreset.parse(&post, "t_test123456789a").unwrap()[..],
+                [ParsedHookEvent::PostFileEdit(_)]
+            ));
         }
     }
 

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -16,8 +16,16 @@ use crate::git::repository::Repository;
 use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+#[cfg(any(test, not(feature = "test-support")))]
+use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+#[cfg(any(test, not(feature = "test-support")))]
+use std::sync::Mutex;
+#[cfg(not(any(test, feature = "test-support")))]
+use std::sync::OnceLock;
+#[cfg(any(test, not(feature = "test-support")))]
+use std::time::Duration;
 use std::time::Instant;
 #[cfg(not(any(test, feature = "test-support")))]
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -43,28 +51,105 @@ use crate::authorship::working_log::AgentId;
 
 #[cfg_attr(any(test, feature = "test-support"), allow(dead_code))]
 const AGENT_USAGE_MIN_INTERVAL_SECS: u64 = 150;
+#[cfg(any(test, not(feature = "test-support")))]
+const AGENT_USAGE_LIMITER_CAPACITY: usize = 10_000;
 
 #[cfg(not(any(test, feature = "test-support")))]
 const KNOWN_HUMAN_MIN_SECS_AFTER_AI: u64 = 1;
 
+#[cfg(any(test, not(feature = "test-support")))]
+struct AgentUsageLimiter {
+    interval: Duration,
+    capacity: usize,
+    last_emitted: HashMap<String, Instant>,
+    expiry_order: VecDeque<(String, Instant)>,
+}
+
+#[cfg(any(test, not(feature = "test-support")))]
+impl AgentUsageLimiter {
+    fn new(interval: Duration, capacity: usize) -> Self {
+        Self {
+            interval,
+            capacity,
+            last_emitted: HashMap::with_capacity(capacity),
+            expiry_order: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    fn should_emit(&mut self, prompt_id: &str, now: Instant) -> bool {
+        self.expire_stale(now);
+
+        if self.last_emitted.contains_key(prompt_id) {
+            return false;
+        }
+        if self.capacity == 0 {
+            return true;
+        }
+
+        while self.last_emitted.len() >= self.capacity {
+            let Some((oldest_id, emitted_at)) = self.expiry_order.pop_front() else {
+                self.last_emitted.clear();
+                break;
+            };
+            if self.last_emitted.get(&oldest_id) == Some(&emitted_at) {
+                self.last_emitted.remove(&oldest_id);
+            }
+        }
+
+        let prompt_id = prompt_id.to_string();
+        self.last_emitted.insert(prompt_id.clone(), now);
+        self.expiry_order.push_back((prompt_id, now));
+        true
+    }
+
+    fn expire_stale(&mut self, now: Instant) {
+        while let Some((prompt_id, emitted_at)) = self.expiry_order.front() {
+            if now.saturating_duration_since(*emitted_at) < self.interval {
+                break;
+            }
+            if self.last_emitted.get(prompt_id) == Some(emitted_at) {
+                self.last_emitted.remove(prompt_id);
+            }
+            self.expiry_order.pop_front();
+        }
+    }
+
+    #[cfg(test)]
+    fn entry_count(&self) -> usize {
+        self.last_emitted.len()
+    }
+
+    #[cfg(test)]
+    fn expiry_count(&self) -> usize {
+        self.expiry_order.len()
+    }
+}
+
+#[cfg(not(any(test, feature = "test-support")))]
+static AGENT_USAGE_LIMITER: OnceLock<Mutex<AgentUsageLimiter>> = OnceLock::new();
+
+#[cfg(any(test, not(feature = "test-support")))]
+fn should_emit_with_limiter(
+    limiter: &Mutex<AgentUsageLimiter>,
+    prompt_id: &str,
+    now: Instant,
+) -> bool {
+    let Ok(mut limiter) = limiter.lock() else {
+        return true;
+    };
+    limiter.should_emit(prompt_id, now)
+}
+
 #[cfg(not(any(test, feature = "test-support")))]
 pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
     let prompt_id = generate_short_hash(&agent_id.id, &agent_id.tool);
-    let now_ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    let Ok(db) = crate::metrics::db::MetricsDatabase::global() else {
-        return true;
-    };
-    let Ok(mut db_lock) = db.lock() else {
-        return true;
-    };
-
-    db_lock
-        .should_emit_agent_usage(&prompt_id, now_ts, AGENT_USAGE_MIN_INTERVAL_SECS)
-        .unwrap_or(true)
+    let limiter = AGENT_USAGE_LIMITER.get_or_init(|| {
+        Mutex::new(AgentUsageLimiter::new(
+            Duration::from_secs(AGENT_USAGE_MIN_INTERVAL_SECS),
+            AGENT_USAGE_LIMITER_CAPACITY,
+        ))
+    });
+    should_emit_with_limiter(limiter, &prompt_id, Instant::now())
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -1112,4 +1197,74 @@ fn compute_line_stats(
     }
 
     Ok(stats)
+}
+
+#[cfg(test)]
+mod agent_usage_limiter_tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn suppresses_until_the_interval_expires() {
+        let mut limiter = AgentUsageLimiter::new(Duration::from_secs(150), 10_000);
+        let start = Instant::now();
+
+        assert!(limiter.should_emit("session", start));
+        assert!(!limiter.should_emit("session", start + Duration::from_secs(149)));
+        assert!(limiter.should_emit("session", start + Duration::from_secs(150)));
+    }
+
+    #[test]
+    fn capacity_is_bounded_and_evicts_the_oldest_valid_entry() {
+        assert_eq!(AGENT_USAGE_LIMITER_CAPACITY, 10_000);
+        let mut limiter = AgentUsageLimiter::new(Duration::from_secs(150), 3);
+        let start = Instant::now();
+
+        assert!(limiter.should_emit("first", start));
+        assert!(limiter.should_emit("second", start + Duration::from_secs(1)));
+        assert!(limiter.should_emit("third", start + Duration::from_secs(2)));
+        assert_eq!(limiter.entry_count(), 3);
+        assert_eq!(limiter.expiry_count(), 3);
+
+        assert!(limiter.should_emit("fourth", start + Duration::from_secs(3)));
+        assert_eq!(limiter.entry_count(), 3);
+        assert_eq!(limiter.expiry_count(), 3);
+        assert!(
+            limiter.should_emit("first", start + Duration::from_secs(4)),
+            "the oldest valid entry should have been evicted"
+        );
+        assert!(
+            !limiter.should_emit("third", start + Duration::from_secs(4)),
+            "newer entries should remain suppressed"
+        );
+    }
+
+    #[test]
+    fn stale_entries_are_expired_before_capacity_eviction() {
+        let mut limiter = AgentUsageLimiter::new(Duration::from_secs(10), 2);
+        let start = Instant::now();
+
+        assert!(limiter.should_emit("stale", start));
+        assert!(limiter.should_emit("live", start + Duration::from_secs(9)));
+        assert!(limiter.should_emit("new", start + Duration::from_secs(10)));
+
+        assert_eq!(limiter.entry_count(), 2);
+        assert_eq!(limiter.expiry_count(), 2);
+        assert!(!limiter.should_emit("live", start + Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn poisoned_lock_fails_open() {
+        let limiter = Mutex::new(AgentUsageLimiter::new(Duration::from_secs(150), 1));
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = limiter.lock().unwrap();
+            panic!("poison limiter");
+        });
+
+        assert!(should_emit_with_limiter(
+            &limiter,
+            "session",
+            Instant::now()
+        ));
+    }
 }

--- a/tests/integration/claude_code.rs
+++ b/tests/integration/claude_code.rs
@@ -76,13 +76,7 @@ fn test_claude_preset_no_filepath_when_tool_input_missing() {
         .parse(hook_input, "t_test")
         .expect("Failed to run ClaudePreset");
 
-    assert_eq!(events.len(), 1);
-    match &events[0] {
-        ParsedHookEvent::PostFileEdit(e) => {
-            assert!(e.file_paths.is_empty());
-        }
-        _ => panic!("Expected PostFileEdit"),
-    }
+    assert!(events.is_empty());
 }
 
 #[test]
@@ -141,7 +135,7 @@ fn test_claude_preset_ignores_cursor_payload() {
 }
 
 #[test]
-fn test_claude_preset_does_not_ignore_when_transcript_path_is_claude() {
+fn test_claude_preset_ignores_unsupported_tool_when_transcript_path_is_claude() {
     let temp = tempfile::tempdir().unwrap();
     let claude_dir = temp.path().join(".claude").join("projects");
     fs::create_dir_all(&claude_dir).unwrap();
@@ -169,12 +163,7 @@ fn test_claude_preset_does_not_ignore_when_transcript_path_is_claude() {
         .parse(&hook_input, "t_test")
         .expect("Expected native Claude preset handling");
 
-    match &events[0] {
-        ParsedHookEvent::PostFileEdit(e) => {
-            assert_eq!(e.context.agent_id.tool, "claude");
-        }
-        _ => panic!("Expected PostFileEdit"),
-    }
+    assert!(events.is_empty());
 }
 
 #[test]
@@ -387,6 +376,6 @@ crate::reuse_tests_in_worktree!(
     test_claude_preset_no_filepath_when_tool_input_missing,
     test_claude_preset_ignores_vscode_copilot_payload,
     test_claude_preset_ignores_cursor_payload,
-    test_claude_preset_does_not_ignore_when_transcript_path_is_claude,
+    test_claude_preset_ignores_unsupported_tool_when_transcript_path_is_claude,
     test_claude_e2e_prefers_latest_checkpoint_for_prompts,
 );

--- a/tests/integration/rewrite_ops_attribution.rs
+++ b/tests/integration/rewrite_ops_attribution.rs
@@ -319,7 +319,7 @@ fn claude_checkpoint(repo: &TestRepo, event: &str, file_path: &Path, session_id:
     let hook_input = json!({
         "cwd": repo.path().to_string_lossy().to_string(),
         "hook_event_name": event,
-        "tool_name": "Update",
+        "tool_name": "Edit",
         "session_id": session_id,
         "transcript_path": transcript_path.to_string_lossy().to_string(),
         "tool_use_id": format!("{session_id}-{event}"),


### PR DESCRIPTION
## Summary

- replace the metrics-database rate-limit lookup with a daemon-local bounded monotonic limiter
- skip read-only and unsupported Claude hook payloads before transcript or repository work
- preserve all mutating Claude file-tool checkpoint behavior

## Tests

- limiter expiry, capacity, eviction, and poison fail-open unit coverage
- Claude read-only suppression and mutating-tool preservation coverage
- full task test, task lint, task fmt, and task build on the completed stack