### PR TITLE
Skip the refs/notes/ai fetch for missing source notes on the http backend

### DIFF
--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -156,6 +156,28 @@ pub fn fetch_missing_notes_for_commits(
                 tracing::debug!("HTTP backend fetch for missing source notes failed: {}", e);
             }
         }
+
+        // On the HTTP backend the server is the sole source of truth:
+        // refs/notes/ai is never pushed there, so the refs fetch below
+        // cannot produce these notes by construction — it only costs a
+        // full negotiation per remote (minutes on large repos) while
+        // daemon op-processing blocks behind it. A note the server does
+        // not have is missing, period.
+        let still_missing: Vec<&String> = {
+            let noted = noted_commits(repository, source_commits);
+            source_commits
+                .iter()
+                .filter(|sha| !noted.contains(sha.as_str()))
+                .collect()
+        };
+        if still_missing.is_empty() {
+            return Ok(());
+        }
+        return Err(GitAiError::Generic(format!(
+            "authorship notes for source commits {:?} are missing from the notes backend \
+             (refs fetch skipped: refs/notes/ai is not populated on the http backend)",
+            still_missing
+        )));
     }
 
     tracing::debug!(
@@ -599,6 +621,80 @@ mod tests {
             result
         );
         assert_eq!(cached, Some("server-note-content".to_string()));
+    }
+
+    /// On the HTTP backend the server is the sole source of truth:
+    /// refs/notes/ai is never pushed there, so the git refs fetch cannot
+    /// succeed by construction and only costs a full negotiation per remote
+    /// (minutes on large repos) while daemon op-processing blocks behind it.
+    /// When the backend lacks a note, the refs fetch must be SKIPPED — even
+    /// if a remote happens to carry a refs/notes/ai ref (non-HTTP history).
+    #[test]
+    #[serial_test::serial(notes_db_env)]
+    fn fetch_missing_notes_skips_refs_fetch_on_http_backend() {
+        use crate::git::test_utils::TmpRepo;
+        use tempfile::NamedTempFile;
+
+        let tmp_db = NamedTempFile::new().expect("tmp notes-db");
+
+        let repo = TmpRepo::new().expect("TmpRepo::new");
+        repo.write_file("src.txt", "content", false).expect("write");
+        let sha = repo.commit_all("source commit").expect("commit");
+
+        // A REAL local origin that carries the note in refs/notes/ai: if the
+        // refs fetch runs, it would succeed and find the note — which is how
+        // this test detects the (unwanted) fall-through.
+        let origin = tempfile::tempdir().expect("origin dir");
+        let origin_path = origin.path().to_str().unwrap().to_string();
+        std::process::Command::new("git")
+            .args(["init", "--bare", &origin_path])
+            .output()
+            .expect("init bare");
+        repo.git_command(&["remote", "add", "origin", &origin_path])
+            .expect("remote add");
+        repo.git_command(&["push", "-q", "origin", "HEAD:refs/heads/main"])
+            .expect("push branch");
+        repo.git_command(&["notes", "--ref=ai", "add", "-m", "{}", &sha])
+            .expect("add note");
+        repo.git_command(&["push", "-q", "origin", "refs/notes/ai:refs/notes/ai"])
+            .expect("push notes ref");
+        repo.git_command(&["update-ref", "-d", "refs/notes/ai"])
+            .expect("drop local notes ref");
+
+        // The HTTP backend does NOT have the note.
+        let mut server = mockito::Server::new();
+        let _mock = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/worker/notes/".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"notes": {}}"#)
+            .create();
+
+        set_http_backend_env(tmp_db.path().to_str().unwrap(), &server.url());
+        let result = fetch_missing_notes_for_commits(repo.gitai_repo(), std::slice::from_ref(&sha));
+        let tracking_ref_after = repo
+            .git_command(&[
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "refs/notes/ai-remote/origin",
+            ])
+            .ok();
+        clear_http_backend_env();
+
+        assert!(
+            tracking_ref_after.is_none() || tracking_ref_after.as_deref() == Some(""),
+            "refs fetch must not run on the HTTP backend (tracking ref was created)"
+        );
+        let err =
+            result.expect_err("missing on the backend must stay missing, not be refs-fetched");
+        assert!(
+            err.to_string().contains(&sha),
+            "error should name the missing sha: {err}"
+        );
     }
 
     /// The error contract is preserved: when neither the HTTP backend nor


### PR DESCRIPTION
Fixes #2099 (first suggested fix there); related to #2093 and a follow-up to #1975.

## Problem

On http-backend deployments, `fetch_missing_notes_for_commits` warms the local cache from the server (#1975) — but whenever the backend legitimately lacks a note (the common case: fresh commits that never had notes), it **falls through to the per-remote `refs/notes/ai` git fetch**. On the http backend that ref is never pushed, so the fetch cannot succeed by construction; it only costs a full negotiation per remote (measured at 1–3 minutes on large monorepos, sometimes failing outright on SSH auth) while daemon op-processing blocks behind it.

Production symptom (#2099): `git push` / `gt submit` stall for minutes; killing the daemon makes the same push instant. Daemon timelines show `fetching authorship notes` immediately preceding every slow push.

## Fix

When the http backend is enabled, its answer is final: warm the cache from the server, and if notes are still missing, report them missing (same loud error contract, SHAs named) **without** attempting the refs fetch. The `git_notes` backend path is unchanged.

## Test

`fetch_missing_notes_skips_refs_fetch_on_http_backend` (TDD — failed before the fix): the repo's origin is a real local remote that *does* carry the note in `refs/notes/ai`, while the mocked http backend lacks it. Pre-fix, the fall-through fetch created the tracking ref and returned Ok; post-fix no tracking ref is created and the error names the missing SHA. The #1975 regression test (backend has the note → cached) and the missing-everywhere error-contract test still pass.

Pre-existing on main, unrelated to this change: 5 lib test failures (`test_run_command_capture_with_timeout_reports_partial_output`, `check_for_update_available_returns_update_ready_when_cache_has_pending_update`, `test_run_logged_command_with_timeout_reports_partial_output`, `test_load_ai_touched_files_for_specific_commits`, `conflict_resolution_note_read_errors_are_not_silently_ignored`) fail identically on clean `origin/main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
