### PR TITLE
Deduplicate staged and unstaged TestFile content setup

### DIFF
--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -693,47 +693,21 @@ impl<'a> TestFile<'a> {
     }
 
     pub fn set_contents<T: Into<ExpectedLine>>(&mut self, lines: Vec<T>) -> &mut Self {
-        let lines: Vec<ExpectedLine> = lines.into_iter().map(|l| l.into()).collect();
-        // stub in AI Lines
-        let line_contents = lines
-            .iter()
-            .map(|s| {
-                if s.author_type == AuthorType::Ai {
-                    "||__AI LINE__ PENDING__||".to_string()
-                } else {
-                    s.contents.clone()
-                }
-            })
-            .collect::<Vec<String>>()
-            .join("\n");
-
-        let human_kind = if lines
-            .iter()
-            .any(|l| l.author_type == AuthorType::UnattributedHuman)
-        {
-            &AuthorType::UnattributedHuman
-        } else {
-            &AuthorType::Human
-        };
-        self.write_and_checkpoint_with_contents(&line_contents, human_kind);
-
-        let line_contents_with_ai = lines
-            .iter()
-            .map(|s| s.contents.clone())
-            .collect::<Vec<String>>()
-            .join("\n");
-
-        self.write_and_checkpoint_with_contents(&line_contents_with_ai, &AuthorType::Ai);
-
-        self.lines = lines;
-        self
+        self.set_contents_with_staging(lines, true)
     }
 
     /// Set file contents without staging (but still creates checkpoints for authorship tracking)
     /// Useful for testing scenarios with precise staging control
     pub fn set_contents_no_stage<T: Into<ExpectedLine>>(&mut self, lines: Vec<T>) -> &mut Self {
-        let lines: Vec<ExpectedLine> = lines.into_iter().map(|l| l.into()).collect();
+        self.set_contents_with_staging(lines, false)
+    }
 
+    fn set_contents_with_staging<T: Into<ExpectedLine>>(
+        &mut self,
+        lines: Vec<T>,
+        stage: bool,
+    ) -> &mut Self {
+        let lines: Vec<ExpectedLine> = lines.into_iter().map(|l| l.into()).collect();
         // stub in AI Lines
         let line_contents = lines
             .iter()
@@ -755,7 +729,7 @@ impl<'a> TestFile<'a> {
         } else {
             &AuthorType::Human
         };
-        self.write_and_checkpoint_no_stage(&line_contents, human_kind);
+        self.write_and_checkpoint_with_contents(&line_contents, human_kind, stage);
 
         let line_contents_with_ai = lines
             .iter()
@@ -763,7 +737,7 @@ impl<'a> TestFile<'a> {
             .collect::<Vec<String>>()
             .join("\n");
 
-        self.write_and_checkpoint_no_stage(&line_contents_with_ai, &AuthorType::Ai);
+        self.write_and_checkpoint_with_contents(&line_contents_with_ai, &AuthorType::Ai, stage);
 
         self.lines = lines;
         self
@@ -815,7 +789,12 @@ impl<'a> TestFile<'a> {
         self.run_checkpoint_for_author_type(author_type);
     }
 
-    fn write_and_checkpoint_with_contents(&self, contents: &str, author_type: &AuthorType) {
+    fn write_and_checkpoint_with_contents(
+        &self,
+        contents: &str,
+        author_type: &AuthorType,
+        stage: bool,
+    ) {
         // Create parent directories if they don't exist (important for nested paths like src/模块/组件.ts)
         if let Some(parent) = self.file_path.parent()
             && !parent.exists()
@@ -824,22 +803,11 @@ impl<'a> TestFile<'a> {
         }
         fs::write(&self.file_path, contents).unwrap();
 
-        // Stage the file first
-        self.repo.git(&["add", "-A"]).unwrap();
-
-        self.run_checkpoint_for_author_type(author_type);
-    }
-
-    fn write_and_checkpoint_no_stage(&self, contents: &str, author_type: &AuthorType) {
-        // Create parent directories if they don't exist (important for nested paths)
-        if let Some(parent) = self.file_path.parent()
-            && !parent.exists()
-        {
-            fs::create_dir_all(parent).expect("failed to create parent directories");
+        if stage {
+            // Stage the file first
+            self.repo.git(&["add", "-A"]).unwrap();
         }
-        fs::write(&self.file_path, contents).unwrap();
 
-        // Create checkpoint without staging - checkpoints work with unstaged files
         self.run_checkpoint_for_author_type(author_type);
     }
 }


### PR DESCRIPTION
## Primary changes

Deduplicate staged and unstaged TestFile content setup behind one private implementation with an explicit staging policy.

## Reviewer walkthrough

1. tests/integration/repos/test_file.rs: set_contents and set_contents_no_stage.
2. The shared content conversion, placeholder rendering, and checkpoint flow.

## Correctness and invariants

The public APIs remain unchanged. Staging is the only policy difference; checkpoint order, author kinds, and final line state remain unchanged. This PR changes tests only.

## Testing and QA

- cargo fmt --all -- --check passed after rebasing.
- cargo check --test integration passed after rebasing.
- Representative targeted integration tests passed on the stack before the upstream rebase.
- The post-rebase daemon-backed integration run is blocked in this environment because CODEX_SANDBOX_NETWORK_DISABLED prevents test daemon startup.
- task lint passed before the upstream rebase; the current upstream base has 11 unrelated pre-existing src/ Clippy warnings, and this stack changes no src files.

## Risk / Rollout

Low risk and test-only. This is the bottom PR of the stack and targets upstream main.

Resolves ENG-222
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->