### PR TITLE
perf(checkpoint): avoid duplicate working-log materialization

### DIFF
--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -293,15 +293,12 @@ fn execute_resolved_checkpoint(
         entries.len(),
         entries_start.elapsed()
     );
+    let entry_count = entries.len();
 
     if !entries.is_empty() {
         let checkpoint_create_start = Instant::now();
-        let mut checkpoint = Checkpoint::new(
-            kind,
-            combined_hash.clone(),
-            author.to_string(),
-            entries.clone(),
-        );
+        let mut checkpoint =
+            Checkpoint::new(kind, combined_hash.clone(), author.to_string(), entries);
         checkpoint.timestamp = (resolved.ts / 1000) as u64;
         checkpoint.line_stats = compute_line_stats(&file_stats)?;
         checkpoint.trace_id = Some(trace_id.clone());
@@ -344,12 +341,14 @@ fn execute_resolved_checkpoint(
         );
 
         let append_start = Instant::now();
-        working_log.append_checkpoint(&checkpoint)?;
+        working_log.append_checkpoint_to(&mut checkpoints, checkpoint)?;
         tracing::debug!(
             "[BENCHMARK] Appending checkpoint to working log took {:?}",
             append_start.elapsed()
         );
-        checkpoints.push(checkpoint.clone());
+        let checkpoint = checkpoints
+            .last()
+            .expect("the appended checkpoint must remain in the working log");
 
         let mut attrs =
             build_checkpoint_attrs(repo, &resolved.base_commit, checkpoint.agent_id.as_ref());
@@ -372,7 +371,7 @@ fn execute_resolved_checkpoint(
             .get("edit_kind")
             .map(|s| s.as_str());
 
-        for (entry, file_stat) in entries.iter().zip(file_stats.iter()) {
+        for (entry, file_stat) in checkpoint.entries.iter().zip(file_stats.iter()) {
             let mut values = crate::metrics::CheckpointValues::new()
                 .checkpoint_ts(checkpoint.timestamp)
                 .kind(checkpoint.kind.to_str().to_string())
@@ -403,7 +402,7 @@ fn execute_resolved_checkpoint(
         None
     };
 
-    let label = if entries.len() > 1 {
+    let label = if entry_count > 1 {
         "checkpoint"
     } else {
         "commit"
@@ -411,7 +410,7 @@ fn execute_resolved_checkpoint(
 
     if !quiet {
         let log_author = agent_tool.unwrap_or(author);
-        let files_with_entries = entries.len();
+        let files_with_entries = entry_count;
         let total_uncommitted_files = resolved.files.len();
 
         if files_with_entries == total_uncommitted_files {
@@ -439,7 +438,7 @@ fn execute_resolved_checkpoint(
         "[BENCHMARK] Total checkpoint run took {:?}",
         checkpoint_start.elapsed()
     );
-    Ok((entries.len(), resolved.files.len(), checkpoints.len()))
+    Ok((entry_count, resolved.files.len(), checkpoints.len()))
 }
 
 fn save_current_file_states(

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -461,23 +461,30 @@ impl PersistedWorkingLog {
 
     /* append checkpoint */
     pub fn append_checkpoint(&self, checkpoint: &Checkpoint) -> Result<(), GitAiError> {
-        crate::wltrace::wltrace("working_log.append_checkpoint", &self.dir, String::new);
-        // Read existing checkpoints
         let mut checkpoints = self.read_all_checkpoints().unwrap_or_default();
+        self.append_checkpoint_to(&mut checkpoints, checkpoint.clone())
+    }
 
-        // Create a copy, potentially without transcript to reduce storage size.
-        //
-        // Tools that DON'T support refetch (transcript must be kept):
-        // - "mock_ai" - test preset, transcript not stored externally
-        // - Any other agent-v1 custom tools (detected by lack of tool-specific metadata)
-        checkpoints.push(checkpoint.clone());
+    /// Append to a checkpoint collection that the caller has already loaded.
+    ///
+    /// Checkpoint execution needs the prior collection to calculate attribution.
+    /// Reusing it here avoids deserializing the entire working log a second time
+    /// and avoids cloning the new checkpoint's attribution payload.
+    pub fn append_checkpoint_to(
+        &self,
+        checkpoints: &mut Vec<Checkpoint>,
+        checkpoint: Checkpoint,
+    ) -> Result<(), GitAiError> {
+        crate::wltrace::wltrace("working_log.append_checkpoint", &self.dir, String::new);
+
+        checkpoints.push(checkpoint);
 
         // Prune char-level attributions from older checkpoints for the same files
         // Only the most recent checkpoint per file needs char-level precision
-        self.prune_old_char_attributions(&mut checkpoints);
+        self.prune_old_char_attributions(checkpoints);
 
         // Write all checkpoints back
-        self.write_all_checkpoints(&checkpoints)
+        self.write_all_checkpoints(checkpoints)
     }
 
     pub fn read_all_checkpoints(&self) -> Result<Vec<Checkpoint>, GitAiError> {
@@ -501,6 +508,7 @@ impl PersistedWorkingLog {
         &self,
         max_bytes: u64,
     ) -> Result<Vec<Checkpoint>, GitAiError> {
+        crate::wltrace::wltrace("working_log.read_checkpoints", &self.dir, String::new);
         let checkpoints_file = self.checkpoints_file();
 
         if !checkpoints_file.exists() {

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1792,9 +1792,6 @@ fn wltrace_captures_daemon_working_log_ops_when_enabled() {
     fs::write(&file_path, "AI content\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "traced.txt"])
         .unwrap();
-    repo.current_working_logs()
-        .read_all_checkpoints()
-        .expect("checkpoint should be readable");
 
     let trace = fs::read_to_string(trace_file.path()).expect("read wltrace output");
     for op in [
@@ -1806,6 +1803,14 @@ fn wltrace_captures_daemon_working_log_ops_when_enabled() {
     ] {
         assert!(trace.contains(op), "wltrace output missing {op}:\n{trace}");
     }
+    assert_eq!(
+        trace
+            .lines()
+            .filter(|line| line.contains("op=working_log.read_checkpoints "))
+            .count(),
+        1,
+        "one checkpoint must deserialize the working log only once:\n{trace}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reuse the checkpoint collection already deserialized for attribution when persisting the new checkpoint
- move the new entry payload into the checkpoint instead of cloning it
- trace working-log reads and assert a daemon checkpoint performs exactly one full deserialization

## Why

The checkpoint path read `checkpoints.jsonl` twice and cloned the newly built attribution payload multiple times before rewriting it. The amplification grows with working-log size and is avoidable because checkpoint execution already owns the complete prior collection.

This remains downstream of trace2 ingestion and adds no Git or filesystem work to the critical ingestion path.

## TDD / validation

The `TestRepo` wltrace regression failed before the implementation with two `working_log.read_checkpoints` events and passes with exactly one.

- `task test`
- `task lint`
- `task fmt`
