### PR TITLE
fix(daemon): reuse bounded Tokio runtimes

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -17,6 +17,17 @@ use std::time::{Duration, Instant};
 #[cfg(windows)]
 use std::{ffi::OsStr, path::Path};
 
+// Tokio otherwise defaults to one async worker per CPU. Those long-lived
+// workers create allocator arenas that are costly in the daemon, while its own
+// queues already bound useful async concurrency. The blocking pool remains
+// larger than the worker pool so block_in_place can hand off async worker cores
+// without stalling trace ingestion.
+const DAEMON_RUNTIME_WORKER_THREADS: usize = 4;
+// Tokio's default permits hundreds of blocking threads. Each can leave a large
+// allocator arena resident after processing checkpoint content, so cap the
+// long-lived daemon while preserving ample spare capacity for block_in_place.
+const DAEMON_RUNTIME_MAX_BLOCKING_THREADS: usize = 16;
+
 pub fn handle_daemon(args: &[String]) {
     if args.is_empty() || is_help(args[0].as_str()) {
         print_help();
@@ -190,10 +201,8 @@ fn handle_run(args: &[String]) -> Result<(), String> {
             e
         )
     })?;
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| e.to_string())?;
+    let runtime = build_daemon_runtime()?;
+    crate::tokio_runtime::initialize();
     let exit_action = runtime
         .block_on(async move { crate::daemon::run_daemon(config).await })
         .map_err(|e| e.to_string())?;
