### PR TITLE
test: drain pending checkpoints before TestRepo teardown

### DIFF
--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -3239,6 +3239,44 @@ impl Drop for TestRepo {
             return;
         }
 
+        // Drain any still-queued checkpoints for this repo before deleting it.
+        // With asynchronous checkpoint acknowledgement, a test whose final
+        // checkpoint is never followed by a synced read can otherwise remove
+        // the repo while the shared daemon still holds the checkpoint,
+        // producing spurious "Failed to resolve git common dir" / ENOENT
+        // daemon errors that pollute forensics. Only sync when the registry
+        // shows un-synced checkpoints, and best-effort: Drop must never panic
+        // (a panic here during unwinding would abort the process and mask the
+        // test's real failure), so skip the drain when the family key can't
+        // be resolved instead of using the panicking accessor.
+        if self.daemon_scope == DaemonTestScope::Shared
+            && self.has_active_daemon()
+            && let Some(family_key) = self
+                .daemon_family_key
+                .get()
+                .cloned()
+                .or_else(|| self.maybe_daemon_family_key_for_repo_path(&self.path))
+        {
+            let has_pending = {
+                let registry = daemon_sync_registry()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                registry.pending_work_summary(&family_key).is_some()
+            };
+            if has_pending {
+                let repo_working_dir = self
+                    .path
+                    .canonicalize()
+                    .unwrap_or_else(|_| self.path.clone())
+                    .to_string_lossy()
+                    .to_string();
+                let _ = send_control_request(
+                    &self.daemon_control_socket_path(),
+                    &ControlRequest::SyncFamily { repo_working_dir },
+                );
+            }
+        }
+
         if self.daemon_scope == DaemonTestScope::Dedicated
             && let Some(daemon) = self.daemon_process.take()
         {


### PR DESCRIPTION
## Summary

- `TestRepo::drop` now issues a best-effort `sync.family` before deleting the temp repo, only when the harness sync registry shows un-synced checkpoints for the family.

## Why

With asynchronous checkpoint acknowledgement (#1996), a test whose final checkpoint is never followed by a synced read can delete its repo while the shared daemon still holds the checkpoint queued. The daemon then fails admission/processing against the missing path, filling daemon logs with `Failed to resolve git common dir` and ENOENT side-effect errors — noise that pollutes exactly the wltrace/daemon-log forensics the stacked investigations rely on.

Clean teardowns pay nothing (registry check only), and Drop can never panic (all fallible calls are ignored).

## Test coverage

- Full integration suite green; kept-repo runs show the teardown error class eliminated from fresh daemon logs.

Depends on #2016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->