### PR TITLE
fix(daemon): drain acknowledged checkpoints on shutdown

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -603,12 +603,7 @@ fn handle_restart(args: &[String]) -> Result<(), String> {
         if hard {
             hard_kill_daemon(&config)?;
         } else {
-            // Attempt soft shutdown; escalate to hard kill on timeout.
-            let _ = send_control_request(&config.control_socket_path, &ControlRequest::Shutdown);
-            if !wait_for_daemon_dead(&config, GRACEFUL_SHUTDOWN_TIMEOUT) {
-                eprintln!("graceful shutdown timed out, force-killing daemon");
-                hard_kill_daemon(&config)?;
-            }
+            stop_daemon(&config, GRACEFUL_SHUTDOWN_TIMEOUT)?;
         }
 
         // Even after lock+sockets are gone, the process may still be alive
@@ -729,14 +724,26 @@ pub(crate) fn stop_daemon(config: &DaemonConfig, timeout: Duration) -> Result<()
         return Ok(());
     }
 
-    // Attempt soft shutdown via control socket if reachable.
+    let deadline = Instant::now() + timeout;
+
+    // Attempt soft shutdown via control socket if reachable. Bound the request
+    // itself by the caller's deadline because shutdown may now wait for
+    // acknowledged checkpoints before responding.
     if local_socket_connects_with_timeout(&config.control_socket_path, Duration::from_millis(100))
         .is_ok()
     {
-        let _ = send_control_request(&config.control_socket_path, &ControlRequest::Shutdown);
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if !remaining.is_zero() {
+            let _ = send_control_request_with_timeout(
+                &config.control_socket_path,
+                &ControlRequest::Shutdown,
+                remaining,
+            );
+        }
     }
 
