### PR TITLE
Guard human recovery by commit author

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -7,7 +7,7 @@ use crate::commands::checkpoint_agent::bash_tool::StatEntry;
 use crate::daemon::bash_history_db::{BashCheckpointCall, distance_to_call_window};
 use crate::error::GitAiError;
 use crate::git::repo_state::worktree_root_for_path;
-use crate::git::repository::{Repository, exec_git};
+use crate::git::repository::{GitAuthorIdentity, Repository, exec_git};
 use crate::metrics::db::SessionEventRecoveryCandidate;
 use crate::metrics::{CheckpointValues, EventAttributes, MetricEvent, PosEncoded};
 use serde_json::json;
@@ -179,6 +179,7 @@ struct CommitMetadata {
     message: String,
     author_name: String,
     author_email: String,
+    author_identity: String,
 }
 
 #[derive(Clone, Debug)]
@@ -191,6 +192,11 @@ struct CommitMetadataSessionSelection {
     event_ts: Option<u32>,
     repo_url: Option<String>,
     external_tool_use_id: Option<String>,
+}
+
+struct CommitMetadataRecoveryContext<'a> {
+    file_timestamps: Option<&'a FileTimestampsByPath>,
+    metadata: &'a CommitMetadata,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -257,6 +263,11 @@ pub(crate) fn recover_attribution(
         return Ok(());
     }
 
+    let commit_metadata = read_commit_metadata(repo, commit_sha)?;
+    let commit_metadata_context = CommitMetadataRecoveryContext {
+        file_timestamps: context.file_timestamps,
+        metadata: &commit_metadata,
+    };
     if recover_commit_metadata(
         repo,
         parent_sha,
@@ -264,12 +275,18 @@ pub(crate) fn recover_attribution(
         human_author,
         authorship_log,
         &unknown_after_session_events,
-        context.file_timestamps,
+        commit_metadata_context,
     )? {
         return Ok(());
     }
 
-    recover_remaining_as_known_human(authorship_log, human_author, unknown_after_session_events);
+    recover_remaining_as_known_human(
+        authorship_log,
+        human_author,
+        &commit_metadata,
+        repo.cached_git_author_identity(),
+        unknown_after_session_events,
+    );
     Ok(())
 }
 
