### PR TITLE
Recover remaining unattributed lines as human

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -1,6 +1,6 @@
-use crate::authorship::authorship_log::{LineRange, SessionRecord};
+use crate::authorship::authorship_log::{HumanRecord, LineRange, SessionRecord};
 use crate::authorship::authorship_log_serialization::{
-    AuthorshipLog, generate_session_id, generate_trace_id,
+    AuthorshipLog, generate_human_short_hash, generate_session_id, generate_trace_id,
 };
 use crate::authorship::working_log::{AgentId, CheckpointKind};
 use crate::commands::checkpoint_agent::bash_tool::StatEntry;
@@ -252,15 +252,24 @@ pub(crate) fn recover_attribution(
         context.file_timestamps,
     )?;
 
-    recover_commit_metadata(
+    let unknown_after_session_events = unknown_lines_by_file(authorship_log, committed_hunks);
+    if unknown_after_session_events.is_empty() {
+        return Ok(());
+    }
+
+    if recover_commit_metadata(
         repo,
         parent_sha,
         commit_sha,
         human_author,
         authorship_log,
-        committed_hunks,
+        &unknown_after_session_events,
         context.file_timestamps,
-    )?;
+    )? {
+        return Ok(());
+    }
+
+    recover_remaining_as_known_human(authorship_log, human_author, unknown_after_session_events);
     Ok(())
 }
 
