### PR TITLE
Count KnownHuman lines in range stats

### DIFF
--- a/src/authorship/diff_ai_accepted.rs
+++ b/src/authorship/diff_ai_accepted.rs
@@ -8,6 +8,9 @@ use crate::git::repository::Repository;
 #[derive(Debug, Default)]
 pub struct DiffAiAcceptedStats {
     pub total_ai_accepted: u32,
+    /// Lines carrying an `h_`-prefixed KnownHuman attestation. Counted from the
+    /// same blame pass as the AI lines, so this costs no extra git work.
+    pub total_known_human_accepted: u32,
     pub per_tool_model: BTreeMap<String, u32>,
     pub per_prompt: BTreeMap<String, u32>,
 }
@@ -64,14 +67,20 @@ pub fn diff_ai_accepted_stats(
         }
 
         for line in &lines {
-            if let Some(author_hash) = line_authors.get(line)
-                && prompt_records.contains_key(author_hash)
-            {
+            let Some(author_hash) = line_authors.get(line) else {
+                continue;
+            };
+            if prompt_records.contains_key(author_hash) {
                 stats.total_ai_accepted += 1;
                 *stats.per_prompt.entry(author_hash.clone()).or_insert(0) += 1;
                 if let Some(tool_model) = author_tool_map.get(author_hash) {
                     *stats.per_tool_model.entry(tool_model.clone()).or_insert(0) += 1;
                 }
+            } else if author_hash.starts_with("h_") {
+                // KnownHuman attestation: blame reports the `h_` hash as the author
+                // when `use_prompt_hashes_as_names` is set, and it is never a prompt
+                // record. Without this branch these lines fall through to "unknown".
+                stats.total_known_human_accepted += 1;
             }
         }
     }
