### PR TITLE
Fix universal PKG architecture verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,7 @@ jobs:
           mkdir -p release
           chmod +x artifacts/git-ai-macos-arm64 artifacts/git-ai-macos-x64
           lipo -create artifacts/git-ai-macos-arm64 artifacts/git-ai-macos-x64 -output artifacts/git-ai-macos-universal
-          lipo -verify_arch x86_64 arm64 artifacts/git-ai-macos-universal
+          lipo artifacts/git-ai-macos-universal -verify_arch x86_64 arm64
           if [[ "${{ inputs.dry_run }}" != "true" ]]; then
             codesign --verify --strict --verbose=2 --all-architectures artifacts/git-ai-macos-universal
           fi
@@ -578,7 +578,7 @@ jobs:
 
           PKG=release/git-ai-macos-universal.pkg
           sudo installer -pkg "$PKG" -target /
-          lipo -verify_arch x86_64 arm64 "$git_ai"
+          lipo "$git_ai" -verify_arch x86_64 arm64
           "$git_ai" --version
 
           binary_owner="$(/usr/bin/stat -f%Su "$git_ai")"


### PR DESCRIPTION
## Summary

- fix both universal-binary architecture checks to use Xcode's required `lipo <input_file> -verify_arch <arch...>` ordering
- keep the build-time and post-install validations aligned

## Root cause

Release run [30296376337](https://github.com/git-ai-project/git-ai/actions/runs/30296376337), job [90080950947](https://github.com/git-ai-project/git-ai/actions/runs/30296376337/job/90080950947), created the universal binary successfully and then failed before PKG creation. The workflow invoked:

```text
lipo -verify_arch x86_64 arm64 artifacts/git-ai-macos-universal
```

Xcode 26 expects the input file before the command. It consequently parsed `artifacts/git-ai-macos-universal` as an architecture and reported `unknown architecture specification flag`.

## Validation

- `task fmt`
- `task lint`
- parsed `.github/workflows/release.yml` with PyYAML
- asserted both expected `lipo <file> -verify_arch x86_64 arm64` forms are present and the invalid command-first form is absent
- `git diff --check`

Per request, the release action was not dispatched from this branch.