### PR TITLE
Allow git-ai trace2 in Claude sandboxes

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -367,6 +367,7 @@ fn print_help() {
     eprintln!("  bg                 Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
     eprintln!("    --skills               Also install agent skill files");
+    eprintln!("    --codex-sandbox        Allow Git to send trace2 events from Codex sandboxes");
     eprintln!("    --visual-studio-extension");
     eprintln!("                           Also install the Visual Studio extension on Windows");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -368,6 +368,7 @@ fn print_help() {
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
     eprintln!("    --skills               Also install agent skill files");
     eprintln!("    --codex-sandbox        Allow Git to send trace2 events from Codex sandboxes");
+    eprintln!("    --claude-sandbox       Allow Claude sandboxes to reach the trace2 socket");
     eprintln!("    --visual-studio-extension");
     eprintln!("                           Also install the Visual Studio extension on Windows");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
-use crate::mdm::agents::{get_all_installers, get_all_installers_with_codex_sandbox};
+use crate::mdm::agents::{SandboxInstallOptions, get_all_installers};
 use crate::mdm::hook_installer::HookInstallerParams;
 use crate::mdm::skills_installer;
 use crate::mdm::spinner::{Spinner, print_diff};
@@ -21,7 +21,7 @@ struct InstallOptions {
     dry_run: bool,
     verbose: bool,
     install_skills: bool,
-    codex_sandbox: bool,
+    sandbox: SandboxInstallOptions,
     include_visual_studio_extension: bool,
     api_base: Option<String>,
     api_key: Option<String>,
@@ -365,7 +365,7 @@ fn parse_install_options(args: &[String]) -> Result<InstallOptions, GitAiError> 
             "--dry-run" | "--dry-run=true" => options.dry_run = true,
             "--verbose" | "-v" => options.verbose = true,
             "--skills" => options.install_skills = true,
-            "--codex-sandbox" => options.codex_sandbox = true,
+            "--codex-sandbox" | "--codex-sandbox=true" => options.sandbox.codex = true,
             "--visual-studio-extension" => options.include_visual_studio_extension = true,
             value if value.starts_with("--api-base=") => {
                 options.api_base = non_empty_value(&value[11..]);
@@ -539,7 +539,7 @@ async fn async_run_install(
     // === Coding Agents ===
     println!("\n\x1b[1mCoding Agents\x1b[0m");
 
-    let installers = get_all_installers_with_codex_sandbox(options.codex_sandbox);
+    let installers = get_all_installers(options.sandbox);
     let mut installed_tools: HashSet<String> = HashSet::new();
     // Track agents whose hooks were updated (name, process_names) for restart warnings
     let mut updated_agents: Vec<(String, Vec<String>)> = Vec::new();
@@ -882,7 +882,7 @@ async fn async_run_uninstall(
     // === Coding Agents ===
     println!("\n\x1b[1mCoding Agents\x1b[0m");
 
-    let installers = get_all_installers();
+    let installers = get_all_installers(SandboxInstallOptions::default());
 
     for installer in installers {
         let name = installer.name();
@@ -1080,7 +1080,7 @@ mod tests {
         let options = parse_install_options(&[]).unwrap();
 
         assert!(!options.include_visual_studio_extension);
-        assert!(!options.codex_sandbox);
+        assert!(!options.sandbox.codex);
         assert!(!should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,
             &options
@@ -1102,12 +1102,19 @@ mod tests {
         assert!(options.dry_run);
         assert!(options.verbose);
         assert!(options.install_skills);
-        assert!(options.codex_sandbox);
+        assert!(options.sandbox.codex);
         assert!(options.include_visual_studio_extension);
         assert!(should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,
             &options
         ));
+    }
+
+    #[test]
+    fn parse_install_options_accepts_codex_sandbox_true_flag() {
+        let options = parse_install_options(&["--codex-sandbox=true".to_string()]).unwrap();
+
+        assert!(options.sandbox.codex);
     }
 
     #[test]

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
-use crate::mdm::agents::get_all_installers;
+use crate::mdm::agents::{get_all_installers, get_all_installers_with_codex_sandbox};
 use crate::mdm::hook_installer::HookInstallerParams;
 use crate::mdm::skills_installer;
 use crate::mdm::spinner::{Spinner, print_diff};
@@ -21,6 +21,7 @@ struct InstallOptions {
     dry_run: bool,
     verbose: bool,
     install_skills: bool,
+    codex_sandbox: bool,
     include_visual_studio_extension: bool,
     api_base: Option<String>,
     api_key: Option<String>,
@@ -364,6 +365,7 @@ fn parse_install_options(args: &[String]) -> Result<InstallOptions, GitAiError> 
             "--dry-run" | "--dry-run=true" => options.dry_run = true,
             "--verbose" | "-v" => options.verbose = true,
             "--skills" => options.install_skills = true,
+            "--codex-sandbox" => options.codex_sandbox = true,
             "--visual-studio-extension" => options.include_visual_studio_extension = true,
             value if value.starts_with("--api-base=") => {
                 options.api_base = non_empty_value(&value[11..]);
@@ -537,7 +539,7 @@ async fn async_run_install(
     // === Coding Agents ===
     println!("\n\x1b[1mCoding Agents\x1b[0m");
 
-    let installers = get_all_installers();
+    let installers = get_all_installers_with_codex_sandbox(options.codex_sandbox);
     let mut installed_tools: HashSet<String> = HashSet::new();
     // Track agents whose hooks were updated (name, process_names) for restart warnings
     let mut updated_agents: Vec<(String, Vec<String>)> = Vec::new();
@@ -1078,6 +1080,7 @@ mod tests {
         let options = parse_install_options(&[]).unwrap();
 
         assert!(!options.include_visual_studio_extension);
+        assert!(!options.codex_sandbox);
         assert!(!should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,
             &options
@@ -1090,6 +1093,7 @@ mod tests {
         let args = vec![
             "--dry-run".to_string(),
             "--visual-studio-extension".to_string(),
+            "--codex-sandbox".to_string(),
             "--skills".to_string(),
             "-v".to_string(),
         ];
@@ -1098,6 +1102,7 @@ mod tests {
         assert!(options.dry_run);
         assert!(options.verbose);
         assert!(options.install_skills);
+        assert!(options.codex_sandbox);
         assert!(options.include_visual_studio_extension);
         assert!(should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -366,6 +366,7 @@ fn parse_install_options(args: &[String]) -> Result<InstallOptions, GitAiError> 
             "--verbose" | "-v" => options.verbose = true,
             "--skills" => options.install_skills = true,
             "--codex-sandbox" | "--codex-sandbox=true" => options.sandbox.codex = true,
+            "--claude-sandbox" | "--claude-sandbox=true" => options.sandbox.claude = true,
             "--visual-studio-extension" => options.include_visual_studio_extension = true,
             value if value.starts_with("--api-base=") => {
                 options.api_base = non_empty_value(&value[11..]);
@@ -1079,6 +1080,7 @@ mod tests {
     fn parse_install_options_defaults_visual_studio_extension_to_disabled() {
         let options = parse_install_options(&[]).unwrap();
 
+        assert!(!options.sandbox.claude);
         assert!(!options.include_visual_studio_extension);
         assert!(!options.sandbox.codex);
         assert!(!should_include_installer(
@@ -1086,6 +1088,13 @@ mod tests {
             &options
         ));
         assert!(should_include_installer("vscode", &options));
+    }
+
+    #[test]
+    fn parse_install_options_enables_claude_sandbox_flag() {
+        let options = parse_install_options(&["--claude-sandbox".to_string()]).unwrap();
+
+        assert!(options.sandbox.claude);
     }
 
     #[test]

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
@@ -19,6 +21,54 @@ pub struct ClaudeCodeInstaller;
 impl ClaudeCodeInstaller {
     fn settings_path() -> PathBuf {
         claude_config_dir().join("settings.json")
+    }
+
+    fn allow_trace2_socket(settings: &mut Value) -> Result<(), GitAiError> {
+        #[cfg(unix)]
+        {
+            let root = settings.as_object_mut().ok_or_else(|| {
+                GitAiError::Generic("Claude Code settings must be a JSON object".to_string())
+            })?;
+            let sandbox = root.entry("sandbox").or_insert_with(|| json!({}));
+            let sandbox = sandbox.as_object_mut().ok_or_else(|| {
+                GitAiError::Generic(
+                    "Claude Code sandbox settings must be a JSON object".to_string(),
+                )
+            })?;
+            let network = sandbox.entry("network").or_insert_with(|| json!({}));
+            let network = network.as_object_mut().ok_or_else(|| {
+                GitAiError::Generic(
+                    "Claude Code sandbox network settings must be a JSON object".to_string(),
+                )
+            })?;
+            let allowed_sockets = network
+                .entry("allowUnixSockets")
+                .or_insert_with(|| json!([]));
+            let allowed_sockets = allowed_sockets.as_array_mut().ok_or_else(|| {
+                GitAiError::Generic(
+                    "Claude Code sandbox network.allowUnixSockets must be an array".to_string(),
+                )
+            })?;
+
+            let trace_socket = DaemonConfig::from_env_or_default_paths()?
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned();
+            let trace_socket = Value::String(trace_socket);
+            if !allowed_sockets.contains(&trace_socket) {
+                allowed_sockets.push(trace_socket);
+            }
+
+            // Linux and WSL seccomp cannot filter Unix sockets by path, so Claude
+            // Code requires this broader switch for allowUnixSockets to take effect.
+            #[cfg(target_os = "linux")]
+            network.insert("allowAllUnixSockets".to_string(), Value::Bool(true));
+        }
+
+        #[cfg(not(unix))]
+        let _ = settings;
+
+        Ok(())
     }
 
     /// Returns `(hooks_installed, hooks_up_to_date)` from a parsed settings value.
@@ -222,6 +272,7 @@ impl ClaudeCodeInstaller {
         if let Some(root) = merged.as_object_mut() {
             root.insert("hooks".to_string(), hooks_obj);
         }
+        Self::allow_trace2_socket(&mut merged)?;
 
         if existing == merged {
             return Ok(None);
@@ -474,17 +525,14 @@ mod tests {
     fn s2_idempotent_already_on_catch_all() {
         let (_td, path) = setup_test_env();
         let cmd = expected_cmd();
-        fs::write(
-            &path,
-            serde_json::to_string_pretty(&json!({
-                "hooks": {
-                    "PreToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}],
-                    "PostToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}]
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
+        let mut settings = json!({
+            "hooks": {
+                "PreToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}],
+                "PostToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}]
+            }
+        });
+        ClaudeCodeInstaller::allow_trace2_socket(&mut settings).unwrap();
+        fs::write(&path, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
 
         let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
         assert!(diff.is_none(), "should return None when already up-to-date");
@@ -688,7 +736,7 @@ mod tests {
     fn s7_idempotent_user_catch_all_plus_git_ai() {
         let (_td, path) = setup_test_env();
         let cmd = expected_cmd();
-        let before = json!({
+        let mut before = json!({
             "hooks": {
                 "PreToolUse": [{"matcher": "*", "hooks": [
                     {"type":"command","command": "my-audit-tool"},
@@ -700,6 +748,7 @@ mod tests {
                 ]}]
             }
         });
+        ClaudeCodeInstaller::allow_trace2_socket(&mut before).unwrap();
         fs::write(&path, serde_json::to_string_pretty(&before).unwrap()).unwrap();
 
         let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -26,29 +26,38 @@ impl ClaudeCodeInstaller {
     fn allow_trace2_socket(settings: &mut Value) -> Result<(), GitAiError> {
         #[cfg(unix)]
         {
-            let root = settings.as_object_mut().ok_or_else(|| {
-                GitAiError::Generic("Claude Code settings must be a JSON object".to_string())
-            })?;
+            let Some(root) = settings.as_object_mut() else {
+                return Ok(());
+            };
+            if root.get("sandbox").is_some_and(|value| !value.is_object()) {
+                return Ok(());
+            }
             let sandbox = root.entry("sandbox").or_insert_with(|| json!({}));
-            let sandbox = sandbox.as_object_mut().ok_or_else(|| {
-                GitAiError::Generic(
-                    "Claude Code sandbox settings must be a JSON object".to_string(),
-                )
-            })?;
+            let sandbox = sandbox
+                .as_object_mut()
+                .expect("sandbox shape checked above");
+            if sandbox
+                .get("network")
+                .is_some_and(|value| !value.is_object())
+            {
+                return Ok(());
+            }
             let network = sandbox.entry("network").or_insert_with(|| json!({}));
-            let network = network.as_object_mut().ok_or_else(|| {
-                GitAiError::Generic(
-                    "Claude Code sandbox network settings must be a JSON object".to_string(),
-                )
-            })?;
+            let network = network
+                .as_object_mut()
+                .expect("network shape checked above");
+            if network
+                .get("allowUnixSockets")
+                .is_some_and(|value| !value.is_array())
+            {
+                return Ok(());
+            }
             let allowed_sockets = network
                 .entry("allowUnixSockets")
                 .or_insert_with(|| json!([]));
-            let allowed_sockets = allowed_sockets.as_array_mut().ok_or_else(|| {
-                GitAiError::Generic(
-                    "Claude Code sandbox network.allowUnixSockets must be an array".to_string(),
-                )
-            })?;
+            let allowed_sockets = allowed_sockets
+                .as_array_mut()
+                .expect("allowUnixSockets shape checked above");
 
             let trace_socket = DaemonConfig::from_env_or_default_paths()?
                 .trace_socket_path
@@ -61,8 +70,11 @@ impl ClaudeCodeInstaller {
 
             // Linux and WSL seccomp cannot filter Unix sockets by path, so Claude
             // Code requires this broader switch for allowUnixSockets to take effect.
+            // Preserve an explicit user restriction rather than widening their sandbox.
             #[cfg(target_os = "linux")]
-            network.insert("allowAllUnixSockets".to_string(), Value::Bool(true));
+            network
+                .entry("allowAllUnixSockets")
+                .or_insert(Value::Bool(true));
         }
 
         #[cfg(not(unix))]

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -59,28 +59,75 @@ impl ClaudeCodeInstaller {
                 .as_array_mut()
                 .expect("allowUnixSockets shape checked above");
 
-            let trace_socket = DaemonConfig::from_env_or_default_paths()?
-                .trace_socket_path
-                .to_string_lossy()
-                .into_owned();
-            let trace_socket = Value::String(trace_socket);
+            let trace_socket = Self::trace2_socket_value()?;
             if !allowed_sockets.contains(&trace_socket) {
                 allowed_sockets.push(trace_socket);
             }
 
-            // Linux and WSL seccomp cannot filter Unix sockets by path, so Claude
-            // Code requires this broader switch for allowUnixSockets to take effect.
-            // Preserve an explicit user restriction rather than widening their sandbox.
-            #[cfg(target_os = "linux")]
-            network
-                .entry("allowAllUnixSockets")
-                .or_insert(Value::Bool(true));
+            // Claude Code ignores path-scoped socket allowances on Linux and WSL2.
+            // Do not enable allowAllUnixSockets as a fallback: it disables Unix
+            // socket isolation for every sandboxed command, not just git.
         }
 
         #[cfg(not(unix))]
         let _ = settings;
 
         Ok(())
+    }
+
+    #[cfg(unix)]
+    fn trace2_socket_value() -> Result<Value, GitAiError> {
+        Ok(Value::String(
+            DaemonConfig::from_env_or_default_paths()?
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned(),
+        ))
+    }
+
+    fn remove_trace2_socket(settings: &mut Value) -> Result<bool, GitAiError> {
+        #[cfg(unix)]
+        {
+            let Some(root) = settings.as_object_mut() else {
+                return Ok(false);
+            };
+            let Some(sandbox) = root.get_mut("sandbox").and_then(Value::as_object_mut) else {
+                return Ok(false);
+            };
+            let Some(network) = sandbox.get_mut("network").and_then(Value::as_object_mut) else {
+                return Ok(false);
+            };
+            let Some(allowed_sockets) = network
+                .get_mut("allowUnixSockets")
+                .and_then(Value::as_array_mut)
+            else {
+                return Ok(false);
+            };
+
+            let trace_socket = Self::trace2_socket_value()?;
+            let original_len = allowed_sockets.len();
+            allowed_sockets.retain(|socket| socket != &trace_socket);
+            if allowed_sockets.len() == original_len {
+                return Ok(false);
+            }
+
+            if allowed_sockets.is_empty() {
+                network.remove("allowUnixSockets");
+            }
+            if network.is_empty() {
+                sandbox.remove("network");
+            }
+            if sandbox.is_empty() {
+                root.remove("sandbox");
+            }
+            Ok(true)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = settings;
+            Ok(false)
+        }
     }
 
     /// Returns `(hooks_installed, hooks_up_to_date)` from a parsed settings value.
@@ -312,12 +359,9 @@ impl ClaudeCodeInstaller {
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();
-        let mut hooks_obj = match merged.get("hooks").cloned() {
-            Some(h) => h,
-            None => return Ok(None),
-        };
+        let mut hooks_obj = merged.get("hooks").cloned().unwrap_or_else(|| json!({}));
 
-        let mut changed = false;
+        let mut hooks_changed = false;
 
         for hook_type in &["PreToolUse", "PostToolUse"] {
             if let Some(hook_type_array) =
@@ -337,19 +381,20 @@ impl ClaudeCodeInstaller {
                             }
                         });
                         if hooks_array.len() != original_len {
-                            changed = true;
+                            hooks_changed = true;
                         }
                     }
                 }
             }
         }
 
-        if !changed {
-            return Ok(None);
-        }
-
-        if let Some(root) = merged.as_object_mut() {
+        if hooks_changed && let Some(root) = merged.as_object_mut() {
             root.insert("hooks".to_string(), hooks_obj);
+        }
+        let socket_changed = Self::remove_trace2_socket(&mut merged)?;
+
+        if !hooks_changed && !socket_changed {
+            return Ok(None);
         }
 
         let new_content = serde_json::to_string_pretty(&merged)?;

--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -16,9 +16,15 @@ const CLAUDE_PRE_TOOL_CMD: &str = "checkpoint claude --hook-input stdin";
 const CLAUDE_POST_TOOL_CMD: &str = "checkpoint claude --hook-input stdin";
 const CLAUDE_CATCH_ALL_MATCHER: &str = "*";
 
-pub struct ClaudeCodeInstaller;
+pub struct ClaudeCodeInstaller {
+    allow_trace_socket: bool,
+}
 
 impl ClaudeCodeInstaller {
+    pub(crate) fn new(allow_trace_socket: bool) -> Self {
+        Self { allow_trace_socket }
+    }
+
     fn settings_path() -> PathBuf {
         claude_config_dir().join("settings.json")
     }
@@ -180,6 +186,7 @@ impl ClaudeCodeInstaller {
     fn install_hooks_at(
         settings_path: &Path,
         params: &HookInstallerParams,
+        allow_trace_socket: bool,
         dry_run: bool,
     ) -> Result<Option<String>, GitAiError> {
         if let Some(dir) = settings_path.parent() {
@@ -331,7 +338,9 @@ impl ClaudeCodeInstaller {
         if let Some(root) = merged.as_object_mut() {
             root.insert("hooks".to_string(), hooks_obj);
         }
-        Self::allow_trace2_socket(&mut merged)?;
+        if allow_trace_socket {
+            Self::allow_trace2_socket(&mut merged)?;
+        }
 
         if existing == merged {
             return Ok(None);
@@ -469,7 +478,12 @@ impl HookInstaller for ClaudeCodeInstaller {
         params: &HookInstallerParams,
         dry_run: bool,
     ) -> Result<Option<String>, GitAiError> {
-        Self::install_hooks_at(&Self::settings_path(), params, dry_run)
+        Self::install_hooks_at(
+            &Self::settings_path(),
+            params,
+            self.allow_trace_socket,
+            dry_run,
+        )
     }
 
     fn uninstall_hooks(
@@ -564,7 +578,7 @@ mod tests {
         // File does not exist yet
         fs::remove_file(&path).ok();
 
-        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
         assert!(diff.is_some(), "should produce a diff");
 
         let settings = read_settings(&path);
@@ -591,7 +605,7 @@ mod tests {
         ClaudeCodeInstaller::allow_trace2_socket(&mut settings).unwrap();
         fs::write(&path, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
 
-        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), true, false).unwrap();
         assert!(diff.is_none(), "should return None when already up-to-date");
     }
 
@@ -611,7 +625,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -661,7 +675,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for (hook_type, user_cmd) in &[
@@ -717,7 +731,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -762,7 +776,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -808,7 +822,7 @@ mod tests {
         ClaudeCodeInstaller::allow_trace2_socket(&mut before).unwrap();
         fs::write(&path, serde_json::to_string_pretty(&before).unwrap()).unwrap();
 
-        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), true, false).unwrap();
         assert!(diff.is_none(), "should be idempotent");
     }
 
@@ -841,7 +855,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -896,7 +910,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -924,7 +938,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -966,7 +980,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -1021,7 +1035,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -1060,7 +1074,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
 
@@ -1349,7 +1363,7 @@ mod tests {
         assert!(!settings_path.parent().unwrap().exists());
 
         let result =
-            ClaudeCodeInstaller::install_hooks_at(&settings_path, &params(), false).unwrap();
+            ClaudeCodeInstaller::install_hooks_at(&settings_path, &params(), false, false).unwrap();
 
         assert!(result.is_some(), "should report changes for fresh install");
         assert!(settings_path.exists(), "settings.json should be created");

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -27,6 +27,47 @@ impl CodexInstaller {
         codex_home_dir().join("hooks.json")
     }
 
+    #[cfg(unix)]
+    fn network_proxy_enabled_marker_path(config_path: &Path) -> Result<PathBuf, GitAiError> {
+        let mut hasher = Sha256::new();
+        hasher.update(config_path.to_string_lossy().as_bytes());
+        let digest = format!("{:x}", hasher.finalize());
+        Ok(DaemonConfig::from_env_or_default_paths()?
+            .internal_dir
+            .join(format!("codex-network-proxy-enabled-{}", &digest[..16])))
+    }
+
+    #[cfg(unix)]
+    fn config_has_network_proxy_enabled(config: &TomlValue) -> bool {
+        config
+            .get("features")
+            .and_then(|features| features.get("network_proxy"))
+            .is_some_and(|network_proxy| {
+                network_proxy.is_bool()
+                    || network_proxy
+                        .as_table()
+                        .is_some_and(|table| table.contains_key("enabled"))
+            })
+    }
+
+    #[cfg(unix)]
+    fn record_network_proxy_enabled_provenance(config_path: &Path) -> Result<(), GitAiError> {
+        let marker_path = Self::network_proxy_enabled_marker_path(config_path)?;
+        if let Some(parent) = marker_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        write_atomic(&marker_path, b"")
+    }
+
+    #[cfg(unix)]
+    fn clear_network_proxy_enabled_provenance(config_path: &Path) -> Result<(), GitAiError> {
+        let marker_path = Self::network_proxy_enabled_marker_path(config_path)?;
+        if marker_path.exists() {
+            fs::remove_file(marker_path)?;
+        }
+        Ok(())
+    }
+
     fn desired_command(binary_path: &Path) -> String {
         format!("{} {}", binary_path.display(), CODEX_CHECKPOINT_CMD)
     }
@@ -297,7 +338,12 @@ impl CodexInstaller {
         }
     }
 
-    fn config_without_trace_socket_allowance(config: &TomlValue) -> Result<TomlValue, GitAiError> {
+    fn config_without_trace_socket_allowance(
+        config: &TomlValue,
+        remove_enabled: bool,
+    ) -> Result<TomlValue, GitAiError> {
+        #[cfg(not(unix))]
+        let _ = remove_enabled;
         #[cfg(not(unix))]
         return Ok(config.clone());
 
@@ -329,7 +375,7 @@ impl CodexInstaller {
             if remove_unix_sockets {
                 network_proxy.remove("unix_sockets");
             }
-            if network_proxy.len() == 1
+            if remove_enabled
                 && network_proxy.get("enabled").and_then(TomlValue::as_bool) == Some(true)
             {
                 network_proxy.remove("enabled");
@@ -872,6 +918,8 @@ impl HookInstaller for CodexInstaller {
         };
 
         let existing_config = Self::parse_config_toml(&existing_config_content)?;
+        #[cfg(unix)]
+        let network_proxy_enabled_added = !Self::config_has_network_proxy_enabled(&existing_config);
 
         let existing_hooks_content = if hooks_json_path.exists() {
             fs::read_to_string(&hooks_json_path)?
@@ -923,6 +971,11 @@ impl HookInstaller for CodexInstaller {
                 if !dry_run {
                     write_atomic(&hooks_json_path, new_hooks_content.as_bytes())?;
                 }
+            }
+
+            #[cfg(unix)]
+            if !dry_run && network_proxy_enabled_added {
+                Self::record_network_proxy_enabled_provenance(&config_path)?;
             }
 
             return Ok(Some(diff_output.join("\n")));
@@ -984,6 +1037,11 @@ impl HookInstaller for CodexInstaller {
             }
         }
 
+        #[cfg(unix)]
+        if !dry_run && network_proxy_enabled_added {
+            Self::record_network_proxy_enabled_provenance(&config_path)?;
+        }
+
         Ok(Some(diff_output.join("\n")))
     }
 
@@ -994,7 +1052,16 @@ impl HookInstaller for CodexInstaller {
     ) -> Result<Option<String>, GitAiError> {
         let config_path = Self::config_path();
         let hooks_json_path = Self::hooks_json_path();
+        #[cfg(unix)]
+        let network_proxy_enabled_added =
+            Self::network_proxy_enabled_marker_path(&config_path)?.exists();
+        #[cfg(not(unix))]
+        let network_proxy_enabled_added = false;
         if !config_path.exists() && !hooks_json_path.exists() {
+            #[cfg(unix)]
+            if !dry_run {
+                Self::clear_network_proxy_enabled_provenance(&config_path)?;
+            }
             return Ok(None);
         }
 
@@ -1010,8 +1077,10 @@ impl HookInstaller for CodexInstaller {
             Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
         let (config_without_hooks, inline_hooks_changed) =
             Self::remove_inline_hooks_from_config(&config_without_notify)?;
-        let config_without_trace_socket =
-            Self::config_without_trace_socket_allowance(&config_without_hooks)?;
+        let config_without_trace_socket = Self::config_without_trace_socket_allowance(
+            &config_without_hooks,
+            network_proxy_enabled_added,
+        )?;
         let merged_config = Self::remove_feature_flags(&config_without_trace_socket)?;
 
         // Check if legacy hooks.json needs cleanup
@@ -1026,6 +1095,10 @@ impl HookInstaller for CodexInstaller {
 
         let config_changed = merged_config != existing_config;
         if !config_changed && !inline_hooks_changed && !hooks_json_changed {
+            #[cfg(unix)]
+            if !dry_run {
+                Self::clear_network_proxy_enabled_provenance(&config_path)?;
+            }
             return Ok(None);
         }
 
@@ -1066,6 +1139,11 @@ impl HookInstaller for CodexInstaller {
                     fs::remove_file(&hooks_json_path)?;
                 }
             }
+        }
+
+        #[cfg(unix)]
+        if !dry_run {
+            Self::clear_network_proxy_enabled_provenance(&config_path)?;
         }
 
         Ok(Some(diff_output.join("\n")))
@@ -2179,6 +2257,66 @@ enabled = true
                     .and_then(TomlValue::as_str),
                 Some("allow"),
                 "uninstall must preserve unrelated socket rules"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn test_uninstall_restores_network_proxy_enabled_provenance() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            fs::write(&config_path, "[features.network_proxy]\nenabled = true\n").unwrap();
+            installer.install_hooks(&params, false).unwrap();
+            installer.uninstall_hooks(&params, false).unwrap();
+            let config =
+                CodexInstaller::parse_config_toml(&fs::read_to_string(&config_path).unwrap())
+                    .unwrap();
+            assert_eq!(
+                config
+                    .get("features")
+                    .and_then(|features| features.get("network_proxy"))
+                    .and_then(|network_proxy| network_proxy.get("enabled"))
+                    .and_then(TomlValue::as_bool),
+                Some(true),
+                "uninstall must preserve a pre-existing enabled setting"
+            );
+
+            fs::write(
+                &config_path,
+                r#"[features.network_proxy.unix_sockets]
+"/tmp/existing-agent.sock" = "allow"
+"#,
+            )
+            .unwrap();
+            installer.install_hooks(&params, false).unwrap();
+            installer.uninstall_hooks(&params, false).unwrap();
+            let config =
+                CodexInstaller::parse_config_toml(&fs::read_to_string(&config_path).unwrap())
+                    .unwrap();
+            let network_proxy = config
+                .get("features")
+                .and_then(|features| features.get("network_proxy"))
+                .expect("unrelated proxy settings should remain");
+            assert!(
+                network_proxy.get("enabled").is_none(),
+                "uninstall must remove enabled when git-ai added it"
+            );
+            assert_eq!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get("/tmp/existing-agent.sock"))
+                    .and_then(TomlValue::as_str),
+                Some("allow")
             );
         });
     }

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -297,6 +297,51 @@ impl CodexInstaller {
         }
     }
 
+    fn config_without_trace_socket_allowance(config: &TomlValue) -> Result<TomlValue, GitAiError> {
+        #[cfg(not(unix))]
+        return Ok(config.clone());
+
+        #[cfg(unix)]
+        {
+            let trace_socket_path = DaemonConfig::from_env_or_default_paths()?.trace_socket_path;
+            let trace_socket = trace_socket_path.to_string_lossy();
+            let mut merged = config.clone();
+            let root = merged.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex config root must be a table".to_string())
+            })?;
+            let Some(features) = root.get_mut("features").and_then(TomlValue::as_table_mut) else {
+                return Ok(merged);
+            };
+            let Some(network_proxy) = features
+                .get_mut("network_proxy")
+                .and_then(TomlValue::as_table_mut)
+            else {
+                return Ok(merged);
+            };
+
+            let remove_unix_sockets = network_proxy
+                .get_mut("unix_sockets")
+                .and_then(TomlValue::as_table_mut)
+                .is_some_and(|unix_sockets| {
+                    unix_sockets.remove(trace_socket.as_ref());
+                    unix_sockets.is_empty()
+                });
+            if remove_unix_sockets {
+                network_proxy.remove("unix_sockets");
+            }
+            // Only the exact socket rule is owned by git-ai. Keep `enabled` and any
+            // other proxy settings because they may have existed before installation.
+            if network_proxy.is_empty() {
+                features.remove("network_proxy");
+            }
+            if features.is_empty() {
+                root.remove("features");
+            }
+
+            Ok(merged)
+        }
+    }
+
     fn config_with_installed_hooks(
         config: &TomlValue,
         binary_path: &Path,
@@ -962,7 +1007,9 @@ impl HookInstaller for CodexInstaller {
             Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
         let (config_without_hooks, inline_hooks_changed) =
             Self::remove_inline_hooks_from_config(&config_without_notify)?;
-        let merged_config = Self::remove_feature_flags(&config_without_hooks)?;
+        let config_without_trace_socket =
+            Self::config_without_trace_socket_allowance(&config_without_hooks)?;
+        let merged_config = Self::remove_feature_flags(&config_without_trace_socket)?;
 
         // Check if legacy hooks.json needs cleanup
         let (hooks_json_changed, existing_hooks_content) = if hooks_json_path.exists() {
@@ -2053,6 +2100,71 @@ codex_hooks = true
                 .expect("second install should succeed");
             assert!(second_install.is_none(), "second install should be a no-op");
             assert_eq!(fs::read_to_string(config_path).unwrap(), installed_content);
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn test_uninstall_removes_trace_socket_and_preserves_network_proxy_settings() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            fs::write(
+                &config_path,
+                r#"[features.network_proxy]
+enabled = true
+
+[features.network_proxy.unix_sockets]
+"/tmp/existing-agent.sock" = "allow"
+"#,
+            )
+            .unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+            installer
+                .uninstall_hooks(&params, false)
+                .expect("uninstall should succeed");
+
+            let uninstalled_content = fs::read_to_string(&config_path).unwrap();
+            let uninstalled = CodexInstaller::parse_config_toml(&uninstalled_content).unwrap();
+            let network_proxy = uninstalled
+                .get("features")
+                .and_then(|features| features.get("network_proxy"))
+                .expect("existing network proxy config should remain");
+            let trace_socket = DaemonConfig::from_home(home)
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned();
+
+            assert_eq!(
+                network_proxy.get("enabled").and_then(TomlValue::as_bool),
+                Some(true),
+                "uninstall must preserve the user's network proxy setting"
+            );
+            assert!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get(&trace_socket))
+                    .is_none(),
+                "uninstall must remove the git-ai trace socket rule"
+            );
+            assert_eq!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get("/tmp/existing-agent.sock"))
+                    .and_then(TomlValue::as_str),
+                Some("allow"),
+                "uninstall must preserve unrelated socket rules"
+            );
         });
     }
 

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -1,4 +1,6 @@
 use crate::config::{CodexHooksFormat, Config};
+#[cfg(unix)]
+use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
@@ -229,6 +231,70 @@ impl CodexInstaller {
         }
 
         Ok(merged)
+    }
+
+    fn config_with_trace_socket_allowed(config: &TomlValue) -> Result<TomlValue, GitAiError> {
+        #[cfg(not(unix))]
+        return Ok(config.clone());
+
+        #[cfg(unix)]
+        {
+            let trace_socket_path = DaemonConfig::from_env_or_default_paths()?.trace_socket_path;
+            let mut merged = config.clone();
+            let root = merged.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex config root must be a table".to_string())
+            })?;
+            let features = root
+                .entry("features")
+                .or_insert_with(|| TomlValue::Table(Map::new()));
+            if !features.is_table() {
+                *features = TomlValue::Table(Map::new());
+            }
+            let features = features.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex config features field must be a table".to_string())
+            })?;
+
+            let network_proxy = features
+                .entry("network_proxy")
+                .or_insert_with(|| TomlValue::Table(Map::new()));
+            if let Some(enabled) = network_proxy.as_bool() {
+                *network_proxy = TomlValue::Table(Map::from_iter([(
+                    "enabled".to_string(),
+                    TomlValue::Boolean(enabled),
+                )]));
+            } else if !network_proxy.is_table() {
+                *network_proxy = TomlValue::Table(Map::new());
+            }
+            let network_proxy = network_proxy.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic(
+                    "Codex config features.network_proxy field must be a table".to_string(),
+                )
+            })?;
+            network_proxy
+                .entry("enabled")
+                .or_insert(TomlValue::Boolean(true));
+
+            let unix_sockets = network_proxy
+                .entry("unix_sockets")
+                .or_insert_with(|| TomlValue::Table(Map::new()));
+            if !unix_sockets.is_table() {
+                *unix_sockets = TomlValue::Table(Map::new());
+            }
+            unix_sockets
+                .as_table_mut()
+                .ok_or_else(|| {
+                    GitAiError::Generic(
+                        "Codex config features.network_proxy.unix_sockets field must be a table"
+                            .to_string(),
+                    )
+                })?
+                .insert(
+                    trace_socket_path.to_string_lossy().into_owned(),
+                    TomlValue::String("allow".to_string()),
+                );
+
+            Ok(merged)
+        }
     }
 
     fn config_with_installed_hooks(
@@ -707,8 +773,9 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&config)?.unwrap_or(config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let desired_config =
-                Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?;
+            let desired_config = Self::config_with_trace_socket_allowed(
+                &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
+            )?;
             let desired_hooks_json =
                 Self::hooks_json_with_installed_hooks(&hooks_json, &params.binary_path)?;
             let has_json_hooks = Self::hooks_json_has_git_ai_entries(&hooks_json);
@@ -722,7 +789,9 @@ impl HookInstaller for CodexInstaller {
             });
         }
 
-        let desired_config = Self::config_with_installed_hooks(&config, &params.binary_path)?;
+        let desired_config = Self::config_with_trace_socket_allowed(
+            &Self::config_with_installed_hooks(&config, &params.binary_path)?,
+        )?;
         let has_inline_hooks = Self::config_has_inline_hooks(&config);
         let has_legacy_hooks_json = Self::hooks_json_has_git_ai_entries(&hooks_json);
         let hooks_installed = Self::config_hooks_feature_enabled(&config)
@@ -768,8 +837,9 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let merged_config =
-                Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?;
+            let merged_config = Self::config_with_trace_socket_allowed(
+                &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
+            )?;
             let merged_hooks =
                 Self::hooks_json_with_installed_hooks(&existing_hooks, &params.binary_path)?;
 
@@ -810,8 +880,9 @@ impl HookInstaller for CodexInstaller {
             return Ok(Some(diff_output.join("\n")));
         }
 
-        let merged_config =
-            Self::config_with_installed_hooks(&existing_config, &params.binary_path)?;
+        let merged_config = Self::config_with_trace_socket_allowed(
+            &Self::config_with_installed_hooks(&existing_config, &params.binary_path)?,
+        )?;
 
         // Check if legacy hooks.json needs migration
         let (hooks_json_changed, existing_hooks_content) = if hooks_json_path.exists() {
@@ -1933,6 +2004,55 @@ codex_hooks = true
             assert!(check.tool_installed);
             assert!(check.hooks_installed);
             assert!(check.hooks_up_to_date);
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn test_hooks_json_install_allows_trace_socket_and_is_idempotent() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+
+            let installed_content = fs::read_to_string(&config_path).unwrap();
+            let installed = CodexInstaller::parse_config_toml(&installed_content).unwrap();
+            let network_proxy = installed
+                .get("features")
+                .and_then(|features| features.get("network_proxy"))
+                .expect("network proxy config");
+            let trace_socket = DaemonConfig::from_home(home)
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned();
+            assert_eq!(
+                network_proxy.get("enabled").and_then(TomlValue::as_bool),
+                Some(true)
+            );
+            assert_eq!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get(&trace_socket))
+                    .and_then(TomlValue::as_str),
+                Some("allow")
+            );
+
+            let second_install = installer
+                .install_hooks(&params, false)
+                .expect("second install should succeed");
+            assert!(second_install.is_none(), "second install should be a no-op");
+            assert_eq!(fs::read_to_string(config_path).unwrap(), installed_content);
         });
     }
 

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -16,9 +16,16 @@ use toml::map::Map;
 const CODEX_CHECKPOINT_CMD: &str = "checkpoint codex --hook-input stdin";
 const CODEX_HOOK_EVENTS: [&str; 3] = ["PreToolUse", "PostToolUse", "Stop"];
 
-pub struct CodexInstaller;
+#[derive(Debug, Default)]
+pub struct CodexInstaller {
+    allow_trace_socket: bool,
+}
 
 impl CodexInstaller {
+    pub(crate) fn new(allow_trace_socket: bool) -> Self {
+        Self { allow_trace_socket }
+    }
+
     fn config_path() -> PathBuf {
         codex_home_dir().join("config.toml")
     }
@@ -335,6 +342,17 @@ impl CodexInstaller {
                 );
 
             Ok(merged)
+        }
+    }
+
+    fn config_with_optional_trace_socket_allowance(
+        &self,
+        config: &TomlValue,
+    ) -> Result<TomlValue, GitAiError> {
+        if self.allow_trace_socket {
+            Self::config_with_trace_socket_allowed(config)
+        } else {
+            Ok(config.clone())
         }
     }
 
@@ -867,7 +885,7 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&config)?.unwrap_or(config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let desired_config = Self::config_with_trace_socket_allowed(
+            let desired_config = self.config_with_optional_trace_socket_allowance(
                 &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
             )?;
             let desired_hooks_json =
@@ -883,7 +901,7 @@ impl HookInstaller for CodexInstaller {
             });
         }
 
-        let desired_config = Self::config_with_trace_socket_allowed(
+        let desired_config = self.config_with_optional_trace_socket_allowance(
             &Self::config_with_installed_hooks(&config, &params.binary_path)?,
         )?;
         let has_inline_hooks = Self::config_has_inline_hooks(&config);
@@ -919,7 +937,8 @@ impl HookInstaller for CodexInstaller {
 
         let existing_config = Self::parse_config_toml(&existing_config_content)?;
         #[cfg(unix)]
-        let network_proxy_enabled_added = !Self::config_has_network_proxy_enabled(&existing_config);
+        let network_proxy_enabled_added =
+            self.allow_trace_socket && !Self::config_has_network_proxy_enabled(&existing_config);
 
         let existing_hooks_content = if hooks_json_path.exists() {
             fs::read_to_string(&hooks_json_path)?
@@ -933,7 +952,7 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let merged_config = Self::config_with_trace_socket_allowed(
+            let merged_config = self.config_with_optional_trace_socket_allowance(
                 &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
             )?;
             let merged_hooks =
@@ -981,7 +1000,7 @@ impl HookInstaller for CodexInstaller {
             return Ok(Some(diff_output.join("\n")));
         }
 
-        let merged_config = Self::config_with_trace_socket_allowed(
+        let merged_config = self.config_with_optional_trace_socket_allowance(
             &Self::config_with_installed_hooks(&existing_config, &params.binary_path)?,
         )?;
 
@@ -1604,7 +1623,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1654,7 +1673,7 @@ codex_hooks = true
             let config_path = custom_codex_home.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1713,7 +1732,7 @@ notify = ["/usr/local/bin/git-ai", "checkpoint", "codex", "--hook-input"]
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1759,7 +1778,7 @@ notify = ["/Users/svarlamov/.git-ai/bin/git-ai", "checkpoint", "codex", "--via-c
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1793,7 +1812,7 @@ notify = ["notify-send", "Codex finished"]
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1849,7 +1868,7 @@ notify = ["notify-send", "Codex finished"]
             let original_content = "model = \"gpt-5\"\n";
             fs::write(&config_path, original_content).unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1876,7 +1895,7 @@ notify = ["notify-send", "Codex finished"]
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1949,7 +1968,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2014,7 +2033,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2084,7 +2103,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2138,6 +2157,49 @@ codex_hooks = true
     #[test]
     #[serial]
     #[cfg(unix)]
+    fn test_hooks_json_install_does_not_configure_sandbox_by_default() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+
+            let installer = CodexInstaller::default();
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+
+            let installed =
+                CodexInstaller::parse_config_toml(&fs::read_to_string(&config_path).unwrap())
+                    .unwrap();
+            assert!(
+                installed
+                    .get("features")
+                    .and_then(|features| features.get("network_proxy"))
+                    .is_none(),
+                "default install must not configure the Codex network proxy"
+            );
+            assert!(
+                !CodexInstaller::network_proxy_enabled_marker_path(&config_path)
+                    .unwrap()
+                    .exists(),
+                "default install must not record proxy ownership"
+            );
+
+            let check = installer
+                .check_hooks(&params)
+                .expect("check should succeed");
+            assert!(check.hooks_up_to_date);
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
     fn test_hooks_json_install_allows_trace_socket_and_is_idempotent() {
         with_temp_home(|home| {
             let codex_dir = home.join(".codex");
@@ -2146,7 +2208,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::new(true);
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2216,7 +2278,7 @@ enabled = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::new(true);
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2270,7 +2332,7 @@ enabled = true
             write_git_ai_config(home, "hooks_json");
             fs::create_dir_all(&codex_dir).unwrap();
             let config_path = codex_dir.join("config.toml");
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::new(true);
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2363,7 +2425,7 @@ command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2449,7 +2511,7 @@ command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2508,7 +2570,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2539,7 +2601,7 @@ codex_hooks = true
             let codex_dir = home.join(".codex");
             assert!(!codex_dir.exists());
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2597,7 +2659,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2692,7 +2754,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"o3\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2740,7 +2802,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"o3\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2793,7 +2855,7 @@ trusted_hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2834,7 +2896,7 @@ trusted_hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"o3\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -329,8 +329,11 @@ impl CodexInstaller {
             if remove_unix_sockets {
                 network_proxy.remove("unix_sockets");
             }
-            // Only the exact socket rule is owned by git-ai. Keep `enabled` and any
-            // other proxy settings because they may have existed before installation.
+            if network_proxy.len() == 1
+                && network_proxy.get("enabled").and_then(TomlValue::as_bool) == Some(true)
+            {
+                network_proxy.remove("enabled");
+            }
             if network_proxy.is_empty() {
                 features.remove("network_proxy");
             }
@@ -2100,6 +2103,18 @@ codex_hooks = true
                 .expect("second install should succeed");
             assert!(second_install.is_none(), "second install should be a no-op");
             assert_eq!(fs::read_to_string(config_path).unwrap(), installed_content);
+
+            installer
+                .uninstall_hooks(&params, false)
+                .expect("uninstall should succeed");
+            let uninstalled = CodexInstaller::parse_config_toml(
+                &fs::read_to_string(codex_dir.join("config.toml")).unwrap(),
+            )
+            .unwrap();
+            assert!(
+                uninstalled.get("features").is_none(),
+                "uninstall should remove proxy config created solely for git-ai"
+            );
         });
     }
 

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -36,13 +36,14 @@ use super::hook_installer::HookInstaller;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SandboxInstallOptions {
+    pub claude: bool,
     pub codex: bool,
 }
 
 /// Get all available hook installers
 pub fn get_all_installers(sandbox: SandboxInstallOptions) -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
-        Box::new(ClaudeCodeInstaller),
+        Box::new(ClaudeCodeInstaller::new(sandbox.claude)),
         Box::new(ClineInstaller),
         Box::new(CodexInstaller::new(sandbox.codex)),
         Box::new(CursorInstaller),

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -34,17 +34,17 @@ pub use windsurf::WindsurfInstaller;
 
 use super::hook_installer::HookInstaller;
 
-/// Get all available hook installers
-pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
-    get_all_installers_with_codex_sandbox(false)
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SandboxInstallOptions {
+    pub codex: bool,
 }
 
-/// Get all available hook installers with optional Codex sandbox integration.
-pub fn get_all_installers_with_codex_sandbox(codex_sandbox: bool) -> Vec<Box<dyn HookInstaller>> {
+/// Get all available hook installers
+pub fn get_all_installers(sandbox: SandboxInstallOptions) -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
         Box::new(ClaudeCodeInstaller),
         Box::new(ClineInstaller),
-        Box::new(CodexInstaller::new(codex_sandbox)),
+        Box::new(CodexInstaller::new(sandbox.codex)),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),
         Box::new(GitHubCopilotInstaller),

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -36,10 +36,15 @@ use super::hook_installer::HookInstaller;
 
 /// Get all available hook installers
 pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
+    get_all_installers_with_codex_sandbox(false)
+}
+
+/// Get all available hook installers with optional Codex sandbox integration.
+pub fn get_all_installers_with_codex_sandbox(codex_sandbox: bool) -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
         Box::new(ClaudeCodeInstaller),
         Box::new(ClineInstaller),
-        Box::new(CodexInstaller),
+        Box::new(CodexInstaller::new(codex_sandbox)),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),
         Box::new(GitHubCopilotInstaller),

--- a/tests/integration/claude_sandbox.rs
+++ b/tests/integration/claude_sandbox.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use crate::repos::test_repo::{DaemonTestScope, TestRepo};
 use git_ai::daemon::DaemonConfig;
 use serde_json::{Value, json};
@@ -17,8 +19,7 @@ fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
                 "enabled": true,
                 "network": {
                     "allowedDomains": ["example.com"],
-                    "allowUnixSockets": ["/tmp/user-owned.sock"],
-                    "allowAllUnixSockets": false
+                    "allowUnixSockets": ["/tmp/user-owned.sock"]
                 }
             }
         }))
@@ -48,4 +49,62 @@ fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
     repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
         .expect("reinstall Claude hooks");
     assert_eq!(fs::read_to_string(settings_path).unwrap(), first_install);
+}
+
+#[test]
+fn install_hooks_preserves_explicit_sandbox_restrictions() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({
+            "sandbox": {
+                "network": {
+                    "allowAllUnixSockets": false
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("install Claude hooks");
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+    assert_eq!(settings["sandbox"]["network"]["allowAllUnixSockets"], false);
+    assert!(settings["hooks"]["PreToolUse"].is_array());
+    assert!(settings["hooks"]["PostToolUse"].is_array());
+}
+
+#[test]
+fn install_hooks_ignores_unexpected_sandbox_shapes() {
+    for (name, sandbox) in [
+        ("sandbox", json!(true)),
+        ("network", json!({"network": true})),
+        (
+            "allow-unix-sockets",
+            json!({"network": {"allowUnixSockets": true}}),
+        ),
+    ] {
+        let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+        let settings_path = repo.test_home_path().join(".claude/settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&json!({"sandbox": sandbox})).unwrap(),
+        )
+        .unwrap();
+
+        repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+            .unwrap_or_else(|error| panic!("install hooks with unexpected {name} shape: {error}"));
+
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_eq!(settings["sandbox"], sandbox);
+        assert!(settings["hooks"]["PreToolUse"].is_array());
+        assert!(settings["hooks"]["PostToolUse"].is_array());
+    }
 }

--- a/tests/integration/claude_sandbox.rs
+++ b/tests/integration/claude_sandbox.rs
@@ -6,8 +6,24 @@ use serde_json::{Value, json};
 use std::fs;
 
 #[test]
-#[cfg(unix)]
-fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
+fn install_hooks_does_not_configure_claude_sandbox_by_default() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(&settings_path, "{}\n").unwrap();
+
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("install Claude hooks");
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+    assert!(settings["sandbox"].is_null());
+    assert!(settings["hooks"]["PreToolUse"].is_array());
+    assert!(settings["hooks"]["PostToolUse"].is_array());
+}
+
+#[test]
+fn install_hooks_claude_sandbox_flag_allows_trace2_socket() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
     let settings_path = repo.test_home_path().join(".claude/settings.json");
     fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
@@ -27,7 +43,7 @@ fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
     )
     .unwrap();
 
-    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks", "--claude-sandbox"])
         .expect("install Claude hooks");
 
     let first_install = fs::read_to_string(&settings_path).unwrap();
@@ -45,7 +61,7 @@ fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
     assert_eq!(settings["theme"], "dark");
     assert!(network["allowAllUnixSockets"].is_null());
 
-    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks", "--claude-sandbox"])
         .expect("reinstall Claude hooks");
     assert_eq!(fs::read_to_string(settings_path).unwrap(), first_install);
 }
@@ -68,7 +84,7 @@ fn install_hooks_preserves_explicit_sandbox_restrictions() {
     )
     .unwrap();
 
-    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks", "--claude-sandbox"])
         .expect("install Claude hooks");
 
     let settings: Value =
@@ -96,7 +112,7 @@ fn uninstall_hooks_removes_only_the_trace2_socket_allowance() {
     )
     .unwrap();
 
-    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks", "--claude-sandbox"])
         .expect("install Claude hooks");
     repo.git_ai_without_pre_sync_for_test(&["uninstall-hooks"])
         .expect("uninstall Claude hooks");
@@ -125,7 +141,7 @@ fn install_hooks_ignores_unexpected_sandbox_shapes() {
         )
         .unwrap();
 
-        repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        repo.git_ai_without_pre_sync_for_test(&["install-hooks", "--claude-sandbox"])
             .unwrap_or_else(|error| panic!("install hooks with unexpected {name} shape: {error}"));
 
         let settings: Value =

--- a/tests/integration/claude_sandbox.rs
+++ b/tests/integration/claude_sandbox.rs
@@ -43,8 +43,7 @@ fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
     assert!(allowed_sockets.contains(&json!(expected_trace_socket)));
     assert_eq!(network["allowedDomains"], json!(["example.com"]));
     assert_eq!(settings["theme"], "dark");
-    #[cfg(target_os = "linux")]
-    assert_eq!(network["allowAllUnixSockets"], true);
+    assert!(network["allowAllUnixSockets"].is_null());
 
     repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
         .expect("reinstall Claude hooks");
@@ -77,6 +76,34 @@ fn install_hooks_preserves_explicit_sandbox_restrictions() {
     assert_eq!(settings["sandbox"]["network"]["allowAllUnixSockets"], false);
     assert!(settings["hooks"]["PreToolUse"].is_array());
     assert!(settings["hooks"]["PostToolUse"].is_array());
+}
+
+#[test]
+fn uninstall_hooks_removes_only_the_trace2_socket_allowance() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    let original_sandbox = json!({
+        "enabled": true,
+        "network": {
+            "allowedDomains": ["example.com"],
+            "allowUnixSockets": ["/tmp/user-owned.sock"]
+        }
+    });
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({"sandbox": original_sandbox})).unwrap(),
+    )
+    .unwrap();
+
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("install Claude hooks");
+    repo.git_ai_without_pre_sync_for_test(&["uninstall-hooks"])
+        .expect("uninstall Claude hooks");
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+    assert_eq!(settings["sandbox"], original_sandbox);
 }
 
 #[test]

--- a/tests/integration/claude_sandbox.rs
+++ b/tests/integration/claude_sandbox.rs
@@ -1,0 +1,51 @@
+use crate::repos::test_repo::{DaemonTestScope, TestRepo};
+use git_ai::daemon::DaemonConfig;
+use serde_json::{Value, json};
+use std::fs;
+
+#[test]
+#[cfg(unix)]
+fn install_hooks_allows_trace2_socket_in_all_claude_sandboxes() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({
+            "theme": "dark",
+            "sandbox": {
+                "enabled": true,
+                "network": {
+                    "allowedDomains": ["example.com"],
+                    "allowUnixSockets": ["/tmp/user-owned.sock"],
+                    "allowAllUnixSockets": false
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("install Claude hooks");
+
+    let first_install = fs::read_to_string(&settings_path).unwrap();
+    let settings: Value = serde_json::from_str(&first_install).unwrap();
+    let network = &settings["sandbox"]["network"];
+    let allowed_sockets = network["allowUnixSockets"].as_array().unwrap();
+    let expected_trace_socket = DaemonConfig::from_home(repo.test_home_path())
+        .trace_socket_path
+        .to_string_lossy()
+        .into_owned();
+
+    assert!(allowed_sockets.contains(&json!("/tmp/user-owned.sock")));
+    assert!(allowed_sockets.contains(&json!(expected_trace_socket)));
+    assert_eq!(network["allowedDomains"], json!(["example.com"]));
+    assert_eq!(settings["theme"], "dark");
+    #[cfg(target_os = "linux")]
+    assert_eq!(network["allowAllUnixSockets"], true);
+
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("reinstall Claude hooks");
+    assert_eq!(fs::read_to_string(settings_path).unwrap(), first_install);
+}

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -275,7 +275,7 @@ fn plain_install_hooks_preserves_the_invoking_user_home() {
 
 #[test]
 #[cfg(unix)]
-fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
+fn install_hooks_only_allows_git_ai_trace_socket_in_codex_sandboxes_when_requested() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
     let codex_dir = repo.test_home_path().join(".codex");
     let config_path = codex_dir.join("config.toml");
@@ -301,6 +301,41 @@ fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
     );
 
     let config: toml::Value =
+        toml::from_str(&fs::read_to_string(&config_path).expect("read default Codex config"))
+            .expect("parse default Codex config");
+    let network_proxy = config
+        .get("features")
+        .and_then(|features| features.get("network_proxy"))
+        .expect("existing Codex network proxy config should remain");
+    assert!(
+        network_proxy.get("enabled").is_none(),
+        "plain install-hooks must not enable the Codex network proxy"
+    );
+    let trace_socket_path = repo.daemon_trace_socket_path();
+    let trace_socket = trace_socket_path.to_string_lossy();
+    assert!(
+        network_proxy
+            .get("unix_sockets")
+            .and_then(toml::Value::as_table)
+            .and_then(|allowed_sockets| allowed_sockets.get(trace_socket.as_ref()))
+            .is_none(),
+        "plain install-hooks must not allow the git-ai trace2 socket"
+    );
+
+    let mut command =
+        repo.git_ai_command_without_pre_sync_for_test(&["install-hooks", "--codex-sandbox"], &[]);
+    command.env_remove("CODEX_HOME");
+    let output = command
+        .output()
+        .expect("run git-ai install-hooks --codex-sandbox");
+    assert!(
+        output.status.success(),
+        "install-hooks --codex-sandbox failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config: toml::Value =
         toml::from_str(&fs::read_to_string(&config_path).expect("read installed Codex config"))
             .expect("parse installed Codex config");
     let allowed_sockets = config
@@ -318,9 +353,6 @@ fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
         Some(true),
         "the Codex network proxy must be enabled for its socket allowlist to apply"
     );
-    let trace_socket_path = repo.daemon_trace_socket_path();
-    let trace_socket = trace_socket_path.to_string_lossy();
-
     assert_eq!(
         allowed_sockets
             .get(trace_socket.as_ref())

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -274,6 +274,70 @@ fn plain_install_hooks_preserves_the_invoking_user_home() {
 }
 
 #[test]
+#[cfg(unix)]
+fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let codex_dir = repo.test_home_path().join(".codex");
+    let config_path = codex_dir.join("config.toml");
+    fs::create_dir_all(&codex_dir).unwrap();
+    fs::write(
+        &config_path,
+        r#"model = "gpt-5"
+
+[features.network_proxy.unix_sockets]
+"/tmp/existing-agent.sock" = "allow"
+"#,
+    )
+    .unwrap();
+
+    let mut command = repo.git_ai_command_without_pre_sync_for_test(&["install-hooks"], &[]);
+    command.env_remove("CODEX_HOME");
+    let output = command.output().expect("run git-ai install-hooks");
+    assert!(
+        output.status.success(),
+        "install-hooks failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config: toml::Value =
+        toml::from_str(&fs::read_to_string(&config_path).expect("read installed Codex config"))
+            .expect("parse installed Codex config");
+    let allowed_sockets = config
+        .get("features")
+        .and_then(|features| features.get("network_proxy"))
+        .and_then(|network_proxy| network_proxy.get("unix_sockets"))
+        .and_then(toml::Value::as_table)
+        .expect("Codex network proxy Unix socket allowlist");
+    assert_eq!(
+        config
+            .get("features")
+            .and_then(|features| features.get("network_proxy"))
+            .and_then(|network_proxy| network_proxy.get("enabled"))
+            .and_then(toml::Value::as_bool),
+        Some(true),
+        "the Codex network proxy must be enabled for its socket allowlist to apply"
+    );
+    let trace_socket_path = repo.daemon_trace_socket_path();
+    let trace_socket = trace_socket_path.to_string_lossy();
+
+    assert_eq!(
+        allowed_sockets
+            .get(trace_socket.as_ref())
+            .and_then(toml::Value::as_str),
+        Some("allow"),
+        "git-ai install-hooks must allow the trace2 socket in Codex sandboxes"
+    );
+    assert_eq!(
+        allowed_sockets
+            .get("/tmp/existing-agent.sock")
+            .and_then(toml::Value::as_str),
+        Some("allow"),
+        "existing Codex Unix socket rules must be preserved"
+    );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn install_hooks_detects_cline_from_vscode_server_extension_manifest() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -335,6 +335,37 @@ fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
         Some("allow"),
         "existing Codex Unix socket rules must be preserved"
     );
+
+    let mut command = repo.git_ai_command_without_pre_sync_for_test(&["uninstall-hooks"], &[]);
+    command.env_remove("CODEX_HOME");
+    let output = command.output().expect("run git-ai uninstall-hooks");
+    assert!(output.status.success(), "uninstall-hooks failed");
+
+    let config: toml::Value =
+        toml::from_str(&fs::read_to_string(&config_path).expect("read uninstalled Codex config"))
+            .expect("parse uninstalled Codex config");
+    let network_proxy = config
+        .get("features")
+        .and_then(|features| features.get("network_proxy"))
+        .expect("existing network proxy config should remain");
+    assert!(
+        network_proxy.get("enabled").is_none(),
+        "uninstall must remove the network proxy setting added by git-ai"
+    );
+    let allowed_sockets = network_proxy
+        .get("unix_sockets")
+        .and_then(toml::Value::as_table)
+        .expect("existing socket rules should remain");
+    assert!(
+        allowed_sockets.get(trace_socket.as_ref()).is_none(),
+        "uninstall must remove the git-ai trace socket rule"
+    );
+    assert_eq!(
+        allowed_sockets
+            .get("/tmp/existing-agent.sock")
+            .and_then(toml::Value::as_str),
+        Some("allow")
+    );
 }
 
 #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -40,6 +40,7 @@ mod ci_local_skip_push;
 mod ci_partial_clone;
 mod ci_squash_rebase;
 mod claude_code;
+mod claude_sandbox;
 mod cli_parser_rebase_args;
 mod codex;
 mod cold_trace2_repo;


### PR DESCRIPTION
## Summary
- add an opt-in `--claude-sandbox` flag to `git-ai install-hooks` / `git-ai install`
- leave Claude sandbox configuration untouched during a plain install
- when opted in, append only the active git-ai trace2 socket to Claude's global `sandbox.network.allowUnixSockets` list while preserving existing sandbox and network settings
- avoid `allowAllUnixSockets` on Linux and WSL2 because the official Claude Code docs say it disables Unix-socket isolation globally; those platforms do not support path-scoped socket access
- remove only the git-ai socket allowance during uninstall and keep repeated installs idempotent
- extend the shared typed sandbox options introduced by #2072, keeping flag parsing and installer construction centralized

## Stack
- depends on #2072

## Official Claude Code references
- https://code.claude.com/docs/en/configuration#sandbox-settings
- https://code.claude.com/docs/en/sandboxing

## Tests
- `task fmt`
- `task lint`
- `task test TEST_FILTER=parse_install_options_`
- `task test TEST_FILTER=claude_sandbox::`
- `task test TEST_FILTER=mdm::agents::claude_code::tests`
