### PR TITLE
fix(daemon): ignore secondary def_repo events when resolving a command's worktree

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -502,6 +502,11 @@ fn trace_payload_worktree_hint(payload: &Value) -> Option<PathBuf> {
         .and_then(Value::as_str)
         .unwrap_or_default();
     if event == "def_repo" {
+        // Secondary repositories (repo index > 1, e.g. an embedded subrepo git
+        // peeked into during a commit) must not hint the command's worktree.
+        if crate::daemon::trace_normalizer::def_repo_is_secondary(payload) {
+            return None;
+        }
         if let Some(path) = payload
             .get("worktree")
             .or_else(|| payload.get("repo_working_dir"))
@@ -8937,6 +8942,30 @@ mod tests {
     use serial_test::serial;
     use std::ffi::OsString;
     use std::io::Write;
+
+    #[test]
+    fn secondary_def_repo_does_not_hint_worktree() {
+        let primary = serde_json::json!({
+            "event": "def_repo",
+            "sid": "s1",
+            "repo": 1,
+            "worktree": "/repo",
+        });
+        assert_eq!(
+            trace_payload_worktree_hint(&primary),
+            Some(PathBuf::from("/repo"))
+        );
+
+        // A nested/embedded repo git peeked into (repo index > 1) must not
+        // retarget the command's worktree at that repo.
+        let secondary = serde_json::json!({
+            "event": "def_repo",
+            "sid": "s1",
+            "repo": 2,
+            "worktree": "/repo/nested",
+        });
+        assert_eq!(trace_payload_worktree_hint(&secondary), None);
+    }
 
     struct EnvVarGuard {
         key: &'static str,

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -351,6 +351,19 @@ impl<B: GitBackend> TraceNormalizer<B> {
         _sid: &str,
         root_sid: &str,
     ) -> Result<Option<NormalizedCommand>, GitAiError> {
+        // Trace2 numbers a process's repositories: the primary repo is 1;
+        // higher indices are secondary repos git merely peeked into (e.g. an
+        // embedded subrepo opened for a gitlink dirtiness check during
+        // commit/status). Only the primary repo defines the command's
+        // worktree/family — letting a secondary def_repo retarget them makes
+        // the ref cursor enrich the command against the wrong repo's reflog
+        // and silently lose attribution.
+        if def_repo_is_secondary(payload) {
+            if let Some(pending) = self.state.pending.get_mut(root_sid) {
+                merge_reflog_start_offsets_from_payload(pending, payload);
+            }
+            return Ok(None);
+        }
         let payload_worktree = payload_worktree(payload);
         let payload_repo = payload
             .get("repo")
@@ -788,6 +801,18 @@ fn payload_argv(payload: &Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+/// Trace2 `def_repo` events carry a `repo` index: 1 is the process's primary
+/// repository; higher indices are secondary repositories git opened in
+/// passing (e.g. an embedded subrepo inspected for a gitlink entry). Absent
+/// or non-numeric indices are treated as primary to preserve behavior for
+/// payloads that don't carry the field.
+pub(crate) fn def_repo_is_secondary(payload: &Value) -> bool {
+    payload
+        .get("repo")
+        .and_then(Value::as_u64)
+        .is_some_and(|index| index > 1)
 }
 
 fn payload_worktree(payload: &Value) -> Option<PathBuf> {
@@ -1269,6 +1294,65 @@ mod tests {
         assert_eq!(cmd.root_sid, "s1");
         assert_eq!(cmd.primary_command.as_deref(), Some("status"));
         assert_eq!(cmd.exit_code, 0);
+    }
+
+    #[test]
+    fn normalizer_keeps_primary_repo_worktree_when_nested_repo_def_repo_arrives() {
+        // Committing a repo that contains an embedded (gitlink) subrepo makes
+        // git emit def_repo events for BOTH repositories on the root sid:
+        // repo:1 (the primary) and repo:2 (the nested repo it peeked into).
+        // Only repo:1 defines the command's worktree; if repo:2 wins, the
+        // whole command is retargeted at the nested repo and the ref cursor
+        // enriches the commit against the wrong reflog (the nested-subrepo
+        // attribution flake).
+        let backend = Arc::new(MockBackend::default());
+        backend.set_family("/repo", "/repo/.git");
+        backend.set_family("/repo/nested", "/repo/nested/.git");
+        let mut normalizer = TraceNormalizer::new(backend);
+
+        let start = serde_json::json!({
+            "event":"start",
+            "sid":"s-nested-def-repo",
+            "ts":1,
+            "argv":["git","commit","-m","msg"],
+            "worktree":"/repo"
+        });
+        let def_repo_primary = serde_json::json!({
+            "event":"def_repo",
+            "sid":"s-nested-def-repo",
+            "ts":2,
+            "repo":1,
+            "worktree":"/repo"
+        });
+        let def_repo_nested = serde_json::json!({
+            "event":"def_repo",
+            "sid":"s-nested-def-repo",
+            "ts":3,
+            "repo":2,
+            "worktree":"/repo/nested"
+        });
+        let atexit = atexit_payload("s-nested-def-repo", 4);
+
+        assert!(normalizer.ingest_payload(&start).unwrap().is_none());
+        assert!(
+            normalizer
+                .ingest_payload(&def_repo_primary)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            normalizer
+                .ingest_payload(&def_repo_nested)
+                .unwrap()
+                .is_none()
+        );
+        let cmd = normalizer.ingest_payload(&atexit).unwrap().unwrap();
+
+        assert_eq!(
+            cmd.worktree.as_deref(),
+            Some(Path::new("/repo")),
+            "secondary def_repo (repo:2) must not retarget the command at the nested repo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes the `cross_repo_cwd_attribution::test_nested_subrepo_mixed_edits_mock_ai` flake ("No authorship log found for new commit … after daemon sync"), which also fires on `main` CI (e.g. run 30271305106).

### Root cause
Committing a repo that contains an embedded (gitlink) subrepo makes git emit `def_repo` trace2 events for **both** repositories on the root sid: the primary repo (`repo:1`) and the nested repo it peeked into for the gitlink dirtiness check (`repo:2`):

```
{"event":"def_repo",…,"repo":1,"worktree":"…/parent-repo"}
{"event":"def_repo",…,"repo":2,"worktree":"…/parent-repo/subrepo"}
```

The normalizer let the later `repo:2` event overwrite the pending command's worktree and family, so the parent repo's commit was sequenced into the **subrepo's** family and enriched against the subrepo's reflog. No matching entry exists there → empty `ref_changes` → no `CommitCreated` → the commit silently loses its authorship note while exiting 0. The wltrace capture from the failing run (via the downstack instrumentation PR) shows it directly:

```
op=ref_cursor.commit_entry path=…/parent-repo/subrepo sid=… entry=NONE messages={"commit: AI edits in parent", …}
```

It is timing-dependent because the checkpoint fan-out to the two repo families races the commit's trace frames; under load the subrepo's `def_repo` frame lands while the commit is still pending.

### Fix
Trace2 numbers a process's repositories; only the primary (`repo:1`, or payloads without the field) may define the command's worktree/family. Secondary `def_repo` events are now ignored in both consumers:
- `TraceNormalizer::handle_def_repo` (still merges their reflog start offsets)
- the daemon ingress `trace_payload_worktree_hint`

### TDD
- RED: `normalizer_keeps_primary_repo_worktree_when_nested_repo_def_repo_arrives` reproduces the overwrite deterministically at the normalizer level (fails without the fix)
- `secondary_def_repo_does_not_hint_worktree` covers the ingress hint path
- Integration-level verification: stress-ran the `cross_repo_cwd_attribution` suite 4-way on 4 pinned cores — fails within ~3 rounds before the fix, **60/60 clean rounds** after; `clone`, `cold_trace2`, and `daemon_mode` suites all pass

## Constant-time note
No new git spawns or object lookups; the check is a single JSON field read on an already-parsed payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)