### PR TITLE
Preserve large squash authorship mappings

### DIFF
--- a/repro_1985.sh
+++ b/repro_1985.sh
@@ -1,0 +1,508 @@
+#!/usr/bin/env bash
+#
+# Regression-checks the git-ai daemon behavior on a "restack undo" — moving a
+# branch ref from a rebased tip back to its pre-rebase tip via
+# `git reset --keep <old-tip>` (exactly what Graphite runs when undoing /
+# aborting a restack). NOTE: `reset --hard` does NOT reproduce this — the
+# daemon's ResetKind::Hard arm only deletes the working log; the non-fast-
+# forward rewrite path fires for the non-hard reset kinds (daemon.rs Reset
+# handling).
+#
+# Older builds created one mapping for every unmatched trunk commit. Current
+# builds must bound and discard that divergent group before note reads or
+# diff-tree work:
+#
+#   For a restack undo, the old range (merge-base..rebased-tip) contains every
+#   trunk commit since the branch forked — thousands on a busy monorepo. If
+#   those leading `<` entries are mapped, each noted trunk commit becomes a
+#   (trunk_commit, stack_commit) full-root-tree diff pair. Each pair reverses
+#   the whole trunk delta:
+#
+#     daemon RSS  ~=  (trunk commits since fork) x (lines modified on trunk) x ~12B
+#
+# This script builds a fully synthetic repo, drives a real rebase + reset
+# through an ISOLATED per-run daemon (same wiring as the integration-test
+# harness; nothing installed system-wide), samples daemon RSS during rewrite
+# processing, and verifies the mapping count stays close to STACK_COMMITS
+# rather than TRUNK_COMMITS.
+#
+# Usage:
+#   ./repro_1985.sh                 # default regression scale (a few minutes)
+#   SCALE=small ./repro_1985.sh     # quick sanity run
+#   SCALE=large ./repro_1985.sh     # high-load regression run
+#   TRUNK_COMMITS=600 BASE_FILES=80 LINES_PER_FILE=1000 ./repro_1985.sh   # custom
+#
+# Knobs (env vars):
+#   STACK_COMMITS    feature-branch commits with parseable AI authorship notes
+#   TRUNK_COMMITS    commits on main after the fork; EVERY one gets an
+#                    authorship note (models an org-wide notes fleet) and each
+#                    would become one bogus full-root-tree mapping without the
+#                    leading-prefix guard
+#   BASE_FILES       pre-fork files that the first trunk commit rewrites
+#   LINES_PER_FILE   lines per pre-fork file; every line is modified on trunk,
+#                    so per-pair '+' lines = BASE_FILES * LINES_PER_FILE
+#   PROCESS_TIMEOUT_SECS  how long to wait for the daemon to finish (default 1800)
+#   KEEP=1           keep the temp workdir + daemon logs
+#   GIT_AI_BIN       path to a git-ai binary (default: <repo>/target/debug/git-ai)
+#
+# Expected mappings            ~= STACK_COMMITS (trunk prefix discarded)
+# Expected per-pair '+' lines  ~= BASE_FILES * LINES_PER_FILE
+# Expected daemon RSS delta    ~= mappings * plus_lines * ~12B
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Knobs
+# ---------------------------------------------------------------------------
+SCALE="${SCALE:-default}"
+case "$SCALE" in
+  small)
+    STACK_COMMITS="${STACK_COMMITS:-4}"
+    TRUNK_COMMITS="${TRUNK_COMMITS:-150}"
+    BASE_FILES="${BASE_FILES:-25}"
+    LINES_PER_FILE="${LINES_PER_FILE:-400}"
+    ;;
+  default)
+    STACK_COMMITS="${STACK_COMMITS:-4}"
+    TRUNK_COMMITS="${TRUNK_COMMITS:-600}"
+    BASE_FILES="${BASE_FILES:-80}"
+    LINES_PER_FILE="${LINES_PER_FILE:-1000}"
+    ;;
+  large)
+    STACK_COMMITS="${STACK_COMMITS:-4}"
+    TRUNK_COMMITS="${TRUNK_COMMITS:-1200}"
+    BASE_FILES="${BASE_FILES:-100}"
+    LINES_PER_FILE="${LINES_PER_FILE:-1500}"
+    ;;
+  *) echo "Unknown SCALE=$SCALE (small|default|large)"; exit 1 ;;
+esac
+PROCESS_TIMEOUT_SECS="${PROCESS_TIMEOUT_SECS:-1800}"
+KEEP="${KEEP:-0}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_AI_BIN="${GIT_AI_BIN:-$SCRIPT_DIR/target/debug/git-ai}"
+
+if [[ ! -x "$GIT_AI_BIN" ]]; then
+  echo "error: git-ai binary not found at $GIT_AI_BIN — run 'task build' first (or set GIT_AI_BIN)" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Sanitize PATH: drop any dir whose `git` is actually a git-ai wrapper, so the
+# repro never talks to a system-installed git-ai (mirrors the test harness).
+# ---------------------------------------------------------------------------
+sanitize_path() {
+  local out="" dir gitp
+  local IFS=':'
+  for dir in $PATH; do
+    gitp="$dir/git"
+    if [[ -f "$gitp" || -L "$gitp" ]]; then
+      if [[ -L "$gitp" ]] && readlink "$gitp" | grep -q "git-ai"; then continue; fi
+      if grep -q "git-ai" "$gitp" 2>/dev/null; then continue; fi
+      local canon
+      canon="$(cd "$(dirname "$gitp")" 2>/dev/null && pwd -P)/$(basename "$gitp")" || canon="$gitp"
+      if [[ "$canon" == *git-ai* ]]; then continue; fi
+    fi
+    out="${out:+$out:}$dir"
+  done
+  printf '%s' "$out"
+}
+SAFE_PATH="$(sanitize_path)"
+
+# ---------------------------------------------------------------------------
+# Isolated workspace: repo + fake HOME + per-run daemon sockets
+# ---------------------------------------------------------------------------
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/git-ai-bomb.XXXXXX")"
+HOME_DIR="$WORK/home"
+REPO="$WORK/repo"
+SOCK_DIR="$WORK/s"
+CONTROL_SOCK="$SOCK_DIR/c.sock"
+TRACE_SOCK="$SOCK_DIR/t.sock"
+TEST_DB="$WORK/git-ai-test-db"
+RSS_LOG="$WORK/rss.log"
+DAEMON_LOG="$WORK/daemon.stderr.log"
+mkdir -p "$HOME_DIR/.git-ai" "$REPO" "$SOCK_DIR"
+
+if (( ${#TRACE_SOCK} >= 100 )); then
+  echo "error: socket path too long for AF_UNIX: $TRACE_SOCK" >&2
+  exit 1
+fi
+
+cat > "$HOME_DIR/.gitconfig" <<'EOF'
+[user]
+	name = Repro User
+	email = repro@example.com
+[init]
+	defaultBranch = main
+[gc]
+	auto = 0
+[advice]
+	detachedHead = false
+EOF
+# Keep the isolated git-ai fully offline / defaults (local git_notes backend).
+cat > "$HOME_DIR/.git-ai/config.json" <<'EOF'
+{
+  "telemetry_oss": "off",
+  "disable_version_checks": true,
+  "disable_auto_updates": true
+}
+EOF
+
+COMMON_ENV=(
+  "PATH=$SAFE_PATH"
+  "HOME=$HOME_DIR"
+  "GIT_CONFIG_GLOBAL=$HOME_DIR/.gitconfig"
+  "GIT_CONFIG_NOSYSTEM=1"
+  "XDG_CONFIG_HOME=$HOME_DIR/.config"
+)
+DAEMON_ENV=(
+  "GIT_AI_DAEMON_HOME=$HOME_DIR"
+  "GIT_AI_DAEMON_CONTROL_SOCKET=$CONTROL_SOCK"
+  "GIT_AI_DAEMON_TRACE_SOCKET=$TRACE_SOCK"
+  "GIT_AI_TEST_DB_PATH=$TEST_DB"
+  "GITAI_TEST_DB_PATH=$TEST_DB"
+)
+
+# Real git wired to the per-run daemon via trace2 (exactly how production learns
+# about git commands — git-ai does NOT wrap git).
+tgit() {
+  env "${COMMON_ENV[@]}" \
+    "GIT_TRACE2_EVENT=af_unix:stream:$TRACE_SOCK" \
+    "GIT_TRACE2_EVENT_NESTING=10" \
+    git -C "$REPO" "$@"
+}
+# git without trace2 (setup plumbing we don't want the daemon to see/process).
+qgit() {
+  env "${COMMON_ENV[@]}" git -C "$REPO" "$@"
+}
+gai() {
+  (cd "$REPO" && env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "$GIT_AI_BIN" "$@")
+}
+
+DAEMON_PID=""
+SAMPLER_PID=""
+cleanup() {
+  [[ -n "$SAMPLER_PID" ]] && kill "$SAMPLER_PID" 2>/dev/null || true
+  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    for _ in $(seq 1 20); do kill -0 "$DAEMON_PID" 2>/dev/null || break; sleep 0.1; done
+    kill -9 "$DAEMON_PID" 2>/dev/null || true
+  fi
+  if [[ "$KEEP" == "1" ]]; then
+    echo "[repro] KEEP=1 — workdir preserved at: $WORK"
+  else
+    rm -rf "$WORK"
+  fi
+}
+trap cleanup EXIT
+
+log() { printf '[repro] %s\n' "$*"; }
+
+PLUS_LINES_PER_PAIR=$(( BASE_FILES * LINES_PER_FILE ))
+log "workdir: $WORK"
+log "scale: SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_COMMITS=$TRUNK_COMMITS BASE_FILES=$BASE_FILES LINES_PER_FILE=$LINES_PER_FILE"
+log "guardrail: discard ~$TRUNK_COMMITS leading commits, avoiding ~$(( TRUNK_COMMITS * PLUS_LINES_PER_PAIR * 12 / 1048576 )) MB of parsed '+'-line structures"
+
+# ---------------------------------------------------------------------------
+# Start the isolated daemon (GIT_AI_DEBUG=1 so the daemon log records
+# "shift_authorship_notes: N mappings" — direct proof of the mapping bomb).
+# ---------------------------------------------------------------------------
+env "${COMMON_ENV[@]}" "${DAEMON_ENV[@]}" "GIT_AI_DEBUG=1" "$GIT_AI_BIN" bg run >/dev/null 2>>"$DAEMON_LOG" &
+DAEMON_PID=$!
+log "daemon pid: $DAEMON_PID"
+for i in $(seq 1 100); do
+  [[ -S "$TRACE_SOCK" && -S "$CONTROL_SOCK" ]] && break
+  kill -0 "$DAEMON_PID" 2>/dev/null || { echo "daemon died at startup; log tail:"; tail -20 "$DAEMON_LOG"; exit 1; }
+  sleep 0.1
+done
+[[ -S "$TRACE_SOCK" ]] || { echo "daemon sockets never appeared"; exit 1; }
+log "daemon sockets ready"
+
+# ---------------------------------------------------------------------------
+# Build the synthetic repo
+# ---------------------------------------------------------------------------
+gen_file() { # path lines salt
+  awk -v n="$2" -v salt="$3" 'BEGIN {
+    for (i = 1; i <= n; i++)
+      printf "line %06d of %s :: 0123456789abcdefghijklmnopqrstuvwxyz-payload-%06d\n", i, salt, i * 7
+  }' > "$1"
+}
+
+qgit init -q -b main .
+
+# Seed commit: the pre-fork content the trunk will later rewrite. The restack
+# undo diffs (trunk commit -> original stack commit), which RESTORES this
+# content — that reversal is the '+' payload parsed into memory per pair.
+mkdir -p "$REPO/src"
+for i in $(seq 1 "$BASE_FILES"); do
+  gen_file "$REPO/src/module_$(printf '%03d' "$i").txt" "$LINES_PER_FILE" "module_$i"
+done
+echo "seed" > "$REPO/README.md"
+qgit add -A
+qgit commit -qm "seed"
+FORK_POINT="$(qgit rev-parse HEAD)"
+log "seed commit done ($BASE_FILES files x $LINES_PER_FILE lines)"
+
+notes_hit_count() { # file-with-shas
+  local list
+  list="$(qgit notes --ref=ai list 2>/dev/null | awk '{print $2}')" || true
+  [[ -z "$list" ]] && { echo 0; return; }
+  grep -cFf <(printf '%s\n' "$list") "$1" || true
+}
+
+# Manufacture one real AI authorship note through the daemon. The synthetic
+# feature and trunk commits below reuse its blob; their construction is pure
+# setup and must stay constant-spawn even when the scale knobs increase.
+FEATURE_FILES_DIR="$WORK/feature-files"
+TRUNK_FILES_DIR="$WORK/trunk-files"
+mkdir -p "$FEATURE_FILES_DIR" "$TRUNK_FILES_DIR"
+for i in $(seq 1 "$STACK_COMMITS"); do
+  f="feature_$(printf '%03d' "$i").txt"
+  gen_file "$FEATURE_FILES_DIR/$f" 40 "feature_$i"
+done
+
+qgit checkout -qb note-donor
+cp "$FEATURE_FILES_DIR/feature_001.txt" "$REPO/feature_001.txt"
+gai checkpoint mock_ai feature_001.txt >/dev/null
+tgit add feature_001.txt
+tgit commit -qm "AI note donor"
+NOTE_DONOR_COMMIT="$(qgit rev-parse HEAD)"
+NOTE_DONOR_FILE="$WORK/note_donor.txt"
+printf '%s\n' "$NOTE_DONOR_COMMIT" > "$NOTE_DONOR_FILE"
+
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  n="$(notes_hit_count "$NOTE_DONOR_FILE")"
+  (( n >= 1 )) && break
+  if (( $(date +%s) > deadline )); then
+    echo "error: note donor did not get an authorship note in 300s" >&2
+    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+# Prepare the first trunk commit's large tree delta outside the repository.
+for i in $(seq 1 "$BASE_FILES"); do
+  f="module_$(printf '%03d' "$i").txt"
+  awk '{ print $0 " [rewritten-on-trunk]" }' \
+    "$REPO/src/$f" > "$TRUNK_FILES_DIR/$f"
+done
+
+emit_fast_import_data() {
+  local value="$1"
+  printf 'data %d\n%s\n' "${#value}" "$value"
+}
+
+emit_fast_import_file() {
+  local repo_path="$1" source_path="$2" content
+  # Command substitution removes the file's one trailing newline; restore it
+  # so the inline blob is byte-identical to the generated source file.
+  content="$(<"$source_path")"
+  content+=$'\n'
+  printf 'M 100644 inline %s\n' "$repo_path"
+  printf 'data %d\n' "${#content}"
+  printf '%s\n' "$content"
+}
+
+# Build both user-scaled histories with one Git process. Each feature commit
+# adds one file; only the first trunk commit changes the tree, while the
+# remaining commits are deliberately empty and differ by message.
+IMPORT_TIME="$(date +%s)"
+{
+  for i in $(seq 1 "$STACK_COMMITS"); do
+    mark="$i"
+    message="AI feature $i"
+    f="feature_$(printf '%03d' "$i").txt"
+    printf 'commit refs/heads/feature\n'
+    printf 'mark :%d\n' "$mark"
+    printf 'committer Repro User <repro@example.com> %d +0000\n' "$(( IMPORT_TIME + i ))"
+    emit_fast_import_data "$message"
+    if (( i == 1 )); then
+      printf 'from %s\n' "$FORK_POINT"
+    else
+      printf 'from :%d\n' "$(( mark - 1 ))"
+    fi
+    emit_fast_import_file "$f" "$FEATURE_FILES_DIR/$f"
+    printf '\n'
+  done
+
+  trunk_mark=$(( STACK_COMMITS + 1 ))
+  message="trunk 1: rewrite all base files"
+  printf 'commit refs/heads/main\n'
+  printf 'mark :%d\n' "$trunk_mark"
+  printf 'committer Repro User <repro@example.com> %d +0000\n' \
+    "$(( IMPORT_TIME + STACK_COMMITS + 1 ))"
+  emit_fast_import_data "$message"
+  printf 'from %s\n' "$FORK_POINT"
+  for i in $(seq 1 "$BASE_FILES"); do
+    f="module_$(printf '%03d' "$i").txt"
+    emit_fast_import_file "src/$f" "$TRUNK_FILES_DIR/$f"
+  done
+  printf '\n'
+
+  for i in $(seq 2 "$TRUNK_COMMITS"); do
+    mark=$(( STACK_COMMITS + i ))
+    message="trunk $i"
+    printf 'commit refs/heads/main\n'
+    printf 'mark :%d\n' "$mark"
+    printf 'committer Repro User <repro@example.com> %d +0000\n' \
+      "$(( IMPORT_TIME + STACK_COMMITS + i ))"
+    emit_fast_import_data "$message"
+    printf 'from :%d\n\n' "$(( mark - 1 ))"
+  done
+  printf 'done\n'
+} | qgit fast-import --quiet --done
+
+ORIG_TIP="$(qgit rev-parse feature)"
+ORIG_COMMITS_FILE="$WORK/orig_commits.txt"
+qgit rev-list --reverse "$FORK_POINT..feature" > "$ORIG_COMMITS_FILE"
+TRUNK_COMMITS_FILE="$WORK/trunk_commits.txt"
+qgit rev-list "$FORK_POINT..main" > "$TRUNK_COMMITS_FILE"
+log "created $STACK_COMMITS feature and $TRUNK_COMMITS trunk commits with one fast-import process"
+
+# Attach the donor blob to every synthetic commit with one notes commit and
+# one Git process. `N` lets fast-import choose the repository's notes fanout.
+NOTE_BLOB="$(qgit notes --ref=ai list "$NOTE_DONOR_COMMIT" 2>/dev/null)"
+[[ -n "$NOTE_BLOB" ]] || { echo "error: no authorship note blob found to reuse" >&2; exit 1; }
+NOTES_PARENT="$(qgit rev-parse refs/notes/ai)"
+{
+  printf 'commit refs/notes/ai\n'
+  printf 'committer git-ai <git-ai@local> %d +0000\n' \
+    "$(( IMPORT_TIME + STACK_COMMITS + TRUNK_COMMITS + 1 ))"
+  printf 'data 0\n'
+  printf 'from %s\n' "$NOTES_PARENT"
+  while read -r sha; do
+    printf 'N %s %s\n' "$NOTE_BLOB" "$sha"
+  done < "$ORIG_COMMITS_FILE"
+  while read -r sha; do
+    printf 'N %s %s\n' "$NOTE_BLOB" "$sha"
+  done < "$TRUNK_COMMITS_FILE"
+  printf '\ndone\n'
+} | qgit fast-import --quiet --done
+
+log "attached authorship notes to all $STACK_COMMITS feature and $TRUNK_COMMITS trunk commits"
+log "trunk advanced by $TRUNK_COMMITS commits (delta: every line of $BASE_FILES x $LINES_PER_FILE rewritten)"
+
+# The setup restack: rebase feature onto the advanced trunk (traced). This is
+# the CHEAP direction — the range-diff old range is just the stack.
+qgit checkout -q feature
+log "running: git rebase main (traced -> daemon)"
+tgit rebase main >/dev/null
+REBASED_TIP="$(qgit rev-parse feature)"
+
+REBASED_COMMITS_FILE="$WORK/rebased_commits.txt"
+qgit rev-list --reverse "main..feature" > "$REBASED_COMMITS_FILE"
+
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  n="$(notes_hit_count "$REBASED_COMMITS_FILE")"
+  (( n >= STACK_COMMITS )) && break
+  if (( $(date +%s) > deadline )); then
+    echo "error: only $n/$STACK_COMMITS rebased commits got migrated notes in 300s" >&2
+    echo "daemon log tail:"; tail -30 "$DAEMON_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+log "rebase note migration complete (notes on all $STACK_COMMITS rebased commits)"
+sleep 2  # let the daemon fully quiesce before baselining
+
+NOTES_REF_BEFORE="$(qgit rev-parse refs/notes/ai)"
+DAEMON_LOG_LINES_BEFORE="$(wc -l < "$DAEMON_LOG" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+# RSS sampler for the daemon (+ its direct children, i.e. the spawned
+# `git diff-tree` / `git range-diff`). Columns: epoch daemon_rss_kb children_rss_kb
+# ---------------------------------------------------------------------------
+(
+  while kill -0 "$DAEMON_PID" 2>/dev/null; do
+    ps -axo pid=,ppid=,rss= | awk -v d="$DAEMON_PID" -v t="$(date +%s)" '
+      $1 == d { drss = $3 } $2 == d { crss += $3 }
+      END { printf "%s %d %d\n", t, drss, crss }' >> "$RSS_LOG"
+    sleep 0.2
+  done
+) &
+SAMPLER_PID=$!
+
+BASELINE_KB="$(ps -o rss= -p "$DAEMON_PID" | tr -d ' ')"
+log "daemon baseline RSS: $(( BASELINE_KB / 1024 )) MB"
+
+# ---------------------------------------------------------------------------
+# THE TRIGGER: undo the restack — move the branch from the rebased tip back
+# to the original tip with `reset --keep`, exactly like gt's restack undo.
+# (`reset --hard` would NOT fire the rewrite path — see header comment.)
+# ---------------------------------------------------------------------------
+log "running: git reset --keep $ORIG_TIP (traced -> daemon)"
+RESET_START=$(date +%s)
+tgit reset --keep "$ORIG_TIP" >/dev/null
+RESET_END=$(date +%s)
+log "git reset finished in $(( RESET_END - RESET_START ))s; daemon now processes the rewrite asynchronously"
+
+# Completion: the shift ends with ONE batched notes write, so refs/notes/ai
+# moving is the "done" signal.
+deadline=$(( $(date +%s) + PROCESS_TIMEOUT_SECS ))
+while :; do
+  now="$(qgit rev-parse refs/notes/ai)"
+  if [[ "$now" != "$NOTES_REF_BEFORE" ]]; then
+    DONE_TS=$(date +%s)
+    break
+  fi
+  if (( $(date +%s) > deadline )); then
+    echo "error: rewrite processing incomplete after ${PROCESS_TIMEOUT_SECS}s (refs/notes/ai unchanged)" >&2
+    echo "daemon log tail:"; tail -40 "$DAEMON_LOG"
+    exit 1
+  fi
+  sleep 0.5
+done
+PROCESS_SECS=$(( DONE_TS - RESET_END ))
+log "rewrite processing complete: refs/notes/ai rewritten ($PROCESS_SECS s after reset exit)"
+
+# Let RSS settle a moment, then stop sampling.
+sleep 2
+kill "$SAMPLER_PID" 2>/dev/null || true
+wait "$SAMPLER_PID" 2>/dev/null || true
+SAMPLER_PID=""
+
+# ---------------------------------------------------------------------------
+# Ground truth
+# ---------------------------------------------------------------------------
+# Mapping count as the daemon derived it (debug log), if present.
+MAPPINGS_LOGGED="$(tail -n "+$(( DAEMON_LOG_LINES_BEFORE + 1 ))" "$DAEMON_LOG" \
+  | grep -o 'shift_authorship_notes: [0-9]* mappings' | grep -o '[0-9]*' | sort -n | tail -1 || true)"
+# Unmatched `<` commits in the same range-diff the daemon ran.
+RANGE_DIFF_DROPPED="$(qgit range-diff --no-color --no-abbrev -s --creation-factor=100 \
+  "$FORK_POINT..$REBASED_TIP" "$FORK_POINT..$ORIG_TIP" | grep -c '<' || true)"
+# One pair's diff, same flags as compute_diff_tree_stdin: '+' lines are what
+# the parser keeps (one u32 per line), bytes are what gets streamed per pair.
+PAIR_STATS="$(qgit diff-tree -p -U0 -M --no-color -r "$(head -1 "$TRUNK_COMMITS_FILE")" "$ORIG_TIP" \
+  | awk '/^\+/ && !/^\+\+\+/ { plus++ } { bytes += length($0) + 1 } END { printf "%d %d", plus, bytes }')"
+PAIR_PLUS_LINES="$(cut -d' ' -f1 <<<"$PAIR_STATS")"
+PAIR_BYTES="$(cut -d' ' -f2 <<<"$PAIR_STATS")"
+
+PEAK_KB="$(awk 'BEGIN{m=0} {if ($2>m) m=$2} END{print m}' "$RSS_LOG")"
+PEAK_CHILD_KB="$(awk 'BEGIN{m=0} {if ($3>m) m=$3} END{print m}' "$RSS_LOG")"
+
+if [[ -n "$MAPPINGS_LOGGED" ]] && (( MAPPINGS_LOGGED > STACK_COMMITS )); then
+  echo "error: restack undo retained $MAPPINGS_LOGGED mappings; expected at most $STACK_COMMITS stack mappings" >&2
+  exit 1
+fi
+
+echo
+echo "================================ RESULTS ================================"
+echo "knobs:                  SCALE=$SCALE STACK_COMMITS=$STACK_COMMITS TRUNK_COMMITS=$TRUNK_COMMITS BASE_FILES=$BASE_FILES LINES_PER_FILE=$LINES_PER_FILE"
+echo "mappings (daemon log):  ${MAPPINGS_LOGGED:-n/a} (range-diff '<' commits: $RANGE_DIFF_DROPPED)"
+echo "per-pair diff:          $PAIR_PLUS_LINES '+' lines, $(( PAIR_BYTES / 1048576 )) MB raw"
+if [[ -n "$MAPPINGS_LOGGED" ]]; then
+  MAPPED_BYTES_ESTIMATE=$(( PAIR_BYTES * MAPPINGS_LOGGED / 1048576 ))
+  AVOIDED_BYTES_ESTIMATE=$(( PAIR_BYTES * RANGE_DIFF_DROPPED / 1048576 ))
+else
+  MAPPED_BYTES_ESTIMATE=0
+  AVOIDED_BYTES_ESTIMATE=0
+fi
+echo "mapped diff estimate:   ~$MAPPED_BYTES_ESTIMATE MB at the sampled per-pair size"
+echo "avoided bogus estimate: ~$AVOIDED_BYTES_ESTIMATE MB from discarded leading commits"
+echo "daemon RSS baseline:    $(( BASELINE_KB / 1024 )) MB"
+echo "daemon RSS peak:        $(( PEAK_KB / 1024 )) MB  (delta +$(( (PEAK_KB - BASELINE_KB) / 1024 )) MB)"
+echo "peak child git RSS:     $(( PEAK_CHILD_KB / 1024 )) MB  (git diff-tree/range-diff spawned by daemon)"
+echo "rewrite processing:     ${PROCESS_SECS}s (reset exit -> batched notes write)"
+echo "========================================================================="

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::hunk_shift::{DiffHunk, parse_hunk_header};
@@ -7,10 +8,11 @@ use crate::error::GitAiError;
 use crate::git::notes_api;
 use crate::git::repo_state::is_valid_git_oid;
 use crate::git::repository::{
-    Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin_streaming,
+    Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin, exec_git_stdin_streaming,
 };
 
 const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const MAX_UNTRUSTED_UNMATCHED_COMMITS: usize = 64;
 
 #[derive(Debug)]
 pub enum RewriteEvent {
@@ -47,6 +49,20 @@ pub(crate) enum RewriteMetricOperation {
     Revert,
     UpdateRef,
     NonFastForward,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnmatchedCommitPolicy {
+    /// The old range begins at the immutable upstream passed to the rebase, so
+    /// every unmatched group belongs to that rewrite.
+    PreserveAll,
+    /// An untrusted old range can contain either a real small squash or a
+    /// divergent-history prefix. Preserve the leading unmatched run only up
+    /// to the historical safety limit.
+    PreserveLeadingBounded,
+    /// An explicit divergent-base rewrite (for example, `rebase --onto`) can
+    /// expose unrelated old-upstream commits even when the prefix is small.
+    DiscardLeading,
 }
 
 impl RewriteMetricOperation {
@@ -288,26 +304,38 @@ fn resolve_tree_shas(
         return Ok(sha_to_tree);
     }
 
-    let mut rev_parse_args = repo.global_args_for_exec();
-    rev_parse_args.push("rev-parse".to_string());
-    for sha in &shas_to_resolve {
-        if let Some(arg) = tree_revision_arg(sha) {
-            rev_parse_args.push(arg);
-        }
-    }
-    let rev_output = exec_git(&rev_parse_args)?;
-    let rev_stdout = String::from_utf8_lossy(&rev_output.stdout);
-    let tree_shas: Vec<&str> = rev_stdout.lines().collect();
+    let mut cat_file_args = repo.global_args_for_exec();
+    cat_file_args.extend([
+        "cat-file".to_string(),
+        "--batch-check=%(objectname) %(objecttype)".to_string(),
+    ]);
+    let stdin_data = shas_to_resolve
+        .iter()
+        .filter_map(|sha| tree_revision_arg(sha))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    let output = exec_git_stdin(&cat_file_args, stdin_data.as_bytes())?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let tree_lines = stdout.lines().collect::<Vec<_>>();
 
-    if tree_shas.len() != shas_to_resolve.len() {
+    if tree_lines.len() != shas_to_resolve.len() {
         return Err(GitAiError::Generic(format!(
-            "rev-parse returned {} trees for {} commits",
-            tree_shas.len(),
+            "cat-file returned {} trees for {} commits",
+            tree_lines.len(),
             shas_to_resolve.len()
         )));
     }
 
-    for (commit, tree) in shas_to_resolve.into_iter().zip(tree_shas) {
+    for (commit, line) in shas_to_resolve.into_iter().zip(tree_lines) {
+        let mut fields = line.split_whitespace();
+        let tree = fields.next().unwrap_or_default();
+        let object_type = fields.next().unwrap_or_default();
+        if object_type != "tree" || !is_valid_git_oid(tree) {
+            return Err(GitAiError::Generic(format!(
+                "cat-file failed to resolve tree for {commit}: {line}"
+            )));
+        }
         sha_to_tree.insert(commit, tree.to_string());
     }
 
@@ -407,6 +435,8 @@ pub(crate) fn handle_rewrite_event_with_metrics(
             new_tip,
             onto.as_deref(),
             RewriteMetricOperation::NonFastForward,
+            None,
+            UnmatchedCommitPolicy::PreserveLeadingBounded,
         ),
         RewriteEvent::CherryPickComplete {
             sources,
@@ -447,6 +477,8 @@ pub fn handle_non_fast_forward_rewrite(
         new_tip,
         onto,
         RewriteMetricOperation::NonFastForward,
+        None,
+        UnmatchedCommitPolicy::PreserveLeadingBounded,
     )
     .map(|_| ())
 }
@@ -457,8 +489,25 @@ pub(crate) fn handle_non_fast_forward_rewrite_with_operation(
     new_tip: &str,
     onto: Option<&str>,
     operation: RewriteMetricOperation,
+    trusted_old_range_base: Option<&str>,
+    untrusted_unmatched_commit_policy: UnmatchedCommitPolicy,
 ) -> Result<RewriteOutcome, GitAiError> {
-    let mappings = derive_mappings_from_range_diff(repo, old_tip, new_tip, onto)?;
+    let (old_range_base, unmatched_commit_policy) = if operation == RewriteMetricOperation::Rebase {
+        match trusted_old_range_base {
+            Some(base) => (Some(base), UnmatchedCommitPolicy::PreserveAll),
+            None => (None, untrusted_unmatched_commit_policy),
+        }
+    } else {
+        (None, untrusted_unmatched_commit_policy)
+    };
+    let mappings = derive_mappings_from_range_diff(
+        repo,
+        old_tip,
+        new_tip,
+        onto,
+        old_range_base,
+        unmatched_commit_policy,
+    )?;
     if mappings.is_empty() {
         return Ok(RewriteOutcome::empty());
     }
@@ -740,7 +789,7 @@ const DIFF_TREE_STREAM_CHUNK_SIZE: usize = 50;
 /// are zipped with shifts positionally.
 struct PendingShift {
     new_sha: String,
-    log: AuthorshipLog,
+    raw_note: Arc<str>,
 }
 
 fn shift_authorship_notes_with_existing_mode(
@@ -755,50 +804,63 @@ fn shift_authorship_notes_with_existing_mode(
     }
 
     // Batch-read all notes for source and target commits in O(1) git calls
-    let all_shas: Vec<String> = mappings
-        .iter()
-        .flat_map(|(src, dst)| [src.clone(), dst.clone()])
-        .collect();
-    let notes_map = notes_api::read_notes_batch(repo, &all_shas)?;
+    let all_shas = unique_pair_shas(mappings);
+    let notes_map = notes_api::read_notes_batch(repo, &all_shas)?
+        .into_iter()
+        .map(|(sha, note)| (sha, Arc::<str>::from(note)))
+        .collect::<HashMap<_, _>>();
 
     // Determine which mappings need processing
     let mut pending: Vec<PendingShift> = Vec::new();
     let mut verbatim_writes: Vec<(String, String)> = Vec::new();
     let mut diff_pairs: Vec<(String, String)> = Vec::new();
     let mut existing_by_target: HashMap<String, AuthorshipLog> = HashMap::new();
+    let mut blocked_targets = HashSet::new();
+    let mut inspected_targets: HashSet<String> = HashSet::new();
 
-    for (source_sha, new_sha) in mappings {
+    for (_, new_sha) in mappings {
+        if !inspected_targets.insert(new_sha.clone()) {
+            continue;
+        }
         if let Some(existing_raw) = notes_map.get(new_sha) {
-            if let Ok(existing_log) = AuthorshipLog::deserialize_from_string(existing_raw) {
-                if !existing_log.attestations.is_empty() {
+            match AuthorshipLog::deserialize_from_string(existing_raw) {
+                Ok(existing_log) if !existing_log.attestations.is_empty() => {
                     if merge_existing_targets {
                         existing_by_target
                             .entry(new_sha.clone())
                             .or_insert(existing_log);
                     } else {
-                        continue;
+                        blocked_targets.insert(new_sha.clone());
                     }
                 }
-            } else {
-                continue;
+                Ok(_) => {}
+                Err(_) => {
+                    blocked_targets.insert(new_sha.clone());
+                }
             }
+        }
+    }
+
+    for (source_sha, new_sha) in mappings {
+        if blocked_targets.contains(new_sha) {
+            continue;
         }
 
         let Some(raw_note) = notes_map.get(source_sha) else {
             continue;
         };
 
-        let Ok(log) = AuthorshipLog::deserialize_from_string(raw_note) else {
+        if AuthorshipLog::deserialize_from_string(raw_note).is_err() {
             if !merge_existing_targets {
-                verbatim_writes.push((new_sha.clone(), raw_note.clone()));
+                verbatim_writes.push((new_sha.clone(), raw_note.to_string()));
             }
             continue;
-        };
+        }
 
         diff_pairs.push((source_sha.clone(), new_sha.clone()));
         pending.push(PendingShift {
             new_sha: new_sha.clone(),
-            log,
+            raw_note: Arc::clone(raw_note),
         });
     }
 
@@ -929,7 +991,9 @@ fn apply_chunk_shifts(
     use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
 
     for (diff_result, shift) in chunk.iter().zip(pending_iter) {
-        let mut log = shift.log;
+        let Ok(mut log) = AuthorshipLog::deserialize_from_string(&shift.raw_note) else {
+            continue;
+        };
 
         for (old_path, new_path) in &diff_result.renames {
             for attestation in &mut log.attestations {
@@ -966,6 +1030,8 @@ fn derive_mappings_from_range_diff(
     old_tip: &str,
     new_tip: &str,
     onto_hint: Option<&str>,
+    trusted_old_range_base: Option<&str>,
+    unmatched_commit_policy: UnmatchedCommitPolicy,
 ) -> Result<Vec<(String, String)>, GitAiError> {
     let Some(base) = find_merge_base(repo, old_tip, new_tip) else {
         return Ok(Vec::new());
@@ -993,13 +1059,41 @@ fn derive_mappings_from_range_diff(
         }
         _ => &base,
     };
-    let range_diff_output = run_range_diff(repo, &base, old_tip, onto, new_tip)?;
-    let mut mappings = parse_range_diff_output(&range_diff_output);
+    let mut old_range_base = trusted_old_range_base.unwrap_or(&base);
+    let mut unmatched_commit_policy = unmatched_commit_policy;
+    let range_diff_output = match run_range_diff(repo, old_range_base, old_tip, onto, new_tip) {
+        Ok(output) => output,
+        Err(error) => {
+            let invalid_trusted_boundary = trusted_old_range_base
+                .is_some_and(|candidate| resolve_commit_revspec(repo, candidate).is_none());
+            if !invalid_trusted_boundary {
+                return Err(error);
+            }
 
-    let merge_mappings = derive_merge_commit_mappings(repo, &base, old_tip, new_tip, &mappings)?;
+            // Trusted boundaries are built from immutable trace2/reflog data and
+            // should resolve. Keep their valid path spawn-free; if range-diff
+            // rejects one, verify that the boundary itself is invalid before
+            // falling back rather than swallowing an unrelated Git failure.
+            old_range_base = &base;
+            unmatched_commit_policy = UnmatchedCommitPolicy::DiscardLeading;
+            run_range_diff(repo, old_range_base, old_tip, onto, new_tip)?
+        }
+    };
+    let mut mappings =
+        parse_range_diff_output_with_policy(&range_diff_output, unmatched_commit_policy);
+
+    let merge_mappings =
+        derive_merge_commit_mappings(repo, old_range_base, old_tip, new_tip, &mappings)?;
     mappings.extend(merge_mappings);
 
     Ok(mappings)
+}
+
+fn resolve_commit_revspec(repo: &Repository, revspec: &str) -> Option<String> {
+    repo.revparse_single(&format!("{revspec}^{{commit}}"))
+        .ok()
+        .map(|object| object.id())
+        .filter(|oid| is_valid_git_oid(oid))
 }
 
 fn is_ancestor(repo: &Repository, ancestor: &str, descendant: &str) -> bool {
@@ -1068,23 +1162,26 @@ fn run_range_diff(
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
-/// Maximum number of unmatched old-range (`<`) commits buffered ahead of the
-/// first matched pair. A genuine rebase squash absorbs a handful of commits
-/// into the first surviving one, so small queues are drained into that match
-/// as before. But when the count exceeds this bound the history is divergent
-/// — e.g. a restack undo (`git reset --keep <pre-rebase-tip>`), where the old
-/// range spans every trunk commit landed since the branch forked — and the
-/// whole queue is discarded, permanently. Without this, each bogus mapping
-/// whose source commit has an authorship note becomes a full-root-tree diff
-/// pair, and daemon memory scales as
-/// (trunk commits since fork) × (lines modified on trunk).
-const MAX_PENDING_DROPPED_COMMITS: usize = 64;
-
-fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
+fn parse_range_diff_output_with_policy(
+    output: &str,
+    unmatched_commit_policy: UnmatchedCommitPolicy,
+) -> Vec<(String, String)> {
     let mut mappings = Vec::new();
-    let mut pending_dropped: Vec<String> = Vec::new();
+    let mut pending_unmatched: Vec<String> = Vec::new();
     let mut pending_overflowed = false;
     let mut previous_new_sha: Option<String> = None;
+
+    let flush_pending = |mappings: &mut Vec<(String, String)>,
+                         pending: &mut Vec<String>,
+                         overflowed: &mut bool,
+                         target: &str| {
+        if !*overflowed {
+            mappings.extend(pending.drain(..).map(|source| (source, target.to_string())));
+        } else {
+            pending.clear();
+        }
+        *overflowed = false;
+    };
 
     for line in output.lines() {
         let trimmed = line.trim();
@@ -1092,7 +1189,7 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
             continue;
         }
 
-        // Find first 40-char hex SHA
+        // Find the first full SHA-1 or SHA-256 object ID.
         let Some((old_sha, rest)) = find_next_sha(trimmed) else {
             continue;
         };
@@ -1105,20 +1202,25 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
 
         match status_char {
             '<' => {
-                // Dropped commit (squashed into a later commit)
-                if !old_sha.chars().all(|c| c == '0') {
-                    if let Some(new_sha) = previous_new_sha.as_ref() {
-                        mappings.push((old_sha, new_sha.clone()));
-                    } else if !pending_overflowed {
-                        pending_dropped.push(old_sha);
-                        if pending_dropped.len() > MAX_PENDING_DROPPED_COMMITS {
-                            // Divergent history (e.g. restack undo), not a
-                            // squash: discard the queue and stop collecting so
-                            // the mapping count stays bounded.
-                            pending_dropped.clear();
-                            pending_dropped.shrink_to_fit();
-                            pending_overflowed = true;
-                        }
+                if old_sha.chars().all(|c| c == '0') {
+                    continue;
+                }
+                if !pending_overflowed {
+                    if previous_new_sha.is_none()
+                        && unmatched_commit_policy == UnmatchedCommitPolicy::DiscardLeading
+                    {
+                        pending_unmatched.clear();
+                        pending_overflowed = true;
+                        continue;
+                    }
+                    pending_unmatched.push(old_sha);
+                    if previous_new_sha.is_none()
+                        && unmatched_commit_policy == UnmatchedCommitPolicy::PreserveLeadingBounded
+                        && pending_unmatched.len() > MAX_UNTRUSTED_UNMATCHED_COMMITS
+                    {
+                        pending_unmatched.clear();
+                        pending_unmatched.shrink_to_fit();
+                        pending_overflowed = true;
                     }
                 }
             }
@@ -1131,10 +1233,13 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
                 if old_sha.chars().all(|c| c == '0') || new_sha.chars().all(|c| c == '0') {
                     continue;
                 }
-                // Map any preceding dropped commits to this new commit (squash)
-                for dropped in pending_dropped.drain(..) {
-                    mappings.push((dropped, new_sha.clone()));
-                }
+                let pending_target = previous_new_sha.as_deref().unwrap_or(&new_sha);
+                flush_pending(
+                    &mut mappings,
+                    &mut pending_unmatched,
+                    &mut pending_overflowed,
+                    pending_target,
+                );
                 previous_new_sha = Some(new_sha.clone());
                 mappings.push((old_sha, new_sha));
             }
@@ -1145,7 +1250,21 @@ fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
         }
     }
 
+    if let Some(previous_new_sha) = previous_new_sha {
+        flush_pending(
+            &mut mappings,
+            &mut pending_unmatched,
+            &mut pending_overflowed,
+            &previous_new_sha,
+        );
+    }
+
     mappings
+}
+
+#[cfg(test)]
+fn parse_range_diff_output(output: &str) -> Vec<(String, String)> {
+    parse_range_diff_output_with_policy(output, UnmatchedCommitPolicy::PreserveAll)
 }
 
 /// Find the first maximal ASCII-hex run in `s` whose length is a valid git OID
@@ -1284,19 +1403,16 @@ fn get_commit_parents_batch(repo: &Repository, shas: &[String]) -> HashMap<Strin
     }
     let mut args = repo.global_args_for_exec();
     args.extend([
-        "show".to_string(),
-        "-s".to_string(),
-        "--format=%H %P".to_string(),
+        "rev-list".to_string(),
+        "--parents".to_string(),
         "--no-walk".to_string(),
+        "--stdin".to_string(),
     ]);
-    args.extend(shas.iter().cloned());
+    let stdin_data = shas.join("\n") + "\n";
 
-    let Ok(output) = exec_git_allow_nonzero(&args) else {
+    let Ok(output) = exec_git_stdin(&args, stdin_data.as_bytes()) else {
         return HashMap::new();
     };
-    if !output.status.success() {
-        return HashMap::new();
-    }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     stdout
@@ -1515,6 +1631,105 @@ fn extract_b_path(diff_header: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_tree_shas_accepts_large_batches_via_stdin() {
+        let repo = crate::git::test_utils::TmpRepo::new().expect("create repo");
+        repo.write_file("file.txt", "content\n", false)
+            .expect("write file");
+        let head = repo.commit_all("initial").expect("commit");
+        let revisions = vec![head.clone(); 2_048];
+
+        let resolved =
+            resolve_tree_shas(repo.gitai_repo(), &revisions).expect("resolve tree batch");
+
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved.contains_key(&head));
+    }
+
+    #[test]
+    fn get_commit_parents_batch_accepts_large_input_via_stdin() {
+        let repo = crate::git::test_utils::TmpRepo::new().expect("create repo");
+        repo.write_file("file.txt", "content\n", false)
+            .expect("write file");
+        let head = repo.commit_all("initial").expect("commit");
+        let revisions = vec![head.clone(); 2_048];
+
+        let parents = get_commit_parents_batch(repo.gitai_repo(), &revisions);
+
+        assert_eq!(parents.get(&head), Some(&Vec::new()));
+    }
+
+    #[test]
+    fn invalid_trusted_old_range_base_falls_back_and_discards_leading_sources() {
+        let repo = crate::git::test_utils::TmpRepo::new().expect("create repo");
+        repo.write_file("seed.txt", "seed\n", false)
+            .expect("write seed");
+        repo.commit_all("seed").expect("commit seed");
+        repo.create_branch("feature").expect("create feature");
+
+        repo.write_file("main.txt", "main\n", false)
+            .expect("write main");
+        let main_tip = repo.commit_all("main").expect("commit main");
+
+        repo.switch_branch("feature").expect("switch to feature");
+        repo.write_file("dropped.txt", "dropped\n", false)
+            .expect("write dropped source");
+        let dropped_source = repo
+            .commit_all("source omitted from rewritten history")
+            .expect("commit dropped source");
+        repo.write_file("feature.txt", "feature\n", false)
+            .expect("write feature");
+        let old_tip = repo.commit_all("feature").expect("commit feature");
+
+        repo.switch_branch("main").expect("switch to main");
+        repo.git_command(&["cherry-pick", &old_tip])
+            .expect("replay retained source");
+        let new_tip = repo
+            .git_command(&["rev-parse", "HEAD"])
+            .expect("resolve rewritten tip")
+            .trim()
+            .to_string();
+
+        let invalid_old_range_base = format!("{old_tip}~999");
+        let mappings = derive_mappings_from_range_diff(
+            repo.gitai_repo(),
+            &old_tip,
+            &new_tip,
+            Some(&main_tip),
+            Some(&invalid_old_range_base),
+            UnmatchedCommitPolicy::PreserveAll,
+        )
+        .expect("invalid trusted boundary should fall back");
+
+        assert_eq!(mappings, vec![(old_tip, new_tip)]);
+        assert!(
+            mappings.iter().all(|(source, _)| source != &dropped_source),
+            "falling back must also downgrade the leading-source policy"
+        );
+    }
+
+    #[test]
+    fn merging_existing_skips_unparseable_source_before_resolving_diff_trees() {
+        let repo = crate::git::test_utils::TmpRepo::new().expect("create repo");
+        repo.write_file("source.txt", "source\n", false)
+            .expect("write source");
+        let source = repo.commit_all("source").expect("commit source");
+        notes_api::write_note(repo.gitai_repo(), &source, "unsupported authorship schema")
+            .expect("write malformed source note");
+
+        // A non-existent destination makes any attempted tree resolution fail.
+        // The malformed source note cannot be shifted, so the mapping must be
+        // rejected before tree lookup and diff-tree work are queued.
+        let nonexistent_target = "f".repeat(40);
+        let writes = shift_authorship_notes_merging_existing_with_notes(
+            repo.gitai_repo(),
+            &[(source, nonexistent_target)],
+        )
+        .expect("unparseable source should be skipped before diff work");
+
+        assert!(writes.is_empty());
+    }
 
     #[test]
     fn metric_commits_from_mappings_groups_squashed_sources() {
@@ -1847,7 +2062,10 @@ Binary files a/image.png and b/image.png differ
             "201:  {} = 1:  {} AI feature commit\n",
             sha_a, sha_b
         ));
-        let mappings = parse_range_diff_output(&output);
+        let mappings = parse_range_diff_output_with_policy(
+            &output,
+            UnmatchedCommitPolicy::PreserveLeadingBounded,
+        );
         // Only the matched pair, not 200 bogus mappings
         assert_eq!(mappings.len(), 1);
         assert_eq!(mappings[0], (sha_a, sha_b));
@@ -1855,9 +2073,8 @@ Binary files a/image.png and b/image.png differ
 
     #[test]
     fn test_parse_range_diff_output_small_pending_dropped_still_mapped() {
-        // A bounded number of `<` commits ahead of the first match is a
-        // genuine squash and must still be drained into it — the overflow
-        // guard only fires past MAX_PENDING_DROPPED_COMMITS.
+        // A scoped rebase maps unmatched commits ahead of the first match to
+        // that destination commit as squash sources.
         let dropped = "1".repeat(40);
         let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
         let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
@@ -1871,6 +2088,123 @@ Binary files a/image.png and b/image.png differ
         assert_eq!(
             mappings,
             vec![(dropped, new_matched.clone()), (old_matched, new_matched),]
+        );
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_bounded_non_rebase_preserves_small_leading_squash() {
+        let dropped = "1".repeat(40);
+        let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+        let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
+        let output = format!(
+            "\
+1:  {} < -:  ---------------------------------------- dropped
+2:  {} = 1:  {} matched\n",
+            dropped, old_matched, new_matched,
+        );
+
+        let mappings = parse_range_diff_output_with_policy(
+            &output,
+            UnmatchedCommitPolicy::PreserveLeadingBounded,
+        );
+
+        assert_eq!(
+            mappings,
+            vec![(dropped, new_matched.clone()), (old_matched, new_matched)]
+        );
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_bounded_non_rebase_enforces_leading_boundary() {
+        let old_matched = "a".repeat(40);
+        let new_matched = "b".repeat(40);
+
+        for (dropped_count, expected_mapping_count) in [(64, 65), (65, 1)] {
+            let mut output = String::new();
+            for index in 1..=dropped_count {
+                let sha = format!("{index:040}");
+                output.push_str(&format!(
+                    "{index}:  {sha} < -:  ---------------------------------------- dropped\n"
+                ));
+            }
+            output.push_str(&format!(
+                "{}:  {old_matched} = 1:  {new_matched} matched\n",
+                dropped_count + 1
+            ));
+
+            let mappings = parse_range_diff_output_with_policy(
+                &output,
+                UnmatchedCommitPolicy::PreserveLeadingBounded,
+            );
+
+            assert_eq!(
+                mappings.len(),
+                expected_mapping_count,
+                "unexpected mapping count for {dropped_count} leading commits"
+            );
+            assert_eq!(
+                mappings.last(),
+                Some(&(old_matched.clone(), new_matched.clone()))
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_bounded_non_rebase_preserves_large_post_match_group() {
+        let old_first = "a".repeat(40);
+        let new_first = "b".repeat(40);
+        let old_second = "c".repeat(40);
+        let new_second = "d".repeat(40);
+        let mut output = format!("1:  {old_first} = 1:  {new_first} first\n");
+        for index in 1..=65 {
+            let sha = format!("{index:040}");
+            output.push_str(&format!(
+                "{}:  {} < -:  ---------------------------------------- dropped\n",
+                index + 1,
+                sha
+            ));
+        }
+        output.push_str(&format!("67:  {old_second} = 2:  {new_second} second\n"));
+
+        let mappings = parse_range_diff_output_with_policy(
+            &output,
+            UnmatchedCommitPolicy::PreserveLeadingBounded,
+        );
+
+        assert_eq!(mappings.len(), 67);
+        assert_eq!(mappings[0], (old_first, new_first.clone()));
+        for (index, (old_sha, mapped_new_sha)) in mappings[1..66].iter().enumerate() {
+            assert_eq!(old_sha, &format!("{:040}", index + 1));
+            assert_eq!(mapped_new_sha, &new_first);
+        }
+        assert_eq!(mappings[66], (old_second, new_second));
+    }
+
+    #[test]
+    fn test_parse_range_diff_output_untrusted_rebase_preserves_small_leading_group() {
+        let leading = "1".repeat(40);
+        let old_matched = "a".repeat(40);
+        let new_matched = "b".repeat(40);
+        let post_match = "c".repeat(40);
+        let output = format!(
+            "\
+1:  {leading} < -:  ---------------------------------------- unrelated upstream
+2:  {old_matched} = 1:  {new_matched} matched
+3:  {post_match} < -:  ---------------------------------------- squashed feature\n"
+        );
+
+        let mappings = parse_range_diff_output_with_policy(
+            &output,
+            UnmatchedCommitPolicy::PreserveLeadingBounded,
+        );
+
+        assert_eq!(
+            mappings,
+            vec![
+                (leading, new_matched.clone()),
+                (old_matched, new_matched.clone()),
+                (post_match, new_matched),
+            ]
         );
     }
 
@@ -1901,16 +2235,14 @@ Binary files a/image.png and b/image.png differ
     }
 
     #[test]
-    fn test_parse_range_diff_output_exactly_64_leading_drops_still_mapped() {
-        // Exactly MAX_PENDING_DROPPED_COMMITS (64) leading `<` commits should
-        // all be mapped to the first matched new SHA, plus the match's own old
-        // SHA — total of 65 mappings. Start at 1 so the first SHA is not all
-        // zeros and is therefore not skipped.
-        const MAX_DROPPED: usize = 64;
+    fn test_parse_range_diff_output_large_squash_preserves_all_leading_drops() {
+        // A scoped rebase can legitimately squash an arbitrary number of old
+        // commits into the first matched destination commit.
+        const DROPPED_COUNT: usize = 65;
         let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
         let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
         let mut output = String::new();
-        for i in 1..=MAX_DROPPED {
+        for i in 1..=DROPPED_COUNT {
             let sha = format!("{:040}", i);
             output.push_str(&format!(
                 "{}:  {} < -:  ---------------------------------------- dropped {}\n",
@@ -1919,49 +2251,43 @@ Binary files a/image.png and b/image.png differ
         }
         output.push_str(&format!(
             "{}:  {} = 1:  {} matched\n",
-            MAX_DROPPED + 1,
+            DROPPED_COUNT + 1,
             old_matched,
             new_matched,
         ));
         let mappings = parse_range_diff_output(&output);
-        // 64 dropped + 1 matched
-        assert_eq!(mappings.len(), MAX_DROPPED + 1);
-        // All dropped commits map to new_matched
-        for i in 1..=MAX_DROPPED {
+        assert_eq!(mappings.len(), DROPPED_COUNT + 1);
+        for i in 1..=DROPPED_COUNT {
             let sha = format!("{:040}", i);
             assert_eq!(mappings[i - 1], (sha, new_matched.clone()));
         }
-        // The matched pair is last
-        assert_eq!(mappings[MAX_DROPPED], (old_matched, new_matched));
+        assert_eq!(mappings[DROPPED_COUNT], (old_matched, new_matched));
     }
 
     #[test]
-    fn test_parse_range_diff_output_exactly_65_leading_drops_discards_all() {
-        // Exactly MAX_PENDING_DROPPED_COMMITS + 1 (65) leading `<` commits
-        // exceeds the limit, so ALL of them are discarded — only the matched
-        // pair's own mapping survives. Start at 1 so the first SHA is not all
-        // zeros and is therefore not skipped.
-        const MAX_DROPPED_PLUS_1: usize = 65;
+    fn test_parse_range_diff_output_non_rebase_preserves_unmatched_after_match() {
         let old_matched = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
         let new_matched = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
-        let mut output = String::new();
-        for i in 1..=MAX_DROPPED_PLUS_1 {
-            let sha = format!("{:040}", i);
-            output.push_str(&format!(
-                "{}:  {} < -:  ---------------------------------------- dropped {}\n",
-                i, sha, i
-            ));
-        }
-        output.push_str(&format!(
-            "{}:  {} = 1:  {} matched\n",
-            MAX_DROPPED_PLUS_1 + 1,
-            old_matched,
-            new_matched,
-        ));
-        let mappings = parse_range_diff_output(&output);
-        // Only the matched pair survived
-        assert_eq!(mappings.len(), 1);
-        assert_eq!(mappings[0], (old_matched, new_matched));
+        let old_unmatched = "cccccccccccccccccccccccccccccccccccccccc".to_string();
+        let output = format!(
+            "\
+1:  {} = 1:  {} matched
+2:  {} < -:  ---------------------------------------- unrelated\n",
+            old_matched, new_matched, old_unmatched,
+        );
+
+        let mappings = parse_range_diff_output_with_policy(
+            &output,
+            UnmatchedCommitPolicy::PreserveLeadingBounded,
+        );
+
+        assert_eq!(
+            mappings,
+            vec![
+                (old_matched, new_matched.clone()),
+                (old_unmatched, new_matched),
+            ]
+        );
     }
 
     #[test]
@@ -2320,9 +2646,14 @@ diff --git a/c.txt b/c.txt
         const SOURCE_COUNT: usize = DIFF_TREE_STREAM_CHUNK_SIZE + 5;
         let target_sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string();
         let pending: Vec<PendingShift> = (1..=SOURCE_COUNT)
-            .map(|index| PendingShift {
-                new_sha: target_sha.clone(),
-                log: authorship_log_for_streaming_merge_test(index),
+            .map(|index| {
+                let raw_note = authorship_log_for_streaming_merge_test(index)
+                    .serialize_to_string()
+                    .expect("serialize source log");
+                PendingShift {
+                    new_sha: target_sha.clone(),
+                    raw_note: Arc::<str>::from(raw_note),
+                }
             })
             .collect();
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1582,6 +1582,102 @@ fn rebase_is_control_mode(cmd: &crate::daemon::domain::NormalizedCommand) -> boo
     summarize_rebase_args(&cmd.invoked_args).is_control_mode
 }
 
+fn immutable_rebase_old_range_base(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+    original_head: &str,
+    observed_onto: Option<&str>,
+) -> Option<String> {
+    if cmd.primary_command.as_deref() == Some("pull") {
+        // A pull fetches before starting its rebase. The observed checkout is
+        // therefore the newly fetched upstream, while Git may use the
+        // pre-fetch remote-tracking reflog as its fork point. Without that
+        // immutable pre-fetch boundary, the old range must remain untrusted.
+        return None;
+    }
+
+    let summary = summarize_rebase_args(&cmd.invoked_args);
+    if summary.is_control_mode || summary.has_root {
+        return None;
+    }
+    let explicitly_uses_fork_point = cmd.invoked_args.iter().any(|arg| arg == "--fork-point");
+    if explicitly_uses_fork_point {
+        return None;
+    }
+    let explicitly_disables_fork_point =
+        cmd.invoked_args.iter().any(|arg| arg == "--no-fork-point");
+    if summary.positionals.is_empty() && !explicitly_disables_fork_point {
+        // Without an explicit upstream, Git implicitly enables --fork-point.
+        // The actual old boundary may then come from the upstream reflog and
+        // cannot be reconstructed from the observed checkout OID.
+        return None;
+    }
+    if cmd.primary_command.as_deref() == Some("rebase")
+        && let Some(upstream) = summary.positionals.first()
+    {
+        if is_valid_oid(upstream) && !is_zero_oid(upstream) {
+            return Some(upstream.clone());
+        }
+
+        // With no explicit branch argument, HEAD-relative revisions are
+        // anchored to the immutable pre-rebase tip captured from
+        // trace2/reflog data.
+        if summary.positionals.len() == 1
+            && let Some(suffix) = upstream
+                .strip_prefix("HEAD")
+                .or_else(|| upstream.strip_prefix('@'))
+            && is_parent_ancestry_suffix(suffix)
+        {
+            return Some(format!("{original_head}{suffix}"));
+        }
+    }
+
+    // Without an explicit --onto, Git checks out the upstream itself. The
+    // exact checkout OID is already present in the cursor-bounded reflog
+    // changes, so it is safe even when argv used a mutable ref name.
+    if summary.onto_spec.is_none()
+        && let Some(onto) = observed_onto
+        && is_valid_oid(onto)
+        && !is_zero_oid(onto)
+    {
+        return Some(onto.to_string());
+    }
+    None
+}
+
+fn untrusted_rebase_unmatched_commit_policy(
+    cmd: &crate::daemon::domain::NormalizedCommand,
+) -> crate::authorship::rewrite::UnmatchedCommitPolicy {
+    if summarize_rebase_args(&cmd.invoked_args).onto_spec.is_some() {
+        // An explicit --onto can replace a divergent upstream with an
+        // unrelated base. Even a short leading `<` run is not reliable squash
+        // evidence in that shape.
+        crate::authorship::rewrite::UnmatchedCommitPolicy::DiscardLeading
+    } else {
+        // Implicit/explicit fork-point selection lacks an immutable old
+        // boundary, but common interactive rebases can still squash a small
+        // leading group. Preserve only through the historical safety limit.
+        crate::authorship::rewrite::UnmatchedCommitPolicy::PreserveLeadingBounded
+    }
+}
+
+fn is_parent_ancestry_suffix(suffix: &str) -> bool {
+    if suffix.is_empty() {
+        return true;
+    }
+    let bytes = suffix.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !matches!(bytes[index], b'^' | b'~') {
+            return false;
+        }
+        index += 1;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+    }
+    true
+}
+
 fn rebase_onto_from_command(
     cmd: &crate::daemon::domain::NormalizedCommand,
     repository: &Repository,
@@ -2682,6 +2778,14 @@ struct PendingSquashMerge {
 }
 
 #[derive(Debug, Clone)]
+struct PendingRebase {
+    original_head: String,
+    onto: Option<String>,
+    old_range_base: Option<String>,
+    untrusted_unmatched_commit_policy: crate::authorship::rewrite::UnmatchedCommitPolicy,
+}
+
+#[derive(Debug, Clone)]
 struct PendingCherryPickNoCommit {
     source_commits: Vec<String>,
     head: String,
@@ -2729,7 +2833,7 @@ pub struct ActorDaemonCoordinator {
             crate::daemon::git_backend::SystemGitBackend,
         >,
     >,
-    pending_rebase_original_head_by_worktree: Mutex<HashMap<String, (String, Option<String>)>>,
+    pending_rebase_original_head_by_worktree: Mutex<HashMap<String, PendingRebase>>,
     pending_cherry_pick_sources_by_worktree: Mutex<HashMap<String, Vec<String>>>,
     pending_cherry_pick_no_commit_by_worktree: Mutex<HashMap<String, PendingCherryPickNoCommit>>,
     pending_squash_merge_by_worktree: Mutex<HashMap<String, PendingSquashMerge>>,
@@ -4996,6 +5100,8 @@ impl ActorDaemonCoordinator {
         worktree: &Path,
         original_head: String,
         onto: Option<String>,
+        old_range_base: Option<String>,
+        untrusted_unmatched_commit_policy: crate::authorship::rewrite::UnmatchedCommitPolicy,
     ) -> Result<(), GitAiError> {
         let mut map = self
             .pending_rebase_original_head_by_worktree
@@ -5003,7 +5109,15 @@ impl ActorDaemonCoordinator {
             .map_err(|_| {
                 GitAiError::Generic("pending rebase original-head map lock poisoned".to_string())
             })?;
-        map.insert(Self::worktree_state_key(worktree), (original_head, onto));
+        map.insert(
+            Self::worktree_state_key(worktree),
+            PendingRebase {
+                original_head,
+                onto,
+                old_range_base,
+                untrusted_unmatched_commit_policy,
+            },
+        );
         Ok(())
     }
 
@@ -5024,7 +5138,7 @@ impl ActorDaemonCoordinator {
     fn take_pending_rebase_original_head_for_worktree(
         &self,
         worktree: &Path,
-    ) -> Result<Option<(String, Option<String>)>, GitAiError> {
+    ) -> Result<Option<PendingRebase>, GitAiError> {
         let mut map = self
             .pending_rebase_original_head_by_worktree
             .lock()
@@ -5351,14 +5465,19 @@ impl ActorDaemonCoordinator {
                     branch_changes.len(),
                     pending_original_head
                         .as_ref()
-                        .map(|(head, _)| head.as_str())
+                        .map(|pending| pending.original_head.as_str())
                         .unwrap_or("NONE"),
                     cmd.ref_changes.len(),
                 )
             },
         );
 
-        if let Some((original_head, stored_onto)) = pending_original_head
+        if let Some(PendingRebase {
+            original_head,
+            onto: stored_onto,
+            old_range_base,
+            untrusted_unmatched_commit_policy,
+        }) = pending_original_head
             && let Some(new_tip) = rebase_new_tip_from_command(cmd, &original_head)
         {
             if original_head != new_tip && !is_ancestor_commit(&repo, &original_head, &new_tip) {
@@ -5378,6 +5497,8 @@ impl ActorDaemonCoordinator {
                         &new_tip,
                         rebase_onto.as_deref(),
                         crate::authorship::rewrite::RewriteMetricOperation::Rebase,
+                        old_range_base.as_deref(),
+                        untrusted_unmatched_commit_policy,
                     )?;
                 repo.storage.rename_working_log(&original_head, &new_tip)?;
                 let conflict_base = rebase_onto.clone();
@@ -5416,12 +5537,16 @@ impl ActorDaemonCoordinator {
                 onto_hint.clone()
             };
             let outcome = if is_rebase_cmd {
+                let old_range_base =
+                    immutable_rebase_old_range_base(cmd, old_tip, rewrite_onto.as_deref());
                 crate::authorship::rewrite::handle_non_fast_forward_rewrite_with_operation(
                     &repo,
                     old_tip,
                     new_tip,
                     rewrite_onto.as_deref(),
                     crate::authorship::rewrite::RewriteMetricOperation::Rebase,
+                    old_range_base.as_deref(),
+                    untrusted_rebase_unmatched_commit_policy(cmd),
                 )?
             } else if cmd.primary_command.as_deref() == Some("update-ref") {
                 crate::authorship::rewrite::handle_non_fast_forward_rewrite_with_operation(
@@ -5430,6 +5555,8 @@ impl ActorDaemonCoordinator {
                     new_tip,
                     rewrite_onto.as_deref(),
                     crate::authorship::rewrite::RewriteMetricOperation::UpdateRef,
+                    None,
+                    crate::authorship::rewrite::UnmatchedCommitPolicy::PreserveLeadingBounded,
                 )?
             } else {
                 crate::authorship::rewrite::handle_non_fast_forward_rewrite_with_operation(
@@ -5438,6 +5565,8 @@ impl ActorDaemonCoordinator {
                     new_tip,
                     rewrite_onto.as_deref(),
                     crate::authorship::rewrite::RewriteMetricOperation::NonFastForward,
+                    None,
+                    crate::authorship::rewrite::UnmatchedCommitPolicy::PreserveLeadingBounded,
                 )?
             };
             repo.storage.rename_working_log(old_tip, new_tip)?;
@@ -5747,6 +5876,8 @@ impl ActorDaemonCoordinator {
                     );
                     if let Some(old_head) = pending_old_head {
                         let rebase_onto = rebase_start.as_ref().map(|(_, new)| new.clone());
+                        let old_range_base =
+                            immutable_rebase_old_range_base(cmd, &old_head, rebase_onto.as_deref());
                         if std::env::var("GIT_AI_DEBUG_DAEMON_TRACE")
                             .ok()
                             .as_deref()
@@ -5763,6 +5894,8 @@ impl ActorDaemonCoordinator {
                             worktree,
                             old_head,
                             rebase_onto,
+                            old_range_base,
+                            untrusted_rebase_unmatched_commit_policy(cmd),
                         )?;
                     }
                 }
@@ -9357,6 +9490,160 @@ mod tests {
             strict_rebase_original_head_from_command(&cmd, MAIN),
             Some(FEATURE.to_string()),
             "explicit branch rebase must store the target branch tip, not the caller's original HEAD"
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_accepts_full_upstream_oid() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        const UPSTREAM: &str = "2222222222222222222222222222222222222222";
+        let cmd = test_rebase_command(&[UPSTREAM], Vec::new());
+
+        assert_eq!(
+            immutable_rebase_old_range_base(&cmd, ORIGINAL, None),
+            Some(UPSTREAM.to_string())
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_anchors_head_relative_upstream_to_original_tip() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        let cmd = test_rebase_command(&["HEAD~65^2"], Vec::new());
+
+        assert_eq!(
+            immutable_rebase_old_range_base(&cmd, ORIGINAL, None),
+            Some(format!("{ORIGINAL}~65^2"))
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_uses_observed_upstream_for_named_standard_rebase() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        assert_eq!(
+            immutable_rebase_old_range_base(
+                &test_rebase_command(&["main"], Vec::new()),
+                ORIGINAL,
+                Some("2222222222222222222222222222222222222222")
+            ),
+            Some("2222222222222222222222222222222222222222".to_string())
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_rejects_mutable_or_ambiguous_upstream_specs() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        assert_eq!(
+            immutable_rebase_old_range_base(
+                &test_rebase_command(&["HEAD~2", "feature"], Vec::new()),
+                ORIGINAL,
+                None
+            ),
+            None,
+            "HEAD is ambiguous when rebase checks out an explicit branch"
+        );
+        assert_eq!(
+            immutable_rebase_old_range_base(
+                &test_rebase_command(&["HEAD@{upstream}"], Vec::new()),
+                ORIGINAL,
+                None
+            ),
+            None
+        );
+        assert_eq!(
+            immutable_rebase_old_range_base(
+                &test_rebase_command(&["--root"], Vec::new()),
+                ORIGINAL,
+                None
+            ),
+            None
+        );
+        assert_eq!(
+            immutable_rebase_old_range_base(
+                &test_rebase_command(&["--onto", "new-base", "old-base"], Vec::new()),
+                ORIGINAL,
+                Some("3333333333333333333333333333333333333333")
+            ),
+            None,
+            "the observed checkout is the new base, not the old range boundary"
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_rejects_fork_point_selection() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        const UPSTREAM: &str = "2222222222222222222222222222222222222222";
+        let cmd = test_rebase_command(&["--fork-point", UPSTREAM], Vec::new());
+
+        assert_eq!(
+            immutable_rebase_old_range_base(&cmd, ORIGINAL, Some(UPSTREAM)),
+            None,
+            "fork-point can select a reflog-derived boundary different from upstream"
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_rejects_implicit_fork_point_selection() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        const OBSERVED_ONTO: &str = "2222222222222222222222222222222222222222";
+        let cmd = test_rebase_command(&[], Vec::new());
+
+        assert_eq!(
+            immutable_rebase_old_range_base(&cmd, ORIGINAL, Some(OBSERVED_ONTO)),
+            None,
+            "rebase without an upstream implicitly uses fork-point, whose old boundary can differ \
+             from the observed checkout"
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_rejects_post_fetch_pull_checkout() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        const FETCHED_UPSTREAM: &str = "2222222222222222222222222222222222222222";
+        let mut cmd = test_rebase_command(&["--rebase", "origin", "main"], Vec::new());
+        cmd.primary_command = Some("pull".to_string());
+        cmd.invoked_command = Some("pull".to_string());
+
+        assert_eq!(
+            immutable_rebase_old_range_base(&cmd, ORIGINAL, Some(FETCHED_UPSTREAM)),
+            None,
+            "pull's observed checkout is post-fetch and cannot identify the old fork point"
+        );
+    }
+
+    #[test]
+    fn untrusted_rebase_policy_bounds_fork_point_but_discards_explicit_onto() {
+        assert_eq!(
+            untrusted_rebase_unmatched_commit_policy(&test_rebase_command(&[], Vec::new())),
+            crate::authorship::rewrite::UnmatchedCommitPolicy::PreserveLeadingBounded,
+            "implicit fork-point rebases should retain small legitimate squash groups"
+        );
+        assert_eq!(
+            untrusted_rebase_unmatched_commit_policy(&test_rebase_command(
+                &["--fork-point", "main"],
+                Vec::new()
+            )),
+            crate::authorship::rewrite::UnmatchedCommitPolicy::PreserveLeadingBounded,
+            "explicit fork-point rebases have the same bounded ambiguity"
+        );
+        assert_eq!(
+            untrusted_rebase_unmatched_commit_policy(&test_rebase_command(
+                &["--onto", "new-base", "old-base"],
+                Vec::new()
+            )),
+            crate::authorship::rewrite::UnmatchedCommitPolicy::DiscardLeading,
+            "explicit --onto can expose a short but unrelated old-upstream prefix"
+        );
+    }
+
+    #[test]
+    fn rebase_old_range_base_accepts_observed_upstream_when_fork_point_is_disabled() {
+        const ORIGINAL: &str = "1111111111111111111111111111111111111111";
+        const OBSERVED_ONTO: &str = "2222222222222222222222222222222222222222";
+        let cmd = test_rebase_command(&["--no-fork-point"], Vec::new());
+
+        assert_eq!(
+            immutable_rebase_old_range_base(&cmd, ORIGINAL, Some(OBSERVED_ONTO)),
+            Some(OBSERVED_ONTO.to_string())
         );
     }
 

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -1553,6 +1553,378 @@ fn test_update_ref_restack_after_parent_amend_preserves_child_attribution() {
     rewritten_child_file.assert_lines_and_blame(lines!["child ai".ai(), "child human".human()]);
 }
 
+#[test]
+fn test_update_ref_preserves_squashed_commit_before_first_match() {
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+    let base = head_sha(&repo);
+    let mut readme = repo.filename("README.md");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+
+    repo.git(&["checkout", "-b", "feature"])
+        .expect("checkout feature should succeed");
+
+    let mut squashed_file = repo.filename("leading_squashed.txt");
+    squashed_file.set_contents(lines!["leading squashed ai".ai()]);
+    let squashed_commit = repo
+        .stage_all_and_commit("leading squash source")
+        .expect("leading squash source commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    squashed_file.assert_lines_and_blame(lines!["leading squashed ai".ai()]);
+
+    // Make this patch dominate the preceding one so range-diff matches it to
+    // the destination commit and reports the squash source before that match.
+    let anchor_lines = (1..=100)
+        .map(|line| format!("anchor line {line}"))
+        .collect::<Vec<_>>();
+    let mut anchor_file = repo.filename("leading_anchor.txt");
+    anchor_file.set_contents(anchor_lines.clone());
+    let anchor_commit = repo
+        .stage_all_and_commit("anchor")
+        .expect("anchor commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    squashed_file.assert_lines_and_blame(lines!["leading squashed ai".ai()]);
+    anchor_file.assert_lines_and_blame(anchor_lines.clone());
+
+    let new_anchor =
+        commit_tree_from_existing_tree(&repo, &anchor_commit.commit_sha, &base, "anchor");
+
+    let old_range = format!("{base}..{}", anchor_commit.commit_sha);
+    let new_range = format!("{base}..{new_anchor}");
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "--no-color",
+            "--no-abbrev",
+            "-s",
+            "--creation-factor=100",
+            &old_range,
+            &new_range,
+        ])
+        .expect("range-diff should succeed");
+    let range_diff_lines = range_diff.lines().collect::<Vec<_>>();
+    let squashed_drop_index = range_diff_lines
+        .iter()
+        .position(|line| line.contains(&squashed_commit.commit_sha) && line.contains(" < "))
+        .expect("squashed source should be unmatched");
+    let anchor_match_index = range_diff_lines
+        .iter()
+        .position(|line| line.contains(&anchor_commit.commit_sha) && line.contains(" ! "))
+        .expect("anchor commit should match the destination commit");
+    assert!(
+        squashed_drop_index < anchor_match_index,
+        "squashed source must appear before the first match\n{range_diff}"
+    );
+
+    repo.git(&[
+        "update-ref",
+        "refs/heads/feature",
+        &new_anchor,
+        &anchor_commit.commit_sha,
+    ])
+    .expect("update-ref should succeed");
+    repo.sync_daemon();
+
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    squashed_file.assert_lines_and_blame(lines!["leading squashed ai".ai()]);
+    anchor_file.assert_lines_and_blame(anchor_lines);
+}
+
+#[test]
+fn test_update_ref_preserves_edited_squashed_commit_before_first_match() {
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+    let base = head_sha(&repo);
+    let mut readme = repo.filename("README.md");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+
+    repo.git(&["checkout", "-b", "feature"])
+        .expect("checkout feature should succeed");
+
+    let mut squashed_file = repo.filename("edited_leading_squashed.txt");
+    squashed_file.set_contents(lines!["leading squashed ai".ai()]);
+    repo.stage_all_and_commit("leading squash source")
+        .expect("leading squash source commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    squashed_file.assert_lines_and_blame(lines!["leading squashed ai".ai()]);
+
+    let anchor_lines = (1..=100)
+        .map(|line| format!("anchor line {line}"))
+        .collect::<Vec<_>>();
+    let anchor_path = repo.path().join("edited_leading_anchor.txt");
+    let mut anchor_file = repo.filename("edited_leading_anchor.txt");
+    fs::write(&anchor_path, anchor_lines.join("\n") + "\n").unwrap();
+    repo.git_ai(&[
+        "checkpoint",
+        "mock_known_human",
+        "edited_leading_anchor.txt",
+    ])
+    .unwrap();
+    let anchor_commit = repo
+        .stage_all_and_commit("anchor")
+        .expect("anchor commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    squashed_file.assert_lines_and_blame(lines!["leading squashed ai".ai()]);
+    anchor_file.assert_lines_and_blame(anchor_lines.clone());
+
+    let edited_anchor_lines = anchor_lines
+        .iter()
+        .cloned()
+        .chain(std::iter::once("cleanup added while squashing".to_string()))
+        .collect::<Vec<_>>();
+    fs::write(&anchor_path, edited_anchor_lines.join("\n") + "\n").unwrap();
+    repo.git(&["add", "edited_leading_anchor.txt"])
+        .expect("stage edited anchor");
+    let edited_tree = repo.git(&["write-tree"]).expect("write edited tree");
+    let new_anchor = repo
+        .git(&[
+            "commit-tree",
+            edited_tree.trim(),
+            "-p",
+            &base,
+            "-m",
+            "edited anchor",
+        ])
+        .expect("create edited squashed commit")
+        .trim()
+        .to_string();
+
+    repo.git(&[
+        "update-ref",
+        "refs/heads/feature",
+        &new_anchor,
+        &anchor_commit.commit_sha,
+    ])
+    .expect("update-ref should succeed");
+    repo.sync_daemon();
+
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    squashed_file.assert_lines_and_blame(lines!["leading squashed ai".ai()]);
+    anchor_file.assert_lines_and_blame(edited_anchor_lines);
+}
+
+#[test]
+fn test_update_ref_preserves_metadata_from_leading_empty_squash_source() {
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+    let mut readme = repo.filename("README.md");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+
+    repo.git(&["checkout", "-b", "feature"])
+        .expect("checkout feature should succeed");
+
+    let mut donor_file = repo.filename("donor.txt");
+    donor_file.set_contents(lines!["donor ai".ai()]);
+    let donor_commit = repo
+        .stage_all_and_commit("metadata donor")
+        .expect("metadata donor commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    donor_file.assert_lines_and_blame(lines!["donor ai".ai()]);
+    let base = donor_commit.commit_sha;
+
+    repo.git(&["commit", "--allow-empty", "-m", "empty squash source"])
+        .expect("empty commit should succeed");
+    repo.sync_daemon();
+    let empty_source = head_sha(&repo);
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    donor_file.assert_lines_and_blame(lines!["donor ai".ai()]);
+
+    let donor_note = repo
+        .read_authorship_note(&base)
+        .expect("metadata donor should have an authorship note");
+    let mut metadata_only_log =
+        AuthorshipLog::deserialize_from_string(&donor_note).expect("parse metadata donor note");
+    metadata_only_log.attestations.clear();
+    metadata_only_log.metadata.base_commit_sha = empty_source.clone();
+    let prompt_record = metadata_only_log.metadata.prompts.values().next().cloned();
+    let session_record = metadata_only_log.metadata.sessions.values().next().cloned();
+    metadata_only_log.metadata.prompts.clear();
+    metadata_only_log.metadata.sessions.clear();
+    if let Some(record) = prompt_record {
+        metadata_only_log
+            .metadata
+            .prompts
+            .insert("empty-source-only-prompt".to_string(), record);
+    }
+    if let Some(record) = session_record {
+        metadata_only_log
+            .metadata
+            .sessions
+            .insert("empty-source-only-session".to_string(), record);
+    }
+    let expected_prompts = metadata_only_log.metadata.prompts.clone();
+    let expected_sessions = metadata_only_log.metadata.sessions.clone();
+    assert!(
+        !expected_prompts.is_empty() || !expected_sessions.is_empty(),
+        "test setup requires AI metadata"
+    );
+    let metadata_only_note = metadata_only_log
+        .serialize_to_string()
+        .expect("serialize metadata-only note");
+    repo.git(&[
+        "notes",
+        "--ref=ai",
+        "add",
+        "-f",
+        "-m",
+        &metadata_only_note,
+        &empty_source,
+    ])
+    .expect("attach metadata-only note to empty commit");
+    repo.sync_daemon();
+
+    let anchor_lines = (1..=100)
+        .map(|line| format!("anchor line {line}"))
+        .collect::<Vec<_>>();
+    let mut anchor_file = repo.filename("empty_source_anchor.txt");
+    anchor_file.set_contents(anchor_lines.clone());
+    let anchor_commit = repo
+        .stage_all_and_commit("anchor")
+        .expect("anchor commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    donor_file.assert_lines_and_blame(lines!["donor ai".ai()]);
+    anchor_file.assert_lines_and_blame(anchor_lines.clone());
+
+    let new_anchor =
+        commit_tree_from_existing_tree(&repo, &anchor_commit.commit_sha, &base, "anchor");
+    let old_range = format!("{base}..{}", anchor_commit.commit_sha);
+    let new_range = format!("{base}..{new_anchor}");
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "--no-color",
+            "--no-abbrev",
+            "-s",
+            "--creation-factor=100",
+            &old_range,
+            &new_range,
+        ])
+        .expect("range-diff should succeed");
+    assert!(
+        range_diff
+            .lines()
+            .any(|line| line.contains(&empty_source) && line.contains(" < ")),
+        "empty metadata source must be the leading unmatched commit\n{range_diff}"
+    );
+
+    repo.git(&[
+        "update-ref",
+        "refs/heads/feature",
+        &new_anchor,
+        &anchor_commit.commit_sha,
+    ])
+    .expect("update-ref should succeed");
+    repo.sync_daemon();
+
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    donor_file.assert_lines_and_blame(lines!["donor ai".ai()]);
+    anchor_file.assert_lines_and_blame(anchor_lines);
+    let destination_note = repo
+        .read_authorship_note(&new_anchor)
+        .expect("squash destination should have an authorship note");
+    let destination_log =
+        AuthorshipLog::deserialize_from_string(&destination_note).expect("parse destination note");
+    for prompt_hash in expected_prompts.keys() {
+        assert!(
+            destination_log.metadata.prompts.contains_key(prompt_hash),
+            "prompt metadata from empty squash source was lost"
+        );
+    }
+    for session_hash in expected_sessions.keys() {
+        assert!(
+            destination_log.metadata.sessions.contains_key(session_hash),
+            "session metadata from empty squash source was lost"
+        );
+    }
+}
+
+#[test]
+fn test_update_ref_preserves_squashed_commit_between_matches() {
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+    let base = head_sha(&repo);
+    let mut readme = repo.filename("README.md");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+
+    repo.git(&["checkout", "-b", "feature"])
+        .expect("checkout feature should succeed");
+
+    // Make this patch dominate the following one so range-diff matches it to
+    // the destination commit that squashes both patches together.
+    let anchor_lines = (1..=100)
+        .map(|line| format!("anchor line {line}"))
+        .collect::<Vec<_>>();
+    let mut anchor_file = repo.filename("anchor.txt");
+    anchor_file.set_contents(anchor_lines.clone());
+    let anchor_commit = repo
+        .stage_all_and_commit("anchor")
+        .expect("anchor commit should succeed");
+    readme.assert_lines_and_blame(lines!["# Test Repo".human()]);
+    anchor_file.assert_lines_and_blame(anchor_lines.clone());
+
+    let mut squashed_file = repo.filename("squashed.txt");
+    squashed_file.set_contents(lines!["squashed ai".ai()]);
+    let squashed_commit = repo
+        .stage_all_and_commit("squashed source")
+        .expect("squashed source commit should succeed");
+    anchor_file.assert_lines_and_blame(anchor_lines.clone());
+    squashed_file.assert_lines_and_blame(lines!["squashed ai".ai()]);
+
+    let mut tail_file = repo.filename("tail.txt");
+    tail_file.set_contents(lines!["tail human"]);
+    let tail_commit = repo
+        .stage_all_and_commit("tail")
+        .expect("tail commit should succeed");
+    anchor_file.assert_lines_and_blame(anchor_lines.clone());
+    squashed_file.assert_lines_and_blame(lines!["squashed ai".ai()]);
+    tail_file.assert_lines_and_blame(lines!["tail human".human()]);
+
+    let new_anchor =
+        commit_tree_from_existing_tree(&repo, &squashed_commit.commit_sha, &base, "anchor");
+    let new_tail =
+        commit_tree_from_existing_tree(&repo, &tail_commit.commit_sha, &new_anchor, "tail");
+
+    let old_range = format!("{base}..{}", tail_commit.commit_sha);
+    let new_range = format!("{base}..{new_tail}");
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "--no-color",
+            "--no-abbrev",
+            "-s",
+            "--creation-factor=100",
+            &old_range,
+            &new_range,
+        ])
+        .expect("range-diff should succeed");
+    let range_diff_lines = range_diff.lines().collect::<Vec<_>>();
+    let anchor_match_index = range_diff_lines
+        .iter()
+        .position(|line| line.contains(&anchor_commit.commit_sha) && line.contains(" ! "))
+        .expect("anchor commit should match the first destination commit");
+    let squashed_drop_index = range_diff_lines
+        .iter()
+        .position(|line| line.contains(&squashed_commit.commit_sha) && line.contains(" < "))
+        .expect("squashed source should be unmatched");
+    assert!(
+        anchor_match_index < squashed_drop_index,
+        "squashed source must appear after the first match\n{range_diff}"
+    );
+
+    repo.git(&[
+        "update-ref",
+        "refs/heads/feature",
+        &new_tail,
+        &tail_commit.commit_sha,
+    ])
+    .expect("update-ref should succeed");
+    repo.sync_daemon();
+
+    anchor_file.assert_lines_and_blame(anchor_lines);
+    squashed_file.assert_lines_and_blame(lines!["squashed ai".ai()]);
+    tail_file.assert_lines_and_blame(lines!["tail human".human()]);
+}
+
 /// Test Graphite-style rebase: replay multiple feature commits via commit-tree,
 /// then move the branch with ONE update-ref from old tip to new tip.
 ///

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -9,7 +9,29 @@ use git_ai::commands::install_hooks::{
 };
 use std::collections::HashMap;
 use std::fs;
-use std::process::Command;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+fn output_retrying_executable_file_busy(command: &mut Command) -> std::io::Result<Output> {
+    const MAX_ATTEMPTS: usize = 20;
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match command.output() {
+            Err(error)
+                if error.kind() == std::io::ErrorKind::ExecutableFileBusy
+                    && attempt < MAX_ATTEMPTS =>
+            {
+                // Some Linux CI filesystems briefly retain the writer after a
+                // binary copy completes. Retrying the exec avoids making this
+                // packaging test depend on that filesystem timing.
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            result => return result,
+        }
+    }
+
+    unreachable!("the final attempt always returns")
+}
 
 // ==============================================================================
 // InstallStatus Tests
@@ -253,7 +275,8 @@ fn plain_install_hooks_preserves_the_invoking_user_home() {
         .env("APPDATA", invoking_home.join("AppData").join("Roaming"))
         .env("LOCALAPPDATA", invoking_home.join("AppData").join("Local"));
 
-    let output = command.output().expect("run copied git-ai binary");
+    let output =
+        output_retrying_executable_file_busy(&mut command).expect("run copied git-ai binary");
     assert!(
         output.status.success(),
         "plain install-hooks failed: {}",

--- a/tests/integration/internal_spawn_safety.rs
+++ b/tests/integration/internal_spawn_safety.rs
@@ -219,3 +219,50 @@ fn ref_cursor_does_not_spawn_git_on_trace_ingestion_path() {
         );
     }
 }
+
+#[test]
+fn performance_repro_batches_user_scaled_git_setup() {
+    let script_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("repro_1985.sh");
+    let script = fs::read_to_string(&script_path).expect("read repro_1985.sh");
+
+    let scaled_loop = Regex::new(
+        r#"(?s)for i in \$\(seq [^)]*"\$(STACK_COMMITS|TRUNK_COMMITS|BASE_FILES)"\); do(.*?)\n[ \t]*done"#,
+    )
+    .unwrap();
+    let mut scaled_variables = Vec::new();
+    for captures in scaled_loop.captures_iter(&script) {
+        let variable = captures.get(1).unwrap().as_str();
+        let body = captures.get(2).unwrap().as_str();
+        scaled_variables.push(variable);
+        for git_command in ["qgit ", "tgit ", "gai "] {
+            assert!(
+                !body.contains(git_command),
+                "{variable} loop must prepare or stream batched input, not invoke `{git_command}`"
+            );
+        }
+    }
+    for variable in ["STACK_COMMITS", "TRUNK_COMMITS", "BASE_FILES"] {
+        assert!(
+            scaled_variables.contains(&variable),
+            "expected to inspect at least one {variable} loop"
+        );
+    }
+
+    let note_loop =
+        Regex::new(r#"(?s)while read -r sha; do(.*?)done < "\$(?:ORIG|TRUNK)_COMMITS_FILE""#)
+            .unwrap();
+    let note_loops = note_loop.captures_iter(&script).collect::<Vec<_>>();
+    assert_eq!(note_loops.len(), 2, "expected feature and trunk note loops");
+    for captures in note_loops {
+        let body = captures.get(1).unwrap().as_str();
+        assert!(
+            !body.contains("qgit "),
+            "note loops must stream one fast-import transaction, not invoke Git per note"
+        );
+    }
+
+    assert!(
+        script.matches("qgit fast-import").count() >= 2,
+        "synthetic histories and notes must each use one batched fast-import process"
+    );
+}

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -1,12 +1,50 @@
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::working_log::AgentId;
 use git_ai::daemon::bash_history_db::{BashCallEnd, BashCallStart, BashHistoryDatabase};
+use git_ai::git::repository::{exec_git_stdin, find_repository_in_path};
 
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use serde_json::json;
 use std::collections::{BTreeSet, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const COMMITS_OVER_UNTRUSTED_LEADING_LIMIT: usize = 65;
+const IMPORTED_OLD_UPSTREAM_REF: &str = "refs/heads/old-upstream-import";
+
+fn import_empty_commit_chain(repo: &TestRepo, parent: &str, count: usize) {
+    let mut stream = String::new();
+
+    for commit_number in 1..=count {
+        let message = format!("old upstream empty {commit_number}");
+        let parent = if commit_number == 1 {
+            parent.to_string()
+        } else {
+            format!(":{}", commit_number - 1)
+        };
+        stream.push_str(&format!(
+            "commit {IMPORTED_OLD_UPSTREAM_REF}\n\
+             mark :{commit_number}\n\
+             committer Test <test@example.com> {} +0000\n\
+             data {}\n\
+             {message}\n\
+             from {parent}\n\n",
+            1_000_000_000 + commit_number,
+            message.len(),
+        ));
+    }
+    stream.push_str("done\n");
+
+    let repository =
+        find_repository_in_path(repo.path().to_str().unwrap()).expect("find test repository");
+    let mut args = repository.global_args_for_exec();
+    args.extend([
+        "fast-import".to_string(),
+        "--quiet".to_string(),
+        "--done".to_string(),
+    ]);
+    exec_git_stdin(&args, stream.as_bytes()).expect("batch-import empty old-upstream commits");
+}
 
 /// Helper struct that provides a local repo with an upstream containing seeded commits.
 /// The local repo is initially behind the upstream (no divergence — fast-forward possible).
@@ -1208,6 +1246,173 @@ fn test_pull_rebase_with_conflict_preserves_ai_notes() {
         "Authorship note should reference README.md, got: {}",
         note_content
     );
+}
+
+#[test]
+fn test_conflicted_explicit_pull_rebase_discards_force_pushed_upstream_authorship() {
+    let (local, upstream) = TestRepo::new_with_remote();
+
+    let mut conflict_file = local.filename("conflict.txt");
+    conflict_file.set_contents(crate::lines!["base"]);
+    local
+        .stage_all_and_commit("initial")
+        .expect("initial commit");
+    conflict_file.assert_committed_lines(crate::lines!["base".human()]);
+    let branch = local.current_branch();
+    local
+        .git(&["push", "-u", "origin", "HEAD"])
+        .expect("push initial commit");
+
+    // Keep a second checkout at the immutable root so it can force-push a
+    // divergent upstream without moving the local branch under test.
+    let contributor_parent = tempfile::tempdir().expect("contributor temp dir");
+    let contributor_path = contributor_parent.path().join("contributor");
+    local
+        .git_og(&[
+            "clone",
+            upstream.path().to_str().expect("upstream path utf-8"),
+            contributor_path.to_str().expect("contributor path utf-8"),
+        ])
+        .expect("clone contributor");
+    let contributor =
+        TestRepo::new_at_path_with_daemon_scope(&contributor_path, DaemonTestScope::NoDaemon);
+
+    let mut shared_file = local.filename("shared.txt");
+    shared_file.set_contents(crate::lines!["abandoned upstream".ai()]);
+    let attributed_old_upstream = local
+        .stage_all_and_commit("attributed old upstream")
+        .expect("commit attributed old upstream");
+    conflict_file.assert_committed_lines(crate::lines!["base".human()]);
+    shared_file.assert_committed_lines(crate::lines!["abandoned upstream".ai()]);
+    assert!(
+        local
+            .read_authorship_note(&attributed_old_upstream.commit_sha)
+            .is_some(),
+        "old upstream source must carry authorship for the corruption check"
+    );
+
+    // Construct the rest of the abandoned lineage with one fast-import
+    // process. Together with the attributed commit, this puts the prefix over
+    // the bounded 64-commit ambiguity limit without spawning Git per commit.
+    import_empty_commit_chain(
+        &local,
+        &attributed_old_upstream.commit_sha,
+        COMMITS_OVER_UNTRUSTED_LEADING_LIMIT - 1,
+    );
+    local
+        .git(&["reset", "--hard", IMPORTED_OLD_UPSTREAM_REF])
+        .expect("advance to imported old-upstream tip");
+    conflict_file.assert_committed_lines(crate::lines!["base".human()]);
+    shared_file.assert_committed_lines(crate::lines!["abandoned upstream".ai()]);
+    local
+        .git(&["push", "origin", &format!("HEAD:{branch}")])
+        .expect("push old upstream lineage");
+
+    conflict_file.set_contents(crate::lines!["local feature".ai()]);
+    let local_feature = local
+        .stage_all_and_commit("local feature")
+        .expect("commit local feature");
+    conflict_file.assert_committed_lines(crate::lines!["local feature".ai()]);
+    shared_file.assert_committed_lines(crate::lines!["abandoned upstream".ai()]);
+
+    let mut contributor_shared_file = contributor.filename("shared.txt");
+    std::fs::write(
+        contributor.path().join("shared.txt"),
+        "abandoned upstream\n",
+    )
+    .expect("write divergent human upstream file");
+    let mut contributor_conflict_file = contributor.filename("conflict.txt");
+    std::fs::write(contributor.path().join("conflict.txt"), "remote upstream\n")
+        .expect("write divergent conflict");
+    contributor
+        .git_og(&["add", "-A"])
+        .expect("stage contributor");
+    contributor
+        .git_og(&["commit", "-m", "force-pushed upstream"])
+        .expect("commit divergent upstream");
+    contributor_shared_file.assert_committed_lines(crate::lines!["abandoned upstream".human()]);
+    contributor_conflict_file.assert_committed_lines(crate::lines!["remote upstream".human()]);
+    let new_upstream_tip = contributor
+        .git_og(&["rev-parse", "HEAD"])
+        .expect("resolve new upstream tip")
+        .trim()
+        .to_string();
+    contributor
+        .git_og(&["push", "--force", "origin", &format!("HEAD:{branch}")])
+        .expect("force-push divergent upstream");
+
+    let pull_result = local.git(&["pull", "--rebase", "origin", &branch]);
+    assert!(
+        pull_result.is_err(),
+        "explicit pull --rebase must stop for the conflict"
+    );
+
+    std::fs::write(
+        local.path().join("conflict.txt"),
+        "remote upstream\nlocal feature\n",
+    )
+    .expect("resolve pull-rebase conflict");
+    local
+        .git(&["add", "conflict.txt"])
+        .expect("stage resolution");
+    local
+        .git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .expect("complete conflicted pull rebase");
+
+    let rebased_tip = local
+        .git(&["rev-parse", "HEAD"])
+        .expect("resolve rebased tip")
+        .trim()
+        .to_string();
+    assert_ne!(
+        rebased_tip, local_feature.commit_sha,
+        "the local feature must be rewritten"
+    );
+    assert_eq!(
+        local
+            .git(&["rev-list", "--count", &format!("{new_upstream_tip}..HEAD")])
+            .expect("count rebased local commits")
+            .trim(),
+        "1",
+        "Git must replay only the local feature, not the abandoned upstream lineage"
+    );
+
+    let range_diff = local
+        .git(&[
+            "range-diff",
+            "-s",
+            "--creation-factor=100",
+            &format!("{new_upstream_tip}..{}", local_feature.commit_sha),
+            &format!("{new_upstream_tip}..{rebased_tip}"),
+        ])
+        .expect("range-diff pull rebase");
+    assert!(
+        range_diff
+            .lines()
+            .take_while(|line| !line.contains(" = ") && !line.contains(" ! "))
+            .filter(|line| line.contains(" < "))
+            .count()
+            > 64,
+        "the observed pull checkout must expose an unsafe leading prefix\n{range_diff}"
+    );
+
+    let note = local
+        .read_authorship_note(&rebased_tip)
+        .expect("rebased feature should retain its authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse rebased feature note");
+    assert!(
+        log.attestations
+            .iter()
+            .all(|attestation| attestation.file_path != "shared.txt"),
+        "abandoned upstream authorship must not be copied into the rebased feature note: {:?}",
+        log.attestations
+    );
+
+    shared_file.assert_committed_lines(crate::lines!["abandoned upstream".human()]);
+    conflict_file.assert_committed_lines(crate::lines![
+        "remote upstream".human(),
+        "local feature".human(),
+    ]);
 }
 
 // =============================================================================

--- a/tests/integration/rebase.rs
+++ b/tests/integration/rebase.rs
@@ -1367,6 +1367,91 @@ sed -i.bak '3s/pick/squash/' "$1"
     feature3.assert_lines_and_blame(crate::lines!["// AI feature 3".ai(), "line 3".ai()]);
 }
 
+/// A no-argument rebase has no immutable old-range boundary because Git may
+/// select a reflog-derived fork point. Small leading squash groups are still
+/// legitimate and should retain authorship within the bounded safety limit.
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_implicit_fork_point_rebase_preserves_small_leading_squash() {
+    let repo = TestRepo::new();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base content"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    base_file.assert_committed_lines(crate::lines!["base content".human()]);
+
+    let default_branch = repo.current_branch();
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    repo.git(&["branch", "--set-upstream-to", &default_branch, "feature"])
+        .unwrap();
+
+    let mut first_file = repo.filename("first.txt");
+    first_file.set_contents(crate::lines!["first AI source".ai()]);
+    repo.stage_all_and_commit("First AI source").unwrap();
+    base_file.assert_committed_lines(crate::lines!["base content".human()]);
+    first_file.assert_committed_lines(crate::lines!["first AI source".ai()]);
+
+    let mut second_file = repo.filename("second.txt");
+    second_file.set_contents(crate::lines!["second AI source".ai()]);
+    repo.stage_all_and_commit("Second AI source").unwrap();
+    base_file.assert_committed_lines(crate::lines!["base content".human()]);
+    first_file.assert_committed_lines(crate::lines!["first AI source".ai()]);
+    second_file.assert_committed_lines(crate::lines!["second AI source".ai()]);
+    let old_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    // Reorder the two commits, then squash the original first commit into the
+    // original second commit. Its commit-message match makes the original
+    // first commit a leading `<` source in range-diff.
+    let script_path = repo.path().join("leading_squash_editor.sh");
+    std::fs::write(
+        &script_path,
+        r#"#!/bin/sh
+first="$(sed -n '1p' "$1")"
+second="$(sed -n '2p' "$1")"
+{
+  printf '%s\n' "$second"
+  printf '%s\n' "$first" | sed 's/^pick /squash /'
+} > "$1.tmp"
+mv "$1.tmp" "$1"
+"#,
+    )
+    .unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(&script_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&script_path, permissions).unwrap();
+
+    repo.git_with_env(
+        &["rebase", "-i"],
+        &[
+            ("GIT_SEQUENCE_EDITOR", script_path.to_str().unwrap()),
+            ("GIT_EDITOR", "true"),
+        ],
+        None,
+    )
+    .expect("implicit-fork-point interactive rebase should succeed");
+
+    let new_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "-s",
+            "--creation-factor=100",
+            &format!("{default_branch}..{old_tip}"),
+            &format!("{default_branch}..{new_tip}"),
+        ])
+        .unwrap();
+    let leading_sources = leading_dropped_commits_before_first_match(&range_diff);
+    assert_eq!(
+        leading_sources, 1,
+        "test setup must produce one leading squash source\n{range_diff}"
+    );
+
+    base_file.assert_committed_lines(crate::lines!["base content".human()]);
+    first_file.assert_committed_lines(crate::lines!["first AI source".ai()]);
+    second_file.assert_committed_lines(crate::lines!["second AI source".ai()]);
+}
+
 /// Test rebase with rewording (renaming) a commit that has 2 children commits
 /// Verifies that authorship is preserved for all 3 commits after reword
 #[test]
@@ -2225,6 +2310,7 @@ crate::reuse_tests_in_worktree!(
 crate::reuse_tests_in_worktree_with_attrs!(
     (#[cfg(not(target_os = "windows"))])
     test_rebase_squash_preserves_all_authorship,
+    test_implicit_fork_point_rebase_preserves_small_leading_squash,
     test_rebase_reword_commit_with_children,
     test_rebase_interactive_drop_preserves_attribution,
     test_rebase_squash_preserves_human_attribution,
@@ -2859,7 +2945,7 @@ fn test_rebase_same_file_then_ff_merge_preserves_attribution() {
     ]);
 }
 
-const COMMITS_OVER_PENDING_DROPPED_LIMIT: usize = 200;
+const COMMITS_OVER_PENDING_DROPPED_LIMIT: usize = 65;
 
 fn numbered_file_contents(prefix: &str, count: usize) -> String {
     (1..=count)
@@ -2867,8 +2953,18 @@ fn numbered_file_contents(prefix: &str, count: usize) -> String {
         .collect::<String>()
 }
 
-fn expected_ai_numbered_lines(prefix: &str, count: usize) -> Vec<ExpectedLine> {
-    (1..=count).map(|i| format!("{prefix} {i}").ai()).collect()
+#[cfg(not(target_os = "windows"))]
+fn expected_first_ai_numbered_lines(prefix: &str, count: usize) -> Vec<ExpectedLine> {
+    (1..=count)
+        .map(|i| {
+            let line = format!("{prefix} {i}");
+            if i == 1 {
+                line.ai()
+            } else {
+                line.unattributed_human()
+            }
+        })
+        .collect()
 }
 
 fn leading_dropped_commits_before_first_match(range_diff: &str) -> usize {
@@ -2896,15 +2992,17 @@ fn leading_dropped_commits_before_first_match(range_diff: &str) -> usize {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn test_rebase_more_commits_than_pending_dropped_limit_preserves_authorship() {
     use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
 
     let repo = TestRepo::new();
 
     let mut base_file = repo.filename("base.txt");
     base_file.set_contents(crate::lines!["base"]);
-    repo.stage_all_and_commit("Initial commit").unwrap();
-    let default_branch = repo.current_branch();
+    let base_commit = repo.stage_all_and_commit("Initial commit").unwrap();
 
     repo.git(&["checkout", "-b", "feature"]).unwrap();
     let feature_path = repo.path().join("feature.txt");
@@ -2916,35 +3014,238 @@ fn test_rebase_more_commits_than_pending_dropped_limit_preserves_authorship() {
             numbered_file_contents("ai feature line", commit_number),
         )
         .unwrap();
-        repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
-            .unwrap();
+        if commit_number == 1 {
+            // One attributed source in the leading unmatched group is enough
+            // to prove that the group was preserved. Leaving the other small
+            // commits unattributed keeps this boundary test fast.
+            repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+                .unwrap();
+        }
         repo.git(&["add", "-A"]).unwrap();
         repo.commit(&format!("feature commit {commit_number}"))
             .unwrap();
     }
 
-    repo.git(&["checkout", &default_branch]).unwrap();
-    let mut main_file = repo.filename("main.txt");
-    main_file.set_contents(crate::lines!["main advance".human()]);
-    repo.stage_all_and_commit("Main advances").unwrap();
+    // Make the last commit dominate range-diff's similarity calculation, then
+    // reorder it before the small commits and fixup all of them into it. The
+    // resulting range-diff matches this last commit to the squashed commit and
+    // emits every small commit as a leading `<` entry.
+    let anchor_path = repo.path().join("anchor.txt");
+    fs::write(
+        &anchor_path,
+        numbered_file_contents("dominant anchor line", 1_000),
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "anchor.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.commit("dominant final commit").unwrap();
+    let original_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
 
-    repo.git(&["checkout", "feature"]).unwrap();
-    repo.git(&["rebase", &default_branch]).unwrap();
+    let script_content = r#"#!/bin/sh
+last="$(grep '^pick ' "$1" | tail -n 1)"
+{
+    printf '%s\n' "$last"
+    grep '^pick ' "$1" | sed '$d; s/^pick /fixup /'
+    grep -v '^pick ' "$1"
+} > "$1.tmp"
+mv "$1.tmp" "$1"
+"#;
+    let script_path = repo.path().join("large_squash_sequence_editor.sh");
+    let mut script_file = fs::File::create(&script_path).unwrap();
+    script_file.write_all(script_content.as_bytes()).unwrap();
+    drop(script_file);
+    let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script_path, permissions).unwrap();
 
-    let rebased_commit_count = repo
-        .git(&["rev-list", "--count", &format!("{}..HEAD", default_branch)])
-        .unwrap()
-        .trim()
-        .parse::<usize>()
+    let head_relative_upstream = format!("HEAD~{}", COMMITS_OVER_PENDING_DROPPED_LIMIT + 1);
+    repo.git_with_env(
+        &["rebase", "-i", &head_relative_upstream],
+        &[
+            ("GIT_SEQUENCE_EDITOR", script_path.to_str().unwrap()),
+            ("GIT_EDITOR", "true"),
+        ],
+        None,
+    )
+    .unwrap();
+
+    let squashed_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let old_range = format!("{}..{original_tip}", base_commit.commit_sha);
+    let new_range = format!("{}..{squashed_tip}", base_commit.commit_sha);
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "-s",
+            "--creation-factor=100",
+            &old_range,
+            &new_range,
+        ])
         .unwrap();
     assert_eq!(
-        rebased_commit_count, COMMITS_OVER_PENDING_DROPPED_LIMIT,
-        "rebase should preserve every feature commit, even when the count exceeds the pending-drop limit"
+        leading_dropped_commits_before_first_match(&range_diff),
+        COMMITS_OVER_PENDING_DROPPED_LIMIT,
+        "test setup must produce one leading `<` entry per small commit\n{range_diff}"
     );
-    feature_file.assert_lines_and_blame(expected_ai_numbered_lines(
+    feature_file.assert_lines_and_blame(expected_first_ai_numbered_lines(
         "ai feature line",
         COMMITS_OVER_PENDING_DROPPED_LIMIT,
     ));
+}
+
+#[test]
+fn test_rebase_onto_divergent_base_does_not_map_old_upstream_authorship() {
+    let repo = TestRepo::new();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    base_file.assert_lines_and_blame(crate::lines!["base".human()]);
+    let root = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    repo.git(&["checkout", "-b", "old-upstream"]).unwrap();
+    let mut shared_file = repo.filename("shared.txt");
+    shared_file.set_contents(crate::lines!["shared content".ai()]);
+    repo.stage_all_and_commit("Old upstream").unwrap();
+    base_file.assert_lines_and_blame(crate::lines!["base".human()]);
+    shared_file.assert_lines_and_blame(crate::lines!["shared content".ai()]);
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature_file = repo.filename("feature.txt");
+    feature_file.set_contents(crate::lines!["feature ai".ai()]);
+    repo.stage_all_and_commit("Feature").unwrap();
+    base_file.assert_lines_and_blame(crate::lines!["base".human()]);
+    shared_file.assert_lines_and_blame(crate::lines!["shared content".ai()]);
+    feature_file.assert_lines_and_blame(crate::lines!["feature ai".ai()]);
+
+    repo.git(&["checkout", "-b", "new-base", &root]).unwrap();
+    shared_file.set_contents(crate::lines!["shared content".human()]);
+    repo.stage_all_and_commit("New base").unwrap();
+    base_file.assert_lines_and_blame(crate::lines!["base".human()]);
+    shared_file.assert_lines_and_blame(crate::lines!["shared content".human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", "--onto", "new-base", "old-upstream"])
+        .unwrap();
+
+    base_file.assert_lines_and_blame(crate::lines!["base".human()]);
+    shared_file.assert_lines_and_blame(crate::lines!["shared content".human()]);
+    feature_file.assert_lines_and_blame(crate::lines!["feature ai".ai()]);
+    let rebased_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let note = repo
+        .read_authorship_note(&rebased_tip)
+        .expect("rebased feature should have an authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse rebased feature note");
+    assert!(
+        log.attestations
+            .iter()
+            .all(|attestation| attestation.file_path != "shared.txt"),
+        "old-upstream attribution must not be copied into the rebased feature note: {:?}",
+        log.attestations
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_implicit_fork_point_rebase_discards_divergent_upstream_authorship() {
+    use std::fs;
+
+    let repo = TestRepo::new();
+
+    let mut base_file = repo.filename("base.txt");
+    base_file.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    base_file.assert_committed_lines(crate::lines!["base".human()]);
+    let root = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    repo.git(&["checkout", "-b", "upstream"]).unwrap();
+    let shared_path = repo.path().join("shared.txt");
+    let mut shared_file = repo.filename("shared.txt");
+    for commit_number in 1..=COMMITS_OVER_PENDING_DROPPED_LIMIT {
+        fs::write(
+            &shared_path,
+            numbered_file_contents("shared line", commit_number),
+        )
+        .unwrap();
+        if commit_number == 1 {
+            repo.git_ai(&["checkpoint", "mock_ai", "shared.txt"])
+                .unwrap();
+        }
+        repo.git(&["add", "-A"]).unwrap();
+        repo.commit(&format!("old upstream {commit_number}"))
+            .unwrap();
+        shared_file.assert_committed_lines(expected_first_ai_numbered_lines(
+            "shared line",
+            commit_number,
+        ));
+    }
+    let old_upstream_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let feature_path = repo.path().join("feature.txt");
+    fs::write(&feature_path, "feature ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.commit("feature").unwrap();
+    let old_feature_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    let mut feature_file = repo.filename("feature.txt");
+    shared_file.assert_committed_lines(expected_first_ai_numbered_lines(
+        "shared line",
+        COMMITS_OVER_PENDING_DROPPED_LIMIT,
+    ));
+    feature_file.assert_committed_lines(crate::lines!["feature ai".ai()]);
+    repo.git(&["branch", "--set-upstream-to=upstream", "feature"])
+        .unwrap();
+
+    // Force-rewrite the configured upstream onto divergent history. Its reflog
+    // retains old_upstream_tip, so no-argument `git rebase` implicitly chooses
+    // that old tip via fork-point even though it checks out the new tip.
+    repo.git(&["checkout", "upstream"]).unwrap();
+    repo.git(&["reset", "--hard", &root]).unwrap();
+    fs::write(
+        &shared_path,
+        numbered_file_contents("shared line", COMMITS_OVER_PENDING_DROPPED_LIMIT),
+    )
+    .unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "shared.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+    repo.commit("divergent upstream").unwrap();
+    let new_upstream_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    shared_file.assert_committed_lines(
+        (1..=COMMITS_OVER_PENDING_DROPPED_LIMIT)
+            .map(|i| format!("shared line {i}").human())
+            .collect(),
+    );
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase"]).unwrap();
+    let rebased_feature_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    let range_diff = repo
+        .git(&[
+            "range-diff",
+            "-s",
+            "--creation-factor=100",
+            &format!("{new_upstream_tip}..{old_feature_tip}"),
+            &format!("{new_upstream_tip}..{rebased_feature_tip}"),
+        ])
+        .unwrap();
+    assert!(
+        leading_dropped_commits_before_first_match(&range_diff) > 64,
+        "the observed checkout boundary must expose the divergent upstream prefix\n{range_diff}"
+    );
+    assert_ne!(
+        old_upstream_tip, new_upstream_tip,
+        "test setup must force-rewrite the configured upstream"
+    );
+    shared_file.assert_committed_lines(
+        (1..=COMMITS_OVER_PENDING_DROPPED_LIMIT)
+            .map(|i| format!("shared line {i}").human())
+            .collect(),
+    );
+    feature_file.assert_committed_lines(crate::lines!["feature ai".ai()]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Preserve genuine leading squash-source authorship for generic `update-ref` / non-fast-forward rewrites up to the historical 64-commit safety boundary, including edited and empty metadata-only sources.
- Preserve arbitrarily large leading squash groups only when a trace2-observed rebase provides an immutable old-range boundary.
- Discard the leading prefix for ambiguous rebases and groups larger than 64 on generic ref moves, so divergent restack-undo history never reaches note reads or diff-tree work.
- Keep the historical unbounded behavior for `<` entries after the first confirmed match; those are established between-match squash sources.
- Bound downstream memory and platform argument usage by deserializing source notes lazily, deduplicating target-note parsing, and feeding tree/merge-parent batches to one Git process over stdin.
- Update `repro_1985.sh` to use this checkout's `target/debug/git-ai` by default and assert that the divergent prefix is discarded.

## Correctness model

A rebase may preserve every leading source only when its old range is immutable and scoped to the operation. The daemon derives that boundary without reading mutable repository state at processing time:

- full upstream OIDs are already immutable;
- `HEAD` / `@` parent-ancestry expressions are anchored to the trace2/reflog-captured original tip;
- standard named rebases use the exact cursor-bounded checkout OID when there is no explicit `--onto`;
- explicit `--fork-point`, `--root`, mutable old boundaries used with `--onto`, and other ambiguous forms fail closed to leading-prefix discard.

Generic ref moves do not have equivalent provenance. They retain the old <=64 behavior for real Graphite/update-ref squashes, while the 65th leading unmatched source discards the whole group. Once range-diff establishes a real pair, later unmatched sources keep mapping to the preceding destination as before.

All boundary capture is pure trace2/reflog-derived parsing. This adds no Git spawn, object lookup, ref lookup, or file read to the critical ingestion path. Rewrite processing remains constant-spawn; the large batches changed here use stdin instead of argv.

## Regression coverage

- Graphite-style `commit-tree` + `update-ref` leading squash
- edited leading squash source
- metadata-only empty leading source
- exact 64/65 generic boundary
- 65-source interactive rebase using an immutable `HEAD~N` boundary
- divergent named `rebase --onto` that must not copy old-upstream authorship
- 65-commit restack undo
- arbitrarily large post-match squash group
- 2,048-item tree and merge-parent stdin batches
- streaming merge across the chunk boundary

## Validation

- `task build`
- `task fmt`
- `task lint`
- `task test` (2,120 unit tests; 3,250 integration tests passed, 85 intentionally ignored; doctests passed)
- full `commit_tree_update_ref` test binary
- focused rebase/restack regression matrix after restacking onto current `main`
- `bash -n repro_1985.sh`
- `SCALE=small ./repro_1985.sh` (150 divergent commits -> 4 real mappings; flat daemon RSS)