### PR TITLE
Fix MSI version smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,13 +550,24 @@ jobs:
           if (Test-Path (Join-Path $env:ProgramFiles 'Git AI')) { throw 'MSI created a system-wide runtime' }
 
           $binaryVersion = (& $gitAi --version).Trim()
-          $registration = Get-ChildItem 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall' |
-            Get-ItemProperty |
-            Where-Object { $_.DisplayName -eq 'Git AI' } |
-            Select-Object -First 1
-          if ($null -eq $registration) { throw 'MSI did not register Git AI for the installing user' }
-          if ($registration.DisplayVersion -ne $binaryVersion) {
-            throw "MSI version '$($registration.DisplayVersion)' does not match binary version '$binaryVersion'"
+          $installer = New-Object -ComObject WindowsInstaller.Installer
+          $database = $installer.GetType().InvokeMember(
+            'OpenDatabase', 'InvokeMethod', $null, $installer, @($msi, 0)
+          )
+          $query = "SELECT ``Value`` FROM ``Property`` WHERE ``Property`` = 'ProductCode'"
+          $view = $database.GetType().InvokeMember(
+            'OpenView', 'InvokeMethod', $null, $database, @($query)
+          )
+          $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null)
+          $record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
+          $productCode = $record.GetType().InvokeMember(
+            'StringData', 'GetProperty', $null, $record, 1
+          )
+          $registeredVersion = $installer.GetType().InvokeMember(
+            'ProductInfo', 'GetProperty', $null, $installer, @($productCode, 'VersionString')
+          )
+          if ($registeredVersion -ne $binaryVersion) {
+            throw "MSI version '$registeredVersion' does not match binary version '$binaryVersion'"
           }
 
           $uninstall = Start-Process msiexec.exe -ArgumentList "/x `"$msi`" /qn /norestart" -Wait -PassThru


### PR DESCRIPTION
## Summary

- resolve the generated MSI `ProductCode` from the downloaded package
- query Windows Installer for that exact installed product's `VersionString`
- retain the binary-versus-MSI version assertion without assuming an uninstall registry hive

## Root cause

PR #2027 added the MSI version smoke check by scanning `HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall`. On the clean Windows Server 2025 runner that parent key did not exist, so PowerShell failed before the test could inspect any registration. The MSI installation itself had already succeeded, including the per-user binary and configuration checks.

Windows Installer is the authority for MSI product registration and installation context. Querying it by the package's generated `ProductCode` avoids hard-coding registry hive/view layout and avoids matching an unrelated product by display name.

## Validation

- `actionlint .github/workflows/release.yml`
- PowerShell 7.6 parser check of the complete MSI smoke-test script
- `task fmt`
- `task lint`
- inspected the failing run's downloaded x64 MSI Property table and confirmed it contains `ProductCode` and `ProductVersion`

The release workflow cannot be manually triggered for this branch, so the Windows installation/API round trip remains for the next release run.