@@ -530,14 +547,13 @@ fn recover_commit_metadata(
     human_author: &str,
     authorship_log: &mut AuthorshipLog,
     unknown_by_file: &UnknownLinesByFile,
-    captured_file_timestamps: Option<&FileTimestampsByPath>,
+    context: CommitMetadataRecoveryContext<'_>,
 ) -> Result<bool, GitAiError> {
     if unknown_by_file.is_empty() {
         return Ok(true);
     }
 
-    let commit_metadata = read_commit_metadata(repo, commit_sha)?;
-    let detections = detect_commit_metadata_agents(&commit_metadata);
+    let detections = detect_commit_metadata_agents(context.metadata);
     if detections.is_empty() {
         return Ok(false);
     }
@@ -545,7 +561,7 @@ fn recover_commit_metadata(
     let workdir = repo.workdir()?;
     let target_repo_url = crate::repo_url::resolve_repo_url_from_repo(repo);
     let (timestamps_by_file, latest_timestamps) =
-        latest_timestamps_for_unknown_files(&workdir, unknown_by_file, captured_file_timestamps);
+        latest_timestamps_for_unknown_files(&workdir, unknown_by_file, context.file_timestamps);
     let Some(selection) = select_commit_metadata_session(
         authorship_log,
         &detections,
@@ -591,8 +607,8 @@ fn recover_commit_metadata(
             "file_path": file_path.as_str(),
             "unknown_lines": &unknown_lines,
             "detected_agents": &detected_agents,
-            "commit_author_name": commit_metadata.author_name.as_str(),
-            "commit_author_email": commit_metadata.author_email.as_str(),
+            "commit_author_name": context.metadata.author_name.as_str(),
+            "commit_author_email": context.metadata.author_email.as_str(),
             "selection_tier": selection.tier,
             "selected_session_id": selection.session_id.as_str(),
             "selected_tool": selection.agent_id.tool.as_str(),
@@ -633,9 +649,13 @@ fn recover_commit_metadata(
 fn recover_remaining_as_known_human(
     authorship_log: &mut AuthorshipLog,
     human_author: &str,
+    commit_metadata: &CommitMetadata,
+    local_git_author: Option<&GitAuthorIdentity>,
     unknown_by_file: UnknownLinesByFile,
 ) {
-    if !should_recover_remaining_as_known_human(authorship_log) {
+    if !commit_author_matches_local_human(commit_metadata, human_author, local_git_author)
+        || !should_recover_remaining_as_known_human(authorship_log)
+    {
         return;
     }
 
@@ -656,6 +676,20 @@ fn recover_remaining_as_known_human(
             LineRange::compress_lines(&unknown_lines),
         );
     }
+}
+
+fn commit_author_matches_local_human(
+    commit_metadata: &CommitMetadata,
+    human_author: &str,
+    local_git_author: Option<&GitAuthorIdentity>,
+) -> bool {
+    commit_metadata.author_identity == human_author
+        || matches!(
+            local_git_author.map(|author| (&author.name, &author.email)),
+            Some((Some(name), Some(email)))
+                if commit_metadata.author_name == *name
+                    && commit_metadata.author_email.eq_ignore_ascii_case(email)
+        )
 }
 
 fn should_recover_remaining_as_known_human(authorship_log: &AuthorshipLog) -> bool {
@@ -687,11 +721,13 @@ fn read_commit_metadata(repo: &Repository, commit_sha: &str) -> Result<CommitMet
     let author_name = parts.next().unwrap_or_default().trim().to_string();
     let author_email = parts.next().unwrap_or_default().trim().to_string();
     let message = parts.next().unwrap_or_default().to_string();
+    let author_identity = format!("{} <{}>", author_name, author_email);
 
     Ok(CommitMetadata {
         message,
         author_name,
         author_email,
+        author_identity,
     })
 }
 
@@ -739,9 +775,13 @@ fn detect_commit_metadata_agents(metadata: &CommitMetadata) -> Vec<CommitAgentDe
         }
     }
 
-    let author_identity = format!("{} <{}>", metadata.author_name, metadata.author_email);
-    if let Some(kind) = detect_agent_from_identity(&author_identity) {
-        push_commit_agent_detection(&mut detections, kind, "author_identity", &author_identity);
+    if let Some(kind) = detect_agent_from_identity(&metadata.author_identity) {
+        push_commit_agent_detection(
+            &mut detections,
+            kind,
+            "author_identity",
+            &metadata.author_identity,
+        );
     }
 
     detections

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1335,6 +1335,10 @@ impl Repository {
             .get_or_init(|| self.resolve_git_var_identity("GIT_COMMITTER_IDENT"))
     }
 
+    pub(crate) fn cached_git_author_identity(&self) -> Option<&GitAuthorIdentity> {
+        self.cached_author_identity.get()
+    }
+
     pub fn git_author_identity_resolution(&self) -> GitIdentityResolution {
         self.resolve_git_var_identity_resolution("GIT_COMMITTER_IDENT")
     }

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -1857,6 +1857,69 @@ fn test_update_ref_fast_forward_bounds_committed_hunks_to_final_commit() {
 }
 
 #[test]
+fn test_fast_forward_update_ref_does_not_attribute_remote_commit_to_local_user() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("base.txt"), "base\n").expect("write local base");
+    let old_tip = repo
+        .stage_all_and_commit("local base")
+        .expect("commit local base")
+        .commit_sha;
+
+    fs::write(repo.path().join("local-draft.txt"), "local draft\n").expect("write local draft");
+    repo.git_ai(&["checkpoint", "human", "local-draft.txt"])
+        .expect("seed old-tip working log");
+
+    fs::write(repo.path().join("remote.txt"), "remote contribution\n")
+        .expect("write remote contribution");
+    repo.git_og(&["add", "base.txt", "remote.txt"])
+        .expect("stage remote tree");
+    let remote_tree = repo.git_og(&["write-tree"]).expect("write remote tree");
+    let remote_tip = repo
+        .git_og_with_env(
+            &[
+                "commit-tree",
+                remote_tree.trim(),
+                "-p",
+                &old_tip,
+                "-m",
+                "remote contribution",
+            ],
+            &[
+                ("GIT_AUTHOR_NAME", "Remote Contributor"),
+                ("GIT_AUTHOR_EMAIL", "remote@example.com"),
+                ("GIT_COMMITTER_NAME", "Remote Contributor"),
+                ("GIT_COMMITTER_EMAIL", "remote@example.com"),
+            ],
+        )
+        .expect("create remote-authored commit")
+        .trim()
+        .to_string();
+
+    let branch = repo.current_branch();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/heads/{branch}"),
+        &remote_tip,
+        &old_tip,
+    ])
+    .expect("fast-forward update-ref should succeed");
+    repo.sync_daemon_force();
+
+    let note = repo
+        .read_authorship_note(&remote_tip)
+        .expect("fast-forward finalization should write an authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse authorship note");
+    assert!(
+        log.attestations
+            .iter()
+            .filter(|attestation| attestation.file_path == "remote.txt")
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| !entry.hash.starts_with("h_")),
+        "the remote contributor's lines must not be attributed to the local user"
+    );
+}
+
+#[test]
 fn test_delayed_current_branch_update_ref_trace_preserves_new_commit_attribution() {
     let repo = TestRepo::new();
     setup_initial_commit(&repo);

--- a/tests/integration/session_event_attribution.rs
+++ b/tests/integration/session_event_attribution.rs
@@ -3,6 +3,7 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::authorship_log::LineRange;
 use git_ai::authorship::authorship_log_serialization::{AuthorshipLog, generate_session_id};
 use git_ai::authorship::working_log::AgentId;
+use git_ai::config::AuthorConfig;
 use git_ai::daemon::bash_history_db::{BashCallEnd, BashCallStart, BashHistoryDatabase};
 use git_ai::metrics::db::MetricsDatabase;
 use git_ai::metrics::{EventAttributes, MetricEvent, PosEncoded, SessionEventValues};
@@ -433,6 +434,45 @@ fn test_terminal_recovery_marks_fully_unknown_commit_known_human() {
         human_attested_lines(&commit.authorship_log, "manual.txt"),
         vec![1, 2],
         "fully unknown committed lines should receive an h_ attestation"
+    );
+}
+
+#[test]
+fn test_terminal_recovery_accepts_local_git_identity_with_author_override() {
+    let (_metrics_db_dir, _bash_db_dir, mut repo) = terminal_recovery_repo();
+    repo.patch_git_ai_config(|patch| {
+        patch.author = Some(AuthorConfig {
+            name: Some("Configured User".to_string()),
+            email: Some("configured@example.com".to_string()),
+        });
+    });
+
+    fs::write(repo.path().join("manual.txt"), "manual edit\n").unwrap();
+    let commit = repo
+        .stage_all_and_commit_with_env(
+            "Manual edit with authorship override",
+            &[
+                ("GIT_AUTHOR_NAME", "Test User"),
+                ("GIT_AUTHOR_EMAIL", "TEST@EXAMPLE.COM"),
+            ],
+        )
+        .expect("manual commit should succeed");
+
+    let mut file = repo.filename("manual.txt");
+    file.assert_committed_lines(lines!["manual edit".human()]);
+    assert_eq!(
+        human_attested_lines(&commit.authorship_log, "manual.txt"),
+        vec![1],
+        "the raw Git identity should still identify a local commit"
+    );
+    assert!(
+        commit
+            .authorship_log
+            .metadata
+            .humans
+            .values()
+            .any(|human| human.author == "Configured User <configured@example.com>"),
+        "the attestation should retain the configured git-ai identity"
     );
 }
 
