### PR TITLE
refactor(daemon): add bounded family drain scheduling

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -60,6 +60,7 @@ pub mod coordinator;
 pub mod daemon_log_layer;
 pub mod domain;
 pub mod family_actor;
+mod family_drain_scheduler;
 pub mod git_backend;
 pub mod global_actor;
 pub mod reducer;
@@ -88,6 +89,8 @@ pub(crate) const TRACE_ROOT_REFLOG_START_OFFSETS_FIELD: &str = "git_ai_root_refl
 const TRACE_CONNECTION_CLOSED_EVENT: &str = "git_ai_connection_closed";
 const DAEMON_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 const DAEMON_CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+const FAMILY_DRAIN_CONCURRENCY: usize = 4;
+const FAMILY_INGRESS_REORDER_GRACE: Duration = Duration::from_millis(100);
 const DAEMON_CHECKPOINT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
 const DAEMON_SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 // Trace2 frames are written synchronously by Git to the daemon's Unix socket.
@@ -2531,7 +2534,7 @@ pub struct ActorDaemonCoordinator {
     recent_replay_prerequisites_by_family:
         Mutex<HashMap<String, VecDeque<RecentReplayPrerequisite>>>,
     side_effect_errors_by_family: Mutex<HashMap<String, BTreeMap<u64, String>>>,
-    side_effect_exec_locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+    family_drain_scheduler: crate::daemon::family_drain_scheduler::FamilyDrainScheduler,
     bash_sessions: Mutex<crate::daemon::bash_sessions::BashSessionState>,
     test_completion_log_dir: Option<PathBuf>,
     test_completion_log_lock: Mutex<()>,
@@ -2615,7 +2618,10 @@ impl ActorDaemonCoordinator {
             commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
             side_effect_errors_by_family: Mutex::new(HashMap::new()),
-            side_effect_exec_locks: Mutex::new(HashMap::new()),
+            family_drain_scheduler:
+                crate::daemon::family_drain_scheduler::FamilyDrainScheduler::new(
+                    FAMILY_DRAIN_CONCURRENCY,
+                ),
             bash_sessions: Mutex::new(crate::daemon::bash_sessions::BashSessionState::new()),
             test_completion_log_dir: std::env::var("GIT_AI_TEST_DB_PATH")
                 .ok()
@@ -2924,9 +2930,7 @@ impl ActorDaemonCoordinator {
         if let Ok(mut map) = self.family_sequencers_by_family.lock() {
             map.retain(|_, state| !state.entries.is_empty());
         }
-        if let Ok(mut map) = self.side_effect_exec_locks.lock() {
-            map.retain(|_, lock| Arc::strong_count(lock) <= 1);
-        }
+        self.family_drain_scheduler.gc_idle_families();
         if let Ok(mut map) = self.pending_rebase_original_head_by_worktree.lock() {
             map.shrink_to_fit();
         }
@@ -3119,12 +3123,10 @@ impl ActorDaemonCoordinator {
     }
 
     async fn append_ready_command_entry(
-        &self,
+        self: &Arc<Self>,
         family: &str,
         command: crate::daemon::domain::NormalizedCommand,
     ) -> Result<(), GitAiError> {
-        let exec_lock = self.side_effect_exec_lock(family)?;
-        let _guard = exec_lock.lock().await;
         {
             let mut sequencers = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
@@ -3145,43 +3147,94 @@ impl ActorDaemonCoordinator {
                 .entries
                 .insert(order, FamilySequencerEntry::ReadyCommand(Box::new(command)));
         }
-        self.drain_ready_family_sequencer_entries_locked(family)
-            .await
+        self.schedule_family_sequencer_drain(family.to_string());
+        Ok(())
     }
 
-    async fn drain_ready_family_sequencer_entries(&self, family: &str) -> Result<(), GitAiError> {
-        let exec_lock = self.side_effect_exec_lock(family)?;
-        let _guard = exec_lock.lock().await;
-        self.drain_ready_family_sequencer_entries_locked(family)
-            .await
+    fn schedule_family_sequencer_drain(self: &Arc<Self>, family: String) {
+        if !self.family_drain_scheduler.schedule(&family) {
+            return;
+        }
+
+        let coordinator = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(FAMILY_INGRESS_REORDER_GRACE).await;
+            coordinator
+                .family_drain_scheduler
+                .run(&family, || {
+                    let coordinator = coordinator.clone();
+                    let family = family.clone();
+                    async move {
+                        coordinator
+                            .drain_ready_family_sequencer_entries_locked(&family)
+                            .await
+                    }
+                })
+                .await;
+        });
     }
 
-    async fn drain_all_ready_family_sequencers(&self) -> Result<(), GitAiError> {
+    async fn drain_ready_family_sequencer_entries(
+        self: &Arc<Self>,
+        family: &str,
+    ) -> Result<(), GitAiError> {
+        self.schedule_family_sequencer_drain(family.to_string());
+        self.family_drain_scheduler.wait_idle(family).await;
+        if let Some(error) = self
+            .family_drain_scheduler
+            .snapshot(family)
+            .and_then(|snapshot| snapshot.last_error)
+        {
+            return Err(GitAiError::Generic(error));
+        }
+        Ok(())
+    }
+
+    async fn drain_all_ready_family_sequencers(self: &Arc<Self>) -> Result<(), GitAiError> {
         let families = {
             let map = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
             })?;
             map.keys().cloned().collect::<Vec<_>>()
         };
+        for family in &families {
+            self.schedule_family_sequencer_drain(family.clone());
+        }
         for family in families {
-            self.drain_ready_family_sequencer_entries(&family).await?;
+            self.family_drain_scheduler.wait_idle(&family).await;
+            if let Some(error) = self
+                .family_drain_scheduler
+                .snapshot(&family)
+                .and_then(|snapshot| snapshot.last_error)
+            {
+                return Err(GitAiError::Generic(error));
+            }
         }
         Ok(())
     }
 
     async fn drain_ready_family_sequencers_after_root_cleared(
-        &self,
+        self: &Arc<Self>,
         family: Option<String>,
     ) -> Result<(), GitAiError> {
         if let Some(family) = family {
-            self.drain_ready_family_sequencer_entries(&family).await
+            self.schedule_family_sequencer_drain(family);
         } else {
-            self.drain_all_ready_family_sequencers().await
+            let families = {
+                let map = self.family_sequencers_by_family.lock().map_err(|_| {
+                    GitAiError::Generic("family sequencer map lock poisoned".to_string())
+                })?;
+                map.keys().cloned().collect::<Vec<_>>()
+            };
+            for family in families {
+                self.schedule_family_sequencer_drain(family);
+            }
         }
+        Ok(())
     }
 
     async fn replace_pending_root_entry(
-        &self,
+        self: &Arc<Self>,
         root_sid: &str,
         replacement: FamilySequencerEntry,
     ) -> Result<Option<String>, GitAiError> {
@@ -3189,8 +3242,6 @@ impl ActorDaemonCoordinator {
             return Ok(None);
         };
         let family = slot.family.clone();
-        let exec_lock = self.side_effect_exec_lock(&family)?;
-        let _guard = exec_lock.lock().await;
         {
             let mut sequencers = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
@@ -3219,8 +3270,7 @@ impl ActorDaemonCoordinator {
                 }
             }
         }
-        self.drain_ready_family_sequencer_entries_locked(&family)
-            .await?;
+        self.schedule_family_sequencer_drain(family.clone());
         Ok(Some(family))
     }
 
@@ -3547,6 +3597,21 @@ impl ActorDaemonCoordinator {
         })
     }
 
