### PR TITLE
Preserve authorship when range-diff abbreviates SHAs

### DIFF
--- a/docs/rewrite-simplification-spec.md
+++ b/docs/rewrite-simplification-spec.md
@@ -235,7 +235,7 @@ If squash detected: return `vec![(old_tip, new_tip)]` immediately (skip range-di
 ### range-diff invocation
 
 ```bash
-git range-diff --no-color --no-abbrev -s --creation-factor=100 <base>..<old_tip> <base>..<new_tip>
+git -c core.abbrev=no range-diff --no-color --no-abbrev -s --creation-factor=100 <base>..<old_tip> <base>..<new_tip>
 ```
 
 - Two-range form is mandatory (three-dot syntax includes upstream noise)

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -1054,7 +1054,10 @@ fn run_range_diff(
     new_tip: &str,
 ) -> Result<String, GitAiError> {
     let mut args = repo.global_args_for_exec();
+    // Some older Git versions ignore --no-abbrev for range-diff summaries.
     args.extend([
+        "-c".to_string(),
+        "core.abbrev=no".to_string(),
         "range-diff".to_string(),
         "--no-color".to_string(),
         "--no-abbrev".to_string(),

--- a/src/bin/git-ai-test-git-shim.rs
+++ b/src/bin/git-ai-test-git-shim.rs
@@ -97,6 +97,36 @@ fn argv_with_test_sync_session(argv: &[String], test_sync_session: &str) -> Vec<
     out
 }
 
+fn argv_with_simulated_legacy_range_diff_abbreviation(argv: &[String]) -> Vec<String> {
+    if env::var("GIT_AI_TEST_GIT_SHIM_ABBREVIATE_RANGE_DIFF").as_deref() != Ok("1") {
+        return argv.to_vec();
+    }
+
+    let Some(range_diff_index) = argv.iter().position(|arg| arg == "range-diff") else {
+        return argv.to_vec();
+    };
+    let has_core_abbrev_override = argv[..range_diff_index]
+        .windows(2)
+        .any(|args| args[0] == "-c" && args[1] == "core.abbrev=no")
+        || argv[..range_diff_index]
+            .iter()
+            .any(|arg| arg == "-ccore.abbrev=no");
+
+    if has_core_abbrev_override {
+        return argv.to_vec();
+    }
+
+    argv.iter()
+        .map(|arg| {
+            if arg == "--no-abbrev" {
+                "--abbrev=8".to_string()
+            } else {
+                arg.clone()
+            }
+        })
+        .collect()
+}
+
 #[cfg(unix)]
 fn exec_target(target: &str, argv: &[String]) -> ! {
     let mut command = Command::new(target);
@@ -145,6 +175,7 @@ fn main() {
             panic!("git-ai-test-git-shim failed: {error}");
         }
     }
+    effective_argv = argv_with_simulated_legacy_range_diff_abbreviation(&effective_argv);
     exec_target(&target, &effective_argv);
 }
 
@@ -170,5 +201,6 @@ fn main() {
             panic!("git-ai-test-git-shim failed: {error}");
         }
     }
+    effective_argv = argv_with_simulated_legacy_range_diff_abbreviation(&effective_argv);
     exec_target(&target, &effective_argv)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,6 +317,8 @@ static TEST_FEATURE_FLAGS_OVERRIDE: RwLock<Option<FeatureFlags>> = RwLock::new(N
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfigPatch {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_prompts_in_repositories: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry_oss_disabled: Option<bool>,
@@ -1682,6 +1684,9 @@ fn apply_test_config_patch(config: &mut Config) {
     if let Ok(patch_json) = env::var("GIT_AI_TEST_CONFIG_PATCH")
         && let Ok(patch) = serde_json::from_str::<ConfigPatch>(&patch_json)
     {
+        if let Some(git_path) = patch.git_path {
+            config.git_path = git_path;
+        }
         if let Some(patterns) = patch.exclude_prompts_in_repositories {
             config.exclude_prompts_in_repositories = patterns
                     .into_iter()

--- a/tests/integration/pull_rebase_ff.rs
+++ b/tests/integration/pull_rebase_ff.rs
@@ -3,7 +3,7 @@ use git_ai::authorship::working_log::AgentId;
 use git_ai::daemon::bash_history_db::{BashCallEnd, BashCallStart, BashHistoryDatabase};
 
 use crate::repos::test_file::ExpectedLineExt;
-use crate::repos::test_repo::{DaemonTestScope, TestRepo};
+use crate::repos::test_repo::{DaemonTestScope, TestRepo, real_git_executable};
 use serde_json::json;
 use std::collections::{BTreeSet, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -101,7 +101,13 @@ struct DivergentPullTestSetup {
 /// - local has diverged from upstream (initial + ai_commit)
 /// - `git pull --rebase` will rebase the AI commit onto the upstream commit
 fn setup_divergent_pull_test() -> DivergentPullTestSetup {
-    let (local, upstream) = TestRepo::new_with_remote();
+    setup_divergent_pull_test_with_daemon_scope(DaemonTestScope::Shared)
+}
+
+fn setup_divergent_pull_test_with_daemon_scope(
+    daemon_scope: DaemonTestScope,
+) -> DivergentPullTestSetup {
+    let (local, upstream) = TestRepo::new_with_remote_with_daemon_scope(daemon_scope);
 
     // Make initial commit and push
     let mut readme = local.filename("README.md");
@@ -533,6 +539,57 @@ fn test_pull_rebase_preserves_committed_ai_authorship() {
     // Verify AI authorship is preserved on the rebased commit
     let mut ai_file = local.filename("ai_feature.txt");
     ai_file.assert_lines_and_blame(vec![
+        "AI generated feature line 1".ai(),
+        "AI generated feature line 2".ai(),
+    ]);
+}
+
+#[test]
+fn test_pull_rebase_preserves_authorship_when_range_diff_ignores_no_abbrev() {
+    let setup = setup_divergent_pull_test_with_daemon_scope(DaemonTestScope::Dedicated);
+    let mut local = setup.local;
+
+    assert!(
+        local
+            .read_authorship_note(&setup.local_ai_commit_sha)
+            .is_some(),
+        "precondition: original local AI commit should have an authorship note"
+    );
+
+    let shim_binary = env!("CARGO_BIN_EXE_git-ai-test-git-shim");
+    let shim_path = local.test_home_path().join(if cfg!(windows) {
+        "legacy-git-shim.exe"
+    } else {
+        "legacy-git-shim"
+    });
+    std::fs::copy(shim_binary, &shim_path).expect("legacy Git shim should be copied");
+    let shim_path = shim_path.to_str().expect("shim path should be utf-8");
+    let real_git = real_git_executable();
+    local.patch_git_ai_config(|patch| patch.git_path = Some(shim_path.to_string()));
+    local.restart_dedicated_daemon_with_env_for_test(&[
+        ("GIT_AI_TEST_GIT_SHIM_TARGET", real_git),
+        ("GIT_AI_TEST_GIT_SHIM_FALLBACK_TARGET", real_git),
+        ("GIT_AI_TEST_GIT_SHIM_ABBREVIATE_RANGE_DIFF", "1"),
+    ]);
+
+    local
+        .git(&["pull", "--rebase"])
+        .expect("pull --rebase should succeed");
+
+    let rebased_head = local
+        .git(&["rev-parse", "HEAD"])
+        .expect("rev-parse should succeed")
+        .trim()
+        .to_string();
+    assert_ne!(rebased_head, setup.local_ai_commit_sha);
+    assert!(
+        local.read_authorship_note(&rebased_head).is_some(),
+        "rebased local AI commit should retain its authorship note even when Git ignores --no-abbrev"
+    );
+
+    local.patch_git_ai_config(|patch| patch.git_path = Some(real_git.to_string()));
+    let mut ai_file = local.filename("ai_feature.txt");
+    ai_file.assert_committed_lines(crate::lines![
         "AI generated feature line 1".ai(),
         "AI generated feature line 2".ai(),
     ]);

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1194,6 +1194,13 @@ impl TestRepo {
 
         let mut config = serde_json::Map::new();
 
+        if let Some(git_path) = &patch.git_path {
+            config.insert(
+                "git_path".to_string(),
+                serde_json::Value::String(git_path.clone()),
+            );
+        }
+
         if let Some(exclude) = &patch.exclude_prompts_in_repositories {
             let values = exclude
                 .iter()
@@ -1823,10 +1830,17 @@ impl TestRepo {
     }
 
     pub(crate) fn restart_dedicated_daemon_for_test(&mut self) {
+        self.restart_dedicated_daemon_with_env_for_test(&[]);
+    }
+
+    pub(crate) fn restart_dedicated_daemon_with_env_for_test(
+        &mut self,
+        daemon_env: &[(&str, &str)],
+    ) {
         assert_eq!(
             self.daemon_scope,
             DaemonTestScope::Dedicated,
-            "restart_dedicated_daemon_for_test requires a dedicated daemon repo"
+            "daemon restart requires a dedicated daemon repo"
         );
         let family_key = self.daemon_family_key();
         let pending_summary = {
@@ -1844,7 +1858,15 @@ impl TestRepo {
         if let Some(daemon) = self.daemon_process.take() {
             daemon.shutdown();
         }
-        self.setup_daemon_mode();
+        let daemon = Arc::new(DaemonProcess::start_with_env(
+            &self.path,
+            &self.test_home,
+            &self.test_db_path,
+            daemon_env,
+        ));
+        self.test_db_path = daemon.test_db_path.clone();
+        self.daemon_process = Some(daemon);
+        self.sync_test_home_config();
     }
 
     fn daemon_completion_log_path_for_family(&self, family_key: &str) -> PathBuf {


### PR DESCRIPTION
Fixes #2101

## Summary
- force full-length range-diff OIDs with `core.abbrev=no` while retaining `--no-abbrev`
- add a TestRepo regression that simulates older Git ignoring `--no-abbrev` and verifies pull-rebase note migration and line attribution
- document the hardened range-diff invocation

## Test coverage
- `task test TEST_FILTER=test_pull_rebase_preserves_authorship_when_range_diff_ignores_no_abbrev`
- `task test TEST_FILTER=pull_rebase`
- `task lint`
- `task fmt`
- `task test` (four pre-existing daemon await/telemetry tests timed out locally; the affected pull-rebase suites pass)