-    if wait_for_daemon_dead(config, timeout) {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if wait_for_daemon_dead(config, remaining) {
         return Ok(());
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2712,6 +2712,7 @@ pub struct ActorDaemonCoordinator {
     next_checkpoint_receipt_seq: AtomicUsize,
     processed_checkpoint_receipt_seq: AtomicUsize,
     unadmitted_checkpoints: AtomicUsize,
+    accepting_checkpoints: AtomicBool,
     checkpoint_progress_notify: Notify,
     bash_sessions: Mutex<crate::daemon::bash_sessions::BashSessionState>,
     test_completion_log_dir: Option<PathBuf>,
@@ -2805,6 +2806,7 @@ impl ActorDaemonCoordinator {
             next_checkpoint_receipt_seq: AtomicUsize::new(0),
             processed_checkpoint_receipt_seq: AtomicUsize::new(0),
             unadmitted_checkpoints: AtomicUsize::new(0),
+            accepting_checkpoints: AtomicBool::new(true),
             checkpoint_progress_notify: Notify::new(),
             bash_sessions: Mutex::new(crate::daemon::bash_sessions::BashSessionState::new()),
             test_completion_log_dir: std::env::var("GIT_AI_TEST_DB_PATH")
@@ -6525,6 +6527,22 @@ impl ActorDaemonCoordinator {
         self.status_for_family(repo_working_dir).await
     }
 
+    async fn drain_accepted_checkpoints(&self) -> Result<(), GitAiError> {
+        loop {
+            let checkpoint_target = self.next_checkpoint_receipt_seq.load(Ordering::Acquire) as u64;
+            self.wait_for_checkpoint_admission_through(checkpoint_target)
+                .await;
+            self.wait_for_no_unadmitted_checkpoints().await;
+            self.wait_for_trace_ingest_processed_through().await;
+            self.drain_all_ready_family_sequencers().await?;
+
+            if self.outstanding_checkpoint_state().0 == 0 {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
     /// Wait for the daemon to finish all in-flight work and telemetry flushing.
     ///
     /// Progress is logged every few seconds. Returns an `AwaitResult` describing
@@ -6688,6 +6706,16 @@ impl ActorDaemonCoordinator {
 
     fn outstanding_checkpoint_state(&self) -> (usize, usize) {
         self.checkpoint_ingress_quota.outstanding()
+    }
+
+    fn set_checkpoint_acceptance(&self, accepting: bool) -> Result<(), GitAiError> {
+        let _sequencers = self
+            .family_sequencers_by_family
+            .lock()
+            .map_err(|_| GitAiError::Generic("family sequencer map lock poisoned".to_string()))?;
+        self.accepting_checkpoints
+            .store(accepting, Ordering::Release);
+        Ok(())
     }
 
     async fn handle_control_request(&self, request: ControlRequest) -> ControlResponse {
@@ -6984,7 +7012,28 @@ impl ActorDaemonCoordinator {
                 };
                 Ok(response)
             }
-            ControlRequest::Shutdown => Ok(ControlResponse::ok(None, None)),
+            ControlRequest::Shutdown => match self.set_checkpoint_acceptance(false) {
+                Err(error) => Err(error),
+                Ok(()) => {
+                    tracing::info!(
+                        component = "daemon",
+                        phase = "shutdown",
+                        "checkpoint acceptance closed for graceful shutdown"
+                    );
+                    match self.drain_accepted_checkpoints().await {
+                        Ok(()) => Ok(ControlResponse::ok(None, None)),
+                        Err(error) => {
+                            if let Err(reopen_error) = self.set_checkpoint_acceptance(true) {
+                                tracing::error!(
+                                    %reopen_error,
+                                    "failed reopening checkpoint acceptance after shutdown error"
+                                );
+                            }
+                            Err(error)
+                        }
+                    }
+                }
+            },
         };
 
         match result {
@@ -7232,6 +7281,27 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
         let mut shutdown_after_response = false;
         let response = match parsed {
             Ok(ControlRequest::CheckpointRun { body_bytes }) => {
+                if !coordinator.accepting_checkpoints.load(Ordering::Acquire) {
+                    let acceptance_closed = {
+                        let _sequencers =
+                            coordinator
+                                .family_sequencers_by_family
+                                .lock()
+                                .map_err(|_| {
+                                    GitAiError::Generic(
+                                        "family sequencer map lock poisoned".to_string(),
+                                    )
+                                })?;
+                        !coordinator.accepting_checkpoints.load(Ordering::Acquire)
+                    };
+                    if acceptance_closed {
+                        write_control_response(
+                            reader.get_mut(),
+                            &ControlResponse::err("daemon is shutting down"),
+                        )?;
+                        continue;
+                    }
+                }
                 let body_bytes = match usize::try_from(body_bytes) {
                     Ok(body_bytes) => body_bytes,
                     Err(error) => {
@@ -7362,38 +7432,50 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                                     "family sequencer map lock poisoned".to_string(),
                                 )
                             })?;
-                    let receipt_seq = coordinator
-                        .next_checkpoint_receipt_seq
-                        .fetch_add(1, Ordering::Relaxed)
-                        as u64
-                        + 1;
-                    let received_at_ns = now_unix_nanos();
-                    let trace_ingest_target =
-                        coordinator.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
-                    coordinator
-                        .unadmitted_checkpoints
-                        .fetch_add(1, Ordering::Release);
-                    permit.send(AcceptedCheckpoint {
-                        receipt_seq,
-                        received_at_ns,
-                        trace_ingest_target,
-                        body,
-                        reservation,
-                    });
-                    receipt_seq
+                    if coordinator.accepting_checkpoints.load(Ordering::Acquire) {
+                        let receipt_seq = coordinator
+                            .next_checkpoint_receipt_seq
+                            .fetch_add(1, Ordering::Relaxed)
+                            as u64
+                            + 1;
+                        let received_at_ns = now_unix_nanos();
+                        let trace_ingest_target =
+                            coordinator.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
+                        coordinator
+                            .unadmitted_checkpoints
+                            .fetch_add(1, Ordering::Release);
+                        permit.send(AcceptedCheckpoint {
+                            receipt_seq,
+                            received_at_ns,
+                            trace_ingest_target,
+                            body,
+                            reservation,
+                        });
+                        Some(receipt_seq)
+                    } else {
+                        None
+                    }
                 };
-                tracing::info!(
-                    component = "daemon",
-                    phase = "checkpoint_receive",
-                    receipt_seq,
-                    retained_bytes = body_bytes,
-                    "checkpoint received into bounded ingress"
-                );
-                ControlResponse::ok(Some(receipt_seq), None)
+                match receipt_seq {
+                    Some(receipt_seq) => {
+                        tracing::info!(
+                            component = "daemon",
+                            phase = "checkpoint_receive",
+                            receipt_seq,
+                            retained_bytes = body_bytes,
+                            "checkpoint received into bounded ingress"
+                        );
+                        ControlResponse::ok(Some(receipt_seq), None)
+                    }
+                    None => ControlResponse::err("daemon is shutting down"),
+                }
             }
             Ok(req) => {
-                shutdown_after_response = matches!(req, ControlRequest::Shutdown);
-                runtime_handle.block_on(async { coordinator.handle_control_request(req).await })
+                let is_shutdown = matches!(req, ControlRequest::Shutdown);
+                let response = runtime_handle
+                    .block_on(async { coordinator.handle_control_request(req).await });
+                shutdown_after_response = is_shutdown && response.ok;
+                response
             }
             Err(error) => {
                 tracing::error!(
@@ -7406,22 +7488,23 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                 ControlResponse::err(format!("invalid control request: {error}"))
             }
         };
-        if let Err(error) = write_control_response(reader.get_mut(), &response) {
-            if let Some(receipt_seq) = response.seq {
-                tracing::error!(
-                    component = "daemon",
-                    phase = "checkpoint_receive",
-                    reason = "receipt_ack_write_failed",
-                    receipt_seq,
-                    %error,
-                    "failed writing checkpoint receipt acknowledgement"
-                );
-            }
-            return Err(error);
+        let write_result = write_control_response(reader.get_mut(), &response);
+        if let Err(error) = &write_result
+            && let Some(receipt_seq) = response.seq
+        {
+            tracing::error!(
+                component = "daemon",
+                phase = "checkpoint_receive",
+                reason = "receipt_ack_write_failed",
+                receipt_seq,
+                %error,
+                "failed writing checkpoint receipt acknowledgement"
+            );
         }
         if shutdown_after_response {
             coordinator.request_stop();
         }
+        write_result?;
     }
     Ok(())
 }
@@ -8352,6 +8435,7 @@ fn checkpoint_control_response_timeout(
         ControlRequest::Await { timeout_secs } => {
             Duration::from_secs(timeout_secs.saturating_add(5))
         }
+        ControlRequest::Shutdown => DAEMON_CHECKPOINT_RESPONSE_TIMEOUT,
         _ => DAEMON_CONTROL_RESPONSE_TIMEOUT,
     }
 }
@@ -8977,6 +9061,14 @@ mod tests {
         assert_eq!(
             checkpoint_control_response_timeout(&sample_checkpoint_request(), false),
             DAEMON_CONTROL_RESPONSE_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn shutdown_requests_allow_checkpoint_drain_timeout() {
+        assert_eq!(
+            checkpoint_control_response_timeout(&ControlRequest::Shutdown, false),
+            DAEMON_CHECKPOINT_RESPONSE_TIMEOUT
         );
     }
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1875,6 +1875,107 @@ fn daemon_checkpoint_ack_does_not_wait_for_checkpoint_processing() {
 
 #[test]
 #[cfg(not(windows))]
+fn daemon_soft_shutdown_drains_acknowledged_checkpoints() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
+        "shutdown-first=1000",
+    )]);
+    let control_socket = daemon_control_socket_path(&repo);
+    let request = |trace_id: &str, path: &str, content: &str| CheckpointRequest {
+        trace_id: trace_id.to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "shutdown-drain-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from(path),
+            content: Some(content.to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Initial,
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+
+    fs::write(repo.path().join("first.txt"), "first\n").unwrap();
+    let first = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &request("shutdown-first", "first.txt", "first\n"),
+        Duration::from_millis(500),
+    )
+    .expect("first checkpoint should be acknowledged");
+    assert!(first.ok, "first checkpoint failed: {first:?}");
+
+    let logs = wait_for_daemon_log(&repo, "checkpoint start");
+    assert!(
+        logs.contains("checkpoint start"),
+        "first checkpoint never started processing:\n{logs}"
+    );
+
+    fs::write(repo.path().join("second.txt"), "second\n").unwrap();
+    let second = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &request("shutdown-second", "second.txt", "second\n"),
+        Duration::from_millis(500),
+    )
+    .expect("second checkpoint should be acknowledged");
+    assert!(second.ok, "second checkpoint failed: {second:?}");
+    assert!(
+        second.seq > first.seq,
+        "checkpoint receipts must preserve acceptance order"
+    );
+
+    let shutdown_socket = control_socket.clone();
+    let shutdown_thread = thread::spawn(move || {
+        send_control_request_with_timeout(
+            &shutdown_socket,
+            &ControlRequest::Shutdown,
+            Duration::from_secs(5),
+        )
+    });
+    let logs = wait_for_daemon_log(&repo, "checkpoint acceptance closed for graceful shutdown");
+    assert!(
+        logs.contains("checkpoint acceptance closed for graceful shutdown"),
+        "daemon never closed checkpoint acceptance:\n{logs}"
+    );
+
+    fs::write(repo.path().join("too-late.txt"), "too late\n").unwrap();
+    let too_late = send_checkpoint_request_with_timeout(
+        &control_socket,
+        &request("shutdown-too-late", "too-late.txt", "too late\n"),
+        Duration::from_millis(500),
+    )
+    .expect("checkpoint submitted during graceful shutdown should receive a response");
+    assert!(
+        !too_late.ok && too_late.error.as_deref() == Some("daemon is shutting down"),
+        "graceful shutdown must stop accepting new checkpoints: {too_late:?}"
+    );
+
+    let shutdown = shutdown_thread
+        .join()
+        .expect("shutdown request thread panicked")
+        .expect("soft shutdown should wait for acknowledged checkpoints");
+    assert!(shutdown.ok, "soft shutdown failed: {shutdown:?}");
+
+    let repository = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let checkpoints = repository
+        .storage
+        .working_log_for_base_commit("initial")
+        .unwrap()
+        .read_all_checkpoints()
+        .unwrap();
+    assert_eq!(
+        checkpoints.len(),
+        2,
+        "soft shutdown must not discard successfully acknowledged checkpoints"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_checkpoint_processing_failure_is_logged_after_receipt_ack() {
     let repo = TestRepo::new_with_daemon_env(&[(
         "GIT_AI_TEST_FAIL_CHECKPOINT_SIDE_EFFECT",


### PR DESCRIPTION
## Summary

- close checkpoint admission under the family-sequencer mutex before graceful shutdown
- drain every already-acknowledged checkpoint through admission, trace ordering, and side effects before stopping
- reject checkpoints arriving after the close with a retryable `daemon is shutting down` response
- stop the daemon after a successful drain even if the shutdown client disconnects before reading the response
- preserve the existing bounded restart/install deadline before hard-kill escalation, while allowing an explicit shutdown request a long drain response budget

## Root cause

PR #1996 acknowledges a checkpoint once its bounded body has entered daemon memory. The old shutdown path responded immediately and stopped the daemon, so acknowledged work still in admission or family sequencing could be discarded.

The acceptance close and final receipt admission now share the sequencer mutex. This creates a real serialization point: a checkpoint is either accepted before the close and included in the drain, or rejected after it. It does not rely on atomic visibility timing.

## Correctness and latency

The normal receipt path adds no git work, object/ref lookup, or file I/O. The added mutex operation occurs only when shutdown closes (or exceptionally reopens) acceptance; the final receipt check already used the same mutex. Internal restart/install callers retain their original total timeout rather than inheriting the explicit shutdown client's 300-second response budget.

## Tests

The TestRepo regression first failed with 0 persisted checkpoints after two successful receipt ACKs. It now proves that shutdown waits for both, rejects a third post-close receipt, and leaves both working-log checkpoints durable.

Cumulative stack validation: `task build`, `task fmt`, `task lint`, and `task test` (5,546 passed, 89 ignored, 0 failed).