### PR TITLE
Enforce daemon peak memory limits

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,6 +63,7 @@ pub mod domain;
 pub mod family_actor;
 pub mod git_backend;
 pub mod global_actor;
+mod memory_watchdog;
 pub mod reducer;
 pub mod ref_cursor;
 pub mod rewrite_metrics;
@@ -8491,6 +8492,11 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     let coordinator = Arc::new(coordinator_inner);
     coordinator.start_trace_ingest_worker()?;
     coordinator.start_checkpoint_ingress_worker()?;
+    if let Some(limit_mb) = config::Config::get().daemon_memory_limit_mb()
+        && let Some(limit_bytes) = limit_mb.checked_mul(config::MEBIBYTE_BYTES)
+    {
+        memory_watchdog::start(Arc::clone(&coordinator), limit_bytes)?;
+    }
     let rt_handle = tokio::runtime::Handle::current();
     let control_socket_path = config.control_socket_path.clone();
     let trace_socket_path = config.trace_socket_path.clone();

--- a/src/daemon/memory_watchdog.rs
+++ b/src/daemon/memory_watchdog.rs
@@ -1,0 +1,350 @@
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::api::types::{DaemonLogEvent, DaemonLogFieldValue, DaemonLogKind, DaemonLogLevel};
+
+use super::ActorDaemonCoordinator;
+use super::telemetry_worker::{EmergencyLogUploadStatus, upload_emergency_daemon_log};
+
+const EMERGENCY_PERCENT: u64 = 85;
+const EMERGENCY_LOG_UPLOAD_TIMEOUT: Duration = Duration::from_millis(500);
+const WATCHDOG_POLL_INTERVAL: Duration = Duration::from_secs(1);
+#[cfg(feature = "test-support")]
+pub(super) const TEST_PEAK_RSS_SEQUENCE_ENV: &str = "GIT_AI_TEST_DAEMON_PEAK_RSS_MB_SEQUENCE";
+#[cfg(feature = "test-support")]
+pub(super) const TEST_POLL_INTERVAL_ENV: &str = "GIT_AI_TEST_DAEMON_MEMORY_POLL_MS";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct MemoryThresholds {
+    pub(super) emergency_bytes: u64,
+    pub(super) limit_bytes: u64,
+}
+
+impl MemoryThresholds {
+    pub(super) fn from_limit_bytes(limit_bytes: u64) -> Self {
+        let emergency_bytes =
+            ((u128::from(limit_bytes) * u128::from(EMERGENCY_PERCENT)).div_ceil(100)) as u64;
+        Self {
+            emergency_bytes,
+            limit_bytes,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MemoryWatchdogDecision {
+    Continue,
+    Abort,
+}
+
+pub(super) fn start(coordinator: Arc<ActorDaemonCoordinator>, limit_bytes: u64) -> io::Result<()> {
+    let thresholds = MemoryThresholds::from_limit_bytes(limit_bytes);
+    std::thread::Builder::new()
+        .name("memory-watchdog".to_string())
+        .spawn(move || {
+            run_watchdog(coordinator, thresholds);
+        })
+        .map(|_| ())
+}
+
+fn run_watchdog(coordinator: Arc<ActorDaemonCoordinator>, thresholds: MemoryThresholds) {
+    let mut sampler = PeakRssSampler::new();
+    let mut measurement_failed = false;
+    let poll_interval = watchdog_poll_interval();
+
+    tracing::info!(
+        memory_limit_bytes = thresholds.limit_bytes,
+        memory_emergency_threshold_bytes = thresholds.emergency_bytes,
+        memory_poll_interval_ms = poll_interval.as_millis() as u64,
+        "daemon memory watchdog started"
+    );
+
+    loop {
+        std::thread::sleep(poll_interval);
+        if coordinator.is_shutting_down() {
+            return;
+        }
+
+        let peak_rss_bytes = match sampler.sample() {
+            Ok(bytes) => {
+                if measurement_failed {
+                    tracing::info!("daemon peak-RSS measurement recovered");
+                    measurement_failed = false;
+                }
+                bytes
+            }
+            Err(error) => {
+                if !measurement_failed {
+                    tracing::warn!(%error, "failed measuring daemon peak RSS; watchdog will retry");
+                    measurement_failed = true;
+                }
+                continue;
+            }
+        };
+
+        match decision_for_peak_rss(peak_rss_bytes, thresholds) {
+            MemoryWatchdogDecision::Continue => {}
+            MemoryWatchdogDecision::Abort => {
+                record_memory_emergency(peak_rss_bytes, thresholds, "abort");
+                std::process::abort();
+            }
+        }
+    }
+}
+
+fn record_memory_emergency(
+    peak_rss_bytes: u64,
+    thresholds: MemoryThresholds,
+    action: &'static str,
+) {
+    tracing::error!(
+        peak_rss_bytes,
+        memory_emergency_threshold_bytes = thresholds.emergency_bytes,
+        memory_limit_bytes = thresholds.limit_bytes,
+        action,
+        "daemon memory emergency threshold reached"
+    );
+    eprintln!(
+        "[git-ai] daemon memory emergency threshold reached (peak RSS {peak_rss_bytes} bytes, emergency threshold {} bytes, hard limit {} bytes); {action}ing immediately without draining",
+        thresholds.emergency_bytes, thresholds.limit_bytes
+    );
+    let _ = io::stderr().flush();
+
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "peak_rss_bytes".to_string(),
+        DaemonLogFieldValue::from(peak_rss_bytes),
+    );
+    fields.insert(
+        "memory_emergency_threshold_bytes".to_string(),
+        DaemonLogFieldValue::from(thresholds.emergency_bytes),
+    );
+    fields.insert(
+        "memory_limit_bytes".to_string(),
+        DaemonLogFieldValue::from(thresholds.limit_bytes),
+    );
+    fields.insert("action".to_string(), DaemonLogFieldValue::from(action));
+    let event = DaemonLogEvent {
+        id: Some(crate::uuid::generate_v4()),
+        kind: DaemonLogKind::Log,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        level: DaemonLogLevel::Error,
+        target: Some("git_ai::daemon::memory_watchdog".to_string()),
+        message: "daemon memory emergency threshold reached".to_string(),
+        fields,
+        repo_url: None,
+        git_ai_version: None,
+    };
+    match upload_emergency_daemon_log(event, EMERGENCY_LOG_UPLOAD_TIMEOUT) {
+        EmergencyLogUploadStatus::Completed => {}
+        EmergencyLogUploadStatus::TimedOut => {
+            eprintln!("[git-ai] emergency daemon log upload timed out; continuing shutdown");
+        }
+        EmergencyLogUploadStatus::ThreadUnavailable => {
+            eprintln!("[git-ai] emergency daemon log upload could not start; continuing shutdown");
+        }
+    }
+    let _ = io::stderr().flush();
+}
+
+fn watchdog_poll_interval() -> Duration {
+    #[cfg(feature = "test-support")]
+    if let Ok(raw) = std::env::var(TEST_POLL_INTERVAL_ENV)
+        && let Ok(milliseconds) = raw.parse::<u64>()
+        && milliseconds > 0
+    {
+        return Duration::from_millis(milliseconds);
+    }
+
+    WATCHDOG_POLL_INTERVAL
+}
+
+struct PeakRssSampler {
+    #[cfg(feature = "test-support")]
+    test_samples: Option<std::collections::VecDeque<u64>>,
+    #[cfg(feature = "test-support")]
+    last_test_sample: Option<u64>,
+}
+
+impl PeakRssSampler {
+    fn new() -> Self {
+        #[cfg(feature = "test-support")]
+        {
+            let test_samples = std::env::var(TEST_PEAK_RSS_SEQUENCE_ENV)
+                .ok()
+                .and_then(|raw| {
+                    raw.split(',')
+                        .map(|part| part.trim().parse::<u64>().ok())
+                        .collect::<Option<std::collections::VecDeque<_>>>()
+                })
+                .filter(|samples| !samples.is_empty());
+            Self {
+                test_samples,
+                last_test_sample: None,
+            }
+        }
+
+        #[cfg(not(feature = "test-support"))]
+        Self {}
+    }
+
+    fn sample(&mut self) -> io::Result<u64> {
+        #[cfg(feature = "test-support")]
+        if let Some(samples) = self.test_samples.as_mut() {
+            let sample_mb = samples
+                .pop_front()
+                .or(self.last_test_sample)
+                .expect("test RSS sequence is non-empty");
+            self.last_test_sample = Some(sample_mb);
+            return sample_mb
+                .checked_mul(crate::config::MEBIBYTE_BYTES)
+                .ok_or_else(|| io::Error::other("test peak RSS sample overflowed bytes"));
+        }
+
+        peak_rss_bytes()
+    }
+}
+
+pub(super) fn decision_for_peak_rss(
+    peak_rss_bytes: u64,
+    thresholds: MemoryThresholds,
+) -> MemoryWatchdogDecision {
+    if peak_rss_bytes >= thresholds.emergency_bytes {
+        return MemoryWatchdogDecision::Abort;
+    }
+    MemoryWatchdogDecision::Continue
+}
+
+#[cfg(unix)]
+pub(super) fn peak_rss_bytes() -> io::Result<u64> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
+    let result = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let max_rss = unsafe { usage.assume_init() }.ru_maxrss;
+    let max_rss = u64::try_from(max_rss)
+        .map_err(|_| io::Error::other("getrusage returned a negative peak RSS"))?;
+
+    #[cfg(target_os = "macos")]
+    return Ok(max_rss);
+
+    #[cfg(not(target_os = "macos"))]
+    max_rss
+        .checked_mul(1024)
+        .ok_or_else(|| io::Error::other("peak RSS overflowed bytes"))
+}
+
+#[cfg(windows)]
+pub(super) fn peak_rss_bytes() -> io::Result<u64> {
+    type Handle = *mut std::ffi::c_void;
+
+    #[repr(C)]
+    struct ProcessMemoryCounters {
+        cb: u32,
+        page_fault_count: u32,
+        peak_working_set_size: usize,
+        working_set_size: usize,
+        quota_peak_paged_pool_usage: usize,
+        quota_paged_pool_usage: usize,
+        quota_peak_non_paged_pool_usage: usize,
+        quota_non_paged_pool_usage: usize,
+        pagefile_usage: usize,
+        peak_pagefile_usage: usize,
+    }
+
+    unsafe extern "system" {
+        fn GetCurrentProcess() -> Handle;
+    }
+
+    #[link(name = "psapi")]
+    unsafe extern "system" {
+        fn GetProcessMemoryInfo(
+            process: Handle,
+            counters: *mut ProcessMemoryCounters,
+            size: u32,
+        ) -> i32;
+    }
+
+    let mut counters = ProcessMemoryCounters {
+        cb: std::mem::size_of::<ProcessMemoryCounters>() as u32,
+        page_fault_count: 0,
+        peak_working_set_size: 0,
+        working_set_size: 0,
+        quota_peak_paged_pool_usage: 0,
+        quota_paged_pool_usage: 0,
+        quota_peak_non_paged_pool_usage: 0,
+        quota_non_paged_pool_usage: 0,
+        pagefile_usage: 0,
+        peak_pagefile_usage: 0,
+    };
+    let result = unsafe {
+        GetProcessMemoryInfo(
+            GetCurrentProcess(),
+            &mut counters,
+            std::mem::size_of::<ProcessMemoryCounters>() as u32,
+        )
+    };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    u64::try_from(counters.peak_working_set_size)
+        .map_err(|_| io::Error::other("peak working set does not fit in u64"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIMIT: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn memory_limit_thresholds_use_eighty_five_percent_headroom() {
+        let thresholds = MemoryThresholds::from_limit_bytes(LIMIT);
+
+        assert_eq!(thresholds.emergency_bytes, 912_680_551);
+        assert_eq!(thresholds.limit_bytes, LIMIT);
+    }
+
+    #[test]
+    fn watchdog_aborts_at_the_emergency_threshold() {
+        let thresholds = MemoryThresholds::from_limit_bytes(LIMIT);
+        assert_eq!(
+            decision_for_peak_rss(thresholds.emergency_bytes - 1, thresholds),
+            MemoryWatchdogDecision::Continue
+        );
+        assert_eq!(
+            decision_for_peak_rss(thresholds.emergency_bytes, thresholds),
+            MemoryWatchdogDecision::Abort
+        );
+    }
+
+    #[test]
+    fn watchdog_aborts_when_startup_is_already_high() {
+        let thresholds = MemoryThresholds::from_limit_bytes(LIMIT);
+        assert_eq!(
+            decision_for_peak_rss(thresholds.emergency_bytes, thresholds),
+            MemoryWatchdogDecision::Abort
+        );
+    }
+
+    #[test]
+    fn watchdog_aborts_at_the_hard_threshold() {
+        let thresholds = MemoryThresholds::from_limit_bytes(LIMIT);
+        assert_eq!(
+            decision_for_peak_rss(thresholds.emergency_bytes - 1, thresholds),
+            MemoryWatchdogDecision::Continue
+        );
+        assert_eq!(
+            decision_for_peak_rss(thresholds.limit_bytes, thresholds),
+            MemoryWatchdogDecision::Abort
+        );
+    }
+
+    #[test]
+    fn peak_rss_sampler_reports_nonzero_memory() {
+        assert!(peak_rss_bytes().expect("peak RSS should be readable") > 0);
+    }
+}

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -34,6 +34,7 @@ const MAX_DAEMON_LOG_BUFFER_EVENTS: usize = 5000;
 
 static METRICS_UPLOAD_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static METRICS_METADATA_BACKFILL_STARTED: AtomicBool = AtomicBool::new(false);
+static DAEMON_RUN_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 static DAEMON_LOG_UPLOAD_IN_FLIGHT: std::sync::OnceLock<Arc<AtomicBool>> =
     std::sync::OnceLock::new();
 
@@ -439,7 +440,7 @@ pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
         buffer: buffer.clone(),
         flush_tx,
     };
-    let daemon_id = crate::uuid::generate_v4();
+    let daemon_id = daemon_run_id().to_string();
 
     spawn_metrics_metadata_backfill();
 
@@ -939,6 +940,10 @@ fn daemon_log_upload_enabled() -> bool {
     Config::fresh().get_feature_flags().daemon_log_upload
 }
 
+fn daemon_run_id() -> &'static str {
+    DAEMON_RUN_ID.get_or_init(crate::uuid::generate_v4).as_str()
+}
+
 fn daemon_heartbeat_event(uptime: std::time::Duration) -> DaemonLogEvent {
     let mut fields = BTreeMap::new();
     fields.insert(
@@ -1058,6 +1063,58 @@ fn flush_daemon_logs(events: Vec<DaemonLogEvent>, daemon_id: &str, install_id: &
     upload_daemon_log_chunk(events, daemon_id, install_id, |request| {
         client.upload_daemon_logs(request).map(|_| ())
     })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum EmergencyLogUploadStatus {
+    Completed,
+    TimedOut,
+    ThreadUnavailable,
+}
+
+/// Give one emergency diagnostic a bounded chance to reach the log endpoint.
+///
+/// Normal daemon-log delivery is deliberately fire-and-forget. Memory-limit
+/// shutdown cannot rely on that worker surviving process exit, so this path
+/// waits briefly for its own upload without allowing a stuck network request to
+/// keep an unhealthy daemon alive.
+pub(super) fn upload_emergency_daemon_log(
+    event: DaemonLogEvent,
+    timeout: std::time::Duration,
+) -> EmergencyLogUploadStatus {
+    upload_emergency_daemon_log_with(event, timeout, |event| {
+        let install_id = get_or_create_distinct_id();
+        let _ = flush_daemon_logs(vec![event], daemon_run_id(), &install_id);
+    })
+}
+
+fn upload_emergency_daemon_log_with<Upload>(
+    event: DaemonLogEvent,
+    timeout: std::time::Duration,
+    upload: Upload,
+) -> EmergencyLogUploadStatus
+where
+    Upload: FnOnce(DaemonLogEvent) + Send + 'static,
+{
+    let (completion_tx, completion_rx) = std::sync::mpsc::sync_channel(0);
+    let spawn_result = std::thread::Builder::new()
+        .name("git-ai-emergency-log-upload".to_string())
+        .spawn(move || {
+            upload(event);
+            let _ = completion_tx.send(());
+        });
+
+    if spawn_result.is_err() {
+        return EmergencyLogUploadStatus::ThreadUnavailable;
+    }
+
+    match completion_rx.recv_timeout(timeout) {
+        Ok(()) => EmergencyLogUploadStatus::Completed,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => EmergencyLogUploadStatus::TimedOut,
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            EmergencyLogUploadStatus::ThreadUnavailable
+        }
+    }
 }
 
 fn upload_daemon_log_chunk<Upload>(
@@ -2208,6 +2265,45 @@ mod tests {
             std::thread::sleep(Duration::from_millis(1));
         }
         assert!(!in_flight.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn emergency_daemon_log_upload_waits_for_completion() {
+        let (uploaded_tx, uploaded_rx) = std::sync::mpsc::channel();
+
+        let status = upload_emergency_daemon_log_with(
+            sample_daemon_log_event("memory emergency"),
+            Duration::from_secs(1),
+            move |event| uploaded_tx.send(event.message).unwrap(),
+        );
+
+        assert_eq!(status, EmergencyLogUploadStatus::Completed);
+        assert_eq!(uploaded_rx.recv().unwrap(), "memory emergency");
+    }
+
+    #[test]
+    fn emergency_daemon_log_upload_reuses_the_daemon_run_id() {
+        let run_id = daemon_run_id().to_string();
+
+        assert_eq!(daemon_run_id(), run_id);
+    }
+
+    #[test]
+    fn emergency_daemon_log_upload_has_a_hard_wait_bound() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let started_at = std::time::Instant::now();
+
+        let status = upload_emergency_daemon_log_with(
+            sample_daemon_log_event("memory emergency"),
+            Duration::from_millis(10),
+            move |_event| {
+                let _ = release_rx.recv_timeout(Duration::from_secs(1));
+            },
+        );
+
+        assert_eq!(status, EmergencyLogUploadStatus::TimedOut);
+        assert!(started_at.elapsed() < Duration::from_millis(500));
+        release_tx.send(()).unwrap();
     }
 
     #[test]

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -462,6 +462,7 @@ struct DaemonGuard {
     control_socket_path: PathBuf,
     trace_socket_path: PathBuf,
     repo_working_dir: String,
+    stderr_log_path: PathBuf,
 }
 
 impl DaemonGuard {
@@ -473,6 +474,14 @@ impl DaemonGuard {
         let daemon_home = repo.daemon_home_path();
         let control_socket_path = daemon_control_socket_path(repo);
         let trace_socket_path = daemon_trace_socket_path(repo);
+        let stderr_log_path = daemon_home.join("daemon-guard.stderr.log");
+        fs::create_dir_all(&daemon_home).expect("failed to create daemon test home");
+        let stderr_log = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&stderr_log_path)
+            .expect("failed to create daemon stderr log");
         let mut command = Command::new(get_binary_path());
         command
             .arg("bg")
@@ -481,7 +490,11 @@ impl DaemonGuard {
             .env("GIT_AI_TEST_DB_PATH", repo.test_db_path())
             .env("GITAI_TEST_DB_PATH", repo.test_db_path())
             .stdout(Stdio::null())
-            .stderr(Stdio::null());
+            .stderr(
+                stderr_log
+                    .try_clone()
+                    .expect("failed to clone daemon stderr log"),
+            );
         for (key, value) in extra_env {
             command.env(key, value);
         }
@@ -504,6 +517,7 @@ impl DaemonGuard {
                 control_socket_path: control_socket_path.clone(),
                 trace_socket_path: trace_socket_path.clone(),
                 repo_working_dir: repo_workdir_string(repo),
+                stderr_log_path: stderr_log_path.clone(),
             };
             match daemon.wait_until_ready() {
                 Ok(()) => return daemon,
@@ -591,6 +605,10 @@ impl DaemonGuard {
 
         let _ = self.child.kill();
         let _ = self.child.wait();
+    }
+
+    fn stderr_contents(&self) -> String {
+        fs::read_to_string(&self.stderr_log_path).unwrap_or_default()
     }
 }
 
@@ -5325,6 +5343,153 @@ fn daemon_memory_does_not_grow_unbounded_under_trace_load() {
     }
 
     guard.shutdown();
+}
+
+#[test]
+#[serial]
+fn daemon_memory_threshold_logs_uploads_and_aborts_without_draining() {
+    let mut mock_api = MockApiServer::start();
+    let mut repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    repo.patch_git_ai_config(|patch| {
+        patch.daemon_memory_limit_mb = Some(1024);
+    });
+
+    let file_path = repo.path().join("memory-emergency.txt");
+    fs::write(&file_path, "Untracked base\n").unwrap();
+    repo.git_og(&["add", "memory-emergency.txt"]).unwrap();
+    repo.git_og(&["commit", "-m", "Initial commit"]).unwrap();
+
+    let mut samples = vec!["100"; 40];
+    samples.push("900");
+    let sample_sequence = samples.join(",");
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            (
+                "GIT_AI_TEST_DAEMON_PEAK_RSS_MB_SEQUENCE",
+                sample_sequence.as_str(),
+            ),
+            ("GIT_AI_TEST_DAEMON_MEMORY_POLL_MS", "25"),
+            (
+                "GIT_AI_TEST_DELAY_CHECKPOINT_ADMISSION",
+                "memory-limit-checkpoint=10000",
+            ),
+            ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+            ("GIT_AI_API_KEY", "test-api-key"),
+        ],
+    );
+    let head = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+
+    fs::write(&file_path, "Untracked base\nAI before emergency\n").unwrap();
+    let request = CheckpointRequest {
+        trace_id: "memory-limit-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "memory-limit-session".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from("memory-emergency.txt"),
+            content: Some("Untracked base\nAI before emergency\n".to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Sha(head),
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+    let checkpoint_response = send_checkpoint_request_with_timeout(
+        &daemon.control_socket_path,
+        &request,
+        Duration::from_secs(1),
+    )
+    .expect("checkpoint should be acknowledged before emergency shutdown");
+    assert!(
+        checkpoint_response.ok,
+        "checkpoint should be accepted before emergency shutdown: {checkpoint_response:?}"
+    );
+    let started = std::time::Instant::now();
+    let status = daemon.child.wait().expect("wait for emergency daemon stop");
+    assert!(!status.success(), "85% threshold should abort the daemon");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "memory emergency shutdown waited for the delayed checkpoint"
+    );
+    let logs = daemon.stderr_contents();
+    assert!(
+        logs.contains("memory emergency threshold reached"),
+        "missing emergency memory diagnostic:\n{logs}"
+    );
+    let requests = mock_api.collect_requests();
+    assert!(
+        requests
+            .iter()
+            .filter(|request| request["path"] == "/worker/logs/upload")
+            .flat_map(|request| request["body"]["events"].as_array().into_iter().flatten())
+            .any(|event| event["message"] == "daemon memory emergency threshold reached"),
+        "emergency diagnostic was not uploaded before shutdown: {requests:?}"
+    );
+}
+
+#[test]
+#[serial]
+fn daemon_memory_limit_below_startup_usage_aborts_without_restart_loop() {
+    let mut repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    repo.patch_git_ai_config(|patch| {
+        patch.daemon_memory_limit_mb = Some(1024);
+    });
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_DAEMON_PEAK_RSS_MB_SEQUENCE", "1024"),
+            ("GIT_AI_TEST_DAEMON_MEMORY_POLL_MS", "250"),
+        ],
+    );
+    let status = daemon.child.wait().expect("wait for daemon stop");
+
+    assert!(!status.success(), "startup-over-limit should abort");
+    thread::sleep(Duration::from_millis(300));
+    assert!(
+        send_control_request(&daemon.control_socket_path, &ControlRequest::Ping).is_err(),
+        "startup-over-limit daemon must not respawn"
+    );
+    let logs = daemon.stderr_contents();
+    assert!(
+        logs.contains("memory emergency threshold reached"),
+        "missing startup-limit diagnostic:\n{logs}"
+    );
+}
+
+#[test]
+#[serial]
+fn daemon_memory_hard_limit_aborts_without_restart() {
+    let mut repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    repo.patch_git_ai_config(|patch| {
+        patch.daemon_memory_limit_mb = Some(1024);
+    });
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_DAEMON_PEAK_RSS_MB_SEQUENCE", "100,100,1024"),
+            ("GIT_AI_TEST_DAEMON_MEMORY_POLL_MS", "100"),
+        ],
+    );
+    let status = daemon.child.wait().expect("wait for daemon abort");
+
+    assert!(!status.success(), "hard memory limit must abort the daemon");
+    thread::sleep(Duration::from_millis(300));
+    assert!(
+        send_control_request(&daemon.control_socket_path, &ControlRequest::Ping).is_err(),
+        "hard-aborted daemon must not respawn"
+    );
+    let logs = daemon.stderr_contents();
+    assert!(
+        logs.contains("memory emergency threshold reached"),
+        "missing hard-limit diagnostic:\n{logs}"
+    );
 }
 
 fn bg_command(repo: &TestRepo, subcommand: &str, extra_args: &[&str]) -> Output {


### PR DESCRIPTION
Monitor process peak RSS outside the trace2 ingestion path and abort at 85% of the configured limit, preserving headroom before the hard ceiling.

Before aborting, flush a durable stderr diagnostic and give a direct daemon-log upload up to 500ms to complete. Do not drain in-flight work or automatically restart; normal demand can start a fresh daemon later. Fail daemon startup if the watchdog thread cannot start, retry failed measurements, and support Unix and Windows RSS APIs.

Test Plan:
- `task test TEST_FILTER=daemon_memory_`
- `task test TEST_FILTER=emergency_daemon_log_upload`
- `task test`
- `task build`
- `task lint`