### PR TITLE
test: give author-config attestation tests dedicated daemons

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -603,12 +603,7 @@ fn handle_restart(args: &[String]) -> Result<(), String> {
         if hard {
             hard_kill_daemon(&config)?;
         } else {
-            // Attempt soft shutdown; escalate to hard kill on timeout.
-            let _ = send_control_request(&config.control_socket_path, &ControlRequest::Shutdown);
-            if !wait_for_daemon_dead(&config, GRACEFUL_SHUTDOWN_TIMEOUT) {
-                eprintln!("graceful shutdown timed out, force-killing daemon");
-                hard_kill_daemon(&config)?;
-            }
+            stop_daemon(&config, GRACEFUL_SHUTDOWN_TIMEOUT)?;
         }
 
         // Even after lock+sockets are gone, the process may still be alive
@@ -729,14 +724,26 @@ pub(crate) fn stop_daemon(config: &DaemonConfig, timeout: Duration) -> Result<()
         return Ok(());
     }
 
-    // Attempt soft shutdown via control socket if reachable.
+    let deadline = Instant::now() + timeout;
+
+    // Attempt soft shutdown via control socket if reachable. Bound the request
+    // itself by the caller's deadline because shutdown may now wait for
+    // acknowledged checkpoints before responding.
     if local_socket_connects_with_timeout(&config.control_socket_path, Duration::from_millis(100))
         .is_ok()
     {
-        let _ = send_control_request(&config.control_socket_path, &ControlRequest::Shutdown);
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if !remaining.is_zero() {
+            let _ = send_control_request_with_timeout(
+                &config.control_socket_path,
+                &ControlRequest::Shutdown,
+                remaining,
+            );
+        }
     }
 
