### PR TITLE
Fix debug self-check step timeouts

### DIFF
--- a/src/bin/git-ai-test-git-shim.rs
+++ b/src/bin/git-ai-test-git-shim.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use std::process::Command;
 #[cfg(not(unix))]
 use std::process::Stdio;
+use std::time::Duration;
 
 #[derive(Serialize)]
 struct StartedGitInvocationLogEntry {
@@ -75,6 +76,16 @@ fn new_test_sync_session() -> String {
     format!("gt-shim-{}", git_ai::uuid::generate_v4())
 }
 
+fn delay_for_test() {
+    let Ok(delay_ms) = env::var("GIT_AI_TEST_GIT_SHIM_DELAY_MS") else {
+        return;
+    };
+    let Ok(delay_ms) = delay_ms.parse::<u64>() else {
+        return;
+    };
+    std::thread::sleep(Duration::from_millis(delay_ms));
+}
+
 fn argv_with_test_sync_session(argv: &[String], test_sync_session: &str) -> Vec<String> {
     let mut out = Vec::with_capacity(argv.len() + 2);
     out.push("-c".to_string());
@@ -115,6 +126,7 @@ fn exec_target(target: &str, argv: &[String]) -> ! {
 #[cfg(unix)]
 fn main() {
     let argv = env::args().skip(1).collect::<Vec<_>>();
+    delay_for_test();
     let target = select_target(&argv).unwrap_or_else(|error| panic!("{error}"));
     let mut effective_argv = argv.clone();
     let mut test_sync_session = None;
@@ -139,6 +151,7 @@ fn main() {
 #[cfg(not(unix))]
 fn main() {
     let argv = env::args().skip(1).collect::<Vec<_>>();
+    delay_for_test();
     let target = select_target(&argv).unwrap_or_else(|error| panic!("{error}"));
     let mut effective_argv = argv.clone();
     let mut test_sync_session = None;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -332,7 +332,6 @@ pub fn check_trace2_global_config(target: &GitDiagnosticTarget) -> DiagnosticChe
 
 pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticCheckResult {
     let mut commands = Vec::new();
-    let deadline = Instant::now() + DEBUG_CHECK_TIMEOUT;
     let repo_path = debug_self_check_root().join(format!(
         "{}-{}",
         sanitize_label(&target.label),
@@ -344,71 +343,64 @@ pub fn run_attribution_self_check(target: &GitDiagnosticTarget) -> DiagnosticChe
         fs::create_dir_all(&repo_path)
             .map_err(|e| format!("failed to create {}: {}", repo_path.display(), e))?;
 
-        run_required_until(
+        run_required(
             &mut commands,
             &target.program,
             &["init", "."],
             Some(&repo_path),
-            deadline,
         )?;
-        run_required_until(
+        run_required(
             &mut commands,
             &target.program,
             &["config", "user.name", "Git AI Debug"],
             Some(&repo_path),
-            deadline,
         )?;
-        run_required_until(
+        run_required(
             &mut commands,
             &target.program,
             &["config", "user.email", "debug-self-check@git-ai.invalid"],
             Some(&repo_path),
-            deadline,
         )?;
-        run_required_until(
+        run_required(
             &mut commands,
             &target.program,
             &["remote", "add", "origin", DEBUG_SELF_CHECK_REMOTE_URL],
             Some(&repo_path),
-            deadline,
         )?;
 
         fs::write(&file_path, SELF_CHECK_CONTENT_UNTRACKED)
             .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
-        run_git_ai_checkpoint(&mut commands, &repo_path, "human", deadline)?;
-        wait_for_checkpoint_count(&repo_path, 1, deadline)?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "human")?;
+        wait_for_checkpoint_count(&repo_path, 1)?;
 
         fs::write(&file_path, SELF_CHECK_CONTENT_KNOWN_HUMAN)
             .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
-        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_known_human", deadline)?;
-        wait_for_checkpoint_count(&repo_path, 2, deadline)?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_known_human")?;
+        wait_for_checkpoint_count(&repo_path, 2)?;
 
         fs::write(&file_path, SELF_CHECK_CONTENT_AI)
             .map_err(|e| format!("failed to write {}: {}", file_path.display(), e))?;
-        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_ai", deadline)?;
-        wait_for_checkpoint_count(&repo_path, 3, deadline)?;
+        run_git_ai_checkpoint(&mut commands, &repo_path, "mock_ai")?;
+        wait_for_checkpoint_count(&repo_path, 3)?;
 
-        run_required_until(
+        run_required(
             &mut commands,
             &target.program,
             &["add", SELF_CHECK_FILE],
             Some(&repo_path),
-            deadline,
         )?;
-        run_required_until(
+        run_required(
             &mut commands,
             &target.program,
             &["commit", "-m", "git-ai debug self check"],
             Some(&repo_path),
-            deadline,
         )?;
 
-        let commit_sha = run_required_until(
+        let commit_sha = run_required(
             &mut commands,
             &target.program,
             &["rev-parse", "HEAD"],
             Some(&repo_path),
-            deadline,
         )?
         .stdout
         .trim()
@@ -603,18 +595,25 @@ fn run_git_ai_checkpoint(
     commands: &mut Vec<CommandRecord>,
     repo_path: &Path,
     preset: &str,
-    deadline: Instant,
 ) -> Result<CommandRecord, String> {
     let git_ai = std::env::current_exe()
         .map_err(|e| format!("failed to resolve git-ai binary path: {}", e))?;
     let git_ai = git_ai.to_string_lossy().to_string();
-    run_required_until(
+    run_required(
         commands,
         &git_ai,
         &["checkpoint", preset, SELF_CHECK_FILE],
         Some(repo_path),
-        deadline,
     )
+}
+
+fn run_required(
+    commands: &mut Vec<CommandRecord>,
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+) -> Result<CommandRecord, String> {
+    run_required_with_timeout(commands, program, args, cwd, DEBUG_CHECK_TIMEOUT)
 }
 
 fn run_required_until(
@@ -776,12 +775,9 @@ fn remaining_timeout(deadline: Instant) -> Duration {
     deadline.saturating_duration_since(Instant::now())
 }
 
-fn wait_for_checkpoint_count(
-    repo_path: &Path,
-    expected_min_count: usize,
-    deadline: Instant,
-) -> Result<(), String> {
+fn wait_for_checkpoint_count(repo_path: &Path, expected_min_count: usize) -> Result<(), String> {
     let start = Instant::now();
+    let deadline = start + DEBUG_CHECK_TIMEOUT;
     let mut last_error = None;
 
     while Instant::now() < deadline {

--- a/tests/integration/debug_diagnostics.rs
+++ b/tests/integration/debug_diagnostics.rs
@@ -1,9 +1,28 @@
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{TestRepo, real_git_executable};
 use git_ai::{daemon::DaemonConfig, diagnostic_sentinels::DEBUG_SELF_CHECK_DIR_NAME};
+use std::fs;
 
 #[test]
 fn attribution_self_checks_do_not_timeout() {
     let repo = TestRepo::new();
+    let slow_git = repo.test_home_path().join(if cfg!(windows) {
+        "slow-git.exe"
+    } else {
+        "slow-git"
+    });
+    fs::copy(env!("CARGO_BIN_EXE_git-ai-test-git-shim"), &slow_git).unwrap();
+    let config_path = repo.test_home_path().join(".git-ai").join("config.json");
+    fs::write(
+        config_path,
+        serde_json::json!({
+            "git_path": slow_git,
+            "prompt_storage": "notes",
+            "exclude_prompts_in_repositories": [],
+            "disable_version_checks": true
+        })
+        .to_string(),
+    )
+    .unwrap();
     let trace2_target =
         DaemonConfig::trace2_event_target_for_path(&repo.daemon_trace_socket_path());
 
@@ -13,10 +32,22 @@ fn attribution_self_checks_do_not_timeout() {
             &[
                 ("GIT_TRACE2_EVENT", trace2_target.as_str()),
                 ("GIT_TRACE2_EVENT_NESTING", "0"),
+                ("GIT_AI_TEST_GIT_SHIM_TARGET", real_git_executable()),
+                (
+                    "GIT_AI_TEST_GIT_SHIM_FALLBACK_TARGET",
+                    real_git_executable(),
+                ),
+                // Each Git command stays well below the three-second timeout,
+                // but their cumulative delay exceeds the old shared deadline.
+                ("GIT_AI_TEST_GIT_SHIM_DELAY_MS", "550"),
             ],
         )
         .expect("git-ai debug should complete");
 
+    assert!(
+        report.contains(&format!("configured git (program: {})", slow_git.display())),
+        "configured self-check should use the delayed Git shim:\n{report}"
+    );
     let passed_checks = report
         .lines()
         .filter(|line| line.contains("Attribution self-check: passed"))


### PR DESCRIPTION
## Summary

- give every attribution self-check subprocess and checkpoint-persistence wait its own bounded timeout
- strengthen the `TestRepo` regression with a cross-platform Git shim that makes the old cumulative-deadline failure deterministic
- preserve the existing separate timeout for asynchronous post-commit attribution polling

## Root cause

The attribution self-check still shared one three-second setup deadline across repository initialization, configuration, three checkpoint commands and persistence waits, staging, commit, and revision lookup. On a loaded Windows runner, the configured-Git check reached `git commit` with effectively no timeout remaining, while the terminal-Git check gave a checkpoint only 1.3 seconds. The previous timeout fix reset the budget only after commit, so it could not protect these earlier operations.

Each operation is independently bounded and can legitimately take up to the diagnostic timeout, so the timeout must be scoped per operation rather than cumulatively across the whole sequence.

## Impact

`git-ai debug` no longer reports false attribution failures when several individually healthy operations cumulatively exceed three seconds. This changes diagnostic orchestration only; daemon trace2 ingestion and attribution processing paths are unchanged.

## Validation

- regression first failed on the old implementation with the delayed configured-Git shim (`git add` received only 0.3 seconds)
- `task test TEST_FILTER=attribution_self_checks_do_not_timeout`
- `task test`
- `task build`
- `task lint`
- `task fmt`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->