### PR TITLE
Allow git-ai trace socket in Codex sandboxes

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -367,6 +367,7 @@ fn print_help() {
     eprintln!("  bg                 Run and control git-ai background service");
     eprintln!("  install-hooks      Install git hooks for AI authorship tracking");
     eprintln!("    --skills               Also install agent skill files");
+    eprintln!("    --codex-sandbox        Allow Git to send trace2 events from Codex sandboxes");
     eprintln!("    --visual-studio-extension");
     eprintln!("                           Also install the Visual Studio extension on Windows");
     eprintln!("  uninstall-hooks    Remove git-ai hooks from all detected tools");

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
-use crate::mdm::agents::{get_all_installers, get_all_installers_with_codex_sandbox};
+use crate::mdm::agents::{SandboxInstallOptions, get_all_installers};
 use crate::mdm::hook_installer::HookInstallerParams;
 use crate::mdm::skills_installer;
 use crate::mdm::spinner::{Spinner, print_diff};
@@ -21,7 +21,7 @@ struct InstallOptions {
     dry_run: bool,
     verbose: bool,
     install_skills: bool,
-    codex_sandbox: bool,
+    sandbox: SandboxInstallOptions,
     include_visual_studio_extension: bool,
     api_base: Option<String>,
     api_key: Option<String>,
@@ -365,7 +365,7 @@ fn parse_install_options(args: &[String]) -> Result<InstallOptions, GitAiError> 
             "--dry-run" | "--dry-run=true" => options.dry_run = true,
             "--verbose" | "-v" => options.verbose = true,
             "--skills" => options.install_skills = true,
-            "--codex-sandbox" => options.codex_sandbox = true,
+            "--codex-sandbox" | "--codex-sandbox=true" => options.sandbox.codex = true,
             "--visual-studio-extension" => options.include_visual_studio_extension = true,
             value if value.starts_with("--api-base=") => {
                 options.api_base = non_empty_value(&value[11..]);
@@ -539,7 +539,7 @@ async fn async_run_install(
     // === Coding Agents ===
     println!("\n\x1b[1mCoding Agents\x1b[0m");
 
-    let installers = get_all_installers_with_codex_sandbox(options.codex_sandbox);
+    let installers = get_all_installers(options.sandbox);
     let mut installed_tools: HashSet<String> = HashSet::new();
     // Track agents whose hooks were updated (name, process_names) for restart warnings
     let mut updated_agents: Vec<(String, Vec<String>)> = Vec::new();
@@ -882,7 +882,7 @@ async fn async_run_uninstall(
     // === Coding Agents ===
     println!("\n\x1b[1mCoding Agents\x1b[0m");
 
-    let installers = get_all_installers();
+    let installers = get_all_installers(SandboxInstallOptions::default());
 
     for installer in installers {
         let name = installer.name();
@@ -1080,7 +1080,7 @@ mod tests {
         let options = parse_install_options(&[]).unwrap();
 
         assert!(!options.include_visual_studio_extension);
-        assert!(!options.codex_sandbox);
+        assert!(!options.sandbox.codex);
         assert!(!should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,
             &options
@@ -1102,12 +1102,19 @@ mod tests {
         assert!(options.dry_run);
         assert!(options.verbose);
         assert!(options.install_skills);
-        assert!(options.codex_sandbox);
+        assert!(options.sandbox.codex);
         assert!(options.include_visual_studio_extension);
         assert!(should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,
             &options
         ));
+    }
+
+    #[test]
+    fn parse_install_options_accepts_codex_sandbox_true_flag() {
+        let options = parse_install_options(&["--codex-sandbox=true".to_string()]).unwrap();
+
+        assert!(options.sandbox.codex);
     }
 
     #[test]

--- a/src/commands/install_hooks.rs
+++ b/src/commands/install_hooks.rs
@@ -1,7 +1,7 @@
 use crate::config;
 use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
-use crate::mdm::agents::get_all_installers;
+use crate::mdm::agents::{get_all_installers, get_all_installers_with_codex_sandbox};
 use crate::mdm::hook_installer::HookInstallerParams;
 use crate::mdm::skills_installer;
 use crate::mdm::spinner::{Spinner, print_diff};
@@ -21,6 +21,7 @@ struct InstallOptions {
     dry_run: bool,
     verbose: bool,
     install_skills: bool,
+    codex_sandbox: bool,
     include_visual_studio_extension: bool,
     api_base: Option<String>,
     api_key: Option<String>,
@@ -364,6 +365,7 @@ fn parse_install_options(args: &[String]) -> Result<InstallOptions, GitAiError> 
             "--dry-run" | "--dry-run=true" => options.dry_run = true,
             "--verbose" | "-v" => options.verbose = true,
             "--skills" => options.install_skills = true,
+            "--codex-sandbox" => options.codex_sandbox = true,
             "--visual-studio-extension" => options.include_visual_studio_extension = true,
             value if value.starts_with("--api-base=") => {
                 options.api_base = non_empty_value(&value[11..]);
@@ -537,7 +539,7 @@ async fn async_run_install(
     // === Coding Agents ===
     println!("\n\x1b[1mCoding Agents\x1b[0m");
 
-    let installers = get_all_installers();
+    let installers = get_all_installers_with_codex_sandbox(options.codex_sandbox);
     let mut installed_tools: HashSet<String> = HashSet::new();
     // Track agents whose hooks were updated (name, process_names) for restart warnings
     let mut updated_agents: Vec<(String, Vec<String>)> = Vec::new();
@@ -1078,6 +1080,7 @@ mod tests {
         let options = parse_install_options(&[]).unwrap();
 
         assert!(!options.include_visual_studio_extension);
+        assert!(!options.codex_sandbox);
         assert!(!should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,
             &options
@@ -1090,6 +1093,7 @@ mod tests {
         let args = vec![
             "--dry-run".to_string(),
             "--visual-studio-extension".to_string(),
+            "--codex-sandbox".to_string(),
             "--skills".to_string(),
             "-v".to_string(),
         ];
@@ -1098,6 +1102,7 @@ mod tests {
         assert!(options.dry_run);
         assert!(options.verbose);
         assert!(options.install_skills);
+        assert!(options.codex_sandbox);
         assert!(options.include_visual_studio_extension);
         assert!(should_include_installer(
             VISUAL_STUDIO_INSTALLER_ID,

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -27,6 +27,47 @@ impl CodexInstaller {
         codex_home_dir().join("hooks.json")
     }
 
+    #[cfg(unix)]
+    fn network_proxy_enabled_marker_path(config_path: &Path) -> Result<PathBuf, GitAiError> {
+        let mut hasher = Sha256::new();
+        hasher.update(config_path.to_string_lossy().as_bytes());
+        let digest = format!("{:x}", hasher.finalize());
+        Ok(DaemonConfig::from_env_or_default_paths()?
+            .internal_dir
+            .join(format!("codex-network-proxy-enabled-{}", &digest[..16])))
+    }
+
+    #[cfg(unix)]
+    fn config_has_network_proxy_enabled(config: &TomlValue) -> bool {
+        config
+            .get("features")
+            .and_then(|features| features.get("network_proxy"))
+            .is_some_and(|network_proxy| {
+                network_proxy.is_bool()
+                    || network_proxy
+                        .as_table()
+                        .is_some_and(|table| table.contains_key("enabled"))
+            })
+    }
+
+    #[cfg(unix)]
+    fn record_network_proxy_enabled_provenance(config_path: &Path) -> Result<(), GitAiError> {
+        let marker_path = Self::network_proxy_enabled_marker_path(config_path)?;
+        if let Some(parent) = marker_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        write_atomic(&marker_path, b"")
+    }
+
+    #[cfg(unix)]
+    fn clear_network_proxy_enabled_provenance(config_path: &Path) -> Result<(), GitAiError> {
+        let marker_path = Self::network_proxy_enabled_marker_path(config_path)?;
+        if marker_path.exists() {
+            fs::remove_file(marker_path)?;
+        }
+        Ok(())
+    }
+
     fn desired_command(binary_path: &Path) -> String {
         format!("{} {}", binary_path.display(), CODEX_CHECKPOINT_CMD)
     }
@@ -297,7 +338,12 @@ impl CodexInstaller {
         }
     }
 
-    fn config_without_trace_socket_allowance(config: &TomlValue) -> Result<TomlValue, GitAiError> {
+    fn config_without_trace_socket_allowance(
+        config: &TomlValue,
+        remove_enabled: bool,
+    ) -> Result<TomlValue, GitAiError> {
+        #[cfg(not(unix))]
+        let _ = remove_enabled;
         #[cfg(not(unix))]
         return Ok(config.clone());
 
@@ -329,7 +375,7 @@ impl CodexInstaller {
             if remove_unix_sockets {
                 network_proxy.remove("unix_sockets");
             }
-            if network_proxy.len() == 1
+            if remove_enabled
                 && network_proxy.get("enabled").and_then(TomlValue::as_bool) == Some(true)
             {
                 network_proxy.remove("enabled");
@@ -872,6 +918,8 @@ impl HookInstaller for CodexInstaller {
         };
 
         let existing_config = Self::parse_config_toml(&existing_config_content)?;
+        #[cfg(unix)]
+        let network_proxy_enabled_added = !Self::config_has_network_proxy_enabled(&existing_config);
 
         let existing_hooks_content = if hooks_json_path.exists() {
             fs::read_to_string(&hooks_json_path)?
@@ -923,6 +971,11 @@ impl HookInstaller for CodexInstaller {
                 if !dry_run {
                     write_atomic(&hooks_json_path, new_hooks_content.as_bytes())?;
                 }
+            }
+
+            #[cfg(unix)]
+            if !dry_run && network_proxy_enabled_added {
+                Self::record_network_proxy_enabled_provenance(&config_path)?;
             }
 
             return Ok(Some(diff_output.join("\n")));
@@ -984,6 +1037,11 @@ impl HookInstaller for CodexInstaller {
             }
         }
 
+        #[cfg(unix)]
+        if !dry_run && network_proxy_enabled_added {
+            Self::record_network_proxy_enabled_provenance(&config_path)?;
+        }
+
         Ok(Some(diff_output.join("\n")))
     }
 
@@ -994,7 +1052,16 @@ impl HookInstaller for CodexInstaller {
     ) -> Result<Option<String>, GitAiError> {
         let config_path = Self::config_path();
         let hooks_json_path = Self::hooks_json_path();
+        #[cfg(unix)]
+        let network_proxy_enabled_added =
+            Self::network_proxy_enabled_marker_path(&config_path)?.exists();
+        #[cfg(not(unix))]
+        let network_proxy_enabled_added = false;
         if !config_path.exists() && !hooks_json_path.exists() {
+            #[cfg(unix)]
+            if !dry_run {
+                Self::clear_network_proxy_enabled_provenance(&config_path)?;
+            }
             return Ok(None);
         }
 
@@ -1010,8 +1077,10 @@ impl HookInstaller for CodexInstaller {
             Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
         let (config_without_hooks, inline_hooks_changed) =
             Self::remove_inline_hooks_from_config(&config_without_notify)?;
-        let config_without_trace_socket =
-            Self::config_without_trace_socket_allowance(&config_without_hooks)?;
+        let config_without_trace_socket = Self::config_without_trace_socket_allowance(
+            &config_without_hooks,
+            network_proxy_enabled_added,
+        )?;
         let merged_config = Self::remove_feature_flags(&config_without_trace_socket)?;
 
         // Check if legacy hooks.json needs cleanup
@@ -1026,6 +1095,10 @@ impl HookInstaller for CodexInstaller {
 
         let config_changed = merged_config != existing_config;
         if !config_changed && !inline_hooks_changed && !hooks_json_changed {
+            #[cfg(unix)]
+            if !dry_run {
+                Self::clear_network_proxy_enabled_provenance(&config_path)?;
+            }
             return Ok(None);
         }
 
@@ -1066,6 +1139,11 @@ impl HookInstaller for CodexInstaller {
                     fs::remove_file(&hooks_json_path)?;
                 }
             }
+        }
+
+        #[cfg(unix)]
+        if !dry_run {
+            Self::clear_network_proxy_enabled_provenance(&config_path)?;
         }
 
         Ok(Some(diff_output.join("\n")))
@@ -2179,6 +2257,66 @@ enabled = true
                     .and_then(TomlValue::as_str),
                 Some("allow"),
                 "uninstall must preserve unrelated socket rules"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn test_uninstall_restores_network_proxy_enabled_provenance() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+
+            fs::write(&config_path, "[features.network_proxy]\nenabled = true\n").unwrap();
+            installer.install_hooks(&params, false).unwrap();
+            installer.uninstall_hooks(&params, false).unwrap();
+            let config =
+                CodexInstaller::parse_config_toml(&fs::read_to_string(&config_path).unwrap())
+                    .unwrap();
+            assert_eq!(
+                config
+                    .get("features")
+                    .and_then(|features| features.get("network_proxy"))
+                    .and_then(|network_proxy| network_proxy.get("enabled"))
+                    .and_then(TomlValue::as_bool),
+                Some(true),
+                "uninstall must preserve a pre-existing enabled setting"
+            );
+
+            fs::write(
+                &config_path,
+                r#"[features.network_proxy.unix_sockets]
+"/tmp/existing-agent.sock" = "allow"
+"#,
+            )
+            .unwrap();
+            installer.install_hooks(&params, false).unwrap();
+            installer.uninstall_hooks(&params, false).unwrap();
+            let config =
+                CodexInstaller::parse_config_toml(&fs::read_to_string(&config_path).unwrap())
+                    .unwrap();
+            let network_proxy = config
+                .get("features")
+                .and_then(|features| features.get("network_proxy"))
+                .expect("unrelated proxy settings should remain");
+            assert!(
+                network_proxy.get("enabled").is_none(),
+                "uninstall must remove enabled when git-ai added it"
+            );
+            assert_eq!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get("/tmp/existing-agent.sock"))
+                    .and_then(TomlValue::as_str),
+                Some("allow")
             );
         });
     }

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -297,6 +297,51 @@ impl CodexInstaller {
         }
     }
 
+    fn config_without_trace_socket_allowance(config: &TomlValue) -> Result<TomlValue, GitAiError> {
+        #[cfg(not(unix))]
+        return Ok(config.clone());
+
+        #[cfg(unix)]
+        {
+            let trace_socket_path = DaemonConfig::from_env_or_default_paths()?.trace_socket_path;
+            let trace_socket = trace_socket_path.to_string_lossy();
+            let mut merged = config.clone();
+            let root = merged.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex config root must be a table".to_string())
+            })?;
+            let Some(features) = root.get_mut("features").and_then(TomlValue::as_table_mut) else {
+                return Ok(merged);
+            };
+            let Some(network_proxy) = features
+                .get_mut("network_proxy")
+                .and_then(TomlValue::as_table_mut)
+            else {
+                return Ok(merged);
+            };
+
+            let remove_unix_sockets = network_proxy
+                .get_mut("unix_sockets")
+                .and_then(TomlValue::as_table_mut)
+                .is_some_and(|unix_sockets| {
+                    unix_sockets.remove(trace_socket.as_ref());
+                    unix_sockets.is_empty()
+                });
+            if remove_unix_sockets {
+                network_proxy.remove("unix_sockets");
+            }
+            // Only the exact socket rule is owned by git-ai. Keep `enabled` and any
+            // other proxy settings because they may have existed before installation.
+            if network_proxy.is_empty() {
+                features.remove("network_proxy");
+            }
+            if features.is_empty() {
+                root.remove("features");
+            }
+
+            Ok(merged)
+        }
+    }
+
     fn config_with_installed_hooks(
         config: &TomlValue,
         binary_path: &Path,
@@ -962,7 +1007,9 @@ impl HookInstaller for CodexInstaller {
             Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
         let (config_without_hooks, inline_hooks_changed) =
             Self::remove_inline_hooks_from_config(&config_without_notify)?;
-        let merged_config = Self::remove_feature_flags(&config_without_hooks)?;
+        let config_without_trace_socket =
+            Self::config_without_trace_socket_allowance(&config_without_hooks)?;
+        let merged_config = Self::remove_feature_flags(&config_without_trace_socket)?;
 
         // Check if legacy hooks.json needs cleanup
         let (hooks_json_changed, existing_hooks_content) = if hooks_json_path.exists() {
@@ -2053,6 +2100,71 @@ codex_hooks = true
                 .expect("second install should succeed");
             assert!(second_install.is_none(), "second install should be a no-op");
             assert_eq!(fs::read_to_string(config_path).unwrap(), installed_content);
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn test_uninstall_removes_trace_socket_and_preserves_network_proxy_settings() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            fs::write(
+                &config_path,
+                r#"[features.network_proxy]
+enabled = true
+
+[features.network_proxy.unix_sockets]
+"/tmp/existing-agent.sock" = "allow"
+"#,
+            )
+            .unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+            installer
+                .uninstall_hooks(&params, false)
+                .expect("uninstall should succeed");
+
+            let uninstalled_content = fs::read_to_string(&config_path).unwrap();
+            let uninstalled = CodexInstaller::parse_config_toml(&uninstalled_content).unwrap();
+            let network_proxy = uninstalled
+                .get("features")
+                .and_then(|features| features.get("network_proxy"))
+                .expect("existing network proxy config should remain");
+            let trace_socket = DaemonConfig::from_home(home)
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned();
+
+            assert_eq!(
+                network_proxy.get("enabled").and_then(TomlValue::as_bool),
+                Some(true),
+                "uninstall must preserve the user's network proxy setting"
+            );
+            assert!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get(&trace_socket))
+                    .is_none(),
+                "uninstall must remove the git-ai trace socket rule"
+            );
+            assert_eq!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get("/tmp/existing-agent.sock"))
+                    .and_then(TomlValue::as_str),
+                Some("allow"),
+                "uninstall must preserve unrelated socket rules"
+            );
         });
     }
 

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -1,4 +1,6 @@
 use crate::config::{CodexHooksFormat, Config};
+#[cfg(unix)]
+use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
@@ -229,6 +231,70 @@ impl CodexInstaller {
         }
 
         Ok(merged)
+    }
+
+    fn config_with_trace_socket_allowed(config: &TomlValue) -> Result<TomlValue, GitAiError> {
+        #[cfg(not(unix))]
+        return Ok(config.clone());
+
+        #[cfg(unix)]
+        {
+            let trace_socket_path = DaemonConfig::from_env_or_default_paths()?.trace_socket_path;
+            let mut merged = config.clone();
+            let root = merged.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex config root must be a table".to_string())
+            })?;
+            let features = root
+                .entry("features")
+                .or_insert_with(|| TomlValue::Table(Map::new()));
+            if !features.is_table() {
+                *features = TomlValue::Table(Map::new());
+            }
+            let features = features.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic("Codex config features field must be a table".to_string())
+            })?;
+
+            let network_proxy = features
+                .entry("network_proxy")
+                .or_insert_with(|| TomlValue::Table(Map::new()));
+            if let Some(enabled) = network_proxy.as_bool() {
+                *network_proxy = TomlValue::Table(Map::from_iter([(
+                    "enabled".to_string(),
+                    TomlValue::Boolean(enabled),
+                )]));
+            } else if !network_proxy.is_table() {
+                *network_proxy = TomlValue::Table(Map::new());
+            }
+            let network_proxy = network_proxy.as_table_mut().ok_or_else(|| {
+                GitAiError::Generic(
+                    "Codex config features.network_proxy field must be a table".to_string(),
+                )
+            })?;
+            network_proxy
+                .entry("enabled")
+                .or_insert(TomlValue::Boolean(true));
+
+            let unix_sockets = network_proxy
+                .entry("unix_sockets")
+                .or_insert_with(|| TomlValue::Table(Map::new()));
+            if !unix_sockets.is_table() {
+                *unix_sockets = TomlValue::Table(Map::new());
+            }
+            unix_sockets
+                .as_table_mut()
+                .ok_or_else(|| {
+                    GitAiError::Generic(
+                        "Codex config features.network_proxy.unix_sockets field must be a table"
+                            .to_string(),
+                    )
+                })?
+                .insert(
+                    trace_socket_path.to_string_lossy().into_owned(),
+                    TomlValue::String("allow".to_string()),
+                );
+
+            Ok(merged)
+        }
     }
 
     fn config_with_installed_hooks(
@@ -707,8 +773,9 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&config)?.unwrap_or(config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let desired_config =
-                Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?;
+            let desired_config = Self::config_with_trace_socket_allowed(
+                &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
+            )?;
             let desired_hooks_json =
                 Self::hooks_json_with_installed_hooks(&hooks_json, &params.binary_path)?;
             let has_json_hooks = Self::hooks_json_has_git_ai_entries(&hooks_json);
@@ -722,7 +789,9 @@ impl HookInstaller for CodexInstaller {
             });
         }
 
-        let desired_config = Self::config_with_installed_hooks(&config, &params.binary_path)?;
+        let desired_config = Self::config_with_trace_socket_allowed(
+            &Self::config_with_installed_hooks(&config, &params.binary_path)?,
+        )?;
         let has_inline_hooks = Self::config_has_inline_hooks(&config);
         let has_legacy_hooks_json = Self::hooks_json_has_git_ai_entries(&hooks_json);
         let hooks_installed = Self::config_hooks_feature_enabled(&config)
@@ -768,8 +837,9 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let merged_config =
-                Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?;
+            let merged_config = Self::config_with_trace_socket_allowed(
+                &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
+            )?;
             let merged_hooks =
                 Self::hooks_json_with_installed_hooks(&existing_hooks, &params.binary_path)?;
 
@@ -810,8 +880,9 @@ impl HookInstaller for CodexInstaller {
             return Ok(Some(diff_output.join("\n")));
         }
 
-        let merged_config =
-            Self::config_with_installed_hooks(&existing_config, &params.binary_path)?;
+        let merged_config = Self::config_with_trace_socket_allowed(
+            &Self::config_with_installed_hooks(&existing_config, &params.binary_path)?,
+        )?;
 
         // Check if legacy hooks.json needs migration
         let (hooks_json_changed, existing_hooks_content) = if hooks_json_path.exists() {
@@ -1933,6 +2004,55 @@ codex_hooks = true
             assert!(check.tool_installed);
             assert!(check.hooks_installed);
             assert!(check.hooks_up_to_date);
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
+    fn test_hooks_json_install_allows_trace_socket_and_is_idempotent() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+
+            let installer = CodexInstaller;
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+
+            let installed_content = fs::read_to_string(&config_path).unwrap();
+            let installed = CodexInstaller::parse_config_toml(&installed_content).unwrap();
+            let network_proxy = installed
+                .get("features")
+                .and_then(|features| features.get("network_proxy"))
+                .expect("network proxy config");
+            let trace_socket = DaemonConfig::from_home(home)
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned();
+            assert_eq!(
+                network_proxy.get("enabled").and_then(TomlValue::as_bool),
+                Some(true)
+            );
+            assert_eq!(
+                network_proxy
+                    .get("unix_sockets")
+                    .and_then(|sockets| sockets.get(&trace_socket))
+                    .and_then(TomlValue::as_str),
+                Some("allow")
+            );
+
+            let second_install = installer
+                .install_hooks(&params, false)
+                .expect("second install should succeed");
+            assert!(second_install.is_none(), "second install should be a no-op");
+            assert_eq!(fs::read_to_string(config_path).unwrap(), installed_content);
         });
     }
 

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -16,9 +16,16 @@ use toml::map::Map;
 const CODEX_CHECKPOINT_CMD: &str = "checkpoint codex --hook-input stdin";
 const CODEX_HOOK_EVENTS: [&str; 3] = ["PreToolUse", "PostToolUse", "Stop"];
 
