### PR TITLE
Stream Git notes fast-import writes

### DIFF
--- a/src/authorship/git_ai_hooks.rs
+++ b/src/authorship/git_ai_hooks.rs
@@ -25,7 +25,20 @@ struct RepoHookContext {
 /// Commands are started in parallel, and we wait up to 3 seconds for completion before
 /// detaching and continuing so git-ai does not block.
 pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
-    if notes.is_empty() {
+    post_notes_updated_refs(
+        repo,
+        notes
+            .iter()
+            .map(|(commit_sha, note_content)| (commit_sha.as_str(), note_content.as_str())),
+    );
+}
+
+pub(crate) fn post_notes_updated_refs<'a>(
+    repo: &Repository,
+    notes: impl IntoIterator<Item = (&'a str, &'a str)>,
+) {
+    let mut notes = notes.into_iter().peekable();
+    if notes.peek().is_none() {
         return;
     }
 
@@ -43,7 +56,6 @@ pub fn post_notes_updated(repo: &Repository, notes: &[(String, String)]) {
     let branch = context.branch;
     let is_default_branch = context.is_default_branch;
     let payload = notes
-        .iter()
         .map(|(commit_sha, note_content)| {
             serde_json::json!({
                 "commit_sha": commit_sha,

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -1,9 +1,12 @@
 use crate::authorship::authorship_log_serialization::{AUTHORSHIP_LOG_VERSION, AuthorshipLog};
 use crate::authorship::working_log::Checkpoint;
 use crate::error::GitAiError;
-use crate::git::repository::{Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin};
+use crate::git::repository::{
+    Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin, exec_git_with_stdin_writer,
+};
 use serde_json;
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 
 // Modern refspecs without force to enable proper merging
 pub const AI_AUTHORSHIP_REFNAME: &str = "ai";
@@ -54,23 +57,48 @@ fn normalize_note_path(path: &mut String) -> Option<usize> {
     (valid && component_len > 0).then_some(fanout_depth)
 }
 
-fn append_note_deletions(script: &mut Vec<u8>, oid: &str) {
-    // Write directly into the fast-import buffer; constructing every path as a
-    // separate String would add 20 allocations for SHA-1 and 32 for SHA-256.
+fn write_note_deletions(writer: &mut (impl Write + ?Sized), oid: &str) -> std::io::Result<()> {
+    // Emit each path directly into fast-import's bounded stdin buffer. Building
+    // one script would retain 20 paths per SHA-1 note and 32 per SHA-256 note.
     let oid = oid.as_bytes();
-    script.extend_from_slice(b"D ");
-    script.extend_from_slice(oid);
-    script.push(b'\n');
+    writer.write_all(b"D ")?;
+    writer.write_all(oid)?;
+    writer.write_all(b"\n")?;
 
     for prefix_end in (2..oid.len()).step_by(2) {
-        script.extend_from_slice(b"D ");
+        writer.write_all(b"D ")?;
         for component_start in (0..prefix_end).step_by(2) {
-            script.extend_from_slice(&oid[component_start..component_start + 2]);
-            script.push(b'/');
+            writer.write_all(&oid[component_start..component_start + 2])?;
+            writer.write_all(b"/")?;
         }
-        script.extend_from_slice(&oid[prefix_end..]);
-        script.push(b'\n');
+        writer.write_all(&oid[prefix_end..])?;
+        writer.write_all(b"\n")?;
     }
+
+    Ok(())
+}
+
+fn write_note_path(writer: &mut (impl Write + ?Sized), oid: &str) -> std::io::Result<()> {
+    if oid.len() <= 2 {
+        writer.write_all(oid.as_bytes())
+    } else {
+        let oid = oid.as_bytes();
+        writer.write_all(&oid[..2])?;
+        writer.write_all(b"/")?;
+        writer.write_all(&oid[2..])
+    }
+}
+
+fn dedupe_note_entries(entries: &[(String, String)]) -> Vec<&(String, String)> {
+    let mut deduped_entries = Vec::with_capacity(entries.len());
+    let mut seen = HashSet::with_capacity(entries.len());
+    for entry in entries.iter().rev() {
+        if seen.insert(entry.0.as_str()) {
+            deduped_entries.push(entry);
+        }
+    }
+    deduped_entries.reverse();
+    deduped_entries
 }
 
 #[doc(hidden)]
@@ -440,49 +468,48 @@ pub(in crate::git) fn notes_add_batch(
         Err(e) => return Err(e),
     };
 
-    let mut deduped_entries: Vec<(String, String)> = Vec::new();
-    let mut seen = HashSet::new();
-    for (commit_sha, note_content) in entries.iter().rev() {
-        if seen.insert(commit_sha.as_str()) {
-            deduped_entries.push((commit_sha.clone(), note_content.clone()));
-        }
-    }
-    deduped_entries.reverse();
+    let deduped_entries = dedupe_note_entries(entries);
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
         .as_secs();
 
-    let mut script = Vec::<u8>::new();
-
-    for (idx, (_commit_sha, note_content)) in deduped_entries.iter().enumerate() {
-        script.extend_from_slice(b"blob\n");
-        script.extend_from_slice(format!("mark :{}\n", idx + 1).as_bytes());
-        script.extend_from_slice(format!("data {}\n", note_content.len()).as_bytes());
-        script.extend_from_slice(note_content.as_bytes());
-        script.extend_from_slice(b"\n");
-    }
-
-    script.extend_from_slice(b"commit refs/notes/ai\n");
-    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
-    script.extend_from_slice(b"data 0\n");
-    if let Some(existing_tip) = existing_notes_tip {
-        script.extend_from_slice(format!("from {}\n", existing_tip).as_bytes());
-    }
-
-    for (idx, (commit_sha, _note_content)) in deduped_entries.iter().enumerate() {
-        let fanout_path = notes_path_for_object(commit_sha);
-        append_note_deletions(&mut script, commit_sha);
-        script.extend_from_slice(format!("M 100644 :{} {}\n", idx + 1, fanout_path).as_bytes());
-    }
-    script.extend_from_slice(b"\n");
-
     let mut fast_import_args = repo.global_args_for_exec();
     fast_import_args.push("fast-import".to_string());
     fast_import_args.push("--quiet".to_string());
-    exec_git_stdin(&fast_import_args, &script)?;
-    crate::authorship::git_ai_hooks::post_notes_updated(repo, &deduped_entries);
+    exec_git_with_stdin_writer(&fast_import_args, |writer| {
+        for (idx, entry) in deduped_entries.iter().enumerate() {
+            let note_content = &entry.1;
+            writer.write_all(b"blob\n")?;
+            writeln!(writer, "mark :{}", idx + 1)?;
+            writeln!(writer, "data {}", note_content.len())?;
+            writer.write_all(note_content.as_bytes())?;
+            writer.write_all(b"\n")?;
+        }
+
+        writer.write_all(b"commit refs/notes/ai\n")?;
+        writeln!(writer, "committer git-ai <git-ai@local> {} +0000", now)?;
+        writer.write_all(b"data 0\n")?;
+        if let Some(existing_tip) = existing_notes_tip.as_deref() {
+            writeln!(writer, "from {}", existing_tip)?;
+        }
+
+        for (idx, entry) in deduped_entries.iter().enumerate() {
+            let commit_sha = &entry.0;
+            write_note_deletions(writer, commit_sha)?;
+            write!(writer, "M 100644 :{} ", idx + 1)?;
+            write_note_path(writer, commit_sha)?;
+            writer.write_all(b"\n")?;
+        }
+        writer.write_all(b"\n")
+    })?;
+    crate::authorship::git_ai_hooks::post_notes_updated_refs(
+        repo,
+        deduped_entries
+            .iter()
+            .map(|entry| (entry.0.as_str(), entry.1.as_str())),
+    );
 
     Ok(())
 }
@@ -512,39 +539,33 @@ pub(in crate::git) fn notes_add_blob_batch(
         Err(e) => return Err(e),
     };
 
-    let mut deduped_entries: Vec<(String, String)> = Vec::new();
-    let mut seen = HashSet::new();
-    for (commit_sha, blob_oid) in entries.iter().rev() {
-        if seen.insert(commit_sha.as_str()) {
-            deduped_entries.push((commit_sha.clone(), blob_oid.clone()));
-        }
-    }
-    deduped_entries.reverse();
+    let deduped_entries = dedupe_note_entries(entries);
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| GitAiError::Generic(format!("System clock before epoch: {}", e)))?
         .as_secs();
 
-    let mut script = Vec::<u8>::new();
-    script.extend_from_slice(b"commit refs/notes/ai\n");
-    script.extend_from_slice(format!("committer git-ai <git-ai@local> {} +0000\n", now).as_bytes());
-    script.extend_from_slice(b"data 0\n");
-    if let Some(existing_tip) = existing_notes_tip {
-        script.extend_from_slice(format!("from {}\n", existing_tip).as_bytes());
-    }
-
-    for (commit_sha, blob_oid) in &deduped_entries {
-        let fanout_path = notes_path_for_object(commit_sha);
-        append_note_deletions(&mut script, commit_sha);
-        script.extend_from_slice(format!("M 100644 {} {}\n", blob_oid, fanout_path).as_bytes());
-    }
-    script.extend_from_slice(b"\n");
-
     let mut fast_import_args = repo.global_args_for_exec();
     fast_import_args.push("fast-import".to_string());
     fast_import_args.push("--quiet".to_string());
-    exec_git_stdin(&fast_import_args, &script)?;
+    exec_git_with_stdin_writer(&fast_import_args, |writer| {
+        writer.write_all(b"commit refs/notes/ai\n")?;
+        writeln!(writer, "committer git-ai <git-ai@local> {} +0000", now)?;
+        writer.write_all(b"data 0\n")?;
+        if let Some(existing_tip) = existing_notes_tip.as_deref() {
+            writeln!(writer, "from {}", existing_tip)?;
+        }
+
+        for entry in &deduped_entries {
+            let (commit_sha, blob_oid) = entry;
+            write_note_deletions(writer, commit_sha)?;
+            write!(writer, "M 100644 {} ", blob_oid)?;
+            write_note_path(writer, commit_sha)?;
+            writer.write_all(b"\n")?;
+        }
+        writer.write_all(b"\n")
+    })?;
 
     let has_post_notes_updated_hooks = crate::config::Config::get()
         .git_ai_hook_commands("post_notes_updated")
@@ -1086,6 +1107,24 @@ pub mod git_backend_for_tests {
 mod tests {
     use super::*;
 
+    #[derive(Default)]
+    struct CountingWriter {
+        bytes_written: usize,
+        max_write_len: usize,
+    }
+
+    impl std::io::Write for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.bytes_written += buf.len();
+            self.max_write_len = self.max_write_len.max(buf.len());
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_parse_batch_check_blob_oid_accepts_sha1_and_sha256() {
         let sha1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa blob 10";
@@ -1125,17 +1164,35 @@ mod tests {
     }
 
     #[test]
-    fn test_append_note_deletions_includes_every_fanout_depth() {
+    fn test_write_note_deletions_includes_every_fanout_depth() {
         let mut short_script = Vec::new();
-        append_note_deletions(&mut short_script, "a");
-        append_note_deletions(&mut short_script, "ab");
+        write_note_deletions(&mut short_script, "a").unwrap();
+        write_note_deletions(&mut short_script, "ab").unwrap();
         assert_eq!(String::from_utf8(short_script).unwrap(), "D a\nD ab\n");
 
         let mut script = Vec::new();
-        append_note_deletions(&mut script, "abcdef");
+        write_note_deletions(&mut script, "abcdef").unwrap();
         assert_eq!(
             String::from_utf8(script).unwrap(),
             "D abcdef\nD ab/cdef\nD ab/cd/ef\n"
+        );
+    }
+
+    #[test]
+    fn test_write_note_deletions_keeps_large_batches_streaming() {
+        const NOTE_COUNT: usize = 100_000;
+        const SHA256_DELETION_BYTES: usize = 2_640;
+
+        let oid = "ab".repeat(32);
+        let mut writer = CountingWriter::default();
+        for _ in 0..NOTE_COUNT {
+            write_note_deletions(&mut writer, &oid).unwrap();
+        }
+
+        assert_eq!(writer.bytes_written, NOTE_COUNT * SHA256_DELETION_BYTES);
+        assert!(
+            writer.max_write_len <= oid.len(),
+            "fanout deletion output must be written incrementally"
         );
     }
 

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2845,10 +2845,7 @@ pub fn exec_git_stdin(args: &[String], stdin_data: &[u8]) -> Result<Output, GitA
 /// prevents it from consuming more stdin, which would block our write_all.
 type StdinWriterHandle = std::thread::JoinHandle<std::io::Result<()>>;
 
-fn spawn_git_stdin_piped(
-    effective_args: &[String],
-    stdin_data: &[u8],
-) -> Result<(Child, Option<StdinWriterHandle>), GitAiError> {
+fn spawn_git_piped(effective_args: &[String]) -> Result<Child, GitAiError> {
     spawn_probe_log(effective_args);
     let mut cmd = Command::new(config::Config::get().git_cmd());
     cmd.args(effective_args)
@@ -2864,8 +2861,14 @@ fn spawn_git_stdin_piped(
         }
     }
 
-    let mut child = cmd.spawn().map_err(GitAiError::IoError)?;
+    cmd.spawn().map_err(GitAiError::IoError)
+}
 
+fn spawn_git_stdin_piped(
+    effective_args: &[String],
+    stdin_data: &[u8],
+) -> Result<(Child, Option<StdinWriterHandle>), GitAiError> {
+    let mut child = spawn_git_piped(effective_args)?;
     let stdin_handle = child.stdin.take().map(|mut stdin| {
         let data = stdin_data.to_vec();
         std::thread::spawn(move || {
@@ -2875,6 +2878,53 @@ fn spawn_git_stdin_piped(
     });
 
     Ok((child, stdin_handle))
+}
+
+/// Execute a git command while producing its stdin incrementally.
+///
+/// The producer runs on a scoped thread so it may borrow caller-owned data
+/// without copying it. A bounded buffer amortizes writes while stdout and
+/// stderr are drained concurrently by `wait_with_output`.
+pub(crate) fn exec_git_with_stdin_writer(
+    args: &[String],
+    write_stdin: impl FnOnce(&mut dyn std::io::Write) -> std::io::Result<()> + Send,
+) -> Result<Output, GitAiError> {
+    let effective_args = args_with_internal_git_profile(
+        &args_with_disabled_hooks_if_needed(args),
+        InternalGitProfile::General,
+    );
+    let mut child = spawn_git_piped(&effective_args)?;
+    let stdin = child.stdin.take().expect("git child stdin is piped");
+
+    let (output, stdin_result) = std::thread::scope(|scope| {
+        let stdin_handle = scope.spawn(move || {
+            use std::io::Write;
+
+            let mut stdin = std::io::BufWriter::new(stdin);
+            write_stdin(&mut stdin)?;
+            stdin.flush()
+        });
+        let output = child.wait_with_output();
+        let stdin_result = stdin_handle.join().expect("stdin writer thread panicked");
+        (output, stdin_result)
+    });
+    let output = output.map_err(GitAiError::IoError)?;
+
+    if let Err(e) = stdin_result
+        && e.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(GitAiError::IoError(e));
+    }
+
+    if !output.status.success() {
+        return Err(GitAiError::GitCliError {
+            code: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            args: effective_args,
+        });
+    }
+
+    Ok(output)
 }
 
 /// Like `exec_git_stdin`, but streams the child's stdout to `on_line` one line

--- a/tests/integration/refs_unit.rs
+++ b/tests/integration/refs_unit.rs
@@ -143,6 +143,24 @@ fn test_notes_add_batch_writes_multiple_notes() {
 }
 
 #[test]
+fn test_notes_add_batch_keeps_last_duplicate_entry() {
+    let (repo, gitai_repo) = repo_with_handle();
+
+    fs::write(repo.path().join("duplicate.txt"), "duplicate\n").unwrap();
+    repo.stage_all_and_commit("Duplicate note target")
+        .expect("commit duplicate note target");
+    let commit_sha = head_sha(&repo);
+
+    let entries = vec![
+        (commit_sha.clone(), "first".to_string()),
+        (commit_sha.clone(), "last".to_string()),
+    ];
+    notes_add_batch(&gitai_repo, &entries).expect("write duplicate batch");
+
+    assert_eq!(read_note(&gitai_repo, &commit_sha).as_deref(), Some("last"));
+}
+
+#[test]
 fn test_notes_add_batch_replaces_notes_at_every_legacy_fanout_depth() {
     let (repo, gitai_repo) = repo_with_handle();
 


### PR DESCRIPTION
Follow-up to #1908.

## Summary

- stream the Git notes fast-import protocol through a bounded stdin buffer
- borrow deduplicated batch entries instead of cloning note contents
- preserve one fast-import process per batch and cleanup across every legacy fanout depth
- retain last-entry-wins behavior for duplicate commit IDs

## Memory impact

For 100,000 notes, this removes the generated deletion script and its writer-thread copy: about 200 MiB for SHA-1 or 504 MiB for SHA-256, before accounting for note contents and the rest of the protocol. Generated fast-import input is now constant-memory.

## Test coverage

- bounded-write regression test over 100,000 SHA-256 notes
- TestRepo integration coverage for duplicate-entry semantics
- existing all-fanout-depth integration tests for both batch paths
- full task test
- task lint
- task fmt