### PR TITLE
feat(debug): add wltrace working-log trace side-channel

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4060,6 +4060,13 @@ impl ActorDaemonCoordinator {
             ));
         };
         let family = self.backend.resolve_family(&repo_work_dir)?.0;
+        crate::wltrace::wltrace("checkpoint.admission", Path::new(&family), || {
+            format!(
+                "receipt_seq={} repo_work_dir={}",
+                accepted.receipt_seq,
+                repo_work_dir.display()
+            )
+        });
 
         self.notify_checkpoint_stream(&request);
         self.wait_for_trace_ingest_seq(accepted.trace_ingest_target)
@@ -4533,6 +4540,22 @@ impl ActorDaemonCoordinator {
 
         let _ = self.begin_family_effect(family);
         for (order, ready_entry) in ready {
+            // Per-family drains must be strictly serialized; overlapping or
+            // order-regressing exec windows in a wltrace capture indicate a
+            // broken exec-lock (see the GC held-lock eviction regression).
+            crate::wltrace::wltrace("drain.exec", Path::new(family), || {
+                let entry = match &ready_entry {
+                    FamilySequencerEntry::ReadyCommand(command) => format!(
+                        "command:{}",
+                        command.primary_command.as_deref().unwrap_or("unknown")
+                    ),
+                    FamilySequencerEntry::Checkpoint { receipt_seq, .. } => {
+                        format!("checkpoint:seq={receipt_seq}")
+                    }
+                    _ => "other".to_string(),
+                };
+                format!("order={order} entry={entry}")
+            });
             match ready_entry {
                 FamilySequencerEntry::ReadyCommand(command) => {
                     // Wrap the entire command + side-effect pipeline in catch_unwind

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -111,6 +111,7 @@ impl RepoStorage {
 
     pub fn delete_working_log_for_base_commit(&self, sha: &str) -> Result<(), GitAiError> {
         let working_log_dir = self.working_logs.join(sha);
+        crate::wltrace::wltrace("working_log.delete", &working_log_dir, String::new);
         if working_log_dir.exists() {
             // Both debug and release: move to old-{sha} for retention
             let old_dir = self.working_logs.join(format!("old-{}", sha));
@@ -195,9 +196,15 @@ impl RepoStorage {
             return Ok(());
         }
         if !new_dir.exists() {
+            crate::wltrace::wltrace("working_log.rename", &old_dir, || {
+                format!("to={}", new_dir.display())
+            });
             fs::rename(&old_dir, &new_dir)?;
             tracing::debug!("Renamed working log from {} to {}", old_sha, new_sha);
         } else {
+            crate::wltrace::wltrace("working_log.merge", &old_dir, || {
+                format!("to={}", new_dir.display())
+            });
             self.merge_working_log_dirs(old_sha, new_sha, &old_dir, &new_dir)?;
             fs::remove_dir_all(&old_dir)?;
             tracing::debug!("Merged working log from {} into {}", old_sha, new_sha);
@@ -329,6 +336,7 @@ impl PersistedWorkingLog {
     }
 
     pub fn reset_working_log(&self) -> Result<(), GitAiError> {
+        crate::wltrace::wltrace("working_log.reset", &self.dir, String::new);
         // Clear all blobs by removing the blobs directory
         let blobs_dir = self.dir.join("blobs");
         if blobs_dir.exists() {
@@ -453,6 +461,7 @@ impl PersistedWorkingLog {
 
     /* append checkpoint */
     pub fn append_checkpoint(&self, checkpoint: &Checkpoint) -> Result<(), GitAiError> {
+        crate::wltrace::wltrace("working_log.append_checkpoint", &self.dir, String::new);
         // Read existing checkpoints
         let mut checkpoints = self.read_all_checkpoints().unwrap_or_default();
 
@@ -512,8 +521,12 @@ impl PersistedWorkingLog {
                 continue;
             }
 
-            let checkpoint: Checkpoint = serde_json::from_str(&line)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            let checkpoint: Checkpoint = serde_json::from_str(&line).map_err(|e| {
+                crate::wltrace::wltrace("working_log.read_checkpoints.TORN", &self.dir, || {
+                    format!("err={e} line_len={}", line.len())
+                });
+                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+            })?;
 
             if checkpoint.api_version != CHECKPOINT_API_VERSION {
                 tracing::debug!(
@@ -663,6 +676,9 @@ impl PersistedWorkingLog {
     /// by post-commit after transcripts have been refetched and need to be preserved
     /// for from_just_working_log() to read them.
     pub fn write_all_checkpoints(&self, checkpoints: &[Checkpoint]) -> Result<(), GitAiError> {
+        crate::wltrace::wltrace("working_log.write_all_checkpoints.begin", &self.dir, || {
+            format!("count={}", checkpoints.len())
+        });
         let checkpoints_file = self.checkpoints_file();
         let mut output = BufWriter::new(fs::File::create(&checkpoints_file)?);
 
@@ -672,6 +688,11 @@ impl PersistedWorkingLog {
         }
 
         output.flush()?;
+        crate::wltrace::wltrace(
+            "working_log.write_all_checkpoints.end",
+            &self.dir,
+            String::new,
+        );
         Ok(())
     }
 
@@ -780,6 +801,7 @@ impl PersistedWorkingLog {
 
     /// Write a fully-formed INITIAL state, preserving any persisted blob references.
     pub fn write_initial(&self, initial: InitialAttributions) -> Result<(), GitAiError> {
+        crate::wltrace::wltrace("working_log.write_initial", &self.dir, String::new);
         let filtered_files: HashMap<String, Vec<LineAttribution>> = initial
             .files
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,4 @@ pub mod streams;
 pub mod tokio_runtime;
 pub mod utils;
 pub mod uuid;
+pub mod wltrace;

--- a/src/wltrace.rs
+++ b/src/wltrace.rs
@@ -1,0 +1,64 @@
+//! Working-log trace: an append-only side-channel for debugging daemon
+//! concurrency and attribution loss in tests.
+//!
+//! When the `GIT_AI_WLTRACE` environment variable names a file, every call
+//! appends one line tagging timestamp, pid, thread, operation, and path, so a
+//! post-run script can reconstruct per-working-log timelines across the test
+//! process, CLI subprocesses, and the daemon. This is how the held-exec-lock
+//! GC eviction race was pinned: overlapping `drain.exec` windows and torn
+//! `checkpoints.jsonl` reads are invisible in ordinary logs but obvious here.
+//!
+//! Compiled only with the `test-support` feature; release builds get a no-op.
+//! With the feature on but the env var unset, the cost per call is one atomic
+//! load (the closure is never invoked).
+
+#[cfg(feature = "test-support")]
+mod imp {
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::sync::OnceLock;
+
+    fn trace_path() -> Option<&'static PathBuf> {
+        static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+        PATH.get_or_init(|| std::env::var_os("GIT_AI_WLTRACE").map(PathBuf::from))
+            .as_ref()
+    }
+
+    pub fn wltrace(op: &str, path: &Path, detail: impl FnOnce() -> String) {
+        let Some(trace_path) = trace_path() else {
+            return;
+        };
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let thread = std::thread::current();
+        let line = format!(
+            "{} pid={} tid={:?} tname={} op={} path={} {}\n",
+            ts,
+            std::process::id(),
+            thread.id(),
+            thread.name().unwrap_or("-").replace(' ', "_"),
+            op,
+            path.display(),
+            detail()
+        );
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(trace_path)
+        {
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+#[cfg(not(feature = "test-support"))]
+mod imp {
+    use std::path::Path;
+
+    #[inline(always)]
+    pub fn wltrace(_op: &str, _path: &Path, _detail: impl FnOnce() -> String) {}
+}
+
+pub use imp::wltrace;

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1787,6 +1787,33 @@ fn daemon_checkpoint_receipt_logs_body_receive_errors() {
 
 #[test]
 #[cfg(not(windows))]
+fn wltrace_captures_daemon_working_log_ops_when_enabled() {
+    let trace_file = tempfile::NamedTempFile::new().expect("wltrace temp file");
+    let trace_path = trace_file.path().to_string_lossy().to_string();
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_WLTRACE", trace_path.as_str())]);
+
+    let file_path = repo.path().join("traced.txt");
+    fs::write(&file_path, "AI content\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "traced.txt"])
+        .unwrap();
+    repo.current_working_logs()
+        .read_all_checkpoints()
+        .expect("checkpoint should be readable");
+
+    let trace = fs::read_to_string(trace_file.path()).expect("read wltrace output");
+    for op in [
+        "op=checkpoint.admission",
+        "op=drain.exec",
+        "op=working_log.append_checkpoint",
+        "op=working_log.write_all_checkpoints.begin",
+        "op=working_log.write_all_checkpoints.end",
+    ] {
+        assert!(trace.contains(op), "wltrace output missing {op}:\n{trace}");
+    }
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_checkpoint_ack_does_not_wait_for_checkpoint_processing() {
     let repo = TestRepo::new_with_daemon_env(&[(
         "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",


### PR DESCRIPTION
## Summary

- Add `src/wltrace.rs`: a test-support-only debugging side-channel. When `GIT_AI_WLTRACE` names a file, each traced operation appends one line tagged with timestamp/pid/thread/path so per-working-log timelines can be reconstructed across the test process, CLI subprocesses, and the daemon.
- Probe points: working-log mutations (append/write/reset/rename/merge/delete), torn `checkpoints.jsonl` reads, per-family drain execution order, and checkpoint admission.
- Release builds compile a no-op; with `test-support` built but the env var unset, cost per call is a single `OnceLock` load.

## Why

This is the instrumentation that pinned the held-exec-lock GC eviction race in #1996: overlapping `drain.exec` windows and torn checkpoint reads are invisible in ordinary logs but obvious in a wltrace capture. The stacked PRs above use it to pin two more long-standing flakes. Landing it keeps that capability one env var away instead of rebuilding it per investigation.

## Test coverage

- `wltrace_captures_daemon_working_log_ops_when_enabled`: end-to-end through a dedicated daemon, asserts admission, drain, and working-log ops all appear in the capture.
- `task fmt` / `task lint` pass; builds clean with and without `test-support`.

Depends on #1996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->