### PR TITLE
test(daemon): sync daemon before asserting wltrace checkpoint ops

### DIFF
--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1792,6 +1792,9 @@ fn wltrace_captures_daemon_working_log_ops_when_enabled() {
     fs::write(&file_path, "AI content\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "traced.txt"])
         .unwrap();
+    // The checkpoint is acknowledged at receipt, before the daemon executes
+    // it; wait for the daemon to drain so every traced op has been written.
+    repo.sync_daemon();
 
     let trace = fs::read_to_string(trace_file.path()).expect("read wltrace output");
     for op in [


### PR DESCRIPTION
## Summary

`wltrace_captures_daemon_working_log_ops_when_enabled` read the wltrace file immediately after `git-ai checkpoint` returned. The CLI is acknowledged at **receipt**, before the daemon executes the checkpoint, so on a slow runner the assertions can run mid-execution and miss the later ops.

Observed on macOS CI in #2030's run: `checkpoint.admission` and `drain.exec` were present in the trace but `working_log.append_checkpoint` was not — the daemon was mid-checkpoint when the file was read. The race exists since #2063 tightened the test's assertions and can bite any PR.

Fix: drain the daemon (`repo.sync_daemon()`) before reading the trace file, matching the idiom used elsewhere in `daemon_mode.rs`. `sync.family` completes only after the family sequencer has fully executed the checkpoint, so all traced ops are on disk by the time the test reads them.

## Validation

- Test-only change; no production code touched.
- CI runs the full matrix including this test on all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->