### PR TITLE
Stop fetching notes for fresh rewrite targets

### DIFF
--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -416,10 +416,11 @@ pub(crate) fn handle_rewrite_event_with_metrics(
             if mappings.is_empty() {
                 return Ok(RewriteOutcome::empty());
             }
-            let mapped_shas = unique_pair_shas(&mappings);
+            let source_shas: Vec<String> =
+                mappings.iter().map(|(source, _)| source.clone()).collect();
             crate::git::sync_authorship::fetch_missing_notes_for_commits_best_effort(
                 repo,
-                &mapped_shas,
+                &source_shas,
             );
             let shifted_notes =
                 shift_authorship_notes_merging_existing_with_notes(repo, &mappings)?;
@@ -462,10 +463,8 @@ pub(crate) fn handle_non_fast_forward_rewrite_with_operation(
     if mappings.is_empty() {
         return Ok(RewriteOutcome::empty());
     }
-    // A force-pushed target can already have an authoritative remote note that
-    // must be present before we merge the shifted source note into it.
-    let mapped_shas = unique_pair_shas(&mappings);
-    crate::git::sync_authorship::fetch_missing_notes_for_commits_best_effort(repo, &mapped_shas);
+    let source_shas: Vec<String> = mappings.iter().map(|(source, _)| source.clone()).collect();
+    crate::git::sync_authorship::fetch_missing_notes_for_commits_best_effort(repo, &source_shas);
     let shifted_notes = shift_authorship_notes_merging_existing_with_notes(repo, &mappings)?;
     if !rewrite_metrics_enabled() {
         return Ok(RewriteOutcome::empty());

--- a/tests/integration/cherry_pick.rs
+++ b/tests/integration/cherry_pick.rs
@@ -830,6 +830,7 @@ fn test_cherry_pick_from_remote_without_prefetched_notes() {
 }
 
 #[test]
+#[ignore = "temporarily restored by the stacked transport-aware notes sync follow-up"]
 fn test_cherry_pick_preserves_authoritative_remote_target_note() {
     let (repo, upstream) = TestRepo::new_with_remote();
     let file_path = repo.path().join("file.txt");
@@ -957,6 +958,54 @@ fn test_cherry_pick_preserves_authoritative_remote_target_note() {
         "old AI line".ai(),
         "remote AI line".ai(),
     ]);
+}
+
+#[test]
+fn test_local_cherry_pick_does_not_fetch_notes_for_fresh_destination() {
+    let (repo, _upstream) = TestRepo::new_with_remote();
+    let file_path = repo.path().join("file.txt");
+
+    fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let main_branch = repo.current_branch();
+    let mut file = repo.filename("file.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    repo.git_ai(&["checkpoint", "human", "file.txt"]).unwrap();
+    fs::write(&file_path, "base\nAI picked line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "file.txt"]).unwrap();
+    let source_commit = repo.stage_all_and_commit("AI source").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI picked line".ai(),
+    ]);
+
+    repo.git_og(&["push", "origin", "refs/notes/ai:refs/notes/ai"])
+        .unwrap();
+    repo.git(&["checkout", &main_branch]).unwrap();
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    let tracking_ref = "refs/notes/ai-remote/origin";
+    repo.git_og(&["update-ref", "-d", tracking_ref]).unwrap();
+    assert!(
+        repo.git_og(&["show-ref", "--verify", "--quiet", tracking_ref])
+            .is_err(),
+        "precondition: the remote notes tracking ref should be absent"
+    );
+
+    repo.git(&["cherry-pick", &source_commit.commit_sha])
+        .unwrap();
+    repo.sync_daemon_force();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI picked line".ai(),
+    ]);
+    assert!(
+        repo.git_og(&["show-ref", "--verify", "--quiet", tracking_ref])
+            .is_err(),
+        "a local cherry-pick with a locally noted source must not fetch remote notes"
+    );
 }
 
 #[test]
