### PR TITLE
Fix installer version metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,6 +549,16 @@ jobs:
           if (Test-Path (Join-Path $env:LOCALAPPDATA 'Git AI')) { throw 'MSI created the retired LocalAppData runtime' }
           if (Test-Path (Join-Path $env:ProgramFiles 'Git AI')) { throw 'MSI created a system-wide runtime' }
 
+          $binaryVersion = (& $gitAi --version).Trim()
+          $registration = Get-ChildItem 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall' |
+            Get-ItemProperty |
+            Where-Object { $_.DisplayName -eq 'Git AI' } |
+            Select-Object -First 1
+          if ($null -eq $registration) { throw 'MSI did not register Git AI for the installing user' }
+          if ($registration.DisplayVersion -ne $binaryVersion) {
+            throw "MSI version '$($registration.DisplayVersion)' does not match binary version '$binaryVersion'"
+          }
+
           $uninstall = Start-Process msiexec.exe -ArgumentList "/x `"$msi`" /qn /norestart" -Wait -PassThru
           if ($uninstall.ExitCode -ne 0) { throw "MSI uninstall failed with exit code $($uninstall.ExitCode)" }
 
@@ -579,7 +589,13 @@ jobs:
           PKG=release/git-ai-macos-universal.pkg
           sudo installer -pkg "$PKG" -target /
           lipo "$git_ai" -verify_arch x86_64 arm64
-          "$git_ai" --version
+          binary_version="$("$git_ai" --version)"
+          receipt_id="com.git-ai.git-ai"
+          receipt_version="$(pkgutil --pkg-info "$receipt_id" | awk -F': ' '$1 == "version" { print $2 }')"
+          if [ "$receipt_version" != "$binary_version" ]; then
+            echo "::error::PKG receipt version '$receipt_version' does not match binary version '$binary_version'"
+            exit 1
+          fi
 
           binary_owner="$(/usr/bin/stat -f%Su "$git_ai")"
           state_owner="$(/usr/bin/stat -f%Su "$console_home/.git-ai")"

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -32,19 +32,20 @@ esac
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORK_DIR="$ROOT/target/package/pkg-$ARCH"
+PAYLOAD_ROOT="$WORK_DIR/payload"
 SCRIPTS="$WORK_DIR/scripts"
 COMPONENT_PKG="$WORK_DIR/git-ai-component.pkg"
 OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$OUTPUT")"
 
 rm -rf "$WORK_DIR"
-mkdir -p "$SCRIPTS" "$(dirname "$OUTPUT_ABS")"
+mkdir -p "$PAYLOAD_ROOT" "$SCRIPTS" "$(dirname "$OUTPUT_ABS")"
 install -m 0755 "$BINARY" "$SCRIPTS/git-ai"
 install -m 0755 "$ROOT/packaging/macos/scripts/preinstall" "$SCRIPTS/preinstall"
 install -m 0755 "$ROOT/packaging/macos/scripts/postinstall" "$SCRIPTS/postinstall"
 xattr -cr "$SCRIPTS" 2>/dev/null || true
 
 pkgbuild \
-  --nopayload \
+  --root "$PAYLOAD_ROOT" \
   --scripts "$SCRIPTS" \
   --identifier "com.git-ai.git-ai" \
   --version "$VERSION" \


### PR DESCRIPTION
## Summary

- build macOS PKGs with an empty payload root so Installer records a receipt while the postinstall script still owns binary placement
- verify the installed macOS receipt version matches the installed binary version sourced from Cargo
- verify the existing MSI per-user registration version matches its installed binary

## Root cause

The macOS package used pkgbuild --nopayload. Script-only packages built this way do not create an Installer receipt, and Munki ignores PackageInfo versions without a payload, producing the reported 0.0 metadata. An empty payload root keeps the package operationally payload-free but gives Installer and Munki versioned receipt metadata.

The MSI already passes the Cargo-derived build version into WiX, so it does not need a packaging change; the release smoke test now guards that behavior.

## Validation

- cargo fmt -- --check
- bash -n for macOS packaging scripts
- actionlint on release.yml

## Prerelease validation

A prerelease was not run, per the task constraints. The next prerelease should be checked with Workspace ONE Admin Assistant or munkiimport and pkgutil --pkg-info com.git-ai.git-ai.