@@ -223,6 +232,15 @@ fn handle_run(args: &[String]) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn build_daemon_runtime() -> Result<tokio::runtime::Runtime, String> {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(DAEMON_RUNTIME_WORKER_THREADS)
+        .max_blocking_threads(DAEMON_RUNTIME_MAX_BLOCKING_THREADS)
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())
 }
 
 pub(crate) fn ensure_daemon_running(
@@ -798,4 +816,62 @@ fn print_help() {
     eprintln!("  git-ai bg shutdown [--hard]");
     eprintln!("  git-ai bg restart [--hard]");
     eprintln!("  git-ai bg tail [-n <lines>] [--full] [-f | --follow]");
+}
+
+#[cfg(all(test, not(windows)))]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    #[test]
+    fn daemon_runtime_worker_pool_is_bounded() {
+        let runtime = build_daemon_runtime().unwrap();
+
+        assert_eq!(
+            runtime.metrics().num_workers(),
+            DAEMON_RUNTIME_WORKER_THREADS
+        );
+    }
+
+    #[test]
+    fn daemon_runtime_blocking_pool_is_memory_bounded() {
+        let runtime = build_daemon_runtime().unwrap();
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(AtomicBool::new(false));
+
+        runtime.block_on(async {
+            let mut handles = Vec::new();
+            for _ in 0..20 {
+                let active = Arc::clone(&active);
+                let peak = Arc::clone(&peak);
+                let release = Arc::clone(&release);
+                handles.push(tokio::task::spawn_blocking(move || {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(current, Ordering::SeqCst);
+                    while !release.load(Ordering::SeqCst) {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    active.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while peak.load(Ordering::SeqCst) < 16 && Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            release.store(true, Ordering::SeqCst);
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        });
+
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            16,
+            "daemon runtime must activate exactly sixteen blocking threads under load"
+        );
+    }
 }

--- a/src/tokio_runtime.rs
+++ b/src/tokio_runtime.rs
@@ -1,12 +1,45 @@
 use std::future::Future;
+use std::sync::OnceLock;
 
 use crate::error::GitAiError;
 
-fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("failed to create Tokio runtime")
+const HELPER_RUNTIME_WORKER_THREADS: usize = 2;
+// File-level helpers can fan out to 30 tasks, but activating a thread for every
+// task creates one allocator arena per thread. Large checkpoints then multiply
+// their high-water memory across those arenas. Queue excess blocking tasks on a
+// small pool instead; this work is downstream of trace ingestion.
+const HELPER_RUNTIME_MAX_BLOCKING_THREADS: usize = 4;
+
+// Post-commit attribution calls this helper from inside the daemon runtime.
+// Recreating a CPU-sized runtime for every call leaves allocator arenas at
+// their high-water marks in the long-lived daemon, so keep one small pool.
+fn runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        #[cfg(feature = "test-support")]
+        if let Some(path) = std::env::var_os("GIT_AI_TEST_TOKIO_RUNTIME_BUILD_LOG") {
+            use std::io::Write;
+
+            let mut log = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .expect("failed opening test Tokio runtime build log");
+            writeln!(log, "runtime").expect("failed writing test Tokio runtime build log");
+        }
+
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(HELPER_RUNTIME_WORKER_THREADS)
+            .max_blocking_threads(HELPER_RUNTIME_MAX_BLOCKING_THREADS)
+            .thread_keep_alive(std::time::Duration::from_secs(60))
+            .enable_all()
+            .build()
+            .expect("failed to create Tokio runtime")
+    })
+}
+
+pub fn initialize() {
+    let _ = runtime();
 }
 
 pub fn block_on<F>(future: F) -> F::Output
@@ -34,4 +67,73 @@ where
     tokio::task::spawn_blocking(task)
         .await
         .map_err(|err| GitAiError::Generic(format!("Tokio blocking task failed: {err}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    fn peak_blocking_concurrency(
+        runtime: &tokio::runtime::Runtime,
+        tasks: usize,
+        expected_limit: usize,
+    ) -> usize {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(AtomicBool::new(false));
+
+        runtime.block_on(async {
+            let mut handles = Vec::new();
+            for _ in 0..tasks {
+                let active = Arc::clone(&active);
+                let peak = Arc::clone(&peak);
+                let release = Arc::clone(&release);
+                handles.push(tokio::task::spawn_blocking(move || {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(current, Ordering::SeqCst);
+                    while !release.load(Ordering::SeqCst) {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    active.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while peak.load(Ordering::SeqCst) < expected_limit && Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            release.store(true, Ordering::SeqCst);
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        });
+
+        peak.load(Ordering::SeqCst)
+    }
+
+    #[test]
+    fn helper_runtime_worker_pool_is_bounded() {
+        assert_eq!(
+            runtime().metrics().num_workers(),
+            HELPER_RUNTIME_WORKER_THREADS
+        );
+    }
+
+    #[test]
+    fn helper_runtime_is_reused() {
+        assert!(std::ptr::eq(runtime(), runtime()));
+    }
+
+    #[test]
+    fn helper_runtime_blocking_pool_is_memory_bounded() {
+        assert_eq!(
+            peak_blocking_concurrency(runtime(), 8, 4),
+            4,
+            "helper runtime must activate exactly four blocking threads under load"
+        );
+    }
 }

--- a/tests/integration/daemon_runtime_memory.rs
+++ b/tests/integration/daemon_runtime_memory.rs
@@ -1,0 +1,50 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use std::fs;
+
+fn runtime_build_count(path: &std::path::Path) -> usize {
+    fs::read_to_string(path).unwrap_or_default().lines().count()
+}
+
+#[test]
+fn repeated_agent_commits_reuse_the_daemon_helper_runtime() {
+    let temp = tempfile::tempdir().unwrap();
+    let runtime_build_log = temp.path().join("runtime-builds.log");
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_TOKIO_RUNTIME_BUILD_LOG",
+        runtime_build_log.to_str().unwrap(),
+    )]);
+    let path = repo.path().join("crew-state.txt");
+
+    fs::write(&path, "base\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut file = repo.filename("crew-state.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    let runtime_builds_before_agent_commits = runtime_build_count(&runtime_build_log);
+    let mut expected = vec!["base".unattributed_human()];
+    let mut contents = String::from("base\n");
+
+    for index in 0..3 {
+        repo.git_ai(&["checkpoint", "human", "crew-state.txt"])
+            .unwrap();
+        let line = format!("agent state {index}");
+        contents.push_str(&line);
+        contents.push('\n');
+        fs::write(&path, &contents).unwrap();
+        repo.git_ai(&["checkpoint", "mock_ai", "crew-state.txt"])
+            .unwrap();
+        repo.stage_all_and_commit(&format!("agent state {index}"))
+            .unwrap();
+
+        expected.push(line.ai());
+        file.assert_committed_lines(expected.clone());
+    }
+
+    let helper_runtimes_built =
+        runtime_build_count(&runtime_build_log) - runtime_builds_before_agent_commits;
+    assert!(
+        helper_runtimes_built <= 1,
+        "the daemon must reuse one bounded helper runtime across commits; built {helper_runtimes_built}"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -52,6 +52,7 @@ mod continue_cli;
 mod cross_repo_cwd_attribution;
 mod cursor;
 mod daemon_commit_carryover;
+mod daemon_runtime_memory;
 mod debug_diagnostics;
 mod diff;
 mod diff_comprehensive;


### PR DESCRIPTION
Post-commit attribution built fresh CPU-sized Tokio runtimes repeatedly, leaving allocator arenas at their high-water mark in the long-lived daemon. Reuse one small helper runtime and bound the daemon runtime's worker and blocking pools.

Add a TestRepo regression that performs repeated agent checkpoint and commit cycles, verifies attribution after each commit, and proves the helper runtime is initialized at most once.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2056" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->