### PR TITLE
Avoid locked Git config during repository discovery

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2518,8 +2518,15 @@ fn is_linked_worktree_git_file(git_file: &Path) -> bool {
 }
 
 pub fn find_repository_in_path(path: &str) -> Result<Repository, GitAiError> {
-    let global_args = vec!["-C".to_string(), path.to_string()];
-    find_repository(&global_args)
+    let path = Path::new(path);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(GitAiError::IoError)?
+            .join(path)
+    };
+    discover_repository_in_path_no_git_exec(&path)
 }
 
 /// Find the git repository that contains the given file path by walking up the directory tree.

--- a/tests/integration/repository_unit.rs
+++ b/tests/integration/repository_unit.rs
@@ -312,6 +312,38 @@ fn find_repository_in_path_supports_bare_repositories() {
     );
 }
 
+#[cfg(windows)]
+#[test]
+fn find_repository_in_path_does_not_read_locked_git_config() {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let repo = TestRepo::new_with_daemon_scope(crate::repos::test_repo::DaemonTestScope::NoDaemon);
+    let _config_lock = OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(repo.path().join(".git").join("config"))
+        .expect("lock repository config");
+    let probe_error = repo
+        .git_og(&["rev-parse", "--show-toplevel"])
+        .expect_err("exclusive config lock should reproduce the Git read failure");
+    assert!(
+        probe_error.contains("Permission denied"),
+        "expected config lock failure, got: {probe_error}"
+    );
+
+    let discovered = find_repository_in_path(repo.path().to_str().unwrap())
+        .expect("repository discovery should not read config");
+    assert_eq!(
+        discovered
+            .workdir()
+            .expect("repository workdir")
+            .canonicalize()
+            .expect("canonical discovered workdir"),
+        repo.path().canonicalize().expect("canonical test repo")
+    );
+}
+
 #[test]
 fn find_repository_in_path_bare_repo_can_read_head_gitattributes() {
     let temp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- replace path-based `git rev-parse` repository probes with the existing filesystem-only discovery helper
- resolve relative paths against the current directory before walking ancestors
- add a Windows `TestRepo` regression that locks `.git/config` and verifies discovery still succeeds

This fixes the Windows integration failure observed on `main` after #2102, where daemon family synchronization encountered `Permission denied` while Git read a transiently locked `.git/config`.

## Test coverage

- `task test CARGO_TEST_ARGS="--test integration"` (3,287 passed, 89 ignored)
- `task test TEST_FILTER=repository_unit::` (17 passed)
- `task test TEST_FILTER=push_after_branch_set_upstream_pushes_authorship_notes_in_worktree`
- `task lint`
- `task fmt`

The unfiltered local `task test` reaches a pre-existing daemon `await` timeout that also reproduces on untouched `origin/main`; the complete integration binary and changed-area tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->