### PR TITLE
Add daemon memory limit configuration

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -2,7 +2,7 @@ use dirs;
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::config::{AuthorConfig, CodexHooksFormat, NotesBackendKind};
+use crate::config::{AuthorConfig, CodexHooksFormat, MAX_DAEMON_MEMORY_LIMIT_MB, NotesBackendKind};
 use crate::git::repository::find_repository_in_path;
 
 /// Determines the type of pattern value provided
@@ -122,6 +122,7 @@ fn print_config_help() {
     println!("  max_checkpoint_file_size_bytes      Per-file checkpoint content limit in bytes");
     println!("  max_checkpoint_total_size_bytes     Per-checkpoint content limit in bytes");
     println!("  max_checkpoint_total_lines          Per-checkpoint content limit in lines");
+    println!("  daemon_memory_limit_mb               Daemon peak-RSS limit in MiB");
     println!("  custom_attributes            Custom telemetry attributes, string->string (object)");
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
     println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
@@ -156,6 +157,7 @@ fn print_config_help() {
     println!("  git-ai config set codex_hooks_format hooks_json");
     println!("  git-ai config set allow_superuser true");
     println!("  git-ai config set transcript_streaming_lookback_days 1");
+    println!("  git-ai config set daemon_memory_limit_mb 1024");
     println!("  git-ai config set custom_attributes '{{\"team\":\"platform\"}}'");
     println!("  git-ai config --add custom_attributes.team platform");
     println!("  git-ai config unset exclude_repositories");
@@ -207,6 +209,7 @@ pub fn handle_config(args: &[String]) {
             if key == "feature_flags.transcript_streaming"
                 || key == "feature_flags.transcript_sweep"
                 || key == "transcript_streaming_lookback_days"
+                || key == "daemon_memory_limit_mb"
             {
                 println!("Run `git-ai bg restart` for changes to take effect.");
             }
@@ -221,6 +224,9 @@ pub fn handle_config(args: &[String]) {
             if let Err(e) = unset_config_value(key) {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
+            }
+            if key == "daemon_memory_limit_mb" {
+                println!("Run `git-ai bg restart` for changes to take effect.");
             }
         }
         key => {
@@ -389,6 +395,13 @@ fn show_all_config() -> Result<(), String> {
         "max_checkpoint_total_lines".to_string(),
         Value::Number(runtime_config.max_checkpoint_total_lines().into()),
     );
+    effective_config.insert(
+        "daemon_memory_limit_mb".to_string(),
+        runtime_config
+            .daemon_memory_limit_mb()
+            .map(|limit| Value::Number(limit.into()))
+            .unwrap_or(Value::Null),
+    );
 
     effective_config.insert(
         "custom_attributes".to_string(),
@@ -528,6 +541,10 @@ fn get_config_value(key: &str) -> Result<(), String> {
             "max_checkpoint_total_lines" => {
                 Value::Number(runtime_config.max_checkpoint_total_lines().into())
             }
+            "daemon_memory_limit_mb" => runtime_config
+                .daemon_memory_limit_mb()
+                .map(|limit| Value::Number(limit.into()))
+                .unwrap_or(Value::Null),
             "custom_attributes" => serde_json::to_value(runtime_config.custom_attributes())
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
             "notes_backend" => {
@@ -864,6 +881,23 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.max_checkpoint_total_lines = Some(lines);
                 crate::config::save_file_config(&file_config)?;
                 println!("[max_checkpoint_total_lines]: {}", lines);
+            }
+            "daemon_memory_limit_mb" => {
+                let limit_mb = value.trim().parse::<u64>().map_err(|_| {
+                    format!(
+                        "Invalid daemon_memory_limit_mb value '{}'. Expected a positive integer in MiB",
+                        value
+                    )
+                })?;
+                if limit_mb == 0 || limit_mb > MAX_DAEMON_MEMORY_LIMIT_MB {
+                    return Err(format!(
+                        "Invalid daemon_memory_limit_mb value '{}'. Expected an integer between 1 and {} MiB",
+                        value, MAX_DAEMON_MEMORY_LIMIT_MB
+                    ));
+                }
+                file_config.daemon_memory_limit_mb = Some(limit_mb);
+                crate::config::save_file_config(&file_config)?;
+                println!("[daemon_memory_limit_mb]: {}", limit_mb);
             }
             "custom_attributes" => {
                 if add_mode {
@@ -1223,6 +1257,13 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [max_checkpoint_total_lines]: {}", v);
+                }
+            }
+            "daemon_memory_limit_mb" => {
+                let old_value = file_config.daemon_memory_limit_mb.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [daemon_memory_limit_mb]: {}", v);
                 }
             }
             "custom_attributes" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,8 @@ pub const DEFAULT_API_BASE_URL: &str = "https://usegitai.com";
 pub const DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES: usize = 3 * 1024 * 1024;
 pub const DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES: usize = 32 * 1024 * 1024;
 pub const DEFAULT_MAX_CHECKPOINT_TOTAL_LINES: usize = 500_000;
+pub(crate) const MEBIBYTE_BYTES: u64 = 1024 * 1024;
+pub(crate) const MAX_DAEMON_MEMORY_LIMIT_MB: u64 = u64::MAX / MEBIBYTE_BYTES;
 
 /// Which backend to use for storing authorship notes.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -187,6 +189,7 @@ pub struct Config {
     max_checkpoint_file_size_bytes: usize,
     max_checkpoint_total_size_bytes: usize,
     max_checkpoint_total_lines: usize,
+    daemon_memory_limit_mb: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
@@ -274,6 +277,8 @@ pub struct FileConfig {
     pub max_checkpoint_total_size_bytes: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_checkpoint_total_lines: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_memory_limit_mb: Option<u64>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -339,6 +344,8 @@ pub struct ConfigPatch {
     pub max_checkpoint_total_size_bytes: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_checkpoint_total_lines: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_memory_limit_mb: Option<u64>,
 }
 
 impl Config {
@@ -658,6 +665,11 @@ impl Config {
     /// Returns the total line budget for content in one checkpoint request.
     pub fn max_checkpoint_total_lines(&self) -> usize {
         self.max_checkpoint_total_lines
+    }
+
+    /// Returns the daemon peak-RSS limit in MiB, or `None` when disabled.
+    pub fn daemon_memory_limit_mb(&self) -> Option<u64> {
+        self.daemon_memory_limit_mb
     }
 
     /// Returns true if quiet mode is enabled (suppresses chart output after commits)
@@ -1211,6 +1223,11 @@ fn build_config() -> Config {
         .or_else(|| file_cfg.as_ref().and_then(|c| c.max_checkpoint_total_lines))
         .unwrap_or(DEFAULT_MAX_CHECKPOINT_TOTAL_LINES);
 
+    let daemon_memory_limit_mb = file_cfg
+        .as_ref()
+        .and_then(|c| c.daemon_memory_limit_mb)
+        .and_then(normalize_daemon_memory_limit_mb);
+
     #[cfg(any(test, feature = "test-support"))]
     {
         let mut config = Config {
@@ -1240,6 +1257,7 @@ fn build_config() -> Config {
             max_checkpoint_file_size_bytes,
             max_checkpoint_total_size_bytes,
             max_checkpoint_total_lines,
+            daemon_memory_limit_mb,
         };
         apply_test_config_patch(&mut config);
         config
@@ -1273,7 +1291,22 @@ fn build_config() -> Config {
         max_checkpoint_file_size_bytes,
         max_checkpoint_total_size_bytes,
         max_checkpoint_total_lines,
+        daemon_memory_limit_mb,
     }
+}
+
+fn normalize_daemon_memory_limit_mb(limit_mb: u64) -> Option<u64> {
+    if limit_mb == 0 {
+        eprintln!(
+            "Warning: daemon_memory_limit_mb must be greater than zero; memory monitoring is disabled"
+        );
+        return None;
+    }
+    if limit_mb > MAX_DAEMON_MEMORY_LIMIT_MB {
+        eprintln!("Warning: daemon_memory_limit_mb is too large; memory monitoring is disabled");
+        return None;
+    }
+    Some(limit_mb)
 }
 
 /// Build custom attributes from file config and `GIT_AI_CUSTOM_ATTRIBUTES` env var.
@@ -1728,6 +1761,9 @@ fn apply_test_config_patch(config: &mut Config) {
         if let Some(max_lines) = patch.max_checkpoint_total_lines {
             config.max_checkpoint_total_lines = max_lines;
         }
+        if let Some(limit_mb) = patch.daemon_memory_limit_mb {
+            config.daemon_memory_limit_mb = normalize_daemon_memory_limit_mb(limit_mb);
+        }
     }
 }
 
@@ -1772,6 +1808,7 @@ mod tests {
             max_checkpoint_file_size_bytes: DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES,
             max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
+            daemon_memory_limit_mb: None,
         }
     }
 
@@ -2017,6 +2054,7 @@ mod tests {
             max_checkpoint_file_size_bytes: DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES,
             max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
+            daemon_memory_limit_mb: None,
         }
     }
 
@@ -2165,6 +2203,7 @@ mod tests {
             max_checkpoint_file_size_bytes: DEFAULT_MAX_CHECKPOINT_FILE_SIZE_BYTES,
             max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
+            daemon_memory_limit_mb: None,
         }
     }
 

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -113,6 +113,39 @@ fn test_config_checkpoint_budget_set_get_unset() {
 }
 
 #[test]
+fn test_config_daemon_memory_limit_set_get_unset() {
+    let repo = TestRepo::new();
+
+    assert_eq!(
+        get_json(&repo, "daemon_memory_limit_mb"),
+        Value::Null,
+        "daemon memory monitoring should be disabled by default"
+    );
+
+    repo.git_ai(&["config", "set", "daemon_memory_limit_mb", "1024"])
+        .expect("set daemon_memory_limit_mb");
+    assert_eq!(
+        get_json(&repo, "daemon_memory_limit_mb"),
+        Value::Number(1024.into())
+    );
+
+    assert!(
+        repo.git_ai(&["config", "set", "daemon_memory_limit_mb", "0"])
+            .is_err(),
+        "zero must be rejected; unset disables the limit"
+    );
+    assert!(
+        repo.git_ai(&["config", "set", "daemon_memory_limit_mb", "-1"])
+            .is_err(),
+        "negative limits must be rejected"
+    );
+
+    repo.git_ai(&["config", "unset", "daemon_memory_limit_mb"])
+        .expect("unset daemon_memory_limit_mb");
+    assert_eq!(get_json(&repo, "daemon_memory_limit_mb"), Value::Null);
+}
+
+#[test]
 fn test_config_custom_attributes_object_set_get_unset() {
     let repo = TestRepo::new();
 
@@ -237,6 +270,7 @@ fn test_config_show_all_includes_new_keys() {
     assert!(value.get("transcript_streaming_lookback_days").is_some());
     assert!(value.get("max_checkpoint_total_size_bytes").is_some());
     assert!(value.get("max_checkpoint_total_lines").is_some());
+    assert!(value.get("daemon_memory_limit_mb").is_some());
     assert!(value.get("custom_attributes").is_some());
 }
 
@@ -303,6 +337,7 @@ fn fully_populated_file_config() -> FileConfig {
         max_checkpoint_file_size_bytes: Some(3 * 1024 * 1024),
         max_checkpoint_total_size_bytes: Some(32 * 1024 * 1024),
         max_checkpoint_total_lines: Some(500_000),
+        daemon_memory_limit_mb: Some(1024),
     }
 }
 

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1266,6 +1266,12 @@ impl TestRepo {
                 serde_json::Value::Number(serde_json::Number::from(max_lines as u64)),
             );
         }
+        if let Some(limit_mb) = patch.daemon_memory_limit_mb {
+            config.insert(
+                "daemon_memory_limit_mb".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(limit_mb)),
+            );
+        }
 
         let config_dir = home.join(".git-ai");
         fs::create_dir_all(&config_dir).expect("failed to create test HOME config directory");


### PR DESCRIPTION
Expose daemon_memory_limit_mb through config.json and the config CLI, with startup-only restart guidance and TestRepo coverage.

The field is optional, uses MiB, rejects invalid CLI values, and remains disabled when unset.

Test Plan:
- task test TEST_FILTER=config_cli_coverage
- task build
- task lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->