### PR TITLE
fix: retry transient Git config reads during repository discovery

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1943,7 +1943,7 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
     rev_parse_args.push("--git-dir".to_string());
     rev_parse_args.push("--git-common-dir".to_string());
 
-    let rev_parse_output = exec_git(&rev_parse_args)?;
+    let rev_parse_output = exec_git_for_repository_discovery(&rev_parse_args)?;
     let rev_parse_stdout = String::from_utf8(rev_parse_output.stdout)?;
     let mut lines = rev_parse_stdout
         .lines()
@@ -2008,7 +2008,7 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
         let mut top_level_args = global_args.to_owned();
         top_level_args.push("rev-parse".to_string());
         top_level_args.push("--show-toplevel".to_string());
-        let output = exec_git(&top_level_args)?;
+        let output = exec_git_for_repository_discovery(&top_level_args)?;
         PathBuf::from(String::from_utf8(output.stdout)?.trim())
     };
 
@@ -2069,6 +2069,40 @@ pub fn find_repository(global_args: &[String]) -> Result<Repository, GitAiError>
         canonical_workdir,
         cached_author_identity: std::sync::OnceLock::new(),
     })
+}
+
+const REPOSITORY_DISCOVERY_CONFIG_RETRY_LIMIT: usize = 3;
+const REPOSITORY_DISCOVERY_CONFIG_RETRY_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(50);
+
+// Git for Windows can briefly deny `.git/config` reads while another process
+// releases its file handle. Repository discovery is read-only, so retry only
+// that exact failure and keep the number of additional Git spawns bounded.
+fn exec_git_for_repository_discovery(args: &[String]) -> Result<Output, GitAiError> {
+    let mut retries = 0;
+    loop {
+        match exec_git(args) {
+            Err(error)
+                if retries < REPOSITORY_DISCOVERY_CONFIG_RETRY_LIMIT
+                    && is_transient_git_config_read_error(&error) =>
+            {
+                retries += 1;
+                std::thread::sleep(REPOSITORY_DISCOVERY_CONFIG_RETRY_DELAY);
+            }
+            result => return result,
+        }
+    }
+}
+
+fn is_transient_git_config_read_error(error: &GitAiError) -> bool {
+    let GitAiError::GitCliError { stderr, .. } = error else {
+        return false;
+    };
+
+    stderr.contains("unable to access")
+        && stderr.contains("config")
+        && stderr.contains("Permission denied")
+        && stderr.contains("unknown error occurred while reading the configuration files")
 }
 
 #[doc(hidden)]
@@ -3311,6 +3345,14 @@ fn parse_hunk_header_counts(line: &str) -> Option<(u32, u32, u32)> {
 mod tests {
     use super::*;
 
+    fn git_cli_error(stderr: &str) -> GitAiError {
+        GitAiError::GitCliError {
+            code: Some(128),
+            stderr: stderr.to_string(),
+            args: vec!["rev-parse".to_string()],
+        }
+    }
+
     fn explicit_command_env(cmd: &Command, key: &str) -> Option<Option<String>> {
         cmd.get_envs()
             .find(|(name, _)| *name == key)
@@ -3338,6 +3380,18 @@ mod tests {
                 Some(Some((*value).to_string()))
             );
         }
+    }
+
+    #[test]
+    fn detects_transient_git_config_read_error() {
+        let error = git_cli_error(
+            "warning: unable to access '.git/config': Permission denied\n\
+             fatal: unknown error occurred while reading the configuration files\n",
+        );
+        assert!(is_transient_git_config_read_error(&error));
+
+        let malformed_config = git_cli_error("fatal: bad config line 1 in file .git/config\n");
+        assert!(!is_transient_git_config_read_error(&malformed_config));
     }
 
     #[test]

--- a/tests/integration/repository_unit.rs
+++ b/tests/integration/repository_unit.rs
@@ -312,6 +312,47 @@ fn find_repository_in_path_supports_bare_repositories() {
     );
 }
 
+#[cfg(windows)]
+#[test]
+fn find_repository_in_path_retries_transient_config_read_lock() {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::thread;
+    use std::time::Duration;
+
+    let repo = TestRepo::new_with_daemon_scope(crate::repos::test_repo::DaemonTestScope::NoDaemon);
+    let config = OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(repo.path().join(".git").join("config"))
+        .expect("lock repository config");
+    let probe_error = repo
+        .git_og(&["rev-parse", "--show-toplevel"])
+        .expect_err("exclusive config lock should reproduce the Git read failure");
+    assert!(
+        probe_error.contains("Permission denied"),
+        "expected config lock failure, got: {probe_error}"
+    );
+
+    let unlock = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100));
+        drop(config);
+    });
+
+    let discovered = find_repository_in_path(repo.path().to_str().unwrap());
+    unlock.join().expect("config unlock thread should join");
+
+    let discovered = discovered.expect("repository discovery should outwait a transient lock");
+    assert_eq!(
+        discovered
+            .workdir()
+            .expect("repository workdir")
+            .canonicalize()
+            .expect("canonical discovered workdir"),
+        repo.path().canonicalize().expect("canonical test repo")
+    );
+}
+
 #[test]
 fn find_repository_in_path_bare_repo_can_read_head_gitattributes() {
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

Fixes the Windows CI flake where daemon-side repository discovery fails with:

```text
warning: unable to access '.git/config': Permission denied
fatal: unknown error occurred while reading the configuration files
```

This signature failed unrelated tests in [run 30461098996](https://github.com/git-ai-project/git-ai/actions/runs/30461098996/job/90607490804) and [run 30224699327](https://github.com/git-ai-project/git-ai/actions/runs/30224699327/job/89852890136), at each of the two read-only `rev-parse` probes used by `find_repository`.

## Root cause

Git for Windows can briefly deny `.git/config` access while another process releases its file handle. Repository discovery previously treated that one-shot read failure as permanent. In daemon tests, the error was recorded in the command completion log and surfaced by the next explicit daemon sync, making whichever test owned the repository appear to fail.

## Fix

- Route both repository-discovery `rev-parse` calls through a narrowly scoped retry helper.
- Retry only the exact transient config-read signature.
- Bound each probe to three retries at 50 ms intervals; successful probes perform no additional work, and malformed config still fails immediately.
- Add a Windows `TestRepo` regression that opens `.git/config` with zero sharing, verifies raw Git reproduces `Permission denied`, releases the lock after 100 ms, and verifies repository discovery succeeds.

No work is added to the critical trace2 ingestion path. The only additional Git spawns are bounded, constant-time retries after this specific read-only failure.

## Validation

- `task fmt`
- `task lint`
- `task build`
- `task test`
- Targeted reproduction-owner tests:
  - `test_commit_metadata_recovery_latest_matching_tool_prefers_current_repo_url`
  - `test_gt_pop_retains_working_tree`
  - `repository_unit` suite
