### PR TITLE
test(daemon): await idle control connection closure

### DIFF
--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -504,18 +504,22 @@ fn send_on_persistent_conn<R: Read + Write>(
 }
 
 #[cfg(not(windows))]
-fn assert_control_connection_closed<R: Read + Write>(reader: &mut BufReader<R>) {
-    let mut request = serde_json::to_vec(&ControlRequest::Ping).expect("serialize ping request");
-    request.push(b'\n');
-    if reader.get_mut().write_all(&request).is_ok() && reader.get_mut().flush().is_ok() {
+fn wait_for_control_connection_close<R: Read>(reader: &mut BufReader<R>, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
         let mut response = String::new();
-        let bytes_read = reader
-            .read_line(&mut response)
-            .expect("idle connection should be closed without a read error");
-        assert_eq!(
-            bytes_read, 0,
-            "daemon should close a control connection after the idle deadline"
-        );
+        match reader.read_line(&mut response) {
+            Ok(0) => return,
+            Ok(_) => panic!("idle control connection unexpectedly received: {response:?}"),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) && std::time::Instant::now() < deadline => {}
+            Err(error) => {
+                panic!("daemon should close the control connection within {timeout:?}: {error}")
+            }
+        }
     }
 }
 
@@ -638,9 +642,7 @@ fn daemon_reaps_silent_initial_control_connection() {
         .expect("should set client receive timeout");
     let mut reader = BufReader::new(stream);
 
-    thread::sleep(Duration::from_millis(2_500));
-
-    assert_control_connection_closed(&mut reader);
+    wait_for_control_connection_close(&mut reader, Duration::from_secs(5));
 
     shutdown_daemon(&repo);
 }
@@ -668,9 +670,7 @@ fn daemon_reaps_idle_control_connection_after_valid_request() {
     );
     assert!(response.ok, "telemetry submit should succeed");
 
-    thread::sleep(Duration::from_millis(10_500));
-
-    assert_control_connection_closed(&mut reader);
+    wait_for_control_connection_close(&mut reader, Duration::from_secs(15));
 
     shutdown_daemon(&repo);
 }


### PR DESCRIPTION
## Summary

Fix the Ubuntu CI flake in `daemon_reaps_idle_control_connection_after_valid_request` by passively waiting for the daemon to close the socket instead of sending a ping after a fixed sleep.

The old assertion slept 10.5 seconds for a 10-second server timeout, then sent a ping. Under scheduler load, that ping could race timeout handling and become valid socket activity, producing the observed 12-byte response. The replacement polls for EOF using the existing client receive timeout and a bounded overall deadline. It covers both the initial two-second receive timeout and the ten-second post-request idle timeout without changing production behavior.

Failure: https://github.com/git-ai-project/git-ai/actions/runs/30764716803/job/91541285786

## Validation

- `task fmt`
- `task lint`
- `task build`
- `task test`
- 10 consecutive focused stress runs of both `daemon_reaps_` tests (20/20 passed)

No daemon code, Git work, file reads, process spawns, or trace2 ingestion-path behavior is changed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->