@@ -173,6 +182,7 @@ mod tests {
     fn test_diff_ai_accepted_stats_default() {
         let stats = DiffAiAcceptedStats::default();
         assert_eq!(stats.total_ai_accepted, 0);
+        assert_eq!(stats.total_known_human_accepted, 0);
         assert_eq!(stats.per_tool_model.len(), 0);
         assert_eq!(stats.per_prompt.len(), 0);
     }
@@ -181,8 +191,7 @@ mod tests {
     fn test_diff_ai_accepted_stats_debug() {
         let stats = DiffAiAcceptedStats {
             total_ai_accepted: 10,
-            per_tool_model: BTreeMap::new(),
-            per_prompt: BTreeMap::new(),
+            ..Default::default()
         };
         let debug_str = format!("{:?}", stats);
         assert!(debug_str.contains("DiffAiAcceptedStats"));

--- a/src/authorship/range_authorship.rs
+++ b/src/authorship/range_authorship.rs
@@ -423,7 +423,7 @@ fn calculate_range_stats_direct(
         git_diff_added_lines,
         git_diff_deleted_lines,
         diff_ai_stats.total_ai_accepted,
-        0,
+        diff_ai_stats.total_known_human_accepted,
         &diff_ai_stats.per_tool_model,
     );
 

--- a/tests/integration/range_authorship_unit.rs
+++ b/tests/integration/range_authorship_unit.rs
@@ -223,9 +223,9 @@ fn test_range_authorship_mixed_commits() {
     // Range authorship merges attributions from start to end, filtering to commits in range
     // The exact AI/human split depends on the merge attribution logic
     assert_eq!(stats.range_stats.ai_additions, 2);
-    // range_authorship passes known_human_accepted=0, so human lines appear as unknown_additions
-    assert_eq!(stats.range_stats.human_additions, 0);
-    assert_eq!(stats.range_stats.unknown_additions, 1);
+    // KnownHuman lines are attested, so they land in human_additions, not unknown_additions
+    assert_eq!(stats.range_stats.human_additions, 1);
+    assert_eq!(stats.range_stats.unknown_additions, 0);
     assert_eq!(stats.range_stats.git_diff_added_lines, 3);
 }
 
@@ -449,10 +449,9 @@ fn test_range_authorship_mixed_lockfile_and_source() {
     assert_eq!(stats.range_stats.git_diff_added_lines, 3); // Only lib.rs, package-lock.json excluded
     // Verify the total is much less than 3003 (if lockfile was included)
     assert!(stats.range_stats.git_diff_added_lines < 100);
-    // Verify that some AI work is detected and unattested lines exist
+    // Verify that some AI work is detected and the KnownHuman line is attested as human
     assert!(stats.range_stats.ai_additions > 0);
-    // range_authorship passes known_human_accepted=0, so human lines show as unknown_additions
-    assert!(stats.range_stats.unknown_additions > 0);
+    assert!(stats.range_stats.human_additions > 0);
 }
 
 #[test]
@@ -1032,4 +1031,108 @@ fn test_range_authorship_with_glob_patterns() {
     // Should only count the 1 line in main.rs, ignoring 1700 lines in lockfiles and generated files
     assert_eq!(stats.range_stats.git_diff_added_lines, 1);
     assert_eq!(stats.range_stats.ai_additions, 1);
+}
+
+/// Regression test for https://github.com/git-ai-project/git-ai/issues/1875
+///
+/// A range query must attribute KnownHuman lines the same way a per-commit
+/// query does. Before the fix, `calculate_range_stats_direct` passed a
+/// hard-coded `known_human_accepted = 0`, so every `h_`-attested line fell
+/// through into `unknown_additions` and `human_additions` was always zero for
+/// ranges. The sum of the per-commit stats is the ground truth the range has to
+/// agree with.
+#[test]
+fn test_range_stats_match_sum_of_per_commit_stats_for_known_human_lines() {
+    use crate::repos::test_file::ExpectedLineExt;
+    use git_ai::authorship::stats::stats_for_commit_stats;
+
+    let repo = TestRepo::new();
+
+    // Base commit: one untracked line, so the range starts from real content.
+    std::fs::write(repo.path().join("test.txt"), "base\n").unwrap();
+    repo.git(&["add", "test.txt"]).unwrap();
+    repo.stage_all_and_commit("Base commit").unwrap();
+    let base_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let mut file = repo.filename("test.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human()]);
+
+    // Commit A: AI writes two lines.
+    std::fs::write(repo.path().join("test.txt"), "base\nai one\nai two\n").unwrap();
+    repo.git(&["add", "test.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "test.txt"]).unwrap();
+    repo.stage_all_and_commit("AI commit").unwrap();
+    let ai_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "ai one".ai(),
+        "ai two".ai(),
+    ]);
+
+    // Commit B: a known human writes one line.
+    std::fs::write(
+        repo.path().join("test.txt"),
+        "base\nai one\nai two\nhuman one\n",
+    )
+    .unwrap();
+    repo.git(&["add", "test.txt"]).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Known human commit").unwrap();
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "ai one".ai(),
+        "ai two".ai(),
+        "human one".human(),
+    ]);
+    let human_sha = repo
+        .git_og(&["rev-parse", "HEAD"])
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let gitai_repo = find_repository_in_path(repo.path().to_str().unwrap()).unwrap();
+    let ignore_patterns: Vec<String> = vec![];
+
+    // Ground truth: the per-commit numbers each commit reports for itself.
+    let ai_commit_stats = stats_for_commit_stats(&gitai_repo, &ai_sha, &ignore_patterns).unwrap();
+    let human_commit_stats =
+        stats_for_commit_stats(&gitai_repo, &human_sha, &ignore_patterns).unwrap();
+
+    assert_eq!(ai_commit_stats.ai_additions, 2);
+    assert_eq!(ai_commit_stats.human_additions, 0);
+    assert_eq!(human_commit_stats.ai_additions, 0);
+    assert_eq!(human_commit_stats.human_additions, 1);
+
+    let commit_range = CommitRange::new_infer_refname(
+        &gitai_repo,
+        base_sha.clone(),
+        human_sha.clone(),
+        Some("HEAD".to_string()),
+    )
+    .unwrap();
+    let range = range_authorship(commit_range, false, &ignore_patterns, None).unwrap();
+
+    assert_eq!(
+        range.range_stats.ai_additions,
+        ai_commit_stats.ai_additions + human_commit_stats.ai_additions,
+    );
+    assert_eq!(
+        range.range_stats.human_additions,
+        ai_commit_stats.human_additions + human_commit_stats.human_additions,
+        "range dropped the KnownHuman line that the per-commit query reports",
+    );
+    assert_eq!(
+        range.range_stats.unknown_additions,
+        ai_commit_stats.unknown_additions + human_commit_stats.unknown_additions,
+        "KnownHuman lines leaked into unknown_additions",
+    );
+    assert_eq!(range.range_stats.git_diff_added_lines, 3);
 }

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -472,10 +472,10 @@ fn test_stats_cli_empty_tree_range() {
     assert_eq!(stats.authorship_stats.total_commits, 2);
     assert_eq!(stats.range_stats.git_diff_added_lines, 2);
     assert_eq!(stats.range_stats.ai_additions, 1);
-    // Range stats use legacy Human checkpoints and pass known_human_accepted=0,
-    // so human lines appear as unknown_additions (not human_additions).
-    assert_eq!(stats.range_stats.human_additions, 0);
-    assert_eq!(stats.range_stats.unknown_additions, 1);
+    // The KnownHuman line is attested, so it counts as human_additions and
+    // nothing is left over as unknown.
+    assert_eq!(stats.range_stats.human_additions, 1);
+    assert_eq!(stats.range_stats.unknown_additions, 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1875

## The report

`git ai stats <A>..<B> --json` disagrees with the sum of the per-commit queries: a commit whose 6 added lines are KnownHuman reports `human_additions: 6` on its own, but inside a range those same 6 lines come back as `unknown_additions: 6, human_additions: 0`. The issue describes it as an inversion; it is narrower than that.

## Root cause

`calculate_range_stats_direct` (`src/authorship/range_authorship.rs`) passes a hard-coded `0` as `known_human_accepted`:

```rust
let stats = stats_from_authorship_log(
    Some(&authorship_log),
    git_diff_added_lines,
    git_diff_deleted_lines,
    diff_ai_stats.total_ai_accepted,
    0,                                   // <-- known_human_accepted
    &diff_ai_stats.per_tool_model,
);
```

`stats_from_authorship_log` then computes `unknown = added - ai_accepted - known_human_accepted`, so with `known_human_accepted = 0` every `h_`-attested line in the range lands in `unknown_additions` and `human_additions` can never be anything but zero. The per-commit path (`stats_for_commit_stats_from_hunks`) passes the real count from `accepted_lines_from_attestations`, which is why the two paths disagree.

## The fix

`diff_ai_accepted_stats` already blames every added line in the range with `use_prompt_hashes_as_names`, and blame reports KnownHuman lines under their `h_` hash (`src/commands/blame.rs`, the `hash.starts_with("h_")` branch). Those lines are simply never counted, because the existing loop only counts hashes present in `prompt_records`.

So the count is taken from the same blame pass, in the same loop, and surfaced as `DiffAiAcceptedStats::total_known_human_accepted`. `calculate_range_stats_direct` passes it through instead of the literal `0`.

No extra git spawns, no extra object lookups, no per-item work — the data was already in hand.

## Tests

TDD, red first. New regression test in `tests/integration/range_authorship_unit.rs` asserts the invariant the issue is really about: **range stats must equal the sum of the per-commit stats.** It builds a base commit, an AI commit (`mock_ai`) and a KnownHuman commit (`mock_known_human`), asserts line-level attribution after every commit, then compares the range against the per-commit ground truth.

Before the fix:

```
test range_authorship_unit::test_range_stats_match_sum_of_per_commit_stats_for_known_human_lines ... FAILED
assertion `left == right` failed: range dropped the KnownHuman line that the per-commit query reports
  left: 0
 right: 1
```

Three existing assertions had pinned the old behaviour as expected, each carrying a comment that named the hard-coded zero as the reason:

- `range_authorship_unit.rs` — `test_range_authorship_mixed_commits`
- `range_authorship_unit.rs` — `test_range_authorship_mixed_lockfile_and_source`
- `stats.rs` — `test_stats_cli_empty_tree_range` (CLI level, `git ai stats <range> --json`)

Each now asserts the corrected numbers, and the comments are updated to say what the behaviour is rather than why it was wrong.

Local results (macOS):

```
cargo test range_authorship   → 29 passed; 0 failed
cargo test stats::            → 25 passed; 0 failed
cargo fmt -- --check          → clean
cargo clippy --all-targets    → no new findings in the touched files
```

The `*_in_worktree` variants do not run on this machine — its git is 2.39.5, and `git worktree add --orphan` needs git >= 2.42. They fail identically on unmodified `main` here, so they are left to CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->