### PR TITLE
Extract narrow initial-file fixture helper for integration tests

### DIFF
--- a/tests/integration/blame_comprehensive.rs
+++ b/tests/integration/blame_comprehensive.rs
@@ -35,16 +35,17 @@ use git_ai::git::repository as GitAiRepository;
 fn test_blame_success_basic_file() {
     // Happy path: Basic blame on a file with mixed human/AI authorship
     let repo = TestRepo::new();
-    let mut file = repo.filename("test.txt");
-
-    file.set_contents(crate::lines![
-        "Human line 1".human(),
-        "AI line 1".ai(),
-        "Human line 2".human(),
-        "AI line 2".ai()
-    ]);
-
-    repo.stage_all_and_commit("Mixed authorship").unwrap();
+    repo.set_file_contents_and_commit(
+        "test.txt",
+        crate::lines![
+            "Human line 1".human(),
+            "AI line 1".ai(),
+            "Human line 2".human(),
+            "AI line 2".ai()
+        ],
+        "Mixed authorship",
+    )
+    .unwrap();
 
     let output = repo.git_ai(&["blame", "test.txt"]).unwrap();
 
@@ -62,14 +63,12 @@ fn test_blame_success_basic_file() {
 fn test_blame_success_only_human_lines() {
     // Happy path: File with only human-authored lines
     let repo = TestRepo::new();
-    let mut file = repo.filename("human.txt");
-
-    file.set_contents(crate::lines![
-        "Human line 1".human(),
-        "Human line 2".human()
-    ]);
-
-    repo.stage_all_and_commit("All human").unwrap();
+    repo.set_file_contents_and_commit(
+        "human.txt",
+        crate::lines!["Human line 1".human(), "Human line 2".human()],
+        "All human",
+    )
+    .unwrap();
 
     let output = repo.git_ai(&["blame", "human.txt"]).unwrap();
 
@@ -83,11 +82,12 @@ fn test_blame_success_only_human_lines() {
 fn test_blame_success_only_ai_lines() {
     // Happy path: File with only AI-authored lines
     let repo = TestRepo::new();
-    let mut file = repo.filename("ai.txt");
-
-    file.set_contents(crate::lines!["AI line 1".ai(), "AI line 2".ai()]);
-
-    repo.stage_all_and_commit("All AI").unwrap();
+    repo.set_file_contents_and_commit(
+        "ai.txt",
+        crate::lines!["AI line 1".ai(), "AI line 2".ai()],
+        "All AI",
+    )
+    .unwrap();
 
     let output = repo.git_ai(&["blame", "ai.txt"]).unwrap();
 

--- a/tests/integration/chinese_text_edits.rs
+++ b/tests/integration/chinese_text_edits.rs
@@ -4,10 +4,13 @@ use crate::repos::test_repo::TestRepo;
 #[test]
 fn test_chinese_simple_additions() {
     let repo = TestRepo::new();
-    let mut file = repo.filename("chinese.txt");
-
-    file.set_contents(crate::lines!["第一行", "第二行", "第三行"]);
-    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo
+        .set_file_contents_and_commit(
+            "chinese.txt",
+            crate::lines!["第一行", "第二行", "第三行"],
+            "Initial commit",
+        )
+        .unwrap();
 
     file.insert_at(3, crate::lines!["新增一行".ai(), "新增二行".ai()]);
     repo.stage_all_and_commit("AI adds chinese lines").unwrap();

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -43,7 +43,7 @@ use windows_sys::Win32::System::JobObjects::{
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
 
-use super::test_file::TestFile;
+use super::test_file::{ExpectedLine, TestFile};
 
 const DAEMON_TEST_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 const DAEMON_TEST_CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
@@ -3060,6 +3060,18 @@ impl TestRepo {
             // New file, start with empty lines
             TestFile::new_with_filename(file_path, vec![], self)
         }
+    }
+
+    pub fn set_file_contents_and_commit<T: Into<ExpectedLine>>(
+        &self,
+        filename: &str,
+        lines: Vec<T>,
+        message: &str,
+    ) -> Result<TestFile<'_>, String> {
+        let mut file = self.filename(filename);
+        file.set_contents(lines);
+        self.stage_all_and_commit(message)?;
+        Ok(file)
     }
 
     pub fn current_working_logs(&self) -> PersistedWorkingLog {


### PR DESCRIPTION
## Primary changes

Extract only the repeated single-file initial fixture sequence into a narrowly named helper.

## Reviewer walkthrough

1. tests/integration/repos/test_repo.rs: set_file_contents_and_commit.
2. The four migrated initial fixtures in blame_comprehensive.rs and chinese_text_edits.rs.

## Correctness and invariants

Scenario-specific multi-file, branch, partial-staging, and evolving-file setup remains explicit. Commit messages and test behavior remain unchanged. This PR changes tests only.

## Testing and QA

- cargo fmt --all -- --check passed after rebasing.
- cargo check --test integration passed after rebasing.
- Representative blame and worktree integration tests passed on the stack before the upstream rebase.
- The post-rebase daemon-backed integration run is blocked because CODEX_SANDBOX_NETWORK_DISABLED prevents test daemon startup.
- task lint passed before the upstream rebase; the current upstream base has 11 unrelated pre-existing src/ Clippy warnings, and this stack changes no src files.

## Risk / Rollout

Low risk and test-only. This is an independent upstream-targeted head because GitHub does not allow a fork branch to be the base of an upstream PR. Merge it after the other DRY PRs if the reviewer wants the issue sequence preserved.

Resolves ENG-228
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->