@@ -520,24 +529,23 @@ fn recover_commit_metadata(
     commit_sha: &str,
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
-    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    unknown_by_file: &UnknownLinesByFile,
     captured_file_timestamps: Option<&FileTimestampsByPath>,
-) -> Result<(), GitAiError> {
-    let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
+) -> Result<bool, GitAiError> {
     if unknown_by_file.is_empty() {
-        return Ok(());
+        return Ok(true);
     }
 
     let commit_metadata = read_commit_metadata(repo, commit_sha)?;
     let detections = detect_commit_metadata_agents(&commit_metadata);
     if detections.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
 
     let workdir = repo.workdir()?;
     let target_repo_url = crate::repo_url::resolve_repo_url_from_repo(repo);
     let (timestamps_by_file, latest_timestamps) =
-        latest_timestamps_for_unknown_files(&workdir, &unknown_by_file, captured_file_timestamps);
+        latest_timestamps_for_unknown_files(&workdir, unknown_by_file, captured_file_timestamps);
     let Some(selection) = select_commit_metadata_session(
         authorship_log,
         &detections,
@@ -545,7 +553,7 @@ fn recover_commit_metadata(
         target_repo_url.as_deref(),
     )?
     else {
-        return Ok(());
+        return Ok(false);
     };
 
     authorship_log
@@ -572,10 +580,10 @@ fn recover_commit_metadata(
     for (file_path, unknown_lines) in unknown_by_file {
         let trace_id = generate_trace_id();
         let author_id = format!("{}::{}", selection.session_id, trace_id);
-        add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
+        add_attestation(authorship_log, file_path, &author_id, unknown_lines);
 
         let file_timestamps = timestamps_by_file
-            .get(&file_path)
+            .get(file_path)
             .cloned()
             .unwrap_or_default();
         let metadata = json!({
@@ -603,7 +611,7 @@ fn recover_commit_metadata(
             repo,
             parent_sha,
             commit_sha,
-            file_path: &file_path,
+            file_path,
             author_id: &author_id,
             session_id: &selection.session_id,
             trace_id: &trace_id,
@@ -619,7 +627,50 @@ fn recover_commit_metadata(
         });
     }
 
-    Ok(())
+    Ok(true)
+}
+
+fn recover_remaining_as_known_human(
+    authorship_log: &mut AuthorshipLog,
+    human_author: &str,
+    unknown_by_file: UnknownLinesByFile,
+) {
+    if !should_recover_remaining_as_known_human(authorship_log) {
+        return;
+    }
+
+    let human_id = generate_human_short_hash(human_author);
+    authorship_log
+        .metadata
+        .humans
+        .entry(human_id.clone())
+        .or_insert_with(|| HumanRecord {
+            author: human_author.to_string(),
+        });
+
+    for (file_path, unknown_lines) in unknown_by_file {
+        add_attestation_ranges(
+            authorship_log,
+            &file_path,
+            &human_id,
+            LineRange::compress_lines(&unknown_lines),
+        );
+    }
+}
+
+fn should_recover_remaining_as_known_human(authorship_log: &AuthorshipLog) -> bool {
+    let mut has_ai_attribution = false;
+    for entry in authorship_log
+        .attestations
+        .iter()
+        .flat_map(|attestation| &attestation.entries)
+    {
+        if entry.hash.starts_with("h_") {
+            return true;
+        }
+        has_ai_attribution |= is_ai_attestation(&entry.hash);
+    }
+    !has_ai_attribution
 }
 
 fn read_commit_metadata(repo: &Repository, commit_sha: &str) -> Result<CommitMetadata, GitAiError> {
@@ -1663,7 +1714,23 @@ fn add_attestation(
     if sorted.is_empty() {
         return;
     }
-    let ranges = LineRange::compress_lines(&sorted);
+    add_attestation_ranges(
+        authorship_log,
+        file_path,
+        author_id,
+        LineRange::compress_lines(&sorted),
+    );
+}
+
+fn add_attestation_ranges(
+    authorship_log: &mut AuthorshipLog,
+    file_path: &str,
+    author_id: &str,
+    ranges: Vec<LineRange>,
+) {
+    if ranges.is_empty() {
+        return;
+    }
     let entry = crate::authorship::authorship_log_serialization::AttestationEntry::new(
         author_id.to_string(),
         ranges,
@@ -2096,6 +2163,50 @@ mod tests {
 
         assert_eq!(selection.candidate.tool_use_id, "tool-coarse");
         assert_eq!(selection.distance_ns, 500_000_000);
+    }
+
+    #[test]
+    fn terminal_human_recovery_uses_attestations_instead_of_metadata() {
+        let mut log = AuthorshipLog::new();
+        log.metadata.sessions.insert(
+            "s_metadata_only".to_string(),
+            SessionRecord {
+                agent_id: test_agent("metadata-only"),
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+        assert!(
+            should_recover_remaining_as_known_human(&log),
+            "AI metadata without landed attribution must not block recovery"
+        );
+
+        log.attestations.push(FileAttestation {
+            file_path: "file.txt".to_string(),
+            entries: vec![AttestationEntry::new(
+                "s_ai::t_1".to_string(),
+                vec![LineRange::Single(1)],
+            )],
+        });
+        log.metadata.humans.insert(
+            "h_metadata_only".to_string(),
+            HumanRecord {
+                author: "Human <human@example.com>".to_string(),
+            },
+        );
+        assert!(
+            !should_recover_remaining_as_known_human(&log),
+            "unattested human metadata must not override landed AI attribution"
+        );
+
+        log.attestations[0].entries.push(AttestationEntry::new(
+            "h_landed".to_string(),
+            vec![LineRange::Single(2)],
+        ));
+        assert!(
+            should_recover_remaining_as_known_human(&log),
+            "a landed known-human attestation must enable recovery"
+        );
     }
 
     #[test]

--- a/tests/integration/cold_trace2_repo.rs
+++ b/tests/integration/cold_trace2_repo.rs
@@ -132,8 +132,9 @@ fn assert_note_has_no_ai_authorship(commit_sha: &str, note: &str) {
     assert!(
         log.attestations
             .iter()
-            .all(|attestation| attestation.entries.is_empty()),
-        "cold raw setup should not create attestations for {}: {:?}",
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "cold raw setup should not create AI attestations for {}: {:?}",
         commit_sha,
         log.attestations
     );

--- a/tests/integration/continue_cli.rs
+++ b/tests/integration/continue_cli.rs
@@ -386,10 +386,13 @@ fn test_continue_cli_e2e_human_checkpoint() {
         "console.log('human edit');".human(),
     ]);
 
-    assert_eq!(
-        commit.authorship_log.attestations.len(),
-        0,
-        "Human checkpoint should not create AI attestations"
+    assert!(
+        commit
+            .authorship_log
+            .attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash.starts_with("h_"))
     );
 }
 

--- a/tests/integration/fuzzer/model.rs
+++ b/tests/integration/fuzzer/model.rs
@@ -266,6 +266,35 @@ impl FileModel {
         }
     }
 
+    pub fn apply_terminal_human_recovery_for_added_lines(
+        &mut self,
+        registry: &mut AttrRegistry,
+        added_lines: &[u32],
+    ) {
+        let added_indices = added_lines
+            .iter()
+            .filter_map(|line| line.checked_sub(1).map(|idx| idx as usize))
+            .filter(|&idx| idx < self.resolved_attrs.len())
+            .collect::<Vec<_>>();
+        let has_known_human = added_indices
+            .iter()
+            .any(|&idx| self.resolved_attrs[idx] == LineAttribution::KnownHuman);
+        let has_ai = added_indices
+            .iter()
+            .any(|&idx| self.resolved_attrs[idx] == LineAttribution::Ai);
+
+        if !has_known_human && has_ai {
+            return;
+        }
+
+        for idx in added_indices {
+            if self.resolved_attrs[idx] == LineAttribution::Untracked {
+                self.resolved_attrs[idx] = LineAttribution::KnownHuman;
+                registry.register(self.lines[idx], LineAttribution::KnownHuman);
+            }
+        }
+    }
+
     fn pending_record_at_index(&self, idx: usize) -> Option<AttrRecord> {
         self.lines
             .get(idx)

--- a/tests/integration/fuzzer/operations.rs
+++ b/tests/integration/fuzzer/operations.rs
@@ -185,6 +185,7 @@ pub fn commit(
 
     op_log.push(format!("commit(\"{}\")", msg));
     model.apply_edge_recovery_for_added_lines(registry, &added_lines);
+    model.apply_terminal_human_recovery_for_added_lines(registry, &added_lines);
     model.reconcile(repo);
     model.assert_blame(repo, op_log, seed);
     model.clear_pending_attestations();
@@ -210,6 +211,7 @@ pub fn amend(
     op_log.push("amend".to_string());
     model.sync_from_disk(repo, registry);
     model.apply_edge_recovery_for_added_lines(registry, &added_lines);
+    model.apply_terminal_human_recovery_for_added_lines(registry, &added_lines);
     model.reconcile(repo);
     model.assert_blame(repo, op_log, seed);
     model.clear_pending_attestations();

--- a/tests/integration/gemini.rs
+++ b/tests/integration/gemini.rs
@@ -353,7 +353,14 @@ fn test_gemini_e2e_human_checkpoint() {
         "console.log('human edit');".human(),
     ]);
 
-    assert_eq!(commit.authorship_log.attestations.len(), 0);
+    assert!(
+        commit
+            .authorship_log
+            .attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash.starts_with("h_"))
+    );
 }
 
 #[test]

--- a/tests/integration/post_commit_unit.rs
+++ b/tests/integration/post_commit_unit.rs
@@ -56,16 +56,20 @@ fn test_post_commit_empty_repo_no_checkpoint() {
         .trim()
         .to_string();
 
-    // With no checkpoints, authorship log should have empty attestations
+    // With no checkpoints, attribution recovery should mark the commit known human.
     let note = repo.read_authorship_note(&head_sha);
     assert!(note.is_some(), "Should have authorship note");
 
-    // No checkpoints = no AI attribution, so note should have empty attestations
+    // No checkpoints = no AI attribution, so every attestation should be known human.
     let log = AuthorshipLog::deserialize_from_string(&note.unwrap()).unwrap();
     assert!(
-        log.attestations.is_empty(),
-        "Should have empty attestations when no checkpoints exist"
+        log.attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash.starts_with("h_")),
+        "Should only have known-human attestations when no checkpoints exist"
     );
+    assert!(!log.attestations.is_empty());
 }
 
 #[test]

--- a/tests/integration/session_event_attribution.rs
+++ b/tests/integration/session_event_attribution.rs
@@ -139,6 +139,33 @@ fn assert_session_attests_lines(
     );
 }
 
+fn human_attested_lines(authorship_log: &AuthorshipLog, file_path: &str) -> Vec<u32> {
+    let mut lines = authorship_log
+        .attestations
+        .iter()
+        .filter(|attestation| attestation.file_path == file_path)
+        .flat_map(|attestation| &attestation.entries)
+        .filter(|entry| entry.hash.starts_with("h_"))
+        .flat_map(|entry| entry.line_ranges.iter().flat_map(LineRange::expand))
+        .collect::<Vec<_>>();
+    lines.sort_unstable();
+    lines.dedup();
+    lines
+}
+
+fn terminal_recovery_repo() -> (tempfile::TempDir, tempfile::TempDir, TestRepo) {
+    let (metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let (bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str()),
+    ];
+    let repo = TestRepo::new_with_daemon_env(&env);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+    (metrics_db_dir, bash_db_dir, repo)
+}
+
 fn session_ids_for_tool(authorship_log: &AuthorshipLog, tool: &str) -> Vec<String> {
     let mut session_ids = authorship_log
         .metadata
@@ -392,6 +419,108 @@ fn test_session_event_recovery_does_not_override_known_human_checkpoint() {
 }
 
 #[test]
+fn test_terminal_recovery_marks_fully_unknown_commit_known_human() {
+    let (_metrics_db_dir, _bash_db_dir, repo) = terminal_recovery_repo();
+
+    fs::write(repo.path().join("manual.txt"), "manual one\nmanual two\n").unwrap();
+    let commit = repo
+        .stage_all_and_commit("Manual edit")
+        .expect("manual commit should succeed");
+
+    let mut file = repo.filename("manual.txt");
+    file.assert_committed_lines(lines!["manual one".human(), "manual two".human()]);
+    assert_eq!(
+        human_attested_lines(&commit.authorship_log, "manual.txt"),
+        vec![1, 2],
+        "fully unknown committed lines should receive an h_ attestation"
+    );
+}
+
+#[test]
+fn test_terminal_recovery_extends_known_human_across_commit() {
+    let (_metrics_db_dir, _bash_db_dir, repo) = terminal_recovery_repo();
+
+    fs::write(repo.path().join("known.txt"), "known human\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "known.txt"])
+        .expect("known-human checkpoint should succeed");
+    fs::write(repo.path().join("unknown.txt"), "uncheckpointed human\n").unwrap();
+    fs::write(repo.path().join("ai.txt"), "AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Mixed known human, unknown, and AI")
+        .expect("mixed commit should succeed");
+
+    let mut known = repo.filename("known.txt");
+    known.assert_committed_lines(lines!["known human".human()]);
+    let mut unknown = repo.filename("unknown.txt");
+    unknown.assert_committed_lines(lines!["uncheckpointed human".human()]);
+    assert_eq!(
+        human_attested_lines(&commit.authorship_log, "unknown.txt"),
+        vec![1],
+        "a known-human attestation anywhere in the commit should cover remaining unknown files"
+    );
+    let mut ai = repo.filename("ai.txt");
+    ai.assert_committed_lines(lines!["AI line".ai()]);
+}
+
+#[test]
+fn test_terminal_recovery_keeps_unknown_when_only_ai_is_present() {
+    let (_metrics_db_dir, _bash_db_dir, repo) = terminal_recovery_repo();
+
+    fs::write(repo.path().join("unknown.txt"), "uncheckpointed line\n").unwrap();
+    fs::write(repo.path().join("ai.txt"), "AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Mixed unknown and AI")
+        .expect("mixed commit should succeed");
+
+    let mut unknown = repo.filename("unknown.txt");
+    unknown.assert_committed_lines(lines!["uncheckpointed line".unattributed_human()]);
+    assert!(
+        human_attested_lines(&commit.authorship_log, "unknown.txt").is_empty(),
+        "AI-only commits must retain unknown holes"
+    );
+    let mut ai = repo.filename("ai.txt");
+    ai.assert_committed_lines(lines!["AI line".ai()]);
+}
+
+#[test]
+fn test_terminal_recovery_ignores_unattested_known_human_metadata() {
+    let (_metrics_db_dir, _bash_db_dir, repo) = terminal_recovery_repo();
+
+    let removed_path = repo.path().join("removed-human.txt");
+    fs::write(&removed_path, "known human that will not land\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "removed-human.txt"])
+        .expect("known-human checkpoint should succeed");
+    fs::remove_file(&removed_path).unwrap();
+    fs::write(repo.path().join("unknown.txt"), "uncheckpointed line\n").unwrap();
+    fs::write(repo.path().join("ai.txt"), "AI line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "ai.txt"])
+        .expect("AI checkpoint should succeed");
+
+    let commit = repo
+        .stage_all_and_commit("Unattested human metadata with AI")
+        .expect("mixed commit should succeed");
+
+    assert!(
+        !commit.authorship_log.metadata.humans.is_empty(),
+        "the non-landing checkpoint should leave human metadata behind"
+    );
+    let mut unknown = repo.filename("unknown.txt");
+    unknown.assert_committed_lines(lines!["uncheckpointed line".unattributed_human()]);
+    assert!(
+        human_attested_lines(&commit.authorship_log, "unknown.txt").is_empty(),
+        "unreferenced human metadata must not count as a known-human attestation"
+    );
+    let mut ai = repo.filename("ai.txt");
+    ai.assert_committed_lines(lines!["AI line".ai()]);
+}
+
+#[test]
 fn test_session_event_recovery_ignores_events_outside_window() {
     let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
     let repo =
@@ -411,11 +540,15 @@ fn test_session_event_recovery_ignores_events_outside_window() {
     );
 
     let commit = repo
-        .stage_all_and_commit("Outside window stays unknown")
+        .stage_all_and_commit("Outside window falls back to human")
         .expect("commit should succeed");
 
     let mut file = repo.filename("outside.txt");
-    file.assert_committed_lines(lines!["outside the window".unattributed_human()]);
+    file.assert_committed_lines(lines!["outside the window".human()]);
+    assert_eq!(
+        human_attested_lines(&commit.authorship_log, "outside.txt"),
+        vec![1]
+    );
     assert!(
         !commit
             .authorship_log
@@ -446,11 +579,15 @@ fn test_session_event_recovery_rejects_time_only_sessions() {
     );
 
     let commit = repo
-        .stage_all_and_commit("Time-only session stays unknown")
+        .stage_all_and_commit("Time-only session falls back to human")
         .expect("commit should succeed");
 
     let mut file = repo.filename("time-only.txt");
-    file.assert_committed_lines(lines!["time only".unattributed_human()]);
+    file.assert_committed_lines(lines!["time only".human()]);
+    assert_eq!(
+        human_attested_lines(&commit.authorship_log, "time-only.txt"),
+        vec![1]
+    );
     assert!(
         !commit
             .authorship_log
@@ -473,7 +610,7 @@ fn test_commit_metadata_recovery_uses_existing_matching_session_after_edge_expan
     repo.stage_all_and_commit("Initial base")
         .expect("initial commit should succeed");
     let mut file = repo.filename("metadata-existing.txt");
-    file.assert_committed_lines(lines!["base".unattributed_human()]);
+    file.assert_committed_lines(lines!["base".human()]);
 
     let external_session_id = "codex-existing-metadata-session";
     codex_checkpoint(
@@ -515,7 +652,7 @@ unknown 6
         .expect("commit should succeed");
 
     file.assert_committed_lines(lines![
-        "base".unattributed_human(),
+        "base".human(),
         "codex line".ai(),
         "unknown 1".ai(),
         "unknown 2".ai(),
@@ -545,7 +682,7 @@ fn test_commit_metadata_recovery_skips_when_edge_expansion_recovers_all_unknown_
     repo.stage_all_and_commit("Initial base")
         .expect("initial commit should succeed");
     let mut file = repo.filename("metadata-edge-skip.txt");
-    file.assert_committed_lines(lines!["base".unattributed_human()]);
+    file.assert_committed_lines(lines!["base".human()]);
 
     let external_session_id = "codex-edge-skip-session";
     codex_checkpoint(
@@ -584,7 +721,7 @@ edge 3
         .expect("commit should succeed");
 
     file.assert_committed_lines(lines![
-        "base".unattributed_human(),
+        "base".human(),
         "codex line".ai(),
         "edge 1".ai(),
         "edge 2".ai(),
@@ -813,7 +950,7 @@ fn test_commit_metadata_recovery_ignores_freeform_message_agent_mentions() {
     let repo = TestRepo::new();
 
     let file_path = repo.path().join("metadata-freeform-agent-mention.txt");
-    fs::write(&file_path, "freeform codex mention should stay unknown\n").unwrap();
+    fs::write(&file_path, "freeform codex mention falls back to human\n").unwrap();
 
     let commit = repo
         .stage_all_and_commit_with_env(
@@ -826,9 +963,14 @@ fn test_commit_metadata_recovery_ignores_freeform_message_agent_mentions() {
         .expect("freeform mention commit should succeed");
 
     let mut file = repo.filename("metadata-freeform-agent-mention.txt");
-    file.assert_committed_lines(lines![
-        "freeform codex mention should stay unknown".unattributed_human()
-    ]);
+    file.assert_committed_lines(lines!["freeform codex mention falls back to human".human()]);
+    assert_eq!(
+        human_attested_lines(
+            &commit.authorship_log,
+            "metadata-freeform-agent-mention.txt"
+        ),
+        vec![1]
+    );
     assert!(
         commit.authorship_log.metadata.sessions.is_empty(),
         "freeform message text mentioning Codex should not synthesize an AI session"
@@ -846,7 +988,11 @@ fn test_commit_metadata_recovery_ignores_ambiguous_identity_markers() {
         .expect("amp trailer commit should succeed");
 
     let mut amp_file = repo.filename("metadata-ambiguous-amp.txt");
-    amp_file.assert_committed_lines(lines!["ambiguous amp trailer".unattributed_human()]);
+    amp_file.assert_committed_lines(lines!["ambiguous amp trailer".human()]);
+    assert_eq!(
+        human_attested_lines(&amp_commit.authorship_log, "metadata-ambiguous-amp.txt"),
+        vec![1]
+    );
     assert!(
         amp_commit.authorship_log.metadata.sessions.is_empty(),
         "ambiguous AMP identity should not synthesize an AI session"
@@ -861,7 +1007,14 @@ fn test_commit_metadata_recovery_ignores_ambiguous_identity_markers() {
         .expect("continue trailer commit should succeed");
 
     let mut continue_file = repo.filename("metadata-ambiguous-continue.txt");
-    continue_file.assert_committed_lines(lines!["ambiguous continue trailer".unattributed_human()]);
+    continue_file.assert_committed_lines(lines!["ambiguous continue trailer".human()]);
+    assert_eq!(
+        human_attested_lines(
+            &continue_commit.authorship_log,
+            "metadata-ambiguous-continue.txt"
+        ),
+        vec![1]
+    );
     assert!(
         continue_commit.authorship_log.metadata.sessions.is_empty(),
         "ambiguous Continue identity should not synthesize an AI session"
@@ -876,9 +1029,14 @@ fn test_commit_metadata_recovery_ignores_ambiguous_identity_markers() {
         .expect("generic OpenAI noreply trailer commit should succeed");
 
     let mut openai_file = repo.filename("metadata-ambiguous-openai.txt");
-    openai_file.assert_committed_lines(lines![
-        "generic openai noreply trailer".unattributed_human()
-    ]);
+    openai_file.assert_committed_lines(lines!["generic openai noreply trailer".human()]);
+    assert_eq!(
+        human_attested_lines(
+            &openai_commit.authorship_log,
+            "metadata-ambiguous-openai.txt"
+        ),
+        vec![1]
+    );
     assert!(
         openai_commit.authorship_log.metadata.sessions.is_empty(),
         "generic OpenAI noreply identity should not synthesize a Codex session"
@@ -913,7 +1071,11 @@ fn test_commit_metadata_recovery_ignores_ambiguous_identity_markers() {
             .expect("ambiguous human identity commit should succeed");
 
         let mut file = repo.filename(file_name);
-        file.assert_committed_lines(lines![line.unattributed_human()]);
+        file.assert_committed_lines(lines![line.human()]);
+        assert_eq!(
+            human_attested_lines(&commit.authorship_log, file_name),
+            vec![1]
+        );
         assert!(
             commit.authorship_log.metadata.sessions.is_empty(),
             "{message}"

--- a/tests/integration/simple_additions.rs
+++ b/tests/integration/simple_additions.rs
@@ -227,8 +227,15 @@ fn test_simple_ai_then_human_deletion() {
 
     let commit = repo.stage_all_and_commit("Human deletes AI line").unwrap();
 
-    // The authorship log should have no attestations since we only deleted lines
-    assert_eq!(commit.authorship_log.attestations.len(), 0);
+    // With no AI attribution remaining, recovery marks the affected lines known human.
+    assert!(
+        commit
+            .authorship_log
+            .attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash.starts_with("h_"))
+    );
 
     file.assert_lines_and_blame(crate::lines![
         "Line 1".human(),
@@ -992,10 +999,14 @@ diff --git a/aidanwashere.md b/aidanwashere.md
     .unwrap();
 
     let first_commit = repo.commit("Commit human top section").unwrap();
-    assert_eq!(
-        first_commit.authorship_log.attestations.len(),
-        0,
-        "first commit should only contain human top insertion"
+    assert!(
+        first_commit
+            .authorship_log
+            .attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash.starts_with("h_")),
+        "first commit should only contain known-human top insertion"
     );
 
     repo.git(&["add", "."]).unwrap();

--- a/tests/integration/squash_merge.rs
+++ b/tests/integration/squash_merge.rs
@@ -559,13 +559,10 @@ fn test_prepare_working_log_squash_multiple_sessions_standard_human() {
     );
     assert_eq!(stats.ai_accepted, 3, "3 AI lines accepted without edits");
     assert_eq!(
-        stats.human_additions, 0,
-        "0 KnownHuman-attested lines (unattributed human via checkpoint --)"
+        stats.human_additions, 1,
+        "1 recovered KnownHuman-attested line"
     );
-    assert_eq!(
-        stats.unknown_additions, 1,
-        "1 unattested line (// Human addition)"
-    );
+    assert_eq!(stats.unknown_additions, 0, "no unattested lines remain");
 }
 
 crate::reuse_tests_in_worktree!(

--- a/tests/integration/windsurf.rs
+++ b/tests/integration/windsurf.rs
@@ -321,9 +321,13 @@ fn test_windsurf_e2e_human_checkpoint() {
         "const y = 2;".human(),
     ]);
 
-    assert_eq!(
-        commit.authorship_log.attestations.len(),
-        0,
+    assert!(
+        commit
+            .authorship_log
+            .attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash.starts_with("h_")),
         "Human checkpoint should not create AI attestations"
     );
 }


### PR DESCRIPTION
## What changed

- add a terminal attribution recovery step that marks remaining unknown lines as known human when the commit already contains known-human attribution
- mark fully unknown commits as known human when no AI attribution landed
- preserve unknown holes when AI attribution exists without any known-human attribution
- update the attribution fuzzer oracle and affected integration expectations

## Why

After the existing recovery flows finished, unattributed lines could remain unknown even when the final attribution state made their human origin unambiguous. The fallback now resolves those lines using only the attribution data already in memory.

## Performance

The implementation reuses the final unknown-line scan that commit-metadata recovery previously performed internally. The eligibility check is a single entry-level scan with an early return for known-human attribution. It adds no Git commands, object lookups, filesystem reads, database work, or ingestion-path work.

## Validation

- `task test`
- `task lint`
- `task fmt`
- `git diff --check`