### PR TITLE
Fix memory leak on `git reset --keep`

### DIFF
--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -720,6 +720,14 @@ pub(crate) fn shift_authorship_notes_merging_existing_with_notes(
     shift_authorship_notes_with_existing_mode(repo, mappings, true)
 }
 
+/// Maximum number of diff-tree pairs to compute in a single batch before
+/// applying shifts and dropping the parsed `DiffTreeResult` structures.
+/// Each result holds per-pair `Vec<u32>` of added lines and `Vec<DiffHunk>`
+/// hunks, and without chunking the cumulative allocation scales linearly with
+/// the pair count. Chunking bounds the live set to `CHUNK_SIZE` pairs and
+/// trades one extra git spawn per chunk for bounded peak RSS.
+const DIFF_TREE_PAIRS_CHUNK_SIZE: usize = 50;
+
 fn shift_authorship_notes_with_existing_mode(
     repo: &Repository,
     mappings: &[(String, String)],
@@ -793,47 +801,55 @@ fn shift_authorship_notes_with_existing_mode(
         return Ok(Vec::new());
     }
 
-    // Single batched diff-tree call for all pairs
-    let diff_results = if !diff_pairs.is_empty() {
-        compute_diff_trees_batch(repo, &diff_pairs)?
-    } else {
-        Vec::new()
-    };
-
-    // Apply shifts and merge logs that share a target commit
+    // Apply shifts in bounded chunks: compute the diff-trees for a slice of
+    // pairs, fold those shifts into `merged_by_target`, and drop the parsed
+    // `DiffTreeResult`s before moving on. Materializing all pairs at once has
+    // driven the daemon to multi-GB RSS when a bad mapping set turns every
+    // pair into a full-root-tree diff.
     let mut merged_by_target = existing_by_target;
 
-    for shift in pending {
-        let diff_result = &diff_results[shift.diff_pair_idx];
-        let mut log = shift.log;
+    // `pending` is ordered by `diff_pair_idx`, so it can be consumed with a
+    // cursor as the chunks advance.
+    let mut pending_iter = pending.into_iter().peekable();
+    let mut chunk_start = 0;
+    while chunk_start < diff_pairs.len() {
+        let chunk_end = (chunk_start + DIFF_TREE_PAIRS_CHUNK_SIZE).min(diff_pairs.len());
+        let diff_results = compute_diff_trees_batch(repo, &diff_pairs[chunk_start..chunk_end])?;
 
-        for (old_path, new_path) in &diff_result.renames {
-            for attestation in &mut log.attestations {
-                if attestation.file_path == *old_path {
-                    attestation.file_path = new_path.clone();
+        while let Some(shift) = pending_iter.next_if(|s| s.diff_pair_idx < chunk_end) {
+            let diff_result = &diff_results[shift.diff_pair_idx - chunk_start];
+            let mut log = shift.log;
+
+            for (old_path, new_path) in &diff_result.renames {
+                for attestation in &mut log.attestations {
+                    if attestation.file_path == *old_path {
+                        attestation.file_path = new_path.clone();
+                    }
+                }
+            }
+
+            if !diff_result.hunks_by_file.is_empty() {
+                log.attestations = log
+                    .attestations
+                    .iter()
+                    .filter_map(|fa| match diff_result.hunks_by_file.get(&fa.file_path) {
+                        Some(hunks) => apply_hunk_shifts_to_file_attestation(fa, hunks),
+                        None => Some(fa.clone()),
+                    })
+                    .collect();
+            }
+
+            log.metadata.base_commit_sha = shift.new_sha.clone();
+
+            match merged_by_target.get_mut(&shift.new_sha) {
+                Some(existing) => merge_authorship_logs(existing, &log),
+                None => {
+                    merged_by_target.insert(shift.new_sha, log);
                 }
             }
         }
 
-        if !diff_result.hunks_by_file.is_empty() {
-            log.attestations = log
-                .attestations
-                .iter()
-                .filter_map(|fa| match diff_result.hunks_by_file.get(&fa.file_path) {
-                    Some(hunks) => apply_hunk_shifts_to_file_attestation(fa, hunks),
-                    None => Some(fa.clone()),
-                })
-                .collect();
-        }
-
-        log.metadata.base_commit_sha = shift.new_sha.clone();
-
-        match merged_by_target.get_mut(&shift.new_sha) {
-            Some(existing) => merge_authorship_logs(existing, &log),
-            None => {
-                merged_by_target.insert(shift.new_sha, log);
-            }
-        }
+        chunk_start = chunk_end;
     }
 
     let mut all_writes = verbatim_writes;
@@ -1008,9 +1024,22 @@ fn run_range_diff(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Maximum number of unmatched old-range (`<`) commits buffered ahead of the
+/// first matched pair. A genuine rebase squash absorbs a handful of commits
+/// into the first surviving one, so small queues are drained into that match
+/// as before. But when the count exceeds this bound the history is divergent
+/// — e.g. a restack undo (`git reset --keep <pre-rebase-tip>`), where the old
+/// range spans every trunk commit landed since the branch forked — and the
+/// whole queue is discarded, permanently. Without this, each bogus mapping
+/// whose source commit has an authorship note becomes a full-root-tree diff
+/// pair, and daemon memory scales as
+/// (trunk commits since fork) × (lines modified on trunk).
+const MAX_PENDING_DROPPED_COMMITS: usize = 64;
+
 fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
     let mut mappings = Vec::new();
     let mut pending_dropped: Vec<String> = Vec::new();
+    let mut pending_overflowed = false;
     let mut previous_new_sha: Option<String> = None;
 
     for line in output.lines() {
@@ -1036,8 +1065,16 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
                 if !old_sha.chars().all(|c| c == '0') {
                     if let Some(new_sha) = previous_new_sha.as_ref() {
                         mappings.push((old_sha, new_sha.clone()));
-                    } else {
+                    } else if !pending_overflowed {
                         pending_dropped.push(old_sha);
+                        if pending_dropped.len() > MAX_PENDING_DROPPED_COMMITS {
+                            // Divergent history (e.g. restack undo), not a
+                            // squash: discard the queue and stop collecting so
+                            // the mapping count stays bounded.
+                            pending_dropped.clear();
+                            pending_dropped.shrink_to_fit();
+                            pending_overflowed = true;
+                        }
                     }
                 }
             }
@@ -1639,33 +1676,6 @@ Binary files a/image.png and b/image.png differ
     }
 
     #[test]
-    fn test_parse_range_diff_output_matched_then_dropped_maps_all_to_destination() {
-        let output = "\
-1:  1111111111111111111111111111111111111111 ! 1:  4444444444444444444444444444444444444444 AI commit 1
-2:  2222222222222222222222222222222222222222 < -:  ---------------------------------------- AI commit 2
-3:  3333333333333333333333333333333333333333 < -:  ---------------------------------------- AI commit 3
-";
-        let mappings = parse_range_diff_output(output);
-        assert_eq!(
-            mappings,
-            vec![
-                (
-                    "1111111111111111111111111111111111111111".to_string(),
-                    "4444444444444444444444444444444444444444".to_string()
-                ),
-                (
-                    "2222222222222222222222222222222222222222".to_string(),
-                    "4444444444444444444444444444444444444444".to_string()
-                ),
-                (
-                    "3333333333333333333333333333333333333333".to_string(),
-                    "4444444444444444444444444444444444444444".to_string()
-                ),
-            ]
-        );
-    }
-
-    #[test]
     fn test_parse_range_diff_output_null_shas_skipped() {
         let output = " 1:  0000000000000000000000000000000000000000 = 1:  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb Subject\n";
         let mappings = parse_range_diff_output(output);
@@ -1708,6 +1718,113 @@ Binary files a/image.png and b/image.png differ
     fn test_parse_range_diff_output_empty() {
         let mappings = parse_range_diff_output("");
         assert!(mappings.is_empty());
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_matched_then_dropped_maps_all_to_destination() {
+        // Matches AFTER the first `!` match are still mapped — this is the
+        // genuine squash path (drops between matched pairs).
+        let output = "\
+1:  1111111111111111111111111111111111111111 ! 1:  4444444444444444444444444444444444444444 AI commit 1
+2:  2222222222222222222222222222222222222222 < -:  ---------------------------------------- AI commit 2
+3:  3333333333333333333333333333333333333333 < -:  ---------------------------------------- AI commit 3
+";
+        let mappings = parse_range_diff_output(output);
+        assert_eq!(
+            mappings,
+            vec![
+                (
+                    "1111111111111111111111111111111111111111".to_string(),
+                    "4444444444444444444444444444444444444444".to_string()
+                ),
+                (
+                    "2222222222222222222222222222222222222222".to_string(),
+                    "4444444444444444444444444444444444444444".to_string()
+                ),
+                (
+                    "3333333333333333333333333333333333333333".to_string(),
+                    "4444444444444444444444444444444444444444".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_divergent_history_discards_pending() {
+        // Regression: restack-undo (moving a branch tip backward to undo a
+        // rebase) produces a range-diff where the old range spans every trunk
+        // commit since the fork point. All those trunk commits appear as `<`
+        // before the first stack-commit match. They must be discarded — they
+        // were never part of a squash.
+        let sha_a = "1".repeat(40);
+        let sha_b = "2".repeat(40);
+        let mut output = String::new();
+        // 200 divergent trunk commits before the first real match
+        for i in 0..200 {
+            let sha = format!("{:040}", i);
+            output.push_str(&format!(
+                "{}:  {} < -:  ---------------------------------------- trunk commit {}\n",
+                i + 1,
+                sha,
+                i
+            ));
+        }
+        // One real matched pair
+        output.push_str(&format!(
+            "201:  {} = 1:  {} AI feature commit\n",
+            sha_a, sha_b
+        ));
+        let mappings = parse_range_diff_output(&output);
+        // Only the matched pair, not 200 bogus mappings
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(mappings[0], (sha_a, sha_b));
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_small_pending_dropped_still_mapped() {
+        // A bounded number of `<` commits ahead of the first match is a
+        // genuine squash and must still be drained into it — the overflow
+        // guard only fires past MAX_PENDING_DROPPED_COMMITS.
+        let dropped = "1".repeat(40);
+        let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+        let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
+        let output = format!(
+            "\
+1:  {} < -:  ---------------------------------------- dropped
+2:  {} = 1:  {} matched\n",
+            dropped, old_matched, new_matched,
+        );
+        let mappings = parse_range_diff_output(&output);
+        assert_eq!(
+            mappings,
+            vec![(dropped, new_matched.clone()), (old_matched, new_matched),]
+        );
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_pending_after_first_match_still_mapped() {
+        // After the first match, `<` commits between matches are genuine
+        // squashes and must still be mapped to the most recently seen new sha.
+        let old_1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+        let new_1 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
+        let old_dropped = "cccccccccccccccccccccccccccccccccccccccc".to_string();
+        let old_2 = "dddddddddddddddddddddddddddddddddddddddd".to_string();
+        let new_2 = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_string();
+        let output = format!(
+            "\
+1:  {} ! 1:  {} commit a
+2:  {} < -:  ---------------------------------------- squashed into previous
+3:  {} ! 2:  {} commit c\n",
+            old_1, new_1, old_dropped, old_2, new_2,
+        );
+        let mappings = parse_range_diff_output(&output);
+        // old_1→new_1 (first match, seen_first_match set to true),
+        // old_dropped→new_1 (maps to previous_new_sha, which is still new_1),
+        // old_2→new_2 (second match, updates previous_new_sha)
+        assert_eq!(mappings.len(), 3);
+        assert_eq!(mappings[0], (old_1, new_1.clone()));
+        assert_eq!(mappings[1], (old_dropped, new_1));
+        assert_eq!(mappings[2], (old_2, new_2));
     }
 
     #[test]

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -340,21 +340,19 @@ fn build_diff_tree_stdin(
     Ok(stdin_data)
 }
 
-fn compute_diff_tree_stdin(
-    repo: &Repository,
-    stdin_data: String,
-    pair_count: usize,
-) -> Result<Vec<DiffTreeResult>, GitAiError> {
-    // Single git diff-tree --stdin call.
-    //
-    // We intentionally use the General profile (no PatchParse prefix forcing)
-    // here: `diff-tree` is plumbing and -- unlike the `git diff` porcelain --
-    // ignores the user's diff.{noprefix,mnemonicPrefix,srcPrefix,dstPrefix},
-    // diff.external, and per-path textconv attributes. It always emits raw
-    // content with default `a/`..`b/` prefixes, which is exactly what
-    // extract_b_path / parse_diff_tree_output expect. (Contrast diff_added_lines
-    // in repository.rs, which DOES run `git diff` and therefore must force
-    // InternalGitProfile::PatchParse.)
+/// Build the arg list for `git diff-tree --stdin -p -U0 -M --no-color -r`.
+/// Shared by the chunked streaming path and the non-chunked
+/// `compute_diff_tree_stdin` path.
+///
+/// We intentionally use the General profile (no PatchParse prefix forcing)
+/// here: `diff-tree` is plumbing and -- unlike the `git diff` porcelain --
+/// ignores the user's diff.{noprefix,mnemonicPrefix,srcPrefix,dstPrefix},
+/// diff.external, and per-path textconv attributes. It always emits raw
+/// content with default `a/`..`b/` prefixes, which is exactly what
+/// extract_b_path / parse_diff_tree_output expect. (Contrast diff_added_lines
+/// in repository.rs, which DOES run `git diff` and therefore must force
+/// InternalGitProfile::PatchParse.)
+fn build_diff_tree_stdin_args(repo: &Repository) -> Vec<String> {
     let mut args = repo.global_args_for_exec();
     args.extend([
         "diff-tree".to_string(),
@@ -365,13 +363,21 @@ fn compute_diff_tree_stdin(
         "--no-color".to_string(),
         "-r".to_string(),
     ]);
+    args
+}
 
+fn compute_diff_tree_stdin(
+    repo: &Repository,
+    stdin_data: String,
+    pair_count: usize,
+) -> Result<Vec<DiffTreeResult>, GitAiError> {
     // Stream the output line-by-line into the parser instead of buffering it:
     // after a rebase across a large trunk delta, every pair's root-tree diff
     // contains that whole delta, so the batched output is
     // (trunk delta bytes) x (pair count) and buffering it has driven the
     // daemon to multi-GB RSS. The parsed hunk/line structures are a small
     // fraction of the raw patch text.
+    let args = build_diff_tree_stdin_args(repo);
     let mut parser = BatchedDiffTreeParser::new(pair_count);
     exec_git_stdin_streaming(&args, stdin_data.as_bytes(), |line| parser.feed_line(line))?;
     Ok(parser.finish())
@@ -720,21 +726,26 @@ pub(crate) fn shift_authorship_notes_merging_existing_with_notes(
     shift_authorship_notes_with_existing_mode(repo, mappings, true)
 }
 
-/// Maximum number of diff-tree pairs to compute in a single batch before
-/// applying shifts and dropping the parsed `DiffTreeResult` structures.
-/// Each result holds per-pair `Vec<u32>` of added lines and `Vec<DiffHunk>`
-/// hunks, and without chunking the cumulative allocation scales linearly with
-/// the pair count. Chunking bounds the live set to `CHUNK_SIZE` pairs and
-/// trades one extra git spawn per chunk for bounded peak RSS.
-const DIFF_TREE_PAIRS_CHUNK_SIZE: usize = 50;
+/// Maximum number of diff-tree results to hold in memory at once before
+/// pausing stdout reads (which blocks git's pipe) to apply shifts and
+/// drop the parsed structures. Bounds peak RSS to `CHUNK_SIZE` pairs worth
+/// of `Vec<u32>` added-line lists + `Vec<DiffHunk>` hunks, without the cost
+/// of extra git spawns.
+const DIFF_TREE_STREAM_CHUNK_SIZE: usize = 50;
+
+/// A pending authorship-log shift awaiting its diff-tree result. Built 1:1
+/// with (and in the same order as) the `diff_pairs` sent to git, so results
+/// are zipped with shifts positionally.
+struct PendingShift {
+    new_sha: String,
+    log: AuthorshipLog,
+}
 
 fn shift_authorship_notes_with_existing_mode(
     repo: &Repository,
     mappings: &[(String, String)],
     merge_existing_targets: bool,
 ) -> Result<Vec<(String, String)>, GitAiError> {
-    use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
-
     tracing::debug!("shift_authorship_notes: {} mappings", mappings.len());
 
     if mappings.is_empty() {
@@ -749,12 +760,6 @@ fn shift_authorship_notes_with_existing_mode(
     let notes_map = notes_api::read_notes_batch(repo, &all_shas)?;
 
     // Determine which mappings need processing
-    struct PendingShift {
-        new_sha: String,
-        log: AuthorshipLog,
-        diff_pair_idx: usize,
-    }
-
     let mut pending: Vec<PendingShift> = Vec::new();
     let mut verbatim_writes: Vec<(String, String)> = Vec::new();
     let mut diff_pairs: Vec<(String, String)> = Vec::new();
@@ -788,12 +793,10 @@ fn shift_authorship_notes_with_existing_mode(
             continue;
         };
 
-        let diff_pair_idx = diff_pairs.len();
         diff_pairs.push((source_sha.clone(), new_sha.clone()));
         pending.push(PendingShift {
             new_sha: new_sha.clone(),
             log,
-            diff_pair_idx,
         });
     }
 
@@ -801,55 +804,46 @@ fn shift_authorship_notes_with_existing_mode(
         return Ok(Vec::new());
     }
 
-    // Apply shifts in bounded chunks: compute the diff-trees for a slice of
-    // pairs, fold those shifts into `merged_by_target`, and drop the parsed
-    // `DiffTreeResult`s before moving on. Materializing all pairs at once has
-    // driven the daemon to multi-GB RSS when a bad mapping set turns every
-    // pair into a full-root-tree diff.
+    // Stream diff-tree output in bounded chunks from a single git spawn.
+    //
+    // One `git diff-tree --stdin` is fired with all pairs. The
+    // `BatchedDiffTreeParser` accumulates results as lines arrive; every
+    // `DIFF_TREE_STREAM_CHUNK_SIZE` completed pairs, the callback drains them,
+    // applies shifts, and drops the parsed structures — all inline inside the
+    // stdout read loop. While we process, we stop reading stdout, the OS pipe
+    // buffer fills, and git blocks on write() until we resume. That
+    // back-pressure bounds peak RSS without spawning one git process per
+    // chunk. Materializing all pairs at once has driven the daemon to
+    // multi-GB RSS when a bad mapping set turns every pair into a
+    // full-root-tree diff.
     let mut merged_by_target = existing_by_target;
 
-    // `pending` is ordered by `diff_pair_idx`, so it can be consumed with a
-    // cursor as the chunks advance.
-    let mut pending_iter = pending.into_iter().peekable();
-    let mut chunk_start = 0;
-    while chunk_start < diff_pairs.len() {
-        let chunk_end = (chunk_start + DIFF_TREE_PAIRS_CHUNK_SIZE).min(diff_pairs.len());
-        let diff_results = compute_diff_trees_batch(repo, &diff_pairs[chunk_start..chunk_end])?;
+    // `pending` is 1:1 with `diff_pairs`, so results are zipped with shifts
+    // positionally as the chunks advance.
+    let mut pending_iter = pending.into_iter();
 
-        while let Some(shift) = pending_iter.next_if(|s| s.diff_pair_idx < chunk_end) {
-            let diff_result = &diff_results[shift.diff_pair_idx - chunk_start];
-            let mut log = shift.log;
+    if !diff_pairs.is_empty() {
+        let unique_shas = unique_pair_shas(&diff_pairs);
+        let sha_to_tree = resolve_tree_shas(repo, &unique_shas)?;
+        let stdin_data = build_diff_tree_stdin(&diff_pairs, &sha_to_tree)?;
+        let diff_args = build_diff_tree_stdin_args(repo);
+        let mut parser = BatchedDiffTreeParser::new(diff_pairs.len());
 
-            for (old_path, new_path) in &diff_result.renames {
-                for attestation in &mut log.attestations {
-                    if attestation.file_path == *old_path {
-                        attestation.file_path = new_path.clone();
-                    }
-                }
+        exec_git_stdin_streaming(&diff_args, stdin_data.as_bytes(), |line| {
+            parser.feed_line(line);
+
+            // Drain completed results inline while we hold the pipe —
+            // this is the back-pressure: git blocks while we process.
+            if parser.completed_count() >= DIFF_TREE_STREAM_CHUNK_SIZE {
+                let chunk = parser.take_completed();
+                apply_chunk_shifts(&mut merged_by_target, chunk, &mut pending_iter);
             }
+        })?;
 
-            if !diff_result.hunks_by_file.is_empty() {
-                log.attestations = log
-                    .attestations
-                    .iter()
-                    .filter_map(|fa| match diff_result.hunks_by_file.get(&fa.file_path) {
-                        Some(hunks) => apply_hunk_shifts_to_file_attestation(fa, hunks),
-                        None => Some(fa.clone()),
-                    })
-                    .collect();
-            }
-
-            log.metadata.base_commit_sha = shift.new_sha.clone();
-
-            match merged_by_target.get_mut(&shift.new_sha) {
-                Some(existing) => merge_authorship_logs(existing, &log),
-                None => {
-                    merged_by_target.insert(shift.new_sha, log);
-                }
-            }
-        }
-
-        chunk_start = chunk_end;
+        // Drain the tail: the in-progress result plus any padding needed if
+        // git produced fewer result separators than expected.
+        let final_chunk = parser.take_all();
+        apply_chunk_shifts(&mut merged_by_target, final_chunk, &mut pending_iter);
     }
 
     let mut all_writes = verbatim_writes;
@@ -914,6 +908,54 @@ fn merge_authorship_logs(target: &mut AuthorshipLog, source: &AuthorshipLog) {
             .humans
             .entry(key.clone())
             .or_insert_with(|| record.clone());
+    }
+}
+
+/// Apply hunk/rename shifts from a chunk of `DiffTreeResult`s to the
+/// corresponding `PendingShift`s, merging shifted logs into
+/// `merged_by_target`. Called inline inside the stdout read loop so the
+/// pipe blocks git while we process.
+///
+/// `pending_iter` yields shifts in the same order as `diff_pairs`, so the
+/// Nth diff result always corresponds to the Nth pending shift — the two
+/// sequences are zipped positionally.
+fn apply_chunk_shifts(
+    merged_by_target: &mut HashMap<String, AuthorshipLog>,
+    chunk: Vec<DiffTreeResult>,
+    pending_iter: &mut impl Iterator<Item = PendingShift>,
+) {
+    use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
+
+    for (diff_result, shift) in chunk.iter().zip(pending_iter) {
+        let mut log = shift.log;
+
+        for (old_path, new_path) in &diff_result.renames {
+            for attestation in &mut log.attestations {
+                if attestation.file_path == *old_path {
+                    attestation.file_path = new_path.clone();
+                }
+            }
+        }
+
+        if !diff_result.hunks_by_file.is_empty() {
+            log.attestations = log
+                .attestations
+                .iter()
+                .filter_map(|fa| match diff_result.hunks_by_file.get(&fa.file_path) {
+                    Some(hunks) => apply_hunk_shifts_to_file_attestation(fa, hunks),
+                    None => Some(fa.clone()),
+                })
+                .collect();
+        }
+
+        log.metadata.base_commit_sha = shift.new_sha.clone();
+
+        match merged_by_target.get_mut(&shift.new_sha) {
+            Some(existing) => merge_authorship_logs(existing, &log),
+            None => {
+                merged_by_target.insert(shift.new_sha, log);
+            }
+        }
     }
 }
 
@@ -1298,7 +1340,7 @@ impl BatchedDiffTreeParser {
     fn new(expected_pairs: usize) -> Self {
         Self {
             expected_pairs,
-            results: Vec::with_capacity(expected_pairs),
+            results: Vec::with_capacity(expected_pairs.min(DIFF_TREE_STREAM_CHUNK_SIZE)),
             current: DiffTreeChunkParser::default(),
             seen_first_header: false,
         }
@@ -1317,19 +1359,48 @@ impl BatchedDiffTreeParser {
         }
     }
 
-    fn finish(mut self) -> Vec<DiffTreeResult> {
-        // Push final chunk
+    fn completed_count(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Drain and return all completed results, leaving the parser ready to
+    /// accumulate more. The `expected_pairs` count is adjusted so final
+    /// padding still accounts for already-drained results.
+    fn take_completed(&mut self) -> Vec<DiffTreeResult> {
+        let drained = std::mem::take(&mut self.results);
+        self.expected_pairs = self.expected_pairs.saturating_sub(drained.len());
+        // Re-allocate at chunk capacity so subsequent push() calls don't
+        // re-allocate incrementally.
+        self.results = Vec::with_capacity(self.expected_pairs.min(DIFF_TREE_STREAM_CHUNK_SIZE));
+        drained
+    }
+
+    /// Drain remaining completed results (including the in-progress chunk) and
+    /// pad with empty entries if git produced fewer result separators than
+    /// expected.
+    fn take_all(&mut self) -> Vec<DiffTreeResult> {
+        // Push the in-progress chunk if any
         if self.seen_first_header {
-            self.results.push(self.current.finish());
+            let chunk = std::mem::take(&mut self.current);
+            self.results.push(chunk.finish());
+            self.seen_first_header = false;
         }
 
-        // If git produced fewer results than pairs, pad with empty results
-        // (happens when trees are identical — no separator line emitted)
-        while self.results.len() < self.expected_pairs {
-            self.results.push(DiffTreeResult::default());
+        let mut drained = std::mem::take(&mut self.results);
+
+        // Pad to expected count for identical trees
+        while drained.len() < self.expected_pairs {
+            drained.push(DiffTreeResult::default());
         }
 
-        self.results
+        self.expected_pairs = 0;
+        drained
+    }
+
+    /// Consume self and return all results (padded to expected_pairs).
+    fn finish(self) -> Vec<DiffTreeResult> {
+        let mut parser = self;
+        parser.take_all()
     }
 }
 
@@ -2016,5 +2087,40 @@ index eee..fff 100644
         assert_eq!(streamed[0].added_lines_by_file["src/new.rs"], vec![5]);
         assert_eq!(streamed[1].added_lines_by_file["g.txt"], vec![11, 12]);
         assert_eq!(streamed[2], DiffTreeResult::default());
+    }
+
+    #[test]
+    fn test_batched_diff_tree_parser_can_drain_completed_chunks() {
+        let output = "\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+diff --git a/a.txt b/a.txt
+@@ -1,0 +1 @@
++a
+cccccccccccccccccccccccccccccccccccccccc dddddddddddddddddddddddddddddddddddddddd
+diff --git a/b.txt b/b.txt
+@@ -1,0 +1 @@
++b
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee ffffffffffffffffffffffffffffffffffffffff
+diff --git a/c.txt b/c.txt
+@@ -1,0 +1 @@
++c
+";
+
+        let mut parser = BatchedDiffTreeParser::new(3);
+        let mut chunks = Vec::new();
+        for line in output.lines() {
+            parser.feed_line(line);
+            if parser.completed_count() >= 2 {
+                chunks.push(parser.take_completed());
+            }
+        }
+        chunks.push(parser.take_all());
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 2);
+        assert_eq!(chunks[1].len(), 1);
+        assert!(chunks[0][0].hunks_by_file.contains_key("a.txt"));
+        assert!(chunks[0][1].hunks_by_file.contains_key("b.txt"));
+        assert!(chunks[1][0].hunks_by_file.contains_key("c.txt"));
     }
 }

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -1899,6 +1899,70 @@ Binary files a/image.png and b/image.png differ
     }
 
     #[test]
+    fn test_parse_range_diff_output_exactly_64_leading_drops_still_mapped() {
+        // Exactly MAX_PENDING_DROPPED_COMMITS (64) leading `<` commits should
+        // all be mapped to the first matched new SHA, plus the match's own old
+        // SHA — total of 65 mappings. Start at 1 so the first SHA is not all
+        // zeros and is therefore not skipped.
+        const MAX_DROPPED: usize = 64;
+        let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+        let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
+        let mut output = String::new();
+        for i in 1..=MAX_DROPPED {
+            let sha = format!("{:040}", i);
+            output.push_str(&format!(
+                "{}:  {} < -:  ---------------------------------------- dropped {}\n",
+                i, sha, i
+            ));
+        }
+        output.push_str(&format!(
+            "{}:  {} = 1:  {} matched\n",
+            MAX_DROPPED + 1,
+            old_matched,
+            new_matched,
+        ));
+        let mappings = parse_range_diff_output(&output);
+        // 64 dropped + 1 matched
+        assert_eq!(mappings.len(), MAX_DROPPED + 1);
+        // All dropped commits map to new_matched
+        for i in 1..=MAX_DROPPED {
+            let sha = format!("{:040}", i);
+            assert_eq!(mappings[i - 1], (sha, new_matched.clone()));
+        }
+        // The matched pair is last
+        assert_eq!(mappings[MAX_DROPPED], (old_matched, new_matched));
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_exactly_65_leading_drops_discards_all() {
+        // Exactly MAX_PENDING_DROPPED_COMMITS + 1 (65) leading `<` commits
+        // exceeds the limit, so ALL of them are discarded — only the matched
+        // pair's own mapping survives. Start at 1 so the first SHA is not all
+        // zeros and is therefore not skipped.
+        const MAX_DROPPED_PLUS_1: usize = 65;
+        let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+        let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
+        let mut output = String::new();
+        for i in 1..=MAX_DROPPED_PLUS_1 {
+            let sha = format!("{:040}", i);
+            output.push_str(&format!(
+                "{}:  {} < -:  ---------------------------------------- dropped {}\n",
+                i, sha, i
+            ));
+        }
+        output.push_str(&format!(
+            "{}:  {} = 1:  {} matched\n",
+            MAX_DROPPED_PLUS_1 + 1,
+            old_matched,
+            new_matched,
+        ));
+        let mappings = parse_range_diff_output(&output);
+        // Only the matched pair survived
+        assert_eq!(mappings.len(), 1);
+        assert_eq!(mappings[0], (old_matched, new_matched));
+    }
+
+    #[test]
     fn test_is_tree_pair_separator_valid() {
         let line =
             "1778ed95466977076f4e5908e6500789be732d2e 471b7bbf5998ffa15a81b17ee9f6854a357a2a6a";
@@ -2122,5 +2186,193 @@ diff --git a/c.txt b/c.txt
         assert!(chunks[0][0].hunks_by_file.contains_key("a.txt"));
         assert!(chunks[0][1].hunks_by_file.contains_key("b.txt"));
         assert!(chunks[1][0].hunks_by_file.contains_key("c.txt"));
+    }
+
+    fn diff_tree_stream_with_identical_pairs(
+        pair_count: usize,
+        identical_pair_numbers: &[usize],
+    ) -> String {
+        let mut output = String::new();
+        for pair_number in 1..=pair_count {
+            let old_oid = format!("{:040x}", pair_number);
+            let new_oid = if identical_pair_numbers.contains(&pair_number) {
+                old_oid.clone()
+            } else {
+                format!("{:040x}", pair_number + 10_000)
+            };
+            output.push_str(&format!("{old_oid} {new_oid}\n"));
+            if !identical_pair_numbers.contains(&pair_number) {
+                output.push_str(&format!(
+                    "diff --git a/file_{pair_number}.txt b/file_{pair_number}.txt\n\
+                     @@ -1,0 +1 @@\n\
+                     +line {pair_number}\n"
+                ));
+            }
+        }
+        output
+    }
+
+    #[test]
+    fn test_batched_diff_tree_parser_preserves_identical_pairs_across_drain_boundary() {
+        let output = diff_tree_stream_with_identical_pairs(
+            DIFF_TREE_STREAM_CHUNK_SIZE + 2,
+            &[
+                DIFF_TREE_STREAM_CHUNK_SIZE - 1,
+                DIFF_TREE_STREAM_CHUNK_SIZE,
+                DIFF_TREE_STREAM_CHUNK_SIZE + 1,
+            ],
+        );
+
+        let mut parser = BatchedDiffTreeParser::new(DIFF_TREE_STREAM_CHUNK_SIZE + 2);
+        let mut chunks = Vec::new();
+        for line in output.lines() {
+            parser.feed_line(line);
+            if parser.completed_count() >= DIFF_TREE_STREAM_CHUNK_SIZE {
+                chunks.push(parser.take_completed());
+            }
+        }
+        chunks.push(parser.take_all());
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), DIFF_TREE_STREAM_CHUNK_SIZE);
+        assert_eq!(chunks[1].len(), 2);
+
+        let results: Vec<_> = chunks.into_iter().flatten().collect();
+        assert_eq!(results.len(), DIFF_TREE_STREAM_CHUNK_SIZE + 2);
+        assert!(
+            results[DIFF_TREE_STREAM_CHUNK_SIZE - 3]
+                .hunks_by_file
+                .contains_key("file_48.txt")
+        );
+        assert_eq!(
+            results[DIFF_TREE_STREAM_CHUNK_SIZE - 2],
+            DiffTreeResult::default()
+        );
+        assert_eq!(
+            results[DIFF_TREE_STREAM_CHUNK_SIZE - 1],
+            DiffTreeResult::default()
+        );
+        assert_eq!(
+            results[DIFF_TREE_STREAM_CHUNK_SIZE],
+            DiffTreeResult::default()
+        );
+        assert!(
+            results[DIFF_TREE_STREAM_CHUNK_SIZE + 1]
+                .hunks_by_file
+                .contains_key("file_52.txt")
+        );
+    }
+
+    fn authorship_log_for_streaming_merge_test(index: usize) -> AuthorshipLog {
+        use crate::authorship::authorship_log::{
+            HumanRecord, LineRange, PromptRecord, SessionRecord,
+        };
+        use crate::authorship::authorship_log_serialization::AttestationEntry;
+        use crate::authorship::working_log::AgentId;
+
+        let hash = format!("{index:016x}");
+        let mut log = AuthorshipLog::new();
+        log.get_or_create_file(&format!("file_{index}.txt"))
+            .add_entry(AttestationEntry::new(
+                hash.clone(),
+                vec![LineRange::Single(1)],
+            ));
+
+        let agent_id = AgentId {
+            tool: "test".to_string(),
+            id: format!("agent-{index}"),
+            model: "model".to_string(),
+        };
+        log.metadata.prompts.insert(
+            hash.clone(),
+            PromptRecord {
+                agent_id: agent_id.clone(),
+                human_author: None,
+                messages_url: Some(format!("https://example.com/{index}")),
+                total_additions: 1,
+                total_deletions: 0,
+                accepted_lines: 1,
+                overriden_lines: 0,
+                custom_attributes: None,
+            },
+        );
+        log.metadata.sessions.insert(
+            format!("s_{index}"),
+            SessionRecord {
+                agent_id,
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+        log.metadata.humans.insert(
+            format!("h_{index}"),
+            HumanRecord {
+                author: format!("Human {index} <human-{index}@example.com>"),
+            },
+        );
+        log
+    }
+
+    #[test]
+    fn test_apply_chunk_shifts_merges_same_target_across_streaming_chunks() {
+        const SOURCE_COUNT: usize = DIFF_TREE_STREAM_CHUNK_SIZE + 5;
+        let target_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
+        let pending: Vec<PendingShift> = (1..=SOURCE_COUNT)
+            .map(|index| PendingShift {
+                new_sha: target_sha.clone(),
+                log: authorship_log_for_streaming_merge_test(index),
+            })
+            .collect();
+
+        let output = diff_tree_stream_with_identical_pairs(
+            SOURCE_COUNT,
+            &(1..=SOURCE_COUNT).collect::<Vec<_>>(),
+        );
+        let mut parser = BatchedDiffTreeParser::new(SOURCE_COUNT);
+        let mut pending_iter = pending.into_iter();
+        let mut merged_by_target = HashMap::new();
+        let mut chunk_lengths = Vec::new();
+
+        for line in output.lines() {
+            parser.feed_line(line);
+            if parser.completed_count() >= DIFF_TREE_STREAM_CHUNK_SIZE {
+                let chunk = parser.take_completed();
+                chunk_lengths.push(chunk.len());
+                apply_chunk_shifts(&mut merged_by_target, chunk, &mut pending_iter);
+            }
+        }
+
+        let final_chunk = parser.take_all();
+        chunk_lengths.push(final_chunk.len());
+        apply_chunk_shifts(&mut merged_by_target, final_chunk, &mut pending_iter);
+
+        assert_eq!(chunk_lengths, vec![DIFF_TREE_STREAM_CHUNK_SIZE, 5]);
+        assert_eq!(pending_iter.count(), 0);
+        let merged = merged_by_target
+            .get(&target_sha)
+            .expect("all source logs should merge into the shared target SHA");
+        assert_eq!(merged.attestations.len(), SOURCE_COUNT);
+        assert_eq!(merged.metadata.prompts.len(), SOURCE_COUNT);
+        assert_eq!(merged.metadata.sessions.len(), SOURCE_COUNT);
+        assert_eq!(merged.metadata.humans.len(), SOURCE_COUNT);
+        assert_eq!(merged.metadata.base_commit_sha, target_sha);
+
+        for index in 1..=SOURCE_COUNT {
+            assert!(
+                merged
+                    .attestations
+                    .iter()
+                    .any(|attestation| attestation.file_path == format!("file_{index}.txt")),
+                "merged target should include file_{index}.txt from source commit {index}"
+            );
+            assert!(
+                merged
+                    .metadata
+                    .prompts
+                    .contains_key(&format!("{index:016x}"))
+            );
+            assert!(merged.metadata.sessions.contains_key(&format!("s_{index}")));
+            assert!(merged.metadata.humans.contains_key(&format!("h_{index}")));
+        }
     }
 }

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -4111,7 +4111,7 @@ mod tests {
     fn commit_reflog_subject_rewritten_by_hook_falls_back_to_hinted_entry() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 
@@ -4159,7 +4159,7 @@ mod tests {
     fn commit_reflog_subject_rewrite_fallback_does_not_guess_without_hint() {
         let temp = tempfile::tempdir().unwrap();
         let worktree = temp.path().join("repo");
-        let git_dir = worktree.join(".git");
+        let git_dir = create_git_dir(&worktree);
         let head_log = git_dir.join("logs/HEAD");
         fs::create_dir_all(head_log.parent().unwrap()).unwrap();
 

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -1,4 +1,4 @@
-use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_file::{ExpectedLine, ExpectedLineExt};
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log::PromptRecord;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
@@ -2857,4 +2857,429 @@ fn test_rebase_same_file_then_ff_merge_preserves_attribution() {
         "ai append 2".ai(),
         "ai append 3".ai(),
     ]);
+}
+
+const COMMITS_OVER_PENDING_DROPPED_LIMIT: usize = 200;
+
+fn numbered_file_contents(prefix: &str, count: usize) -> String {
+    (1..=count)
+        .map(|i| format!("{prefix} {i}\n"))
+        .collect::<String>()
+}
+
+fn expected_ai_numbered_lines(prefix: &str, count: usize) -> Vec<ExpectedLine> {
+    (1..=count).map(|i| format!("{prefix} {i}").ai()).collect()
+}
+
+fn leading_dropped_commits_before_first_match(range_diff: &str) -> usize {
+    let mut dropped = 0;
+
+    for line in range_diff.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut parts = trimmed.split_whitespace();
+        let (_ordinal, _old_sha, Some(status)) = (parts.next(), parts.next(), parts.next()) else {
+            continue;
+        };
+
+        match status {
+            "<" => dropped += 1,
+            "=" | "!" => break,
+            _ => {}
+        }
+    }
+
+    dropped
+}
+
+#[test]
+fn test_rebase_more_commits_than_pending_dropped_limit_preserves_authorship() {
+    use std::fs;
+
+    let repo = TestRepo::new();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let feature_path = repo.path().join("feature.txt");
+    let mut feature_file = repo.filename("feature.txt");
+
+    for commit_number in 1..=COMMITS_OVER_PENDING_DROPPED_LIMIT {
+        fs::write(
+            &feature_path,
+            numbered_file_contents("ai feature line", commit_number),
+        )
+        .unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+            .unwrap();
+        repo.git(&["add", "-A"]).unwrap();
+        repo.commit(&format!("feature commit {commit_number}"))
+            .unwrap();
+    }
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main advance".human()]);
+    repo.stage_all_and_commit("Main advances").unwrap();
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+
+    let rebased_commit_count = repo
+        .git(&["rev-list", "--count", &format!("{}..HEAD", default_branch)])
+        .unwrap()
+        .trim()
+        .parse::<usize>()
+        .unwrap();
+    assert_eq!(
+        rebased_commit_count, COMMITS_OVER_PENDING_DROPPED_LIMIT,
+        "rebase should preserve every feature commit, even when the count exceeds the pending-drop limit"
+    );
+    feature_file.assert_lines_and_blame(expected_ai_numbered_lines(
+        "ai feature line",
+        COMMITS_OVER_PENDING_DROPPED_LIMIT,
+    ));
+}
+
+#[test]
+fn test_reset_keep_undo_rebase_discards_many_old_upstream_commits() {
+    use std::fs;
+
+    let repo = TestRepo::new();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let base_sha = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let feature_path = repo.path().join("feature.txt");
+    fs::write(&feature_path, "ai feature line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.commit("feature commit").unwrap();
+    let original_feature_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let mut feature_file = repo.filename("feature.txt");
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let trunk_path = repo.path().join("trunk.txt");
+    for commit_number in 1..=COMMITS_OVER_PENDING_DROPPED_LIMIT {
+        fs::write(
+            &trunk_path,
+            numbered_file_contents("untracked trunk line", commit_number),
+        )
+        .unwrap();
+        repo.git(&["add", "-A"]).unwrap();
+        repo.commit(&format!("trunk commit {commit_number}"))
+            .unwrap();
+    }
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+    let rebased_feature_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(
+        original_feature_tip, rebased_feature_tip,
+        "feature commit should be rewritten onto the advanced trunk"
+    );
+    feature_file.assert_lines_and_blame(crate::lines!["ai feature line".ai()]);
+
+    let old_range = format!("{base_sha}..{rebased_feature_tip}");
+    let new_range = format!("{base_sha}..{original_feature_tip}");
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "-s",
+            "--creation-factor=100",
+            &old_range,
+            &new_range,
+        ])
+        .unwrap();
+    let leading_drops = leading_dropped_commits_before_first_match(&range_diff);
+    assert!(
+        leading_drops > 64,
+        "test setup must exceed the pending-dropped cutoff before the first match; got {leading_drops}\n{range_diff}"
+    );
+
+    repo.git(&["reset", "--keep", &original_feature_tip])
+        .unwrap();
+    assert_eq!(
+        repo.git(&["rev-parse", "HEAD"]).unwrap().trim(),
+        original_feature_tip
+    );
+    assert!(
+        !repo.path().join("trunk.txt").exists(),
+        "reset --keep back to the pre-rebase feature tip should remove upstream-only files"
+    );
+    feature_file.assert_lines_and_blame(crate::lines!["ai feature line".ai()]);
+
+    let note = repo
+        .read_authorship_note(&original_feature_tip)
+        .expect("original feature commit should still have an authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse original feature note");
+    assert!(
+        log.attestations
+            .iter()
+            .any(|attestation| attestation.file_path == "feature.txt"),
+        "feature authorship note should still describe the feature file"
+    );
+    assert!(
+        log.attestations
+            .iter()
+            .all(|attestation| attestation.file_path != "trunk.txt"),
+        "discarded upstream-only commits must not add trunk attestations to the feature note"
+    );
+}
+
+/// Test rebase with more than DIFF_TREE_STREAM_CHUNK_SIZE (50) rewritten commits.
+///
+/// The streaming diff-tree path drains completed results in chunks of 50 and
+/// applies hunk/rename shifts inline. This test verifies that commits around the
+/// chunk boundary (49, 50, 51, 52) all have correct authorship note attestations
+/// after rebase, and that the final HEAD has correct attribution for all lines.
+#[test]
+fn test_rebase_across_streaming_chunk_boundary_preserves_attribution() {
+    use std::fs;
+
+    const FEATURE_COMMIT_COUNT: usize = 60;
+
+    let repo = TestRepo::new();
+
+    // Initial commit
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let default_branch = repo.current_branch();
+
+    // Create feature branch
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let feature_path = repo.path().join("feature.txt");
+    let mut feature_file = repo.filename("feature.txt");
+
+    // Build ~60 commits with a varied modification pattern:
+    // - Every commit appends a new AI line.
+    // - Every 5th commit also modifies an earlier line (different from all prior
+    //   modifications), producing non-trivial diff-tree results across the boundary.
+    for commit_number in 1..=FEATURE_COMMIT_COUNT {
+        let mut content = String::new();
+        for i in 1..=commit_number {
+            if i % 5 == 0 && i != commit_number && commit_number % 5 == 0 {
+                // Every 5th commit modifies an earlier line that was last changed
+                // in a previous commit
+                content.push_str(&format!(
+                    "ai feature line {i} (modified in commit {commit_number})\n"
+                ));
+            } else {
+                content.push_str(&format!("ai feature line {i}\n"));
+            }
+        }
+        fs::write(&feature_path, &content).unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+            .unwrap();
+        repo.git(&["add", "-A"]).unwrap();
+        repo.commit(&format!("feature commit {commit_number}"))
+            .unwrap();
+    }
+
+    // Capture original commit SHAs in order (oldest first)
+    let original_shas_output = repo
+        .git(&[
+            "rev-list",
+            "--reverse",
+            &format!("{}..HEAD", default_branch),
+        ])
+        .unwrap();
+    let original_shas: Vec<&str> = original_shas_output.trim().lines().collect();
+    assert_eq!(
+        original_shas.len(),
+        FEATURE_COMMIT_COUNT,
+        "should have exactly {FEATURE_COMMIT_COUNT} feature commits before rebase"
+    );
+
+    // Advance main with one human commit
+    repo.git(&["checkout", &default_branch]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main advance".human()]);
+    repo.stage_all_and_commit("Main advances").unwrap();
+
+    // Rebase feature onto main
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+
+    // Get rebased commit SHAs in order (oldest first)
+    let rebased_shas_output = repo
+        .git(&[
+            "rev-list",
+            "--reverse",
+            &format!("{}..HEAD", default_branch),
+        ])
+        .unwrap();
+    let rebased_shas: Vec<&str> = rebased_shas_output.trim().lines().collect();
+    assert_eq!(
+        rebased_shas.len(),
+        FEATURE_COMMIT_COUNT,
+        "rebase should preserve all {FEATURE_COMMIT_COUNT} commits"
+    );
+
+    // Verify authorship notes for commits around the chunk boundary (0-based: 48, 49, 50, 51)
+    // The streaming chunk size is 50, so these straddle the boundary.
+    let boundary_indices: [usize; 4] = [48, 49, 50, 51];
+
+    for &idx in &boundary_indices {
+        let sha = rebased_shas[idx];
+        let note = repo
+            .read_authorship_note(sha)
+            .unwrap_or_else(|| panic!("commit {idx} (sha={sha}) should have an authorship note"));
+
+        let log = AuthorshipLog::deserialize_from_string(&note)
+            .unwrap_or_else(|e| panic!("parse authorship note for commit {idx}: {e}"));
+
+        assert!(
+            log.attestations
+                .iter()
+                .any(|attestation| attestation.file_path == "feature.txt"),
+            "commit {idx} (sha={sha}) should have attestation for feature.txt"
+        );
+
+        // Verify each boundary commit has at least one non-empty attestation entry
+        let total_lines: u32 = log
+            .attestations
+            .iter()
+            .flat_map(|a| &a.entries)
+            .flat_map(|e| &e.line_ranges)
+            .map(|r| match r {
+                git_ai::authorship::authorship_log::LineRange::Single(_) => 1,
+                git_ai::authorship::authorship_log::LineRange::Range(s, e) => e - s + 1,
+            })
+            .sum();
+        assert!(
+            total_lines > 0,
+            "commit {idx} should have at least one attested line; got {total_lines}"
+        );
+    }
+
+    // Verify the final HEAD file has correct attribution for all expected AI lines.
+    // After 60 commits, lines 5, 10, 15, …, 55 (indices divisible by 5, excluding
+    // 60) were last modified in commit 60 (which itself is divisible by 5) and
+    // carry the "(modified in commit 60)" suffix. All other lines use the base
+    // "ai feature line {N}" text.
+    let expected_lines: Vec<ExpectedLine> = (1..=FEATURE_COMMIT_COUNT)
+        .map(|i| {
+            if i % 5 == 0 && i != FEATURE_COMMIT_COUNT {
+                format!("ai feature line {i} (modified in commit {FEATURE_COMMIT_COUNT})").ai()
+            } else {
+                format!("ai feature line {i}").ai()
+            }
+        })
+        .collect();
+    feature_file.assert_lines_and_blame(expected_lines);
+}
+
+/// Test rebase where diff-tree pairs are identical across the streaming chunk boundary.
+///
+/// An empty commit on the upstream branch changes the parent graph without changing the
+/// base tree. Replaying feature commits onto it rewrites commit SHAs, but each old/new
+/// commit pair has the same tree. This forces the streaming diff-tree parser to pad
+/// empty results for identical tree pairs while draining at the 50-result boundary.
+#[test]
+fn test_rebase_identical_tree_pairs_across_streaming_chunk_boundary() {
+    use std::fs;
+
+    const FEATURE_COMMIT_COUNT: usize = 60;
+    const BOUNDARY_INDICES: [usize; 4] = [48, 49, 50, 51];
+
+    let repo = TestRepo::new();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let default_branch = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    for commit_number in 1..=FEATURE_COMMIT_COUNT {
+        let file_name = format!("file_{commit_number}.txt");
+        fs::write(
+            repo.path().join(&file_name),
+            format!("ai content for file {commit_number}\n"),
+        )
+        .unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", &file_name]).unwrap();
+        repo.git(&["add", "-A"]).unwrap();
+        repo.commit(&format!("feature commit {commit_number}"))
+            .unwrap();
+    }
+
+    let original_shas_output = repo
+        .git(&[
+            "rev-list",
+            "--reverse",
+            &format!("{}..HEAD", default_branch),
+        ])
+        .unwrap();
+    let original_shas: Vec<&str> = original_shas_output.trim().lines().collect();
+    assert_eq!(original_shas.len(), FEATURE_COMMIT_COUNT);
+
+    repo.git(&["checkout", &default_branch]).unwrap();
+    repo.git(&["commit", "--allow-empty", "-m", "Main empty advance"])
+        .unwrap();
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &default_branch]).unwrap();
+
+    let rebased_shas_output = repo
+        .git(&[
+            "rev-list",
+            "--reverse",
+            &format!("{}..HEAD", default_branch),
+        ])
+        .unwrap();
+    let rebased_shas: Vec<&str> = rebased_shas_output.trim().lines().collect();
+    assert_eq!(rebased_shas.len(), FEATURE_COMMIT_COUNT);
+
+    for &idx in &BOUNDARY_INDICES {
+        let original_tree = repo
+            .git(&["show", "-s", "--format=%T", original_shas[idx]])
+            .unwrap();
+        let rebased_tree = repo
+            .git(&["show", "-s", "--format=%T", rebased_shas[idx]])
+            .unwrap();
+        assert_eq!(
+            original_tree.trim(),
+            rebased_tree.trim(),
+            "commit {} should be an identical-tree rewrite",
+            idx + 1
+        );
+
+        let expected_file = format!("file_{}.txt", idx + 1);
+        let note = repo
+            .read_authorship_note(rebased_shas[idx])
+            .unwrap_or_else(|| {
+                panic!(
+                    "rebased boundary commit {} ({}) should have an authorship note",
+                    idx + 1,
+                    rebased_shas[idx]
+                )
+            });
+        let log = AuthorshipLog::deserialize_from_string(&note)
+            .unwrap_or_else(|e| panic!("parse authorship note for commit {}: {e}", idx + 1));
+        assert!(
+            log.attestations
+                .iter()
+                .any(|attestation| attestation.file_path == expected_file),
+            "rebased commit {} should keep attestation for {expected_file}",
+            idx + 1
+        );
+
+        let mut file = repo.filename(&expected_file);
+        file.assert_lines_and_blame(crate::lines![
+            format!("ai content for file {}", idx + 1).ai()
+        ]);
+    }
 }


### PR DESCRIPTION
Problem: when running a `git reset --keep` to move a branch backward (which Graphite does when undoing a restack; the same problem can also apply when moving a branch from one base to another), the memory usage is potentially unbounded.

Solution: process in chunks, throw away meaningless commits while looking for first match.

Results on repro script:

```
Default scale (SCALE=default): 600 trunk commits, 80,160 + lines per pair

┌───────────────────────────────┬──────────┬───────────┐
│            Metric             │  Before  │   After   │
├───────────────────────────────┼──────────┼───────────┤
│ Mappings derived              │ 604      │ 4         │
├───────────────────────────────┼──────────┼───────────┤
│ Range-diff < commits          │ 600      │ 600       │
├───────────────────────────────┼──────────┼───────────┤
│ Per-pair raw diff             │ 13 MB    │ 13 MB     │
├───────────────────────────────┼──────────┼───────────┤
│ Total streamed through parser │ 8,385 MB │ 52 MB*    │
├───────────────────────────────┼──────────┼───────────┤
│ RSS baseline                  │ 28 MB    │ 26 MB     │
├───────────────────────────────┼──────────┼───────────┤
│ RSS peak                      │ 234 MB   │ 26 MB     │
├───────────────────────────────┼──────────┼───────────┤
│ RSS delta                     │ +206 MB  │ +0 MB     │
├───────────────────────────────┼──────────┼───────────┤
│ Peak child git RSS            │ n/a      │ 20 MB     │
├───────────────────────────────┼──────────┼───────────┤
│ Rewrite processing            │ 33s      │ 1s        │
└───────────────────────────────┴──────────┴───────────┘
```

I tried running the large repro variant; with this fix it completed in 2s with +4 MB RSS delta and 92MB peak child git RSS. Without this fix it crashed my computer 😅

<details>
<summary>Info for repro:</summary>

# Repro: daemon memory blowup on restack undo (range-diff mapping bomb)

Minimal, fully synthetic reproduction of a production incident where the git-ai
daemon reached ~30 GB RSS (and made every git command crawl via machine-wide
memory pressure) while processing the rewrite-attribution side effect of a
**restack undo** — moving a branch from its rebased tip back to the pre-rebase
tip, which is exactly what Graphite runs (`git reset --keep <old-tip>`) when a
restack is undone or aborted.

This fires **despite** the streaming diff-tree fix ("Fix high memory usage on
large rebases", `b0efde3fb`, shipped in v1.6.15). That fix stopped buffering
the raw patch text; this bug is the *parsed* structures, multiplied by an
unbounded mapping count.

Everything here is isolated: the script creates a brand-new temp repo, a fake
`$HOME`, and a **per-run daemon** wired via trace2 sockets (the same wiring the
integration-test harness uses). Nothing is installed system-wide and nothing
touches your real `~/.git-ai`.

## Root cause

A non-hard `git reset` to a non-ancestor (the daemon's Reset handling in
`src/daemon.rs`, non-fast-forward arm) raises
`RewriteEvent::NonFastForward { old_tip: rebased_tip, new_tip: orig_tip }`,
which flows into `handle_non_fast_forward_rewrite_with_operation`
(`src/authorship/rewrite.rs:445`):

1. `derive_mappings_from_range_diff` (`rewrite.rs:901`) runs
   `git range-diff <merge-base>..<rebased-tip> <merge-base>..<orig-tip>`
   (`run_range_diff`, `rewrite.rs:987`). For a restack undo the merge base is
   the branch's **fork point**, so the left range contains **every trunk
   commit landed since the branch forked** — thousands on a busy monorepo.
   None of them match the right range, so each is emitted as an unmatched `<`
   line, and `parse_range_diff_output` (`rewrite.rs:1008`) maps **every one**
   of them to a commit of the new range (`previous_new_sha` / the
   `pending_dropped` drain, `rewrite.rs:1031-1055`). Mapping count is
   unbounded: ~= trunk commits since fork.
2. `shift_authorship_notes_with_existing_mode` (`rewrite.rs:720`) batch-reads
   the notes for all mapping endpoints (`read_notes_batch`, `rewrite.rs:738`)
   and queues a **full-root-tree diff pair per mapping whose source commit has
   a note** (`rewrite.rs:752-787`). On the Robinhood fleet effectively every
   trunk commit has an authorship note, so ~every bogus mapping becomes a diff
   pair — plus its parsed `AuthorshipLog` held in `pending`.
3. `compute_diff_trees_batch` (`rewrite.rs:1231`) streams one
   `git diff-tree --stdin -p -U0 -M -r` over all pairs. The raw text is no
   longer buffered, **but** each pair still materializes a `DiffTreeResult`
   (`rewrite.rs:34`): `added_lines_by_file` holds **one `u32` per `+` line**
   and `hunks_by_file` one 16-byte `DiffHunk` per hunk
   (`DiffTreeChunkParser`, `rewrite.rs:1321`), all collected into
   `Vec<DiffTreeResult>` — alive until every pair is parsed and shifted.

The blowup: each pair diffs a **trunk commit's tree against the original
branch tip's tree**, i.e. it *reverses the entire trunk delta*. Every line the
trunk modified since the fork point comes back as a `+` line (its pre-fork
content), so:

```
daemon RSS  ≈  (trunk commits since fork)  ×  (lines modified on trunk)  ×  ~12 B
```

Both factors are unbounded and multiplicative. A monorepo branch forked a few
weeks back easily has thousands of trunk commits × millions of modified lines
— tens of GB. On top of the memory, `-U0 -M` diff generation across thousands
of full-tree pairs is what burns the CPU/wall-clock (the raw patch text
streamed through the parser is `pairs × trunk-delta bytes`, even though it is
no longer held).

Note `git reset --hard` does **not** reproduce this: the daemon's
`ResetKind::Hard` arm only deletes the working log. The rewrite path fires for
the non-hard kinds — and `--keep` is what Graphite uses.

## Running it

```bash
task build   # produces target/debug/git-ai (or pass GIT_AI_BIN=...)
./scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh              # default scale
SCALE=small ./scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh  # quick sanity
SCALE=large ./scripts/repro/daemon-restack-undo-mapping-bomb/repro.sh  # multi-GB peak
```

What the script does:

1. `git init` a temp repo; seed commit with `BASE_FILES × LINES_PER_FILE`
   lines of pre-fork content.
2. Create a `feature` branch with `STACK_COMMITS` commits, each preceded by
   `git-ai checkpoint mock_ai <file>` so the daemon writes real authorship
   notes. Waits until all notes exist.
3. Advance `main` by `TRUNK_COMMITS` commits; the first one rewrites **every
   line** of the pre-fork files (the trunk delta), the rest are cheap. Attach
   an authorship note to **every** trunk commit (reusing a real note blob) —
   modeling the org-wide notes fleet, where virtually every commit has one.
4. `git rebase main` on the feature branch (traced → daemon) — the *cheap*
   direction; waits for note migration to finish.
5. **The trigger:** `git reset --keep <orig-tip>` (traced → daemon), i.e. the
   restack undo. Samples daemon RSS (and child git processes) every 200 ms.
6. Waits for the batched notes write that ends the shift, then prints peak
   RSS, the mapping count straight from the daemon's debug log
   (`shift_authorship_notes: N mappings`), the unmatched-commit count from the
   same range-diff the daemon ran, and one pair's `+`-line/byte counts as
   ground truth.

### Knobs

| Env var | Meaning |
|---|---|
| `STACK_COMMITS` | feature-branch commits with real AI notes (default 4) |
| `TRUNK_COMMITS` | trunk commits after the fork; each gets a note and becomes one bogus mapping = one full-root-tree diff pair |
| `BASE_FILES` | pre-fork files the first trunk commit rewrites |
| `LINES_PER_FILE` | lines per pre-fork file; per-pair `+` lines = `BASE_FILES × LINES_PER_FILE` |
| `PROCESS_TIMEOUT_SECS` | max wait for daemon processing (default 1800) |
| `KEEP=1` | keep the temp workdir (repo, daemon stderr log, raw RSS samples) |
| `GIT_AI_BIN` | git-ai binary to use (default `target/debug/git-ai`) |

Expected: mappings ≈ `TRUNK_COMMITS`; parsed-structure memory ≈
`TRUNK_COMMITS × BASE_FILES × LINES_PER_FILE × ~12 B`; bytes streamed through
the parser ≈ `TRUNK_COMMITS ×` (one pair's raw diff bytes).

## Measured results

Measured on an M-series MacBook Pro (48 GB), macOS, debug build of git-ai
(post-streaming-fix, branch `andrew/best-effort-source-note-fetch`). "Peak" is
daemon RSS sampled at 200 ms during rewrite processing; baseline is daemon RSS
immediately before the reset. Mapping counts are read from the daemon's own
debug log (`shift_authorship_notes: N mappings`).

| | `SCALE=small` | `SCALE=default` |
|---|---|---|
| trunk commits since fork | 150 | 600 |
| trunk delta (`+` lines per pair) | 10,160 | 80,160 |
| **mappings derived by the daemon** | **154** | **604** |
| raw diff streamed through parser | 263 MB | 8,385 MB |
| daemon RSS baseline | 26 MB | 28 MB |
| daemon RSS peak | 36 MB | 234 MB |
| daemon RSS delta | **+9 MB** | **+206 MB** |
| rewrite processing wall time | 7 s | 33 s |
| RSS delta per `+` line per pair | ~6 B | ~4.3 B |

Two things worth noting:

- The stack is 4 commits in both runs. The 150/600 extra mappings are pure
  fabrication by `parse_range_diff_output` — the daemon literally logs
  `shift_authorship_notes: 604 mappings` for a 4-commit branch move.
- The RSS delta tracks `mappings × per-pair '+' lines × ~4–6 B` (the
  `Vec<u32>` in `added_lines_by_file`, plus map/allocator overhead), while the
  *streamed* raw text (8.4 GB at default scale) no longer shows up in RSS —
  i.e. the streaming fix works, and the residual growth is exactly the parsed
  accumulation.

Extrapolation to the production incident (v1.6.15, rh monorepo): a stack
forked weeks earlier easily faces ~3,000 trunk commits × ~2 M lines modified
on trunk; at ~4–6 B per line per pair that is **24–36 GB of daemon RSS** —
matching the observed ~30 GB — with the `-U0 -M` diff generation over
thousands of full-tree pairs supplying the multi-minute-to-hours runtime and
the machine-wide memory pressure that makes ordinary git commands take 30+
seconds.

## Fix directions

The two factors need independent bounds:

- **Clamp mapping derivation**: unmatched `<` commits mapped to
  `previous_new_sha` should be bounded (or dropped entirely when the
  unmatched count dwarfs the new range — a restack undo is not a squash of
  3000 trunk commits into a 4-commit stack).
- **Bound the per-batch parsed accumulation**: process diff pairs in bounded
  chunks and drop each `DiffTreeResult` after its shift is applied, instead
  of materializing all pairs before applying any.


Repro script:

```sh
#!/usr/bin/env bash
#
# Reproduces the git-ai daemon memory blowup on a "restack undo" — moving a
# branch ref from a rebased tip back to its pre-rebase tip via
# `git reset --keep <old-tip>` (exactly what Graphite runs when undoing /
# aborting a restack). NOTE: `reset --hard` does NOT reproduce this — the
# daemon's ResetKind::Hard arm only deletes the working log; the non-fast-
# forward rewrite path fires for the non-hard reset kinds (daemon.rs Reset
# handling).
#
# This fires DESPITE the streaming diff-tree fix ("Fix high memory usage on
# large rebases"): the raw patch text is no longer buffered, but the daemon
# still materializes one parsed DiffTreeResult per mapping, and the mapping
# count is unbounded (see README.md in this directory):
#
#   parse_range_diff_output (src/authorship/rewrite.rs) maps EVERY unmatched
#   `<` commit in the range-diff to a commit of the new range. For a restack
#   undo, the old range (merge-base..rebased-tip) contains every trunk commit
#   since the branch forked — thousands on a busy monorepo — and on a fleet
#   where every commit has an authorship note, each one becomes a
#   (trunk_commit, stack_commit) full-root-tree diff pair. Each pair's diff
#   REVERSES the whole trunk delta, so its '+' lines are the pre-fork content
#   of every line the trunk modified, and the parsed per-pair structures
#   (added_lines_by_file: one u32 per '+' line) accumulate:
#
#     daemon RSS  ~=  (trunk commits since fork) x (lines modified on trunk) x ~12B
#
# This script builds a fully synthetic repo, drives a real rebase + reset
# through an ISOLATED per-run daemon (same wiring as the integration-test
# harness; nothing installed system-wide), samples daemon RSS during rewrite
# processing, and prints the peak alongside ground-truth mapping count and
# per-pair diff size.
#
# Usage:
#   ./repro.sh                 # default scale (several-hundred-MB peak, a few minutes)
#   SCALE=small ./repro.sh     # quick sanity run (~2 min)
#   SCALE=large ./repro.sh     # multi-GB peak (long runtime)
#   TRUNK_COMMITS=600 BASE_FILES=80 LINES_PER_FILE=1000 ./repro.sh   # custom
#
# Knobs (env vars):
#   STACK_COMMITS    feature-branch commits with real AI authorship notes
#   TRUNK_COMMITS    commits on main after the fork; EVERY one gets an
#                    authorship note (models an org-wide notes fleet) and each
#                    becomes one bogus mapping = one full-root-tree diff pair
#   BASE_FILES       pre-fork files that the first trunk commit rewrites
#   LINES_PER_FILE   lines per pre-fork file; every line is modified on trunk,
#                    so per-pair '+' lines = BASE_FILES * LINES_PER_FILE
#   PROCESS_TIMEOUT_SECS  how long to wait for the daemon to finish (default 1800)
#   KEEP=1           keep the temp workdir + daemon logs
#   GIT_AI_BIN       path to a git-ai binary (default: <repo>/target/debug/git-ai)
#
# Expected mappings            ~= TRUNK_COMMITS (+ STACK_COMMITS real ones)
# Expected per-pair '+' lines  ~= BASE_FILES * LINES_PER_FILE
# Expected daemon RSS delta    ~= mappings * plus_lines * ~12B
set -euo pipefail

# ---------------------------------------------------------------------------
# Knobs
# ---------------------------------------------------------------------------
SCALE="${SCALE:-default}"
case "$SCALE" in
  small)
    STACK_COMMITS="${STACK_COMMITS:-4}"
    TRUNK_COMMITS="${TRUNK_COMMITS:-150}"
    BASE_FILES="${BASE_FILES:-25}"
    LINES_PER_FILE="${LINES_PER_FILE:-400}"
    ;;
  default)
    STACK_COMMITS="${STACK_COMMITS:-4}"
    TRUNK_COMMITS="${TRUNK_COMMITS:-600}"
    BASE_FILES="${BASE_FILES:-80}"
    LINES_PER_FILE="${LINES_PER_FILE:-1000}"
    ;;
  large)
    STACK_COMMITS="${STACK_COMMITS:-4}"
    TRUNK_COMMITS="${TRUNK_COMMITS:-1200}"
    BASE_FILES="${BASE_FILES:-100}"
    LINES_PER_FILE="${LINES_PER_FILE:-1500}"
    ;;
  *) echo "Unknown SCALE=$SCALE (small|default|large)"; exit 1 ;;
esac
PROCESS_TIMEOUT_SECS="${PROCESS_TIMEOUT_SECS:-1800}"
KEEP="${KEEP:-0}"

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
GIT_AI_BIN="${GIT_AI_BIN:-$REPO_ROOT/target/debug/git-ai}"

if [[ ! -x "$GIT_AI_BIN" ]]; then
  echo "error: git-ai binary not found at $GIT_AI_BIN — run 'task build' first (or set GIT_AI_BIN)" >&2
  exit 1
fi

# ---------------------------------------------------------------------------
# Sanitize PATH: drop any dir whose `git` is actually a git-ai wrapper, so the
# repro never talks to a system-installed git-ai (mirrors the test harness).
# ---------------------------------------------------------------------------
sanitize_path() {
  local out="" dir gitp
  local IFS=':'
  for dir in $PATH; do
    gitp="$dir/git"
    if [[ -f "$gitp" || -L "$gitp" ]]; then
      if [[ -L "$gitp" ]] && readlink "$gitp" | grep -q "git-ai"; then continue; fi
      if grep -q "git-ai" "$gitp" 2>/dev/null; then continue; fi
      local canon
      canon="$(cd "$(dirname "$gitp")" 2>/dev/null && pwd -P)/$(basename "$gitp")" || canon="$gitp"
      if [[ "$canon" == *git-ai* ]]; then continue; fi
    fi
    out="${out:+$out:}$dir"
  done
  printf '%s' "$out"
}
SAFE_PATH="$(sanitize_path)"

# ---------------------------------------------------------------------------
# Isolated workspace: repo + fake HOME + per-run daemon sockets
# ---------------------------------------------------------------------------
WORK="$(mktemp -d "${TMPDIR:-/tmp}/git-ai-bomb.XXXXXX")"
HOME_DIR="$WORK/home"
REPO="$WORK/repo"
SOCK_DIR="$WORK/s"
CONTROL_SOCK="$SOCK_DIR/c.sock"
TRACE_SOCK="$SOCK_DIR/t.sock"
TEST_DB="$WORK/git-ai-test-db"
RSS_LOG="$WORK/rss.log"
DAEMON_LOG="$WORK/daemon.stderr.log"
mkdir -p "$HOME_DIR/.git-ai" "$REPO" "$SOCK_DIR"

if (( ${#TRACE_SOCK} >= 100 )); then
  echo "error: socket path too long for AF_UNIX: $TRACE_SOCK" >&2
  exit 1
fi

cat > "$HOME_DIR/.gitconfig" <<'EOF'
[user]
	name = Repro User
	email = repro@example.com
[init]
	defaultBranch = main
[gc]
	auto = 0
[advice]
	detachedHead = false
EOF
# Keep the isolated git-ai fully offline / defaults (local git_notes backend).
cat > "$HOME_DIR/.git-ai/config.json" <<'EOF'
{
  "telemetry_oss": "off",
  "disable_version_checks": true,
  "disable_auto_updates": true
}
EOF

COMMON_ENV=(
  "PATH=$SAFE_PATH"
  "HOME=$HOME_DIR"
  "GIT_CONFIG_GLOBAL=$HOME_DIR/.gitconfig"
  "GIT_CONFIG_NOSYSTEM=1"
  "XDG_CONFIG_HOME=$HOME_DIR/.config"
)
DAEMON_ENV=(
  "GIT_AI_DAEMON_HOME=$HOME_DIR"
  "GIT_AI_DAEMON_CONTROL_SOCKET=$CONTROL_SOCK"
  "GIT_AI_DAEMON_TRACE_SOCKET=$TRACE_SOCK"
  "GIT_AI_TEST_DB_PATH=$TEST_DB"
  "GITAI_TEST_DB_PATH=$TEST_DB"
)

# Real git wired to the per-run daemon via trace2 (exactly how production learns
# about git commands — git-ai does NOT wrap git).
tgit() {
  env "${COMMON_ENV[@]}" \
    "GIT_TRACE2_EVENT=af_unix:stream:$TRACE_SOCK" \
    "GIT_TRACE2_EVENT_NESTING=10" \
    git -C "$REPO" "$@"
}
# git without trace2 (setup plumbing we don't want the daemon to see/process).
qgit() {
  env "${COMMON_ENV[@]}" git -C "$REPO" "$@"
}
gai() {
  (cd "$REPO" && env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "$GIT_AI_BIN" "$@")
}

DAEMON_PID=""
SAMPLER_PID=""
cleanup() {
  [[ -n "$SAMPLER_PID" ]] && kill "$SAMPLER_PID" 2>/dev/null || true
  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
    kill "$DAEMON_PID" 2>/dev/null || true
    for _ in $(seq 1 20); do kill -0 "$DAEMON_PID" 2>/dev/null || break; sleep 0.1; done
    kill -9 "$DAEMON_PID" 2>/dev/null || true
  fi
  if [[ "$KEEP" == "1" ]]; then
    echo "[repro] KEEP=1 — workdir preserved at: $WORK"
  else
    rm -rf "$WORK"
  fi
}
trap cleanup EXIT

log() { printf '[repro] %s\n' "$*"; }

PLUS_LINES_PER_PAIR=$(( BASE_FILES * LINES_PER_FILE ))
log "workdir: $WORK"
log "scale: SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_COMMITS=$TRUNK_COMMITS BASE_FILES=$BASE_FILES LINES_PER_FILE=$LINES_PER_FILE"
log "expected: ~$TRUNK_COMMITS bogus mappings x ~$PLUS_LINES_PER_PAIR '+' lines/pair -> parsed structures ~$(( TRUNK_COMMITS * PLUS_LINES_PER_PAIR * 12 / 1048576 )) MB"

# ---------------------------------------------------------------------------
# Start the isolated daemon (GIT_AI_DEBUG=1 so the daemon log records
# "shift_authorship_notes: N mappings" — direct proof of the mapping bomb).
# ---------------------------------------------------------------------------
env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "GIT_AI_DEBUG=1" "$GIT_AI_BIN" bg run >/dev/null 2>>"$DAEMON_LOG" &
DAEMON_PID=$!
log "daemon pid: $DAEMON_PID"
for i in $(seq 1 100); do
  [[ -S "$TRACE_SOCK" && -S "$CONTROL_SOCK" ]] && break
  kill -0 "$DAEMON_PID" 2>/dev/null || { echo "daemon died at startup; log tail:"; tail -20 "$DAEMON_LOG"; exit 1; }
  sleep 0.1
done
[[ -S "$TRACE_SOCK" ]] || { echo "daemon sockets never appeared"; exit 1; }
log "daemon sockets ready"

# ---------------------------------------------------------------------------
# Build the synthetic repo
# ---------------------------------------------------------------------------
gen_file() { # path lines salt
  awk -v n="$2" -v salt="$3" 'BEGIN {
    for (i = 1; i <= n; i++)
      printf "line %06d of %s :: 0123456789abcdefghijklmnopqrstuvwxyz-payload-%06d\n", i, salt, i * 7
  }' > "$1"
}

qgit init -q -b main .

# Seed commit: the pre-fork content the trunk will later rewrite. The restack
# undo diffs (trunk commit -> original stack commit), which RESTORES this
# content — that reversal is the '+' payload parsed into memory per pair.
mkdir -p "$REPO/src"
for i in $(seq 1 "$BASE_FILES"); do
  gen_file "$REPO/src/module_$(printf '%03d' "$i").txt" "$LINES_PER_FILE" "module_$i"
done
echo "seed" > "$REPO/README.md"
qgit add -A
qgit commit -qm "seed"
FORK_POINT="$(qgit rev-parse HEAD)"
log "seed commit done ($BASE_FILES files x $LINES_PER_FILE lines)"

# Feature branch: STACK_COMMITS commits with real AI authorship notes
# (mock_ai checkpoint before commit => daemon writes an authorship note).
qgit checkout -qb feature
for i in $(seq 1 "$STACK_COMMITS"); do
  f="feature_$(printf '%03d' "$i").txt"
  gen_file "$REPO/$f" 40 "feature_$i"
  gai checkpoint mock_ai "$f" >/dev/null
  tgit add "$f"
  tgit commit -qm "AI feature $i"
done
ORIG_TIP="$(qgit rev-parse feature)"
log "created $STACK_COMMITS feature commits (waiting for authorship notes...)"

ORIG_COMMITS_FILE="$WORK/orig_commits.txt"
qgit rev-list --reverse "$FORK_POINT..feature" > "$ORIG_COMMITS_FILE"

notes_hit_count() { # file-with-shas
  local list
  list="$(qgit notes --ref=ai list 2>/dev/null | awk '{print $2}')" || true
  [[ -z "$list" ]] && { echo 0; return; }
  grep -cFf <(printf '%s\n' "$list") "$1" || true
}

deadline=$(( $(date +%s) + 300 ))
while :; do
  n="$(notes_hit_count "$ORIG_COMMITS_FILE")"
  (( n >= STACK_COMMITS )) && break
  if (( $(date +%s) > deadline )); then
    echo "error: only $n/$STACK_COMMITS feature commits got authorship notes in 300s" >&2
    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
    exit 1
  fi
  sleep 1
done
log "all $STACK_COMMITS feature commits have authorship notes (refs/notes/ai)"

# Trunk advance: first commit rewrites EVERY line of every pre-fork file (the
# large delta), then TRUNK_COMMITS-1 cheap commits. Untraced — pure setup.
qgit checkout -q main
for i in $(seq 1 "$BASE_FILES"); do
  f="$REPO/src/module_$(printf '%03d' "$i").txt"
  awk '{ print $0 " [rewritten-on-trunk]" }' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
done
qgit add -A
qgit commit -qm "trunk 1: rewrite all base files"
for i in $(seq 2 "$TRUNK_COMMITS"); do
  echo "tick $i" >> "$REPO/counter.txt"
  qgit add counter.txt
  qgit commit -qm "trunk $i"
done
log "trunk advanced by $TRUNK_COMMITS commits (delta: every line of $BASE_FILES x $LINES_PER_FILE rewritten)"

# Give every trunk commit an authorship note (org-wide notes fleet: on the
# real deployment virtually every trunk commit has one). Reuse the blob of a
# real note — content just has to be a parseable AuthorshipLog for the mapping
# to be queued as a diff pair (rewrite.rs pair queuing). Use stack commit #2's
# note: the bogus trunk mappings all target stack commit #1 (pending_dropped ->
# first matched pair), and merging a feature_002 attestation into commit #1's
# note guarantees its content changes — which is our completion signal.
NOTE_DONOR="$(sed -n 2p "$ORIG_COMMITS_FILE")"
NOTE_BLOB="$(qgit notes --ref=ai list "$NOTE_DONOR" 2>/dev/null || qgit notes --ref=ai list | head -1 | awk '{print $1}')"
[[ -n "$NOTE_BLOB" ]] || { echo "error: no authorship note blob found to reuse" >&2; exit 1; }
TRUNK_COMMITS_FILE="$WORK/trunk_commits.txt"
qgit rev-list "$FORK_POINT..main" > "$TRUNK_COMMITS_FILE"
while read -r sha; do
  qgit notes --ref=ai add -f -C "$NOTE_BLOB" "$sha" 2>/dev/null
done < "$TRUNK_COMMITS_FILE"
log "attached authorship notes to all $TRUNK_COMMITS trunk commits"

# The setup restack: rebase feature onto the advanced trunk (traced). This is
# the CHEAP direction — the range-diff old range is just the stack.
qgit checkout -q feature
log "running: git rebase main (traced -> daemon)"
tgit rebase main >/dev/null
REBASED_TIP="$(qgit rev-parse feature)"

REBASED_COMMITS_FILE="$WORK/rebased_commits.txt"
qgit rev-list --reverse "main..feature" > "$REBASED_COMMITS_FILE"

deadline=$(( $(date +%s) + 300 ))
while :; do
  n="$(notes_hit_count "$REBASED_COMMITS_FILE")"
  (( n >= STACK_COMMITS )) && break
  if (( $(date +%s) > deadline )); then
    echo "error: only $n/$STACK_COMMITS rebased commits got migrated notes in 300s" >&2
    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
    exit 1
  fi
  sleep 1
done
log "rebase note migration complete (notes on all $STACK_COMMITS rebased commits)"
sleep 2  # let the daemon fully quiesce before baselining

NOTES_REF_BEFORE="$(qgit rev-parse refs/notes/ai)"
DAEMON_LOG_LINES_BEFORE="$(wc -l < "$DAEMON_LOG" | tr -d ' ')"

# ---------------------------------------------------------------------------
# RSS sampler for the daemon (+ its direct children, i.e. the spawned
# `git diff-tree` / `git range-diff`). Columns: epoch daemon_rss_kb children_rss_kb
# ---------------------------------------------------------------------------
(
  while kill -0 "$DAEMON_PID" 2>/dev/null; do
    ps -axo pid=,ppid=,rss= | awk -v d="$DAEMON_PID" -v t="$(date +%s)" '
      $1 == d { drss = $3 } $2 == d { crss += $3 }
      END { printf "%s %d %d\n", t, drss, crss }' >> "$RSS_LOG"
    sleep 0.2
  done
) &
SAMPLER_PID=$!

BASELINE_KB="$(ps -o rss= -p "$DAEMON_PID" | tr -d ' ')"
log "daemon baseline RSS: $(( BASELINE_KB / 1024 )) MB"

# ---------------------------------------------------------------------------
# THE TRIGGER: undo the restack — move the branch from the rebased tip back
# to the original tip with `reset --keep`, exactly like gt's restack undo.
# (`reset --hard` would NOT fire the rewrite path — see header comment.)
# ---------------------------------------------------------------------------
log "running: git reset --keep $ORIG_TIP (traced -> daemon)"
RESET_START=$(date +%s)
tgit reset --keep "$ORIG_TIP" >/dev/null
RESET_END=$(date +%s)
log "git reset finished in $(( RESET_END - RESET_START ))s; daemon now processes the rewrite asynchronously"

# Completion: the shift ends with ONE batched notes write, so refs/notes/ai
# moving is the "done" signal.
deadline=$(( $(date +%s) + PROCESS_TIMEOUT_SECS ))
while :; do
  now="$(qgit rev-parse refs/notes/ai)"
  if [[ "$now" != "$NOTES_REF_BEFORE" ]]; then
    DONE_TS=$(date +%s)
    break
  fi
  if (( $(date +%s) > deadline )); then
    echo "error: rewrite processing incomplete after ${PROCESS_TIMEOUT_SECS}s (refs/notes/ai unchanged)" >&2
    echo "daemon log tail:"; tail -40 "$DAEMON_LOG"
    exit 1
  fi
  sleep 0.5
done
PROCESS_SECS=$(( DONE_TS - RESET_END ))
log "rewrite processing complete: refs/notes/ai rewritten ($PROCESS_SECS s after reset exit)"

# Let RSS settle a moment, then stop sampling.
sleep 2
kill "$SAMPLER_PID" 2>/dev/null || true
wait "$SAMPLER_PID" 2>/dev/null || true
SAMPLER_PID=""

# ---------------------------------------------------------------------------
# Ground truth
# ---------------------------------------------------------------------------
# Mapping count as the daemon derived it (debug log), if present.
MAPPINGS_LOGGED="$(tail -n "+$(( DAEMON_LOG_LINES_BEFORE + 1 ))" "$DAEMON_LOG" \
  | grep -o 'shift_authorship_notes: [0-9]* mappings' | grep -o '[0-9]*' | sort -n | tail -1 || true)"
# Unmatched `<` commits in the same range-diff the daemon ran.
RANGE_DIFF_DROPPED="$(qgit range-diff --no-color --no-abbrev -s --creation-factor=100 \
  "$FORK_POINT..$REBASED_TIP" "$FORK_POINT..$ORIG_TIP" | grep -c '<' || true)"
# One pair's diff, same flags as compute_diff_tree_stdin: '+' lines are what
# the parser keeps (one u32 per line), bytes are what gets streamed per pair.
PAIR_STATS="$(qgit diff-tree -p -U0 -M --no-color -r "$(head -1 "$TRUNK_COMMITS_FILE")" "$ORIG_TIP" \
  | awk '/^\+/ && !/^\+\+\+/ { plus++ } { bytes += length($0) + 1 } END { printf "%d %d", plus, bytes }')"
PAIR_PLUS_LINES="$(cut -d' ' -f1 <<<"$PAIR_STATS")"
PAIR_BYTES="$(cut -d' ' -f2 <<<"$PAIR_STATS")"

PEAK_KB="$(awk 'BEGIN{m=0} {if ($2>m) m=$2} END{print m}' "$RSS_LOG")"
PEAK_CHILD_KB="$(awk 'BEGIN{m=0} {if ($3>m) m=$3} END{print m}' "$RSS_LOG")"

echo
echo "================================ RESULTS ================================"
echo "knobs:                  SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_COMMITS=$TRUNK_COMMITS BASE_FILES=$BASE_FILES LINES_PER_FILE=$LINES_PER_FILE"
echo "mappings (daemon log):  ${MAPPINGS_LOGGED:-n/a} (range-diff '<' commits: $RANGE_DIFF_DROPPED)"
echo "per-pair diff:          $PAIR_PLUS_LINES '+' lines, $(( PAIR_BYTES / 1048576 )) MB raw"
echo "streamed total:         ~$(( PAIR_BYTES * TRUNK_COMMITS / 1048576 )) MB through the parser (not buffered)"
echo "daemon RSS baseline:    $(( BASELINE_KB / 1024 )) MB"
echo "daemon RSS peak:        $(( PEAK_KB / 1024 )) MB  (delta +$(( (PEAK_KB - BASELINE_KB) / 1024 )) MB)"
echo "peak child git RSS:     $(( PEAK_CHILD_KB / 1024 )) MB  (git diff-tree/range-diff spawned by daemon)"
echo "rewrite processing:     ${PROCESS_SECS}s (reset exit -> batched notes write)"
echo "========================================================================="

```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->