### PR TITLE
fix(amp): skip read-only checkpoint requests

### DIFF
--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -334,8 +334,10 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             _ => ToolClass::Skip,
         },
         Agent::Amp => match tool_name {
-            "Write" | "Edit" => ToolClass::FileEdit,
-            "Bash" => ToolClass::Bash,
+            "Write" | "Edit" | "create_file" | "edit_file" | "apply_patch" | "undo_edit" => {
+                ToolClass::FileEdit
+            }
+            "Bash" | "shell_command" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
         Agent::OpenCode => match tool_name {
@@ -1520,7 +1522,18 @@ mod tests {
 
         // Amp
         assert_eq!(classify_tool(Agent::Amp, "Write"), ToolClass::FileEdit);
+        assert_eq!(
+            classify_tool(Agent::Amp, "create_file"),
+            ToolClass::FileEdit
+        );
+        assert_eq!(classify_tool(Agent::Amp, "edit_file"), ToolClass::FileEdit);
+        assert_eq!(
+            classify_tool(Agent::Amp, "apply_patch"),
+            ToolClass::FileEdit
+        );
+        assert_eq!(classify_tool(Agent::Amp, "undo_edit"), ToolClass::FileEdit);
         assert_eq!(classify_tool(Agent::Amp, "Bash"), ToolClass::Bash);
+        assert_eq!(classify_tool(Agent::Amp, "shell_command"), ToolClass::Bash);
 
         // OpenCode
         assert_eq!(classify_tool(Agent::OpenCode, "edit"), ToolClass::FileEdit);

--- a/src/commands/checkpoint_agent/presets/amp.rs
+++ b/src/commands/checkpoint_agent/presets/amp.rs
@@ -249,13 +249,19 @@ impl AgentPreset for AmpPreset {
         let hook_input: AmpHookInput = serde_json::from_str(hook_input)
             .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
 
-        let is_pre = hook_input.hook_event_name == "PreToolUse";
-
-        let is_bash = hook_input
+        let tool_class = hook_input
             .tool_name
             .as_deref()
-            .map(|name| bash_tool::classify_tool(Agent::Amp, name) == ToolClass::Bash)
-            .unwrap_or(false);
+            .map(|name| bash_tool::classify_tool(Agent::Amp, name))
+            // Preserve payloads from older Amp integrations that omitted tool_name.
+            .unwrap_or(ToolClass::FileEdit);
+        if tool_class == ToolClass::Skip {
+            return Ok(Vec::new());
+        }
+
+        let is_pre = hook_input.hook_event_name == "PreToolUse";
+
+        let is_bash = tool_class == ToolClass::Bash;
 
         let cwd = hook_input.cwd.as_deref().unwrap_or(".");
 
@@ -461,6 +467,68 @@ mod tests {
                 assert_eq!(e.tool_use_id, "tu-abc");
             }
             _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_amp_ignores_read_only_and_unsupported_tools() {
+        for hook_event in ["PreToolUse", "PostToolUse"] {
+            for tool_name in ["Read", "finder", "glob", "Grep", "Task", "unknown_tool"] {
+                let input = make_amp_input(hook_event, tool_name);
+                let events = AmpPreset.parse(&input, "t_test").unwrap();
+                assert!(
+                    events.is_empty(),
+                    "{hook_event} {tool_name} unexpectedly produced events"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ignored_amp_hook_produces_no_checkpoint_requests() {
+        let input = make_amp_input("PostToolUse", "Read");
+        let requests = crate::commands::checkpoint_agent::orchestrator::execute_preset_checkpoint(
+            "amp", &input,
+        )
+        .unwrap();
+        assert!(requests.is_empty());
+    }
+
+    #[test]
+    fn test_amp_preserves_all_mutating_tools() {
+        for tool_name in [
+            "Write",
+            "Edit",
+            "create_file",
+            "edit_file",
+            "apply_patch",
+            "undo_edit",
+        ] {
+            let pre = make_amp_input("PreToolUse", tool_name);
+            assert!(matches!(
+                AmpPreset.parse(&pre, "t_test").unwrap()[..],
+                [ParsedHookEvent::PreFileEdit(_)]
+            ));
+
+            let post = make_amp_input("PostToolUse", tool_name);
+            assert!(matches!(
+                AmpPreset.parse(&post, "t_test").unwrap()[..],
+                [ParsedHookEvent::PostFileEdit(_)]
+            ));
+        }
+
+        for tool_name in ["Bash", "shell_command"] {
+            let pre = make_amp_input("PreToolUse", tool_name);
+            assert!(matches!(
+                AmpPreset.parse(&pre, "t_test").unwrap()[..],
+                [ParsedHookEvent::PreBashCall(_)]
+            ));
+
+            let post = make_amp_input("PostToolUse", tool_name);
+            assert!(matches!(
+                AmpPreset.parse(&post, "t_test").unwrap()[..],
+                [ParsedHookEvent::PostBashCall(_)]
+            ));
         }
     }
 

--- a/tests/integration/bash_tool_conformance.rs
+++ b/tests/integration/bash_tool_conformance.rs
@@ -618,7 +618,18 @@ fn test_classify_tool_droid() {
 fn test_classify_tool_amp() {
     assert_eq!(classify_tool(Agent::Amp, "Write"), ToolClass::FileEdit);
     assert_eq!(classify_tool(Agent::Amp, "Edit"), ToolClass::FileEdit);
+    assert_eq!(
+        classify_tool(Agent::Amp, "create_file"),
+        ToolClass::FileEdit
+    );
+    assert_eq!(classify_tool(Agent::Amp, "edit_file"), ToolClass::FileEdit);
+    assert_eq!(
+        classify_tool(Agent::Amp, "apply_patch"),
+        ToolClass::FileEdit
+    );
+    assert_eq!(classify_tool(Agent::Amp, "undo_edit"), ToolClass::FileEdit);
     assert_eq!(classify_tool(Agent::Amp, "Bash"), ToolClass::Bash);
+    assert_eq!(classify_tool(Agent::Amp, "shell_command"), ToolClass::Bash);
     assert_eq!(classify_tool(Agent::Amp, "Read"), ToolClass::Skip);
     assert_eq!(classify_tool(Agent::Amp, "unknown"), ToolClass::Skip);
 }


### PR DESCRIPTION
## Summary

- discard named read-only and unsupported Amp tool events before repository, transcript, or checkpoint work
- recognize Amp's current create, edit, patch, undo, and shell aliases while retaining legacy aliases
- preserve unnamed legacy payload behavior

## Why

The Amp plugin forwards every tool call/result to the checkpoint parser. The parser previously reduced classification to a Bash boolean, so every named non-shell tool—including read-only tools—fell through to the file-edit checkpoint path.

## Validation

- `task test TEST_FILTER=amp`
- `task test`
- `task lint`
- `task fmt`

Stacked on #2036.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
