### PR TITLE
fix(daemon): decouple trace ingestion from side effects

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -190,7 +190,12 @@ fn handle_run(args: &[String]) -> Result<(), String> {
             e
         )
     })?;
+    let worker_threads = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(4)
+        .max(4);
     let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
         .enable_all()
         .build()
         .map_err(|e| e.to_string())?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,7 +48,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::time::Duration;
 
 pub mod analyzers;
@@ -2514,9 +2514,11 @@ pub struct ActorDaemonCoordinator {
     backend: Arc<crate::daemon::git_backend::SystemGitBackend>,
     coordinator:
         Arc<crate::daemon::coordinator::Coordinator<crate::daemon::git_backend::SystemGitBackend>>,
-    normalizer: AsyncMutex<
-        crate::daemon::trace_normalizer::TraceNormalizer<
-            crate::daemon::git_backend::SystemGitBackend,
+    normalizer: Arc<
+        Mutex<
+            crate::daemon::trace_normalizer::TraceNormalizer<
+                crate::daemon::git_backend::SystemGitBackend,
+            >,
         >,
     >,
     pending_rebase_original_head_by_worktree: Mutex<HashMap<String, (String, Option<String>)>>,
@@ -2592,7 +2594,6 @@ impl DaemonExitAction {
 
 enum TracePayloadApplyOutcome {
     None,
-    Applied(Box<crate::daemon::domain::AppliedCommand>),
     QueuedFamily,
 }
 
@@ -2603,8 +2604,8 @@ impl ActorDaemonCoordinator {
             coordinator: Arc::new(crate::daemon::coordinator::Coordinator::new(
                 backend.clone(),
             )),
-            normalizer: AsyncMutex::new(crate::daemon::trace_normalizer::TraceNormalizer::new(
-                backend.clone(),
+            normalizer: Arc::new(Mutex::new(
+                crate::daemon::trace_normalizer::TraceNormalizer::new(backend.clone()),
             )),
             backend,
             pending_rebase_original_head_by_worktree: Mutex::new(HashMap::new()),
@@ -4148,7 +4149,7 @@ impl ActorDaemonCoordinator {
     }
 
     async fn drain_ready_family_sequencer_entries_locked(
-        &self,
+        self: &Arc<Self>,
         family: &str,
     ) -> Result<(), GitAiError> {
         let mut ready: Vec<(u64, FamilySequencerEntry)> = Vec::new();
@@ -4208,13 +4209,27 @@ impl ActorDaemonCoordinator {
                             let mut commit_file_timestamp_snapshots =
                                 self.take_cached_commit_file_timestamp_snapshots(&root_sid)?;
                             let applied = self.coordinator.route_command(*command).await?;
-                            let side_effect = self
-                                .maybe_apply_side_effects_for_applied_command(
-                                    Some(family),
-                                    &applied,
-                                    &mut commit_file_timestamp_snapshots,
-                                )
-                                .await;
+                            let coordinator = self.clone();
+                            let applied_for_side_effect = applied.clone();
+                            let family_for_side_effect = family.to_string();
+                            let runtime_handle = tokio::runtime::Handle::current();
+                            let side_effect = tokio::task::spawn_blocking(move || {
+                                runtime_handle.block_on(async move {
+                                    coordinator
+                                        .maybe_apply_side_effects_for_applied_command(
+                                            Some(&family_for_side_effect),
+                                            &applied_for_side_effect,
+                                            &mut commit_file_timestamp_snapshots,
+                                        )
+                                        .await
+                                })
+                            })
+                            .await
+                            .map_err(|error| {
+                                GitAiError::Generic(format!(
+                                    "command side-effect blocking task failed: {error}"
+                                ))
+                            })?;
                             Ok::<_, GitAiError>((applied, side_effect))
                         };
                         let caught = std::panic::AssertUnwindSafe(future);
@@ -4366,12 +4381,18 @@ impl ActorDaemonCoordinator {
                                     self.coordinator.apply_checkpoint(Path::new(&repo_wd)).await;
                                 match ack {
                                     Ok(ack) => {
-                                        apply_checkpoint_side_effect(*request).map(|_| ack.seq)
+                                        crate::tokio_runtime::spawn_blocking_result(move || {
+                                            apply_checkpoint_side_effect(*request).map(|_| ack.seq)
+                                        })
+                                        .await
                                     }
                                     Err(error) => Err(error),
                                 }
                             } else {
-                                apply_checkpoint_side_effect(*request).map(|_| 0)
+                                crate::tokio_runtime::spawn_blocking_result(move || {
+                                    apply_checkpoint_side_effect(*request).map(|_| 0)
+                                })
+                                .await
                             }
                         };
                         let caught = std::panic::AssertUnwindSafe(future);
@@ -5871,14 +5892,25 @@ impl ActorDaemonCoordinator {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
+        let payload_sid = payload
+            .get("sid")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
         if event == TRACE_CONNECTION_CLOSED_EVENT {
             let Some(root_sid) = payload_root_sid.as_deref() else {
                 return Ok(TracePayloadApplyOutcome::None);
             };
-            {
-                let mut normalizer = self.normalizer.lock().await;
-                let _ = normalizer.sweep_orphans_for_roots(&[root_sid.to_string()]);
-            }
+            let normalizer = self.normalizer.clone();
+            let root_sid_owned = root_sid.to_string();
+            crate::tokio_runtime::spawn_blocking_result(move || {
+                let mut normalizer = normalizer.lock().map_err(|_| {
+                    GitAiError::Generic("trace normalizer lock poisoned".to_string())
+                })?;
+                let _ = normalizer.sweep_orphans_for_roots(&[root_sid_owned]);
+                Ok(())
+            })
+            .await?;
             let replaced_family = self
                 .replace_pending_root_entry(root_sid, FamilySequencerEntry::Canceled)
                 .await?;
@@ -5894,17 +5926,18 @@ impl ActorDaemonCoordinator {
         }
 
         self.maybe_append_pending_root_from_trace_payload(&payload)?;
-        let emitted = {
-            let mut normalizer = self.normalizer.lock().await;
-            normalizer.ingest_payload(&payload)?
-        };
+        let normalizer = self.normalizer.clone();
+        let emitted = crate::tokio_runtime::spawn_blocking_result(move || {
+            normalizer
+                .lock()
+                .map_err(|_| GitAiError::Generic("trace normalizer lock poisoned".to_string()))?
+                .ingest_payload(&payload)
+        })
+        .await?;
         let Some(command) = emitted else {
             if is_terminal_root_trace_event(
                 &event,
-                payload
-                    .get("sid")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default(),
+                &payload_sid,
                 payload_root_sid.as_deref().unwrap_or_default(),
             ) && let Some(root_sid) = payload_root_sid.as_deref()
                 && let Some(family) = self
@@ -5931,24 +5964,14 @@ impl ActorDaemonCoordinator {
             self.cache_commit_file_timestamp_snapshots_for_command(&command)?;
             family_to_drain_after_clear = Some(family);
             TracePayloadApplyOutcome::QueuedFamily
-        } else if let Some(family) = command.family_key.as_ref().map(|family| family.0.clone())
-            && Self::trace_invocation_participates_in_family_sequencer(
-                command.primary_command.as_deref(),
-                &command.raw_argv,
-            )
-        {
+        } else if let Some(family) = command.family_key.as_ref().map(|family| family.0.clone()) {
             self.cache_commit_file_timestamp_snapshots_for_command(&command)?;
             self.append_ready_command_entry(&family, command).await?;
             family_to_drain_after_clear = Some(family);
             TracePayloadApplyOutcome::QueuedFamily
         } else {
-            match self.coordinator.route_command(command).await {
-                Ok(applied) => TracePayloadApplyOutcome::Applied(Box::new(applied)),
-                Err(error) => {
-                    let _ = self.clear_trace_root_tracking(&root_sid);
-                    return Err(error);
-                }
-            }
+            self.coordinator.route_command(command).await?;
+            TracePayloadApplyOutcome::None
         };
         self.clear_trace_root_tracking(&root_sid)?;
         self.drain_ready_family_sequencers_after_root_cleared(family_to_drain_after_clear)
@@ -5960,44 +5983,7 @@ impl ActorDaemonCoordinator {
         if !is_trace_payload(&payload) {
             return Ok(());
         }
-        match self.apply_trace_payload_to_state(payload).await? {
-            TracePayloadApplyOutcome::None | TracePayloadApplyOutcome::QueuedFamily => {}
-            TracePayloadApplyOutcome::Applied(applied) => {
-                if let Some(family) = applied.command.family_key.as_ref().map(|key| key.0.clone()) {
-                    self.begin_family_effect(&family)?;
-                    let mut commit_file_timestamp_snapshots =
-                        Self::start_commit_file_timestamp_snapshots_for_command(&applied.command);
-                    let result = self
-                        .maybe_apply_side_effects_for_applied_command(
-                            Some(&family),
-                            &applied,
-                            &mut commit_file_timestamp_snapshots,
-                        )
-                        .await;
-                    let _ = self.end_family_effect(&family);
-                    if let Err(error) = &result {
-                        let _ = self.record_side_effect_error(&family, applied.seq, error);
-                        tracing::error!(
-                            %error,
-                            %family,
-                            seq = applied.seq,
-                            "async side-effect error"
-                        );
-                    }
-                    if let Err(error) =
-                        self.append_command_completion_log(&family, &applied, &result, applied.seq)
-                    {
-                        let _ = self.record_side_effect_error(&family, applied.seq, &error);
-                        tracing::error!(
-                            %error,
-                            %family,
-                            seq = applied.seq,
-                            "async completion log write failed"
-                        );
-                    }
-                }
-            }
-        }
+        let _ = self.apply_trace_payload_to_state(payload).await?;
 
         Ok(())
     }
@@ -6852,82 +6838,18 @@ fn trace_listener_loop_actor(
                 tracing::debug!(%error, "trace connection open bookkeeping error");
                 continue;
             }
-            if let Err(error) =
-                stream.set_recv_timeout(Some(TRACE_CONNECTION_BOOTSTRAP_READ_TIMEOUT))
-            {
-                tracing::debug!(%error, "trace connection bootstrap timeout setup failed");
-            }
-            let mut reader = BufReader::new(stream);
-            let mut observed_roots = std::collections::BTreeSet::new();
-            match bootstrap_trace_connection_actor_reader(
-                &mut reader,
-                coordinator.clone(),
-                &mut observed_roots,
-            ) {
-                Ok(TraceConnectionBootstrap::Eof) => {
-                    if let Err(error) =
-                        finalize_trace_connection_roots(coordinator.clone(), observed_roots)
-                    {
-                        tracing::debug!(
-                            %error,
-                            "trace connection close bookkeeping error"
-                        );
-                    }
-                    continue;
-                }
-                Ok(TraceConnectionBootstrap::Stop) => {
-                    if let Err(error) =
-                        finalize_trace_connection_roots(coordinator.clone(), observed_roots)
-                    {
-                        tracing::debug!(
-                            %error,
-                            "trace connection close bookkeeping error"
-                        );
-                    }
-                    continue;
-                }
-                Ok(TraceConnectionBootstrap::Continue) => {}
-                Err(error) => {
-                    tracing::debug!(%error, "trace connection bootstrap error");
-                    if let Err(error) =
-                        finalize_trace_connection_roots(coordinator.clone(), observed_roots)
-                    {
-                        tracing::debug!(
-                            %error,
-                            "trace connection close bookkeeping error"
-                        );
-                    }
-                    continue;
-                }
-            }
-            if let Err(error) = reader.get_ref().set_recv_timeout(None) {
-                tracing::debug!(%error, "trace connection bootstrap timeout clear failed");
-            }
-            #[cfg(feature = "test-support")]
-            if let Ok(raw_delay_ms) =
-                std::env::var("GIT_AI_TEST_TRACE_LISTENER_WORKER_SPAWN_DELAY_MS")
-                && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
-                && delay_ms > 0
-            {
-                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-            }
             let coord = coordinator.clone();
-            let observed_roots_on_spawn_failure = observed_roots.clone();
             if std::thread::Builder::new()
                 .spawn(move || {
-                    if let Err(e) =
-                        handle_trace_connection_actor_reader(reader, coord, observed_roots)
-                    {
+                    if let Err(e) = handle_trace_connection_actor_with_bootstrap(stream, coord) {
                         tracing::debug!(%e, "trace connection error");
                     }
                 })
                 .is_err()
             {
                 tracing::error!("trace listener: failed to spawn handler thread");
-                if let Err(error) = finalize_trace_connection_roots(
-                    coordinator.clone(),
-                    observed_roots_on_spawn_failure,
-                ) {
+                if let Err(error) = coordinator.trace_unidentified_connection_identified_or_closed()
+                {
                     tracing::debug!(
                         %error,
                         "trace connection close bookkeeping error"
@@ -6985,6 +6907,43 @@ fn trace_listener_loop_actor(
 
         Ok(())
     }
+}
+
+#[cfg(not(windows))]
+fn handle_trace_connection_actor_with_bootstrap(
+    stream: LocalSocketStream,
+    coordinator: Arc<ActorDaemonCoordinator>,
+) -> Result<(), GitAiError> {
+    if let Err(error) = stream.set_recv_timeout(Some(TRACE_CONNECTION_BOOTSTRAP_READ_TIMEOUT)) {
+        tracing::debug!(%error, "trace connection bootstrap timeout setup failed");
+    }
+    let mut reader = BufReader::new(stream);
+    let mut observed_roots = std::collections::BTreeSet::new();
+    match bootstrap_trace_connection_actor_reader(
+        &mut reader,
+        coordinator.clone(),
+        &mut observed_roots,
+    ) {
+        Ok(TraceConnectionBootstrap::Continue) => {}
+        Ok(TraceConnectionBootstrap::Eof | TraceConnectionBootstrap::Stop) => {
+            return finalize_trace_connection_roots(coordinator, observed_roots);
+        }
+        Err(error) => {
+            tracing::debug!(%error, "trace connection bootstrap error");
+            return finalize_trace_connection_roots(coordinator, observed_roots);
+        }
+    }
+    if let Err(error) = reader.get_ref().set_recv_timeout(None) {
+        tracing::debug!(%error, "trace connection bootstrap timeout clear failed");
+    }
+    #[cfg(feature = "test-support")]
+    if let Ok(raw_delay_ms) = std::env::var("GIT_AI_TEST_TRACE_LISTENER_WORKER_SPAWN_DELAY_MS")
+        && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
+        && delay_ms > 0
+    {
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+    }
+    handle_trace_connection_actor_reader(reader, coordinator, observed_roots)
 }
 
 #[cfg(windows)]

--- a/src/daemon/family_actor.rs
+++ b/src/daemon/family_actor.rs
@@ -7,6 +7,7 @@ use crate::daemon::reducer;
 use crate::daemon::ref_cursor::RefCursor;
 use crate::error::GitAiError;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
 
 pub enum FamilyMsg {
@@ -95,52 +96,84 @@ pub fn spawn_family_actor(family_key: FamilyKey) -> FamilyActorHandle {
     };
 
     tokio::spawn(async move {
-        let analyzers = AnalyzerRegistry::new();
-        let mut state = FamilyState {
+        let analyzers = Arc::new(AnalyzerRegistry::new());
+        let state = Arc::new(Mutex::new(FamilyState {
             family_key: family_key.clone(),
             refs: HashMap::new(),
             worktrees: HashMap::new(),
             last_error: None,
             applied_seq: 0,
             watermarks: WatermarkState::default(),
-        };
-        let mut ref_cursor = RefCursor::new(family_key.clone());
+        }));
+        let ref_cursor = Arc::new(Mutex::new(RefCursor::new(family_key.clone())));
 
         while let Some(msg) = rx.recv().await {
             match msg {
                 FamilyMsg::Apply(cmd, respond_to) => {
-                    let mut cmd = *cmd;
-                    let result = ref_cursor.enrich_command(&mut cmd, &state).and_then(
-                        |command_start_refs| {
-                            reducer::reduce_family_command_with_ref_snapshot(
-                                &mut state,
-                                cmd,
-                                &analyzers,
-                                &command_start_refs,
-                            )
-                            .map(|(applied, _)| applied)
-                        },
-                    );
+                    let state = state.clone();
+                    let ref_cursor = ref_cursor.clone();
+                    let analyzers = analyzers.clone();
+                    let result = crate::tokio_runtime::spawn_blocking_result(move || {
+                        let mut state = state.lock().map_err(|_| {
+                            GitAiError::Generic("family state lock poisoned".to_string())
+                        })?;
+                        let mut ref_cursor = ref_cursor.lock().map_err(|_| {
+                            GitAiError::Generic("ref cursor lock poisoned".to_string())
+                        })?;
+                        let mut cmd = *cmd;
+                        ref_cursor
+                            .enrich_command(&mut cmd, &state)
+                            .and_then(|command_start_refs| {
+                                reducer::reduce_family_command_with_ref_snapshot(
+                                    &mut state,
+                                    cmd,
+                                    &analyzers,
+                                    &command_start_refs,
+                                )
+                                .map(|(applied, _)| applied)
+                            })
+                    })
+                    .await;
                     let _ = respond_to.send(result);
                 }
                 FamilyMsg::ApplyCheckpoint(respond_to) => {
-                    reducer::reduce_checkpoint(&mut state);
-                    let _ = respond_to.send(Ok(ApplyAck {
-                        seq: state.applied_seq,
-                        applied: true,
-                    }));
+                    let state = state.clone();
+                    let result = crate::tokio_runtime::spawn_blocking_result(move || {
+                        let mut state = state.lock().map_err(|_| {
+                            GitAiError::Generic("family state lock poisoned".to_string())
+                        })?;
+                        reducer::reduce_checkpoint(&mut state);
+                        Ok(ApplyAck {
+                            seq: state.applied_seq,
+                            applied: true,
+                        })
+                    })
+                    .await;
+                    let _ = respond_to.send(result);
                 }
                 FamilyMsg::Status(respond_to) => {
-                    let _ = respond_to.send(Ok(FamilyStatus {
-                        family_key: state.family_key.clone(),
-                        applied_seq: state.applied_seq,
-                        last_error: state.last_error.clone(),
-                    }));
+                    let result = state
+                        .lock()
+                        .map_err(|_| GitAiError::Generic("family state lock poisoned".to_string()))
+                        .map(|state| FamilyStatus {
+                            family_key: state.family_key.clone(),
+                            applied_seq: state.applied_seq,
+                            last_error: state.last_error.clone(),
+                        });
+                    let _ = respond_to.send(result);
                 }
                 FamilyMsg::GetWatermarks(respond_to) => {
-                    let _ = respond_to.send(Ok(state.watermarks.clone()));
+                    let result = state
+                        .lock()
+                        .map_err(|_| GitAiError::Generic("family state lock poisoned".to_string()))
+                        .map(|state| state.watermarks.clone());
+                    let _ = respond_to.send(result);
                 }
                 FamilyMsg::UpdateWatermarks(update) => {
+                    let Ok(mut state) = state.lock() else {
+                        tracing::error!("family state lock poisoned");
+                        continue;
+                    };
                     for (path, mtime_ns) in update.per_file {
                         let entry = state.watermarks.per_file.entry(path).or_insert(0);
                         if mtime_ns > *entry {

--- a/src/daemon/global_actor.rs
+++ b/src/daemon/global_actor.rs
@@ -2,6 +2,7 @@ use crate::daemon::analyzers::AnalyzerRegistry;
 use crate::daemon::domain::{AppliedCommand, GlobalState, NormalizedCommand};
 use crate::daemon::reducer;
 use crate::error::GitAiError;
+use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
 
 pub enum GlobalMsg {
@@ -41,14 +42,22 @@ pub fn spawn_global_actor() -> GlobalActorHandle {
     let handle = GlobalActorHandle { tx };
 
     tokio::spawn(async move {
-        let analyzers = AnalyzerRegistry::new();
-        let mut state = GlobalState { applied_seq: 0 };
+        let analyzers = Arc::new(AnalyzerRegistry::new());
+        let state = Arc::new(Mutex::new(GlobalState { applied_seq: 0 }));
 
         while let Some(msg) = rx.recv().await {
             match msg {
                 GlobalMsg::Apply(cmd, respond_to) => {
-                    let result = reducer::reduce_global_command(&mut state, *cmd, &analyzers)
-                        .map(|(applied, _)| applied);
+                    let state = state.clone();
+                    let analyzers = analyzers.clone();
+                    let result = crate::tokio_runtime::spawn_blocking_result(move || {
+                        let mut state = state.lock().map_err(|_| {
+                            GitAiError::Generic("global state lock poisoned".to_string())
+                        })?;
+                        reducer::reduce_global_command(&mut state, *cmd, &analyzers)
+                            .map(|(applied, _)| applied)
+                    })
+                    .await;
                     let _ = respond_to.send(result);
                 }
                 GlobalMsg::Shutdown => break,

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1596,6 +1596,83 @@ fn daemon_trace_listener_stalled_connection_does_not_block_later_trace_connectio
 }
 
 #[test]
+#[serial]
+fn daemon_slow_unsequenced_side_effect_does_not_block_unrelated_trace_progress() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let _daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[(
+            "GIT_AI_TEST_DELAY_SIDE_EFFECT_MS_FOR_COMMAND",
+            "frobnicate=1500",
+        )],
+    );
+    let trace_socket = daemon_trace_socket_path(&repo);
+
+    let other_repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+
+    let slow_session = repos::test_repo::new_daemon_test_sync_session_id();
+    let slow_session_arg = format!("git-ai.testSyncSession={slow_session}");
+    let slow_worktree = repo_workdir_string(&repo);
+    let slow_git_dir = repo.path().join(".git").to_string_lossy().to_string();
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "slow-unsequenced-side-effect",
+                "argv": ["git", "-c", slow_session_arg, "frobnicate"],
+                "time_ns": 20_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "slow-unsequenced-side-effect",
+                "worktree": slow_worktree,
+                "repo": slow_git_dir,
+                "time_ns": 20_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "slow-unsequenced-side-effect",
+                "code": 0,
+                "time_ns": 20_100u64,
+            }),
+            trace_atexit_frame("slow-unsequenced-side-effect", 0, 20_101u64),
+        ],
+    );
+    thread::sleep(Duration::from_millis(150));
+
+    let trace_env = git_trace_env(&trace_socket);
+    let trace_env_refs = [
+        (trace_env[0].0, trace_env[0].1.as_str()),
+        (trace_env[1].0, trace_env[1].1.as_str()),
+    ];
+    fs::write(other_repo.path().join("fast.txt"), "fast\n")
+        .expect("failed to write unrelated repository file");
+    other_repo
+        .git_og_with_env(&["add", "fast.txt"], &trace_env_refs)
+        .expect("unrelated add should succeed");
+    other_repo
+        .git_og_with_env(&["commit", "-m", "unrelated commit"], &trace_env_refs)
+        .expect("unrelated commit should succeed");
+
+    let started = std::time::Instant::now();
+    let response = send_control_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &ControlRequest::SyncFamily {
+            repo_working_dir: repo_workdir_string(&other_repo),
+        },
+        Duration::from_millis(750),
+    )
+    .expect("slow side effect blocked unrelated trace sequencing");
+    assert!(response.ok, "unrelated family sync failed: {response:?}");
+    assert!(
+        started.elapsed() < Duration::from_millis(750),
+        "unrelated family sync took {:?}",
+        started.elapsed()
+    );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn daemon_stalled_unidentified_trace_connection_does_not_block_checkpoint_control_request() {
     let repo = TestRepo::new_dedicated_daemon();


### PR DESCRIPTION
## Summary

- move trace normalization and repository side effects off the trace socket ingress tasks
- run family and global actor work on blocking workers while preserving per-family ordering
- keep trace accept and frame handoff responsive under deliberately slow side effects

## Tests

- slow-side-effect regression proving unrelated trace progress
- stalled and silent trace connection coverage
- full task test, task lint, task fmt, and task build on the completed stack

Depends on #1980.