-    if wait_for_daemon_dead(config, timeout) {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if wait_for_daemon_dead(config, remaining) {
         return Ok(());
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,6 +20,7 @@ use crate::{
     commands::checkpoint_agent::orchestrator::CheckpointRequest,
     daemon::checkpoint::PreparedPathRole,
 };
+use futures::{StreamExt, stream};
 #[cfg(not(windows))]
 use interprocess::local_socket::ConnectOptions;
 #[cfg(not(windows))]
@@ -48,7 +49,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
+use tokio::sync::{Mutex as AsyncMutex, Notify, Semaphore, mpsc};
 use tokio::time::Duration;
 
 pub mod analyzers;
@@ -93,6 +94,7 @@ const DAEMON_CHECKPOINT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
 const DAEMON_SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 const CHECKPOINT_INGRESS_REQUEST_LIMIT: usize = 1_024;
 const CHECKPOINT_INGRESS_BYTE_LIMIT: usize = 64 * 1024 * 1024;
+const CHECKPOINT_FAMILY_DRAIN_CONCURRENCY: usize = 2;
 // Trace2 frames are written synchronously by Git to the daemon's Unix socket.
 // With small kernel socket buffers (macOS defaults to ~8 KiB), a bursty trace2
 // stream can fill the buffer and block the raw `git` process in `write()` until
@@ -982,22 +984,53 @@ fn rfc3339_to_unix_nanos(value: &str) -> Option<u128> {
         .and_then(|timestamp| u128::try_from(timestamp.timestamp_nanos_opt()?).ok())
 }
 
+#[cfg(feature = "test-support")]
+fn checkpoint_test_delay(env_var: &str, trace_id: &str) -> Option<Duration> {
+    let spec = std::env::var(env_var).ok()?;
+    spec.split(',').find_map(|entry| {
+        let (entry_trace_id, delay_ms) = entry.split_once('=')?;
+        if entry_trace_id != trace_id {
+            return None;
+        }
+        delay_ms
+            .parse::<u64>()
+            .ok()
+            .filter(|delay_ms| *delay_ms > 0)
+            .map(Duration::from_millis)
+    })
+}
+
+#[cfg(feature = "test-support")]
+fn wait_at_checkpoint_test_barrier(trace_id: &str) -> Result<(), GitAiError> {
+    let Ok(barrier_dir) = std::env::var("GIT_AI_TEST_CHECKPOINT_SIDE_EFFECT_BARRIER_DIR") else {
+        return Ok(());
+    };
+    let barrier_dir = PathBuf::from(barrier_dir);
+    fs::create_dir_all(&barrier_dir)?;
+    let marker = format!("{:x}", Sha256::digest(trace_id.as_bytes()));
+    fs::write(barrier_dir.join(marker), [])?;
+
+    let started = std::time::Instant::now();
+    while started.elapsed() < Duration::from_secs(2) {
+        if fs::read_dir(&barrier_dir)?.count() >= 2 {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Err(GitAiError::Generic(format!(
+        "checkpoint test barrier timed out for {trace_id}"
+    )))
+}
+
 fn apply_checkpoint_side_effect(mut request: CheckpointRequest) -> Result<(), GitAiError> {
     #[cfg(feature = "test-support")]
     {
-        if let Ok(spec) = std::env::var("GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT") {
-            for entry in spec.split(',') {
-                let Some((trace_id, delay_ms)) = entry.split_once('=') else {
-                    continue;
-                };
-                if trace_id == request.trace_id
-                    && let Ok(delay_ms) = delay_ms.parse::<u64>()
-                    && delay_ms > 0
-                {
-                    std::thread::sleep(Duration::from_millis(delay_ms));
-                    break;
-                }
-            }
+        wait_at_checkpoint_test_barrier(&request.trace_id)?;
+        if let Some(delay) = checkpoint_test_delay(
+            "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
+            &request.trace_id,
+        ) {
+            std::thread::sleep(delay);
         }
         if std::env::var("GIT_AI_TEST_FAIL_CHECKPOINT_SIDE_EFFECT")
             .is_ok_and(|trace_id| trace_id == request.trace_id)
@@ -2707,6 +2740,7 @@ pub struct ActorDaemonCoordinator {
         Mutex<HashMap<String, VecDeque<RecentReplayPrerequisite>>>,
     side_effect_errors_by_family: Mutex<HashMap<String, BTreeMap<u64, String>>>,
     side_effect_exec_locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+    checkpoint_side_effect_semaphore: Semaphore,
     checkpoint_ingress_quota: Arc<CheckpointIngressQuota>,
     checkpoint_ingress_tx: std::sync::OnceLock<mpsc::Sender<AcceptedCheckpoint>>,
     next_checkpoint_receipt_seq: AtomicUsize,
@@ -2798,6 +2832,7 @@ impl ActorDaemonCoordinator {
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
             side_effect_errors_by_family: Mutex::new(HashMap::new()),
             side_effect_exec_locks: Mutex::new(HashMap::new()),
+            checkpoint_side_effect_semaphore: Semaphore::new(CHECKPOINT_FAMILY_DRAIN_CONCURRENCY),
             checkpoint_ingress_quota: Arc::new(CheckpointIngressQuota::new(
                 CHECKPOINT_INGRESS_REQUEST_LIMIT,
                 CHECKPOINT_INGRESS_BYTE_LIMIT,
@@ -3359,10 +3394,20 @@ impl ActorDaemonCoordinator {
             let map = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
             })?;
-            map.keys().cloned().collect::<Vec<_>>()
+            map.iter()
+                .filter(|(_, state)| !state.entries.is_empty())
+                .map(|(family, _)| family.clone())
+                .collect::<Vec<_>>()
         };
-        for family in families {
-            self.drain_ready_family_sequencer_entries(&family).await?;
+        let first_error = stream::iter(families)
+            .map(|family| async move { self.drain_ready_family_sequencer_entries(&family).await })
+            .buffer_unordered(CHECKPOINT_FAMILY_DRAIN_CONCURRENCY)
+            .fold(None, |first_error, result| async move {
+                first_error.or_else(|| result.err())
+            })
+            .await;
+        if let Some(error) = first_error {
+            return Err(error);
         }
         Ok(())
     }
@@ -4058,6 +4103,12 @@ impl ActorDaemonCoordinator {
             serde_json::from_slice(&accepted.body).map_err(|error| {
                 GitAiError::Generic(format!("invalid accepted checkpoint body: {error}"))
             })?;
+        #[cfg(feature = "test-support")]
+        if let Some(delay) =
+            checkpoint_test_delay("GIT_AI_TEST_DELAY_CHECKPOINT_ADMISSION", &request.trace_id)
+        {
+            tokio::time::sleep(delay).await;
+        }
         let trace_id = request.trace_id.clone();
         let file_count = request.files.len();
         let Some(repo_work_dir) = request.files.first().map(|file| file.repo_work_dir.clone())
@@ -4507,12 +4558,9 @@ impl ActorDaemonCoordinator {
             if self.unadmitted_checkpoints.load(Ordering::Acquire) > 0 {
                 return Ok(());
             }
-            let state = map
-                .entry(family.to_string())
-                .or_insert_with(|| FamilySequencerState {
-                    next_ordinal: 1,
-                    entries: BTreeMap::new(),
-                });
+            let Some(state) = map.get_mut(family) else {
+                return Ok(());
+            };
             while let Some(first_entry) = state.entries.first_entry() {
                 if matches!(first_entry.get(), FamilySequencerEntry::PendingRoot) {
                     break;
@@ -4732,6 +4780,15 @@ impl ActorDaemonCoordinator {
 
                     let should_log_completion = true; // Always log for test sync
                     tracing::info!(kind = %checkpoint_kind_str, repo = %repo_wd, "checkpoint start");
+                    let checkpoint_side_effect_permit = self
+                        .checkpoint_side_effect_semaphore
+                        .acquire()
+                        .await
+                        .map_err(|_| {
+                            GitAiError::Generic(
+                                "checkpoint side-effect semaphore closed".to_string(),
+                            )
+                        })?;
                     let checkpoint_start = std::time::Instant::now();
                     let checkpoint_request = {
                         let future = async {
@@ -4739,14 +4796,21 @@ impl ActorDaemonCoordinator {
                                 let ack =
                                     self.coordinator.apply_checkpoint(Path::new(&repo_wd)).await;
                                 match ack {
-                                    Ok(ack) => run_blocking_side_effect(|| {
-                                        apply_checkpoint_side_effect(*request)
-                                    })
-                                    .map(|_| ack.seq),
+                                    Ok(ack) => {
+                                        crate::tokio_runtime::spawn_blocking_result(move || {
+                                            apply_checkpoint_side_effect(*request)
+                                        })
+                                        .await
+                                        .map(|_| ack.seq)
+                                    }
                                     Err(error) => Err(error),
                                 }
                             } else {
-                                apply_checkpoint_side_effect(*request).map(|_| 0)
+                                crate::tokio_runtime::spawn_blocking_result(move || {
+                                    apply_checkpoint_side_effect(*request)
+                                })
+                                .await
+                                .map(|_| 0)
                             }
                         };
                         let caught = std::panic::AssertUnwindSafe(future);
@@ -4778,6 +4842,7 @@ impl ActorDaemonCoordinator {
                             )))
                         }
                     };
+                    drop(checkpoint_side_effect_permit);
                     let checkpoint_duration_ms = checkpoint_start.elapsed().as_millis();
                     if result.is_ok() {
                         tracing::info!(
@@ -9098,6 +9163,22 @@ mod tests {
         assert!(
             !map.contains_key("family-idle"),
             "GC should evict idle exec locks to bound the map"
+        );
+    }
+
+    #[tokio::test]
+    async fn draining_an_unknown_family_does_not_retain_empty_sequencer_state() {
+        let coord = ActorDaemonCoordinator::new();
+
+        coord
+            .drain_ready_family_sequencer_entries_locked("family-with-no-work")
+            .await
+            .expect("empty family drain");
+
+        let map = coord.family_sequencers_by_family.lock().unwrap();
+        assert!(
+            !map.contains_key("family-with-no-work"),
+            "global drains must not grow the sequencer map with empty families"
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2712,6 +2712,7 @@ pub struct ActorDaemonCoordinator {
     next_checkpoint_receipt_seq: AtomicUsize,
     processed_checkpoint_receipt_seq: AtomicUsize,
     unadmitted_checkpoints: AtomicUsize,
+    accepting_checkpoints: AtomicBool,
     checkpoint_progress_notify: Notify,
     bash_sessions: Mutex<crate::daemon::bash_sessions::BashSessionState>,
     test_completion_log_dir: Option<PathBuf>,
@@ -2805,6 +2806,7 @@ impl ActorDaemonCoordinator {
             next_checkpoint_receipt_seq: AtomicUsize::new(0),
             processed_checkpoint_receipt_seq: AtomicUsize::new(0),
             unadmitted_checkpoints: AtomicUsize::new(0),
+            accepting_checkpoints: AtomicBool::new(true),
             checkpoint_progress_notify: Notify::new(),
             bash_sessions: Mutex::new(crate::daemon::bash_sessions::BashSessionState::new()),
             test_completion_log_dir: std::env::var("GIT_AI_TEST_DB_PATH")
@@ -6525,6 +6527,22 @@ impl ActorDaemonCoordinator {
         self.status_for_family(repo_working_dir).await
     }
 
+    async fn drain_accepted_checkpoints(&self) -> Result<(), GitAiError> {
+        loop {
+            let checkpoint_target = self.next_checkpoint_receipt_seq.load(Ordering::Acquire) as u64;
+            self.wait_for_checkpoint_admission_through(checkpoint_target)
+                .await;
+            self.wait_for_no_unadmitted_checkpoints().await;
+            self.wait_for_trace_ingest_processed_through().await;
+            self.drain_all_ready_family_sequencers().await?;
+
+            if self.outstanding_checkpoint_state().0 == 0 {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
     /// Wait for the daemon to finish all in-flight work and telemetry flushing.
     ///
     /// Progress is logged every few seconds. Returns an `AwaitResult` describing
@@ -6688,6 +6706,16 @@ impl ActorDaemonCoordinator {
 
     fn outstanding_checkpoint_state(&self) -> (usize, usize) {
         self.checkpoint_ingress_quota.outstanding()
+    }
+
+    fn set_checkpoint_acceptance(&self, accepting: bool) -> Result<(), GitAiError> {
+        let _sequencers = self
+            .family_sequencers_by_family
+            .lock()
+            .map_err(|_| GitAiError::Generic("family sequencer map lock poisoned".to_string()))?;
+        self.accepting_checkpoints
+            .store(accepting, Ordering::Release);
+        Ok(())
     }
 
     async fn handle_control_request(&self, request: ControlRequest) -> ControlResponse {
@@ -6984,7 +7012,28 @@ impl ActorDaemonCoordinator {
                 };
                 Ok(response)
             }
-            ControlRequest::Shutdown => Ok(ControlResponse::ok(None, None)),
+            ControlRequest::Shutdown => match self.set_checkpoint_acceptance(false) {
+                Err(error) => Err(error),
+                Ok(()) => {
+                    tracing::info!(
+                        component = "daemon",
+                        phase = "shutdown",
+                        "checkpoint acceptance closed for graceful shutdown"
+                    );
+                    match self.drain_accepted_checkpoints().await {
+                        Ok(()) => Ok(ControlResponse::ok(None, None)),
+                        Err(error) => {
+                            if let Err(reopen_error) = self.set_checkpoint_acceptance(true) {
+                                tracing::error!(
+                                    %reopen_error,
+                                    "failed reopening checkpoint acceptance after shutdown error"
+                                );
+                            }
+                            Err(error)
+                        }
+                    }
+                }
+            },
         };
 
         match result {
@@ -7232,6 +7281,27 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
         let mut shutdown_after_response = false;
         let response = match parsed {
             Ok(ControlRequest::CheckpointRun { body_bytes }) => {
+                if !coordinator.accepting_checkpoints.load(Ordering::Acquire) {
+                    let acceptance_closed = {
+                        let _sequencers =
+                            coordinator
+                                .family_sequencers_by_family
+                                .lock()
+                                .map_err(|_| {
+                                    GitAiError::Generic(
+                                        "family sequencer map lock poisoned".to_string(),
+                                    )
+                                })?;
+                        !coordinator.accepting_checkpoints.load(Ordering::Acquire)
+                    };
+                    if acceptance_closed {
+                        write_control_response(
+                            reader.get_mut(),
+                            &ControlResponse::err("daemon is shutting down"),
+                        )?;
+                        continue;
+                    }
+                }
                 let body_bytes = match usize::try_from(body_bytes) {
                     Ok(body_bytes) => body_bytes,
                     Err(error) => {
@@ -7362,38 +7432,50 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                                     "family sequencer map lock poisoned".to_string(),
                                 )
                             })?;
-                    let receipt_seq = coordinator
-                        .next_checkpoint_receipt_seq
-                        .fetch_add(1, Ordering::Relaxed)
-                        as u64
-                        + 1;
-                    let received_at_ns = now_unix_nanos();
-                    let trace_ingest_target =
-                        coordinator.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
-                    coordinator
-                        .unadmitted_checkpoints
-                        .fetch_add(1, Ordering::Release);
-                    permit.send(AcceptedCheckpoint {
-                        receipt_seq,
-                        received_at_ns,
-                        trace_ingest_target,
-                        body,
-                        reservation,
-                    });
-                    receipt_seq
+                    if coordinator.accepting_checkpoints.load(Ordering::Acquire) {
+                        let receipt_seq = coordinator
+                            .next_checkpoint_receipt_seq
+                            .fetch_add(1, Ordering::Relaxed)
+                            as u64
+                            + 1;
+                        let received_at_ns = now_unix_nanos();
+                        let trace_ingest_target =
+                            coordinator.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
+                        coordinator
+                            .unadmitted_checkpoints
+                            .fetch_add(1, Ordering::Release);
+                        permit.send(AcceptedCheckpoint {
+                            receipt_seq,
+                            received_at_ns,
+                            trace_ingest_target,
+                            body,
+                            reservation,
+                        });
+                        Some(receipt_seq)
+                    } else {
+                        None
+                    }
                 };
-                tracing::info!(
-                    component = "daemon",
-                    phase = "checkpoint_receive",
-                    receipt_seq,
-                    retained_bytes = body_bytes,
-                    "checkpoint received into bounded ingress"
-                );
-                ControlResponse::ok(Some(receipt_seq), None)
+                match receipt_seq {
+                    Some(receipt_seq) => {
+                        tracing::info!(
+                            component = "daemon",
+                            phase = "checkpoint_receive",
+                            receipt_seq,
+                            retained_bytes = body_bytes,
+                            "checkpoint received into bounded ingress"
+                        );
+                        ControlResponse::ok(Some(receipt_seq), None)
+                    }
+                    None => ControlResponse::err("daemon is shutting down"),
+                }
             }
             Ok(req) => {
-                shutdown_after_response = matches!(req, ControlRequest::Shutdown);
-                runtime_handle.block_on(async { coordinator.handle_control_request(req).await })
+                let is_shutdown = matches!(req, ControlRequest::Shutdown);
+                let response = runtime_handle
+                    .block_on(async { coordinator.handle_control_request(req).await });
+                shutdown_after_response = is_shutdown && response.ok;
+                response
             }
             Err(error) => {
                 tracing::error!(
@@ -7406,22 +7488,23 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                 ControlResponse::err(format!("invalid control request: {error}"))
             }
         };
-        if let Err(error) = write_control_response(reader.get_mut(), &response) {
-            if let Some(receipt_seq) = response.seq {
-                tracing::error!(
-                    component = "daemon",
-                    phase = "checkpoint_receive",
-                    reason = "receipt_ack_write_failed",
-                    receipt_seq,
-                    %error,
-                    "failed writing checkpoint receipt acknowledgement"
-                );
-            }
-            return Err(error);
+        let write_result = write_control_response(reader.get_mut(), &response);
+        if let Err(error) = &write_result
+            && let Some(receipt_seq) = response.seq
+        {
+            tracing::error!(
+                component = "daemon",
+                phase = "checkpoint_receive",
+                reason = "receipt_ack_write_failed",
+                receipt_seq,
+                %error,
+                "failed writing checkpoint receipt acknowledgement"
+            );
         }
         if shutdown_after_response {
             coordinator.request_stop();
         }
+        write_result?;
     }
     Ok(())
 }
@@ -8352,6 +8435,7 @@ fn checkpoint_control_response_timeout(
         ControlRequest::Await { timeout_secs } => {
             Duration::from_secs(timeout_secs.saturating_add(5))
         }
+        ControlRequest::Shutdown => DAEMON_CHECKPOINT_RESPONSE_TIMEOUT,
         _ => DAEMON_CONTROL_RESPONSE_TIMEOUT,
     }
 }
@@ -8977,6 +9061,14 @@ mod tests {
         assert_eq!(
             checkpoint_control_response_timeout(&sample_checkpoint_request(), false),
             DAEMON_CONTROL_RESPONSE_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn shutdown_requests_allow_checkpoint_drain_timeout() {
+        assert_eq!(
+            checkpoint_control_response_timeout(&ControlRequest::Shutdown, false),
+            DAEMON_CHECKPOINT_RESPONSE_TIMEOUT
         );
     }
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1976,6 +1976,89 @@ fn daemon_soft_shutdown_drains_acknowledged_checkpoints() {
 
 #[test]
 #[cfg(not(windows))]
+fn daemon_drains_independent_checkpoint_families_concurrently() {
+    let barrier_dir = tempfile::tempdir().expect("checkpoint side-effect barrier directory");
+    let barrier_path = barrier_dir.path().to_string_lossy().to_string();
+    let first_repo = TestRepo::new_with_daemon_env(&[
+        (
+            "GIT_AI_TEST_DELAY_CHECKPOINT_ADMISSION",
+            "concurrent-family-first=250",
+        ),
+        (
+            "GIT_AI_TEST_CHECKPOINT_SIDE_EFFECT_BARRIER_DIR",
+            barrier_path.as_str(),
+        ),
+    ]);
+    let second_repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket = daemon_control_socket_path(&first_repo);
+    let request = |repo: &TestRepo, trace_id: &str, path: &str| CheckpointRequest {
+        trace_id: trace_id.to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: trace_id.to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from(path),
+            content: Some(format!("{trace_id}\n")),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Initial,
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+
+    fs::write(
+        first_repo.path().join("first.txt"),
+        "concurrent-family-first\n",
+    )
+    .unwrap();
+    fs::write(
+        second_repo.path().join("second.txt"),
+        "concurrent-family-second\n",
+    )
+    .unwrap();
+
+    for checkpoint in [
+        request(&first_repo, "concurrent-family-first", "first.txt"),
+        request(&second_repo, "concurrent-family-second", "second.txt"),
+    ] {
+        let response = send_checkpoint_request_with_timeout(
+            &control_socket,
+            &checkpoint,
+            Duration::from_millis(500),
+        )
+        .expect("checkpoint should be acknowledged before processing");
+        assert!(response.ok, "checkpoint failed: {response:?}");
+    }
+
+    let started = std::time::Instant::now();
+    loop {
+        let checkpoint_count = |repo: &TestRepo| {
+            find_repository_in_path(repo.path().to_str().unwrap())
+                .unwrap()
+                .storage
+                .working_log_for_base_commit("initial")
+                .unwrap()
+                .read_all_checkpoints()
+                .map(|checkpoints| checkpoints.len())
+                .unwrap_or(0)
+        };
+        if checkpoint_count(&first_repo) == 1 && checkpoint_count(&second_repo) == 1 {
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "independent checkpoint families did not finish processing"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_checkpoint_processing_failure_is_logged_after_receipt_ack() {
     let repo = TestRepo::new_with_daemon_env(&[(
         "GIT_AI_TEST_FAIL_CHECKPOINT_SIDE_EFFECT",

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1875,6 +1875,107 @@ fn daemon_checkpoint_ack_does_not_wait_for_checkpoint_processing() {
 
 #[test]
 #[cfg(not(windows))]
+fn daemon_soft_shutdown_drains_acknowledged_checkpoints() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
+        "shutdown-first=1000",
+    )]);
+    let control_socket = daemon_control_socket_path(&repo);
+    let request = |trace_id: &str, path: &str, content: &str| CheckpointRequest {
+        trace_id: trace_id.to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "shutdown-drain-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from(path),
+            content: Some(content.to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Initial,
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+
+    fs::write(repo.path().join("first.txt"), "first\n").unwrap();
+    let first = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &request("shutdown-first", "first.txt", "first\n"),
+        Duration::from_millis(500),
+    )
+    .expect("first checkpoint should be acknowledged");
+    assert!(first.ok, "first checkpoint failed: {first:?}");
+
+    let logs = wait_for_daemon_log(&repo, "checkpoint start");
+    assert!(
+        logs.contains("checkpoint start"),
+        "first checkpoint never started processing:\n{logs}"
+    );
+
+    fs::write(repo.path().join("second.txt"), "second\n").unwrap();
+    let second = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &request("shutdown-second", "second.txt", "second\n"),
+        Duration::from_millis(500),
+    )
+    .expect("second checkpoint should be acknowledged");
+    assert!(second.ok, "second checkpoint failed: {second:?}");
+    assert!(
+        second.seq > first.seq,
+        "checkpoint receipts must preserve acceptance order"
+    );
+
+    let shutdown_socket = control_socket.clone();
+    let shutdown_thread = thread::spawn(move || {
+        send_control_request_with_timeout(
+            &shutdown_socket,
+            &ControlRequest::Shutdown,
+            Duration::from_secs(5),
+        )
+    });
+    let logs = wait_for_daemon_log(&repo, "checkpoint acceptance closed for graceful shutdown");
+    assert!(
+        logs.contains("checkpoint acceptance closed for graceful shutdown"),
+        "daemon never closed checkpoint acceptance:\n{logs}"
+    );
+
+    fs::write(repo.path().join("too-late.txt"), "too late\n").unwrap();
+    let too_late = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &request("shutdown-too-late", "too-late.txt", "too late\n"),
+        Duration::from_millis(500),
+    )
+    .expect("checkpoint submitted during graceful shutdown should receive a response");
+    assert!(
+        !too_late.ok && too_late.error.as_deref() == Some("daemon is shutting down"),
+        "graceful shutdown must stop accepting new checkpoints: {too_late:?}"
+    );
+
+    let shutdown = shutdown_thread
+        .join()
+        .expect("shutdown request thread panicked")
+        .expect("soft shutdown should wait for acknowledged checkpoints");
+    assert!(shutdown.ok, "soft shutdown failed: {shutdown:?}");
+
+    let repository = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let checkpoints = repository
+        .storage
+        .working_log_for_base_commit("initial")
+        .unwrap()
+        .read_all_checkpoints()
+        .unwrap();
+    assert_eq!(
+        checkpoints.len(),
+        2,
+        "soft shutdown must not discard successfully acknowledged checkpoints"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_checkpoint_processing_failure_is_logged_after_receipt_ack() {
     let repo = TestRepo::new_with_daemon_env(&[(
         "GIT_AI_TEST_FAIL_CHECKPOINT_SIDE_EFFECT",

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -1974,7 +1974,11 @@ fn test_author_config_cli_set_get_unset() {
 
 #[test]
 fn test_author_config_overrides_session_and_known_human_records() {
-    let mut repo = TestRepo::new();
+    // The author override must be visible to the daemon, which reads
+    // config.json from its own home. A shared pool daemon's config is
+    // rewritten by every concurrent test (clobbering the author key), so
+    // this test needs a dedicated daemon.
+    let mut repo = TestRepo::new_dedicated_daemon();
     repo.patch_git_ai_config(|patch| {
         patch.author = Some(AuthorConfig {
             name: Some("Config User".to_string()),
@@ -2023,7 +2027,8 @@ fn test_author_config_overrides_session_and_known_human_records() {
 
 #[test]
 fn test_author_config_partial_overrides_fall_back_to_git_committer_identity() {
-    let mut name_repo = TestRepo::new();
+    // Dedicated daemons: see test_author_config_overrides_session_and_known_human_records.
+    let mut name_repo = TestRepo::new_dedicated_daemon();
     name_repo.patch_git_ai_config(|patch| {
         patch.author = Some(AuthorConfig {
             name: Some("Config Name".to_string()),
@@ -2057,7 +2062,7 @@ fn test_author_config_partial_overrides_fall_back_to_git_committer_identity() {
         );
     }
 
-    let mut email_repo = TestRepo::new();
+    let mut email_repo = TestRepo::new_dedicated_daemon();
     email_repo.patch_git_ai_config(|patch| {
         patch.author = Some(AuthorConfig {
             name: None,


### PR DESCRIPTION
## Summary

- `test_author_config_overrides_session_and_known_human_records` and `test_author_config_partial_overrides_fall_back_to_git_committer_identity` now use dedicated daemons.

## Why

These tests patch the git-ai author config and assert the attested identity in the resulting authorship note. The attested author is resolved **in the daemon** (`effective_author_identity` → `Config::fresh_author_cached`), which reads `config.json` from its own home. On the shared test daemon pool, every test's `patch_git_ai_config` rewrites that same `config.json` — any concurrently-running test clobbers the author key and the daemon attests the default identity. This made these two tests the suite's most persistent flakes: failing in nearly every loaded run (including every configuration tested during the #1996 investigation), always passing solo.

Config-patch tests whose values must be daemon-visible already use dedicated daemons elsewhere (daemon_mode's content-budget tests); this applies the same established pattern.

## Test coverage

- `simple_additions` module 3× under parallel load: 80/80 green each (previously failed nearly every loaded batch).
- Two consecutive fully-green full-suite runs (3,256/3,256) on this stack tip — the first zero-failure full-suite runs of the entire investigation.

Depends on #2018.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

**Update:** this PR also absorbs two daemon fixes folded up from the (now-closed) #2022 and #2023:

- **Drain acknowledged checkpoints on shutdown** (`8962c91b6`): a daemon shutting down with accepted-but-unprocessed checkpoints now drains them instead of dropping them, closing a silent-loss window on restart.
- **Drain independent checkpoint families concurrently** (`c109325bc`): the global unadmitted-checkpoints drain gate no longer serializes unrelated families — each family drains as soon as its own admissions are settled, removing the cross-repo head-of-line coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)