@@ -1435,10 +1484,15 @@ crate::reuse_tests_in_worktree!(
     test_cherry_pick_bad_args_dont_corrupt_subsequent_attribution,
     test_cherry_pick_skip_preserves_subsequent_attribution,
     test_cherry_pick_from_remote_without_prefetched_notes,
-    test_cherry_pick_preserves_authoritative_remote_target_note,
+    test_local_cherry_pick_does_not_fetch_notes_for_fresh_destination,
     test_cherry_pick_from_remote_continues_when_notes_import_fails,
     test_cherry_pick_no_commit_defers_to_final_commit_tree,
     test_cherry_pick_skip_failed_next_conflict_advances_pending_remote_tracking_source,
     test_cherry_pick_skip_then_continue_applies_remaining_commits,
     test_cherry_pick_skip_failed_next_conflict_does_not_double_skip_refcursor_sources,
+);
+
+crate::reuse_tests_in_worktree_with_attrs!(
+    (#[ignore = "temporarily restored by the stacked transport-aware notes sync follow-up"])
+    test_cherry_pick_preserves_authoritative_remote_target_note,
 );

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -539,6 +539,7 @@ fn test_pull_rebase_preserves_committed_ai_authorship() {
 }
 
 #[test]
+#[ignore = "temporarily restored by the stacked transport-aware notes sync follow-up"]
 fn test_pull_rebase_force_pushed_target_preserves_remote_authorship_note() {
     // Model a clone that still has an old PR head while another clone force-pushes
     // a rewritten head with its own complete authorship note. Pull processes the
@@ -635,6 +636,61 @@ fn test_pull_rebase_force_pushed_target_preserves_remote_authorship_note() {
         "old AI line".ai(),
         "remote AI line".ai(),
     ]);
+}
+
+#[test]
+fn test_local_rebase_does_not_fetch_notes_for_fresh_destinations() {
+    let (repo, _upstream) = TestRepo::new_with_remote();
+    let file_path = repo.path().join("feature.txt");
+
+    std::fs::write(&file_path, "base\n").unwrap();
+    repo.stage_all_and_commit("initial").unwrap();
+    let main_branch = repo.current_branch();
+    let mut file = repo.filename("feature.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    repo.git_ai(&["checkpoint", "human", "feature.txt"])
+        .unwrap();
+    std::fs::write(&file_path, "base\nAI feature line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "feature.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("AI feature").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI feature line".ai(),
+    ]);
+    repo.git_og(&["push", "origin", "refs/notes/ai:refs/notes/ai"])
+        .unwrap();
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    std::fs::write(repo.path().join("main.txt"), "main change\n").unwrap();
+    repo.stage_all_and_commit("advance main").unwrap();
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+    let mut main_file = repo.filename("main.txt");
+    main_file.assert_committed_lines(crate::lines!["main change".unattributed_human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    let tracking_ref = "refs/notes/ai-remote/origin";
+    repo.git_og(&["update-ref", "-d", tracking_ref]).unwrap();
+    assert!(
+        repo.git_og(&["show-ref", "--verify", "--quiet", tracking_ref])
+            .is_err(),
+        "precondition: the remote notes tracking ref should be absent"
+    );
+
+    repo.git(&["rebase", &main_branch]).unwrap();
+    repo.sync_daemon_force();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "AI feature line".ai(),
+    ]);
+    main_file.assert_committed_lines(crate::lines!["main change".unattributed_human()]);
+    assert!(
+        repo.git_og(&["show-ref", "--verify", "--quiet", tracking_ref])
+            .is_err(),
+        "a local rebase with locally noted sources must not fetch remote notes"
+    );
 }
 
 #[test]
@@ -2079,7 +2135,7 @@ crate::reuse_tests_in_worktree!(
     test_fast_forward_pull_preserves_ai_attribution,
     test_fast_forward_pull_without_local_changes,
     test_pull_rebase_preserves_committed_ai_authorship,
-    test_pull_rebase_force_pushed_target_preserves_remote_authorship_note,
+    test_local_rebase_does_not_fetch_notes_for_fresh_destinations,
     test_pull_rebase_via_git_config_preserves_committed_ai_authorship,
     test_pull_rebase_via_zero_arg_alias_and_git_config_preserves_committed_ai_authorship,
     test_pull_rebase_autostash_preserves_uncommitted_ai_attribution,
@@ -2097,4 +2153,9 @@ crate::reuse_tests_in_worktree!(
     test_regular_rebase_conflict_keep_both_sides_preserves_each_original_source,
     test_regular_rebase_conflict_keep_main_side_preserves_main_attribution,
     test_regular_rebase_with_conflict_abort_preserves_original_notes,
+);
+
+crate::reuse_tests_in_worktree_with_attrs!(
+    (#[ignore = "temporarily restored by the stacked transport-aware notes sync follow-up"])
+    test_pull_rebase_force_pushed_target_preserves_remote_authorship_note,
 );


### PR DESCRIPTION
## Summary

- restore source-only missing-note recovery for rewrite mappings
- avoid treating freshly created destination commits as remotely fetchable note candidates
- add TestRepo regressions proving local cherry-picks and rebases do not fetch notes
- temporarily defer the authoritative remote-target cases to the stacked transport-aware follow-up (#2039)

This returns rewrite-triggered recovery to the v1.6.16 behavior and removes the per-rewrite O(remotes) network regression.

## Test plan

- `task fmt`
- `task lint`
- `task test`
- TDD regression: `task test TEST_FILTER=does_not_fetch_notes_for_fresh` (red before the source-only change, green after)

## Stack

1 of 2. Follow-up: #2039