### PR TITLE
Deduplicate ExpectedLine attribution constructors

### DIFF
--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -52,51 +52,41 @@ impl ExpectedLine {
 }
 
 /// Trait to add .ai(), .human(), and .unattributed_human() methods to string types
-pub trait ExpectedLineExt {
-    fn ai(self) -> ExpectedLine;
-    fn human(self) -> ExpectedLine;
-    fn unattributed_human(self) -> ExpectedLine;
-}
+pub trait ExpectedLineExt: Sized {
+    #[doc(hidden)]
+    fn into_expected_line_contents(self) -> String;
 
-impl ExpectedLineExt for &str {
     fn ai(self) -> ExpectedLine {
-        ExpectedLine::new(self.to_string(), AuthorType::Ai)
+        ExpectedLine::new(self.into_expected_line_contents(), AuthorType::Ai)
     }
 
     fn human(self) -> ExpectedLine {
-        ExpectedLine::new(self.to_string(), AuthorType::Human)
+        ExpectedLine::new(self.into_expected_line_contents(), AuthorType::Human)
     }
 
     fn unattributed_human(self) -> ExpectedLine {
-        ExpectedLine::new(self.to_string(), AuthorType::UnattributedHuman)
+        ExpectedLine::new(
+            self.into_expected_line_contents(),
+            AuthorType::UnattributedHuman,
+        )
+    }
+}
+
+impl ExpectedLineExt for &str {
+    fn into_expected_line_contents(self) -> String {
+        self.to_string()
     }
 }
 
 impl ExpectedLineExt for String {
-    fn ai(self) -> ExpectedLine {
-        ExpectedLine::new(self, AuthorType::Ai)
-    }
-
-    fn human(self) -> ExpectedLine {
-        ExpectedLine::new(self, AuthorType::Human)
-    }
-
-    fn unattributed_human(self) -> ExpectedLine {
-        ExpectedLine::new(self, AuthorType::UnattributedHuman)
+    fn into_expected_line_contents(self) -> String {
+        self
     }
 }
 
 impl ExpectedLineExt for ExpectedLine {
-    fn ai(self) -> ExpectedLine {
-        ExpectedLine::new(self.contents, AuthorType::Ai)
-    }
-
-    fn human(self) -> ExpectedLine {
-        ExpectedLine::new(self.contents, AuthorType::Human)
-    }
-
-    fn unattributed_human(self) -> ExpectedLine {
-        ExpectedLine::new(self.contents, AuthorType::UnattributedHuman)
+    fn into_expected_line_contents(self) -> String {
+        self.contents
     }
 }
 


### PR DESCRIPTION
## Primary changes

Route the ExpectedLine fluent attribution methods through one shared conversion path.

## Reviewer walkthrough

1. tests/integration/repos/test_file.rs: ExpectedLineExt.
2. The ai, human, and unattributed_human call sites and input implementations.

## Correctness and invariants

The fluent API, newline validation, author kinds, and ownership behavior remain unchanged for str, String, and ExpectedLine inputs. This PR changes tests only.

## Testing and QA

- cargo fmt --all -- --check passed after rebasing.
- cargo check --test integration passed after rebasing.
- Representative targeted integration tests passed on the stack before the upstream rebase.
- The post-rebase daemon-backed integration run is blocked because CODEX_SANDBOX_NETWORK_DISABLED prevents test daemon startup.
- task lint passed before the upstream rebase; the current upstream base has 11 unrelated pre-existing src/ Clippy warnings, and this stack changes no src files.

## Risk / Rollout

Low risk and test-only. This is an independent upstream-targeted head because GitHub does not allow a fork branch to be the base of an upstream PR. Merge it after ENG-222 if the reviewer wants the issue sequence preserved.

Resolves ENG-223
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->