### PR TITLE
Centralize standard TestRepo edit and checkpoint flows

### DIFF
--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -787,42 +787,21 @@ impl<'a> TestFile<'a> {
 
     fn run_checkpoint_for_author_type(&self, author_type: &AuthorType) {
         let relative_path = self.repo_relative_path();
-        let result = match author_type {
-            AuthorType::Ai => self
-                .repo
-                .git_ai(&["checkpoint", "mock_ai", relative_path.as_str()]),
-            AuthorType::Human => {
-                self.repo
-                    .git_ai(&["checkpoint", "mock_known_human", relative_path.as_str()])
-            }
-            AuthorType::UnattributedHuman => {
-                self.repo
-                    .git_ai(&["checkpoint", "--", relative_path.as_str()])
-            }
-        };
-        result.unwrap();
+        self.repo
+            .checkpoint_file(&relative_path, author_type)
+            .unwrap();
     }
 
     fn write_and_checkpoint(&self, author_type: &AuthorType) {
-        // Create parent directories if they don't exist (important for nested paths)
-        if let Some(parent) = self.file_path.parent()
-            && !parent.exists()
-        {
-            fs::create_dir_all(parent).expect("failed to create parent directories");
-        }
         let contents = self.contents();
-        fs::write(&self.file_path, contents).unwrap();
+        let relative_path = self.repo_relative_path();
+        self.repo.write_file(&relative_path, &contents);
         self.run_checkpoint_for_author_type(author_type);
     }
 
     fn write_and_checkpoint_with_contents(&self, contents: &str, author_type: &AuthorType) {
-        // Create parent directories if they don't exist (important for nested paths like src/模块/组件.ts)
-        if let Some(parent) = self.file_path.parent()
-            && !parent.exists()
-        {
-            fs::create_dir_all(parent).expect("failed to create parent directories");
-        }
-        fs::write(&self.file_path, contents).unwrap();
+        let relative_path = self.repo_relative_path();
+        self.repo.write_file(&relative_path, contents);
 
         // Stage the file first
         self.repo.git(&["add", "-A"]).unwrap();
@@ -831,13 +810,8 @@ impl<'a> TestFile<'a> {
     }
 
     fn write_and_checkpoint_no_stage(&self, contents: &str, author_type: &AuthorType) {
-        // Create parent directories if they don't exist (important for nested paths)
-        if let Some(parent) = self.file_path.parent()
-            && !parent.exists()
-        {
-            fs::create_dir_all(parent).expect("failed to create parent directories");
-        }
-        fs::write(&self.file_path, contents).unwrap();
+        let relative_path = self.repo_relative_path();
+        self.repo.write_file(&relative_path, contents);
 
         // Create checkpoint without staging - checkpoints work with unstaged files
         self.run_checkpoint_for_author_type(author_type);

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -43,7 +43,7 @@ use windows_sys::Win32::System::JobObjects::{
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
 
-use super::test_file::TestFile;
+use super::test_file::{AuthorType, TestFile};
 
 const DAEMON_TEST_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 const DAEMON_TEST_CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
@@ -2451,6 +2451,75 @@ impl TestRepo {
         self.path
             .canonicalize()
             .expect("failed to canonicalize test repo path")
+    }
+
+    /// Write raw file contents into the repo, creating parent directories as
+    /// needed. Plain `fs::write` — no checkpoint side effects.
+    pub fn write_file(&self, rel: &str, contents: &str) {
+        let abs = self.path.join(rel);
+        if let Some(parent) = abs.parent() {
+            fs::create_dir_all(parent).expect("parent directory should be creatable");
+        }
+        fs::write(&abs, contents).expect("file write should succeed");
+    }
+
+    /// Scenario builder for the real AI-agent checkpoint flow on a single
+    /// file: write `pre_contents`, fire the file-scoped "human" pre-edit
+    /// checkpoint (the legacy/untracked checkpoint every AI preset fires
+    /// before it edits, so any changes made by something else are excluded),
+    /// then write `post_contents` and fire the file-scoped "mock_ai"
+    /// post-edit checkpoint. This is exactly the pre/post pattern documented
+    /// in CLAUDE.md and used by the real agent presets.
+    ///
+    /// Checkpoint-NUANCE tests — ordering, partial staging, unscoped
+    /// checkpoints, or assertions interleaved between the pre and post
+    /// steps — must keep writing the manual `fs::write` + `git_ai(&["checkpoint", ...])`
+    /// sequence themselves; this helper intentionally hides those steps.
+    pub fn ai_edit(&self, rel: &str, pre_contents: &str, post_contents: &str) {
+        self.write_file(rel, pre_contents);
+        self.checkpoint_file_with_preset(rel, "human")
+            .expect("pre-edit human checkpoint should succeed");
+        self.write_file(rel, post_contents);
+        self.checkpoint_file(rel, &AuthorType::Ai)
+            .expect("post-edit mock_ai checkpoint should succeed");
+    }
+
+    /// Scenario builder for the real known-human checkpoint flow: write
+    /// `contents`, then fire the file-scoped "mock_known_human" checkpoint.
+    /// Mirrors what our IDE/editor extensions do when they detect an actual
+    /// human keystroke, as opposed to the legacy/untracked "human" checkpoint.
+    ///
+    /// Checkpoint-NUANCE tests must keep writing the manual sequence
+    /// themselves; this helper intentionally hides those steps.
+    pub fn human_edit(&self, rel: &str, contents: &str) {
+        self.write_file(rel, contents);
+        self.checkpoint_file(rel, &AuthorType::Human)
+            .expect("known-human checkpoint should succeed");
+    }
+
+    /// Scenario builder for an untracked edit: write `contents` with no
+    /// checkpoint call at all. Identical to `write_file` — this alias exists
+    /// so call sites read as the matched `ai_edit`/`human_edit`/`untracked_edit`
+    /// trio rather than mixing a differently-named primitive in.
+    pub fn untracked_edit(&self, rel: &str, contents: &str) {
+        self.write_file(rel, contents);
+    }
+
+    pub(crate) fn checkpoint_file(
+        &self,
+        rel: &str,
+        author_type: &AuthorType,
+    ) -> Result<String, String> {
+        let args = match author_type {
+            AuthorType::Ai => ["checkpoint", "mock_ai", rel],
+            AuthorType::Human => ["checkpoint", "mock_known_human", rel],
+            AuthorType::UnattributedHuman => ["checkpoint", "--", rel],
+        };
+        self.git_ai(&args)
+    }
+
+    fn checkpoint_file_with_preset(&self, rel: &str, preset: &str) -> Result<String, String> {
+        self.git_ai(&["checkpoint", preset, rel])
     }
 
     pub fn test_db_path(&self) -> &PathBuf {


### PR DESCRIPTION
## Primary changes

Share standard TestRepo write and checkpoint plumbing while keeping nuanced checkpoint and staging scenarios explicit.

## Reviewer walkthrough

1. tests/integration/repos/test_repo.rs: write_file, checkpoint_file, ai_edit, human_edit, and untracked_edit.
2. tests/integration/repos/test_file.rs: delegation of ordinary file writes and checkpoints.

## Correctness and invariants

The legacy human pre-edit checkpoint used by ai_edit remains distinct from mock_known_human. Manual low-level flows remain available for ordering and staging tests. This PR changes tests only.

## Testing and QA

- cargo fmt --all -- --check passed after rebasing.
- cargo check --test integration passed after rebasing.
- Representative targeted integration tests passed on the stack before the upstream rebase.
- The post-rebase daemon-backed integration run is blocked because CODEX_SANDBOX_NETWORK_DISABLED prevents test daemon startup.
- task lint passed before the upstream rebase; the current upstream base has 11 unrelated pre-existing src/ Clippy warnings, and this stack changes no src files.

## Risk / Rollout

Low risk and test-only. This is an independent upstream-targeted head because GitHub does not allow a fork branch to be the base of an upstream PR. Merge it after ENG-224 if the reviewer wants the issue sequence preserved.

Resolves ENG-225
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->