### PR TITLE
fix(daemon): scope checkpoint receive timeout

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -90,6 +90,7 @@ const TRACE_CONNECTION_CLOSED_EVENT: &str = "git_ai_connection_closed";
 const DAEMON_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 const DAEMON_CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
 const DAEMON_CONTROL_RECEIVE_TIMEOUT: Duration = Duration::from_secs(2);
+const DAEMON_CONTROL_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
 const DAEMON_CHECKPOINT_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
 const DAEMON_SOCKET_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 const CHECKPOINT_INGRESS_REQUEST_LIMIT: usize = 1_024;
@@ -7312,12 +7313,11 @@ fn windows_control_pipe_worker_loop(
 
 #[cfg(windows)]
 fn handle_windows_control_pipe_connection(
-    mut server: WindowsPipeServer,
+    server: WindowsPipeServer,
     coordinator: Arc<ActorDaemonCoordinator>,
     runtime_handle: tokio::runtime::Handle,
 ) {
-    server.set_read_timeout(Some(DAEMON_CONTROL_RECEIVE_TIMEOUT));
-    let mut reader = BufReader::new(&mut server);
+    let mut reader = BufReader::new(server);
     if let Err(e) = handle_control_connection_actor_reader(&mut reader, coordinator, runtime_handle)
     {
         tracing::error!(
@@ -7330,34 +7330,82 @@ fn handle_windows_control_pipe_connection(
     }
 }
 
+trait ControlConnection: Read + Write {
+    fn set_receive_timeout(&mut self, timeout: Option<Duration>) -> Result<(), GitAiError>;
+}
+
+#[cfg(windows)]
+impl ControlConnection for WindowsPipeServer {
+    fn set_receive_timeout(&mut self, timeout: Option<Duration>) -> Result<(), GitAiError> {
+        self.set_read_timeout(timeout);
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+impl ControlConnection for LocalSocketStream {
+    fn set_receive_timeout(&mut self, timeout: Option<Duration>) -> Result<(), GitAiError> {
+        self.set_recv_timeout(timeout).map_err(|error| {
+            GitAiError::Generic(format!(
+                "failed setting daemon control receive timeout: {error}"
+            ))
+        })
+    }
+}
+
+fn control_receive_timed_out(error: &GitAiError) -> bool {
+    matches!(
+        error,
+        GitAiError::IoError(io_error)
+            if matches!(
+                io_error.kind(),
+                std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+            )
+    )
+}
+
 #[cfg(not(windows))]
 fn handle_control_connection_actor(
     stream: LocalSocketStream,
     coordinator: Arc<ActorDaemonCoordinator>,
     runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), GitAiError> {
-    stream
-        .set_recv_timeout(Some(DAEMON_CONTROL_RECEIVE_TIMEOUT))
-        .map_err(|error| {
-            GitAiError::Generic(format!(
-                "failed setting daemon control receive timeout: {error}"
-            ))
-        })?;
     let mut reader = BufReader::new(stream);
     handle_control_connection_actor_reader(&mut reader, coordinator, runtime_handle)
 }
 
-fn handle_control_connection_actor_reader<R: Read + Write>(
+fn handle_control_connection_actor_reader<R: ControlConnection>(
     reader: &mut BufReader<R>,
     coordinator: Arc<ActorDaemonCoordinator>,
     runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), GitAiError> {
-    while let Some(line) = read_json_line(reader)? {
+    reader
+        .get_mut()
+        .set_receive_timeout(Some(DAEMON_CONTROL_RECEIVE_TIMEOUT))?;
+    let mut uses_idle_timeout = false;
+    loop {
+        let line = match read_json_line(reader) {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(error) if control_receive_timed_out(&error) => break,
+            Err(error) => return Err(error),
+        };
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
         let parsed = serde_json::from_str::<ControlRequest>(trimmed);
+        if !uses_idle_timeout
+            && matches!(
+                &parsed,
+                Ok(request) if !matches!(request, ControlRequest::CheckpointRun { .. })
+            )
+        {
+            reader
+                .get_mut()
+                .set_receive_timeout(Some(DAEMON_CONTROL_IDLE_TIMEOUT))?;
+            uses_idle_timeout = true;
+        }
         let mut shutdown_after_response = false;
         let response = match parsed {
             Ok(ControlRequest::CheckpointRun { body_bytes }) => {
@@ -7440,6 +7488,11 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                     return Err(error);
                 }
 
+                if uses_idle_timeout {
+                    reader
+                        .get_mut()
+                        .set_receive_timeout(Some(DAEMON_CONTROL_RECEIVE_TIMEOUT))?;
+                }
                 let body = match read_checkpoint_body(reader, reservation.body_bytes()) {
                     Ok(body) => body,
                     Err(error) => {
@@ -7454,6 +7507,11 @@ fn handle_control_connection_actor_reader<R: Read + Write>(
                         return Err(error);
                     }
                 };
+                if uses_idle_timeout {
+                    reader
+                        .get_mut()
+                        .set_receive_timeout(Some(DAEMON_CONTROL_IDLE_TIMEOUT))?;
+                }
                 let Some(checkpoint_tx) = coordinator.checkpoint_ingress_tx.get().cloned() else {
                     tracing::error!(
                         component = "daemon",
@@ -8096,10 +8154,10 @@ fn daemon_min_uptime_for_self_restart() -> u64 {
         .unwrap_or(DAEMON_MIN_UPTIME_FOR_SELF_RESTART_SECS)
 }
 
-/// Background loop that verifies the daemon's sockets are reachable by
-/// actually connecting to them.  A successful connect proves the socket file
-/// exists, points to this daemon's listener, and that the listener thread is
-/// alive and calling accept().  If either probe fails (deleted file, stale
+/// Background loop that verifies the daemon's sockets are reachable. The
+/// control probe performs a bounded Ping request so it also proves a handler
+/// can receive and respond, while the write-only trace2 socket is verified by
+/// connecting to its listener. If either probe fails (deleted file, stale
 /// socket, hung listener), the daemon spawns a detached restart process and
 /// shuts down.
 ///
@@ -8140,8 +8198,21 @@ fn daemon_socket_health_check_loop(
             return;
         }
 
-        let control_ok =
-            local_socket_connects_with_timeout(&control_socket_path, DAEMON_SOCKET_PROBE_TIMEOUT);
+        let control_ok = send_control_request_with_timeouts(
+            &control_socket_path,
+            &ControlRequest::Ping,
+            DAEMON_SOCKET_PROBE_TIMEOUT,
+            DAEMON_CONTROL_RESPONSE_TIMEOUT,
+        )
+        .and_then(|response| {
+            if response.ok {
+                Ok(())
+            } else {
+                Err(GitAiError::Generic(response.error.unwrap_or_else(|| {
+                    "daemon Ping returned an error".to_string()
+                })))
+            }
+        });
         let trace_ok =
             local_socket_connects_with_timeout(&trace_socket_path, DAEMON_SOCKET_PROBE_TIMEOUT);
 

--- a/src/daemon/telemetry_handle.rs
+++ b/src/daemon/telemetry_handle.rs
@@ -30,7 +30,7 @@ static DAEMON_TELEMETRY_HANDLE: OnceLock<Mutex<Option<DaemonTelemetryHandle>>> =
 
 struct DaemonTelemetryHandle {
     socket_path: PathBuf,
-    conn: BufReader<DaemonClientStream>,
+    conn: Option<BufReader<DaemonClientStream>>,
 }
 
 impl DaemonTelemetryHandle {
@@ -45,23 +45,32 @@ impl DaemonTelemetryHandle {
         );
     }
 
+    fn connect(&mut self) -> Result<(), String> {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&self.socket_path, DAEMON_SOCKET_IO_TIMEOUT)
+                .map_err(|error| error.to_string())?;
+        Self::apply_socket_timeouts(&mut stream, &self.socket_path);
+        self.conn = Some(BufReader::new(stream));
+        Ok(())
+    }
+
     /// Send a control request over the persistent connection and read the response.
     /// On I/O error, attempts to reconnect once before giving up.
     fn send(&mut self, request: &ControlRequest) -> Result<ControlResponse, String> {
-        match self.send_inner(request) {
+        let first_attempt = if self.conn.is_none() {
+            self.connect().and_then(|()| self.send_inner(request))
+        } else {
+            self.send_inner(request)
+        };
+        match first_attempt {
             Ok(resp) => Ok(resp),
             Err(first_err) => {
                 // Connection may have been dropped by the daemon; try reconnecting once.
-                match open_local_socket_stream_with_timeout(
-                    &self.socket_path,
-                    Duration::from_secs(1),
-                ) {
-                    Ok(mut stream) => {
-                        Self::apply_socket_timeouts(&mut stream, &self.socket_path);
-                        self.conn = BufReader::new(stream);
-                        self.send_inner(request)
-                            .map_err(|e| format!("reconnect ok but send failed: {}", e))
-                    }
+                self.conn = None;
+                match self.connect() {
+                    Ok(()) => self
+                        .send_inner(request)
+                        .map_err(|e| format!("reconnect ok but send failed: {}", e)),
                     Err(reconnect_err) => Err(format!(
                         "send failed ({}), reconnect also failed ({})",
                         first_err, reconnect_err
@@ -74,18 +83,19 @@ impl DaemonTelemetryHandle {
     fn send_inner(&mut self, request: &ControlRequest) -> Result<ControlResponse, String> {
         let mut body = serde_json::to_vec(request).map_err(|e| e.to_string())?;
         body.push(b'\n');
-        self.conn
-            .get_mut()
+        let conn = self
+            .conn
+            .as_mut()
+            .ok_or_else(|| "daemon telemetry handle not connected".to_string())?;
+        conn.get_mut()
             .write_all(&body)
             .map_err(|e| format!("write: {}", e))?;
-        self.conn
-            .get_mut()
+        conn.get_mut()
             .flush()
             .map_err(|e| format!("flush: {}", e))?;
 
         let mut line = String::new();
-        self.conn
-            .read_line(&mut line)
+        conn.read_line(&mut line)
             .map_err(|e| format!("read: {}", e))?;
         if line.trim().is_empty() {
             return Err("empty response from daemon".to_string());
@@ -96,7 +106,7 @@ impl DaemonTelemetryHandle {
 
 /// Result of attempting to initialize the global daemon telemetry handle.
 pub enum DaemonTelemetryInitResult {
-    /// Successfully connected to daemon.
+    /// The daemon is available and the lazy connection handle is ready.
     Connected,
     /// Failed to connect; contains the error message.
     Failed(String),
@@ -107,9 +117,9 @@ pub enum DaemonTelemetryInitResult {
 /// Initialize the global daemon telemetry handle.
 ///
 /// Should be called once on process start when daemon mode is active.
-/// Attempts to connect to the daemon control socket (starting the daemon if needed)
-/// with a 2-second timeout. The connection is kept open and reused for all
-/// subsequent telemetry and CAS submissions.
+/// Ensures the daemon is running, then opens the persistent connection lazily
+/// when the first request is ready to send. The connection is reused for
+/// subsequent telemetry, CAS, and note-flush submissions.
 ///
 /// Returns the result indicating success, failure, or skip.
 pub fn init_daemon_telemetry_handle() -> DaemonTelemetryInitResult {
@@ -119,7 +129,7 @@ pub fn init_daemon_telemetry_handle() -> DaemonTelemetryInitResult {
         return DaemonTelemetryInitResult::Skipped;
     }
 
-    // In test builds, only connect if the daemon control socket is explicitly set.
+    // In test builds, only initialize if the daemon control socket is explicitly set.
     #[cfg(any(test, feature = "test-support"))]
     {
         let socket_path = std::env::var("GIT_AI_DAEMON_CONTROL_SOCKET")
@@ -130,21 +140,12 @@ pub fn init_daemon_telemetry_handle() -> DaemonTelemetryInitResult {
 
         match socket_path {
             Some(path) => {
-                match open_local_socket_stream_with_timeout(&path, Duration::from_secs(2)) {
-                    Ok(mut stream) => {
-                        DaemonTelemetryHandle::apply_socket_timeouts(&mut stream, &path);
-                        let handle = DaemonTelemetryHandle {
-                            socket_path: path,
-                            conn: BufReader::new(stream),
-                        };
-                        let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(Some(handle)));
-                        DaemonTelemetryInitResult::Connected
-                    }
-                    Err(e) => {
-                        let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(None));
-                        DaemonTelemetryInitResult::Failed(e.to_string())
-                    }
-                }
+                let handle = DaemonTelemetryHandle {
+                    socket_path: path,
+                    conn: None,
+                };
+                let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(Some(handle)));
+                DaemonTelemetryInitResult::Connected
             }
             None => {
                 let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(None));
@@ -155,7 +156,7 @@ pub fn init_daemon_telemetry_handle() -> DaemonTelemetryInitResult {
 
     #[cfg(not(any(test, feature = "test-support")))]
     {
-        // Try to ensure daemon is running and connect
+        // Ensure the daemon is running before making its socket available to the lazy handle.
         let config = match crate::commands::daemon::ensure_daemon_running(
             DAEMON_TELEMETRY_CONNECT_TIMEOUT,
         ) {
@@ -166,28 +167,12 @@ pub fn init_daemon_telemetry_handle() -> DaemonTelemetryInitResult {
             }
         };
 
-        // Open a persistent connection to the control socket
-        match open_local_socket_stream_with_timeout(
-            &config.control_socket_path,
-            DAEMON_TELEMETRY_CONNECT_TIMEOUT,
-        ) {
-            Ok(mut stream) => {
-                DaemonTelemetryHandle::apply_socket_timeouts(
-                    &mut stream,
-                    &config.control_socket_path,
-                );
-                let handle = DaemonTelemetryHandle {
-                    socket_path: config.control_socket_path,
-                    conn: BufReader::new(stream),
-                };
-                let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(Some(handle)));
-                DaemonTelemetryInitResult::Connected
-            }
-            Err(e) => {
-                let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(None));
-                DaemonTelemetryInitResult::Failed(e.to_string())
-            }
-        }
+        let handle = DaemonTelemetryHandle {
+            socket_path: config.control_socket_path,
+            conn: None,
+        };
+        let _ = DAEMON_TELEMETRY_HANDLE.get_or_init(|| Mutex::new(Some(handle)));
+        DaemonTelemetryInitResult::Connected
     }
 }
 

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -8,6 +8,8 @@ use git_ai::daemon::{
     local_socket_connects_with_timeout, open_local_socket_stream_with_timeout,
     send_control_request,
 };
+#[cfg(not(windows))]
+use interprocess::local_socket::traits::Stream;
 use repos::test_repo::{DaemonTestScope, TestRepo, get_binary_path, real_git_executable};
 use serde_json::Value;
 use std::fs;
@@ -501,6 +503,22 @@ fn send_on_persistent_conn<R: Read + Write>(
     serde_json::from_str::<ControlResponse>(line.trim()).expect("parse daemon response")
 }
 
+#[cfg(not(windows))]
+fn assert_control_connection_closed<R: Read + Write>(reader: &mut BufReader<R>) {
+    let mut request = serde_json::to_vec(&ControlRequest::Ping).expect("serialize ping request");
+    request.push(b'\n');
+    if reader.get_mut().write_all(&request).is_ok() && reader.get_mut().flush().is_ok() {
+        let mut response = String::new();
+        let bytes_read = reader
+            .read_line(&mut response)
+            .expect("idle connection should be closed without a read error");
+        assert_eq!(
+            bytes_read, 0,
+            "daemon should close a control connection after the idle deadline"
+        );
+    }
+}
+
 /// Integration test: verifies that a persistent control socket connection can
 /// deliver telemetry envelopes and CAS payloads to the daemon, and that the
 /// daemon acknowledges each request with `ok: true` without closing the
@@ -543,6 +561,11 @@ fn daemon_telemetry_and_cas_over_persistent_connection() {
     };
     let resp = send_on_persistent_conn(&mut reader, &telemetry_req);
     assert!(resp.ok, "telemetry submit should succeed: {:?}", resp.error);
+
+    // The daemon telemetry handle intentionally keeps this connection open
+    // between sparse events. It must survive beyond the checkpoint body
+    // receive timeout, which does not apply to ordinary control traffic.
+    thread::sleep(Duration::from_millis(2_500));
 
     // 2. Send CAS payloads over the *same* connection
     let cas_req = ControlRequest::SubmitCas {
@@ -590,5 +613,64 @@ fn daemon_telemetry_and_cas_over_persistent_connection() {
 
     // Clean up
     drop(reader);
+    shutdown_daemon(&repo);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_reaps_silent_initial_control_connection() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+
+    let start_output = daemon_command_output(&repo, &["bg", "start"], repo.path());
+    assert!(
+        start_output.status.success(),
+        "daemon start should succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&start_output.stdout),
+        String::from_utf8_lossy(&start_output.stderr)
+    );
+    wait_for_daemon_sockets(&repo);
+
+    let control_path = daemon_control_socket_path(&repo);
+    let stream = open_local_socket_stream_with_timeout(&control_path, Duration::from_secs(2))
+        .expect("should connect to daemon control socket");
+    stream
+        .set_recv_timeout(Some(Duration::from_secs(1)))
+        .expect("should set client receive timeout");
+    let mut reader = BufReader::new(stream);
+
+    thread::sleep(Duration::from_millis(2_500));
+
+    assert_control_connection_closed(&mut reader);
+
+    shutdown_daemon(&repo);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_reaps_idle_control_connection_after_valid_request() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    start_daemon(&repo);
+    wait_for_daemon_sockets(&repo);
+
+    let control_path = daemon_control_socket_path(&repo);
+    let stream = open_local_socket_stream_with_timeout(&control_path, Duration::from_secs(2))
+        .expect("should connect to daemon control socket");
+    stream
+        .set_recv_timeout(Some(Duration::from_secs(1)))
+        .expect("should set client receive timeout");
+    let mut reader = BufReader::new(stream);
+
+    let response = send_on_persistent_conn(
+        &mut reader,
+        &ControlRequest::SubmitTelemetry {
+            envelopes: Vec::new(),
+        },
+    );
+    assert!(response.ok, "telemetry submit should succeed");
+
+    thread::sleep(Duration::from_millis(10_500));
+
+    assert_control_connection_closed(&mut reader);
+
     shutdown_daemon(&repo);
 }


### PR DESCRIPTION
## Summary

Keep daemon control reads bounded without applying the checkpoint-body deadline to legitimate sparse control traffic.

The previous global two-second per-connection timeout affected every control protocol. On macOS, connect-and-close health probes could race timeout setup and emit `EINVAL`, while persistent telemetry/CAS clients that idled for more than two seconds inherited the same deadline and later failed with `EAGAIN` or a broken pipe.

## Change

- preserve the original two-second timeout for an untrusted initial request header
- open the shared telemetry connection lazily only when its first request is ready to write
- use a finite 10-second idle timeout after a valid ordinary control request; idle expiry closes cleanly and the existing client reconnect path handles the next sparse event
- keep normal checkpoint-only connections on the original timeout mode and retain the strict two-second admitted-body deadline
- upgrade the internal control health probe from connect-and-close to the existing `Ping` protocol
- preserve the existing 100 ms health connect budget while allowing the normal two-second control-response budget
- preserve the bounded-ingress quota and stalled-sender safeguard unchanged
- add regressions for persistent reuse, silent initial reaping, and reaping after a valid telemetry request

No Git work, file reads, process spawns, or additional trace2 ingestion-path work is introduced. Lazy open avoids a startup round trip and active telemetry flushes retain connection reuse.

## Validation

- strict TDD: the persistent-connection test fails on `main` with a broken pipe and passes with this change
- strict TDD for review follow-up: a silent-client test fails without bounded header reads and passes here
- a valid telemetry connection is proven closed after the real 10-second idle deadline
- checkpoint malformed, oversized, and stalled-body quota tests pass
- daemon listener, socket deletion, and self-healing tests pass
- `task fmt`, `task lint`, and `task build` pass
- complete suite passes: 2,130 library, 16 async-mode, 75 daemon-mode, 3,256 integration, 22 notes-sync, and all runnable doctests; zero failures
- installed with `task dev`; a real pre/post checkpoint and commit produced the expected authorship note
- observed the installed macOS daemon beyond three 30-second health intervals with no control receive, `EINVAL`, `EAGAIN`, timeout, or daemon errors

## Performance

Contemporary five-run comparison of `bench_checkpoint_single_file_daemon` on `main` and this change:

| Metric | main | this change |
| --- | ---: | ---: |
| median p50 | 13.1 ms | 13.1 ms |
| median p95 | 13.2 ms | 13.2 ms |

No measured checkpoint latency regression.