+    fn has_open_trace_roots_that_may_mutate_family(&self, family: &str) -> bool {
+        let Ok(ingress) = self.trace_ingress_state.lock() else {
+            return false;
+        };
+        ingress.root_open_connections.iter().any(|(root, count)| {
+            *count > 0
+                && !ingress.root_definitely_read_only.contains(root)
+                && ingress.root_mutating.get(root).copied().unwrap_or(true)
+                && ingress
+                    .root_families
+                    .get(root)
+                    .is_none_or(|root_family| root_family == family)
+        })
+    }
+
     fn next_trace_ingest_seq(&self) -> u64 {
         // Relaxed: we only need fetch_add atomicity (unique monotone values),
         // not ordering w.r.t. any other atomic.
@@ -3835,6 +3900,36 @@ impl ActorDaemonCoordinator {
         }
     }
 
+    async fn wait_for_trace_ingest_processed_through_family(&self, family: &str) {
+        loop {
+            let target = self.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
+            loop {
+                let processed = self.processed_trace_ingest_seq.load(Ordering::Acquire) as u64;
+                if processed >= target {
+                    break;
+                }
+                let progress = self.trace_ingest_progress_notify.notified();
+                tokio::select! {
+                    _ = progress => {}
+                    _ = self.wait_for_shutdown() => return,
+                }
+            }
+
+            if !self.has_open_trace_roots_that_may_mutate_family(family) {
+                return;
+            }
+
+            let progress = self.trace_ingest_progress_notify.notified();
+            if !self.has_open_trace_roots_that_may_mutate_family(family) {
+                return;
+            }
+            tokio::select! {
+                _ = progress => {}
+                _ = self.wait_for_shutdown() => return,
+            }
+        }
+    }
+
     /// Prepares `payload` for ingestion and returns whether it should be
     /// enqueued.
     ///
