### PR TITLE
feat(debug): extend wltrace to ref-cursor commit enrichment

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6113,6 +6113,16 @@ impl ActorDaemonCoordinator {
                             let repo = find_repository_in_path(&worktree)?;
                             let author = repo.effective_author_identity().formatted_or_unknown();
                             let base_opt = base.clone().filter(|b| !b.is_empty() && b != "initial");
+                            crate::wltrace::wltrace(
+                                "commit.post_commit",
+                                Path::new(cmd.worktree.as_deref().unwrap_or(Path::new(""))),
+                                || {
+                                    format!(
+                                        "sid={} base={:?} new_head={}",
+                                        cmd.root_sid, base_opt, new_head
+                                    )
+                                },
+                            );
                             let recovery_file_timestamps = Self::take_commit_file_timestamps(
                                 commit_file_timestamp_snapshots,
                                 new_head,

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -465,7 +465,48 @@ impl RefCursor {
             .head_expected_transition(cmd, state)
             .without_old_oid_constraint()
             .with_reflog_messages(commit_reflog_messages(&args, amend));
-        let Some(entry) = self.find_commit_head_entry(cmd, prefixes, expected)? else {
+        let entry = self.find_commit_head_entry(cmd, prefixes, expected.clone())?;
+        crate::wltrace::wltrace(
+            "ref_cursor.commit_entry",
+            cmd.worktree.as_deref().unwrap_or(Path::new("")),
+            || {
+                let cursor = cmd
+                    .worktree
+                    .as_deref()
+                    .and_then(git_dir_for_worktree)
+                    .map(|git_dir| head_key(&git_dir))
+                    .map(|key| {
+                        format!(
+                            "offset={:?} hint={:?} consumed={:?}",
+                            self.offsets.get(&key),
+                            self.command_start_hints.get(&key),
+                            self.consumed_offsets.get(&key),
+                        )
+                    })
+                    .unwrap_or_else(|| "no-key".to_string());
+                format!(
+                    "sid={} exit={} entry={} expected_new={:?} messages={:?} {cursor}",
+                    cmd.root_sid,
+                    cmd.exit_code,
+                    entry
+                        .as_ref()
+                        .map(|entry| format!(
+                            "{}->{}@{} msg={}",
+                            &entry.old[..8.min(entry.old.len())],
+                            &entry.new[..8.min(entry.new.len())],
+                            entry.start_offset,
+                            entry.message.chars().take(40).collect::<String>()
+                        ))
+                        .unwrap_or_else(|| "NONE".to_string()),
+                    expected
+                        .new_oid
+                        .as_ref()
+                        .map(|oid| &oid[..8.min(oid.len())]),
+                    expected.messages,
+                )
+            },
+        );
+        let Some(entry) = entry else {
             return Ok(());
         };
 
@@ -1223,6 +1264,21 @@ impl RefCursor {
         cmd: &mut NormalizedCommand,
         entry: CursorEntry,
     ) -> Result<(), GitAiError> {
+        crate::wltrace::wltrace(
+            "ref_cursor.consume_head_entry",
+            cmd.worktree.as_deref().unwrap_or(Path::new("")),
+            || {
+                format!(
+                    "sid={} cmd={} entry={}->{}@{} msg={}",
+                    cmd.root_sid,
+                    cmd.primary_command.as_deref().unwrap_or("unknown"),
+                    &entry.old[..8.min(entry.old.len())],
+                    &entry.new[..8.min(entry.new.len())],
+                    entry.start_offset,
+                    entry.message.chars().take(40).collect::<String>(),
+                )
+            },
+        );
         self.consume_entry(&entry)?;
         let old = entry.old.clone();
         let new = entry.new.clone();


### PR DESCRIPTION
## Summary
Extends the `GIT_AI_WLTRACE` debug side-channel (#2016) with taps at the three points that decide whether a commit gets post-commit authorship:

- `ref_cursor.commit_entry` — which reflog entry (if any) commit enrichment selected, plus cursor offset/hint state
- `ref_cursor.consume_head_entry` — the entry actually consumed for a command
- `commit.post_commit` — the post-commit authorship side effect firing (sid, base, new head)

These taps pinned the `test_nested_subrepo_mixed_edits_mock_ai` attribution flake (fixed upstack): the failing run's trace showed the parent repo's final commit being enriched against the **nested subrepo's** reflog (`path=…/parent-repo/subrepo`, `entry=NONE`), which is invisible in ordinary logs.

Same cost model as the rest of wltrace: test-support feature only, one atomic load when `GIT_AI_WLTRACE` is unset, no-op in release builds.

## Testing
- `cargo test --lib daemon::` passes
- `daemon_mode` suite (73 tests) passes, including the existing wltrace coverage test

🤖 Generated with [Claude Code](https://claude.com/claude-code)