### PR TITLE
fix(metrics): run metadata backfill once

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -471,7 +471,7 @@ fn backfill_metrics_event_metadata() -> Result<(), GitAiError> {
             let mut db_lock = db
                 .lock()
                 .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
-            db_lock.backfill_event_metadata_batch_after(after_id, METADATA_BACKFILL_BATCH_SIZE)?
+            db_lock.backfill_event_metadata_batch_once(after_id, METADATA_BACKFILL_BATCH_SIZE)?
         };
 
         let Some(id) = last_id else {

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -24,6 +24,7 @@ const SCHEMA_VERSION: usize = 5;
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
+const EVENT_METADATA_BACKFILL_COMPLETED_KEY: &str = "event_metadata_backfill_completed";
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
 const RETRYABLE_METRIC_IDS_SQL: &str = "SELECT id FROM metrics \
@@ -1195,6 +1196,39 @@ impl MetricsDatabase {
     ) -> Result<MetricMetadataBackfillSummary, GitAiError> {
         self.backfill_event_metadata_batch_after(0, limit)
             .map(|(summary, _)| summary)
+    }
+
+    pub(crate) fn event_metadata_backfill_completed(&self) -> Result<bool, GitAiError> {
+        let completed: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT value FROM schema_metadata WHERE key = ?1",
+                params![EVENT_METADATA_BACKFILL_COMPLETED_KEY],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(completed.as_deref() == Some("1"))
+    }
+
+    /// Backfill one bounded batch, permanently marking the one-time migration complete
+    /// after a successful scan reaches the end of the table.
+    pub(crate) fn backfill_event_metadata_batch_once(
+        &mut self,
+        after_id: i64,
+        limit: usize,
+    ) -> Result<(MetricMetadataBackfillSummary, Option<i64>), GitAiError> {
+        if limit == 0 || self.event_metadata_backfill_completed()? {
+            return Ok((MetricMetadataBackfillSummary::default(), None));
+        }
+
+        let result = self.backfill_event_metadata_batch_after(after_id, limit)?;
+        if result.0.scanned < limit {
+            self.conn.execute(
+                "INSERT OR REPLACE INTO schema_metadata (key, value) VALUES (?1, '1')",
+                params![EVENT_METADATA_BACKFILL_COMPLETED_KEY],
+            )?;
+        }
+        Ok(result)
     }
 
     /// Backfill cached event metadata for all currently eligible legacy rows.
@@ -2466,6 +2500,55 @@ mod tests {
             .unwrap();
         assert_eq!(empty_summary, MetricMetadataBackfillSummary::default());
         assert_eq!(empty_last_id, None);
+    }
+
+    #[test]
+    fn test_backfill_event_metadata_batch_once_marks_completion() {
+        let (mut db, temp_dir) = create_test_db();
+        db.conn
+            .execute(
+                "INSERT INTO metrics (event_json) VALUES (?1), (?2)",
+                params![event_json(days_ago(2)), event_json(days_ago(1))],
+            )
+            .unwrap();
+
+        let (first_summary, last_id) = db.backfill_event_metadata_batch_once(0, 1).unwrap();
+        assert_eq!(first_summary.scanned, 1);
+        assert!(!db.event_metadata_backfill_completed().unwrap());
+
+        let (second_summary, _) = db
+            .backfill_event_metadata_batch_once(last_id.unwrap(), 2)
+            .unwrap();
+        assert_eq!(second_summary.scanned, 1);
+        assert!(db.event_metadata_backfill_completed().unwrap());
+
+        drop(db);
+        let conn = crate::sqlite::open_with_memory_limits(temp_dir.path().join("test-metrics.db"))
+            .unwrap();
+        let mut db = MetricsDatabase { conn };
+        db.initialize_schema().unwrap();
+        assert!(db.event_metadata_backfill_completed().unwrap());
+
+        db.conn
+            .execute(
+                "INSERT INTO metrics (event_json) VALUES (?1)",
+                params![event_json(days_ago(0))],
+            )
+            .unwrap();
+        let inserted_after_completion = db.conn.last_insert_rowid();
+
+        let skipped = db.backfill_event_metadata_batch_once(0, 100).unwrap();
+        assert_eq!(skipped, (MetricMetadataBackfillSummary::default(), None));
+        assert_eq!(
+            db.conn
+                .query_row(
+                    "SELECT event_ts FROM metrics WHERE id = ?1",
+                    params![inserted_after_completion],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .unwrap(),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist a completion marker after the legacy metrics metadata backfill reaches the end successfully
- skip the full-table backfill scan on every later daemon startup
- preserve bounded batch processing and retry the migration if any batch fails

## Why

The backfill query scans the full metrics table when no legacy rows remain. On a 5.1 GB / 1.48M-row database this held the metrics DB mutex for 8-12 seconds on every daemon restart and caused `telemetry flush exceeded its scheduling interval` warnings. Current metric inserts already populate the migrated metadata columns, so the historical backfill is one-time work.

## Validation

- strict TDD: focused test failed before implementation and passes afterward
- `task test TEST_FILTER=backfill_event_metadata`
- `task lint`
- `task fmt`
- live 5.1 GB database: first fixed startup completed the final scan and persisted the marker; second startup uploaded metrics in ~3.2s with no scheduling warning
- full local suite passes aside from existing environment-specific tests that assume `droid` is absent and a pre-existing wltrace timing failure on latest main