### PR TITLE
fix e2e daemon routing after async checkpoints

### DIFF
--- a/.github/workflows/install-scripts-local.yml
+++ b/.github/workflows/install-scripts-local.yml
@@ -7,7 +7,14 @@ on:
   schedule:
     - cron: '0 3 * * *'  # 3 AM UTC nightly
   pull_request:
-    types: [labeled]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'install.sh'
+      - 'install.ps1'
+      - 'scripts/**'
+      - '.github/workflows/install-scripts-local.yml'
   push:
     branches: [main]
     paths:
@@ -24,9 +31,8 @@ on:
 
 env:
   # The daemon is always required — the git proxy only performs attribution
-  # when connected to a daemon (see git_handlers.rs). Each job starts a
-  # per-job daemon via start-async-daemon.sh (Unix) or inline PowerShell
-  # (Windows, using named pipes).
+  # when connected to a daemon (see git_handlers.rs). The isolated TEST_HOME
+  # makes the daemon started by `git-ai install` private to each matrix job.
   GIT_AI_TEST_FORCE_TTY: "1"
   GIT_AI_POST_COMMIT_TIMEOUT_MS: "30000"
 
@@ -34,12 +40,6 @@ jobs:
   install-local-unix:
     name: E2E ${{ matrix.agent.name }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'integration')
     strategy:
       fail-fast: false
       matrix:
@@ -142,10 +142,15 @@ jobs:
           cd /tmp/e2e-test-repo
           "$INSTALL_DIR/git-ai" install
 
-      - name: Start async daemon
+      - name: Verify Git and checkpoints use the installed daemon
         run: |
-          source "$GITHUB_WORKSPACE/scripts/nightly/start-async-daemon.sh" \
-            "$HOME/.git-ai/bin/git-ai"
+          INSTALL_DIR="$HOME/.git-ai/bin"
+          cd /tmp/e2e-test-repo
+          test -z "${GIT_AI_DAEMON_HOME:-}"
+          "$INSTALL_DIR/git-ai" bg status
+          actual_target="$(git config --global --get trace2.eventTarget)"
+          expected_target="af_unix:stream:$HOME/.git-ai/internal/daemon/trace2.sock"
+          test "$actual_target" = "$expected_target"
 
       - name: Run synthetic agent commit
         env:
@@ -163,11 +168,12 @@ jobs:
           bash "$GITHUB_WORKSPACE/scripts/nightly/verify-synthetic-attribution.sh" \
             "${{ matrix.agent.name }}" /tmp/e2e-test-repo
 
-      - name: Stop async daemon
+      - name: Stop installed daemon
         if: always()
         run: |
-          bash "$GITHUB_WORKSPACE/scripts/nightly/stop-async-daemon.sh" \
-            "$HOME/.git-ai/bin/git-ai"
+          if [ -x "$HOME/.git-ai/bin/git-ai" ]; then
+            "$HOME/.git-ai/bin/git-ai" bg shutdown || true
+          fi
 
       - name: Upload E2E test results
         if: always()
@@ -181,12 +187,6 @@ jobs:
   install-local-windows:
     name: E2E ${{ matrix.agent.name }} on windows-latest
     runs-on: windows-latest
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'integration')
     strategy:
       fail-fast: false
       matrix:
@@ -308,7 +308,7 @@ jobs:
           & $gitAiExe install
           if ($LASTEXITCODE -ne 0) { throw "git-ai install failed with exit code $LASTEXITCODE" }
 
-      - name: Start async daemon (Windows)
+      - name: Verify Git and checkpoints use the installed daemon
         shell: pwsh
         env:
           HOME: ${{ env.TEST_HOME }}
@@ -318,36 +318,24 @@ jobs:
         run: |
           $installDir = Join-Path $env:USERPROFILE ".git-ai\bin"
           $gitAiExe = Join-Path $installDir "git-ai.exe"
