### PR TITLE
fix(daemon): cap glibc allocator arena retention

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -17,17 +17,6 @@ use std::time::{Duration, Instant};
 #[cfg(windows)]
 use std::{ffi::OsStr, path::Path};
 
-// Tokio otherwise defaults to one async worker per CPU. Those long-lived
-// workers create allocator arenas that are costly in the daemon, while its own
-// queues already bound useful async concurrency. The blocking pool remains
-// larger than the worker pool so block_in_place can hand off async worker cores
-// without stalling trace ingestion.
-const DAEMON_RUNTIME_WORKER_THREADS: usize = 4;
-// Tokio's default permits hundreds of blocking threads. Each can leave a large
-// allocator arena resident after processing checkpoint content, so cap the
-// long-lived daemon while preserving ample spare capacity for block_in_place.
-const DAEMON_RUNTIME_MAX_BLOCKING_THREADS: usize = 16;
-
 pub fn handle_daemon(args: &[String]) {
     if args.is_empty() || is_help(args[0].as_str()) {
         print_help();
@@ -191,6 +180,7 @@ fn handle_run(args: &[String]) -> Result<(), String> {
     if has_flag(args, "--mode") {
         return Err("--mode is no longer supported; daemon always runs in write mode".to_string());
     }
+    crate::tokio_runtime::configure_daemon_allocator()?;
     ensure_daemon_start_allowed()?;
     let config = daemon_config_from_env_or_default_paths()?;
     let runtime_dir = daemon_runtime_dir(&config)?;
@@ -201,7 +191,7 @@ fn handle_run(args: &[String]) -> Result<(), String> {
             e
         )
     })?;
-    let runtime = build_daemon_runtime()?;
+    let runtime = crate::tokio_runtime::build_daemon_runtime()?;
     crate::tokio_runtime::initialize();
     let exit_action = runtime
         .block_on(async move { crate::daemon::run_daemon(config).await })
@@ -232,15 +222,6 @@ fn handle_run(args: &[String]) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-fn build_daemon_runtime() -> Result<tokio::runtime::Runtime, String> {
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(DAEMON_RUNTIME_WORKER_THREADS)
-        .max_blocking_threads(DAEMON_RUNTIME_MAX_BLOCKING_THREADS)
-        .enable_all()
-        .build()
-        .map_err(|e| e.to_string())
 }
 
 pub(crate) fn ensure_daemon_running(
@@ -816,62 +797,4 @@ fn print_help() {
     eprintln!("  git-ai bg shutdown [--hard]");
     eprintln!("  git-ai bg restart [--hard]");
     eprintln!("  git-ai bg tail [-n <lines>] [--full] [-f | --follow]");
-}
-
-#[cfg(all(test, not(windows)))]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
-    #[test]
-    fn daemon_runtime_worker_pool_is_bounded() {
-        let runtime = build_daemon_runtime().unwrap();
-
-        assert_eq!(
-            runtime.metrics().num_workers(),
-            DAEMON_RUNTIME_WORKER_THREADS
-        );
-    }
-
-    #[test]
-    fn daemon_runtime_blocking_pool_is_memory_bounded() {
-        let runtime = build_daemon_runtime().unwrap();
-        let active = Arc::new(AtomicUsize::new(0));
-        let peak = Arc::new(AtomicUsize::new(0));
-        let release = Arc::new(AtomicBool::new(false));
-
-        runtime.block_on(async {
-            let mut handles = Vec::new();
-            for _ in 0..20 {
-                let active = Arc::clone(&active);
-                let peak = Arc::clone(&peak);
-                let release = Arc::clone(&release);
-                handles.push(tokio::task::spawn_blocking(move || {
-                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-                    peak.fetch_max(current, Ordering::SeqCst);
-                    while !release.load(Ordering::SeqCst) {
-                        std::thread::sleep(Duration::from_millis(1));
-                    }
-                    active.fetch_sub(1, Ordering::SeqCst);
-                }));
-            }
-
-            let deadline = Instant::now() + Duration::from_secs(2);
-            while peak.load(Ordering::SeqCst) < 16 && Instant::now() < deadline {
-                tokio::time::sleep(Duration::from_millis(1)).await;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-            release.store(true, Ordering::SeqCst);
-            for handle in handles {
-                handle.await.unwrap();
-            }
-        });
-
-        assert_eq!(
-            peak.load(Ordering::SeqCst),
-            16,
-            "daemon runtime must activate exactly sixteen blocking threads under load"
-        );
-    }
 }

--- a/src/daemon/checkpoint.rs
+++ b/src/daemon/checkpoint.rs
@@ -593,6 +593,14 @@ fn get_checkpoint_entry_for_file(
     parent_note_attributions: Arc<HashMap<String, Vec<LineAttribution>>>,
     ts: u128,
 ) -> Result<Option<(WorkingLogEntry, FileLineStats)>, GitAiError> {
+    // Deterministic blocking work for the TestRepo throughput guard; release builds omit it.
+    #[cfg(feature = "test-support")]
+    if let Some(delay_millis) = std::env::var_os("GIT_AI_TEST_CHECKPOINT_FILE_DELAY_MS")
+        .and_then(|value| value.to_str().and_then(|value| value.parse::<u64>().ok()))
+    {
+        std::thread::sleep(std::time::Duration::from_millis(delay_millis));
+    }
+
     let file_start = Instant::now();
     let initial_attrs_for_file = initial_attributions
         .get(&file_path)

--- a/src/tokio_runtime.rs
+++ b/src/tokio_runtime.rs
@@ -9,6 +9,67 @@ const HELPER_RUNTIME_WORKER_THREADS: usize = 2;
 // their high-water memory across those arenas. Queue excess blocking tasks on a
 // small pool instead; this work is downstream of trace ingestion.
 const HELPER_RUNTIME_MAX_BLOCKING_THREADS: usize = 4;
+// The daemon's own queues already bound useful async concurrency. Keeping this
+// runtime small prevents CPU-count-sized worker and allocator arena growth.
+const DAEMON_RUNTIME_WORKER_THREADS: usize = 4;
+const DAEMON_RUNTIME_MAX_BLOCKING_THREADS: usize = 16;
+const BLOCKING_THREAD_KEEP_ALIVE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Constrain glibc's per-thread allocation arenas before the daemon creates
+/// worker threads. Large checkpoint buffers otherwise leave hundreds of MiB
+/// resident in arenas that glibc keeps for the lifetime of the daemon.
+pub(crate) fn configure_daemon_allocator() -> Result<(), String> {
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    {
+        const DEFAULT_ARENA_MAX: i32 = 2;
+        let arena_max = std::env::var("MALLOC_ARENA_MAX")
+            .ok()
+            .and_then(|value| value.parse::<i32>().ok())
+            .filter(|value| *value > 0)
+            .map_or(DEFAULT_ARENA_MAX, |value| value.min(DEFAULT_ARENA_MAX));
+
+        // SAFETY: mallopt is process-global and this runs before either Tokio
+        // runtime creates worker threads. M_ARENA_MAX accepts a positive int.
+        if unsafe { libc::mallopt(libc::M_ARENA_MAX, arena_max) } == 0 {
+            return Err("failed to configure glibc allocator arena limit".to_string());
+        }
+
+        #[cfg(feature = "test-support")]
+        if let Some(path) = std::env::var_os("GIT_AI_TEST_ALLOCATOR_POLICY_LOG") {
+            use std::io::Write;
+
+            let mut log = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .expect("failed opening test allocator policy log");
+            writeln!(log, "arena_max={arena_max}")
+                .expect("failed writing test allocator policy log");
+        }
+    }
+
+    Ok(())
+}
+
+fn build_bounded_runtime(
+    worker_threads: usize,
+    max_blocking_threads: usize,
+) -> Result<tokio::runtime::Runtime, String> {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(worker_threads)
+        .max_blocking_threads(max_blocking_threads)
+        .thread_keep_alive(BLOCKING_THREAD_KEEP_ALIVE)
+        .enable_all()
+        .build()
+        .map_err(|err| err.to_string())
+}
+
+pub(crate) fn build_daemon_runtime() -> Result<tokio::runtime::Runtime, String> {
+    build_bounded_runtime(
+        DAEMON_RUNTIME_WORKER_THREADS,
+        DAEMON_RUNTIME_MAX_BLOCKING_THREADS,
+    )
+}
 
 // Post-commit attribution calls this helper from inside the daemon runtime.
 // Recreating a CPU-sized runtime for every call leaves allocator arenas at
@@ -28,13 +89,11 @@ fn runtime() -> &'static tokio::runtime::Runtime {
             writeln!(log, "runtime").expect("failed writing test Tokio runtime build log");
         }
 
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(HELPER_RUNTIME_WORKER_THREADS)
-            .max_blocking_threads(HELPER_RUNTIME_MAX_BLOCKING_THREADS)
-            .thread_keep_alive(std::time::Duration::from_secs(60))
-            .enable_all()
-            .build()
-            .expect("failed to create Tokio runtime")
+        build_bounded_runtime(
+            HELPER_RUNTIME_WORKER_THREADS,
+            HELPER_RUNTIME_MAX_BLOCKING_THREADS,
+        )
+        .expect("failed to create Tokio runtime")
     })
 }
 
