### PR TITLE
Preserve remote target notes during rewrites

### DIFF
--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -416,10 +416,10 @@ pub(crate) fn handle_rewrite_event_with_metrics(
             if mappings.is_empty() {
                 return Ok(RewriteOutcome::empty());
             }
-            let source_shas: Vec<String> = mappings.iter().map(|(src, _)| src.clone()).collect();
+            let mapped_shas = unique_pair_shas(&mappings);
             crate::git::sync_authorship::fetch_missing_notes_for_commits_best_effort(
                 repo,
-                &source_shas,
+                &mapped_shas,
             );
             let shifted_notes =
                 shift_authorship_notes_merging_existing_with_notes(repo, &mappings)?;
@@ -462,8 +462,10 @@ pub(crate) fn handle_non_fast_forward_rewrite_with_operation(
     if mappings.is_empty() {
         return Ok(RewriteOutcome::empty());
     }
-    let source_shas: Vec<String> = mappings.iter().map(|(src, _)| src.clone()).collect();
-    crate::git::sync_authorship::fetch_missing_notes_for_commits_best_effort(repo, &source_shas);
+    // A force-pushed target can already have an authoritative remote note that
+    // must be present before we merge the shifted source note into it.
+    let mapped_shas = unique_pair_shas(&mappings);
+    crate::git::sync_authorship::fetch_missing_notes_for_commits_best_effort(repo, &mapped_shas);
     let shifted_notes = shift_authorship_notes_merging_existing_with_notes(repo, &mappings)?;
     if !rewrite_metrics_enabled() {
         return Ok(RewriteOutcome::empty());

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log::LineRange;
 use git_ai::authorship::authorship_log::PromptRecord;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::working_log::AgentId;
@@ -829,6 +830,136 @@ fn test_cherry_pick_from_remote_without_prefetched_notes() {
 }
 
 #[test]
+fn test_cherry_pick_preserves_authoritative_remote_target_note() {
+    let (repo, upstream) = TestRepo::new_with_remote();
+    let file_path = repo.path().join("file.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    let base_commit = repo.stage_all_and_commit("initial").unwrap();
+    let main_branch = repo.current_branch();
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    repo.git_ai(&["checkpoint", "human", "file.txt"]).unwrap();
+    fs::write(&file_path, "base\nold AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "file.txt"]).unwrap();
+    fs::write(&file_path, "base\nold AI line\nremote AI line\n").unwrap();
+    let source_commit = repo.stage_all_and_commit("feature").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "old AI line".ai(),
+        "remote AI line".ai(),
+    ]);
+    let source_note = repo
+        .read_authorship_note(&source_commit.commit_sha)
+        .expect("source note should exist locally");
+    let mut source_log =
+        AuthorshipLog::deserialize_from_string(&source_note).expect("parse source note");
+    let source_attestation = source_log
+        .attestations
+        .iter_mut()
+        .find(|file_attestation| file_attestation.file_path == "file.txt")
+        .expect("source note should contain file.txt");
+    for entry in &mut source_attestation.entries {
+        entry.remove_line_ranges(&[LineRange::Single(3)]);
+    }
+    source_attestation
+        .entries
+        .retain(|entry| !entry.line_ranges.is_empty());
+    assert!(
+        source_attestation
+            .entries
+            .iter()
+            .all(|entry| entry.line_ranges.iter().all(|range| !range.contains(3))),
+        "stale source note should not attribute the remote-only line"
+    );
+    let source_note = source_log
+        .serialize_to_string()
+        .expect("serialize stale source note");
+    let git_ai_repo = git_ai::git::find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("find repository");
+    write_note(&git_ai_repo, &source_commit.commit_sha, &source_note)
+        .expect("write stale source note");
+
+    repo.git_og(&["push", "origin", "feature"]).unwrap();
+    repo.git_og(&["push", "origin", "refs/notes/ai:refs/notes/ai"])
+        .unwrap();
+    let source_notes_ref = repo.git_og(&["rev-parse", "refs/notes/ai"]).unwrap();
+    let source_notes_ref = source_notes_ref.trim();
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    let deterministic_date = "2030-01-03T00:00:00Z";
+    repo.git_og_with_env(
+        &["cherry-pick", &source_commit.commit_sha],
+        &[("GIT_COMMITTER_DATE", deterministic_date)],
+    )
+    .unwrap();
+    let target_commit = repo.git_og(&["rev-parse", "HEAD"]).unwrap();
+    let target_commit = target_commit.trim();
+
+    let mut target_log =
+        AuthorshipLog::deserialize_from_string(&source_note).expect("parse source note");
+    target_log.metadata.base_commit_sha = target_commit.to_string();
+    let target_entry = target_log
+        .attestations
+        .iter_mut()
+        .find(|file_attestation| file_attestation.file_path == "file.txt")
+        .and_then(|file_attestation| {
+            file_attestation
+                .entries
+                .iter_mut()
+                .find(|entry| entry.line_ranges.iter().any(|range| range.contains(2)))
+        })
+        .expect("source note should attribute the old AI line");
+    target_entry.line_ranges.push(LineRange::Single(3));
+    let target_note = target_log
+        .serialize_to_string()
+        .expect("serialize authoritative target note");
+    write_note(&git_ai_repo, target_commit, &target_note).expect("write authoritative target note");
+    repo.git_og(&["push", "--force", "origin", "refs/notes/ai:refs/notes/ai"])
+        .unwrap();
+
+    repo.git_og(&["reset", "--hard", &base_commit.commit_sha])
+        .unwrap();
+    repo.git_og(&["update-ref", "refs/notes/ai", source_notes_ref])
+        .unwrap();
+    repo.git_og(&["update-ref", "-d", "refs/notes/ai-remote/origin"])
+        .unwrap();
+
+    assert!(
+        repo.read_authorship_note(&source_commit.commit_sha)
+            .is_some(),
+        "precondition: stale source note should already exist locally"
+    );
+    assert!(
+        upstream.read_authorship_note(target_commit).is_some(),
+        "precondition: authoritative target note should exist remotely"
+    );
+    assert!(
+        repo.read_authorship_note(target_commit).is_none(),
+        "precondition: target note should not exist locally"
+    );
+
+    repo.git_with_env(
+        &["cherry-pick", &source_commit.commit_sha],
+        &[("GIT_COMMITTER_DATE", deterministic_date)],
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        repo.git(&["rev-parse", "HEAD"]).unwrap().trim(),
+        target_commit,
+        "deterministic cherry-pick should recreate the remotely noted target"
+    );
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "old AI line".ai(),
+        "remote AI line".ai(),
+    ]);
+}
+
+#[test]
 fn test_cherry_pick_local_remote_tracking_ref_missing_from_daemon_snapshot() {
     let repo = TestRepo::new();
     let mut file = repo.filename("file.txt");
@@ -1304,6 +1435,7 @@ crate::reuse_tests_in_worktree!(
     test_cherry_pick_bad_args_dont_corrupt_subsequent_attribution,
     test_cherry_pick_skip_preserves_subsequent_attribution,
     test_cherry_pick_from_remote_without_prefetched_notes,
+    test_cherry_pick_preserves_authoritative_remote_target_note,
     test_cherry_pick_from_remote_continues_when_notes_import_fails,
     test_cherry_pick_no_commit_defers_to_final_commit_tree,
     test_cherry_pick_skip_failed_next_conflict_advances_pending_remote_tracking_source,

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -539,6 +539,104 @@ fn test_pull_rebase_preserves_committed_ai_authorship() {
 }
 
 #[test]
+fn test_pull_rebase_force_pushed_target_preserves_remote_authorship_note() {
+    // Model a clone that still has an old PR head while another clone force-pushes
+    // a rewritten head with its own complete authorship note. Pull processes the
+    // non-fast-forward branch update before its post-pull notes fetch, so rewrite
+    // handling must fetch the target note before shifting the stale source note.
+    let (local, upstream) = TestRepo::new_with_remote();
+    let file_path = local.path().join("feature.txt");
+
+    std::fs::write(&file_path, "base\n").unwrap();
+    local.stage_all_and_commit("initial").unwrap();
+    let mut local_file = local.filename("feature.txt");
+    local_file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    local
+        .git_ai(&["checkpoint", "human", "feature.txt"])
+        .unwrap();
+    std::fs::write(&file_path, "base\nold AI line\n").unwrap();
+    local
+        .git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+        .unwrap();
+    let old_commit = local.stage_all_and_commit("old feature version").unwrap();
+    local_file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "old AI line".ai(),
+    ]);
+    local.git(&["push", "-u", "origin", "main"]).unwrap();
+
+    let contributor_parent = tempfile::tempdir().expect("contributor temp dir");
+    let contributor_path = contributor_parent.path().join("contributor");
+    local
+        .git_og(&[
+            "clone",
+            upstream.path().to_str().unwrap(),
+            contributor_path.to_str().unwrap(),
+        ])
+        .unwrap();
+    let contributor =
+        TestRepo::new_at_path_with_daemon_scope(&contributor_path, DaemonTestScope::Shared);
+    contributor
+        .git(&["reset", "--hard", &format!("{}^", old_commit.commit_sha)])
+        .unwrap();
+
+    let contributor_file_path = contributor.path().join("feature.txt");
+    contributor
+        .git_ai(&["checkpoint", "human", "feature.txt"])
+        .unwrap();
+    std::fs::write(
+        &contributor_file_path,
+        "base\nold AI line\nremote AI line\n",
+    )
+    .unwrap();
+    contributor
+        .git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+        .unwrap();
+    let remote_commit = contributor
+        .stage_all_and_commit("force-pushed feature version")
+        .unwrap();
+    let mut contributor_file = contributor.filename("feature.txt");
+    contributor_file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "old AI line".ai(),
+        "remote AI line".ai(),
+    ]);
+
+    contributor
+        .git(&["push", "--force", "origin", "HEAD:main"])
+        .unwrap();
+    contributor
+        .git_og(&["push", "--force", "origin", "refs/notes/ai:refs/notes/ai"])
+        .unwrap();
+
+    assert!(
+        upstream
+            .read_authorship_note(&remote_commit.commit_sha)
+            .is_some(),
+        "precondition: force-pushed target note must exist on the remote"
+    );
+    assert!(
+        local
+            .read_authorship_note(&remote_commit.commit_sha)
+            .is_none(),
+        "precondition: local clone must not have fetched the force-pushed target note"
+    );
+
+    local.git(&["pull", "--rebase"]).unwrap();
+    assert_eq!(
+        local.git(&["rev-parse", "HEAD"]).unwrap().trim(),
+        remote_commit.commit_sha,
+        "pull should accept the force-pushed remote target without replaying a local commit"
+    );
+    local_file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "old AI line".ai(),
+        "remote AI line".ai(),
+    ]);
+}
+
+#[test]
 fn test_rejected_push_failed_pull_then_pull_rebase_preserves_committed_ai_authorship() {
     let (local, upstream) = TestRepo::new_with_remote();
 
@@ -1980,6 +2078,7 @@ crate::reuse_tests_in_worktree!(
     test_fast_forward_pull_preserves_ai_attribution,
     test_fast_forward_pull_without_local_changes,
     test_pull_rebase_preserves_committed_ai_authorship,
+    test_pull_rebase_force_pushed_target_preserves_remote_authorship_note,
     test_pull_rebase_via_git_config_preserves_committed_ai_authorship,
     test_pull_rebase_via_zero_arg_alias_and_git_config_preserves_committed_ai_authorship,
     test_pull_rebase_autostash_preserves_uncommitted_ai_attribution,


### PR DESCRIPTION
## Summary

- prefetch authorship notes for both sides of non-fast-forward rewrite mappings
- preserve an authoritative remote target note when `git pull --rebase` accepts a force-pushed branch
- add a TestRepo end-to-end regression covering the production failure mode

## Root cause

During a pull of a force-pushed branch, trace2 rewrite handling runs before the post-pull notes sync. The rewrite path prefetched only source-commit notes, then shifted the stale local source note onto the new target commit. If the authoritative target note existed only on the remote, there was nothing local to merge, so target-only attribution was recorded as untracked and the later notes sync could not repair the overwritten note.

The rewrite path now batch-prefetches the deduplicated source and target SHAs before shifting notes. This remains one constant-count operation outside the critical trace ingestion path.

## Validation

- regression test failed before the fix in both normal and linked-worktree variants
- `task test TEST_FILTER=pull_rebase`
- `task lint`
- `task fmt`
- full `task test` with a sanitized `PATH` (the normal developer `PATH` contains a locally installed Droid binary that invalidates an unrelated absence-detection unit-test precondition)
