### PR TITLE
Fix macOS package payload permissions

### DIFF
--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -39,6 +39,7 @@ OUTPUT_ABS="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$
 
 rm -rf "$WORK_DIR"
 mkdir -p "$PAYLOAD_ROOT" "$SCRIPTS" "$(dirname "$OUTPUT_ABS")"
+chmod 0755 "$PAYLOAD_ROOT"
 install -m 0755 "$BINARY" "$SCRIPTS/git-ai"
 install -m 0755 "$ROOT/packaging/macos/scripts/preinstall" "$SCRIPTS/preinstall"
 install -m 0755 "$ROOT/packaging/macos/scripts/postinstall" "$SCRIPTS/postinstall"


### PR DESCRIPTION
## Summary

- force the empty macOS package payload root to mode `0755`
- prevent restrictive build umasks from being recorded in installer payload metadata
- follow up on the post-merge review feedback from #2027

## Validation

- `bash -n packaging/macos/build-pkg.sh`
- `git diff --check`
- `task fmt`
- `task lint`