### PR TITLE
Test mock agent usage throttle short-circuit

### DIFF
--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -72,8 +72,15 @@ fn should_emit_real_agent_usage(_agent_id: &AgentId) -> bool {
     false
 }
 
-pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
+fn should_emit_agent_usage_with_throttle(
+    agent_id: &AgentId,
+    should_emit_real_agent_usage: impl FnOnce(&AgentId) -> bool,
+) -> bool {
     agent_id.tool != "mock_ai" && should_emit_real_agent_usage(agent_id)
+}
+
+pub(crate) fn should_emit_agent_usage(agent_id: &AgentId) -> bool {
+    should_emit_agent_usage_with_throttle(agent_id, should_emit_real_agent_usage)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1124,12 +1131,17 @@ mod tests {
 
     #[test]
     fn mock_ai_skips_agent_usage_throttle() {
-        let agent_id = AgentId {
+        let mut agent_id = AgentId {
             tool: "mock_ai".to_string(),
             id: "debug-self-check".to_string(),
             model: "unknown".to_string(),
         };
 
-        assert!(!should_emit_agent_usage(&agent_id));
+        assert!(!should_emit_agent_usage_with_throttle(&agent_id, |_| {
+            panic!("mock checkpoints must not evaluate the real throttle")
+        }));
+
+        agent_id.tool = "claude".to_string();
+        assert!(should_emit_agent_usage_with_throttle(&agent_id, |_| true));
     }
 }


### PR DESCRIPTION
## Summary

- make the `mock_ai` agent-usage short-circuit independently testable without relying on the test-build throttle stub
- verify mock checkpoints never evaluate the real throttle callback
- verify non-mock checkpoints still defer to the real throttle decision

## Context

Follow-up to #1944 for the late Devin review finding that `mock_ai_skips_agent_usage_throttle` was tautological in test builds. The production behavior is unchanged; this makes the existing short-circuit regression-proof.

## Validation

- `task test TEST_FILTER=mock_ai_skips_agent_usage_throttle`
- `task test TEST_FILTER=attribution_self_checks_do_not_timeout`
- `task test`
- `task build`
- `task lint`
- `task fmt`