@@ -953,13 +993,7 @@ fn test_commit_metadata_recovery_ignores_freeform_message_agent_mentions() {
     fs::write(&file_path, "freeform codex mention falls back to human\n").unwrap();
 
     let commit = repo
-        .stage_all_and_commit_with_env(
-            "codex did things",
-            &[
-                ("GIT_AUTHOR_NAME", "Sasha Varlamov"),
-                ("GIT_AUTHOR_EMAIL", "sasha@sashavarlamov.com"),
-            ],
-        )
+        .stage_all_and_commit("codex did things")
         .expect("freeform mention commit should succeed");
 
     let mut file = repo.filename("metadata-freeform-agent-mention.txt");


### PR DESCRIPTION
## Summary

- guard terminal known-human recovery so it only applies when the commit author matches the local human identity
- accept either the configured git-ai identity or the already-cached raw Git identity, comparing email case-insensitively
- reuse commit metadata already read by the commit-metadata recovery solver and consult identity cache without initialization, adding no Git calls or I/O
- cover remote fast-forward attribution and git-ai author overrides with TestRepo regressions

## Why

A fast-forward ref update can finalize attribution for a pulled commit while passing the local user as `human_author`. When that remote commit had no AI attribution, terminal recovery could previously record its unknown lines as typed by the local user. The fallback now fails closed for other-authored commits while still recognizing locally authored commits when a git-ai author override or email casing makes the display identity differ.

## Validation

- `task test`
- `task test TEST_FILTER=test_fast_forward_update_ref_does_not_attribute_remote_commit_to_local_user`
- `task test TEST_FILTER=terminal_recovery`
- `task test TEST_FILTER=test_commit_metadata_recovery_ignores_freeform_message_agent_mentions`
- `task test TEST_FILTER=test_cherry_pick_conflict_ai_rewrite_resolution_is_attributed` (5 consecutive runs)
- `task lint`
- `task fmt`
- `git diff --check`