-pub struct CodexInstaller;
+#[derive(Debug, Default)]
+pub struct CodexInstaller {
+    allow_trace_socket: bool,
+}
 
 impl CodexInstaller {
+    pub(crate) fn new(allow_trace_socket: bool) -> Self {
+        Self { allow_trace_socket }
+    }
+
     fn config_path() -> PathBuf {
         codex_home_dir().join("config.toml")
     }
@@ -335,6 +342,17 @@ impl CodexInstaller {
                 );
 
             Ok(merged)
+        }
+    }
+
+    fn config_with_optional_trace_socket_allowance(
+        &self,
+        config: &TomlValue,
+    ) -> Result<TomlValue, GitAiError> {
+        if self.allow_trace_socket {
+            Self::config_with_trace_socket_allowed(config)
+        } else {
+            Ok(config.clone())
         }
     }
 
@@ -867,7 +885,7 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&config)?.unwrap_or(config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let desired_config = Self::config_with_trace_socket_allowed(
+            let desired_config = self.config_with_optional_trace_socket_allowance(
                 &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
             )?;
             let desired_hooks_json =
@@ -883,7 +901,7 @@ impl HookInstaller for CodexInstaller {
             });
         }
 
-        let desired_config = Self::config_with_trace_socket_allowed(
+        let desired_config = self.config_with_optional_trace_socket_allowance(
             &Self::config_with_installed_hooks(&config, &params.binary_path)?,
         )?;
         let has_inline_hooks = Self::config_has_inline_hooks(&config);
@@ -919,7 +937,8 @@ impl HookInstaller for CodexInstaller {
 
         let existing_config = Self::parse_config_toml(&existing_config_content)?;
         #[cfg(unix)]
-        let network_proxy_enabled_added = !Self::config_has_network_proxy_enabled(&existing_config);
+        let network_proxy_enabled_added =
+            self.allow_trace_socket && !Self::config_has_network_proxy_enabled(&existing_config);
 
         let existing_hooks_content = if hooks_json_path.exists() {
             fs::read_to_string(&hooks_json_path)?
@@ -933,7 +952,7 @@ impl HookInstaller for CodexInstaller {
                 Self::remove_notify_if_git_ai(&existing_config)?.unwrap_or(existing_config.clone());
             let (config_without_inline_hooks, _) =
                 Self::remove_inline_hooks_from_config(&config_without_notify)?;
-            let merged_config = Self::config_with_trace_socket_allowed(
+            let merged_config = self.config_with_optional_trace_socket_allowance(
                 &Self::config_with_hooks_feature_enabled(&config_without_inline_hooks)?,
             )?;
             let merged_hooks =
@@ -981,7 +1000,7 @@ impl HookInstaller for CodexInstaller {
             return Ok(Some(diff_output.join("\n")));
         }
 
-        let merged_config = Self::config_with_trace_socket_allowed(
+        let merged_config = self.config_with_optional_trace_socket_allowance(
             &Self::config_with_installed_hooks(&existing_config, &params.binary_path)?,
         )?;
 
@@ -1604,7 +1623,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1654,7 +1673,7 @@ codex_hooks = true
             let config_path = custom_codex_home.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1713,7 +1732,7 @@ notify = ["/usr/local/bin/git-ai", "checkpoint", "codex", "--hook-input"]
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1759,7 +1778,7 @@ notify = ["/Users/svarlamov/.git-ai/bin/git-ai", "checkpoint", "codex", "--via-c
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1793,7 +1812,7 @@ notify = ["notify-send", "Codex finished"]
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1849,7 +1868,7 @@ notify = ["notify-send", "Codex finished"]
             let original_content = "model = \"gpt-5\"\n";
             fs::write(&config_path, original_content).unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1876,7 +1895,7 @@ notify = ["notify-send", "Codex finished"]
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -1949,7 +1968,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2014,7 +2033,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2084,7 +2103,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2138,6 +2157,49 @@ codex_hooks = true
     #[test]
     #[serial]
     #[cfg(unix)]
+    fn test_hooks_json_install_does_not_configure_sandbox_by_default() {
+        with_temp_home(|home| {
+            let codex_dir = home.join(".codex");
+            write_git_ai_config(home, "hooks_json");
+            fs::create_dir_all(&codex_dir).unwrap();
+            let config_path = codex_dir.join("config.toml");
+            fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+
+            let installer = CodexInstaller::default();
+            let params = HookInstallerParams {
+                binary_path: test_binary_path(),
+            };
+            installer
+                .install_hooks(&params, false)
+                .expect("install should succeed");
+
+            let installed =
+                CodexInstaller::parse_config_toml(&fs::read_to_string(&config_path).unwrap())
+                    .unwrap();
+            assert!(
+                installed
+                    .get("features")
+                    .and_then(|features| features.get("network_proxy"))
+                    .is_none(),
+                "default install must not configure the Codex network proxy"
+            );
+            assert!(
+                !CodexInstaller::network_proxy_enabled_marker_path(&config_path)
+                    .unwrap()
+                    .exists(),
+                "default install must not record proxy ownership"
+            );
+
+            let check = installer
+                .check_hooks(&params)
+                .expect("check should succeed");
+            assert!(check.hooks_up_to_date);
+        });
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(unix)]
     fn test_hooks_json_install_allows_trace_socket_and_is_idempotent() {
         with_temp_home(|home| {
             let codex_dir = home.join(".codex");
@@ -2146,7 +2208,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::new(true);
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2216,7 +2278,7 @@ enabled = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::new(true);
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2270,7 +2332,7 @@ enabled = true
             write_git_ai_config(home, "hooks_json");
             fs::create_dir_all(&codex_dir).unwrap();
             let config_path = codex_dir.join("config.toml");
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::new(true);
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2363,7 +2425,7 @@ command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2449,7 +2511,7 @@ command = "/usr/local/bin/git-ai checkpoint codex --hook-input stdin"
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2508,7 +2570,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2539,7 +2601,7 @@ codex_hooks = true
             let codex_dir = home.join(".codex");
             assert!(!codex_dir.exists());
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2597,7 +2659,7 @@ codex_hooks = true
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2692,7 +2754,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"o3\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2740,7 +2802,7 @@ codex_hooks = true
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"o3\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2793,7 +2855,7 @@ trusted_hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123
             )
             .unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };
@@ -2834,7 +2896,7 @@ trusted_hash = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef123
             let config_path = codex_dir.join("config.toml");
             fs::write(&config_path, "model = \"o3\"\n").unwrap();
 
-            let installer = CodexInstaller;
+            let installer = CodexInstaller::default();
             let params = HookInstallerParams {
                 binary_path: test_binary_path(),
             };

--- a/src/mdm/agents/codex.rs
+++ b/src/mdm/agents/codex.rs
@@ -329,8 +329,11 @@ impl CodexInstaller {
             if remove_unix_sockets {
                 network_proxy.remove("unix_sockets");
             }
-            // Only the exact socket rule is owned by git-ai. Keep `enabled` and any
-            // other proxy settings because they may have existed before installation.
+            if network_proxy.len() == 1
+                && network_proxy.get("enabled").and_then(TomlValue::as_bool) == Some(true)
+            {
+                network_proxy.remove("enabled");
+            }
             if network_proxy.is_empty() {
                 features.remove("network_proxy");
             }
@@ -2100,6 +2103,18 @@ codex_hooks = true
                 .expect("second install should succeed");
             assert!(second_install.is_none(), "second install should be a no-op");
             assert_eq!(fs::read_to_string(config_path).unwrap(), installed_content);
+
+            installer
+                .uninstall_hooks(&params, false)
+                .expect("uninstall should succeed");
+            let uninstalled = CodexInstaller::parse_config_toml(
+                &fs::read_to_string(codex_dir.join("config.toml")).unwrap(),
+            )
+            .unwrap();
+            assert!(
+                uninstalled.get("features").is_none(),
+                "uninstall should remove proxy config created solely for git-ai"
+            );
         });
     }
 

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -34,17 +34,17 @@ pub use windsurf::WindsurfInstaller;
 
 use super::hook_installer::HookInstaller;
 
-/// Get all available hook installers
-pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
-    get_all_installers_with_codex_sandbox(false)
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SandboxInstallOptions {
+    pub codex: bool,
 }
 
-/// Get all available hook installers with optional Codex sandbox integration.
-pub fn get_all_installers_with_codex_sandbox(codex_sandbox: bool) -> Vec<Box<dyn HookInstaller>> {
+/// Get all available hook installers
+pub fn get_all_installers(sandbox: SandboxInstallOptions) -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
         Box::new(ClaudeCodeInstaller),
         Box::new(ClineInstaller),
-        Box::new(CodexInstaller::new(codex_sandbox)),
+        Box::new(CodexInstaller::new(sandbox.codex)),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),
         Box::new(GitHubCopilotInstaller),

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -36,10 +36,15 @@ use super::hook_installer::HookInstaller;
 
 /// Get all available hook installers
 pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
+    get_all_installers_with_codex_sandbox(false)
+}
+
+/// Get all available hook installers with optional Codex sandbox integration.
+pub fn get_all_installers_with_codex_sandbox(codex_sandbox: bool) -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
         Box::new(ClaudeCodeInstaller),
         Box::new(ClineInstaller),
-        Box::new(CodexInstaller),
+        Box::new(CodexInstaller::new(codex_sandbox)),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),
         Box::new(GitHubCopilotInstaller),

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -275,7 +275,7 @@ fn plain_install_hooks_preserves_the_invoking_user_home() {
 
 #[test]
 #[cfg(unix)]
-fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
+fn install_hooks_only_allows_git_ai_trace_socket_in_codex_sandboxes_when_requested() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
     let codex_dir = repo.test_home_path().join(".codex");
     let config_path = codex_dir.join("config.toml");
@@ -301,6 +301,41 @@ fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
     );
 
     let config: toml::Value =
+        toml::from_str(&fs::read_to_string(&config_path).expect("read default Codex config"))
+            .expect("parse default Codex config");
+    let network_proxy = config
+        .get("features")
+        .and_then(|features| features.get("network_proxy"))
+        .expect("existing Codex network proxy config should remain");
+    assert!(
+        network_proxy.get("enabled").is_none(),
+        "plain install-hooks must not enable the Codex network proxy"
+    );
+    let trace_socket_path = repo.daemon_trace_socket_path();
+    let trace_socket = trace_socket_path.to_string_lossy();
+    assert!(
+        network_proxy
+            .get("unix_sockets")
+            .and_then(toml::Value::as_table)
+            .and_then(|allowed_sockets| allowed_sockets.get(trace_socket.as_ref()))
+            .is_none(),
+        "plain install-hooks must not allow the git-ai trace2 socket"
+    );
+
+    let mut command =
+        repo.git_ai_command_without_pre_sync_for_test(&["install-hooks", "--codex-sandbox"], &[]);
+    command.env_remove("CODEX_HOME");
+    let output = command
+        .output()
+        .expect("run git-ai install-hooks --codex-sandbox");
+    assert!(
+        output.status.success(),
+        "install-hooks --codex-sandbox failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config: toml::Value =
         toml::from_str(&fs::read_to_string(&config_path).expect("read installed Codex config"))
             .expect("parse installed Codex config");
     let allowed_sockets = config
@@ -318,9 +353,6 @@ fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
         Some(true),
         "the Codex network proxy must be enabled for its socket allowlist to apply"
     );
-    let trace_socket_path = repo.daemon_trace_socket_path();
-    let trace_socket = trace_socket_path.to_string_lossy();
-
     assert_eq!(
         allowed_sockets
             .get(trace_socket.as_ref())

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -274,6 +274,70 @@ fn plain_install_hooks_preserves_the_invoking_user_home() {
 }
 
 #[test]
+#[cfg(unix)]
+fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let codex_dir = repo.test_home_path().join(".codex");
+    let config_path = codex_dir.join("config.toml");
+    fs::create_dir_all(&codex_dir).unwrap();
+    fs::write(
+        &config_path,
+        r#"model = "gpt-5"
+
+[features.network_proxy.unix_sockets]
+"/tmp/existing-agent.sock" = "allow"
+"#,
+    )
+    .unwrap();
+
+    let mut command = repo.git_ai_command_without_pre_sync_for_test(&["install-hooks"], &[]);
+    command.env_remove("CODEX_HOME");
+    let output = command.output().expect("run git-ai install-hooks");
+    assert!(
+        output.status.success(),
+        "install-hooks failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config: toml::Value =
+        toml::from_str(&fs::read_to_string(&config_path).expect("read installed Codex config"))
+            .expect("parse installed Codex config");
+    let allowed_sockets = config
+        .get("features")
+        .and_then(|features| features.get("network_proxy"))
+        .and_then(|network_proxy| network_proxy.get("unix_sockets"))
+        .and_then(toml::Value::as_table)
+        .expect("Codex network proxy Unix socket allowlist");
+    assert_eq!(
+        config
+            .get("features")
+            .and_then(|features| features.get("network_proxy"))
+            .and_then(|network_proxy| network_proxy.get("enabled"))
+            .and_then(toml::Value::as_bool),
+        Some(true),
+        "the Codex network proxy must be enabled for its socket allowlist to apply"
+    );
+    let trace_socket_path = repo.daemon_trace_socket_path();
+    let trace_socket = trace_socket_path.to_string_lossy();
+
+    assert_eq!(
+        allowed_sockets
+            .get(trace_socket.as_ref())
+            .and_then(toml::Value::as_str),
+        Some("allow"),
+        "git-ai install-hooks must allow the trace2 socket in Codex sandboxes"
+    );
+    assert_eq!(
+        allowed_sockets
+            .get("/tmp/existing-agent.sock")
+            .and_then(toml::Value::as_str),
+        Some("allow"),
+        "existing Codex Unix socket rules must be preserved"
+    );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn install_hooks_detects_cline_from_vscode_server_extension_manifest() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);

--- a/tests/integration/install_hooks_comprehensive.rs
+++ b/tests/integration/install_hooks_comprehensive.rs
@@ -335,6 +335,37 @@ fn install_hooks_allows_git_ai_trace_socket_in_codex_sandboxes() {
         Some("allow"),
         "existing Codex Unix socket rules must be preserved"
     );
+
+    let mut command = repo.git_ai_command_without_pre_sync_for_test(&["uninstall-hooks"], &[]);
+    command.env_remove("CODEX_HOME");
+    let output = command.output().expect("run git-ai uninstall-hooks");
+    assert!(output.status.success(), "uninstall-hooks failed");
+
+    let config: toml::Value =
+        toml::from_str(&fs::read_to_string(&config_path).expect("read uninstalled Codex config"))
+            .expect("parse uninstalled Codex config");
+    let network_proxy = config
+        .get("features")
+        .and_then(|features| features.get("network_proxy"))
+        .expect("existing network proxy config should remain");
+    assert!(
+        network_proxy.get("enabled").is_none(),
+        "uninstall must remove the network proxy setting added by git-ai"
+    );
+    let allowed_sockets = network_proxy
+        .get("unix_sockets")
+        .and_then(toml::Value::as_table)
+        .expect("existing socket rules should remain");
+    assert!(
+        allowed_sockets.get(trace_socket.as_ref()).is_none(),
+        "uninstall must remove the git-ai trace socket rule"
+    );
+    assert_eq!(
+        allowed_sockets
+            .get("/tmp/existing-agent.sock")
+            .and_then(toml::Value::as_str),
+        Some("allow")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an opt-in `--codex-sandbox` flag to `git-ai install-hooks` / `git-ai install`
- leave Codex sandbox and network proxy configuration untouched during a plain install
- when opted in, add the active git-ai trace2 socket to Codex's global sandbox Unix socket allowlist while preserving existing socket rules and explicit proxy opt-outs
- remove git-ai-owned sandbox configuration during uninstall without clobbering user-owned proxy settings
- centralize sandbox flag plumbing in a typed `SandboxInstallOptions` value for this PR and the dependent Claude layer
- cover both inline and hooks.json Codex install flows, including a TestRepo integration test that proves the default-off behavior

## Stack
- foundation for #2071

## Testing
- `task test TEST_FILTER=mdm::agents::codex::tests`
- `task test TEST_FILTER=install_hooks_only_allows_git_ai_trace_socket_in_codex_sandboxes_when_requested`
- `task test TEST_FILTER=parse_install_options_`
- `task lint`
- `task fmt`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