@@ -4012,29 +4107,16 @@ impl ActorDaemonCoordinator {
         read_only_root
     }
 
-    fn side_effect_exec_lock(&self, family: &str) -> Result<Arc<AsyncMutex<()>>, GitAiError> {
-        let mut map = self
-            .side_effect_exec_locks
-            .lock()
-            .map_err(|_| GitAiError::Generic("side effect lock map lock poisoned".to_string()))?;
-        Ok(map
-            .entry(family.to_string())
-            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-            .clone())
-    }
-
     async fn append_checkpoint_to_family_sequencer(
-        &self,
+        self: &Arc<Self>,
         family: &str,
         request: CheckpointRequest,
         respond_to: Option<oneshot::Sender<Result<u64, GitAiError>>>,
     ) -> Result<(), GitAiError> {
         // Causal drain fence: ensure already-visible trace2 work has reached
         // the family sequencer before inserting this checkpoint.
-        self.wait_for_trace_ingest_processed_through().await;
-
-        let exec_lock = self.side_effect_exec_lock(family)?;
-        let _guard = exec_lock.lock().await;
+        self.wait_for_trace_ingest_processed_through_family(family)
+            .await;
 
         {
             let mut sequencers = self.family_sequencers_by_family.lock().map_err(|_| {
@@ -4061,8 +4143,8 @@ impl ActorDaemonCoordinator {
             );
         }
 
-        self.drain_ready_family_sequencer_entries_locked(family)
-            .await
+        self.schedule_family_sequencer_drain(family.to_string());
+        Ok(())
     }
 
     async fn drain_ready_family_sequencer_entries_locked(
@@ -5780,7 +5862,7 @@ impl ActorDaemonCoordinator {
     }
 
     async fn apply_trace_payload_to_state(
-        &self,
+        self: &Arc<Self>,
         payload: Value,
     ) -> Result<TracePayloadApplyOutcome, GitAiError> {
         let payload_root_sid = Self::trace_payload_root_sid(&payload);
@@ -5921,7 +6003,7 @@ impl ActorDaemonCoordinator {
     }
 
     async fn ingest_checkpoint_payload(
-        &self,
+        self: &Arc<Self>,
         request: CheckpointRequest,
     ) -> Result<ControlResponse, GitAiError> {
         if request.files.is_empty() {
@@ -5965,18 +6047,45 @@ impl ActorDaemonCoordinator {
             latest_seq,
             last_error: status
                 .last_error
-                .or_else(|| self.latest_side_effect_error(&family_key).ok().flatten()),
+                .or_else(|| self.latest_side_effect_error(&family_key).ok().flatten())
+                .or_else(|| {
+                    self.family_drain_scheduler
+                        .snapshot(&family_key)
+                        .and_then(|snapshot| snapshot.last_error)
+                }),
         })
     }
 
-    async fn sync_family(&self, repo_working_dir: String) -> Result<FamilyStatus, GitAiError> {
+    async fn sync_family(
+        self: &Arc<Self>,
+        repo_working_dir: String,
+    ) -> Result<FamilyStatus, GitAiError> {
         let family = self.backend.resolve_family(Path::new(&repo_working_dir))?;
-        self.wait_for_trace_ingest_processed_through().await;
+        loop {
+            self.wait_for_trace_ingest_processed_through_family(&family.0)
+                .await;
+            self.drain_ready_family_sequencer_entries(&family.0).await?;
 
-        let exec_lock = self.side_effect_exec_lock(&family.0)?;
-        let _guard = exec_lock.lock().await;
-        self.drain_ready_family_sequencer_entries_locked(&family.0)
-            .await?;
+            let has_entries = self
+                .family_sequencers_by_family
+                .lock()
+                .map_err(|_| GitAiError::Generic("family sequencer map lock poisoned".to_string()))?
+                .get(&family.0)
+                .is_some_and(|state| !state.entries.is_empty());
+            let scheduler_busy = self
+                .family_drain_scheduler
+                .snapshot(&family.0)
+                .is_some_and(|snapshot| !snapshot.is_idle());
+            let effects_in_flight = self
+                .inflight_effects_by_family
+                .lock()
+                .map_err(|_| GitAiError::Generic("inflight effects map lock poisoned".to_string()))?
+                .contains_key(&family.0);
+            if !has_entries && !scheduler_busy && !effects_in_flight {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
 
         self.status_for_family(repo_working_dir).await
     }
@@ -5986,7 +6095,7 @@ impl ActorDaemonCoordinator {
     /// Progress is logged every few seconds. Returns an `AwaitResult` describing
     /// whether the daemon was idle before the timeout and how much telemetry
     /// (if any) is still pending.
-    async fn await_completion(&self, timeout_secs: u64) -> AwaitResult {
+    async fn await_completion(self: &Arc<Self>, timeout_secs: u64) -> AwaitResult {
         use tokio::time::{Duration, Instant, timeout};
 
         let start = Instant::now();
@@ -6130,6 +6239,17 @@ impl ActorDaemonCoordinator {
             return true;
         }
         if let Ok(map) = self.family_sequencers_by_family.lock() {
+            for family in map.keys() {
+                if self
+                    .family_drain_scheduler
+                    .snapshot(family)
+                    .is_some_and(|snapshot| !snapshot.is_idle())
+                {
+                    return true;
+                }
+            }
+        }
+        if let Ok(map) = self.family_sequencers_by_family.lock() {
             for state in map.values() {
                 if !state.entries.is_empty() {
                     return true;
@@ -6139,7 +6259,7 @@ impl ActorDaemonCoordinator {
         false
     }
 
-    async fn handle_control_request(&self, request: ControlRequest) -> ControlResponse {
+    async fn handle_control_request(self: &Arc<Self>, request: ControlRequest) -> ControlResponse {
         let result = match request {
             ControlRequest::Ping => Ok(ControlResponse::ok(None, None)),
             ControlRequest::CheckpointRun { request } => {
@@ -8609,7 +8729,7 @@ mod tests {
 
     #[tokio::test]
     async fn mutating_pending_root_is_created_when_repo_and_argv_arrive_on_different_events() {
-        let coord = ActorDaemonCoordinator::new();
+        let coord = Arc::new(ActorDaemonCoordinator::new());
         let temp = tempfile::tempdir().unwrap();
         let repo = temp.path().join("repo");
         let init = std::process::Command::new("git")
@@ -8749,6 +8869,63 @@ mod tests {
         )
         .await
         .expect("checkpoint fence should pass once the mutating trace root closes");
+    }
+
+    #[tokio::test]
+    async fn family_fence_blocks_globally_only_until_root_identification() {
+        let coord = Arc::new(ActorDaemonCoordinator::new());
+        let sid = "20260411T120000.000000-Psid-family-identification";
+        {
+            let mut ingress = coord.trace_ingress_state.lock().unwrap();
+            ingress.root_open_connections.insert(sid.to_string(), 1);
+            ingress.root_mutating.insert(sid.to_string(), true);
+        }
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                coord.wait_for_trace_ingest_processed_through_family("family-b")
+            )
+            .await
+            .is_err(),
+            "an unidentified mutating root must block every family"
+        );
+
+        {
+            let mut ingress = coord.trace_ingress_state.lock().unwrap();
+            ingress
+                .root_families
+                .insert(sid.to_string(), "family-a".to_string());
+        }
+        coord.trace_ingest_progress_notify.notify_waiters();
+
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            coord.wait_for_trace_ingest_processed_through_family("family-b"),
+        )
+        .await
+        .expect("an identified root must not block an unrelated family");
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                coord.wait_for_trace_ingest_processed_through_family("family-a")
+            )
+            .await
+            .is_err(),
+            "an identified live root must continue blocking its own family"
+        );
+
+        {
+            let mut ingress = coord.trace_ingress_state.lock().unwrap();
+            ingress.root_open_connections.remove(sid);
+        }
+        coord.trace_ingest_progress_notify.notify_waiters();
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            coord.wait_for_trace_ingest_processed_through_family("family-a"),
+        )
+        .await
+        .expect("same-family fence should pass after the live root closes");
     }
 
     #[tokio::test]

--- a/src/daemon/family_drain_scheduler.rs
+++ b/src/daemon/family_drain_scheduler.rs
@@ -1,0 +1,443 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use tokio::sync::{Mutex as AsyncMutex, Notify, Semaphore};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct FamilyDrainSnapshot {
+    pub queued: bool,
+    pub dirty: bool,
+    pub in_flight: bool,
+    pub last_error: Option<String>,
+}
+
+impl FamilyDrainSnapshot {
+    pub fn is_idle(&self) -> bool {
+        !self.queued && !self.dirty && !self.in_flight
+    }
+}
+
+#[derive(Default)]
+struct FamilyDrainState {
+    queued: bool,
+    dirty: bool,
+    in_flight: bool,
+    last_error: Option<String>,
+}
+
+struct FamilyDrain {
+    state: Mutex<FamilyDrainState>,
+    execution_lock: Arc<AsyncMutex<()>>,
+    completion: Notify,
+}
+
+impl FamilyDrain {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(FamilyDrainState::default()),
+            execution_lock: Arc::new(AsyncMutex::new(())),
+            completion: Notify::new(),
+        }
+    }
+
+    fn snapshot(&self) -> FamilyDrainSnapshot {
+        let state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        FamilyDrainSnapshot {
+            queued: state.queued,
+            dirty: state.dirty,
+            in_flight: state.in_flight,
+            last_error: state.last_error.clone(),
+        }
+    }
+}
+
+pub(crate) struct FamilyDrainScheduler {
+    families: Mutex<HashMap<String, Arc<FamilyDrain>>>,
+    permits: Arc<Semaphore>,
+}
+
+impl FamilyDrainScheduler {
+    pub fn new(max_concurrent_drains: usize) -> Self {
+        Self {
+            families: Mutex::new(HashMap::new()),
+            permits: Arc::new(Semaphore::new(max_concurrent_drains)),
+        }
+    }
+
+    fn family(&self, family: &str) -> Arc<FamilyDrain> {
+        let mut families = self
+            .families
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        families
+            .entry(family.to_string())
+            .or_insert_with(|| Arc::new(FamilyDrain::new()))
+            .clone()
+    }
+
+    /// Marks a family as needing a drain and returns whether a runner must be spawned.
+    pub fn schedule(&self, family: &str) -> bool {
+        let family = self.family(family);
+        let mut state = family
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if state.in_flight {
+            state.dirty = true;
+            return false;
+        }
+        if state.queued {
+            return false;
+        }
+        state.queued = true;
+        true
+    }
+
+    pub async fn run<F, Fut, E>(&self, family_key: &str, mut drain: F)
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<(), E>>,
+        E: Display,
+    {
+        let family = self.family(family_key);
+        {
+            let mut state = family
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            if state.in_flight || !state.queued {
+                return;
+            }
+            state.queued = false;
+            state.in_flight = true;
+        }
+
+        loop {
+            let permit = match self.permits.clone().acquire_owned().await {
+                Ok(permit) => permit,
+                Err(error) => {
+                    self.finish_pass(&family, Err(error.to_string()));
+                    return;
+                }
+            };
+            let execution_lock = family.execution_lock.clone();
+            let _execution_guard = execution_lock.lock_owned().await;
+            let result = drain().await.map_err(|error| error.to_string());
+            drop(_execution_guard);
+            drop(permit);
+
+            if !self.finish_pass(&family, result) {
+                return;
+            }
+        }
+    }
+
+    /// Finishes one pass. Returns true when work arrived during that pass.
+    fn finish_pass(&self, family: &FamilyDrain, result: Result<(), String>) -> bool {
+        let mut state = family
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Err(error) = result {
+            state.last_error = Some(error);
+        }
+        if state.dirty {
+            state.dirty = false;
+            state.queued = true;
+            return true;
+        }
+
+        state.queued = false;
+        state.in_flight = false;
+        family.completion.notify_waiters();
+        false
+    }
+
+    pub fn snapshot(&self, family: &str) -> Option<FamilyDrainSnapshot> {
+        let family = {
+            let families = self
+                .families
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            families.get(family).cloned()
+        }?;
+        Some(family.snapshot())
+    }
+
+    pub async fn wait_idle(&self, family_key: &str) {
+        let family = self.family(family_key);
+        loop {
+            let notified = family.completion.notified();
+            if family.snapshot().is_idle() {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    #[cfg(test)]
+    pub fn execution_lock(&self, family: &str) -> Arc<AsyncMutex<()>> {
+        self.family(family).execution_lock.clone()
+    }
+
+    pub fn gc_idle_families(&self) {
+        let mut families = self
+            .families
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        families.retain(|_, family| {
+            !family.snapshot().is_idle()
+                || Arc::strong_count(family) > 1
+                || Arc::strong_count(&family.execution_lock) > 1
+        });
+    }
+
+    #[cfg(test)]
+    fn family_count(&self) -> usize {
+        self.families
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, timeout};
+
+    #[tokio::test]
+    async fn single_flight_runs_a_dirty_second_pass() {
+        let scheduler = Arc::new(FamilyDrainScheduler::new(4));
+        let first_started = Arc::new(Notify::new());
+        let release_first = Arc::new(Notify::new());
+        let passes = Arc::new(AtomicUsize::new(0));
+
+        assert!(scheduler.schedule("family"));
+        let task = {
+            let scheduler = scheduler.clone();
+            let first_started = first_started.clone();
+            let release_first = release_first.clone();
+            let passes = passes.clone();
+            tokio::spawn(async move {
+                scheduler
+                    .run("family", move || {
+                        let first_started = first_started.clone();
+                        let release_first = release_first.clone();
+                        let pass = passes.fetch_add(1, Ordering::SeqCst);
+                        async move {
+                            if pass == 0 {
+                                first_started.notify_one();
+                                release_first.notified().await;
+                            }
+                            Ok::<_, String>(())
+                        }
+                    })
+                    .await;
+            })
+        };
+
+        first_started.notified().await;
+        assert!(!scheduler.schedule("family"));
+        assert!(scheduler.snapshot("family").unwrap().dirty);
+        release_first.notify_one();
+        task.await.unwrap();
+
+        assert_eq!(passes.load(Ordering::SeqCst), 2);
+        assert!(scheduler.snapshot("family").unwrap().is_idle());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn limits_global_concurrent_drains_to_four() {
+        let scheduler = Arc::new(FamilyDrainScheduler::new(4));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::new();
+
+        for family in 0..12 {
+            let family = format!("family-{family}");
+            assert!(scheduler.schedule(&family));
+            let scheduler = scheduler.clone();
+            let active = active.clone();
+            let maximum = maximum.clone();
+            tasks.push(tokio::spawn(async move {
+                scheduler
+                    .run(&family, move || {
+                        let active = active.clone();
+                        let maximum = maximum.clone();
+                        async move {
+                            let concurrent = active.fetch_add(1, Ordering::SeqCst) + 1;
+                            maximum.fetch_max(concurrent, Ordering::SeqCst);
+                            tokio::time::sleep(Duration::from_millis(25)).await;
+                            active.fetch_sub(1, Ordering::SeqCst);
+                            Ok::<_, String>(())
+                        }
+                    })
+                    .await;
+            }));
+        }
+
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert_eq!(maximum.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn serializes_one_family_while_another_family_progresses() {
+        let scheduler = Arc::new(FamilyDrainScheduler::new(4));
+        let same_family_active = Arc::new(AtomicUsize::new(0));
+        let same_family_max = Arc::new(AtomicUsize::new(0));
+        let family_a_passes = Arc::new(AtomicUsize::new(0));
+        let family_a_started = Arc::new(Notify::new());
+        let release_family_a = Arc::new(Notify::new());
+        let family_b_finished = Arc::new(Notify::new());
+
+        assert!(scheduler.schedule("family-a"));
+        let family_a_task = {
+            let scheduler = scheduler.clone();
+            let same_family_active = same_family_active.clone();
+            let same_family_max = same_family_max.clone();
+            let family_a_passes = family_a_passes.clone();
+            let family_a_started = family_a_started.clone();
+            let release_family_a = release_family_a.clone();
+            tokio::spawn(async move {
+                scheduler
+                    .run("family-a", move || {
+                        let same_family_active = same_family_active.clone();
+                        let same_family_max = same_family_max.clone();
+                        let pass = family_a_passes.fetch_add(1, Ordering::SeqCst);
+                        let family_a_started = family_a_started.clone();
+                        let release_family_a = release_family_a.clone();
+                        async move {
+                            let concurrent = same_family_active.fetch_add(1, Ordering::SeqCst) + 1;
+                            same_family_max.fetch_max(concurrent, Ordering::SeqCst);
+                            if pass == 0 {
+                                family_a_started.notify_one();
+                                release_family_a.notified().await;
+                            }
+                            same_family_active.fetch_sub(1, Ordering::SeqCst);
+                            Ok::<_, String>(())
+                        }
+                    })
+                    .await;
+            })
+        };
+
+        family_a_started.notified().await;
+        assert!(!scheduler.schedule("family-a"));
+        assert!(scheduler.schedule("family-b"));
+        let family_b_task = {
+            let scheduler = scheduler.clone();
+            let family_b_finished = family_b_finished.clone();
+            tokio::spawn(async move {
+                scheduler
+                    .run("family-b", move || {
+                        let family_b_finished = family_b_finished.clone();
+                        async move {
+                            family_b_finished.notify_one();
+                            Ok::<_, String>(())
+                        }
+                    })
+                    .await;
+            })
+        };
+
+        timeout(Duration::from_millis(250), family_b_finished.notified())
+            .await
+            .expect("unrelated family should progress");
+        release_family_a.notify_waiters();
+        family_a_task.await.unwrap();
+        family_b_task.await.unwrap();
+        assert_eq!(same_family_max.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_cannot_create_overlapping_drains_for_an_active_family() {
+        let scheduler = Arc::new(FamilyDrainScheduler::new(4));
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let passes = Arc::new(AtomicUsize::new(0));
+
+        assert!(scheduler.schedule("family"));
+        let task = {
+            let scheduler = scheduler.clone();
+            let started = started.clone();
+            let release = release.clone();
+            let active = active.clone();
+            let maximum = maximum.clone();
+            let passes = passes.clone();
+            tokio::spawn(async move {
+                scheduler
+                    .run("family", move || {
+                        let started = started.clone();
+                        let release = release.clone();
+                        let active = active.clone();
+                        let maximum = maximum.clone();
+                        let pass = passes.fetch_add(1, Ordering::SeqCst);
+                        async move {
+                            let concurrent = active.fetch_add(1, Ordering::SeqCst) + 1;
+                            maximum.fetch_max(concurrent, Ordering::SeqCst);
+                            if pass == 0 {
+                                started.notify_one();
+                                release.notified().await;
+                            }
+                            active.fetch_sub(1, Ordering::SeqCst);
+                            Ok::<_, String>(())
+                        }
+                    })
+                    .await;
+            })
+        };
+
+        started.notified().await;
+        scheduler.gc_idle_families();
+        assert!(!scheduler.schedule("family"));
+        release.notify_one();
+        task.await.unwrap();
+
+        assert_eq!(passes.load(Ordering::SeqCst), 2);
+        assert_eq!(maximum.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn cleanup_removes_only_idle_unreferenced_families() {
+        let scheduler = FamilyDrainScheduler::new(4);
+        let retained_lock = scheduler.execution_lock("retained");
+        scheduler.execution_lock("idle");
+
+        scheduler.gc_idle_families();
+        assert_eq!(scheduler.family_count(), 1);
+        assert!(Arc::ptr_eq(
+            &retained_lock,
+            &scheduler.execution_lock("retained")
+        ));
+    }
+
+    #[tokio::test]
+    async fn records_the_last_error_and_notifies_completion() {
+        let scheduler = Arc::new(FamilyDrainScheduler::new(4));
+        assert!(scheduler.schedule("family"));
+        let waiter = {
+            let scheduler = scheduler.clone();
+            tokio::spawn(async move {
+                scheduler.wait_idle("family").await;
+            })
+        };
+
+        scheduler
+            .run("family", || async { Err::<(), _>("failed drain") })
+            .await;
+        waiter.await.unwrap();
+
+        let snapshot = scheduler.snapshot("family").unwrap();
+        assert!(snapshot.is_idle());
+        assert_eq!(snapshot.last_error.as_deref(), Some("failed drain"));
+    }
+}


### PR DESCRIPTION
## Summary

- add a bounded family drain scheduler with four global permits
- preserve single-flight ordering per repository family and schedule a dirty follow-up pass
- retain family errors and completion notifications while safely collecting idle state

## Tests

- family serialization, cross-family concurrency, dirty-pass, error, notification, and cleanup unit coverage
- full task test, task lint, task fmt, and task build on the completed stack

Depends on #1979.