### PR TITLE
feat: add lite mode for daemon note rewrites

### DIFF
--- a/docs/rewrite-ops-spec.md
+++ b/docs/rewrite-ops-spec.md
@@ -72,6 +72,18 @@ history rewrite (rebase, `pull --rebase`, amend, `commit-tree`+`update-ref`
 restacks, squashes) into these events with *exact* commit SHAs. The rewrite
 core never guesses what operation happened; that is the ingestion layer's job.
 
+### Lite mode
+
+The `lite_mode` feature flag disables authorship-note migration for rewrites
+handled asynchronously by the daemon. In lite mode, ordinary new commits and
+regular `merge --squash` commits still write authorship notes, while rebase,
+amend, cherry-pick, revert, divergent reset/restack, and direct `update-ref`
+rewrites do not create notes for their replacement commits. Working-log moves
+that do not rewrite notes are preserved.
+
+This gate belongs only to daemon side-effect dispatch. Explicit `git-ai ci`
+commands continue to use the rewrite core regardless of lite mode.
+
 ## Core note-shift algorithm
 
 Given a set of `(source_commit, destination_commit)` mappings:

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -208,6 +208,7 @@ pub fn handle_config(args: &[String]) {
             }
             if key == "feature_flags.transcript_streaming"
                 || key == "feature_flags.transcript_sweep"