-          # Create daemon home with config
-          $daemonHome = Join-Path $env:RUNNER_TEMP "git-ai-daemon"
-          New-Item -ItemType Directory -Force -Path (Join-Path $daemonHome ".git-ai") | Out-Null
-          # Find the real git (not the proxy)
-          $realGit = (Get-Command git -CommandType Application | Where-Object { $_.Source -notlike "*\.git-ai\*" } | Select-Object -First 1).Source
-          if (-not $realGit) { $realGit = "C:\Program Files\Git\cmd\git.exe" }
-          $config = @{
-            git_path = $realGit
-            disable_auto_updates = $true
-            feature_flags = @{ git_hooks_enabled = $false }
-            quiet = $false
-          } | ConvertTo-Json -Depth 5
-          Set-Content -Path (Join-Path $daemonHome ".git-ai\config.json") -Value $config
-          # Export daemon env vars
-          Add-Content -Path $env:GITHUB_ENV -Value "GIT_AI_DAEMON_HOME=$daemonHome"
-          $env:GIT_AI_DAEMON_HOME = $daemonHome
-          # Start the daemon in the background
-          $proc = Start-Process -FilePath $gitAiExe -ArgumentList "bg","run" -PassThru -NoNewWindow
-          Add-Content -Path $env:GITHUB_ENV -Value "ASYNC_DAEMON_PID=$($proc.Id)"
-          # Wait for the daemon to be ready (up to 15s)
-          $waited = 0
-          while ($waited -lt 15000) {
-            # Test connectivity by running a simple command that requires the daemon
-            $testResult = & $gitAiExe bg status 2>&1
-            if ($LASTEXITCODE -eq 0) { break }
-            Start-Sleep -Milliseconds 250
-            $waited += 250
+          if ($env:GIT_AI_DAEMON_HOME) {
+            throw "GIT_AI_DAEMON_HOME changed after install: $env:GIT_AI_DAEMON_HOME"
           }
-          if ($waited -ge 15000) { throw "Daemon did not start within 15 seconds" }
-          Write-Host "Async daemon started (PID=$($proc.Id))"
+          Set-Location $env:E2E_TEST_REPO
+          & $gitAiExe bg status
+          if ($LASTEXITCODE -ne 0) { throw "Installed daemon is not running" }
+
+          $actualTarget = (git config --global --get trace2.eventTarget | Out-String).Trim()
+          if ($LASTEXITCODE -ne 0) { throw "trace2.eventTarget is not configured" }
+          $internalDir = Join-Path $env:USERPROFILE ".git-ai\internal"
+          $pathBytes = [System.Text.Encoding]::UTF8.GetBytes($internalDir)
+          $pathHash = [System.Convert]::ToHexString(
+            [System.Security.Cryptography.SHA256]::HashData($pathBytes)
+          ).ToLowerInvariant()
+          $expectedTarget = "\\.\pipe\git-ai-$($pathHash.Substring(0, 16))-trace2"
+          if ($actualTarget -ne $expectedTarget) {
+            throw "Git trace2 target '$actualTarget' does not match installed daemon '$expectedTarget'"
+          }
 
       - name: Run synthetic agent commit (Windows)
         shell: pwsh
@@ -521,7 +509,7 @@ jobs:
           $lines | Set-Content -Path $log
           Write-Log "=== Synthetic attribution verification COMPLETE: $agent ==="
 
-      - name: Stop async daemon (Windows)
+      - name: Stop installed daemon (Windows)
         if: always()
         shell: pwsh
         env:
@@ -534,12 +522,7 @@ jobs:
           $gitAiExe = Join-Path $installDir "git-ai.exe"
           if (Test-Path $gitAiExe) {
             & $gitAiExe bg shutdown 2>&1 | Out-Null
-          }
-          if ($env:ASYNC_DAEMON_PID) {
-            $proc = Get-Process -Id $env:ASYNC_DAEMON_PID -ErrorAction SilentlyContinue
-            if ($proc) {
-              $proc | Stop-Process -Force -ErrorAction SilentlyContinue
-            }
+            $global:LASTEXITCODE = 0
           }
 
       - name: Upload E2E test results

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2,19 +2,15 @@
 #[path = "integration/repos/mod.rs"]
 mod repos;
 
-#[cfg(not(windows))]
 use git_ai::authorship::working_log::AgentId;
 use git_ai::authorship::working_log::CheckpointKind;
-#[cfg(not(windows))]
 use git_ai::commands::checkpoint_agent::orchestrator::{
     BaseCommit, CheckpointFile, CheckpointRequest,
 };
 use git_ai::config::{NotesBackendConfig, NotesBackendKind};
 #[cfg(not(windows))]
 use git_ai::daemon::ControlResponse;
-#[cfg(not(windows))]
 use git_ai::daemon::checkpoint::PreparedPathRole;
-#[cfg(not(windows))]
 use git_ai::daemon::send_checkpoint_request_with_timeout;
 use git_ai::daemon::send_control_request_with_timeout;
 use git_ai::daemon::{
@@ -1813,8 +1809,7 @@ fn wltrace_captures_daemon_working_log_ops_when_enabled() {
 }
 
 #[test]
-#[cfg(not(windows))]
-fn daemon_checkpoint_ack_does_not_wait_for_checkpoint_processing() {
+fn daemon_checkpoint_ack_preserves_order_with_immediate_commit() {
     let repo = TestRepo::new_with_daemon_env(&[(
         "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
         "slow-checkpoint=2000",
@@ -1857,20 +1852,37 @@ fn daemon_checkpoint_ack_does_not_wait_for_checkpoint_processing() {
         "receipt acknowledgement waited for checkpoint processing"
     );
 
-    let sync = send_control_request_with_timeout(
-        &daemon_control_socket_path(&repo),
-        &ControlRequest::SyncFamily {
-            repo_working_dir: repo_workdir_string(&repo),
-        },
-        Duration::from_secs(5),
-    )
-    .expect("sync.family should wait for asynchronous checkpoint processing");
-    assert!(sync.ok, "sync.family failed: {sync:?}");
-
-    repo.stage_all_and_commit("Commit asynchronously processed checkpoint")
+    repo.git_without_test_sync_for_test(&["add", "."], &[])
         .unwrap();
+    repo.git_without_test_sync_for_test(
+        &[
+            "commit",
+            "-m",
+            "Commit immediately after checkpoint receipt",
+        ],
+        &[],
+    )
+    .unwrap();
+
     let mut file = repo.filename("slow-checkpoint.txt");
     file.assert_committed_lines(lines!["AI content".ai()]);
+
+    let head = repo.git(&["rev-parse", "HEAD"]).unwrap();
+    let note = repo
+        .read_authorship_note(head.trim())
+        .expect("immediate commit should have an authorship note");
+    let log =
+        git_ai::authorship::authorship_log_serialization::AuthorshipLog::deserialize_from_string(
+            &note,
+        )
+        .expect("authorship note should deserialize");
+    assert!(
+        log.metadata
+            .sessions
+            .values()
+            .any(|session| session.agent_id.id == "slow-checkpoint-session"),
+        "immediate commit should retain checkpoint session metadata"
+    );
 }
 
 #[test]
@@ -2120,7 +2132,6 @@ fn daemon_checkpoint_processing_failure_is_logged_after_receipt_ack() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn daemon_async_checkpoint_receipts_preserve_file_edit_order_before_commit() {
     let repo = TestRepo::new_with_daemon_env(&[(
         "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
@@ -2211,28 +2222,6 @@ fn daemon_async_checkpoint_receipts_preserve_file_edit_order_before_commit() {
     assert!(post_receipt.ok && post_receipt.seq.is_some());
     assert!(pre_receipt.seq < post_receipt.seq);
 
-    let checkpoints = repo
-        .current_working_logs()
-        .read_all_checkpoints()
-        .expect("ordered checkpoints should be readable");
-    assert_eq!(
-        checkpoints
-            .iter()
-            .map(|checkpoint| checkpoint.kind)
-            .collect::<Vec<_>>(),
-        vec![CheckpointKind::Human, CheckpointKind::AiAgent],
-        "checkpoint processing must preserve receipt order"
-    );
-    assert_eq!(
-        checkpoints[1].entries[0]
-            .line_attributions
-            .iter()
-            .map(|attribution| (attribution.start_line, attribution.end_line))
-            .collect::<Vec<_>>(),
-        vec![(4, 4)],
-        "the AI checkpoint should only attribute the post-edit addition"
-    );
-
     repo.git_without_test_sync_for_test(&["add", "."], &[])
         .unwrap();
     repo.git_without_test_sync_for_test(&["commit", "-m", "Immediate commit after receipts"], &[])
@@ -2244,6 +2233,23 @@ fn daemon_async_checkpoint_receipts_preserve_file_edit_order_before_commit() {
         "unchanged two".unattributed_human(),
         "AI addition".ai(),
     ]);
+
+    let head = repo.git(&["rev-parse", "HEAD"]).unwrap();
+    let note = repo
+        .read_authorship_note(head.trim())
+        .expect("immediate commit should have an authorship note");
+    let log =
+        git_ai::authorship::authorship_log_serialization::AuthorshipLog::deserialize_from_string(
+            &note,
+        )
+        .expect("authorship note should deserialize");
+    assert!(
+        log.metadata
+            .sessions
+            .values()
+            .any(|session| session.agent_id.id == "ordered-edit-session"),
+        "immediate commit should retain ordered checkpoint session metadata"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- use the daemon started by `git-ai install` for both checkpoint control requests and Git trace2 ingestion
- fail E2E setup when the installed daemon is unavailable or `trace2.eventTarget` points elsewhere
- run installer E2E automatically for pull requests that touch the runtime, installers, scripts, or this workflow
- exercise delayed asynchronous checkpoint receipts followed by an immediate commit on every platform, with no pre-commit synchronization

## Root cause

The E2E workflow ran `git-ai install`, which configured Git trace2 and started one daemon, then started a second daemon under a new `GIT_AI_DAEMON_HOME`. Checkpoints went to the second daemon while Git commit events went to the first. Synchronous checkpoint completion previously hid that split because both processes shared the repository working log. Receipt acknowledgements made the race visible, especially on Windows.

This keeps the asynchronous checkpoint contract intact and restores the required single-daemon ordering boundary.

## Validation

- `task fmt`
- `task lint`
- `task test` (2,118 unit, 75 daemon, 3,256 integration, 22 notes-sync, and doctests)
- focused immediate-commit checkpoint ordering tests with delayed side effects
- workflow YAML parsing
