### PR TITLE
Fix Copilot VS Code model attribution

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -360,10 +360,15 @@ fn recover_bash_mtime(
             continue;
         }
 
+        let mut agent_id = candidate.agent_id.clone();
+        crate::streams::model_extraction::enrich_copilot_agent_model(
+            &mut agent_id,
+            &candidate.metadata,
+        );
         let trace_id = generate_trace_id();
-        let session_id = generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool);
+        let session_id = generate_session_id(&agent_id.id, &agent_id.tool);
         let author_id = format!("{}::{}", session_id, trace_id);
-        insert_session_record(authorship_log, &session_id, candidate, human_author);
+        insert_session_record(authorship_log, &session_id, &agent_id, human_author);
         add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
 
         let metadata = json!({
@@ -395,9 +400,9 @@ fn recover_bash_mtime(
             author_id: &author_id,
             session_id: &session_id,
             trace_id: &trace_id,
-            tool: &candidate.agent_id.tool,
-            model: &candidate.agent_id.model,
-            external_session_id: &candidate.agent_id.id,
+            tool: &agent_id.tool,
+            model: &agent_id.model,
+            external_session_id: &agent_id.id,
             external_tool_use_id: Some(&candidate.tool_use_id),
             edit_kind: "bash",
             checkpoint_type: "recovered_bash",
@@ -1515,7 +1520,7 @@ fn path_is_equal_or_child(child: &str, parent: &str) -> bool {
 fn insert_session_record(
     authorship_log: &mut AuthorshipLog,
     session_id: &str,
-    candidate: &BashCheckpointCall,
+    agent_id: &AgentId,
     human_author: &str,
 ) {
     authorship_log
@@ -1523,7 +1528,7 @@ fn insert_session_record(
         .sessions
         .entry(session_id.to_string())
         .or_insert_with(|| SessionRecord {
-            agent_id: candidate.agent_id.clone(),
+            agent_id: agent_id.clone(),
             human_author: Some(human_author.to_string()),
             custom_attributes: None,
         });

--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -7,9 +7,8 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::authorship::working_log::AgentId;
 use crate::commands::checkpoint_agent::bash_tool::ToolClass;
 use crate::error::GitAiError;
-use crate::streams::model_extraction;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
 // Legacy extension path (before_edit / after_edit)
@@ -105,14 +104,9 @@ pub(super) fn parse_legacy_extension_hooks(
         agent_id: AgentId {
             tool: "github-copilot".to_string(),
             id: session_id.clone(),
-            model: model_extraction::extract_model(
-                Path::new(chat_session_path),
-                crate::streams::sweep::StreamFormat::CopilotSessionJson,
-                None,
-            )
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| "unknown".to_string()),
+            // The daemon resolves this from the session path so the short-lived hook
+            // process does not reread the transcript for every edit.
+            model: "unknown".to_string(),
         },
         external_session_id: session_id,
         trace_id: trace_id.to_string(),
@@ -476,10 +470,17 @@ mod tests {
 
     #[test]
     fn test_copilot_legacy_after_edit() {
+        let dir = tempfile::tempdir().unwrap();
+        let chat_session_path = dir.path().join("sess-123.json");
+        std::fs::write(
+            &chat_session_path,
+            r#"{"requests":[{"modelId":"copilot/claude-sonnet-5"}]}"#,
+        )
+        .unwrap();
         let input = json!({
             "hook_event_name": "after_edit",
             "workspace_folder": "/home/user/project",
-            "chat_session_path": "/home/user/.vscode/sessions/sess-123.json",
+            "chat_session_path": chat_session_path,
             "session_id": "sess-123",
             "edited_filepaths": ["src/main.rs"]
         })
@@ -491,6 +492,7 @@ mod tests {
         match &events[0] {
             ParsedHookEvent::PostFileEdit(e) => {
                 assert_eq!(e.context.agent_id.tool, "github-copilot");
+                assert_eq!(e.context.agent_id.model, "unknown");
                 assert_eq!(e.context.external_session_id, "sess-123");
                 assert_eq!(
                     e.file_paths,

--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -220,25 +220,9 @@ pub(super) fn parse_vscode_native_hooks(
         agent_id: AgentId {
             tool: "github-copilot".to_string(),
             id: session_id.clone(),
-            model: transcript_path
-                .as_ref()
-                .and_then(|tp| {
-                    let path = Path::new(tp.as_str());
-                    let sweep_format = match transcript_format {
-                        StreamFormat::CopilotEventStreamJsonl => {
-                            crate::streams::sweep::StreamFormat::CopilotEventStreamJsonl
-                        }
-                        _ => crate::streams::sweep::StreamFormat::CopilotSessionJson,
-                    };
-                    model_extraction::extract_model_from_copilot_vscode_transcript(
-                        path,
-                        sweep_format,
-                        &session_id,
-                    )
-                    .ok()
-                    .flatten()
-                })
-                .unwrap_or_else(|| "unknown".to_string()),
+            // Native hooks do not include the model. Resolve it once per session in the
+            // long-lived daemon instead of reading VS Code storage in every hook process.
+            model: "unknown".to_string(),
         },
         external_session_id: session_id,
         trace_id: trace_id.to_string(),
@@ -606,7 +590,7 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_native_model_prefers_otel_selected_model_over_models_json_default() {
+    fn test_copilot_native_defers_model_lookup_to_daemon() {
         let dir = tempfile::tempdir().unwrap();
         let user_dir = dir.path().join("User");
         let transcript_path = user_dir
@@ -632,30 +616,6 @@ mod tests {
         std::fs::create_dir_all(models_path.parent().unwrap()).unwrap();
         std::fs::write(&models_path, r#"[{"id":"gpt-4.1","is_chat_default":true}]"#).unwrap();
 
-        let otel_db_path = user_dir
-            .join("globalStorage")
-            .join("github.copilot-chat")
-            .join("agent-traces.db");
-        std::fs::create_dir_all(otel_db_path.parent().unwrap()).unwrap();
-        let conn = crate::sqlite::open_with_memory_limits(&otel_db_path).unwrap();
-        conn.execute_batch(
-            "CREATE TABLE spans (
-                span_id TEXT PRIMARY KEY,
-                chat_session_id TEXT,
-                request_model TEXT,
-                response_model TEXT,
-                end_time_ms REAL NOT NULL
-            );",
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO spans (span_id, chat_session_id, request_model, response_model, end_time_ms)
-             VALUES ('span-1', 'session-abc', 'claude-sonnet-4', 'claude-sonnet-4-20250514', 1000)",
-            [],
-        )
-        .unwrap();
-        drop(conn);
-
         let input = json!({
             "hook_event_name": "PostToolUse",
             "cwd": "/home/user/project",
@@ -672,7 +632,7 @@ mod tests {
 
         match &events[0] {
             ParsedHookEvent::PostFileEdit(e) => {
-                assert_eq!(e.context.agent_id.model, "claude-sonnet-4");
+                assert_eq!(e.context.agent_id.model, "unknown");
             }
             _ => panic!("Expected PostFileEdit"),
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1052,6 +1052,12 @@ fn apply_checkpoint_side_effect(mut request: CheckpointRequest) -> Result<(), Gi
         return Ok(());
     }
 
+    if request.checkpoint_kind.is_ai()
+        && let Some(agent_id) = request.agent_id.as_mut()
+    {
+        crate::streams::model_extraction::enrich_copilot_agent_model(agent_id, &request.metadata);
+    }
+
     let repo_work_dir = &request.files[0].repo_work_dir;
     let repo = match discover_repository_in_path_no_git_exec(repo_work_dir) {
         Ok(repo) => repo,

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -13,6 +13,7 @@ const MAX_JSONL_SCAN_BYTES: u64 = 50 * 1024;
 const MAX_JSONL_HEAD_SCAN_BYTES: usize = 1024 * 1024;
 const MAX_JSONL_HEAD_LINES: usize = 20;
 const MAX_CODEX_CONFIG_BYTES: u64 = 1024 * 1024;
+const MAX_COPILOT_SESSION_SCAN_BYTES: u64 = 1024 * 1024;
 const COPILOT_MODEL_CACHE_CAPACITY: usize = 1024;
 const COPILOT_MODEL_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -487,32 +488,49 @@ fn collect_copilot_jsonl_line(line: &str, candidates: &mut CopilotModelCandidate
 fn extract_model_from_copilot_chat_session(
     path: &Path,
 ) -> Result<Option<CopilotModelEvidence>, StreamError> {
-    let file = match File::open(path) {
+    let mut file = match File::open(path) {
         Ok(file) => file,
         Err(_) => return Ok(None),
     };
     let mut candidates = CopilotModelCandidates::default();
 
     if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
-        if let Ok(state) =
-            serde_json::from_reader::<_, CopilotChatSessionState>(BufReader::new(file))
-        {
+        if file.metadata().map_or(true, |metadata| {
+            metadata.len() > MAX_COPILOT_SESSION_SCAN_BYTES
+        }) {
+            return Ok(None);
+        }
+        if let Ok(state) = serde_json::from_reader::<_, CopilotChatSessionState>(BufReader::new(
+            file.take(MAX_COPILOT_SESSION_SCAN_BYTES + 1),
+        )) {
             collect_copilot_session_state(state, &mut candidates);
         }
         return Ok(candidates.best());
     }
 
-    let mut reader = BufReader::new(file);
-    let mut line = String::new();
-    loop {
-        line.clear();
-        let bytes_read = match reader.read_line(&mut line) {
-            Ok(bytes_read) => bytes_read,
-            Err(_) => return Ok(None),
+    let file_size = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(_) => return Ok(None),
+    };
+    let read_size = file_size.min(MAX_COPILOT_SESSION_SCAN_BYTES);
+    let seek_pos = file_size.saturating_sub(read_size);
+    if file.seek(SeekFrom::Start(seek_pos)).is_err() {
+        return Ok(None);
+    }
+    let mut tail = Vec::with_capacity(read_size as usize);
+    if file.take(read_size).read_to_end(&mut tail).is_err() {
+        return Ok(None);
+    }
+    let Ok(mut tail) = std::str::from_utf8(&tail) else {
+        return Ok(None);
+    };
+    if seek_pos > 0 {
+        let Some(first_newline) = tail.find('\n') else {
+            return Ok(None);
         };
-        if bytes_read == 0 {
-            break;
-        }
+        tail = &tail[first_newline + 1..];
+    }
+    for line in tail.lines() {
         let line = line.trim();
         if !line.is_empty() {
             collect_copilot_jsonl_line(line, &mut candidates);
@@ -702,6 +720,12 @@ fn copilot_vscode_transcript_format(stream_path: &Path) -> StreamFormat {
     if stream_path
         .extension()
         .and_then(|extension| extension.to_str())
+        == Some("json")
+    {
+        StreamFormat::CopilotSessionJson
+    } else if stream_path
+        .extension()
+        .and_then(|extension| extension.to_str())
         == Some("jsonl")
         || path.contains("/workspaceStorage/")
         || path.contains("\\workspaceStorage\\")
@@ -886,28 +910,8 @@ fn extract_model_from_copilot_otel_sqlite(
 }
 
 fn extract_model_from_copilot_session_json(path: &Path) -> Result<Option<String>, StreamError> {
-    let content = match std::fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return Ok(None),
-    };
-
-    let json: serde_json::Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return Ok(None),
-    };
-
-    let model = json
-        .get("requests")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| {
-            arr.iter().find_map(|req| {
-                req.get("modelId")
-                    .and_then(|v| v.as_str())
-                    .map(String::from)
-            })
-        });
-
-    Ok(model)
+    extract_model_from_copilot_chat_session(path)
+        .map(|model| model.map(|model| model.model().to_string()))
 }
 
 fn extract_model_from_amp_thread_json(path: &Path) -> Result<Option<String>, StreamError> {
@@ -1669,7 +1673,10 @@ model = "profile-only-model"
     #[test]
     fn test_cached_copilot_vscode_model_reads_legacy_json_transcript() {
         let dir = tempfile::tempdir().unwrap();
-        let transcript_path = dir.path().join("legacy-session.json");
+        let transcript_path = dir
+            .path()
+            .join("workspaceStorage/workspace-id/chatSessions/legacy-session.json");
+        std::fs::create_dir_all(transcript_path.parent().unwrap()).unwrap();
         std::fs::write(
             &transcript_path,
             r#"{
@@ -1683,6 +1690,52 @@ model = "profile-only-model"
         let result =
             extract_cached_copilot_vscode_model(&transcript_path, "legacy-session").unwrap();
         assert_eq!(result, Some("copilot/claude-sonnet-5".to_string()));
+    }
+
+    #[test]
+    fn test_copilot_chat_session_json_rejects_oversized_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript_path = dir.path().join("oversized-session.json");
+        std::fs::write(
+            &transcript_path,
+            serde_json::json!({
+                "padding": "x".repeat(MAX_JSONL_HEAD_SCAN_BYTES),
+                "requests": [{"modelId": "copilot/claude-sonnet-5"}]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_chat_session(&transcript_path).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_copilot_chat_session_jsonl_skips_oversized_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript_path = dir.path().join("large-session.jsonl");
+        let oversized_snapshot = serde_json::json!({
+            "kind": 0,
+            "v": {"padding": "x".repeat(MAX_COPILOT_SESSION_SCAN_BYTES as usize)}
+        });
+        let request = serde_json::json!({
+            "kind": 2,
+            "k": ["requests"],
+            "v": [{"modelId": "copilot/claude-sonnet-5"}]
+        });
+        std::fs::write(
+            &transcript_path,
+            format!("{oversized_snapshot}\n{request}\n"),
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_chat_session(&transcript_path).unwrap();
+        assert_eq!(
+            result,
+            Some(CopilotModelEvidence::Concrete(
+                "copilot/claude-sonnet-5".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -354,7 +354,7 @@ impl CopilotModelCandidates {
 #[serde(default, rename_all = "camelCase")]
 struct CopilotChatSessionState {
     input_state: CopilotInputState,
-    requests: Vec<CopilotRequestModel>,
+    requests: CopilotRequestCandidates,
 }
 
 #[derive(Default, Deserialize)]
@@ -388,6 +388,43 @@ struct CopilotRequestMetadata {
     resolved_model: Option<String>,
 }
 
+#[derive(Default)]
+struct CopilotRequestCandidates {
+    latest: Option<CopilotModelEvidence>,
+}
+
+impl<'de> Deserialize<'de> for CopilotRequestCandidates {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct RequestVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for RequestVisitor {
+            type Value = CopilotRequestCandidates;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a Copilot request array")
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut candidates = CopilotModelCandidates::default();
+                while let Some(request) = sequence.next_element::<CopilotRequestModel>()? {
+                    candidates.record_request(request);
+                }
+                Ok(CopilotRequestCandidates {
+                    latest: candidates.latest_request,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(RequestVisitor)
+    }
+}
+
 #[derive(Default, Deserialize)]
 #[serde(default)]
 struct CopilotPatchHeader {
@@ -405,8 +442,8 @@ fn collect_copilot_session_state(
     candidates: &mut CopilotModelCandidates,
 ) {
     candidates.record_selected(state.input_state.selected_model.identifier.as_deref());
-    for request in state.requests {
-        candidates.record_request(request);
+    if state.requests.latest.is_some() {
+        candidates.latest_request = state.requests.latest;
     }
 }
 
@@ -433,11 +470,10 @@ fn collect_copilot_jsonl_line(line: &str, candidates: &mut CopilotModelCandidate
         }
         Some(2) if copilot_patch_path_matches(&header.k, &["requests"]) => {
             if let Ok(patch) =
-                serde_json::from_str::<CopilotPatchValue<Vec<CopilotRequestModel>>>(line)
+                serde_json::from_str::<CopilotPatchValue<CopilotRequestCandidates>>(line)
+                && patch.v.latest.is_some()
             {
-                for request in patch.v {
-                    candidates.record_request(request);
-                }
+                candidates.latest_request = patch.v.latest;
             }
         }
         Some(1)
@@ -495,14 +531,9 @@ fn extract_model_from_copilot_chat_session(
     let mut candidates = CopilotModelCandidates::default();
 
     if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
-        if file.metadata().map_or(true, |metadata| {
-            metadata.len() > MAX_COPILOT_SESSION_SCAN_BYTES
-        }) {
-            return Ok(None);
-        }
-        if let Ok(state) = serde_json::from_reader::<_, CopilotChatSessionState>(BufReader::new(
-            file.take(MAX_COPILOT_SESSION_SCAN_BYTES + 1),
-        )) {
+        if let Ok(state) =
+            serde_json::from_reader::<_, CopilotChatSessionState>(BufReader::new(file))
+        {
             collect_copilot_session_state(state, &mut candidates);
         }
         return Ok(candidates.best());
@@ -521,15 +552,17 @@ fn extract_model_from_copilot_chat_session(
     if file.take(read_size).read_to_end(&mut tail).is_err() {
         return Ok(None);
     }
-    let Ok(mut tail) = std::str::from_utf8(&tail) else {
-        return Ok(None);
-    };
-    if seek_pos > 0 {
-        let Some(first_newline) = tail.find('\n') else {
+    let tail = if seek_pos > 0 {
+        let Some(first_newline) = tail.iter().position(|byte| *byte == b'\n') else {
             return Ok(None);
         };
-        tail = &tail[first_newline + 1..];
-    }
+        &tail[first_newline + 1..]
+    } else {
+        &tail
+    };
+    let Ok(tail) = std::str::from_utf8(tail) else {
+        return Ok(None);
+    };
     for line in tail.lines() {
         let line = line.trim();
         if !line.is_empty() {
@@ -1693,7 +1726,7 @@ model = "profile-only-model"
     }
 
     #[test]
-    fn test_copilot_chat_session_json_rejects_oversized_document() {
+    fn test_copilot_chat_session_json_streams_large_document() {
         let dir = tempfile::tempdir().unwrap();
         let transcript_path = dir.path().join("oversized-session.json");
         std::fs::write(
@@ -1707,7 +1740,12 @@ model = "profile-only-model"
         .unwrap();
 
         let result = extract_model_from_copilot_chat_session(&transcript_path).unwrap();
-        assert_eq!(result, None);
+        assert_eq!(
+            result,
+            Some(CopilotModelEvidence::Concrete(
+                "copilot/claude-sonnet-5".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -1728,6 +1766,34 @@ model = "profile-only-model"
             format!("{oversized_snapshot}\n{request}\n"),
         )
         .unwrap();
+
+        let result = extract_model_from_copilot_chat_session(&transcript_path).unwrap();
+        assert_eq!(
+            result,
+            Some(CopilotModelEvidence::Concrete(
+                "copilot/claude-sonnet-5".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_copilot_chat_session_jsonl_handles_utf8_at_tail_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript_path = dir.path().join("unicode-session.jsonl");
+        let request = format!(
+            "{}\n",
+            serde_json::json!({
+                "kind": 2,
+                "k": ["requests"],
+                "v": [{"modelId": "copilot/claude-sonnet-5"}]
+            })
+        );
+        let oversized_line_len = MAX_COPILOT_SESSION_SCAN_BYTES as usize + 10 - request.len();
+        let mut oversized_line = vec![b'x'; oversized_line_len];
+        oversized_line[8..12].copy_from_slice("😀".as_bytes());
+        oversized_line.push(b'\n');
+        oversized_line.extend_from_slice(request.as_bytes());
+        std::fs::write(&transcript_path, oversized_line).unwrap();
 
         let result = extract_model_from_copilot_chat_session(&transcript_path).unwrap();
         assert_eq!(

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -494,7 +494,9 @@ fn extract_model_from_copilot_chat_session(
     let mut candidates = CopilotModelCandidates::default();
 
     if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
-        if let Ok(state) = serde_json::from_reader::<_, CopilotChatSessionState>(file) {
+        if let Ok(state) =
+            serde_json::from_reader::<_, CopilotChatSessionState>(BufReader::new(file))
+        {
             collect_copilot_session_state(state, &mut candidates);
         }
         return Ok(candidates.best());

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -328,11 +328,14 @@ impl CopilotModelCandidates {
             .as_deref()
             .and_then(CopilotModelEvidence::from_model);
 
-        self.latest_request = match request_model {
+        let latest_request = match request_model {
             Some(CopilotModelEvidence::Auto) => resolved_model.or(Some(CopilotModelEvidence::Auto)),
             Some(model) => Some(model),
             None => resolved_model,
         };
+        if latest_request.is_some() {
+            self.latest_request = latest_request;
+        }
     }
 
     fn record_selected(&mut self, model: Option<&str>) {
@@ -692,29 +695,37 @@ fn copilot_model_cache_entry(
     )
 }
 
+fn copilot_vscode_transcript_format(stream_path: &Path) -> StreamFormat {
+    let path = stream_path.to_string_lossy();
+    if stream_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        == Some("jsonl")
+        || path.contains("/workspaceStorage/")
+        || path.contains("\\workspaceStorage\\")
+    {
+        StreamFormat::CopilotEventStreamJsonl
+    } else {
+        StreamFormat::CopilotSessionJson
+    }
+}
+
 pub(crate) fn extract_cached_copilot_vscode_model(
     stream_path: &Path,
     chat_session_id: &str,
 ) -> Result<Option<String>, StreamError> {
     let entry = copilot_model_cache_entry(stream_path, chat_session_id);
+    let format = copilot_vscode_transcript_format(stream_path);
     let Ok(mut entry) = entry.lock() else {
-        return load_copilot_vscode_model(
-            stream_path,
-            StreamFormat::CopilotEventStreamJsonl,
-            chat_session_id,
-        )
-        .map(|model| model.map(|model| model.model().to_string()));
+        return load_copilot_vscode_model(stream_path, format, chat_session_id)
+            .map(|model| model.map(|model| model.model().to_string()));
     };
     let now = Instant::now();
     if let Some(model) = entry.cached_model(now) {
         return Ok(model);
     }
 
-    let model = load_copilot_vscode_model(
-        stream_path,
-        StreamFormat::CopilotEventStreamJsonl,
-        chat_session_id,
-    )?;
+    let model = load_copilot_vscode_model(stream_path, format, chat_session_id)?;
     Ok(entry.store(model, now))
 }
 
@@ -1622,6 +1633,53 @@ model = "profile-only-model"
             "session-abc",
         )
         .unwrap();
+        assert_eq!(result, Some("copilot/claude-sonnet-5".to_string()));
+    }
+
+    #[test]
+    fn test_extract_model_copilot_vscode_keeps_model_before_empty_request() {
+        let (_dir, transcript_path, _otel_db_path) = create_copilot_vscode_workspace();
+        let (chat_session_path, _) =
+            copilot_chat_session_paths(&transcript_path, "session-abc").unwrap();
+        std::fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            chat_session_path,
+            concat!(
+                r#"{"kind":0,"v":{"inputState":{"selectedModel":{"identifier":"copilot/auto"}},"requests":[]}}"#,
+                "\n",
+                r#"{"kind":2,"k":["requests"],"v":[{"modelId":"copilot/claude-sonnet-5"}]}"#,
+                "\n",
+                r#"{"kind":2,"k":["requests"],"v":[{"requestId":"pending-request"}]}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_vscode_transcript(
+            &transcript_path,
+            StreamFormat::CopilotEventStreamJsonl,
+            "session-abc",
+        )
+        .unwrap();
+        assert_eq!(result, Some("copilot/claude-sonnet-5".to_string()));
+    }
+
+    #[test]
+    fn test_cached_copilot_vscode_model_reads_legacy_json_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript_path = dir.path().join("legacy-session.json");
+        std::fs::write(
+            &transcript_path,
+            r#"{
+                "requests": [
+                    {"modelId": "copilot/claude-sonnet-5"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let result =
+            extract_cached_copilot_vscode_model(&transcript_path, "legacy-session").unwrap();
         assert_eq!(result, Some("copilot/claude-sonnet-5".to_string()));
     }
 

--- a/src/streams/model_extraction.rs
+++ b/src/streams/model_extraction.rs
@@ -1,13 +1,20 @@
+use crate::authorship::working_log::AgentId;
 use crate::streams::sweep::StreamFormat;
 use crate::streams::types::StreamError;
+use serde::Deserialize;
+use std::collections::{HashMap, VecDeque};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 const MAX_JSONL_SCAN_BYTES: u64 = 50 * 1024;
 const MAX_JSONL_HEAD_SCAN_BYTES: usize = 1024 * 1024;
 const MAX_JSONL_HEAD_LINES: usize = 20;
 const MAX_CODEX_CONFIG_BYTES: u64 = 1024 * 1024;
+const COPILOT_MODEL_CACHE_CAPACITY: usize = 1024;
+const COPILOT_MODEL_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 pub fn extract_model(
     path: &Path,
@@ -272,6 +279,470 @@ fn normalize_model(model: &str) -> Option<String> {
     Some(model.to_string())
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CopilotModelEvidence {
+    Concrete(String),
+    Auto,
+}
+
+impl CopilotModelEvidence {
+    fn from_model(model: &str) -> Option<Self> {
+        let model = normalize_model(model)?;
+        if model.eq_ignore_ascii_case("copilot/auto") {
+            Some(Self::Auto)
+        } else if model.eq_ignore_ascii_case("unknown") {
+            None
+        } else {
+            Some(Self::Concrete(model))
+        }
+    }
+
+    fn model(&self) -> &str {
+        match self {
+            Self::Concrete(model) => model,
+            Self::Auto => "copilot/auto",
+        }
+    }
+
+    fn is_concrete(&self) -> bool {
+        matches!(self, Self::Concrete(_))
+    }
+}
+
+#[derive(Default)]
+struct CopilotModelCandidates {
+    latest_request: Option<CopilotModelEvidence>,
+    selected: Option<CopilotModelEvidence>,
+}
+
+impl CopilotModelCandidates {
+    fn record_request(&mut self, request: CopilotRequestModel) {
+        let request_model = request
+            .model_id
+            .as_deref()
+            .and_then(CopilotModelEvidence::from_model);
+        let resolved_model = request
+            .result
+            .metadata
+            .resolved_model
+            .as_deref()
+            .and_then(CopilotModelEvidence::from_model);
+
+        self.latest_request = match request_model {
+            Some(CopilotModelEvidence::Auto) => resolved_model.or(Some(CopilotModelEvidence::Auto)),
+            Some(model) => Some(model),
+            None => resolved_model,
+        };
+    }
+
+    fn record_selected(&mut self, model: Option<&str>) {
+        if let Some(model) = model.and_then(CopilotModelEvidence::from_model) {
+            self.selected = Some(model);
+        }
+    }
+
+    fn best(self) -> Option<CopilotModelEvidence> {
+        self.latest_request.or(self.selected)
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct CopilotChatSessionState {
+    input_state: CopilotInputState,
+    requests: Vec<CopilotRequestModel>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct CopilotInputState {
+    selected_model: CopilotSelectedModel,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct CopilotSelectedModel {
+    identifier: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct CopilotRequestModel {
+    model_id: Option<String>,
+    result: CopilotRequestResult,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct CopilotRequestResult {
+    metadata: CopilotRequestMetadata,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct CopilotRequestMetadata {
+    resolved_model: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct CopilotPatchHeader {
+    kind: Option<u8>,
+    k: Vec<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct CopilotPatchValue<T> {
+    v: T,
+}
+
+fn collect_copilot_session_state(
+    state: CopilotChatSessionState,
+    candidates: &mut CopilotModelCandidates,
+) {
+    candidates.record_selected(state.input_state.selected_model.identifier.as_deref());
+    for request in state.requests {
+        candidates.record_request(request);
+    }
+}
+
+fn copilot_patch_path_matches(path: &[serde_json::Value], expected: &[&str]) -> bool {
+    path.len() == expected.len()
+        && path
+            .iter()
+            .zip(expected)
+            .all(|(actual, expected)| actual.as_str() == Some(*expected))
+}
+
+fn collect_copilot_jsonl_line(line: &str, candidates: &mut CopilotModelCandidates) {
+    let Ok(header) = serde_json::from_str::<CopilotPatchHeader>(line) else {
+        return;
+    };
+
+    match header.kind {
+        Some(0) => {
+            if let Ok(patch) =
+                serde_json::from_str::<CopilotPatchValue<CopilotChatSessionState>>(line)
+            {
+                collect_copilot_session_state(patch.v, candidates);
+            }
+        }
+        Some(2) if copilot_patch_path_matches(&header.k, &["requests"]) => {
+            if let Ok(patch) =
+                serde_json::from_str::<CopilotPatchValue<Vec<CopilotRequestModel>>>(line)
+            {
+                for request in patch.v {
+                    candidates.record_request(request);
+                }
+            }
+        }
+        Some(1)
+            if copilot_patch_path_matches(
+                &header.k,
+                &["inputState", "selectedModel", "identifier"],
+            ) =>
+        {
+            if let Ok(patch) = serde_json::from_str::<CopilotPatchValue<String>>(line) {
+                candidates.record_selected(Some(&patch.v));
+            }
+        }
+        Some(1) if copilot_patch_path_matches(&header.k, &["inputState", "selectedModel"]) => {
+            if let Ok(patch) = serde_json::from_str::<CopilotPatchValue<CopilotSelectedModel>>(line)
+            {
+                candidates.record_selected(patch.v.identifier.as_deref());
+            }
+        }
+        Some(1) if header.k.last().and_then(serde_json::Value::as_str) == Some("modelId") => {
+            if let Ok(patch) = serde_json::from_str::<CopilotPatchValue<String>>(line) {
+                candidates.record_request(CopilotRequestModel {
+                    model_id: Some(patch.v),
+                    ..Default::default()
+                });
+            }
+        }
+        Some(1) if header.k.last().and_then(serde_json::Value::as_str) == Some("resolvedModel") => {
+            if let Ok(patch) = serde_json::from_str::<CopilotPatchValue<String>>(line) {
+                candidates.record_request(CopilotRequestModel {
+                    result: CopilotRequestResult {
+                        metadata: CopilotRequestMetadata {
+                            resolved_model: Some(patch.v),
+                        },
+                    },
+                    ..Default::default()
+                });
+            }
+        }
+        None => {
+            if let Ok(state) = serde_json::from_str::<CopilotChatSessionState>(line) {
+                collect_copilot_session_state(state, candidates);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn extract_model_from_copilot_chat_session(
+    path: &Path,
+) -> Result<Option<CopilotModelEvidence>, StreamError> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(_) => return Ok(None),
+    };
+    let mut candidates = CopilotModelCandidates::default();
+
+    if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
+        if let Ok(state) = serde_json::from_reader::<_, CopilotChatSessionState>(file) {
+            collect_copilot_session_state(state, &mut candidates);
+        }
+        return Ok(candidates.best());
+    }
+
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes_read = match reader.read_line(&mut line) {
+            Ok(bytes_read) => bytes_read,
+            Err(_) => return Ok(None),
+        };
+        if bytes_read == 0 {
+            break;
+        }
+        let line = line.trim();
+        if !line.is_empty() {
+            collect_copilot_jsonl_line(line, &mut candidates);
+        }
+    }
+
+    Ok(candidates.best())
+}
+
+fn copilot_chat_session_paths(
+    stream_path: &Path,
+    chat_session_id: &str,
+) -> Option<(PathBuf, PathBuf)> {
+    let session_component = Path::new(chat_session_id);
+    if chat_session_id.is_empty()
+        || session_component.file_name().and_then(|name| name.to_str()) != Some(chat_session_id)
+    {
+        return None;
+    }
+
+    let transcripts_dir = stream_path.parent()?;
+    if !transcripts_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("transcripts"))
+    {
+        return None;
+    }
+    let copilot_dir = transcripts_dir.parent()?;
+    if !copilot_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("github.copilot-chat"))
+    {
+        return None;
+    }
+
+    let chat_sessions_dir = copilot_dir.parent()?.join("chatSessions");
+    Some((
+        chat_sessions_dir.join(format!("{chat_session_id}.jsonl")),
+        chat_sessions_dir.join(format!("{chat_session_id}.json")),
+    ))
+}
+
+fn load_copilot_vscode_model(
+    stream_path: &Path,
+    format: StreamFormat,
+    chat_session_id: &str,
+) -> Result<Option<CopilotModelEvidence>, StreamError> {
+    let session_evidence = if let Some((jsonl_path, json_path)) =
+        copilot_chat_session_paths(stream_path, chat_session_id)
+    {
+        extract_model_from_copilot_chat_session(&jsonl_path)?
+            .or(extract_model_from_copilot_chat_session(&json_path)?)
+    } else {
+        None
+    };
+
+    if session_evidence
+        .as_ref()
+        .is_some_and(CopilotModelEvidence::is_concrete)
+    {
+        return Ok(session_evidence);
+    }
+
+    if let Some(model) = extract_model(stream_path, format, None)?
+        .as_deref()
+        .and_then(CopilotModelEvidence::from_model)
+        && model.is_concrete()
+    {
+        return Ok(Some(model));
+    }
+
+    if let Some(model) =
+        extract_model_from_copilot_otel_for_transcript(stream_path, chat_session_id)?
+            .as_deref()
+            .and_then(CopilotModelEvidence::from_model)
+        && model.is_concrete()
+    {
+        return Ok(Some(model));
+    }
+
+    Ok(session_evidence)
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct CopilotModelCacheKey {
+    chat_session_id: String,
+    stream_path: PathBuf,
+}
+
+#[derive(Default)]
+struct CopilotModelCacheEntry {
+    concrete_model: Option<String>,
+    retryable_model: Option<String>,
+    retry_after: Option<Instant>,
+}
+
+impl CopilotModelCacheEntry {
+    fn cached_model(&self, now: Instant) -> Option<Option<String>> {
+        if let Some(model) = &self.concrete_model {
+            return Some(Some(model.clone()));
+        }
+        self.retry_after
+            .filter(|retry_after| *retry_after > now)
+            .map(|_| self.retryable_model.clone())
+    }
+
+    fn store(&mut self, model: Option<CopilotModelEvidence>, now: Instant) -> Option<String> {
+        match model {
+            Some(CopilotModelEvidence::Concrete(model)) => {
+                self.concrete_model = Some(model.clone());
+                self.retryable_model = None;
+                self.retry_after = None;
+                Some(model)
+            }
+            retryable => {
+                let model = retryable.map(|model| model.model().to_string());
+                self.retryable_model = model.clone();
+                self.retry_after = Some(now + COPILOT_MODEL_RETRY_INTERVAL);
+                model
+            }
+        }
+    }
+}
+
+struct CopilotModelCache {
+    capacity: usize,
+    entries: HashMap<CopilotModelCacheKey, Arc<Mutex<CopilotModelCacheEntry>>>,
+    insertion_order: VecDeque<CopilotModelCacheKey>,
+}
+
+impl CopilotModelCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: HashMap::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    fn entry(&mut self, key: CopilotModelCacheKey) -> Arc<Mutex<CopilotModelCacheEntry>> {
+        if let Some(entry) = self.entries.get(&key) {
+            return Arc::clone(entry);
+        }
+
+        while self.entries.len() >= self.capacity.max(1) {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                self.entries.clear();
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+
+        let entry = Arc::new(Mutex::new(CopilotModelCacheEntry::default()));
+        self.entries.insert(key.clone(), Arc::clone(&entry));
+        self.insertion_order.push_back(key);
+        entry
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+static COPILOT_MODEL_CACHE: OnceLock<Mutex<CopilotModelCache>> = OnceLock::new();
+
+fn copilot_model_cache_entry(
+    stream_path: &Path,
+    chat_session_id: &str,
+) -> Arc<Mutex<CopilotModelCacheEntry>> {
+    let key = CopilotModelCacheKey {
+        chat_session_id: chat_session_id.to_string(),
+        stream_path: stream_path.to_path_buf(),
+    };
+    let cache = COPILOT_MODEL_CACHE
+        .get_or_init(|| Mutex::new(CopilotModelCache::new(COPILOT_MODEL_CACHE_CAPACITY)));
+    cache.lock().map_or_else(
+        |_| Arc::new(Mutex::new(CopilotModelCacheEntry::default())),
+        |mut cache| cache.entry(key),
+    )
+}
+
+pub(crate) fn extract_cached_copilot_vscode_model(
+    stream_path: &Path,
+    chat_session_id: &str,
+) -> Result<Option<String>, StreamError> {
+    let entry = copilot_model_cache_entry(stream_path, chat_session_id);
+    let Ok(mut entry) = entry.lock() else {
+        return load_copilot_vscode_model(
+            stream_path,
+            StreamFormat::CopilotEventStreamJsonl,
+            chat_session_id,
+        )
+        .map(|model| model.map(|model| model.model().to_string()));
+    };
+    let now = Instant::now();
+    if let Some(model) = entry.cached_model(now) {
+        return Ok(model);
+    }
+
+    let model = load_copilot_vscode_model(
+        stream_path,
+        StreamFormat::CopilotEventStreamJsonl,
+        chat_session_id,
+    )?;
+    Ok(entry.store(model, now))
+}
+
+pub(crate) fn enrich_copilot_agent_model(
+    agent_id: &mut AgentId,
+    metadata: &HashMap<String, String>,
+) {
+    if agent_id.tool != "github-copilot"
+        || !matches!(
+            agent_id.model.trim().to_ascii_lowercase().as_str(),
+            "" | "unknown" | "copilot/auto"
+        )
+    {
+        return;
+    }
+    let Some(stream_path) = metadata
+        .get("transcript_path")
+        .or_else(|| metadata.get("chat_session_path"))
+    else {
+        return;
+    };
+    if let Ok(Some(model)) =
+        extract_cached_copilot_vscode_model(Path::new(stream_path), &agent_id.id)
+    {
+        agent_id.model = model;
+    }
+}
+
 /// Extracts the model from VS Code Copilot's `models.json` debug log.
 /// Given a transcript path like `.../transcripts/{session_id}.jsonl`,
 /// derives `.../debug-logs/{session_id}/models.json` and reads the default model.
@@ -327,17 +798,8 @@ pub fn extract_model_from_copilot_vscode_transcript(
     format: StreamFormat,
     chat_session_id: &str,
 ) -> Result<Option<String>, StreamError> {
-    if let Some(model) = extract_model(stream_path, format, None)? {
-        return Ok(Some(model));
-    }
-
-    if let Some(model) =
-        extract_model_from_copilot_otel_for_transcript(stream_path, chat_session_id)?
-    {
-        return Ok(Some(model));
-    }
-
-    extract_model_from_copilot_models_json(stream_path)
+    load_copilot_vscode_model(stream_path, format, chat_session_id)
+        .map(|model| model.map(|model| model.model().to_string()))
 }
 
 pub fn extract_model_from_copilot_otel_for_transcript(
@@ -1125,7 +1587,7 @@ model = "profile-only-model"
     }
 
     #[test]
-    fn test_extract_model_copilot_vscode_transcript_falls_back_to_models_json() {
+    fn test_extract_model_copilot_vscode_transcript_ignores_models_json_default() {
         let (_dir, transcript_path, _otel_db_path) = create_copilot_vscode_workspace();
 
         let result = extract_model_from_copilot_vscode_transcript(
@@ -1134,7 +1596,144 @@ model = "profile-only-model"
             "session-abc",
         )
         .unwrap();
-        assert_eq!(result, Some("gpt-4.1".to_string()));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_extract_model_copilot_vscode_transcript_reads_request_patch() {
+        let (_dir, transcript_path, _otel_db_path) = create_copilot_vscode_workspace();
+        let (chat_session_path, _) =
+            copilot_chat_session_paths(&transcript_path, "session-abc").unwrap();
+        std::fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            chat_session_path,
+            concat!(
+                r#"{"kind":0,"v":{"inputState":{"selectedModel":{"identifier":"copilot/auto"}},"requests":[]}}"#,
+                "\n",
+                r#"{"kind":2,"k":["requests"],"v":[{"modelId":"copilot/claude-sonnet-5","result":{"details":"GPT-5.3 Codex"}}]}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_vscode_transcript(
+            &transcript_path,
+            StreamFormat::CopilotEventStreamJsonl,
+            "session-abc",
+        )
+        .unwrap();
+        assert_eq!(result, Some("copilot/claude-sonnet-5".to_string()));
+    }
+
+    #[test]
+    fn test_extract_model_copilot_vscode_auto_uses_resolved_model() {
+        let (_dir, transcript_path, _otel_db_path) = create_copilot_vscode_workspace();
+        let (chat_session_path, _) =
+            copilot_chat_session_paths(&transcript_path, "session-abc").unwrap();
+        std::fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            chat_session_path,
+            concat!(
+                r#"{"kind":0,"v":{"inputState":{"selectedModel":{"identifier":"copilot/auto"}},"requests":[]}}"#,
+                "\n",
+                r#"{"kind":2,"k":["requests"],"v":[{"modelId":"copilot/auto","result":{"metadata":{"resolvedModel":"claude-sonnet-5"}}}]}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_vscode_transcript(
+            &transcript_path,
+            StreamFormat::CopilotEventStreamJsonl,
+            "session-abc",
+        )
+        .unwrap();
+        assert_eq!(result, Some("claude-sonnet-5".to_string()));
+    }
+
+    #[test]
+    fn test_extract_model_copilot_vscode_supports_plain_json_state() {
+        let (_dir, transcript_path, _otel_db_path) = create_copilot_vscode_workspace();
+        let (_, chat_session_path) =
+            copilot_chat_session_paths(&transcript_path, "session-abc").unwrap();
+        std::fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            chat_session_path,
+            r#"{"requests":[{"modelId":"copilot/claude-sonnet-5"}]}"#,
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_vscode_transcript(
+            &transcript_path,
+            StreamFormat::CopilotEventStreamJsonl,
+            "session-abc",
+        )
+        .unwrap();
+        assert_eq!(result, Some("copilot/claude-sonnet-5".to_string()));
+    }
+
+    #[test]
+    fn test_extract_model_copilot_vscode_uses_exact_session_file() {
+        let (_dir, transcript_path, _otel_db_path) = create_copilot_vscode_workspace();
+        let (chat_session_path, _) =
+            copilot_chat_session_paths(&transcript_path, "other-session").unwrap();
+        std::fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            chat_session_path,
+            r#"{"inputState":{"selectedModel":{"identifier":"copilot/claude-sonnet-5"}}}"#,
+        )
+        .unwrap();
+
+        let result = extract_model_from_copilot_vscode_transcript(
+            &transcript_path,
+            StreamFormat::CopilotEventStreamJsonl,
+            "session-abc",
+        )
+        .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_copilot_model_cache_bounds_entries() {
+        let key = |session: &str| CopilotModelCacheKey {
+            chat_session_id: session.to_string(),
+            stream_path: PathBuf::from(format!("/{session}.jsonl")),
+        };
+        let mut cache = CopilotModelCache::new(2);
+        cache.entry(key("one"));
+        cache.entry(key("two"));
+        cache.entry(key("three"));
+
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.entries.contains_key(&key("one")));
+        assert!(cache.entries.contains_key(&key("two")));
+        assert!(cache.entries.contains_key(&key("three")));
+    }
+
+    #[test]
+    fn test_copilot_model_cache_retries_non_concrete_results() {
+        let now = Instant::now();
+        let mut entry = CopilotModelCacheEntry::default();
+        assert_eq!(
+            entry.store(Some(CopilotModelEvidence::Auto), now),
+            Some("copilot/auto".to_string())
+        );
+        assert_eq!(
+            entry.cached_model(now + Duration::from_secs(4)),
+            Some(Some("copilot/auto".to_string()))
+        );
+        assert_eq!(entry.cached_model(now + Duration::from_secs(5)), None);
+
+        entry.store(
+            Some(CopilotModelEvidence::Concrete(
+                "copilot/claude-sonnet-5".to_string(),
+            )),
+            now + Duration::from_secs(5),
+        );
+        assert_eq!(
+            entry.cached_model(now + Duration::from_secs(500)),
+            Some(Some("copilot/claude-sonnet-5".to_string()))
+        );
     }
 
     #[test]

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1810,6 +1810,7 @@ fn wltrace_captures_daemon_working_log_ops_when_enabled() {
     fs::write(&file_path, "AI content\n").unwrap();
     repo.git_ai(&["checkpoint", "mock_ai", "traced.txt"])
         .unwrap();
+    repo.sync_daemon();
 
     let trace = fs::read_to_string(trace_file.path()).expect("read wltrace output");
     for op in [

--- a/tests/integration/bash_attribution.rs
+++ b/tests/integration/bash_attribution.rs
@@ -254,6 +254,106 @@ fn test_bash_checkpoints_v2_records_for_recovery_without_working_log_checkpoints
 }
 
 #[test]
+fn test_copilot_bash_recovery_uses_selected_vscode_model() {
+    let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
+    let env = [("GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH", bash_db_path.as_str())];
+    let mut repo = TestRepo::new_with_daemon_env(&env);
+    repo.patch_git_ai_config(|patch| {
+        patch.feature_flags = Some(json!({"bash_checkpoints_v2": true}));
+    });
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("copilot-bash.txt");
+
+    fs::write(&file_path, "original line\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    let mut file = repo.filename("copilot-bash.txt");
+    file.assert_committed_lines(lines!["original line".unattributed_human()]);
+
+    let session_id = "copilot-bash-model-session";
+    let storage = tempfile::tempdir().unwrap();
+    let workspace_storage = storage.path().join("workspaceStorage/workspace-id");
+    let transcript_path = workspace_storage
+        .join("GitHub.copilot-chat/transcripts")
+        .join(format!("{session_id}.jsonl"));
+    fs::create_dir_all(transcript_path.parent().unwrap()).unwrap();
+    fs::write(
+        &transcript_path,
+        format!(r#"{{"type":"session.start","data":{{"sessionId":"{session_id}"}}}}\n"#),
+    )
+    .unwrap();
+    let chat_session_path = workspace_storage
+        .join("chatSessions")
+        .join(format!("{session_id}.jsonl"));
+    fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+    fs::write(
+        chat_session_path,
+        format!(
+            "{}\n{}\n",
+            json!({
+                "kind": 0,
+                "v": {
+                    "inputState": {
+                        "selectedModel": {"identifier": "copilot/claude-sonnet-5"}
+                    },
+                    "requests": []
+                }
+            }),
+            json!({
+                "kind": 2,
+                "k": ["requests"],
+                "v": [{
+                    "modelId": "copilot/claude-sonnet-5",
+                    "result": {"metadata": {"sessionId": session_id}}
+                }]
+            })
+        ),
+    )
+    .unwrap();
+
+    let hook_input = |event_name: &str| {
+        json!({
+            "hookEventName": event_name,
+            "cwd": repo_root,
+            "toolName": "run_in_terminal",
+            "toolUseId": "copilot-bash-tool",
+            "toolInput": {"command": "printf 'written by Copilot bash\\n' >> copilot-bash.txt"},
+            "sessionId": session_id,
+            "transcript_path": transcript_path
+        })
+        .to_string()
+    };
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &hook_input("PreToolUse"),
+    ])
+    .expect("Copilot pre-bash hook should succeed");
+    fs::write(&file_path, "original line\nwritten by Copilot bash\n").unwrap();
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &hook_input("PostToolUse"),
+    ])
+    .expect("Copilot post-bash hook should succeed");
+
+    let commit = repo.stage_all_and_commit("After Copilot bash").unwrap();
+    file.assert_committed_lines(lines![
+        "original line".unattributed_human(),
+        "written by Copilot bash".ai(),
+    ]);
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .find(|session| session.agent_id.tool == "github-copilot")
+        .expect("Copilot Bash session should be present");
+    assert_eq!(session.agent_id.model, "copilot/claude-sonnet-5");
+}
+
+#[test]
 fn test_bash_recovery_uses_commit_time_file_timestamps_when_processing_is_delayed() {
     let (_bash_db_dir, bash_db_path) = isolated_bash_history_db_path();
     let env = [

--- a/tests/integration/github_copilot_integration.rs
+++ b/tests/integration/github_copilot_integration.rs
@@ -1,6 +1,7 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use serde_json::json;
+use std::fs;
 
 /// Test human checkpoint via github-copilot preset with before_edit hook
 #[test]
@@ -275,6 +276,245 @@ fn test_github_copilot_human_checkpoint_with_clean_file() {
     ]);
 }
 
+fn setup_vscode_copilot_session(
+    session_id: &str,
+    request_model: &str,
+    resolved_model: Option<&str>,
+) -> (tempfile::TempDir, String, std::path::PathBuf) {
+    let storage = tempfile::tempdir().unwrap();
+    let workspace_storage = storage.path().join("workspaceStorage/workspace-id");
+    let transcript_path = workspace_storage
+        .join("GitHub.copilot-chat/transcripts")
+        .join(format!("{session_id}.jsonl"));
+    fs::create_dir_all(transcript_path.parent().unwrap()).unwrap();
+    fs::write(
+        &transcript_path,
+        format!(r#"{{"type":"session.start","data":{{"sessionId":"{session_id}"}}}}\n"#),
+    )
+    .unwrap();
+
+    let chat_session_path = workspace_storage
+        .join("chatSessions")
+        .join(format!("{session_id}.jsonl"));
+    fs::create_dir_all(chat_session_path.parent().unwrap()).unwrap();
+    write_vscode_chat_session(
+        &chat_session_path,
+        session_id,
+        request_model,
+        resolved_model,
+    );
+
+    let models_path = workspace_storage
+        .join("GitHub.copilot-chat/debug-logs")
+        .join(session_id)
+        .join("models.json");
+    fs::create_dir_all(models_path.parent().unwrap()).unwrap();
+    fs::write(
+        models_path,
+        r#"[{"id":"gpt-5.3-codex","is_chat_default":true}]"#,
+    )
+    .unwrap();
+
+    (
+        storage,
+        transcript_path.to_string_lossy().into_owned(),
+        chat_session_path,
+    )
+}
+
+fn write_vscode_chat_session(
+    chat_session_path: &std::path::Path,
+    session_id: &str,
+    request_model: &str,
+    resolved_model: Option<&str>,
+) {
+    let snapshot = json!({
+        "kind": 0,
+        "v": {
+            "sessionId": session_id,
+            "inputState": { "selectedModel": { "identifier": request_model } },
+            "requests": []
+        }
+    });
+    let request_patch = json!({
+        "kind": 2,
+        "k": ["requests"],
+        "v": [{
+            "requestId": "request-1",
+            "modelId": request_model,
+            "result": {
+                "metadata": {
+                    "sessionId": session_id,
+                    "resolvedModel": resolved_model
+                }
+            }
+        }]
+    });
+    fs::write(
+        chat_session_path,
+        format!("{}\n{}\n", snapshot, request_patch),
+    )
+    .unwrap();
+}
+
+fn native_edit_hook_input(
+    event_name: &str,
+    repo: &TestRepo,
+    file_path: &std::path::Path,
+    transcript_path: &str,
+    session_id: &str,
+    tool_use_id: &str,
+) -> String {
+    json!({
+        "hookEventName": event_name,
+        "cwd": repo.path(),
+        "toolName": "copilot_replaceString",
+        "toolUseId": tool_use_id,
+        "toolInput": { "file_path": file_path },
+        "sessionId": session_id,
+        "transcript_path": transcript_path
+    })
+    .to_string()
+}
+
+fn create_committed_human_file(repo: &TestRepo, filename: &str) -> std::path::PathBuf {
+    let file_path = repo.path().join(filename);
+    fs::write(&file_path, "const human = true;\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", filename])
+        .unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+    repo.filename(filename)
+        .assert_committed_lines(crate::lines!["const human = true;".human()]);
+    file_path
+}
+
+fn checkpoint_native_copilot_edit(
+    repo: &TestRepo,
+    file_path: &std::path::Path,
+    contents: &str,
+    transcript_path: &str,
+    session_id: &str,
+    tool_use_id: &str,
+) {
+    for event_name in ["PreToolUse", "PostToolUse"] {
+        if event_name == "PostToolUse" {
+            fs::write(file_path, contents).unwrap();
+        }
+        let hook = native_edit_hook_input(
+            event_name,
+            repo,
+            file_path,
+            transcript_path,
+            session_id,
+            tool_use_id,
+        );
+        repo.git_ai(&["checkpoint", "github-copilot", "--hook-input", &hook])
+            .unwrap();
+    }
+}
+
+fn copilot_model(commit: &crate::repos::test_repo::NewCommit) -> &str {
+    commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .find(|session| session.agent_id.tool == "github-copilot")
+        .expect("Copilot session should be present")
+        .agent_id
+        .model
+        .as_str()
+}
+
+#[test]
+fn test_vscode_copilot_uses_selected_model_in_authorship() {
+    let repo = TestRepo::new();
+    let file_path = create_committed_human_file(&repo, "model.ts");
+    let mut file = repo.filename("model.ts");
+    let session_id = "selected-model-session";
+    let (_storage, transcript_path, _chat_session_path) =
+        setup_vscode_copilot_session(session_id, "copilot/claude-sonnet-5", None);
+    checkpoint_native_copilot_edit(
+        &repo,
+        &file_path,
+        "const human = true;\nconst generatedByClaude = true;\n",
+        &transcript_path,
+        session_id,
+        "tool-1",
+    );
+
+    let commit = repo.stage_all_and_commit("Add generated line").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "const human = true;".human(),
+        "const generatedByClaude = true;".ai(),
+    ]);
+    assert_eq!(copilot_model(&commit), "copilot/claude-sonnet-5");
+}
+
+#[test]
+fn test_vscode_copilot_auto_uses_resolved_model() {
+    let repo = TestRepo::new();
+    let file_path = create_committed_human_file(&repo, "auto.ts");
+    let mut file = repo.filename("auto.ts");
+    let session_id = "auto-model-session";
+    let (_storage, transcript_path, _chat_session_path) =
+        setup_vscode_copilot_session(session_id, "copilot/auto", Some("claude-sonnet-5"));
+    checkpoint_native_copilot_edit(
+        &repo,
+        &file_path,
+        "const human = true;\nconst generatedByAuto = true;\n",
+        &transcript_path,
+        session_id,
+        "tool-auto",
+    );
+
+    let commit = repo
+        .stage_all_and_commit("Add Auto-generated line")
+        .unwrap();
+    file.assert_committed_lines(crate::lines![
+        "const human = true;".human(),
+        "const generatedByAuto = true;".ai(),
+    ]);
+    assert_eq!(copilot_model(&commit), "claude-sonnet-5");
+}
+
+#[test]
+fn test_vscode_copilot_caches_first_concrete_session_model() {
+    let repo = TestRepo::new();
+    let file_path = create_committed_human_file(&repo, "cached.ts");
+    let mut file = repo.filename("cached.ts");
+    let session_id = "cached-model-session";
+    let (_storage, transcript_path, chat_session_path) =
+        setup_vscode_copilot_session(session_id, "copilot/claude-sonnet-5", None);
+    checkpoint_native_copilot_edit(
+        &repo,
+        &file_path,
+        "const human = true;\nconst firstGeneratedLine = true;\n",
+        &transcript_path,
+        session_id,
+        "tool-cache-1",
+    );
+    repo.sync_daemon_force();
+
+    write_vscode_chat_session(&chat_session_path, session_id, "copilot/gpt-5.4", None);
+    checkpoint_native_copilot_edit(
+        &repo,
+        &file_path,
+        "const human = true;\nconst firstGeneratedLine = true;\nconst secondGeneratedLine = true;\n",
+        &transcript_path,
+        session_id,
+        "tool-cache-2",
+    );
+
+    let commit = repo.stage_all_and_commit("Add cached-model lines").unwrap();
+    file.assert_committed_lines(crate::lines![
+        "const human = true;".human(),
+        "const firstGeneratedLine = true;".ai(),
+        "const secondGeneratedLine = true;".ai(),
+    ]);
+    assert_eq!(copilot_model(&commit), "copilot/claude-sonnet-5");
+}
+
 crate::reuse_tests_in_worktree!(
     test_github_copilot_human_checkpoint_before_edit,
     test_github_copilot_human_checkpoint_scoped_to_files,
@@ -282,4 +522,7 @@ crate::reuse_tests_in_worktree!(
     test_github_copilot_multiple_files_with_dirty_files,
     test_github_copilot_empty_will_edit_filepaths_fails,
     test_github_copilot_human_checkpoint_with_clean_file,
+    test_vscode_copilot_uses_selected_model_in_authorship,
+    test_vscode_copilot_auto_uses_resolved_model,
+    test_vscode_copilot_caches_first_concrete_session_model,
 );


### PR DESCRIPTION
## Summary

- resolve VS Code Copilot model attribution from the matching `chatSessions/<session>.jsonl` state instead of the unrelated `models.json` availability default
- preserve the first concrete model seen for a session, including the resolved backing model for Copilot Auto
- apply the same resolution to normal checkpoints and recovered Bash edits

## Performance

- removes VS Code storage/OTEL reads from each short-lived hook invocation
- performs resolution in the daemon background checkpoint path, never trace2 ingestion
- uses direct session paths with no directory scans and a bounded 1,024-entry cache
- caches concrete models for the session; missing/Auto state retries only after five seconds
- parses only model-bearing fields and does not retain chat messages or responses

## Tests

- strict red/green TestRepo regression reproduces `gpt-5.3-codex` being selected from `models.json` before the fix
- selected Claude model attribution, Copilot Auto resolved model, first-model cache behavior, and Bash recovery
- `task lint`, `task fmt`, `task build`, and all change-focused test suites pass
- full local unit run: 2,171 passed; one pre-existing environment-sensitive Droid detection test fails because `droid` is installed on this machine