+                || key == "feature_flags.lite_mode"
                 || key == "transcript_streaming_lookback_days"
                 || key == "daemon_memory_limit_mb"
             {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6438,6 +6438,8 @@ impl ActorDaemonCoordinator {
                         continue;
                     }
                     if lite_mode {
+                        // The trace-derived pass above already moved the working log when this
+                        // transition also moved HEAD. Avoid the commit-graph lookup and note write.
                         continue;
                     }
                     let repo = find_repository_in_path(&worktree.to_string_lossy())?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5381,7 +5381,9 @@ impl ActorDaemonCoordinator {
             if let Some((original_head, _)) = pending_original_head.as_ref()
                 && let Some(new_tip) = rebase_new_tip_from_command(cmd, original_head)
             {
-                repo.storage.rename_working_log(original_head, &new_tip)?;
+                if original_head != &new_tip {
+                    repo.storage.rename_working_log(original_head, &new_tip)?;
+                }
                 return Ok(());
             }
             for (old_tip, new_tip) in collapsed.values() {
@@ -5977,6 +5979,13 @@ impl ActorDaemonCoordinator {
                         new_commits,
                     } => {
                         if lite_mode {
+                            if !original_head.is_empty()
+                                && !new_head.is_empty()
+                                && original_head != new_head
+                            {
+                                let repo = find_repository_in_path(&worktree)?;
+                                repo.storage.rename_working_log(original_head, new_head)?;
+                            }
                             self.clear_pending_cherry_pick_sources_for_worktree(worktree.as_ref())?;
                         } else if !new_head.is_empty() {
                             let repo = find_repository_in_path(&worktree)?;
@@ -6180,6 +6189,14 @@ impl ActorDaemonCoordinator {
                             if !handled_revert_commits {
                                 handled_revert_commits = true;
                                 if lite_mode {
+                                    if let Some(base) = base.as_deref()
+                                        && let Some(destination) =
+                                            revert_destination_changes(cmd).last()
+                                        && base != destination.new
+                                    {
+                                        let repo = find_repository_in_path(&worktree)?;
+                                        repo.storage.rename_working_log(base, &destination.new)?;
+                                    }
                                     continue;
                                 }
                                 // A single `git revert A B` creates one commit per source.
@@ -6262,8 +6279,7 @@ impl ActorDaemonCoordinator {
                         }
                     }
                     crate::daemon::domain::SemanticEvent::CommitAmended { old_head, new_head } => {
-                        if !lite_mode
-                            && !old_head.is_empty()
+                        if !old_head.is_empty()
                             && !new_head.is_empty()
                             && old_head != new_head
                             && is_valid_oid(old_head)
@@ -6272,6 +6288,10 @@ impl ActorDaemonCoordinator {
                             && !is_zero_oid(new_head)
                         {
                             let repo = find_repository_in_path(&worktree)?;
+                            if lite_mode {
+                                repo.storage.rename_working_log(old_head, new_head)?;
+                                continue;
+                            }
                             let author = repo.effective_author_identity().formatted_or_unknown();
                             let recovery_file_timestamps = Self::take_commit_file_timestamps(
                                 commit_file_timestamp_snapshots,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2690,6 +2690,13 @@ struct PendingCherryPickNoCommit {
 }
 
 #[derive(Debug, Clone)]
+struct PendingRebase {
+    original_head: String,
+    onto: Option<String>,
+    checkpoint_bases: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 enum RecentReplayPrerequisite {
     CheckoutSwitchRename {
@@ -2731,7 +2738,7 @@ pub struct ActorDaemonCoordinator {
             crate::daemon::git_backend::SystemGitBackend,
         >,
     >,
-    pending_rebase_original_head_by_worktree: Mutex<HashMap<String, (String, Option<String>)>>,
+    pending_rebase_original_head_by_worktree: Mutex<HashMap<String, PendingRebase>>,
     pending_cherry_pick_sources_by_worktree: Mutex<HashMap<String, Vec<String>>>,
     pending_cherry_pick_no_commit_by_worktree: Mutex<HashMap<String, PendingCherryPickNoCommit>>,
     pending_squash_merge_by_worktree: Mutex<HashMap<String, PendingSquashMerge>>,
@@ -4763,6 +4770,13 @@ impl ActorDaemonCoordinator {
                         .map(|f| f.path.to_string_lossy().to_string())
                         .collect();
                     let checkpoint_kind = request.checkpoint_kind;
+                    let checkpoint_base_commit = request.files.first().map(|file| {
+                        use crate::commands::checkpoint_agent::orchestrator::BaseCommit;
+                        match &file.base_commit {
+                            BaseCommit::Sha(sha) => sha.clone(),
+                            BaseCommit::Initial => "initial".to_string(),
+                        }
+                    });
                     let checkpoint_trace_id = request.trace_id.clone();
                     let checkpoint_path_role = request.path_role;
                     let checkpoint_has_agent = request.agent_id.is_some();
@@ -4912,6 +4926,25 @@ impl ActorDaemonCoordinator {
                         );
                     }
                     if result.is_ok() {
+                        if config::Config::get().get_feature_flags().lite_mode
+                            && let Some(base_commit) = checkpoint_base_commit
+                            && let Err(error) = self
+                                .record_pending_rebase_checkpoint_base_for_worktree(
+                                    Path::new(&repo_wd),
+                                    base_commit,
+                                )
+                        {
+                            let _ = self.record_side_effect_error(family, order, &error);
+                            tracing::error!(
+                                component = "daemon",
+                                phase = "checkpoint_processing",
+                                reason = "pending_rebase_checkpoint_tracking_failed",
+                                %family,
+                                order,
+                                %error,
+                                "pending rebase checkpoint tracking failed"
+                            );
+                        }
                         // Clear pending AI edit state once the PostFileEdit completes.
                         if checkpoint_kind.is_ai()
                             && checkpoint_path_role == PreparedPathRole::Edited
@@ -5050,7 +5083,31 @@ impl ActorDaemonCoordinator {
             .map_err(|_| {
                 GitAiError::Generic("pending rebase original-head map lock poisoned".to_string())
             })?;
-        map.insert(Self::worktree_state_key(worktree), (original_head, onto));
+        map.insert(
+            Self::worktree_state_key(worktree),
+            PendingRebase {
+                original_head,
+                onto,
+                checkpoint_bases: HashSet::new(),
+            },
+        );
+        Ok(())
+    }
+
+    fn record_pending_rebase_checkpoint_base_for_worktree(
+        &self,
+        worktree: &Path,
+        base_commit: String,
+    ) -> Result<(), GitAiError> {
+        let mut map = self
+            .pending_rebase_original_head_by_worktree
+            .lock()
+            .map_err(|_| {
+                GitAiError::Generic("pending rebase original-head map lock poisoned".to_string())
+            })?;
+        if let Some(pending) = map.get_mut(&Self::worktree_state_key(worktree)) {
+            pending.checkpoint_bases.insert(base_commit);
+        }
         Ok(())
     }
 
@@ -5071,7 +5128,7 @@ impl ActorDaemonCoordinator {
     fn take_pending_rebase_original_head_for_worktree(
         &self,
         worktree: &Path,
-    ) -> Result<Option<(String, Option<String>)>, GitAiError> {
+    ) -> Result<Option<PendingRebase>, GitAiError> {
         let mut map = self
             .pending_rebase_original_head_by_worktree
             .lock()
@@ -5378,12 +5435,25 @@ impl ActorDaemonCoordinator {
         // inspect the commit graph or migrate authorship notes. Everything needed for
         // this bookkeeping comes from the already-normalized trace2/ref transition.
         if config::Config::get().get_feature_flags().lite_mode {
-            if let Some((original_head, _)) = pending_original_head.as_ref()
-                && let Some(new_tip) = rebase_new_tip_from_command(cmd, original_head)
+            if let Some(pending) = pending_original_head.as_ref()
+                && let Some(new_tip) = rebase_new_tip_from_command(cmd, &pending.original_head)
             {
-                if original_head != &new_tip {
-                    repo.storage.rename_working_log(original_head, &new_tip)?;
+                for checkpoint_base in &pending.checkpoint_bases {
+                    if checkpoint_base != &pending.original_head && checkpoint_base != &new_tip {
+                        repo.storage
+                            .delete_working_log_for_base_commit(checkpoint_base)?;
+                    }
                 }
+                if pending.original_head != new_tip {
+                    repo.storage
+                        .rename_working_log(&pending.original_head, &new_tip)?;
+                }
+                return Ok(());
+            }
+            if !matches!(
+                cmd.primary_command.as_deref(),
+                Some("rebase" | "pull" | "update-ref")
+            ) {
                 return Ok(());
             }
             let command_moves_checked_out_history =
@@ -5426,22 +5496,25 @@ impl ActorDaemonCoordinator {
                     branch_changes.len(),
                     pending_original_head
                         .as_ref()
-                        .map(|(head, _)| head.as_str())
+                        .map(|pending| pending.original_head.as_str())
                         .unwrap_or("NONE"),
                     cmd.ref_changes.len(),
                 )
             },
         );
 
-        if let Some((original_head, stored_onto)) = pending_original_head
-            && let Some(new_tip) = rebase_new_tip_from_command(cmd, &original_head)
+        if let Some(pending) = pending_original_head
+            && let Some(new_tip) = rebase_new_tip_from_command(cmd, &pending.original_head)
         {
-            if original_head != new_tip && !is_ancestor_commit(&repo, &original_head, &new_tip) {
+            if pending.original_head != new_tip
+                && !is_ancestor_commit(&repo, &pending.original_head, &new_tip)
+            {
                 let command_rebase_onto =
-                    rebase_onto_from_command(cmd, &repo, &original_head, &new_tip);
-                let rebase_onto = stored_onto
+                    rebase_onto_from_command(cmd, &repo, &pending.original_head, &new_tip);
+                let rebase_onto = pending
+                    .onto
                     .filter(|onto| {
-                        onto != &original_head
+                        onto != &pending.original_head
                             && onto != &new_tip
                             && is_ancestor_commit(&repo, onto, &new_tip)
                     })
@@ -5449,12 +5522,13 @@ impl ActorDaemonCoordinator {
                 let outcome =
                     crate::authorship::rewrite::handle_non_fast_forward_rewrite_with_operation(
                         &repo,
-                        &original_head,
+                        &pending.original_head,
                         &new_tip,
                         rebase_onto.as_deref(),
                         crate::authorship::rewrite::RewriteMetricOperation::Rebase,
                     )?;
-                repo.storage.rename_working_log(&original_head, &new_tip)?;
+                repo.storage
+                    .rename_working_log(&pending.original_head, &new_tip)?;
                 let conflict_base = rebase_onto.clone();
                 let metric_context = process_conflict_resolution_working_logs(
                     &repo,
@@ -5464,8 +5538,12 @@ impl ActorDaemonCoordinator {
                 let metric_commits =
                     rewrite_metric_commits_with_context(outcome.metric_commits, metric_context);
                 if !metric_commits.is_empty() {
-                    let branch =
-                        rewrite_metric_branch_for_transition(cmd, &original_head, &new_tip, None);
+                    let branch = rewrite_metric_branch_for_transition(
+                        cmd,
+                        &pending.original_head,
+                        &new_tip,
+                        None,
+                    );
                     crate::daemon::rewrite_metrics::spawn_rewrite_commit_metrics(
                         &repo,
                         rewrite_metric_commits_with_branch(metric_commits, branch),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2693,7 +2693,6 @@ struct PendingCherryPickNoCommit {
 struct PendingRebase {
     original_head: String,
     onto: Option<String>,
-    checkpoint_bases: HashSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -4770,13 +4769,6 @@ impl ActorDaemonCoordinator {
                         .map(|f| f.path.to_string_lossy().to_string())
                         .collect();
                     let checkpoint_kind = request.checkpoint_kind;
-                    let checkpoint_base_commit = request.files.first().map(|file| {
-                        use crate::commands::checkpoint_agent::orchestrator::BaseCommit;
-                        match &file.base_commit {
-                            BaseCommit::Sha(sha) => sha.clone(),
-                            BaseCommit::Initial => "initial".to_string(),
-                        }
-                    });
                     let checkpoint_trace_id = request.trace_id.clone();
                     let checkpoint_path_role = request.path_role;
                     let checkpoint_has_agent = request.agent_id.is_some();
@@ -4926,25 +4918,6 @@ impl ActorDaemonCoordinator {
                         );
                     }
                     if result.is_ok() {
-                        if config::Config::get().get_feature_flags().lite_mode
-                            && let Some(base_commit) = checkpoint_base_commit
-                            && let Err(error) = self
-                                .record_pending_rebase_checkpoint_base_for_worktree(
-                                    Path::new(&repo_wd),
-                                    base_commit,
-                                )
-                        {
-                            let _ = self.record_side_effect_error(family, order, &error);
-                            tracing::error!(
-                                component = "daemon",
-                                phase = "checkpoint_processing",
-                                reason = "pending_rebase_checkpoint_tracking_failed",
-                                %family,
-                                order,
-                                %error,
-                                "pending rebase checkpoint tracking failed"
-                            );
-                        }
                         // Clear pending AI edit state once the PostFileEdit completes.
                         if checkpoint_kind.is_ai()
                             && checkpoint_path_role == PreparedPathRole::Edited
@@ -5088,26 +5061,8 @@ impl ActorDaemonCoordinator {
             PendingRebase {
                 original_head,
                 onto,
-                checkpoint_bases: HashSet::new(),
             },
         );
-        Ok(())
-    }
-
-    fn record_pending_rebase_checkpoint_base_for_worktree(
-        &self,
-        worktree: &Path,
-        base_commit: String,
-    ) -> Result<(), GitAiError> {
-        let mut map = self
-            .pending_rebase_original_head_by_worktree
-            .lock()
-            .map_err(|_| {
-                GitAiError::Generic("pending rebase original-head map lock poisoned".to_string())
-            })?;
-        if let Some(pending) = map.get_mut(&Self::worktree_state_key(worktree)) {
-            pending.checkpoint_bases.insert(base_commit);
-        }
         Ok(())
     }
 
@@ -5438,12 +5393,6 @@ impl ActorDaemonCoordinator {
             if let Some(pending) = pending_original_head.as_ref()
                 && let Some(new_tip) = rebase_new_tip_from_command(cmd, &pending.original_head)
             {
-                for checkpoint_base in &pending.checkpoint_bases {
-                    if checkpoint_base != &pending.original_head && checkpoint_base != &new_tip {
-                        repo.storage
-                            .delete_working_log_for_base_commit(checkpoint_base)?;
-                    }
-                }
                 if pending.original_head != new_tip {
                     repo.storage
                         .rename_working_log(&pending.original_head, &new_tip)?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5458,12 +5458,24 @@ impl ActorDaemonCoordinator {
             }
             let command_moves_checked_out_history =
                 matches!(cmd.primary_command.as_deref(), Some("rebase" | "pull"));
+            let mut collapsed_head: Option<(&str, &str)> = None;
+            for change in cmd.ref_changes.iter().filter(|change| {
+                change.reference == "HEAD"
+                    && is_valid_oid(&change.old)
+                    && !is_zero_oid(&change.old)
+                    && is_valid_oid(&change.new)
+                    && !is_zero_oid(&change.new)
+            }) {
+                if let Some((_old, new)) = &mut collapsed_head {
+                    *new = &change.new;
+                } else {
+                    collapsed_head = Some((&change.old, &change.new));
+                }
+            }
             for (old_tip, new_tip) in collapsed.values() {
                 let moves_head = command_moves_checked_out_history
-                    || cmd.ref_changes.iter().any(|change| {
-                        change.reference == "HEAD"
-                            && change.old.as_str() == *old_tip
-                            && change.new.as_str() == *new_tip
+                    || collapsed_head.is_some_and(|(head_old, head_new)| {
+                        head_old == *old_tip && head_new == *new_tip
                     });
                 if old_tip != new_tip && moves_head {
                     repo.storage.rename_working_log(old_tip, new_tip)?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5386,8 +5386,16 @@ impl ActorDaemonCoordinator {
                 }
                 return Ok(());
             }
+            let command_moves_checked_out_history =
+                matches!(cmd.primary_command.as_deref(), Some("rebase" | "pull"));
             for (old_tip, new_tip) in collapsed.values() {
-                if old_tip != new_tip {
+                let moves_head = command_moves_checked_out_history
+                    || cmd.ref_changes.iter().any(|change| {
+                        change.reference == "HEAD"
+                            && change.old.as_str() == *old_tip
+                            && change.new.as_str() == *new_tip
+                    });
+                if old_tip != new_tip && moves_head {
                     repo.storage.rename_working_log(old_tip, new_tip)?;
                 }
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5374,6 +5374,24 @@ impl ActorDaemonCoordinator {
                 .or_insert((&rc.old, &rc.new));
         }
 
+        // Lite mode keeps working logs aligned with the final ref tips, but does not
+        // inspect the commit graph or migrate authorship notes. Everything needed for
+        // this bookkeeping comes from the already-normalized trace2/ref transition.
+        if config::Config::get().get_feature_flags().lite_mode {
+            if let Some((original_head, _)) = pending_original_head.as_ref()
+                && let Some(new_tip) = rebase_new_tip_from_command(cmd, original_head)
+            {
+                repo.storage.rename_working_log(original_head, &new_tip)?;
+                return Ok(());
+            }
+            for (old_tip, new_tip) in collapsed.values() {
+                if old_tip != new_tip {
+                    repo.storage.rename_working_log(old_tip, new_tip)?;
+                }
+            }
+            return Ok(());
+        }
+
         // Extract "onto" hint from HEAD ref changes for rebases.
         // During a rebase, the first HEAD change target is the onto commit.
         let onto_hint: Option<String> = cmd
@@ -5512,6 +5530,12 @@ impl ActorDaemonCoordinator {
     fn start_commit_file_timestamp_snapshots_for_command(
         command: &crate::daemon::domain::NormalizedCommand,
     ) -> CommitFileTimestampSnapshotHandles {
+        if config::Config::get().get_feature_flags().lite_mode
+            && command.primary_command.as_deref() == Some("commit")
+            && command.invoked_args.iter().any(|arg| arg == "--amend")
+        {
+            return HashMap::new();
+        }
         let Some(worktree) = command.worktree.clone() else {
             return HashMap::new();
         };
@@ -5625,6 +5649,7 @@ impl ActorDaemonCoordinator {
         let events = &applied.analysis.events;
 
         let primary = cmd.primary_command.as_deref().unwrap_or("unknown");
+        let lite_mode = config::Config::get().get_feature_flags().lite_mode;
 
         #[cfg(feature = "test-support")]
         if let Ok(spec) = std::env::var("GIT_AI_TEST_DELAY_SIDE_EFFECT_MS_FOR_COMMAND") {
@@ -5824,7 +5849,7 @@ impl ActorDaemonCoordinator {
                 if cmd.invoked_args.iter().any(|arg| arg == "--abort") {
                     self.clear_pending_cherry_pick_sources_for_worktree(worktree)?;
                     self.clear_pending_cherry_pick_no_commit_for_worktree(worktree)?;
-                } else if cmd.exit_code != 0 {
+                } else if !lite_mode && cmd.exit_code != 0 {
                     let new_commits = cherry_pick_destination_commits(cmd);
                     let is_continue = cherry_pick_command_has_flag(cmd, "--continue");
                     let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
@@ -5951,7 +5976,9 @@ impl ActorDaemonCoordinator {
                         source_commits,
                         new_commits,
                     } => {
-                        if !new_head.is_empty() {
+                        if lite_mode {
+                            self.clear_pending_cherry_pick_sources_for_worktree(worktree.as_ref())?;
+                        } else if !new_head.is_empty() {
                             let repo = find_repository_in_path(&worktree)?;
                             let mut sources = source_commits.clone();
                             let is_skip = cherry_pick_command_has_flag(cmd, "--skip");
@@ -6004,18 +6031,21 @@ impl ActorDaemonCoordinator {
                         source_commits,
                         head,
                     } => {
-                        let mut sources = source_commits.clone();
-                        if sources.is_empty() {
-                            let repo = find_repository_in_path(&worktree)?;
-                            sources =
-                                resolve_explicit_cherry_pick_sources_for_side_effect(&repo, cmd)?;
-                        }
-                        if !head.is_empty() && !sources.is_empty() {
-                            self.set_pending_cherry_pick_no_commit_for_worktree(
-                                worktree.as_ref(),
-                                sources,
-                                head.clone(),
-                            )?;
+                        if !lite_mode {
+                            let mut sources = source_commits.clone();
+                            if sources.is_empty() {
+                                let repo = find_repository_in_path(&worktree)?;
+                                sources = resolve_explicit_cherry_pick_sources_for_side_effect(
+                                    &repo, cmd,
+                                )?;
+                            }
+                            if !head.is_empty() && !sources.is_empty() {
+                                self.set_pending_cherry_pick_no_commit_for_worktree(
+                                    worktree.as_ref(),
+                                    sources,
+                                    head.clone(),
+                                )?;
+                            }
                         }
                     }
                     crate::daemon::domain::SemanticEvent::MergeSquash { source_head, onto } => {
@@ -6148,6 +6178,10 @@ impl ActorDaemonCoordinator {
                             && cmd.primary_command.as_deref() == Some("revert")
                         {
                             if !handled_revert_commits {
+                                handled_revert_commits = true;
+                                if lite_mode {
+                                    continue;
+                                }
                                 // A single `git revert A B` creates one commit per source.
                                 // Reconstruct each destination from the matching HEAD transition
                                 // instead of treating the command as one final CommitCreated event.
@@ -6159,7 +6193,6 @@ impl ActorDaemonCoordinator {
                                     )?;
                                 }
                                 apply_revert_complete_rewrite(&repo, cmd, &source_oids)?;
-                                handled_revert_commits = true;
                             }
                         } else if !new_head.is_empty() {
                             let repo = find_repository_in_path(&worktree)?;
@@ -6204,7 +6237,8 @@ impl ActorDaemonCoordinator {
                                 )
                             })?;
 
-                            if cmd.primary_command.as_deref() == Some("commit")
+                            if !lite_mode
+                                && cmd.primary_command.as_deref() == Some("commit")
                                 && let Some(pending) = self
                                     .take_pending_cherry_pick_no_commit_for_worktree(
                                         worktree.as_ref(),
@@ -6228,7 +6262,8 @@ impl ActorDaemonCoordinator {
                         }
                     }
                     crate::daemon::domain::SemanticEvent::CommitAmended { old_head, new_head } => {
-                        if !old_head.is_empty()
+                        if !lite_mode
+                            && !old_head.is_empty()
                             && !new_head.is_empty()
                             && old_head != new_head
                             && is_valid_oid(old_head)
@@ -6300,7 +6335,7 @@ impl ActorDaemonCoordinator {
                                     // commit): carry the working log to the new base,
                                     // matching the pull fast-forward side effect.
                                     repo.storage.rename_working_log(old_head, new_head)?;
-                                } else {
+                                } else if !lite_mode {
                                     let outcome =
                                         crate::authorship::rewrite::handle_rewrite_event_with_metrics(
                                         &repo,
@@ -6372,6 +6407,9 @@ impl ActorDaemonCoordinator {
                         || is_zero_oid(new)
                         || old == new
                     {
+                        continue;
+                    }
+                    if lite_mode {
                         continue;
                     }
                     let repo = find_repository_in_path(&worktree.to_string_lossy())?;

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -78,6 +78,7 @@ macro_rules! define_feature_flags {
 // Define all feature flags in one place
 // Format: struct_field: file_and_env_name, debug = <bool>, release = <bool>
 define_feature_flags!(
+    lite_mode: lite_mode, debug = false, release = false,
     auth_keyring: auth_keyring, debug = false, release = false,
     transcript_streaming: transcript_streaming, debug = true, release = true,
     transcript_sweep: transcript_sweep, debug = true, release = true,
@@ -134,6 +135,7 @@ mod tests {
         let flags = FeatureFlags::default();
         #[cfg(debug_assertions)]
         {
+            assert!(!flags.lite_mode);
             assert!(!flags.auth_keyring);
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
@@ -144,6 +146,7 @@ mod tests {
         }
         #[cfg(not(debug_assertions))]
         {
+            assert!(!flags.lite_mode);
             assert!(!flags.auth_keyring);
             assert!(flags.transcript_streaming);
             assert!(flags.transcript_sweep);
@@ -151,6 +154,37 @@ mod tests {
             assert!(!flags.bash_checkpoints_v2);
             assert!(flags.daemon_log_upload);
             assert!(!flags.rewrite_metrics_events);
+        }
+    }
+
+    #[test]
+    fn test_lite_mode_file_override() {
+        let deserializable = DeserializableFeatureFlags {
+            lite_mode: Some(true),
+            ..Default::default()
+        };
+
+        let flags = FeatureFlags::from_deserializable(deserializable);
+        assert!(flags.lite_mode);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_lite_mode_env_overrides_file() {
+        unsafe {
+            std::env::set_var("GIT_AI_LITE_MODE", "true");
+        }
+
+        let file_flags = DeserializableFeatureFlags {
+            lite_mode: Some(false),
+            ..Default::default()
+        };
+
+        let flags = FeatureFlags::from_env_and_file(Some(file_flags));
+        assert!(flags.lite_mode);
+
+        unsafe {
+            std::env::remove_var("GIT_AI_LITE_MODE");
         }
     }
 
@@ -233,6 +267,7 @@ mod tests {
     #[test]
     fn test_serialization() {
         let flags = FeatureFlags {
+            lite_mode: true,
             auth_keyring: true,
             transcript_streaming: true,
             transcript_sweep: true,
@@ -243,6 +278,7 @@ mod tests {
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
+        assert!(serialized.contains("lite_mode"));
         assert!(serialized.contains("auth_keyring"));
         assert!(serialized.contains("transcript_streaming"));
         assert!(serialized.contains("transcript_sweep"));
@@ -255,6 +291,7 @@ mod tests {
     #[test]
     fn test_clone_trait() {
         let flags = FeatureFlags {
+            lite_mode: true,
             auth_keyring: true,
             transcript_streaming: true,
             transcript_sweep: true,
@@ -264,6 +301,7 @@ mod tests {
             rewrite_metrics_events: true,
         };
         let cloned = flags.clone();
+        assert_eq!(cloned.lite_mode, flags.lite_mode);
         assert_eq!(cloned.auth_keyring, flags.auth_keyring);
         assert_eq!(cloned.transcript_streaming, flags.transcript_streaming);
         assert_eq!(cloned.transcript_sweep, flags.transcript_sweep);

--- a/src/git/repo_storage.rs
+++ b/src/git/repo_storage.rs
@@ -190,6 +190,9 @@ impl RepoStorage {
     /// If the destination already has checkpoints, preserve the old-base entries first and
     /// append the destination entries after them.
     pub fn rename_working_log(&self, old_sha: &str, new_sha: &str) -> Result<(), GitAiError> {
+        if old_sha == new_sha {
+            return Ok(());
+        }
         let old_dir = self.working_logs.join(old_sha);
         let new_dir = self.working_logs.join(new_sha);
         if !old_dir.exists() {
@@ -989,5 +992,36 @@ mod tests {
         // Both sides' unique entries survive.
         assert!(merged.files.contains_key("old_only.txt"));
         assert!(merged.files.contains_key("new_only.txt"));
+    }
+
+    #[test]
+    fn test_rename_working_log_to_same_sha_preserves_log() {
+        let tmp = TempDir::new().unwrap();
+        let workdir = tmp.path().join("workdir");
+        fs::create_dir_all(&workdir).unwrap();
+        let ai_dir = tmp.path().join("ai");
+        let storage = RepoStorage::for_repo_path(&ai_dir, &workdir).unwrap();
+        let sha = "1111111111111111111111111111111111111111";
+
+        let log = storage.working_log_for_base_commit(sha).unwrap();
+        let mut initial = InitialAttributions::default();
+        initial
+            .files
+            .insert("pending.txt".into(), attr("ai_PENDING"));
+        log.write_initial(initial).unwrap();
+
+        storage.rename_working_log(sha, sha).unwrap();
+
+        let preserved = storage
+            .working_log_for_base_commit(sha)
+            .unwrap()
+            .read_initial_attributions();
+        assert_eq!(
+            preserved
+                .files
+                .get("pending.txt")
+                .map(|attrs| attrs[0].author_id.as_str()),
+            Some("ai_PENDING")
+        );
     }
 }

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -405,7 +405,12 @@ fn test_ci_local_sync_skips_non_rebase_force_push() {
 fn test_ci_local_open_pr_rebase_single_commit() {
     use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 
-    let repo = direct_test_repo();
+    let mut repo = direct_test_repo();
+    // `git-ai ci` is explicit rewrite processing, so daemon lite mode must not
+    // change its behavior.
+    repo.patch_git_ai_config(|patch| {
+        patch.feature_flags = Some(serde_json::json!({ "lite_mode": true }));
+    });
 
     let mut base_file = repo.filename("base.txt");
     base_file.set_contents(crate::lines!["base content"]);

--- a/tests/integration/ci_squash_rebase.rs
+++ b/tests/integration/ci_squash_rebase.rs
@@ -405,12 +405,7 @@ fn test_ci_local_sync_skips_non_rebase_force_push() {
 fn test_ci_local_open_pr_rebase_single_commit() {
     use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 
-    let mut repo = direct_test_repo();
-    // `git-ai ci` is explicit rewrite processing, so daemon lite mode must not
-    // change its behavior.
-    repo.patch_git_ai_config(|patch| {
-        patch.feature_flags = Some(serde_json::json!({ "lite_mode": true }));
-    });
+    let repo = direct_test_repo();
 
     let mut base_file = repo.filename("base.txt");
     base_file.set_contents(crate::lines!["base content"]);

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -7,6 +7,14 @@ fn lite_repo() -> TestRepo {
     TestRepo::new_with_daemon_env(&[("GIT_AI_LITE_MODE", "true")])
 }
 
+fn working_log_dir(repo: &TestRepo, commit: &str) -> std::path::PathBuf {
+    repo.path()
+        .join(".git")
+        .join("ai")
+        .join("working_logs")
+        .join(commit)
+}
+
 #[test]
 fn test_lite_mode_skips_rebase_notes_but_tracks_the_next_commit() {
     let repo = lite_repo();
@@ -314,6 +322,147 @@ fn test_lite_mode_moves_working_log_for_checked_out_fast_forward_update_ref() {
     base.assert_committed_lines(crate::lines!["base".human()]);
     let mut pending = repo.filename("pending.txt");
     pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
+fn test_lite_mode_does_not_move_working_log_for_fast_forward_merge() {
+    let repo = lite_repo();
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "base.txt"])
+        .unwrap();
+    let base_tip = repo.stage_all_and_commit("base").unwrap().commit_sha;
+    let mut base = repo.filename("base.txt");
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let merged_path = repo.path().join("merged.txt");
+    fs::write(&merged_path, "merged\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "merged.txt"])
+        .unwrap();
+    let feature_tip = repo.stage_all_and_commit("feature").unwrap().commit_sha;
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let mut merged = repo.filename("merged.txt");
+    merged.assert_committed_lines(crate::lines!["merged".human()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    let pending_path = repo.path().join("pending.txt");
+    fs::write(&pending_path, "pending AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "pending.txt"])
+        .unwrap();
+    repo.sync_daemon();
+    assert!(working_log_dir(&repo, &base_tip).exists());
+
+    repo.git(&["merge", "--ff-only", "feature"]).unwrap();
+    assert_eq!(
+        repo.git(&["rev-parse", "HEAD"]).unwrap().trim(),
+        feature_tip
+    );
+    assert!(working_log_dir(&repo, &base_tip).exists());
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    merged.assert_committed_lines(crate::lines!["merged".human()]);
+}
+
+#[test]
+fn test_lite_mode_does_not_move_working_log_for_merge_commit() {
+    let repo = lite_repo();
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "base.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut base = repo.filename("base.txt");
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let merged_path = repo.path().join("merged.txt");
+    fs::write(&merged_path, "merged\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "merged.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("feature").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let mut merged = repo.filename("merged.txt");
+    merged.assert_committed_lines(crate::lines!["merged".human()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    let main_path = repo.path().join("main.txt");
+    fs::write(&main_path, "main\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "main.txt"])
+        .unwrap();
+    let pre_merge_tip = repo.stage_all_and_commit("main").unwrap().commit_sha;
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let mut main_file = repo.filename("main.txt");
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    let pending_path = repo.path().join("pending.txt");
+    fs::write(&pending_path, "pending AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "pending.txt"])
+        .unwrap();
+    repo.sync_daemon();
+    assert!(working_log_dir(&repo, &pre_merge_tip).exists());
+
+    repo.git(&["merge", "--no-ff", "feature", "-m", "merge feature"])
+        .unwrap();
+    let merge_tip = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(merge_tip, pre_merge_tip);
+    assert!(working_log_dir(&repo, &pre_merge_tip).exists());
+    assert!(!working_log_dir(&repo, &merge_tip).exists());
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+    merged.assert_committed_lines(crate::lines!["merged".human()]);
+}
+
+#[test]
+fn test_lite_mode_archives_conflict_resolution_working_log_after_rebase() {
+    let repo = lite_repo();
+    let conflict_path = repo.path().join("conflict.txt");
+    fs::write(&conflict_path, "base\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut conflict = repo.filename("conflict.txt");
+    conflict.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    fs::write(&conflict_path, "feature\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict.txt"])
+        .unwrap();
+    let original_feature = repo.stage_all_and_commit("feature").unwrap().commit_sha;
+    conflict.assert_committed_lines(crate::lines!["feature".human()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    fs::write(&conflict_path, "main\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "conflict.txt"])
+        .unwrap();
+    let onto = repo.stage_all_and_commit("main").unwrap().commit_sha;
+    conflict.assert_committed_lines(crate::lines!["main".human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    assert!(repo.git(&["rebase", &main]).is_err());
+    assert_eq!(repo.git(&["rev-parse", "HEAD"]).unwrap().trim(), onto);
+
+    fs::write(&conflict_path, "resolved AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "conflict.txt"])
+        .unwrap();
+    repo.sync_daemon();
+    let resolution_log = repo.working_logs_for_base_commit(&onto);
+    assert!(!resolution_log.read_all_checkpoints().unwrap().is_empty());
+
+    repo.git(&["add", "conflict.txt"]).unwrap();
+    repo.git_with_env(&["rebase", "--continue"], &[("GIT_EDITOR", "true")], None)
+        .unwrap();
+    let rebased = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(rebased, original_feature);
+    assert!(repo.read_authorship_note(&rebased).is_none());
+    assert!(!working_log_dir(&repo, &onto).exists());
+    assert!(
+        working_log_dir(&repo, &format!("old-{onto}")).exists(),
+        "the consumed conflict-resolution log should be archived"
+    );
+    conflict.assert_committed_lines(crate::lines!["resolved AI".human()]);
 }
 
 #[test]

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -1,7 +1,9 @@
 use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
 
 use crate::repos::test_file::ExpectedLineExt;
-use crate::repos::test_repo::TestRepo;
+use crate::repos::test_repo::{TestRepo, real_git_executable};
 
 fn lite_repo() -> TestRepo {
     TestRepo::new_with_daemon_env(&[("GIT_AI_LITE_MODE", "true")])
@@ -13,6 +15,54 @@ fn working_log_dir(repo: &TestRepo, commit: &str) -> std::path::PathBuf {
         .join("ai")
         .join("working_logs")
         .join(commit)
+}
+
+fn traced_git_with_stdin(repo: &TestRepo, args: &[&str], stdin: &str) {
+    repo.sync_daemon();
+
+    let mut command = Command::new(real_git_executable());
+    command.arg("-C").arg(repo.path()).args(args);
+    command.env("HOME", repo.test_home_path());
+    command.env(
+        "GIT_CONFIG_GLOBAL",
+        repo.test_home_path().join(".gitconfig"),
+    );
+    command.env("XDG_CONFIG_HOME", repo.test_home_path().join(".config"));
+    command.env("GIT_CONFIG_NOSYSTEM", "1");
+    command.env(
+        "GIT_TRACE2_EVENT",
+        git_ai::daemon::DaemonConfig::trace2_event_target_for_path(
+            &repo.daemon_trace_socket_path(),
+        ),
+    );
+    command.env(
+        "GIT_TRACE2_EVENT_NESTING",
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
+    );
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("failed to run traced git {args:?}: {error}"));
+    child
+        .stdin
+        .take()
+        .expect("stdin should be piped")
+        .write_all(stdin.as_bytes())
+        .expect("write traced git stdin");
+    let output = child
+        .wait_with_output()
+        .unwrap_or_else(|error| panic!("failed to wait for traced git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "traced git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    repo.sync_daemon();
 }
 
 #[test]
@@ -94,6 +144,96 @@ fn test_lite_mode_preserves_uncommitted_ai_attribution_through_amend() {
 
     repo.stage_all_and_commit("commit pending work").unwrap();
     pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
+fn test_lite_mode_does_not_reapply_amended_attribution_on_the_next_commit() {
+    let repo = lite_repo();
+    let path = repo.path().join("amend-same-file.txt");
+
+    fs::write(&path, "base\n").unwrap();
+    repo.stage_all_and_commit("base").unwrap();
+    let mut file = repo.filename("amend-same-file.txt");
+    file.assert_committed_lines(crate::lines!["base".unattributed_human()]);
+
+    fs::write(&path, "base\namended AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "amend-same-file.txt"])
+        .unwrap();
+    repo.git(&["add", "amend-same-file.txt"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"]).unwrap();
+    let amended = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(repo.read_authorship_note(&amended).is_none());
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "amended AI".unattributed_human(),
+    ]);
+
+    fs::write(&path, "base\namended AI\nlater AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "amend-same-file.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("later work").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "base".unattributed_human(),
+        "amended AI".unattributed_human(),
+        "later AI".ai(),
+    ]);
+}
+
+#[test]
+fn test_ci_rewrites_rebase_notes_with_a_lite_mode_daemon() {
+    let repo = lite_repo();
+    let mut base = repo.filename("ci-base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    repo.git(&["branch", "-M", "main"]).unwrap();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature = repo.filename("ci-feature.txt");
+    feature.set_contents(crate::lines!["feature AI".ai()]);
+    let original_feature = repo.stage_all_and_commit("feature").unwrap().commit_sha;
+    feature.assert_committed_lines(crate::lines!["feature AI".ai()]);
+
+    repo.git(&["checkout", "main"]).unwrap();
+    let mut main_file = repo.filename("ci-main.txt");
+    main_file.set_contents(crate::lines!["main"]);
+    let base_sha = repo
+        .stage_all_and_commit("advance main")
+        .unwrap()
+        .commit_sha;
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", "main"]).unwrap();
+    let rebased_feature = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(rebased_feature, original_feature);
+    assert!(
+        repo.read_authorship_note(&rebased_feature).is_none(),
+        "the lite daemon must skip automatic note rewriting"
+    );
+
+    let output = repo
+        .git_ai(&[
+            "ci",
+            "local",
+            "sync",
+            "--previous-head-sha",
+            &original_feature,
+            "--base-ref",
+            "main",
+            "--base-sha",
+            &base_sha,
+            "--head-sha",
+            &rebased_feature,
+            "--skip-fetch-notes",
+            "--skip-push",
+        ])
+        .expect("ci local sync should succeed in lite mode");
+    assert!(
+        output.contains("Local CI (sync): authorship rewritten successfully"),
+        "expected explicit CI rewrite, got: {output}"
+    );
+    feature.assert_committed_lines(crate::lines!["feature AI".ai()]);
 }
 
 #[test]
@@ -321,6 +461,58 @@ fn test_lite_mode_moves_working_log_for_checked_out_fast_forward_update_ref() {
     repo.stage_all_and_commit("commit pending work").unwrap();
     base.assert_committed_lines(crate::lines!["base".human()]);
     let mut pending = repo.filename("pending.txt");
+    pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
+fn test_lite_mode_moves_working_log_for_multi_step_checked_out_update_ref() {
+    let repo = lite_repo();
+    let base_path = repo.path().join("multi-step-base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    let old_tip = repo.stage_all_and_commit("base").unwrap().commit_sha;
+    let mut base = repo.filename("multi-step-base.txt");
+    base.assert_committed_lines(crate::lines!["base".human()]);
+
+    let pending_path = repo.path().join("multi-step-pending.txt");
+    fs::write(&pending_path, "pending AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "multi-step-pending.txt"])
+        .unwrap();
+    repo.sync_daemon();
+    assert!(working_log_dir(&repo, &old_tip).exists());
+
+    let tree = repo
+        .git(&["rev-parse", &format!("{old_tip}^{{tree}}")])
+        .unwrap()
+        .trim()
+        .to_string();
+    let middle_tip = repo
+        .git(&["commit-tree", &tree, "-p", &old_tip, "-m", "middle"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let new_tip = repo
+        .git(&["commit-tree", &tree, "-p", &middle_tip, "-m", "new tip"])
+        .unwrap()
+        .trim()
+        .to_string();
+    traced_git_with_stdin(
+        &repo,
+        &["update-ref", "--stdin"],
+        &format!(
+            "start\nupdate HEAD {middle_tip} {old_tip}\nprepare\ncommit\n\
+             start\nupdate HEAD {new_tip} {middle_tip}\nprepare\ncommit\n"
+        ),
+    );
+
+    assert_eq!(repo.git(&["rev-parse", "HEAD"]).unwrap().trim(), new_tip);
+    assert!(!working_log_dir(&repo, &old_tip).exists());
+    assert!(working_log_dir(&repo, &new_tip).exists());
+    assert!(repo.read_authorship_note(&new_tip).is_none());
+    base.assert_committed_lines(crate::lines!["base".human()]);
+
+    repo.stage_all_and_commit("commit pending work").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let mut pending = repo.filename("multi-step-pending.txt");
     pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
 }
 

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -68,6 +68,27 @@ fn test_lite_mode_skips_amend_notes() {
 }
 
 #[test]
+fn test_lite_mode_preserves_uncommitted_ai_attribution_through_amend() {
+    let repo = lite_repo();
+    let mut committed = repo.filename("committed.txt");
+    committed.set_contents(crate::lines!["committed"]);
+    repo.stage_all_and_commit("base").unwrap();
+    committed.assert_committed_lines(crate::lines!["committed".human()]);
+
+    let mut pending = repo.filename("pending.txt");
+    pending.set_contents_no_stage(crate::lines!["pending AI".ai()]);
+    committed.insert_at(1, crate::lines!["amended"]);
+    repo.git(&["add", "committed.txt"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"]).unwrap();
+
+    let amended = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(repo.read_authorship_note(&amended).is_none());
+
+    repo.stage_all_and_commit("commit pending work").unwrap();
+    pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
 fn test_lite_mode_skips_cherry_pick_notes() {
     let repo = lite_repo();
     let mut base = repo.filename("base.txt");
@@ -97,6 +118,37 @@ fn test_lite_mode_skips_cherry_pick_notes() {
 }
 
 #[test]
+fn test_lite_mode_preserves_uncommitted_ai_attribution_through_cherry_pick() {
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "source"]).unwrap();
+    let mut picked = repo.filename("picked.txt");
+    picked.set_contents(crate::lines!["picked"]);
+    let source = repo.stage_all_and_commit("source").unwrap().commit_sha;
+    picked.assert_committed_lines(crate::lines!["picked".human()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main"]);
+    repo.stage_all_and_commit("advance main").unwrap();
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    let mut pending = repo.filename("pending.txt");
+    pending.set_contents_no_stage(crate::lines!["pending AI".ai()]);
+    repo.git(&["cherry-pick", &source]).unwrap();
+    let destination = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(repo.read_authorship_note(&destination).is_none());
+
+    repo.stage_all_and_commit("commit pending work").unwrap();
+    pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
 fn test_lite_mode_skips_revert_notes() {
     let repo = lite_repo();
     let path = repo.path().join("revert.txt");
@@ -118,6 +170,27 @@ fn test_lite_mode_skips_revert_notes() {
     let reverted = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
     assert!(repo.read_authorship_note(&reverted).is_none());
     file.assert_committed_lines(crate::lines!["keep".ai(), "restored AI".human(),]);
+}
+
+#[test]
+fn test_lite_mode_preserves_uncommitted_ai_attribution_through_revert() {
+    let repo = lite_repo();
+    let mut reverted = repo.filename("reverted.txt");
+    reverted.set_contents(crate::lines!["restore me"]);
+    repo.stage_all_and_commit("base").unwrap();
+    reverted.assert_committed_lines(crate::lines!["restore me".human()]);
+
+    fs::remove_file(repo.path().join("reverted.txt")).unwrap();
+    let deletion = repo.stage_all_and_commit("delete file").unwrap().commit_sha;
+
+    let mut pending = repo.filename("pending.txt");
+    pending.set_contents_no_stage(crate::lines!["pending AI".ai()]);
+    repo.git(&["revert", "--no-edit", &deletion]).unwrap();
+    let destination = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(repo.read_authorship_note(&destination).is_none());
+
+    repo.stage_all_and_commit("commit pending work").unwrap();
+    pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
 }
 
 #[test]

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -1,0 +1,236 @@
+use std::fs;
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+
+fn lite_repo() -> TestRepo {
+    TestRepo::new_with_daemon_env(&[("GIT_AI_LITE_MODE", "true")])
+}
+
+#[test]
+fn test_lite_mode_skips_rebase_notes_but_tracks_the_next_commit() {
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature = repo.filename("feature.txt");
+    feature.set_contents(crate::lines!["feature AI".ai()]);
+    let original_feature = repo.stage_all_and_commit("feature").unwrap().commit_sha;
+    feature.assert_committed_lines(crate::lines!["feature AI".ai()]);
+    assert!(repo.read_authorship_note(&original_feature).is_some());
+
+    repo.git(&["checkout", &main]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main"]);
+    repo.stage_all_and_commit("advance main").unwrap();
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    repo.git(&["rebase", &main]).unwrap();
+    let rebased_feature = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(rebased_feature, original_feature);
+    assert!(
+        repo.read_authorship_note(&rebased_feature).is_none(),
+        "lite mode must not rewrite the source note onto the rebased commit"
+    );
+    assert!(
+        repo.read_authorship_note(&original_feature).is_some(),
+        "lite mode must leave the original source note intact"
+    );
+    feature.assert_committed_lines(crate::lines!["feature AI".human()]);
+
+    feature.insert_at(1, crate::lines!["new AI after rebase".ai()]);
+    let post_rebase_commit = repo.stage_all_and_commit("new work").unwrap().commit_sha;
+    feature.assert_committed_lines(crate::lines!["feature AI".ai(), "new AI after rebase".ai(),]);
+    assert!(repo.read_authorship_note(&post_rebase_commit).is_some());
+}
+
+#[test]
+fn test_lite_mode_skips_amend_notes() {
+    let repo = lite_repo();
+    let mut file = repo.filename("amend.txt");
+    file.set_contents(crate::lines!["original AI".ai()]);
+    let original = repo.stage_all_and_commit("original").unwrap().commit_sha;
+    file.assert_committed_lines(crate::lines!["original AI".ai()]);
+
+    file.insert_at(1, crate::lines!["amended AI".ai()]);
+    repo.git(&["add", "amend.txt"]).unwrap();
+    repo.git(&["commit", "--amend", "--no-edit"]).unwrap();
+    let amended = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(amended, original);
+    assert!(repo.read_authorship_note(&amended).is_none());
+    assert!(repo.read_authorship_note(&original).is_some());
+    file.assert_committed_lines(crate::lines!["original AI".human(), "amended AI".human(),]);
+}
+
+#[test]
+fn test_lite_mode_skips_cherry_pick_notes() {
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "source"]).unwrap();
+    let mut picked = repo.filename("picked.txt");
+    picked.set_contents(crate::lines!["picked AI".ai()]);
+    let source = repo.stage_all_and_commit("source").unwrap().commit_sha;
+    picked.assert_committed_lines(crate::lines!["picked AI".ai()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main"]);
+    repo.stage_all_and_commit("advance main").unwrap();
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    repo.git(&["cherry-pick", &source]).unwrap();
+    let destination = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert_ne!(destination, source);
+    assert!(repo.read_authorship_note(&destination).is_none());
+    assert!(repo.read_authorship_note(&source).is_some());
+    picked.assert_committed_lines(crate::lines!["picked AI".human()]);
+}
+
+#[test]
+fn test_lite_mode_skips_revert_notes() {
+    let repo = lite_repo();
+    let path = repo.path().join("revert.txt");
+
+    fs::write(&path, "keep\nrestored AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "revert.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("source AI").unwrap();
+    let mut file = repo.filename("revert.txt");
+    file.assert_committed_lines(crate::lines!["keep".ai(), "restored AI".ai()]);
+
+    fs::write(&path, "keep\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "revert.txt"])
+        .unwrap();
+    let deletion = repo.stage_all_and_commit("delete AI").unwrap().commit_sha;
+    file.assert_committed_lines(crate::lines!["keep".ai()]);
+
+    repo.git(&["revert", "--no-edit", &deletion]).unwrap();
+    let reverted = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(repo.read_authorship_note(&reverted).is_none());
+    file.assert_committed_lines(crate::lines!["keep".ai(), "restored AI".human(),]);
+}
+
+#[test]
+fn test_lite_mode_skips_update_ref_restack_notes() {
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature = repo.filename("restack.txt");
+    feature.set_contents(crate::lines!["restacked AI".ai()]);
+    let original = repo.stage_all_and_commit("feature").unwrap().commit_sha;
+    feature.assert_committed_lines(crate::lines!["restacked AI".ai()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main"]);
+    let new_parent = repo
+        .stage_all_and_commit("advance main")
+        .unwrap()
+        .commit_sha;
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    let tree = repo
+        .git(&["rev-parse", &format!("{original}^{{tree}}")])
+        .unwrap()
+        .trim()
+        .to_string();
+    let restacked = repo
+        .git(&["commit-tree", &tree, "-p", &new_parent, "-m", "restacked"])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["update-ref", "refs/heads/feature", &restacked, &original])
+        .unwrap();
+    assert!(repo.read_authorship_note(&restacked).is_none());
+    assert!(repo.read_authorship_note(&original).is_some());
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    feature.assert_committed_lines(crate::lines!["restacked AI".human()]);
+}
+
+#[test]
+fn test_lite_mode_preserves_regular_squash_notes() {
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut feature = repo.filename("squash.txt");
+    feature.set_contents(crate::lines!["squashed AI".ai()]);
+    repo.stage_all_and_commit("feature").unwrap();
+    feature.assert_committed_lines(crate::lines!["squashed AI".ai()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    repo.git(&["merge", "--squash", "feature"]).unwrap();
+    let squash = repo.stage_all_and_commit("squash").unwrap().commit_sha;
+    feature.assert_committed_lines(crate::lines!["squashed AI".ai()]);
+    assert!(repo.read_authorship_note(&squash).is_some());
+}
+
+#[test]
+#[cfg(unix)]
+fn test_lite_mode_skips_interactive_rebase_squash_notes() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    repo.stage_all_and_commit("base").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let main = repo.current_branch();
+
+    repo.git(&["checkout", "-b", "feature"]).unwrap();
+    let mut first = repo.filename("first.txt");
+    first.set_contents(crate::lines!["first AI".ai()]);
+    repo.stage_all_and_commit("first").unwrap();
+    first.assert_committed_lines(crate::lines!["first AI".ai()]);
+    let mut second = repo.filename("second.txt");
+    second.set_contents(crate::lines!["second AI".ai()]);
+    repo.stage_all_and_commit("second").unwrap();
+    second.assert_committed_lines(crate::lines!["second AI".ai()]);
+
+    repo.git(&["checkout", &main]).unwrap();
+    let mut main_file = repo.filename("main.txt");
+    main_file.set_contents(crate::lines!["main"]);
+    repo.stage_all_and_commit("advance main").unwrap();
+    main_file.assert_committed_lines(crate::lines!["main".human()]);
+
+    repo.git(&["checkout", "feature"]).unwrap();
+    let editor = repo.path().join("squash-editor.sh");
+    fs::write(&editor, "#!/bin/sh\nsed -i.bak '2s/^pick/squash/' \"$1\"\n").unwrap();
+    let mut permissions = fs::metadata(&editor).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&editor, permissions).unwrap();
+    repo.git_with_env(
+        &["rebase", "-i", &main],
+        &[
+            ("GIT_SEQUENCE_EDITOR", editor.to_str().unwrap()),
+            ("GIT_EDITOR", "true"),
+        ],
+        None,
+    )
+    .unwrap();
+
+    let squashed = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
+    assert!(repo.read_authorship_note(&squashed).is_none());
+    first.assert_committed_lines(crate::lines!["first AI".human()]);
+    second.assert_committed_lines(crate::lines!["second AI".human()]);
+}

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -141,8 +141,10 @@ fn test_lite_mode_preserves_uncommitted_ai_attribution_through_amend() {
 
     let amended = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
     assert!(repo.read_authorship_note(&amended).is_none());
+    committed.assert_committed_lines(crate::lines!["committed".human(), "amended".human(),]);
 
     repo.stage_all_and_commit("commit pending work").unwrap();
+    committed.assert_committed_lines(crate::lines!["committed".human(), "amended".human(),]);
     pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
 }
 
@@ -291,8 +293,10 @@ fn test_lite_mode_preserves_uncommitted_ai_attribution_through_cherry_pick() {
     repo.git(&["cherry-pick", &source]).unwrap();
     let destination = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
     assert!(repo.read_authorship_note(&destination).is_none());
+    picked.assert_committed_lines(crate::lines!["picked".human()]);
 
     repo.stage_all_and_commit("commit pending work").unwrap();
+    picked.assert_committed_lines(crate::lines!["picked".human()]);
     pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
 }
 
@@ -330,14 +334,17 @@ fn test_lite_mode_preserves_uncommitted_ai_attribution_through_revert() {
 
     fs::remove_file(repo.path().join("reverted.txt")).unwrap();
     let deletion = repo.stage_all_and_commit("delete file").unwrap().commit_sha;
+    assert!(!repo.path().join("reverted.txt").exists());
 
     let mut pending = repo.filename("pending.txt");
     pending.set_contents_no_stage(crate::lines!["pending AI".ai()]);
     repo.git(&["revert", "--no-edit", &deletion]).unwrap();
     let destination = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
     assert!(repo.read_authorship_note(&destination).is_none());
+    reverted.assert_committed_lines(crate::lines!["restore me".human()]);
 
     repo.stage_all_and_commit("commit pending work").unwrap();
+    reverted.assert_committed_lines(crate::lines!["restore me".human()]);
     pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
 }
 
@@ -607,7 +614,7 @@ fn test_lite_mode_does_not_move_working_log_for_merge_commit() {
 }
 
 #[test]
-fn test_lite_mode_archives_conflict_resolution_working_log_after_rebase() {
+fn test_lite_mode_leaves_conflict_stop_working_log_at_its_rebase_base() {
     let repo = lite_repo();
     let conflict_path = repo.path().join("conflict.txt");
     fs::write(&conflict_path, "base\n").unwrap();
@@ -639,6 +646,10 @@ fn test_lite_mode_archives_conflict_resolution_working_log_after_rebase() {
     fs::write(&conflict_path, "resolved AI\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "conflict.txt"])
         .unwrap();
+    let pending_path = repo.path().join("pending-during-rebase.txt");
+    fs::write(&pending_path, "pending AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "pending-during-rebase.txt"])
+        .unwrap();
     repo.sync_daemon();
     let resolution_log = repo.working_logs_for_base_commit(&onto);
     assert!(!resolution_log.read_all_checkpoints().unwrap().is_empty());
@@ -649,12 +660,13 @@ fn test_lite_mode_archives_conflict_resolution_working_log_after_rebase() {
     let rebased = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
     assert_ne!(rebased, original_feature);
     assert!(repo.read_authorship_note(&rebased).is_none());
-    assert!(!working_log_dir(&repo, &onto).exists());
     assert!(
-        working_log_dir(&repo, &format!("old-{onto}")).exists(),
-        "the consumed conflict-resolution log should be archived"
+        working_log_dir(&repo, &onto).exists(),
+        "lite mode should leave the conflict-stop log scoped to its rebase base"
     );
+    assert!(!resolution_log.read_all_checkpoints().unwrap().is_empty());
     conflict.assert_committed_lines(crate::lines!["resolved AI".human()]);
+    assert_eq!(fs::read_to_string(pending_path).unwrap(), "pending AI\n");
 }
 
 #[test]

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -334,7 +334,7 @@ fn test_lite_mode_preserves_uncommitted_ai_attribution_through_revert() {
 
     fs::remove_file(repo.path().join("reverted.txt")).unwrap();
     let deletion = repo.stage_all_and_commit("delete file").unwrap().commit_sha;
-    assert!(!repo.path().join("reverted.txt").exists());
+    reverted.assert_committed_lines(crate::lines![]);
 
     let mut pending = repo.filename("pending.txt");
     pending.set_contents_no_stage(crate::lines!["pending AI".ai()]);

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -274,6 +274,49 @@ fn test_lite_mode_does_not_move_working_log_for_unrelated_branch_update() {
 }
 
 #[test]
+fn test_lite_mode_moves_working_log_for_checked_out_fast_forward_update_ref() {
+    let repo = lite_repo();
+    let base_path = repo.path().join("base.txt");
+    fs::write(&base_path, "base\n").unwrap();
+    let old_tip = repo.stage_all_and_commit("base").unwrap().commit_sha;
+    let mut base = repo.filename("base.txt");
+    base.assert_committed_lines(crate::lines!["base".human()]);
+
+    let pending_path = repo.path().join("pending.txt");
+    fs::write(&pending_path, "pending AI\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "pending.txt"])
+        .unwrap();
+
+    let tree = repo
+        .git(&["rev-parse", &format!("{old_tip}^{{tree}}")])
+        .unwrap()
+        .trim()
+        .to_string();
+    let new_tip = repo
+        .git(&["commit-tree", &tree, "-p", &old_tip, "-m", "fast-forward"])
+        .unwrap()
+        .trim()
+        .to_string();
+    let branch = repo.current_branch();
+    repo.git(&[
+        "update-ref",
+        &format!("refs/heads/{branch}"),
+        &new_tip,
+        &old_tip,
+    ])
+    .unwrap();
+
+    assert_eq!(repo.git(&["rev-parse", "HEAD"]).unwrap().trim(), new_tip);
+    assert!(repo.read_authorship_note(&new_tip).is_none());
+    base.assert_committed_lines(crate::lines!["base".human()]);
+
+    repo.stage_all_and_commit("commit pending work").unwrap();
+    base.assert_committed_lines(crate::lines!["base".human()]);
+    let mut pending = repo.filename("pending.txt");
+    pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
 fn test_lite_mode_preserves_regular_squash_notes() {
     let repo = lite_repo();
     let mut base = repo.filename("base.txt");

--- a/tests/integration/lite_mode.rs
+++ b/tests/integration/lite_mode.rs
@@ -237,6 +237,43 @@ fn test_lite_mode_skips_update_ref_restack_notes() {
 }
 
 #[test]
+fn test_lite_mode_does_not_move_working_log_for_unrelated_branch_update() {
+    let repo = lite_repo();
+    let mut base = repo.filename("base.txt");
+    base.set_contents(crate::lines!["base"]);
+    let shared_tip = repo.stage_all_and_commit("base").unwrap().commit_sha;
+    base.assert_committed_lines(crate::lines!["base".human()]);
+
+    repo.git(&["checkout", "-b", "work"]).unwrap();
+    let mut pending = repo.filename("pending.txt");
+    pending.set_contents_no_stage(crate::lines!["pending AI".ai()]);
+
+    let tree = repo
+        .git(&["rev-parse", &format!("{shared_tip}^{{tree}}")])
+        .unwrap()
+        .trim()
+        .to_string();
+    let advanced_main = repo
+        .git(&[
+            "commit-tree",
+            &tree,
+            "-p",
+            &shared_tip,
+            "-m",
+            "advance main",
+        ])
+        .unwrap()
+        .trim()
+        .to_string();
+    repo.git(&["update-ref", "refs/heads/main", &advanced_main, &shared_tip])
+        .unwrap();
+    assert_eq!(repo.git(&["rev-parse", "HEAD"]).unwrap().trim(), shared_tip);
+
+    repo.stage_all_and_commit("commit pending work").unwrap();
+    pending.assert_committed_lines(crate::lines!["pending AI".ai()]);
+}
+
+#[test]
 fn test_lite_mode_preserves_regular_squash_notes() {
     let repo = lite_repo();
     let mut base = repo.filename("base.txt");

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -88,6 +88,7 @@ mod issue_1204_multi_agent;
 mod issue_1415_empty_git_dir;
 mod jetbrains_download;
 mod jetbrains_ide_types;
+mod lite_mode;
 mod log;
 mod merge_rebase;
 mod metrics_retry_idle;

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -15,6 +15,7 @@ fn setup() {
 
     // Test that we can override feature flags
     let test_flags = FeatureFlags {
+        lite_mode: false,
         auth_keyring: false,
         transcript_streaming: true,
         transcript_sweep: true,

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -344,6 +344,20 @@ impl<'a> TestFile<'a> {
     pub fn assert_committed_lines<T: Into<ExpectedLine>>(&mut self, lines: Vec<T>) {
         let expected_lines: Vec<ExpectedLine> = lines.into_iter().map(|l| l.into()).collect();
 
+        if expected_lines.is_empty() && !self.file_path.exists() {
+            let relative_path = self
+                .file_path
+                .strip_prefix(self.repo.path())
+                .expect("test file should be inside the test repository");
+            let relative_path = git_ai::utils::normalize_to_posix(&relative_path.to_string_lossy());
+            let head_path = format!("HEAD:{relative_path}");
+            assert!(
+                self.repo.git_og(&["cat-file", "-e", &head_path]).is_err(),
+                "Expected no committed lines, but {relative_path} still exists in HEAD"
+            );
+            return;
+        }
+
         // Get blame output
         let filename = self.file_path.to_str().expect("valid path");
         let blame_output = self


### PR DESCRIPTION
## Summary

- add a disabled-by-default lite_mode feature flag
- skip daemon authorship-note rewrites while preserving ordinary commits and regular squash merges
- leave explicit git-ai ci rewrite processing unchanged
- preserve working-log-only migrations and avoid amend timestamp snapshots in lite mode

## Validation

- task fmt
- task build
- task lint
- task test
- task test TEST_FILTER=lite_mode
- task test TEST_FILTER=test_ci_local_open_pr_rebase_single_commit