### PR TITLE
Show pending checkpoint processing in status

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -4,6 +4,7 @@ use crate::authorship::ignore::{
 use crate::authorship::stats::{CommitStats, stats_from_authorship_log, write_stats_to_terminal};
 use crate::authorship::virtual_attribution::VirtualAttributions;
 use crate::authorship::working_log::CheckpointKind;
+use crate::daemon::control_api::ControlRequest;
 use crate::error::GitAiError;
 use crate::git::find_repository;
 use crate::git::repo_storage::InitialAttributions;
@@ -11,7 +12,9 @@ use crate::git::repository::{InternalGitProfile, Repository, exec_git_with_profi
 use crate::git::status::MAX_PATHSPEC_ARGS;
 use serde::Serialize;
 use std::collections::{BTreeMap, HashSet};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const DAEMON_STATUS_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Serialize)]
 struct CheckpointInfo {
@@ -25,6 +28,7 @@ struct CheckpointInfo {
 #[derive(Serialize)]
 struct StatusOutput {
     stats: CommitStats,
+    checkpoint_processing_pending: bool,
     /// Per-checkpoint session breakdown. Omitted entirely when `--diff-only`
     /// is requested, so consumers that only care about the current diff scope
     /// get just the diff-scoped `stats`.
@@ -54,6 +58,7 @@ pub fn handle_status(args: &[String]) {
 
 fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     let repo = find_repository(&[])?;
+    let checkpoint_processing_pending = checkpoint_processing_pending(&repo);
     let ignore_patterns = effective_ignore_patterns(&repo, &[], &[]);
     let ignore_matcher = build_ignore_matcher(&ignore_patterns);
 
@@ -73,10 +78,13 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
         if json {
             let output = StatusOutput {
                 stats: CommitStats::default(),
+                checkpoint_processing_pending,
                 checkpoints: if diff_only { None } else { Some(vec![]) },
             };
             let json_str = serde_json::to_string(&output)?;
             println!("{}", json_str);
+        } else if checkpoint_processing_pending {
+            print_checkpoint_processing_pending();
         } else {
             eprintln!(
                 "No checkpoints recorded since last commit ({})",
@@ -167,6 +175,7 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     if json {
         let output = StatusOutput {
             stats,
+            checkpoint_processing_pending,
             checkpoints: if diff_only {
                 None
             } else {
@@ -178,6 +187,9 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
         return Ok(());
     }
 
+    if checkpoint_processing_pending {
+        print_checkpoint_processing_pending();
+    }
     write_stats_to_terminal(&stats, true);
 
     if diff_only {
@@ -210,6 +222,35 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
     }
 
     Ok(())
+}
+
+fn checkpoint_processing_pending(repo: &Repository) -> bool {
+    let Ok(config) = crate::daemon::DaemonConfig::from_env_or_default_paths() else {
+        return false;
+    };
+    let request = ControlRequest::StatusFamily {
+        repo_working_dir: repo.path().to_string_lossy().to_string(),
+    };
+    let Ok(response) = crate::daemon::send_control_request_with_timeout(
+        &config.control_socket_path,
+        &request,
+        DAEMON_STATUS_TIMEOUT,
+    ) else {
+        return false;
+    };
+
+    response.ok
+        && response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("pending_checkpoints"))
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|count| count > 0)
+}
+
+fn print_checkpoint_processing_pending() {
+    eprintln!("Checkpoint processing is still in progress. Status may be incomplete.");
+    eprintln!();
 }
 
 fn format_time_ago(timestamp: u64) -> String {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6544,6 +6544,7 @@ impl ActorDaemonCoordinator {
             last_error: status
                 .last_error
                 .or_else(|| self.latest_side_effect_error(&family_key).ok().flatten()),
+            pending_checkpoints: self.outstanding_checkpoint_state().0,
         })
     }
 

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -141,6 +141,8 @@ pub struct FamilyStatus {
     pub family_key: String,
     pub latest_seq: u64,
     pub last_error: Option<String>,
+    #[serde(default)]
+    pub pending_checkpoints: usize,
 }
 
 /// A telemetry envelope sent from client to daemon.

--- a/tests/integration/status_unit.rs
+++ b/tests/integration/status_unit.rs
@@ -1,13 +1,22 @@
 use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use git_ai::authorship::stats::CommitStats;
+use git_ai::authorship::working_log::{AgentId, CheckpointKind};
+use git_ai::commands::checkpoint_agent::orchestrator::{
+    BaseCommit, CheckpointFile, CheckpointRequest,
+};
+use git_ai::daemon::checkpoint::PreparedPathRole;
+use git_ai::daemon::send_checkpoint_request_with_timeout;
 use serde::Deserialize;
 use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct StatusOutput {
     stats: CommitStats,
     checkpoints: Vec<serde_json::Value>,
+    checkpoint_processing_pending: bool,
 }
 
 fn extract_json_object(output: &str) -> String {
@@ -60,6 +69,81 @@ fn test_status_remains_available_when_daemon_is_not_running() {
     assert!(
         status.checkpoints.is_empty(),
         "offline status should preserve the empty-checkpoint result"
+    );
+    assert!(
+        !status.checkpoint_processing_pending,
+        "an unavailable daemon should not break status or report a pending checkpoint"
+    );
+}
+
+#[test]
+fn test_status_reports_pending_checkpoint_without_waiting_for_daemon_sync() {
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_DELAY_CHECKPOINT_SIDE_EFFECT",
+        "status-pending-checkpoint=2000",
+    )]);
+    write_file(&repo, "pending.txt", "committed\n");
+    repo.git_og(&["add", "pending.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "initial"]).unwrap();
+    let base_commit = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    write_file(&repo, "pending.txt", "committed\nAI edit\n");
+    let request = CheckpointRequest {
+        trace_id: "status-pending-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "status-pending-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from("pending.txt"),
+            content: Some("committed\nAI edit\n".to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Sha(base_commit),
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+    let response = send_checkpoint_request_with_timeout(
+        &repo.daemon_control_socket_path(),
+        &request,
+        Duration::from_millis(500),
+    )
+    .expect("checkpoint should receive an asynchronous receipt");
+    assert!(
+        response.ok,
+        "checkpoint receipt should succeed: {response:?}"
+    );
+
+    let text = repo
+        .git_ai_without_pre_sync_for_test(&["status"])
+        .expect("text status should succeed while checkpoint processing is pending");
+    assert!(
+        text.contains("Checkpoint processing is still in progress. Status may be incomplete."),
+        "text status should warn that its results may be incomplete: {text}"
+    );
+
+    let started = Instant::now();
+    let raw = repo
+        .git_ai_without_pre_sync_for_test(&["status", "--json"])
+        .expect("status should succeed while checkpoint processing is pending");
+    let elapsed = started.elapsed();
+    let status: StatusOutput =
+        serde_json::from_str(&extract_json_object(&raw)).expect("valid status JSON");
+
+    assert!(
+        status.checkpoint_processing_pending,
+        "status should report the accepted checkpoint as pending"
+    );
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "status should not wait for the delayed checkpoint side effect: {elapsed:?}"
     );
 }
 


### PR DESCRIPTION
## What changed

- expose the daemon's existing outstanding checkpoint count through the non-blocking family status response
- show a warning in human-readable `git-ai status` output while checkpoint processing is pending
- add `checkpoint_processing_pending` to JSON status output
- treat daemon configuration, connection, response, and decoding failures as a best-effort `false` result

## Why

Async checkpoint receipts can return before the working log is updated, so `git-ai status` may otherwise display incomplete information with no indication that more attribution is still being processed.

## Validation

- `task fmt`
- `task lint`
- `task test`
