### PR TITLE
fix(daemon): acknowledge checkpoints asynchronously

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -564,6 +564,12 @@ fn handle_checkpoint(args: &[String]) {
         }
         match send_result {
             Ok(response) if response.ok => {
+                if response.seq.is_none() {
+                    eprintln!(
+                        "Failed to send checkpoint to background worker: daemon receipt acknowledgement omitted sequence"
+                    );
+                    std::process::exit(0);
+                }
                 sent_count += 1;
             }
             Ok(response) => {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -4,6 +4,7 @@ use crate::authorship::ignore::{
 use crate::authorship::stats::{CommitStats, stats_from_authorship_log, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::CheckpointKind;
+use crate::daemon::{ControlRequest, DaemonConfig, send_control_request};
 use crate::error::GitAiError;
 use crate::git::find_repository;
 use crate::git::repo_storage::InitialAttributions;
@@ -54,6 +55,8 @@ pub fn handle_status(args: &[String]) {
 
 fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     let repo = find_repository(&[])?;
+    let repo_working_dir = repo.workdir()?.to_string_lossy().to_string();
+    sync_pending_checkpoints(repo_working_dir)?;
     let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&ignore_patterns);
 
@@ -210,6 +213,27 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     }
 
     Ok(())
+}
+
+fn sync_pending_checkpoints(repo_working_dir: String) -> Result<(), GitAiError> {
+    let Ok(daemon_config) = DaemonConfig::from_env_or_default_paths() else {
+        return Ok(());
+    };
+    let Ok(sync) = send_control_request(
+        &daemon_config.control_socket_path,
+        &ControlRequest::SyncFamily { repo_working_dir },
+    ) else {
+        // Status historically remains available without the daemon. If it is
+        // reachable, synchronization prevents accepted checkpoints from
+        // racing the working-log read below.
+        return Ok(());
+    };
+    if sync.ok {
+        return Ok(());
+    }
+    Err(GitAiError::Generic(sync.error.unwrap_or_else(|| {
+        "daemon rejected status synchronization".to_string()
+    })))
 }
 
 fn format_time_ago(timestamp: u64) -> String {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -4,7 +4,6 @@ use crate::authorship::ignore::{
 use crate::authorship::stats::{CommitStats, stats_from_authorship_log, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::CheckpointKind;
-use crate::daemon::{ControlRequest, DaemonConfig, send_control_request};
 use crate::error::GitAiError;
 use crate::git::find_repository;
 use crate::git::repo_storage::InitialAttributions;
@@ -55,8 +54,6 @@ pub fn handle_status(args: &[String]) {
 
 fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     let repo = find_repository(&[])?;
-    let repo_working_dir = repo.workdir()?.to_string_lossy().to_string();
-    sync_pending_checkpoints(repo_working_dir)?;
     let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&ignore_patterns);
 
@@ -213,27 +210,6 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     }
 
     Ok(())
-}
-
-fn sync_pending_checkpoints(repo_working_dir: String) -> Result<(), GitAiError> {
-    let Ok(daemon_config) = DaemonConfig::from_env_or_default_paths() else {
-        return Ok(());
-    };
-    let Ok(sync) = send_control_request(
-        &daemon_config.control_socket_path,
-        &ControlRequest::SyncFamily { repo_working_dir },
-    ) else {
-        // Status historically remains available without the daemon. If it is
-        // reachable, synchronization prevents accepted checkpoints from
-        // racing the working-log read below.
-        return Ok(());
-    };
-    if sync.ok {
-        return Ok(());
-    }
-    Err(GitAiError::Generic(sync.error.unwrap_or_else(|| {
-        "daemon rejected status synchronization".to_string()
-    })))
 }
 
 fn format_time_ago(timestamp: u64) -> String {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,7 +48,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc, oneshot};
+use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
 use tokio::time::Duration;
 
 pub mod analyzers;
@@ -144,6 +144,24 @@ struct CheckpointIngressReservation {
     body_bytes: usize,
 }
 
+#[derive(Debug)]
+struct AcceptedCheckpoint {
+    receipt_seq: u64,
+    received_at_ns: u128,
+    trace_ingest_target: u64,
+    body: Vec<u8>,
+    reservation: CheckpointIngressReservation,
+}
+
+#[derive(Debug)]
+struct PreparedCheckpointAdmission {
+    receipt_seq: u64,
+    received_at_ns: u128,
+    family: String,
+    request: CheckpointRequest,
+    reservation: CheckpointIngressReservation,
+}
+
 impl CheckpointIngressQuota {
     fn new(request_limit: usize, byte_limit: usize) -> Self {
         Self {
@@ -185,6 +203,14 @@ impl CheckpointIngressQuota {
             quota: Arc::clone(self),
             body_bytes,
         })
+    }
+
+    fn outstanding(&self) -> (usize, usize) {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        (state.requests, state.bytes)
     }
 }
 
@@ -952,6 +978,31 @@ fn rfc3339_to_unix_nanos(value: &str) -> Option<u128> {
 }
 
 fn apply_checkpoint_side_effect(mut request: CheckpointRequest) -> Result<(), GitAiError> {
+    #[cfg(feature = "test-support")]
+    {
+        if let Ok(spec) = std::env::var("GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT") {
+            for entry in spec.split(',') {
+                let Some((trace_id, delay_ms)) = entry.split_once('=') else {
+                    continue;
+                };
+                if trace_id == request.trace_id
+                    && let Ok(delay_ms) = delay_ms.parse::<u64>()
+                    && delay_ms > 0
+                {
+                    std::thread::sleep(Duration::from_millis(delay_ms));
+                    break;
+                }
+            }
+        }
+        if std::env::var("GIT_AI_TEST_FAIL_CHECKPOINT_SIDE_EFFECT")
+            .is_ok_and(|trace_id| trace_id == request.trace_id)
+        {
+            return Err(GitAiError::Generic(
+                "synthetic checkpoint processing failure".to_string(),
+            ));
+        }
+    }
+
     if request.files.is_empty() {
         return Ok(());
     }
@@ -2539,7 +2590,8 @@ enum FamilySequencerEntry {
     ReadyCommand(Box<crate::daemon::domain::NormalizedCommand>),
     Checkpoint {
         request: Box<CheckpointRequest>,
-        respond_to: Option<oneshot::Sender<Result<u64, GitAiError>>>,
+        receipt_seq: u64,
+        reservation: CheckpointIngressReservation,
     },
     Canceled,
 }
@@ -2651,6 +2703,11 @@ pub struct ActorDaemonCoordinator {
     side_effect_errors_by_family: Mutex<HashMap<String, BTreeMap<u64, String>>>,
     side_effect_exec_locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
     checkpoint_ingress_quota: Arc<CheckpointIngressQuota>,
+    checkpoint_ingress_tx: std::sync::OnceLock<mpsc::Sender<AcceptedCheckpoint>>,
+    next_checkpoint_receipt_seq: AtomicUsize,
+    processed_checkpoint_receipt_seq: AtomicUsize,
+    unadmitted_checkpoints: AtomicUsize,
+    checkpoint_progress_notify: Notify,
     bash_sessions: Mutex<crate::daemon::bash_sessions::BashSessionState>,
     test_completion_log_dir: Option<PathBuf>,
     test_completion_log_lock: Mutex<()>,
@@ -2739,6 +2796,11 @@ impl ActorDaemonCoordinator {
                 CHECKPOINT_INGRESS_REQUEST_LIMIT,
                 CHECKPOINT_INGRESS_BYTE_LIMIT,
             )),
+            checkpoint_ingress_tx: std::sync::OnceLock::new(),
+            next_checkpoint_receipt_seq: AtomicUsize::new(0),
+            processed_checkpoint_receipt_seq: AtomicUsize::new(0),
+            unadmitted_checkpoints: AtomicUsize::new(0),
+            checkpoint_progress_notify: Notify::new(),
             bash_sessions: Mutex::new(crate::daemon::bash_sessions::BashSessionState::new()),
             test_completion_log_dir: std::env::var("GIT_AI_TEST_DB_PATH")
                 .ok()
@@ -3863,6 +3925,262 @@ impl ActorDaemonCoordinator {
         Ok(())
     }
 
+    fn start_checkpoint_ingress_worker(self: &Arc<Self>) -> Result<(), GitAiError> {
+        if self.checkpoint_ingress_tx.get().is_some() {
+            return Ok(());
+        }
+
+        let (tx, mut rx) = mpsc::channel::<AcceptedCheckpoint>(CHECKPOINT_INGRESS_REQUEST_LIMIT);
+        if self.checkpoint_ingress_tx.set(tx).is_err() {
+            return Ok(());
+        }
+
+        let coordinator = Arc::clone(self);
+        tokio::spawn(async move {
+            loop {
+                let accepted = tokio::select! {
+                    biased;
+                    maybe = rx.recv() => match maybe {
+                        Some(accepted) => accepted,
+                        None => {
+                            if !coordinator.is_shutting_down() {
+                                tracing::error!(
+                                    component = "daemon",
+                                    phase = "checkpoint_ingress_worker",
+                                    reason = "ingress_channel_closed",
+                                    "checkpoint ingress channel closed unexpectedly"
+                                );
+                                coordinator.request_shutdown();
+                            }
+                            break;
+                        }
+                    },
+                    _ = coordinator.wait_for_shutdown() => break,
+                };
+                let receipt_seq = accepted.receipt_seq;
+                let prepare = coordinator.prepare_checkpoint_admission(accepted);
+                let caught = std::panic::AssertUnwindSafe(prepare);
+                match futures::FutureExt::catch_unwind(caught).await {
+                    Ok(Ok(prepared)) => {
+                        if let Err(error) = coordinator.complete_checkpoint_admission(prepared) {
+                            tracing::error!(
+                                component = "daemon",
+                                phase = "checkpoint_admission",
+                                reason = "sequencer_admission_failed",
+                                receipt_seq,
+                                %error,
+                                "failed admitting checkpoint to family sequencer"
+                            );
+                            coordinator.request_shutdown();
+                            break;
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        tracing::error!(
+                            component = "daemon",
+                            phase = "checkpoint_admission",
+                            reason = "checkpoint_prepare_failed",
+                            receipt_seq,
+                            %error,
+                            "failed preparing accepted checkpoint"
+                        );
+                        if let Err(accounting_error) =
+                            coordinator.complete_failed_checkpoint_admission(receipt_seq)
+                        {
+                            tracing::error!(
+                                component = "daemon",
+                                phase = "checkpoint_admission",
+                                reason = "failed_admission_accounting_error",
+                                receipt_seq,
+                                error = %accounting_error,
+                                "failed releasing checkpoint admission gate"
+                            );
+                            coordinator.request_shutdown();
+                            break;
+                        }
+                    }
+                    Err(panic_payload) => {
+                        let panic_msg =
+                            if let Some(message) = panic_payload.downcast_ref::<String>() {
+                                message.clone()
+                            } else if let Some(message) = panic_payload.downcast_ref::<&str>() {
+                                message.to_string()
+                            } else {
+                                "unknown panic".to_string()
+                            };
+                        tracing::error!(
+                            component = "daemon",
+                            phase = "checkpoint_ingress_worker",
+                            reason = "worker_panic",
+                            receipt_seq,
+                            panic_msg = %panic_msg,
+                            "checkpoint ingress worker panicked"
+                        );
+                        let _ = coordinator.complete_failed_checkpoint_admission(receipt_seq);
+                        coordinator.request_shutdown();
+                        break;
+                    }
+                }
+            }
+
+            let buffered_count = rx.len();
+            if buffered_count > 0 {
+                tracing::error!(
+                    component = "daemon",
+                    phase = "checkpoint_ingress_worker",
+                    reason = "buffered_receipts_on_exit",
+                    buffered_count,
+                    "checkpoint ingress worker exited with accepted receipts buffered"
+                );
+            }
+        });
+        Ok(())
+    }
+
+    async fn prepare_checkpoint_admission(
+        &self,
+        accepted: AcceptedCheckpoint,
+    ) -> Result<PreparedCheckpointAdmission, GitAiError> {
+        let request: CheckpointRequest =
+            serde_json::from_slice(&accepted.body).map_err(|error| {
+                GitAiError::Generic(format!("invalid accepted checkpoint body: {error}"))
+            })?;
+        let trace_id = request.trace_id.clone();
+        let file_count = request.files.len();
+        let Some(repo_work_dir) = request.files.first().map(|file| file.repo_work_dir.clone())
+        else {
+            return Err(GitAiError::Generic(
+                "accepted checkpoint contains no files".to_string(),
+            ));
+        };
+        let family = self.backend.resolve_family(&repo_work_dir)?.0;
+
+        self.notify_checkpoint_stream(&request);
+        self.wait_for_trace_ingest_seq(accepted.trace_ingest_target)
+            .await;
+
+        tracing::info!(
+            component = "daemon",
+            phase = "checkpoint_admission",
+            receipt_seq = accepted.receipt_seq,
+            %trace_id,
+            %family,
+            file_count,
+            retained_bytes = accepted.reservation.body_bytes(),
+            receipt_to_admission_ms =
+                now_unix_nanos().saturating_sub(accepted.received_at_ns) / 1_000_000,
+            "checkpoint prepared for family admission"
+        );
+
+        Ok(PreparedCheckpointAdmission {
+            receipt_seq: accepted.receipt_seq,
+            received_at_ns: accepted.received_at_ns,
+            family,
+            request,
+            reservation: accepted.reservation,
+        })
+    }
+
+    fn notify_checkpoint_stream(&self, request: &CheckpointRequest) {
+        if let Some(worker) = &self.stream_worker
+            && let Some(stream_source) = &request.stream_source
+        {
+            let tool = request
+                .agent_id
+                .as_ref()
+                .map(|agent| agent.tool.clone())
+                .unwrap_or_else(|| "unknown".to_string());
+            worker.notify_checkpoint(
+                stream_source.session_id.clone(),
+                tool,
+                request.trace_id.clone(),
+                request.metadata.get("tool_use_id").cloned(),
+                stream_source.path.clone(),
+                request.files.first().map(|file| file.repo_work_dir.clone()),
+                stream_source.external_session_id.clone(),
+                stream_source.external_parent_session_id.clone(),
+            );
+        }
+    }
+
+    fn complete_checkpoint_admission(
+        self: &Arc<Self>,
+        prepared: PreparedCheckpointAdmission,
+    ) -> Result<(), GitAiError> {
+        let remaining = {
+            let mut sequencers = self.family_sequencers_by_family.lock().map_err(|_| {
+                GitAiError::Generic("family sequencer map lock poisoned".to_string())
+            })?;
+            let state = sequencers
+                .entry(prepared.family.clone())
+                .or_insert_with(|| FamilySequencerState {
+                    next_ordinal: 1,
+                    entries: BTreeMap::new(),
+                });
+            let order = FamilySequencerOrder {
+                started_at_ns: prepared.received_at_ns,
+                ordinal: state.next_ordinal,
+            };
+            state.next_ordinal = state.next_ordinal.saturating_add(1);
+            state.entries.insert(
+                order,
+                FamilySequencerEntry::Checkpoint {
+                    request: Box::new(prepared.request),
+                    receipt_seq: prepared.receipt_seq,
+                    reservation: prepared.reservation,
+                },
+            );
+            self.unadmitted_checkpoints
+                .fetch_sub(1, Ordering::AcqRel)
+                .saturating_sub(1)
+        };
+        self.record_checkpoint_admission_processed(prepared.receipt_seq);
+        if remaining == 0 {
+            self.schedule_all_ready_family_drains();
+        }
+        Ok(())
+    }
+
+    fn complete_failed_checkpoint_admission(
+        self: &Arc<Self>,
+        receipt_seq: u64,
+    ) -> Result<(), GitAiError> {
+        let remaining = {
+            let _sequencers = self.family_sequencers_by_family.lock().map_err(|_| {
+                GitAiError::Generic("family sequencer map lock poisoned".to_string())
+            })?;
+            self.unadmitted_checkpoints
+                .fetch_sub(1, Ordering::AcqRel)
+                .saturating_sub(1)
+        };
+        self.record_checkpoint_admission_processed(receipt_seq);
+        if remaining == 0 {
+            self.schedule_all_ready_family_drains();
+        }
+        Ok(())
+    }
+
+    fn record_checkpoint_admission_processed(&self, receipt_seq: u64) {
+        self.processed_checkpoint_receipt_seq
+            .store(receipt_seq as usize, Ordering::Release);
+        self.checkpoint_progress_notify.notify_waiters();
+    }
+
+    fn schedule_all_ready_family_drains(self: &Arc<Self>) {
+        let coordinator = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(error) = coordinator.drain_all_ready_family_sequencers().await {
+                tracing::error!(
+                    component = "daemon",
+                    phase = "checkpoint_processing",
+                    reason = "family_drain_failed",
+                    %error,
+                    "failed draining family sequencers after checkpoint admission"
+                );
+            }
+        });
+    }
+
     fn enqueue_trace_payload(&self, payload: Value) -> Result<(), GitAiError> {
         let tx =
             self.trace_ingest_tx.get().cloned().ok_or_else(|| {
@@ -3912,6 +4230,20 @@ impl ActorDaemonCoordinator {
         Ok(())
     }
 
+    async fn wait_for_trace_ingest_seq(&self, target: u64) {
+        loop {
+            let processed = self.processed_trace_ingest_seq.load(Ordering::Acquire) as u64;
+            if processed >= target {
+                return;
+            }
+            let progress = self.trace_ingest_progress_notify.notified();
+            tokio::select! {
+                _ = progress => {}
+                _ = self.wait_for_shutdown() => return,
+            }
+        }
+    }
+
     /// Waits until all trace payloads enqueued up to now have been processed
     /// by the ingest worker, and any identified trace root that may mutate refs
     /// has closed. This is a causal drain fence: it guarantees that trace2 data
@@ -3931,17 +4263,7 @@ impl ActorDaemonCoordinator {
             // point has a seq <= this value. We need to wait until the ingest
             // worker has processed through at least this seq.
             let target = self.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
-            loop {
-                let processed = self.processed_trace_ingest_seq.load(Ordering::Acquire) as u64;
-                if processed >= target {
-                    break;
-                }
-                let progress = self.trace_ingest_progress_notify.notified();
-                tokio::select! {
-                    _ = progress => {}
-                    _ = self.wait_for_shutdown() => return,
-                }
-            }
+            self.wait_for_trace_ingest_seq(target).await;
 
             if !self.has_open_trace_roots_that_may_mutate_refs() {
                 return;
@@ -4146,48 +4468,6 @@ impl ActorDaemonCoordinator {
             .clone())
     }
 
-    async fn append_checkpoint_to_family_sequencer(
-        &self,
-        family: &str,
-        request: CheckpointRequest,
-        respond_to: Option<oneshot::Sender<Result<u64, GitAiError>>>,
-    ) -> Result<(), GitAiError> {
-        // Causal drain fence: ensure already-visible trace2 work has reached
-        // the family sequencer before inserting this checkpoint.
-        self.wait_for_trace_ingest_processed_through().await;
-
-        let exec_lock = self.side_effect_exec_lock(family)?;
-        let _guard = exec_lock.lock().await;
-
-        {
-            let mut sequencers = self.family_sequencers_by_family.lock().map_err(|_| {
-                GitAiError::Generic("family sequencer map lock poisoned".to_string())
-            })?;
-            let state =
-                sequencers
-                    .entry(family.to_string())
-                    .or_insert_with(|| FamilySequencerState {
-                        next_ordinal: 1,
-                        entries: BTreeMap::new(),
-                    });
-            let order = FamilySequencerOrder {
-                started_at_ns: now_unix_nanos(),
-                ordinal: state.next_ordinal,
-            };
-            state.next_ordinal = state.next_ordinal.saturating_add(1);
-            state.entries.insert(
-                order,
-                FamilySequencerEntry::Checkpoint {
-                    request: Box::new(request),
-                    respond_to,
-                },
-            );
-        }
-
-        self.drain_ready_family_sequencer_entries_locked(family)
-            .await
-    }
-
     async fn drain_ready_family_sequencer_entries_locked(
         &self,
         family: &str,
@@ -4198,6 +4478,9 @@ impl ActorDaemonCoordinator {
             let mut map = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
             })?;
+            if self.unadmitted_checkpoints.load(Ordering::Acquire) > 0 {
+                return Ok(());
+            }
             let state = map
                 .entry(family.to_string())
                 .or_insert_with(|| FamilySequencerState {
@@ -4324,7 +4607,8 @@ impl ActorDaemonCoordinator {
                 }
                 FamilySequencerEntry::Checkpoint {
                     mut request,
-                    respond_to,
+                    receipt_seq,
+                    reservation: _reservation,
                 } => {
                     let repo_wd = request
                         .files
@@ -4337,6 +4621,7 @@ impl ActorDaemonCoordinator {
                         .map(|f| f.path.to_string_lossy().to_string())
                         .collect();
                     let checkpoint_kind = request.checkpoint_kind;
+                    let checkpoint_trace_id = request.trace_id.clone();
                     let checkpoint_path_role = request.path_role;
                     let checkpoint_has_agent = request.agent_id.is_some();
                     let checkpoint_kind_str = format!("{:?}", checkpoint_kind);
@@ -4380,9 +4665,15 @@ impl ActorDaemonCoordinator {
                                     error: None,
                                 };
                                 let _ = self.maybe_append_test_completion_log(family, &log_entry);
-                                if let Some(respond_to) = respond_to {
-                                    let _ = respond_to.send(Ok(0));
-                                }
+                                tracing::info!(
+                                    component = "daemon",
+                                    phase = "checkpoint_processing",
+                                    receipt_seq,
+                                    trace_id = %checkpoint_trace_id,
+                                    %family,
+                                    status = "suppressed",
+                                    "checkpoint processing completed"
+                                );
                                 continue;
                             }
                         }
@@ -4406,9 +4697,10 @@ impl ActorDaemonCoordinator {
                                 let ack =
                                     self.coordinator.apply_checkpoint(Path::new(&repo_wd)).await;
                                 match ack {
-                                    Ok(ack) => {
-                                        apply_checkpoint_side_effect(*request).map(|_| ack.seq)
-                                    }
+                                    Ok(ack) => run_blocking_side_effect(|| {
+                                        apply_checkpoint_side_effect(*request)
+                                    })
+                                    .map(|_| ack.seq),
                                     Err(error) => Err(error),
                                 }
                             } else {
@@ -4484,8 +4776,8 @@ impl ActorDaemonCoordinator {
                         } else {
                             std::collections::HashMap::new()
                         };
-                        if !per_file.is_empty() || !per_worktree.is_empty() {
-                            let _ = self
+                        if (!per_file.is_empty() || !per_worktree.is_empty())
+                            && let Err(error) = self
                                 .coordinator
                                 .update_watermarks_family(
                                     Path::new(&repo_wd),
@@ -4494,13 +4786,30 @@ impl ActorDaemonCoordinator {
                                         per_worktree,
                                     },
                                 )
-                                .await;
+                                .await
+                        {
+                            let _ = self.record_side_effect_error(family, order, &error);
+                            tracing::error!(
+                                component = "daemon",
+                                phase = "checkpoint_processing",
+                                reason = "watermark_update_failed",
+                                receipt_seq,
+                                %family,
+                                order,
+                                %error,
+                                "checkpoint watermark update failed"
+                            );
                         }
                     }
                     // Removed captured_checkpoint_id cleanup - no more captured checkpoints
                     if let Err(error) = &result {
                         let _ = self.record_side_effect_error(family, order, error);
                         tracing::error!(
+                            component = "daemon",
+                            phase = "checkpoint_processing",
+                            reason = "side_effect_failed",
+                            receipt_seq,
+                            trace_id = %checkpoint_trace_id,
                             %error,
                             %family,
                             order,
@@ -4528,6 +4837,11 @@ impl ActorDaemonCoordinator {
                         {
                             let _ = self.record_side_effect_error(family, order, &error);
                             tracing::error!(
+                                component = "daemon",
+                                phase = "checkpoint_processing",
+                                reason = "completion_log_failed",
+                                receipt_seq,
+                                trace_id = %checkpoint_trace_id,
                                 %error,
                                 %family,
                                 order,
@@ -4535,9 +4849,16 @@ impl ActorDaemonCoordinator {
                             );
                         }
                     }
-                    if let Some(respond_to) = respond_to {
-                        let _ = respond_to.send(result);
-                    }
+                    tracing::info!(
+                        component = "daemon",
+                        phase = "checkpoint_processing",
+                        receipt_seq,
+                        trace_id = %checkpoint_trace_id,
+                        %family,
+                        status = if result.is_ok() { "ok" } else { "error" },
+                        duration_ms = checkpoint_duration_ms as u64,
+                        "checkpoint processing completed"
+                    );
                 }
                 FamilySequencerEntry::Canceled => {}
                 FamilySequencerEntry::PendingRoot => {}
@@ -6043,26 +6364,6 @@ impl ActorDaemonCoordinator {
         Ok(())
     }
 
-    async fn ingest_checkpoint_payload(
-        &self,
-        request: CheckpointRequest,
-    ) -> Result<ControlResponse, GitAiError> {
-        if request.files.is_empty() {
-            return Ok(ControlResponse::ok(None, None));
-        }
-
-        let repo_work_dir = request.files[0].repo_work_dir.clone();
-        let family = self.backend.resolve_family(&repo_work_dir)?;
-
-        let (respond_to, response) = oneshot::channel();
-        self.append_checkpoint_to_family_sequencer(&family.0, request, Some(respond_to))
-            .await?;
-        response
-            .await
-            .map_err(|_| GitAiError::Generic("checkpoint response channel closed".to_string()))??;
-        Ok(ControlResponse::ok(None, None))
-    }
-
     async fn watermarks_for_family(
         &self,
         repo_working_dir: String,
@@ -6092,14 +6393,58 @@ impl ActorDaemonCoordinator {
         })
     }
 
+    async fn wait_for_checkpoint_admission_through(&self, target: u64) {
+        loop {
+            let processed = self
+                .processed_checkpoint_receipt_seq
+                .load(Ordering::Acquire) as u64;
+            if processed >= target {
+                return;
+            }
+            let progress = self.checkpoint_progress_notify.notified();
+            tokio::select! {
+                _ = progress => {}
+                _ = self.wait_for_shutdown() => return,
+            }
+        }
+    }
+
+    async fn wait_for_no_unadmitted_checkpoints(&self) {
+        loop {
+            if self.unadmitted_checkpoints.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            let progress = self.checkpoint_progress_notify.notified();
+            if self.unadmitted_checkpoints.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            tokio::select! {
+                _ = progress => {}
+                _ = self.wait_for_shutdown() => return,
+            }
+        }
+    }
+
     async fn sync_family(&self, repo_working_dir: String) -> Result<FamilyStatus, GitAiError> {
+        let checkpoint_target = self.next_checkpoint_receipt_seq.load(Ordering::Acquire) as u64;
+        self.wait_for_checkpoint_admission_through(checkpoint_target)
+            .await;
+        self.wait_for_no_unadmitted_checkpoints().await;
         let family = self.backend.resolve_family(Path::new(&repo_working_dir))?;
         self.wait_for_trace_ingest_processed_through().await;
 
         let exec_lock = self.side_effect_exec_lock(&family.0)?;
-        let _guard = exec_lock.lock().await;
-        self.drain_ready_family_sequencer_entries_locked(&family.0)
-            .await?;
+        loop {
+            self.wait_for_no_unadmitted_checkpoints().await;
+            let guard = exec_lock.lock().await;
+            self.drain_ready_family_sequencer_entries_locked(&family.0)
+                .await?;
+            if self.unadmitted_checkpoints.load(Ordering::Acquire) == 0 {
+                drop(guard);
+                break;
+            }
+            drop(guard);
+        }
 
         self.status_for_family(repo_working_dir).await
     }
@@ -6236,6 +6581,9 @@ impl ActorDaemonCoordinator {
     }
 
     fn has_pending_daemon_work(&self) -> bool {
+        if self.checkpoint_ingress_quota.outstanding().0 > 0 {
+            return true;
+        }
         if self.queued_trace_payloads.load(Ordering::Acquire) > 0 {
             return true;
         }
@@ -6262,36 +6610,8 @@ impl ActorDaemonCoordinator {
         false
     }
 
-    async fn handle_checkpoint_request(&self, request: CheckpointRequest) -> ControlResponse {
-        if let Some(worker) = &self.stream_worker
-            && let Some(stream_source) = &request.stream_source
-        {
-            let session_id = stream_source.session_id.clone();
-            let tool = request
-                .agent_id
-                .as_ref()
-                .map(|aid| aid.tool.clone())
-                .unwrap_or_else(|| "unknown".to_string());
-            let trace_id = request.trace_id.clone();
-            let tool_use_id = request.metadata.get("tool_use_id").cloned();
-            let repo_work_dir = request.files.first().map(|f| f.repo_work_dir.clone());
-
-            worker.notify_checkpoint(
-                session_id,
-                tool,
-                trace_id,
-                tool_use_id,
-                stream_source.path.clone(),
-                repo_work_dir,
-                stream_source.external_session_id.clone(),
-                stream_source.external_parent_session_id.clone(),
-            );
-        }
-
-        match self.ingest_checkpoint_payload(request).await {
-            Ok(response) => response,
-            Err(error) => ControlResponse::err(error.to_string()),
-        }
+    fn outstanding_checkpoint_state(&self) -> (usize, usize) {
+        self.checkpoint_ingress_quota.outstanding()
     }
 
     async fn handle_control_request(&self, request: ControlRequest) -> ControlResponse {
@@ -6623,7 +6943,13 @@ fn control_listener_loop_actor(
             if std::thread::Builder::new()
                 .spawn(move || {
                     if let Err(e) = handle_control_connection_actor(stream, coord, handle) {
-                        tracing::debug!(%e, "control connection error");
+                        tracing::error!(
+                            component = "daemon",
+                            phase = "control_receive",
+                            reason = "connection_error",
+                            error = %e,
+                            "daemon control connection failed"
+                        );
                     }
                 })
                 .is_err()
@@ -6789,7 +7115,13 @@ fn handle_windows_control_pipe_connection(
     let mut reader = BufReader::new(&mut server);
     if let Err(e) = handle_control_connection_actor_reader(&mut reader, coordinator, runtime_handle)
     {
-        tracing::debug!(%e, "control connection error");
+        tracing::error!(
+            component = "daemon",
+            phase = "control_receive",
+            reason = "connection_error",
+            error = %e,
+            "daemon control connection failed"
+        );
     }
 }
 
@@ -6896,21 +7228,92 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                         return Err(error);
                     }
                 };
-                match serde_json::from_slice::<CheckpointRequest>(&body) {
-                    Ok(request) => runtime_handle
-                        .block_on(async { coordinator.handle_checkpoint_request(request).await }),
-                    Err(error) => {
+                let Some(checkpoint_tx) = coordinator.checkpoint_ingress_tx.get().cloned() else {
+                    tracing::error!(
+                        component = "daemon",
+                        phase = "checkpoint_receive",
+                        reason = "ingress_worker_not_started",
+                        body_bytes,
+                        "checkpoint ingress worker is unavailable"
+                    );
+                    coordinator.request_shutdown();
+                    write_control_response(
+                        reader.get_mut(),
+                        &ControlResponse::err("checkpoint ingress worker is unavailable"),
+                    )?;
+                    continue;
+                };
+                let permit = match checkpoint_tx.try_reserve_owned() {
+                    Ok(permit) => permit,
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                         tracing::error!(
                             component = "daemon",
                             phase = "checkpoint_receive",
-                            reason = "body_decode_failed",
+                            reason = "ingress_queue_full",
                             body_bytes,
-                            %error,
-                            "failed decoding checkpoint body"
+                            queue_limit = CHECKPOINT_INGRESS_REQUEST_LIMIT,
+                            "checkpoint ingress queue is full despite quota reservation"
                         );
-                        ControlResponse::err(format!("invalid checkpoint body: {error}"))
+                        write_control_response(
+                            reader.get_mut(),
+                            &ControlResponse::err("checkpoint ingress busy: queue_full"),
+                        )?;
+                        continue;
                     }
-                }
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        tracing::error!(
+                            component = "daemon",
+                            phase = "checkpoint_receive",
+                            reason = "ingress_channel_closed",
+                            body_bytes,
+                            "checkpoint ingress channel is closed"
+                        );
+                        coordinator.request_shutdown();
+                        write_control_response(
+                            reader.get_mut(),
+                            &ControlResponse::err("checkpoint ingress worker is unavailable"),
+                        )?;
+                        continue;
+                    }
+                };
+                let receipt_seq = {
+                    let _sequencers =
+                        coordinator
+                            .family_sequencers_by_family
+                            .lock()
+                            .map_err(|_| {
+                                GitAiError::Generic(
+                                    "family sequencer map lock poisoned".to_string(),
+                                )
+                            })?;
+                    let receipt_seq = coordinator
+                        .next_checkpoint_receipt_seq
+                        .fetch_add(1, Ordering::Relaxed)
+                        as u64
+                        + 1;
+                    let received_at_ns = now_unix_nanos();
+                    let trace_ingest_target =
+                        coordinator.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
+                    coordinator
+                        .unadmitted_checkpoints
+                        .fetch_add(1, Ordering::Release);
+                    permit.send(AcceptedCheckpoint {
+                        receipt_seq,
+                        received_at_ns,
+                        trace_ingest_target,
+                        body,
+                        reservation,
+                    });
+                    receipt_seq
+                };
+                tracing::info!(
+                    component = "daemon",
+                    phase = "checkpoint_receive",
+                    receipt_seq,
+                    retained_bytes = body_bytes,
+                    "checkpoint received into bounded ingress"
+                );
+                ControlResponse::ok(Some(receipt_seq), None)
             }
             Ok(req) => {
                 shutdown_after_response = matches!(req, ControlRequest::Shutdown);
@@ -6927,7 +7330,19 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                 ControlResponse::err(format!("invalid control request: {error}"))
             }
         };
-        write_control_response(reader.get_mut(), &response)?;
+        if let Err(error) = write_control_response(reader.get_mut(), &response) {
+            if let Some(receipt_seq) = response.seq {
+                tracing::error!(
+                    component = "daemon",
+                    phase = "checkpoint_receive",
+                    reason = "receipt_ack_write_failed",
+                    receipt_seq,
+                    %error,
+                    "failed writing checkpoint receipt acknowledgement"
+                );
+            }
+            return Err(error);
+        }
         if shutdown_after_response {
             coordinator.request_stop();
         }
@@ -7492,6 +7907,21 @@ fn daemon_socket_health_check_loop(
             local_socket_connects_with_timeout(&trace_socket_path, DAEMON_SOCKET_PROBE_TIMEOUT);
 
         if control_ok.is_err() || trace_ok.is_err() {
+            let (outstanding_checkpoints, retained_checkpoint_bytes) =
+                coordinator.outstanding_checkpoint_state();
+            if outstanding_checkpoints > 0 {
+                tracing::error!(
+                    component = "daemon",
+                    phase = "socket_health",
+                    reason = "restart_deferred_for_checkpoints",
+                    outstanding_checkpoints,
+                    retained_checkpoint_bytes,
+                    control = %control_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
+                    trace = %trace_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
+                    "socket health restart deferred while accepted checkpoints remain"
+                );
+                continue;
+            }
             let uptime = started.elapsed();
             let min_uptime = std::time::Duration::from_secs(daemon_min_uptime_for_self_restart());
 
@@ -7550,9 +7980,19 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
 
         match check_for_update_available() {
             Ok(DaemonUpdateCheckResult::UpdateReady) => {
-                tracing::info!("update check: newer version available, requesting shutdown");
-                coordinator.request_restart_after_update();
-                return;
+                let (outstanding_checkpoints, retained_checkpoint_bytes) =
+                    coordinator.outstanding_checkpoint_state();
+                if outstanding_checkpoints > 0 {
+                    tracing::info!(
+                        outstanding_checkpoints,
+                        retained_checkpoint_bytes,
+                        "update restart deferred while accepted checkpoints remain"
+                    );
+                } else {
+                    tracing::info!("update check: newer version available, requesting shutdown");
+                    coordinator.request_restart_after_update();
+                    return;
+                }
             }
             Ok(DaemonUpdateCheckResult::NoUpdate) => {
                 tracing::info!("update check: no update needed");
@@ -7564,9 +8004,19 @@ fn daemon_update_check_loop(coordinator: Arc<ActorDaemonCoordinator>, started_at
 
         let uptime_ns = now_unix_nanos().saturating_sub(started_at_ns);
         if uptime_ns >= daemon_max_uptime_ns() {
-            tracing::info!("uptime exceeded max, requesting restart");
-            coordinator.request_restart();
-            return;
+            let (outstanding_checkpoints, retained_checkpoint_bytes) =
+                coordinator.outstanding_checkpoint_state();
+            if outstanding_checkpoints > 0 {
+                tracing::info!(
+                    outstanding_checkpoints,
+                    retained_checkpoint_bytes,
+                    "uptime restart deferred while accepted checkpoints remain"
+                );
+            } else {
+                tracing::info!("uptime exceeded max, requesting restart");
+                coordinator.request_restart();
+                return;
+            }
         }
     }
 }
@@ -7684,6 +8134,7 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
 
     let coordinator = Arc::new(coordinator_inner);
     coordinator.start_trace_ingest_worker()?;
+    coordinator.start_checkpoint_ingress_worker()?;
     let rt_handle = tokio::runtime::Handle::current();
     let control_socket_path = config.control_socket_path.clone();
     let trace_socket_path = config.trace_socket_path.clone();
@@ -9083,76 +9534,6 @@ mod tests {
         )
         .await
         .expect("checkpoint fence should pass once the mutating trace root closes");
-    }
-
-    #[tokio::test]
-    async fn checkpoint_control_request_waits_while_blocked_behind_pending_root() {
-        use crate::commands::checkpoint_agent::orchestrator::{BaseCommit, CheckpointFile};
-
-        let coord = Arc::new(ActorDaemonCoordinator::new());
-        let temp = tempfile::tempdir().unwrap();
-        let repo = temp.path().join("repo");
-        std::fs::create_dir_all(&repo).unwrap();
-        let init = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&repo)
-            .arg("init")
-            .output()
-            .expect("git init should run");
-        assert!(
-            init.status.success(),
-            "git init failed: {}",
-            String::from_utf8_lossy(&init.stderr)
-        );
-        std::fs::write(repo.join("test.txt"), "checkpoint content\n").unwrap();
-
-        let family = coord.backend.resolve_family(&repo).unwrap().0;
-        let root_sid = "20260411T120000.000000-Psid-blocking-root";
-        coord
-            .append_pending_root_entry(&family, root_sid, 1)
-            .unwrap();
-
-        let request = CheckpointRequest {
-            trace_id: "blocked-checkpoint".to_string(),
-            checkpoint_kind: CheckpointKind::Human,
-            agent_id: None,
-            files: vec![CheckpointFile {
-                path: PathBuf::from("test.txt"),
-                content: Some("checkpoint content\n".to_string()),
-                repo_work_dir: repo.clone(),
-                base_commit: BaseCommit::Initial,
-            }],
-            path_role: PreparedPathRole::Edited,
-            stream_source: None,
-            metadata: HashMap::new(),
-        };
-
-        let mut checkpoint = {
-            let coord = coord.clone();
-            tokio::spawn(async move { coord.ingest_checkpoint_payload(request).await })
-        };
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), &mut checkpoint)
-                .await
-                .is_err(),
-            "checkpoint control request must not complete before its sequenced side effect runs"
-        );
-
-        coord
-            .replace_pending_root_entry(root_sid, FamilySequencerEntry::Canceled)
-            .await
-            .unwrap();
-
-        let response = tokio::time::timeout(Duration::from_secs(1), checkpoint)
-            .await
-            .expect("checkpoint should finish once the prior root is released")
-            .expect("checkpoint task should not panic")
-            .expect("checkpoint request should succeed");
-        assert!(
-            response.ok,
-            "checkpoint response should be ok: {response:?}"
-        );
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4238,13 +4238,19 @@ impl ActorDaemonCoordinator {
 
     async fn wait_for_trace_ingest_seq(&self, target: u64) {
         loop {
+            // Enroll in the notification BEFORE checking the condition.
+            // `Notify::notify_waiters` only wakes already-enrolled waiters, so
+            // checking first would leave a window where the final progress
+            // notification is lost and the waiter stalls until shutdown.
+            let progress = self.trace_ingest_progress_notify.notified();
+            tokio::pin!(progress);
+            progress.as_mut().enable();
             let processed = self.processed_trace_ingest_seq.load(Ordering::Acquire) as u64;
             if processed >= target {
                 return;
             }
-            let progress = self.trace_ingest_progress_notify.notified();
             tokio::select! {
-                _ = progress => {}
+                _ = &mut progress => {}
                 _ = self.wait_for_shutdown() => return,
             }
         }
@@ -6401,15 +6407,19 @@ impl ActorDaemonCoordinator {
 
     async fn wait_for_checkpoint_admission_through(&self, target: u64) {
         loop {
+            // Enroll before checking (see wait_for_trace_ingest_seq): the
+            // final admission's notify_waiters must not race the load.
+            let progress = self.checkpoint_progress_notify.notified();
+            tokio::pin!(progress);
+            progress.as_mut().enable();
             let processed = self
                 .processed_checkpoint_receipt_seq
                 .load(Ordering::Acquire) as u64;
             if processed >= target {
                 return;
             }
-            let progress = self.checkpoint_progress_notify.notified();
             tokio::select! {
-                _ = progress => {}
+                _ = &mut progress => {}
                 _ = self.wait_for_shutdown() => return,
             }
         }
@@ -6417,15 +6427,15 @@ impl ActorDaemonCoordinator {
 
     async fn wait_for_no_unadmitted_checkpoints(&self) {
         loop {
-            if self.unadmitted_checkpoints.load(Ordering::Acquire) == 0 {
-                return;
-            }
+            // Enroll before checking (see wait_for_trace_ingest_seq).
             let progress = self.checkpoint_progress_notify.notified();
+            tokio::pin!(progress);
+            progress.as_mut().enable();
             if self.unadmitted_checkpoints.load(Ordering::Acquire) == 0 {
                 return;
             }
             tokio::select! {
-                _ = progress => {}
+                _ = &mut progress => {}
                 _ = self.wait_for_shutdown() => return,
             }
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3110,7 +3110,13 @@ impl ActorDaemonCoordinator {
             map.retain(|_, state| !state.entries.is_empty());
         }
         if let Ok(mut map) = self.side_effect_exec_locks.lock() {
-            map.retain(|_, lock| Arc::strong_count(lock) <= 1);
+            // Evict only IDLE locks (strong_count == 1: the map holds the sole
+            // Arc). A lock with clones out is held or awaited by a drain;
+            // evicting it would hand the next drain a fresh unlocked mutex and
+            // run two drains concurrently on one family, tearing working-log
+            // read-modify-writes. The map mutex makes this check atomic with
+            // removal; idle locks are safely recreated on demand.
+            map.retain(|_, lock| Arc::strong_count(lock) > 1);
         }
         if let Ok(mut map) = self.pending_rebase_original_head_by_worktree.lock() {
             map.shrink_to_fit();
@@ -8901,6 +8907,35 @@ mod tests {
         assert_eq!(
             checkpoint_control_response_timeout(&sample_checkpoint_request(), false),
             DAEMON_CONTROL_RESPONSE_TIMEOUT
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_keeps_held_family_exec_locks_and_evicts_only_idle_ones() {
+        let coord = ActorDaemonCoordinator::new();
+
+        let held_lock = coord
+            .side_effect_exec_lock("family-held")
+            .expect("held family lock");
+        let _held_guard = held_lock.lock().await;
+        coord
+            .side_effect_exec_lock("family-idle")
+            .expect("idle family lock");
+
+        coord.gc_stale_family_state();
+
+        let map = coord.side_effect_exec_locks.lock().unwrap();
+        let surviving = map.get("family-held").expect(
+            "GC must never evict a held exec lock: a re-created lock would let a \
+             second drain run concurrently on the same family",
+        );
+        assert!(
+            Arc::ptr_eq(surviving, &held_lock),
+            "GC must keep the SAME lock instance while it is held"
+        );
+        assert!(
+            !map.contains_key("family-idle"),
+            "GC should evict idle exec locks to bound the map"
         );
     }
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -11,6 +11,8 @@ use git_ai::commands::checkpoint_agent::orchestrator::{
 };
 use git_ai::config::{NotesBackendConfig, NotesBackendKind};
 #[cfg(not(windows))]
+use git_ai::daemon::ControlResponse;
+#[cfg(not(windows))]
 use git_ai::daemon::checkpoint::PreparedPathRole;
 #[cfg(not(windows))]
 use git_ai::daemon::send_checkpoint_request_with_timeout;
@@ -62,6 +64,18 @@ fn daemon_trace_socket_path(repo: &TestRepo) -> PathBuf {
 
 fn daemon_lock_path(repo: &TestRepo) -> PathBuf {
     DaemonConfig::from_home(&repo.daemon_home_path()).lock_path
+}
+
+#[cfg(not(windows))]
+fn wait_for_daemon_log(repo: &TestRepo, needle: &str) -> String {
+    let started = std::time::Instant::now();
+    loop {
+        let logs = repo.daemon_stderr_contents();
+        if logs.contains(needle) || started.elapsed() >= Duration::from_secs(2) {
+            return logs;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 #[allow(clippy::zombie_processes)]
@@ -1725,6 +1739,300 @@ fn daemon_checkpoint_receipt_rejects_oversized_body_before_receiving_it() {
         response.error.as_deref(),
         Some("checkpoint ingress busy: byte_limit")
     );
+    let daemon_logs = wait_for_daemon_log(&repo, "checkpoint ingress quota exhausted");
+    assert!(
+        daemon_logs.contains("reason=\"byte_limit\"")
+            && daemon_logs.contains("requested_bytes=67108865"),
+        "daemon logs did not contain checkpoint overflow context:\n{daemon_logs}"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_checkpoint_receipt_logs_body_receive_errors() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let control_socket = daemon_control_socket_path(&repo);
+    let stream = open_local_socket_stream_with_timeout(&control_socket, Duration::from_millis(500))
+        .expect("connect to daemon control socket");
+    let mut reader = BufReader::new(stream);
+    let mut header = serde_json::to_vec(&ControlRequest::CheckpointRun { body_bytes: 4 }).unwrap();
+    header.push(b'\n');
+    reader.get_mut().write_all(&header).unwrap();
+    reader.get_mut().flush().unwrap();
+
+    let mut ready_line = String::new();
+    reader.read_line(&mut ready_line).unwrap();
+    let ready: ControlResponse = serde_json::from_str(ready_line.trim()).unwrap();
+    assert_eq!(
+        ready.data.as_ref().and_then(|data| data.get("ready")),
+        Some(&Value::Bool(true))
+    );
+
+    reader.get_mut().write_all(b"body!").unwrap();
+    reader.get_mut().flush().unwrap();
+    let mut final_line = String::new();
+    assert_eq!(
+        reader.read_line(&mut final_line).unwrap(),
+        0,
+        "invalid body delimiter must close the connection without an acknowledgement"
+    );
+
+    let daemon_logs = wait_for_daemon_log(&repo, "failed receiving checkpoint body");
+    assert!(
+        daemon_logs.contains("reason=\"body_receive_failed\"")
+            && daemon_logs.contains("body_bytes=4"),
+        "daemon logs did not contain checkpoint body receive context:\n{daemon_logs}"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_checkpoint_ack_does_not_wait_for_checkpoint_processing() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
+        "slow-checkpoint=2000",
+    )]);
+    let file_path = repo.path().join("slow-checkpoint.txt");
+    fs::write(&file_path, "AI content\n").unwrap();
+    let request = CheckpointRequest {
+        trace_id: "slow-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "slow-checkpoint-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from("slow-checkpoint.txt"),
+            content: Some("AI content\n".to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Initial,
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+
+    let started = std::time::Instant::now();
+    let response = send_checkpoint_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &request,
+        Duration::from_millis(500),
+    )
+    .expect("checkpoint receipt acknowledgement must not wait for processing");
+    assert!(response.ok, "checkpoint receipt failed: {response:?}");
+    assert!(
+        response.seq.is_some(),
+        "receipt acknowledgement needs a sequence"
+    );
+    assert!(
+        started.elapsed() < Duration::from_millis(500),
+        "receipt acknowledgement waited for checkpoint processing"
+    );
+
+    let sync = send_control_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &ControlRequest::SyncFamily {
+            repo_working_dir: repo_workdir_string(&repo),
+        },
+        Duration::from_secs(5),
+    )
+    .expect("sync.family should wait for asynchronous checkpoint processing");
+    assert!(sync.ok, "sync.family failed: {sync:?}");
+
+    repo.stage_all_and_commit("Commit asynchronously processed checkpoint")
+        .unwrap();
+    let mut file = repo.filename("slow-checkpoint.txt");
+    file.assert_committed_lines(lines!["AI content".ai()]);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_checkpoint_processing_failure_is_logged_after_receipt_ack() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_FAIL_CHECKPOINT_SIDE_EFFECT",
+        "failing-checkpoint",
+    )]);
+    let file_path = repo.path().join("failing-checkpoint.txt");
+    fs::write(&file_path, "content\n").unwrap();
+    let request = CheckpointRequest {
+        trace_id: "failing-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::Human,
+        agent_id: None,
+        files: vec![CheckpointFile {
+            path: PathBuf::from("failing-checkpoint.txt"),
+            content: Some("content\n".to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Initial,
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+
+    let receipt = send_checkpoint_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &request,
+        Duration::from_millis(500),
+    )
+    .expect("processing failure must happen after receipt acknowledgement");
+    assert!(receipt.ok, "checkpoint receipt failed: {receipt:?}");
+    let receipt_seq = receipt.seq.expect("receipt sequence");
+
+    let sync = send_control_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &ControlRequest::SyncFamily {
+            repo_working_dir: repo_workdir_string(&repo),
+        },
+        Duration::from_secs(5),
+    )
+    .expect("sync.family should complete with family error state");
+    assert!(sync.ok, "sync.family request failed: {sync:?}");
+    let last_error = sync
+        .data
+        .as_ref()
+        .and_then(|data| data.get("last_error"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        last_error.contains("synthetic checkpoint processing failure"),
+        "sync.family did not surface checkpoint failure: {sync:?}"
+    );
+
+    let daemon_logs = repo.daemon_stderr_contents();
+    assert!(
+        daemon_logs.contains("side_effect_failed")
+            && daemon_logs.contains("synthetic checkpoint processing failure")
+            && daemon_logs.contains(&format!("receipt_seq={receipt_seq}")),
+        "daemon logs did not contain structured checkpoint failure context:\n{daemon_logs}"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_async_checkpoint_receipts_preserve_file_edit_order_before_commit() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
+        "pre-edit-checkpoint=500",
+    )]);
+    let control_socket = daemon_control_socket_path(&repo);
+    let file_path = repo.path().join("ordered-edit.txt");
+
+    fs::write(
+        &file_path,
+        "committed baseline\nunchanged one\nunchanged two\nunchanged three\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("Initial baseline").unwrap();
+    let mut file = repo.filename("ordered-edit.txt");
+    file.assert_committed_lines(lines![
+        "committed baseline".unattributed_human(),
+        "unchanged one".unattributed_human(),
+        "unchanged two".unattributed_human(),
+        "unchanged three".unattributed_human(),
+    ]);
+    let base_commit = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    fs::write(
+        &file_path,
+        "untracked before AI\nunchanged one\nunchanged two\nunchanged three\n",
+    )
+    .unwrap();
+    let pre_edit = CheckpointRequest {
+        trace_id: "pre-edit-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::Human,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "ordered-edit-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from("ordered-edit.txt"),
+            content: Some(
+                "untracked before AI\nunchanged one\nunchanged two\nunchanged three\n".to_string(),
+            ),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Sha(base_commit.clone()),
+        }],
+        path_role: PreparedPathRole::WillEdit,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+    let pre_receipt = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &pre_edit,
+        Duration::from_millis(500),
+    )
+    .expect("pre-edit receipt");
+    assert!(pre_receipt.ok && pre_receipt.seq.is_some());
+
+    fs::write(
+        &file_path,
+        "untracked before AI\nunchanged one\nunchanged two\nAI addition\n",
+    )
+    .unwrap();
+    let post_edit = CheckpointRequest {
+        trace_id: "post-edit-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "ordered-edit-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from("ordered-edit.txt"),
+            content: Some(
+                "untracked before AI\nunchanged one\nunchanged two\nAI addition\n".to_string(),
+            ),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Sha(base_commit),
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+    let post_receipt = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &post_edit,
+        Duration::from_millis(500),
+    )
+    .expect("post-edit receipt");
+    assert!(post_receipt.ok && post_receipt.seq.is_some());
+    assert!(pre_receipt.seq < post_receipt.seq);
+
+    let checkpoints = repo
+        .current_working_logs()
+        .read_all_checkpoints()
+        .expect("ordered checkpoints should be readable");
+    assert_eq!(
+        checkpoints
+            .iter()
+            .map(|checkpoint| checkpoint.kind)
+            .collect::<Vec<_>>(),
+        vec![CheckpointKind::Human, CheckpointKind::AiAgent],
+        "checkpoint processing must preserve receipt order"
+    );
+    assert_eq!(
+        checkpoints[1].entries[0]
+            .line_attributions
+            .iter()
+            .map(|attribution| (attribution.start_line, attribution.end_line))
+            .collect::<Vec<_>>(),
+        vec![(4, 4)],
+        "the AI checkpoint should only attribute the post-edit addition"
+    );
+
+    repo.git_without_test_sync_for_test(&["add", "."], &[])
+        .unwrap();
+    repo.git_without_test_sync_for_test(&["commit", "-m", "Immediate commit after receipts"], &[])
+        .unwrap();
+
+    file.assert_committed_lines(lines![
+        "untracked before AI".unattributed_human(),
+        "unchanged one".unattributed_human(),
+        "unchanged two".unattributed_human(),
+        "AI addition".ai(),
+    ]);
 }
 
 #[test]
@@ -1817,6 +2125,15 @@ fn daemon_checkpoint_initial_base_does_not_fall_back_to_processing_time_head() {
         send_checkpoint_request_with_timeout(&control_socket, &request, Duration::from_secs(5))
             .expect("checkpoint control request should succeed");
     assert!(response.ok, "checkpoint failed: {response:?}");
+    let sync = send_control_request_with_timeout(
+        &control_socket,
+        &ControlRequest::SyncFamily {
+            repo_working_dir: repo_workdir_string(&repo),
+        },
+        Duration::from_secs(5),
+    )
+    .expect("sync.family should wait for checkpoint processing");
+    assert!(sync.ok, "sync.family failed: {sync:?}");
 
     let repository = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let initial_working_log = repository

--- a/tests/integration/checkpoint_size.rs
+++ b/tests/integration/checkpoint_size.rs
@@ -1,6 +1,5 @@
 use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::working_log::CheckpointKind;
-use git_ai::git::repository::find_repository_in_path;
 use rand::{RngExt, distr::Alphanumeric};
 use serde_json::json;
 use std::{fs, time::Instant};
@@ -102,11 +101,7 @@ fn test_checkpoint_skips_oversized_files() {
     repo.git_ai(&["checkpoint", "mock_ai", "small.txt", "big.txt"])
         .expect("git-ai checkpoint should succeed");
 
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit("initial")
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit("initial");
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     assert_eq!(checkpoints.len(), 1, "expected exactly one checkpoint");
     let latest = checkpoints.last().unwrap();
@@ -130,11 +125,7 @@ fn test_checkpoint_saves_normal_files_under_limit() {
     repo.git_ai(&["checkpoint", "mock_ai", "normal.txt"])
         .expect("git-ai checkpoint should succeed");
 
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit("initial")
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit("initial");
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     assert_eq!(checkpoints.len(), 1, "expected exactly one checkpoint");
     let latest = checkpoints.last().unwrap();

--- a/tests/integration/checkpoint_unit.rs
+++ b/tests/integration/checkpoint_unit.rs
@@ -49,16 +49,12 @@ fn test_checkpoint_with_staged_changes() {
         .unwrap();
 
     // Verify the checkpoint was created with correct entries
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let base_commit = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -95,16 +91,12 @@ fn test_checkpoint_with_staged_changes_after_previous_checkpoint() {
         .unwrap();
 
     // Verify the checkpoint was created with correct entries
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let base_commit = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -141,16 +133,12 @@ fn test_checkpoint_with_only_staged_no_unstaged_changes() {
         .unwrap();
 
     // Verify the checkpoint was created with correct entries
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let base_commit = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -180,16 +168,12 @@ fn test_checkpoint_with_only_unstaged_changes_for_ai_without_pathspec() {
         .unwrap();
 
     // Verify the checkpoint was created
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let base_commit = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -359,17 +343,15 @@ fn test_checkpoint_records_conflicted_files() {
     assert!(has_conflicts, "Should have merge conflicts");
 
     // Try to checkpoint while there are conflicts
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let base_commit = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
+    let checkpoints_before = repo
+        .working_logs_for_base_commit(&base_commit)
+        .read_all_checkpoints()
         .unwrap();
-    let checkpoints_before = working_log.read_all_checkpoints().unwrap();
     let count_before = checkpoints_before.len();
 
     repo.git_ai(&["checkpoint", "mock_known_human", &lines_file])
@@ -377,7 +359,10 @@ fn test_checkpoint_records_conflicted_files() {
 
     // Checkpoints record conflicted files so conflict-resolution attribution can be
     // merged into the eventual rebase/merge commit.
-    let checkpoints_after = working_log.read_all_checkpoints().unwrap();
+    let checkpoints_after = repo
+        .working_logs_for_base_commit(&base_commit)
+        .read_all_checkpoints()
+        .unwrap();
     assert!(
         checkpoints_after.len() > count_before,
         "Should create a checkpoint for conflicted files"
@@ -465,10 +450,7 @@ fn test_checkpoint_filters_external_paths_from_stored_checkpoints() {
 
     // Manually inject a checkpoint with an external file path (simulating the bug)
     // This is what happens when a file outside the repo was tracked before the fix
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
 
     let external_entry = WorkingLogEntry::new(
         "/external/path/outside/repo.txt".to_string(),
@@ -507,10 +489,7 @@ fn test_checkpoint_filters_external_paths_from_stored_checkpoints() {
     );
 
     // Verify the new checkpoint only processed the valid file
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -564,24 +543,25 @@ fn test_checkpoint_works_after_conflict_resolution_maintains_authorship() {
 
     // While there are conflicts, checkpoint should still record the file so the
     // eventual resolution can carry explicit attribution.
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let base_commit = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
+    let checkpoints_before_conflict_checkpoint = repo
+        .working_logs_for_base_commit(&base_commit)
+        .read_all_checkpoints()
         .unwrap();
-    let checkpoints_before_conflict_checkpoint = working_log.read_all_checkpoints().unwrap();
     let count_before = checkpoints_before_conflict_checkpoint.len();
 
     repo.git_ai(&["checkpoint", "mock_known_human", &lines_file])
         .unwrap();
 
     // Checkpoint should record conflicted files during the conflict.
-    let checkpoints_after_conflict_checkpoint = working_log.read_all_checkpoints().unwrap();
+    let checkpoints_after_conflict_checkpoint = repo
+        .working_logs_for_base_commit(&base_commit)
+        .read_all_checkpoints()
+        .unwrap();
     assert!(
         checkpoints_after_conflict_checkpoint.len() > count_before,
         "Should create a checkpoint for conflicted files"
@@ -626,10 +606,7 @@ fn test_checkpoint_works_after_conflict_resolution_maintains_authorship() {
     repo.git_ai(&["checkpoint", "mock_known_human", &lines_file])
         .unwrap();
 
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -672,10 +649,7 @@ fn test_known_human_checkpoint_without_ai_history_records_h_hash_attributions() 
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
     let entry = latest
@@ -742,10 +716,7 @@ fn test_human_checkpoint_keeps_attributions_for_ai_touched_file() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints.last().unwrap();
 
@@ -801,10 +772,7 @@ fn test_checkpoint_skips_default_ignored_files() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
 
     // Should have at least one checkpoint
@@ -862,10 +830,7 @@ fn test_checkpoint_skips_linguist_generated_files_from_root_gitattributes() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
 
     // Should have at least one checkpoint
@@ -900,10 +865,6 @@ fn test_compute_line_stats_ignores_whitespace_only_lines() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
 
     std::fs::write(repo.path().join("whitespace.txt"), "Seed line\n").unwrap();
     repo.git(&["add", "whitespace.txt"]).unwrap();
@@ -920,7 +881,8 @@ fn test_compute_line_stats_ignores_whitespace_only_lines() {
     repo.git_ai(&["checkpoint", "mock_known_human", "whitespace.txt"])
         .expect("First checkpoint should succeed");
 
-    let after_add_stats = working_log
+    let after_add_stats = repo
+        .working_logs_for_base_commit(&base_commit)
         .read_all_checkpoints()
         .expect("Should read checkpoints after addition");
     let after_add_last = after_add_stats
@@ -955,7 +917,8 @@ fn test_compute_line_stats_ignores_whitespace_only_lines() {
     repo.git_ai(&["checkpoint", "mock_known_human", "whitespace.txt"])
         .expect("Second checkpoint should succeed");
 
-    let after_delete_stats = working_log
+    let after_delete_stats = repo
+        .working_logs_for_base_commit(&base_commit)
         .read_all_checkpoints()
         .expect("Should read checkpoints after deletion");
     let latest_stats = after_delete_stats
@@ -1105,10 +1068,7 @@ fn test_checkpoint_crlf_blob_vs_lf_working_tree_stats_not_inflated() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
     let latest = checkpoints
         .last()
@@ -1154,10 +1114,7 @@ fn test_checkpoint_crlf_blob_vs_lf_working_tree_no_changes_skipped() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
 
     // The checkpoint may be empty (no entries) or absent entirely,
@@ -1216,10 +1173,7 @@ fn test_checkpoint_stale_crlf_blob_causes_ai_reattribution() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&base_commit);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
 
     // Find the AI checkpoint entry for test.txt
@@ -1296,10 +1250,7 @@ fn test_checkpoint_fails_with_initial_missing_blobs() {
     // Strip file_blobs from INITIAL to simulate legacy data (pre-March-2026)
     let git_ai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let head_sha = git_ai_repo.head().unwrap().target().unwrap();
-    let working_log = git_ai_repo
-        .storage
-        .working_log_for_base_commit(&head_sha)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&head_sha);
     let initial = working_log.read_initial_attributions();
     assert!(
         initial.files.contains_key("file_a.txt"),
@@ -1401,16 +1352,12 @@ fn test_scoped_checkpoint_records_file_deletion() {
     );
 
     // Verify the checkpoint was recorded in the working log with deletion stats
-    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
     let head_sha = repo
         .git_og(&["rev-parse", "HEAD"])
         .unwrap()
         .trim()
         .to_string();
-    let working_log = gitai_repo
-        .storage
-        .working_log_for_base_commit(&head_sha)
-        .unwrap();
+    let working_log = repo.working_logs_for_base_commit(&head_sha);
     let checkpoints = working_log.read_all_checkpoints().unwrap();
 
     // The AI post-edit checkpoint should be recorded (human pre-edit is a no-op since

--- a/tests/integration/cursor.rs
+++ b/tests/integration/cursor.rs
@@ -519,8 +519,6 @@ fn test_cursor_checkpoint_routes_nested_worktree_file_to_worktree_repo() {
         .expect("cursor checkpoint should succeed");
     println!("Checkpoint output: {}", output);
 
-    repo.sync_daemon_force();
-
     let parent_repo =
         find_repository_in_path(repo.path().to_str().unwrap()).expect("find parent repo");
     let parent_base = parent_repo
@@ -528,10 +526,7 @@ fn test_cursor_checkpoint_routes_nested_worktree_file_to_worktree_repo() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let parent_working_log = parent_repo
-        .storage
-        .working_log_for_base_commit(&parent_base)
-        .expect("parent working log");
+    let parent_working_log = repo.working_logs_for_base_commit(&parent_base);
 
     assert!(
         parent_working_log
@@ -548,10 +543,8 @@ fn test_cursor_checkpoint_routes_nested_worktree_file_to_worktree_repo() {
         .ok()
         .and_then(|head| head.target().ok())
         .unwrap_or_else(|| "initial".to_string());
-    let worktree_working_log = worktree_repo
-        .storage
-        .working_log_for_base_commit(&worktree_base)
-        .expect("worktree working log");
+    let worktree_working_log =
+        repo.working_logs_for_repo_path_and_base_commit(&worktree_path, &worktree_base);
 
     let touched_files = worktree_working_log
         .all_ai_touched_files()

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -606,6 +606,7 @@ fn test_pull_rebase_force_pushed_target_preserves_remote_authorship_note() {
     contributor
         .git(&["push", "--force", "origin", "HEAD:main"])
         .unwrap();
+    contributor.sync_daemon_force();
     contributor
         .git_og(&["push", "--force", "origin", "refs/notes/ai:refs/notes/ai"])
         .unwrap();

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1856,6 +1856,13 @@ impl TestRepo {
         self.daemon_completion_entries_for_family(&family_key)
     }
 
+    pub(crate) fn daemon_stderr_contents(&self) -> String {
+        let Some(daemon) = self.daemon_process.as_ref() else {
+            return String::new();
+        };
+        fs::read_to_string(&daemon.stderr_log_path).unwrap_or_default()
+    }
+
     fn daemon_completion_entries_for_family(
         &self,
         family_key: &str,
@@ -2310,7 +2317,20 @@ impl TestRepo {
                     repo_working_dir: repo_working_dir.clone(),
                 },
             ) {
-                Ok(response) if response.ok => return,
+                Ok(response) if response.ok => {
+                    if let Some(error) = response
+                        .data
+                        .as_ref()
+                        .and_then(|data| data.get("last_error"))
+                        .and_then(serde_json::Value::as_str)
+                    {
+                        panic!(
+                            "daemon completion log reported an error: {error}\ndaemon logs:\n{}",
+                            self.daemon_stderr_contents()
+                        );
+                    }
+                    return;
+                }
                 Ok(response) => {
                     panic!(
                         "daemon sync.family failed: {}",
@@ -2895,6 +2915,7 @@ impl TestRepo {
                             .unwrap_or_else(|poisoned| poisoned.into_inner());
                         registry.raise_expected_checkpoint_count(family_key, *per_family_count);
                     }
+                    self.sync_daemon_force();
                 }
             }
             let combined = if stdout.is_empty() {
@@ -2945,6 +2966,9 @@ impl TestRepo {
                 let count = parse_checkpoint_request_count(&stdout);
                 if count > 0 {
                     self.record_pending_checkpoint_completions(count);
+                    if sync_before_read {
+                        self.sync_daemon_force();
+                    }
                 }
             }
             // Combine stdout and stderr since git-ai often writes to stderr
@@ -3007,6 +3031,7 @@ impl TestRepo {
                 let count = parse_checkpoint_request_count(&stdout);
                 if count > 0 {
                     self.record_pending_checkpoint_completions(count);
+                    self.sync_daemon_force();
                 }
             }
             // Combine stdout and stderr since git-ai often writes to stderr

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -2915,7 +2915,6 @@ impl TestRepo {
                             .unwrap_or_else(|poisoned| poisoned.into_inner());
                         registry.raise_expected_checkpoint_count(family_key, *per_family_count);
                     }
-                    self.sync_daemon_force();
                 }
             }
             let combined = if stdout.is_empty() {
@@ -2966,9 +2965,6 @@ impl TestRepo {
                 let count = parse_checkpoint_request_count(&stdout);
                 if count > 0 {
                     self.record_pending_checkpoint_completions(count);
-                    if sync_before_read {
-                        self.sync_daemon_force();
-                    }
                 }
             }
             // Combine stdout and stderr since git-ai often writes to stderr
@@ -3031,7 +3027,6 @@ impl TestRepo {
                 let count = parse_checkpoint_request_count(&stdout);
                 if count > 0 {
                     self.record_pending_checkpoint_completions(count);
-                    self.sync_daemon_force();
                 }
             }
             // Combine stdout and stderr since git-ai often writes to stderr
@@ -3068,21 +3063,40 @@ impl TestRepo {
     }
 
     pub fn current_working_logs(&self) -> PersistedWorkingLog {
+        let commit_sha = {
+            let repo = GitAiRepository::find_repository_in_path(self.path.to_str().unwrap())
+                .expect("Failed to find repository");
+            // Get the current HEAD commit SHA, or use "initial" for empty repos
+            repo.head()
+                .ok()
+                .and_then(|head| head.target().ok())
+                .unwrap_or_else(|| "initial".to_string())
+        };
+        self.working_logs_for_base_commit(&commit_sha)
+    }
+
+    /// Opens the working log for `base_commit` after synchronizing the daemon,
+    /// so accepted-but-unprocessed checkpoints are visible to the read. Tests
+    /// must use this (or `current_working_logs`) instead of reading working
+    /// logs through raw storage APIs whenever checkpoints were issued through
+    /// the daemon.
+    pub fn working_logs_for_base_commit(&self, base_commit: &str) -> PersistedWorkingLog {
+        self.working_logs_for_repo_path_and_base_commit(&self.path, base_commit)
+    }
+
+    /// As [`Self::working_logs_for_base_commit`], but for a specific repo or
+    /// worktree path (e.g. a linked worktree that shares this repo's family).
+    pub fn working_logs_for_repo_path_and_base_commit(
+        &self,
+        repo_path: &Path,
+        base_commit: &str,
+    ) -> PersistedWorkingLog {
         self.sync_daemon_force();
 
-        let repo = GitAiRepository::find_repository_in_path(self.path.to_str().unwrap())
+        let repo = GitAiRepository::find_repository_in_path(repo_path.to_str().unwrap())
             .expect("Failed to find repository");
-
-        // Get the current HEAD commit SHA, or use "initial" for empty repos
-        let commit_sha = repo
-            .head()
-            .ok()
-            .and_then(|head| head.target().ok())
-            .unwrap_or_else(|| "initial".to_string());
-
-        // Get the working log for the current HEAD commit
         repo.storage
-            .working_log_for_base_commit(&commit_sha)
+            .working_log_for_base_commit(base_commit)
             .unwrap()
     }
 

--- a/tests/integration/status_unit.rs
+++ b/tests/integration/status_unit.rs
@@ -1,4 +1,4 @@
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use git_ai::authorship::stats::CommitStats;
 use serde::Deserialize;
 use std::fs;
@@ -45,6 +45,22 @@ fn write_file(repo: &TestRepo, path: &str, contents: &str) {
         fs::create_dir_all(parent).expect("parent directory should be creatable");
     }
     fs::write(abs_path, contents).expect("file write should succeed");
+}
+
+#[test]
+fn test_status_remains_available_when_daemon_is_not_running() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    write_file(&repo, "offline-status.txt", "committed\n");
+    repo.git_og(&["add", "offline-status.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "initial"]).unwrap();
+
+    write_file(&repo, "offline-status.txt", "committed\nlocal edit\n");
+    let status = status_json(&repo);
+
+    assert!(
+        status.checkpoints.is_empty(),
+        "offline status should preserve the empty-checkpoint result"
+    );
 }
 
 /// Migrated from src/commands/status.rs test_get_working_dir_diff_stats_post_filter_equivalence

--- a/tests/integration/worktrees.rs
+++ b/tests/integration/worktrees.rs
@@ -593,10 +593,7 @@ fn checkpoint_routes_to_linked_worktree_when_cwd_is_main_repo() {
         .expect("wt repo should have a HEAD")
         .target()
         .expect("HEAD should resolve");
-    let wt_working_log = wt_repo
-        .storage
-        .working_log_for_base_commit(&commit_sha)
-        .expect("open worktree working log");
+    let wt_working_log = repo.working_logs_for_repo_path_and_base_commit(&linked_wt, &commit_sha);
 
     let checkpoints = wt_working_log
         .read_all_checkpoints()
@@ -697,10 +694,7 @@ fn checkpoint_routes_to_nested_linked_worktree_when_cwd_is_main_repo() {
         .expect("wt repo should have a HEAD")
         .target()
         .expect("HEAD should resolve");
-    let wt_working_log = wt_repo
-        .storage
-        .working_log_for_base_commit(&commit_sha)
-        .expect("open worktree working log");
+    let wt_working_log = repo.working_logs_for_repo_path_and_base_commit(&linked_wt, &commit_sha);
 
     let checkpoints = wt_working_log
         .read_all_checkpoints()
@@ -766,10 +760,7 @@ fn human_checkpoint_routes_to_linked_worktree_when_cwd_is_main_repo() {
         .expect("wt repo should have a HEAD")
         .target()
         .expect("HEAD should resolve");
-    let wt_working_log = wt_repo
-        .storage
-        .working_log_for_base_commit(&commit_sha)
-        .expect("open worktree working log");
+    let wt_working_log = repo.working_logs_for_repo_path_and_base_commit(&linked_wt, &commit_sha);
 
     let checkpoints = wt_working_log
         .read_all_checkpoints()
@@ -826,10 +817,7 @@ fn human_checkpoint_routes_to_nested_linked_worktree_when_cwd_is_main_repo() {
         .expect("wt repo should have a HEAD")
         .target()
         .expect("HEAD should resolve");
-    let wt_working_log = wt_repo
-        .storage
-        .working_log_for_base_commit(&commit_sha)
-        .expect("open worktree working log");
+    let wt_working_log = repo.working_logs_for_repo_path_and_base_commit(&linked_wt, &commit_sha);
 
     let checkpoints = wt_working_log
         .read_all_checkpoints()


### PR DESCRIPTION
## Summary

- Acknowledge checkpoints immediately after their complete framed body is admitted to the bounded daemon queue, returning a monotonic receipt sequence.
- Decode, resolve, trace-fence, sequence, and process accepted checkpoints on an asynchronous worker.
- Preserve receipt order relative to later checkpoints and Git trace2 commands by admitting through the existing per-family sequencer.
- Keep ingress quota reserved until each checkpoint reaches a terminal processing outcome.
- Make `sync.family`, `await`, status reads, test synchronization, and automatic restarts account for accepted asynchronous checkpoints.
- Log structured daemon errors for overflow, body receive failures, queue/worker failures, admission errors, processing failures, watermark failures, and completion-log failures.
- Require receipt sequences in the CLI protocol; there is intentionally no backward compatibility because daemon and binary versions update together.
- **Fix a pre-existing daemon GC race that async acknowledgement made routine:** `gc_stale_family_state` evicted per-family side-effect exec locks while they were held (`strong_count <= 1` keeps idle locks and removes in-use ones — inverted). The next drain for that family got a fresh unlocked mutex and ran concurrently with the in-flight drain, tearing the working log's read-modify-write of `checkpoints.jsonl` and silently losing attribution. The predicate now evicts only idle locks. Under async ACK this reproduced readily (~1,100 held-lock evictions and 160 torn checkpoint reads in one instrumented full-suite run; zero after the fix).

## Behavior and checkpoint types

File-edit and Bash checkpoints use the same receipt queue and ordering guarantees. Both already carry capture-time file contents/base context, so asynchronous processing does not reread capture-time state. Bash-specific snapshot/history interpretation remains unchanged.

`git-ai status` remains a pure local read and never contacts the daemon.

## Test synchronization (faithful to production timing)

The test harness does **not** inject synchronization after checkpoint writes — a checkpoint followed immediately by `git commit` exercises the same async window production agents hit. Synchronization happens only on the read side, matching the pre-existing harness design: `git-ai` read commands (blame/status/diff/…) pre-sync, and tests that read working logs directly now go through `TestRepo::working_logs_for_base_commit` / `working_logs_for_repo_path_and_base_commit`, which sync the daemon before opening the log.

## Test coverage

- Proves ACK latency remains below 500 ms while processing is artificially stalled for 2 seconds.
- Proves pre/post file-edit receipt order and final attribution across an immediate commit.
- Verifies daemon-visible overflow, malformed-body receive, and post-ACK processing-error logs.
- `gc_keeps_held_family_exec_locks_and_evicts_only_idle_ones` locks in the GC eviction fix (fails against the inverted predicate).
- Full local suite: library tests, daemon tests, and two full integration runs with the faithful (no write-side sync) harness.
- `task fmt`, `task build`, and `task lint` pass.

Depends on #1995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)