### PR TITLE
fix(ref-cursor): stop failed rebase --continue from stealing the final continue's reflog entry

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -829,6 +829,11 @@ fn process_conflict_resolution_working_logs(
     new_tip: &str,
     onto: Option<&str>,
 ) -> Result<RewriteMetricContext, GitAiError> {
+    crate::wltrace::wltrace(
+        "rebase.conflict_logs",
+        &repo.workdir().unwrap_or_default(),
+        || format!("new_tip={new_tip} onto={}", onto.unwrap_or("NONE")),
+    );
     let onto_sha = match onto {
         Some(s) if !s.is_empty() => s,
         _ => return Ok(RewriteMetricContext::default()),
@@ -5264,6 +5269,23 @@ impl ActorDaemonCoordinator {
         // with the branch ref update as new_tip. This handles rebase --skip/--continue
         // where HEAD can contain extra checkout/detach movement that is not the
         // rebased branch tip.
+        crate::wltrace::wltrace(
+            "rewrite.branch_transition",
+            Path::new(cmd.worktree.as_deref().unwrap_or(Path::new(""))),
+            || {
+                format!(
+                    "cmd={} branch_changes={} pending_original_head={} ref_changes={}",
+                    cmd.primary_command.as_deref().unwrap_or("unknown"),
+                    branch_changes.len(),
+                    pending_original_head
+                        .as_ref()
+                        .map(|(head, _)| head.as_str())
+                        .unwrap_or("NONE"),
+                    cmd.ref_changes.len(),
+                )
+            },
+        );
+
         if let Some((original_head, stored_onto)) = pending_original_head
             && let Some(new_tip) = rebase_new_tip_from_command(cmd, &original_head)
         {
@@ -5636,6 +5658,21 @@ impl ActorDaemonCoordinator {
                         .unwrap_or("");
                     let pending_old_head =
                         strict_rebase_original_head_from_command(cmd, semantic_old_head);
+                    crate::wltrace::wltrace(
+                        "rebase.pending_head",
+                        cmd.worktree.as_deref().unwrap_or(Path::new("")),
+                        || {
+                            format!(
+                                "old_head={} rebase_start={} ref_changes={}",
+                                pending_old_head.as_deref().unwrap_or("NONE"),
+                                rebase_start
+                                    .as_ref()
+                                    .map(|(old, new)| format!("{old}->{new}"))
+                                    .unwrap_or_else(|| "NONE".to_string()),
+                                cmd.ref_changes.len(),
+                            )
+                        },
+                    );
                     if let Some(old_head) = pending_old_head {
                         let rebase_onto = rebase_start.as_ref().map(|(_, new)| new.clone());
                         if std::env::var("GIT_AI_DEBUG_DAEMON_TRACE")

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -1007,13 +1007,72 @@ impl RefCursor {
             return Ok(());
         }
 
+        // A failed control-mode rebase (--continue/--skip that stopped on a
+        // later conflict) may have produced no reflog entry of its own (e.g.
+        // an empty resolution git skipped). Because trace processing is
+        // asynchronous, the entry written by the EVENTUAL successful continue
+        // can already be in the reflog by the time this command is enriched;
+        // consuming it here starves that final continue of its evidence and
+        // loses the rebased-branch transition (and with it the migration of
+        // conflict-resolution working logs). Failed commands take no side
+        // effects, so their ref evidence is never used: consume nothing. Any
+        // entry this command did create is picked up by the successful
+        // continue's chain walk below.
+        if cmd.exit_code != 0 && summarize_rebase_args(&rebase_command_args(cmd)).is_control_mode {
+            return Ok(());
+        }
+
         let expected = self.head_expected_transition(cmd, state);
         let first = match self.find_rebase_start_entry(cmd, expected.clone())? {
             Some(entry) => Some(entry),
-            None => {
-                self.find_head_entry_without_hint(cmd.worktree.as_deref(), &["rebase"], expected)?
-            }
+            None => self.find_head_entry_without_hint(
+                cmd.worktree.as_deref(),
+                &["rebase"],
+                expected.clone(),
+            )?,
         };
+        crate::wltrace::wltrace(
+            "ref_cursor.rebase_first_entry",
+            cmd.worktree.as_deref().unwrap_or(std::path::Path::new("")),
+            || {
+                let cursor = cmd
+                    .worktree
+                    .as_deref()
+                    .and_then(git_dir_for_worktree)
+                    .map(|git_dir| head_key(&git_dir))
+                    .map(|key| {
+                        format!(
+                            "offset={:?} hint={:?}",
+                            self.offsets.get(&key),
+                            self.command_start_hints.get(&key)
+                        )
+                    })
+                    .unwrap_or_else(|| "no-key".to_string());
+                format!(
+                    "sid={} exit={} first={} expected_old={:?} expected_new={:?} {cursor}",
+                    cmd.root_sid,
+                    cmd.exit_code,
+                    first
+                        .as_ref()
+                        .map(|entry| format!(
+                            "{}->{} msg={}",
+                            &entry.old[..8.min(entry.old.len())],
+                            &entry.new[..8.min(entry.new.len())],
+                            entry.message.chars().take(40).collect::<String>()
+                        ))
+                        .unwrap_or_else(|| "NONE".to_string()),
+                    expected
+                        .old_oids
+                        .iter()
+                        .map(|oid| oid.chars().take(8).collect::<String>())
+                        .collect::<Vec<_>>(),
+                    expected
+                        .new_oid
+                        .as_ref()
+                        .map(|oid| &oid[..8.min(oid.len())]),
+                )
+            },
+        );
         let Some(first) = first else {
             return Ok(());
         };
@@ -5216,6 +5275,86 @@ mod tests {
                     new: E.to_string(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn failed_rebase_continue_does_not_steal_final_continue_entry() {
+        // Two-conflict rebase: the FIRST `rebase --continue` resolves conflict
+        // one with an empty/kept-side resolution and stops again on conflict
+        // two (exit != 0). Its only reflog evidence so far is the start entry
+        // (already consumed by the initial failed `rebase <branch>`); the
+        // continue entry that later appears belongs to the SECOND, successful
+        // `rebase --continue`. The failed continue must not consume it — doing
+        // so leaves the final continue with no entry, no ref_changes, and the
+        // conflict-resolution working log is never attributed (the
+        // two-conflicts attribution flake).
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = create_git_dir(&worktree);
+        fs::create_dir_all(git_dir.join("logs")).unwrap();
+        append_reflog(
+            &git_dir,
+            "HEAD",
+            &[
+                (A, B, "rebase (start): checkout main"),
+                (B, C, "rebase (continue): Add Rust joke"),
+                (C, C, "rebase (finish): returning to refs/heads/topic"),
+            ],
+        );
+        append_reflog(
+            &git_dir,
+            "refs/heads/topic",
+            &[(D, C, "rebase (finish): refs/heads/topic onto main")],
+        );
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let state = family_state(&family);
+        let mut cursor = RefCursor::new(family.clone());
+
+        // Initial rebase stops on the first conflict: consumes the start entry.
+        let mut initial =
+            command_with_worktree(&family, Some(worktree.clone()), &["rebase", "main"]);
+        initial.exit_code = 1;
+        cursor.enrich_command(&mut initial, &state).unwrap();
+        assert_eq!(
+            initial.ref_changes,
+            vec![RefChange {
+                reference: "HEAD".to_string(),
+                old: A.to_string(),
+                new: B.to_string(),
+            }],
+            "initial failed rebase should consume only the start entry"
+        );
+
+        // First --continue resolves conflict one and stops on conflict two.
+        // It produced no reflog entry of its own and must consume nothing.
+        let mut stopped_continue =
+            command_with_worktree(&family, Some(worktree.clone()), &["rebase", "--continue"]);
+        stopped_continue.exit_code = 1;
+        cursor
+            .enrich_command(&mut stopped_continue, &state)
+            .unwrap();
+        assert_eq!(
+            stopped_continue.ref_changes,
+            Vec::<RefChange>::new(),
+            "a --continue that stops on the next conflict must not steal the final continue's entry"
+        );
+
+        // Final --continue finishes the rebase: its continue + finish entries
+        // must still be available so the branch transition is established.
+        let mut final_continue =
+            command_with_worktree(&family, Some(worktree), &["rebase", "--continue"]);
+        cursor.enrich_command(&mut final_continue, &state).unwrap();
+        assert!(
+            final_continue
+                .ref_changes
+                .iter()
+                .any(|change| change.reference == "refs/heads/topic"
+                    && change.old == D
+                    && change.new == C),
+            "final --continue must recover the branch transition; got {:?}",
+            final_continue.ref_changes
         );
     }
 


### PR DESCRIPTION
## Summary

- A failed control-mode rebase (`--continue`/`--skip` that stopped on a later conflict) no longer consumes HEAD reflog entries during enrichment.
- Adds wltrace probes to the rebase/rewrite pipeline (pending-head capture, branch-transition evaluation, conflict-log processing, first-entry selection).

## The bug

A rebase with two conflicts in the same file runs: `rebase <branch>` (exit 1) → `rebase --continue` (resolves conflict one, stops on conflict two, exit 1) → `rebase --continue` (exit 0). The middle continue often writes no reflog entry of its own. Because trace processing is asynchronous, by the time the daemon enriches that failed continue, the reflog already contains the entry written by the final successful continue — and `consume_rebase_transition` consumed it. The final continue then found no unconsumed entry, produced zero `ref_changes`, the rebased-branch transition failed closed, and `process_conflict_resolution_working_logs` never attributed the AI conflict resolution. Result: the AI-resolved line landed as plain human (the `test_regular_rebase_two_conflicts_*` flake, also seen on Windows CI in #1996).

Pinned with the wltrace harness (#2016): the failing capture shows the stopped continue consuming `rebase (continue): Add Rust joke` (cursor 1155→1316) and the final continue finding `first=NONE`, followed by `rewrite.branch_transition ... ref_changes=0`.

## The fix

Failed commands take no side effects, so their ref evidence is never used — skip reflog consumption entirely for failed control-mode rebases. Any entry such a command did produce is picked up by the successful continue's chain walk.

## Test coverage

- `failed_rebase_continue_does_not_steal_final_continue_entry`: unit test replicating the exact captured interleaving; fails without the fix.
- All 49 ref_cursor unit tests, 399 rebase-related integration tests, daemon_mode suite green.
- `pull_rebase` module 6/6 consecutive green (previously failed ~1 in 3 under load); two consecutive fully-green full-suite runs (3,256/3,256) on the stack tip.

Depends on #2016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->