### PR TITLE
fix: use no-exec path repository discovery

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2518,8 +2518,7 @@ fn is_linked_worktree_git_file(git_file: &Path) -> bool {
 }
 
 pub fn find_repository_in_path(path: &str) -> Result<Repository, GitAiError> {
-    let global_args = vec!["-C".to_string(), path.to_string()];
-    find_repository(&global_args)
+    discover_repository_in_path_no_git_exec(Path::new(path))
 }
 
 /// Find the git repository that contains the given file path by walking up the directory tree.

--- a/tests/integration/repository_unit.rs
+++ b/tests/integration/repository_unit.rs
@@ -312,6 +312,38 @@ fn find_repository_in_path_supports_bare_repositories() {
     );
 }
 
+#[cfg(windows)]
+#[test]
+fn find_repository_in_path_does_not_read_locked_git_config() {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let repo = TestRepo::new_with_daemon_scope(crate::repos::test_repo::DaemonTestScope::NoDaemon);
+    let _config_lock = OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(repo.path().join(".git").join("config"))
+        .expect("lock repository config");
+    let probe_error = repo
+        .git_og(&["rev-parse", "--show-toplevel"])
+        .expect_err("exclusive config lock should reproduce the Git read failure");
+    assert!(
+        probe_error.contains("Permission denied"),
+        "expected config lock failure, got: {probe_error}"
+    );
+
+    let discovered = find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("repository discovery should not read config");
+    assert_eq!(
+        discovered
+            .workdir()
+            .expect("repository workdir")
+            .canonicalize()
+            .expect("canonical discovered workdir"),
+        repo.path().canonicalize().expect("canonical test repo")
+    );
+}
+
 #[test]
 fn find_repository_in_path_bare_repo_can_read_head_gitattributes() {
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- replace the path-based `git rev-parse` repository probes with the existing filesystem-only discovery helper
- preserve `find_repository` for callers that need arbitrary Git global arguments such as `--git-dir` and `--work-tree`
- add a Windows regression that exclusively locks `.git/config`, confirms raw `git rev-parse` fails, and confirms repository discovery succeeds while the lock is held

## Why

The failing Windows jobs were not exposing a transient process-start failure. Git was starting successfully, then failing while reading a briefly locked `.git/config` during repository discovery. Retrying that subprocess would only mask the underlying issue. This path does not need configuration data, and the existing no-exec helper already handles normal repositories, bare repositories, and linked worktrees.

This supersedes #2032.

Observed failures:
- https://github.com/git-ai-project/git-ai/actions/runs/30461098996/job/90607490804
- https://github.com/git-ai-project/git-ai/actions/runs/30224699327/job/89852890136

## Validation

- `task fmt`
- `task lint`
- `task build`
- `task test`
- `task test TEST_FILTER=repository_unit::`
- `task test TEST_FILTER=test_commit_metadata_recovery_latest_matching_tool_prefers_current_repo_url`
- `task test TEST_FILTER=test_gt_pop_retains_working_tree`