@@ -134,6 +193,24 @@ mod tests {
             peak_blocking_concurrency(runtime(), 8, 4),
             4,
             "helper runtime must activate exactly four blocking threads under load"
+        );
+    }
+
+    #[test]
+    fn daemon_runtime_worker_pool_is_bounded() {
+        assert_eq!(
+            build_daemon_runtime().unwrap().metrics().num_workers(),
+            DAEMON_RUNTIME_WORKER_THREADS
+        );
+    }
+
+    #[test]
+    fn daemon_runtime_blocking_pool_is_memory_bounded() {
+        let runtime = build_daemon_runtime().unwrap();
+        assert_eq!(
+            peak_blocking_concurrency(&runtime, 20, DAEMON_RUNTIME_MAX_BLOCKING_THREADS),
+            DAEMON_RUNTIME_MAX_BLOCKING_THREADS,
+            "daemon runtime must enforce the shared blocking-thread policy"
         );
     }
 }

--- a/tests/integration/daemon_runtime_memory.rs
+++ b/tests/integration/daemon_runtime_memory.rs
@@ -1,9 +1,93 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use std::fs;
+use std::time::{Duration, Instant};
 
 fn runtime_build_count(path: &std::path::Path) -> usize {
     fs::read_to_string(path).unwrap_or_default().lines().count()
+}
+
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[test]
+fn daemon_limits_glibc_allocator_arenas() {
+    let temp = tempfile::tempdir().unwrap();
+    let allocator_policy_log = temp.path().join("allocator-policy.log");
+    let _repo = TestRepo::new_with_daemon_env(&[
+        (
+            "GIT_AI_TEST_ALLOCATOR_POLICY_LOG",
+            allocator_policy_log.to_str().unwrap(),
+        ),
+        ("MALLOC_ARENA_MAX", "2"),
+    ]);
+
+    assert_eq!(
+        fs::read_to_string(&allocator_policy_log).unwrap_or_default(),
+        "arena_max=2\n",
+        "the long-lived daemon must constrain glibc arena retention before starting worker threads"
+    );
+}
+
+#[test]
+fn bounded_helper_pool_sustains_multifile_checkpoint_throughput() {
+    const FILE_COUNT: usize = 12;
+    const FILE_WORK_MILLIS: u64 = 200;
+    const MIN_FILES_PER_SECOND: f64 = 10.0;
+
+    let file_work_millis = FILE_WORK_MILLIS.to_string();
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_CHECKPOINT_FILE_DELAY_MS",
+        file_work_millis.as_str(),
+    )]);
+    let filenames: Vec<_> = (0..FILE_COUNT)
+        .map(|index| format!("throughput-{index}.txt"))
+        .collect();
+
+    for filename in &filenames {
+        fs::write(repo.path().join(filename), "base\n").unwrap();
+    }
+    repo.stage_all_and_commit("throughput base").unwrap();
+    for filename in &filenames {
+        repo.filename(filename)
+            .assert_committed_lines(lines!["base".unattributed_human()]);
+    }
+
+    for (index, filename) in filenames.iter().enumerate() {
+        fs::write(
+            repo.path().join(filename),
+            format!("base\nAI throughput line {index}\n"),
+        )
+        .unwrap();
+    }
+    let mut checkpoint_args = vec!["checkpoint", "mock_ai"];
+    checkpoint_args.extend(filenames.iter().map(String::as_str));
+
+    let started = Instant::now();
+    repo.git_ai(&checkpoint_args).unwrap();
+    repo.sync_daemon();
+    let elapsed = started.elapsed();
+    let files_per_second = FILE_COUNT as f64 / elapsed.as_secs_f64();
+    eprintln!(
+        "bounded helper checkpoint throughput: {files_per_second:.1} files/s \
+         ({FILE_COUNT} files in {elapsed:?})"
+    );
+
+    assert!(
+        elapsed >= Duration::from_millis(FILE_WORK_MILLIS),
+        "the injected per-file work was not exercised; elapsed={elapsed:?}"
+    );
+    assert!(
+        files_per_second >= MIN_FILES_PER_SECOND,
+        "bounded helper pool checkpoint throughput regressed: {files_per_second:.1} files/s \
+         ({FILE_COUNT} files in {elapsed:?}, minimum {MIN_FILES_PER_SECOND:.1} files/s)"
+    );
+
+    repo.stage_all_and_commit("throughput checkpoint").unwrap();
+    for (index, filename) in filenames.iter().enumerate() {
+        repo.filename(filename).assert_committed_lines(lines![
+            "base".unattributed_human(),
+            format!("AI throughput line {index}").ai(),
+        ]);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- centralize all production multi-thread Tokio runtime construction behind one bounded policy
- retire idle blocking workers after 10 seconds
- on Linux/glibc, set `M_ARENA_MAX=2` before the daemon creates worker threads
- preserve an explicitly stricter user arena limit
- add a `TestRepo` daemon-start regression proving allocator policy installation
- add a deterministic `TestRepo` throughput guard for the bounded helper pool

## Root cause and measured effect

Large checkpoint buffers raised glibc per-thread arenas to high-water marks that stayed resident in the long-lived daemon. Bounding Tokio reduced the number of arenas, but the surviving arenas still retained hundreds of MiB. The causal control—unmodified v1.6.17 with `MALLOC_ARENA_MAX=2`—had already isolated this behavior.

Exact 12-file × 2 MiB real-agent flow, with `git-ai await` after every commit:

| build | duration | commits | peak RSS | final RSS | peak VmSize | errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| v1.6.17 | 45s | 8 | 1,180 MB | — | 5,929 MB | 0 |
| bounded runtimes | 120s | 18 | 887 MB | — | 1,809 MB | 0 |
| this PR stack | 45s | 7 | 230 MB | 154 MB | 337 MB | 0 |
| this PR stack | 120s | 17 | 225 MB | 111 MB | 278 MB | 0 |

The 120-second run plateaued rather than climbing and remained responsive with zero control-probe failures and zero backlog. This is about 80% below the exact incident-release reproduction.

The allocator policy is daemon-only and Linux/glibc-only. Other platforms and short-lived CLI processes retain native allocator behavior. No work is added to trace2 ingestion.

## Throughput guard

The new test checkpoints 12 files through a real `TestRepo` daemon and waits for the daemon to drain. Test-support builds inject 200 ms of deterministic blocking work per file, giving a serialized implementation a 2.4-second floor (5 files/s). The bounded four-worker pool completes in about 617 ms (19.4 files/s), and the test enforces a conservative minimum of 10 files/s. The injected work is compiled out of release builds.

## Validation

- `task test`: 2,150 library, 75 daemon, 3,264 integration, 22 notes-sync tests, plus doctests; zero failures
- `task lint`
- `task fmt`
- deterministic runtime concurrency tests
- `TestRepo` allocator-policy regression
- `TestRepo` bounded-helper throughput regression: 19.4 files/s measured, 10 files/s minimum
- 45-second and 120-second isolated high-volume RSS reproductions
