### PR TITLE
Whitelist trace2 socket in Claude sandboxes

### DIFF
--- a/src/mdm/agents/claude_code.rs
+++ b/src/mdm/agents/claude_code.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use crate::daemon::DaemonConfig;
 use crate::error::GitAiError;
 use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
 use crate::mdm::utils::{
@@ -14,11 +16,124 @@ const CLAUDE_PRE_TOOL_CMD: &str = "checkpoint claude --hook-input stdin";
 const CLAUDE_POST_TOOL_CMD: &str = "checkpoint claude --hook-input stdin";
 const CLAUDE_CATCH_ALL_MATCHER: &str = "*";
 
-pub struct ClaudeCodeInstaller;
+pub struct ClaudeCodeInstaller {
+    allow_trace_socket: bool,
+}
 
 impl ClaudeCodeInstaller {
+    pub(crate) fn new(allow_trace_socket: bool) -> Self {
+        Self { allow_trace_socket }
+    }
+
     fn settings_path() -> PathBuf {
         claude_config_dir().join("settings.json")
+    }
+
+    fn allow_trace2_socket(settings: &mut Value) -> Result<(), GitAiError> {
+        #[cfg(unix)]
+        {
+            let Some(root) = settings.as_object_mut() else {
+                return Ok(());
+            };
+            if root.get("sandbox").is_some_and(|value| !value.is_object()) {
+                return Ok(());
+            }
+            let sandbox = root.entry("sandbox").or_insert_with(|| json!({}));
+            let sandbox = sandbox
+                .as_object_mut()
+                .expect("sandbox shape checked above");
+            if sandbox
+                .get("network")
+                .is_some_and(|value| !value.is_object())
+            {
+                return Ok(());
+            }
+            let network = sandbox.entry("network").or_insert_with(|| json!({}));
+            let network = network
+                .as_object_mut()
+                .expect("network shape checked above");
+            if network
+                .get("allowUnixSockets")
+                .is_some_and(|value| !value.is_array())
+            {
+                return Ok(());
+            }
+            let allowed_sockets = network
+                .entry("allowUnixSockets")
+                .or_insert_with(|| json!([]));
+            let allowed_sockets = allowed_sockets
+                .as_array_mut()
+                .expect("allowUnixSockets shape checked above");
+
+            let trace_socket = Self::trace2_socket_value()?;
+            if !allowed_sockets.contains(&trace_socket) {
+                allowed_sockets.push(trace_socket);
+            }
+
+            // Claude Code ignores path-scoped socket allowances on Linux and WSL2.
+            // Do not enable allowAllUnixSockets as a fallback: it disables Unix
+            // socket isolation for every sandboxed command, not just git.
+        }
+
+        #[cfg(not(unix))]
+        let _ = settings;
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn trace2_socket_value() -> Result<Value, GitAiError> {
+        Ok(Value::String(
+            DaemonConfig::from_env_or_default_paths()?
+                .trace_socket_path
+                .to_string_lossy()
+                .into_owned(),
+        ))
+    }
+
+    fn remove_trace2_socket(settings: &mut Value) -> Result<bool, GitAiError> {
+        #[cfg(unix)]
+        {
+            let Some(root) = settings.as_object_mut() else {
+                return Ok(false);
+            };
+            let Some(sandbox) = root.get_mut("sandbox").and_then(Value::as_object_mut) else {
+                return Ok(false);
+            };
+            let Some(network) = sandbox.get_mut("network").and_then(Value::as_object_mut) else {
+                return Ok(false);
+            };
+            let Some(allowed_sockets) = network
+                .get_mut("allowUnixSockets")
+                .and_then(Value::as_array_mut)
+            else {
+                return Ok(false);
+            };
+
+            let trace_socket = Self::trace2_socket_value()?;
+            let original_len = allowed_sockets.len();
+            allowed_sockets.retain(|socket| socket != &trace_socket);
+            if allowed_sockets.len() == original_len {
+                return Ok(false);
+            }
+
+            if allowed_sockets.is_empty() {
+                network.remove("allowUnixSockets");
+            }
+            if network.is_empty() {
+                sandbox.remove("network");
+            }
+            if sandbox.is_empty() {
+                root.remove("sandbox");
+            }
+            Ok(true)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = settings;
+            Ok(false)
+        }
     }
 
     /// Returns `(hooks_installed, hooks_up_to_date)` from a parsed settings value.
@@ -71,6 +186,7 @@ impl ClaudeCodeInstaller {
     fn install_hooks_at(
         settings_path: &Path,
         params: &HookInstallerParams,
+        allow_trace_socket: bool,
         dry_run: bool,
     ) -> Result<Option<String>, GitAiError> {
         if let Some(dir) = settings_path.parent() {
@@ -222,6 +338,9 @@ impl ClaudeCodeInstaller {
         if let Some(root) = merged.as_object_mut() {
             root.insert("hooks".to_string(), hooks_obj);
         }
+        if allow_trace_socket {
+            Self::allow_trace2_socket(&mut merged)?;
+        }
 
         if existing == merged {
             return Ok(None);
@@ -249,12 +368,9 @@ impl ClaudeCodeInstaller {
         let existing: Value = serde_json::from_str(&existing_content)?;
 
         let mut merged = existing.clone();
-        let mut hooks_obj = match merged.get("hooks").cloned() {
-            Some(h) => h,
-            None => return Ok(None),
-        };
+        let mut hooks_obj = merged.get("hooks").cloned().unwrap_or_else(|| json!({}));
 
-        let mut changed = false;
+        let mut hooks_changed = false;
 
         for hook_type in &["PreToolUse", "PostToolUse"] {
             if let Some(hook_type_array) =
@@ -274,19 +390,20 @@ impl ClaudeCodeInstaller {
                             }
                         });
                         if hooks_array.len() != original_len {
-                            changed = true;
+                            hooks_changed = true;
                         }
                     }
                 }
             }
         }
 
-        if !changed {
-            return Ok(None);
-        }
-
-        if let Some(root) = merged.as_object_mut() {
+        if hooks_changed && let Some(root) = merged.as_object_mut() {
             root.insert("hooks".to_string(), hooks_obj);
+        }
+        let socket_changed = Self::remove_trace2_socket(&mut merged)?;
+
+        if !hooks_changed && !socket_changed {
+            return Ok(None);
         }
 
         let new_content = serde_json::to_string_pretty(&merged)?;
@@ -361,7 +478,12 @@ impl HookInstaller for ClaudeCodeInstaller {
         params: &HookInstallerParams,
         dry_run: bool,
     ) -> Result<Option<String>, GitAiError> {
-        Self::install_hooks_at(&Self::settings_path(), params, dry_run)
+        Self::install_hooks_at(
+            &Self::settings_path(),
+            params,
+            self.allow_trace_socket,
+            dry_run,
+        )
     }
 
     fn uninstall_hooks(
@@ -456,7 +578,7 @@ mod tests {
         // File does not exist yet
         fs::remove_file(&path).ok();
 
-        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
         assert!(diff.is_some(), "should produce a diff");
 
         let settings = read_settings(&path);
@@ -474,19 +596,16 @@ mod tests {
     fn s2_idempotent_already_on_catch_all() {
         let (_td, path) = setup_test_env();
         let cmd = expected_cmd();
-        fs::write(
-            &path,
-            serde_json::to_string_pretty(&json!({
-                "hooks": {
-                    "PreToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}],
-                    "PostToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}]
-                }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
+        let mut settings = json!({
+            "hooks": {
+                "PreToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}],
+                "PostToolUse": [{"matcher": "*", "hooks": [{"type":"command","command": cmd}]}]
+            }
+        });
+        ClaudeCodeInstaller::allow_trace2_socket(&mut settings).unwrap();
+        fs::write(&path, serde_json::to_string_pretty(&settings).unwrap()).unwrap();
 
-        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), true, false).unwrap();
         assert!(diff.is_none(), "should return None when already up-to-date");
     }
 
@@ -506,7 +625,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -556,7 +675,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for (hook_type, user_cmd) in &[
@@ -612,7 +731,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -657,7 +776,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -688,7 +807,7 @@ mod tests {
     fn s7_idempotent_user_catch_all_plus_git_ai() {
         let (_td, path) = setup_test_env();
         let cmd = expected_cmd();
-        let before = json!({
+        let mut before = json!({
             "hooks": {
                 "PreToolUse": [{"matcher": "*", "hooks": [
                     {"type":"command","command": "my-audit-tool"},
@@ -700,9 +819,10 @@ mod tests {
                 ]}]
             }
         });
+        ClaudeCodeInstaller::allow_trace2_socket(&mut before).unwrap();
         fs::write(&path, serde_json::to_string_pretty(&before).unwrap()).unwrap();
 
-        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        let diff = ClaudeCodeInstaller::install_hooks_at(&path, &params(), true, false).unwrap();
         assert!(diff.is_none(), "should be idempotent");
     }
 
@@ -735,7 +855,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -790,7 +910,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -818,7 +938,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -860,7 +980,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -915,7 +1035,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
         for hook_type in &["PreToolUse", "PostToolUse"] {
@@ -954,7 +1074,7 @@ mod tests {
         )
         .unwrap();
 
-        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        ClaudeCodeInstaller::install_hooks_at(&path, &params(), false, false).unwrap();
 
         let settings = read_settings(&path);
 
@@ -1243,7 +1363,7 @@ mod tests {
         assert!(!settings_path.parent().unwrap().exists());
 
         let result =
-            ClaudeCodeInstaller::install_hooks_at(&settings_path, &params(), false).unwrap();
+            ClaudeCodeInstaller::install_hooks_at(&settings_path, &params(), false, false).unwrap();
 
         assert!(result.is_some(), "should report changes for fresh install");
         assert!(settings_path.exists(), "settings.json should be created");

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -37,7 +37,7 @@ use super::hook_installer::HookInstaller;
 /// Get all available hook installers
 pub fn get_all_installers(whitelist_agent_sandboxes: bool) -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
-        Box::new(ClaudeCodeInstaller),
+        Box::new(ClaudeCodeInstaller::new(whitelist_agent_sandboxes)),
         Box::new(ClineInstaller),
         Box::new(CodexInstaller::new(whitelist_agent_sandboxes)),
         Box::new(CursorInstaller),

--- a/tests/integration/claude_sandbox.rs
+++ b/tests/integration/claude_sandbox.rs
@@ -1,0 +1,164 @@
+#![cfg(unix)]
+
+use crate::repos::test_repo::{DaemonTestScope, TestRepo};
+use git_ai::daemon::DaemonConfig;
+use serde_json::{Value, json};
+use std::fs;
+
+fn enable_agent_sandbox_whitelisting(repo: &TestRepo) {
+    repo.git_ai_without_pre_sync_for_test(&[
+        "config",
+        "set",
+        "feature_flags.whitelist_agent_sandboxes",
+        "true",
+    ])
+    .expect("enable agent sandbox whitelisting");
+}
+
+fn install_hooks(repo: &TestRepo) {
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("install Claude hooks");
+}
+
+#[test]
+fn install_hooks_does_not_configure_claude_sandbox_by_default() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(&settings_path, "{}\n").unwrap();
+
+    repo.git_ai_without_pre_sync_for_test(&["install-hooks"])
+        .expect("install Claude hooks");
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+    assert!(settings["sandbox"].is_null());
+    assert!(settings["hooks"]["PreToolUse"].is_array());
+    assert!(settings["hooks"]["PostToolUse"].is_array());
+}
+
+#[test]
+fn configured_install_hooks_allows_trace2_socket_in_claude_sandbox() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({
+            "theme": "dark",
+            "sandbox": {
+                "enabled": true,
+                "network": {
+                    "allowedDomains": ["example.com"],
+                    "allowUnixSockets": ["/tmp/user-owned.sock"]
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    enable_agent_sandbox_whitelisting(&repo);
+    install_hooks(&repo);
+
+    let first_install = fs::read_to_string(&settings_path).unwrap();
+    let settings: Value = serde_json::from_str(&first_install).unwrap();
+    let network = &settings["sandbox"]["network"];
+    let allowed_sockets = network["allowUnixSockets"].as_array().unwrap();
+    let expected_trace_socket = DaemonConfig::from_home(repo.test_home_path())
+        .trace_socket_path
+        .to_string_lossy()
+        .into_owned();
+
+    assert!(allowed_sockets.contains(&json!("/tmp/user-owned.sock")));
+    assert!(allowed_sockets.contains(&json!(expected_trace_socket)));
+    assert_eq!(network["allowedDomains"], json!(["example.com"]));
+    assert_eq!(settings["theme"], "dark");
+    assert!(network["allowAllUnixSockets"].is_null());
+
+    install_hooks(&repo);
+    assert_eq!(fs::read_to_string(settings_path).unwrap(), first_install);
+}
+
+#[test]
+fn install_hooks_preserves_explicit_sandbox_restrictions() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({
+            "sandbox": {
+                "network": {
+                    "allowAllUnixSockets": false
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    enable_agent_sandbox_whitelisting(&repo);
+    install_hooks(&repo);
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+    assert_eq!(settings["sandbox"]["network"]["allowAllUnixSockets"], false);
+    assert!(settings["hooks"]["PreToolUse"].is_array());
+    assert!(settings["hooks"]["PostToolUse"].is_array());
+}
+
+#[test]
+fn uninstall_hooks_removes_only_the_trace2_socket_allowance() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let settings_path = repo.test_home_path().join(".claude/settings.json");
+    fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+    let original_sandbox = json!({
+        "enabled": true,
+        "network": {
+            "allowedDomains": ["example.com"],
+            "allowUnixSockets": ["/tmp/user-owned.sock"]
+        }
+    });
+    fs::write(
+        &settings_path,
+        serde_json::to_string_pretty(&json!({"sandbox": original_sandbox})).unwrap(),
+    )
+    .unwrap();
+
+    enable_agent_sandbox_whitelisting(&repo);
+    install_hooks(&repo);
+    repo.git_ai_without_pre_sync_for_test(&["uninstall-hooks"])
+        .expect("uninstall Claude hooks");
+
+    let settings: Value =
+        serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+    assert_eq!(settings["sandbox"], original_sandbox);
+}
+
+#[test]
+fn install_hooks_ignores_unexpected_sandbox_shapes() {
+    for sandbox in [
+        json!(true),
+        json!({"network": true}),
+        json!({"network": {"allowUnixSockets": true}}),
+    ] {
+        let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+        let settings_path = repo.test_home_path().join(".claude/settings.json");
+        fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&json!({"sandbox": sandbox})).unwrap(),
+        )
+        .unwrap();
+
+        enable_agent_sandbox_whitelisting(&repo);
+        install_hooks(&repo);
+
+        let settings: Value =
+            serde_json::from_str(&fs::read_to_string(settings_path).unwrap()).unwrap();
+        assert_eq!(settings["sandbox"], sandbox);
+        assert!(settings["hooks"]["PreToolUse"].is_array());
+        assert!(settings["hooks"]["PostToolUse"].is_array());
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -40,6 +40,7 @@ mod ci_local_skip_push;
 mod ci_partial_clone;
 mod ci_squash_rebase;
 mod claude_code;
+mod claude_sandbox;
 mod cli_parser_rebase_args;
 mod codex;
 mod cold_trace2_repo;


### PR DESCRIPTION
## Summary
- extend the shared `whitelist_agent_sandboxes` opt-in to Claude Code
- add only the active trace2 socket to `sandbox.network.allowUnixSockets`
- preserve existing sandbox settings, remain idempotent, and remove only git-ai's socket on uninstall
- fail safely on unexpected sandbox config shapes and never enable broad `allowAllUnixSockets` access

## Stack
Depends on #2091.

## Claude Code documentation
- https://code.claude.com/docs/en/configuration#sandbox-settings
- https://code.claude.com/docs/en/sandboxing

## Tests
- `task fmt`
- `task lint`
- `task test TEST_FILTER=claude_sandbox::`
- `task test TEST_FILTER=mdm::agents::claude_code::`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->