### PR TITLE
Add universal macOS PKG installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,8 +471,14 @@ jobs:
           VERSION="${VERSION#v}"
           mkdir -p release
           chmod +x artifacts/git-ai-macos-arm64 artifacts/git-ai-macos-x64
+          lipo -create artifacts/git-ai-macos-arm64 artifacts/git-ai-macos-x64 -output artifacts/git-ai-macos-universal
+          lipo -verify_arch x86_64 arm64 artifacts/git-ai-macos-universal
+          if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+            codesign --verify --strict --verbose=2 --all-architectures artifacts/git-ai-macos-universal
+          fi
           packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-arm64 --arch arm64 --version "$VERSION" --output release/git-ai-macos-arm64.pkg
           packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-x64 --arch x64 --version "$VERSION" --output release/git-ai-macos-x64.pkg
+          packaging/macos/build-pkg.sh --binary artifacts/git-ai-macos-universal --arch universal --version "$VERSION" --output release/git-ai-macos-universal.pkg
 
       - name: Notarize PKG installers
         if: inputs.dry_run != true
@@ -570,12 +576,9 @@ jobs:
           console_home="$(/usr/bin/dscl . -read "/Users/$console_user" NFSHomeDirectory | /usr/bin/awk 'NR == 1 { print $2 }')"
           git_ai="$console_home/.git-ai/bin/git-ai"
 
-          if [ "$(uname -m)" = "arm64" ]; then
-            PKG=release/git-ai-macos-arm64.pkg
-          else
-            PKG=release/git-ai-macos-x64.pkg
-          fi
+          PKG=release/git-ai-macos-universal.pkg
           sudo installer -pkg "$PKG" -target /
+          lipo -verify_arch x86_64 arm64 "$git_ai"
           "$git_ai" --version
 
           binary_owner="$(/usr/bin/stat -f%Su "$git_ai")"
@@ -777,6 +780,7 @@ jobs:
             - **macOS (Apple Silicon)**: `git-ai-macos-arm64`
             - **macOS PKG (Intel)**: `git-ai-macos-x64.pkg`
             - **macOS PKG (Apple Silicon)**: `git-ai-macos-arm64.pkg`
+            - **macOS PKG (Universal)**: `git-ai-macos-universal.pkg`
 
             ### SHA256 Checksums
             ```

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -9,7 +9,8 @@ responsibility of `git-ai install-hooks`.
 
 The release workflow builds signed/notarized production packages when the
 required Apple and Azure signing secrets are configured. Dry-run releases can
-build unsigned packages for validation.
+build unsigned packages for validation. macOS releases include Intel, Apple
+Silicon, and universal PKGs.
 
 The Windows MSI is per-user: it installs under
 `%USERPROFILE%\\.git-ai\\bin` and changes only that user's `PATH`. It has no

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'USAGE'
-usage: build-pkg.sh --binary <path> --arch <x64|arm64> --version <version> --output <path>
+usage: build-pkg.sh --binary <path> --arch <x64|arm64|universal> --version <version> --output <path>
 USAGE
 }
 
@@ -26,7 +26,7 @@ done
 [ -f "$BINARY" ] || { echo "binary not found: $BINARY" >&2; exit 1; }
 
 case "$ARCH" in
-  x64|arm64) ;;
+  x64|arm64|universal) ;;
   *) echo "unsupported arch: $ARCH" >&2; exit 2 ;;
 esac
 


### PR DESCRIPTION
## Summary

- build a universal macOS binary from the signed Intel and Apple Silicon release binaries
- verify both architectures and all production code signatures before packaging
- build, notarize, checksum, publish, and document `git-ai-macos-universal.pkg` alongside the existing per-architecture PKGs
- install the universal PKG in the macOS release smoke test and verify the installed binary contains both slices

## Why

The release pipeline currently publishes separate Intel and Apple Silicon PKG installers. A universal PKG gives macOS users and managed deployment systems one installer that runs natively on either architecture without removing the existing architecture-specific choices.

## Validation

- `task fmt`
- `task lint`
- `task test`
- `bash -n packaging/macos/build-pkg.sh packaging/macos/scripts/preinstall packaging/macos/scripts/postinstall`
- parsed `.github/workflows/release.yml` with PyYAML
- mocked `pkgbuild` to exercise the `universal` package variant on Linux

The release workflow performs the native macOS end-to-end validation: `lipo` architecture verification, production signature verification, PKG creation/notarization, installation, and post-install architecture verification.