### PR TITLE
Isolate HTTP notes and bound Git transport

### DIFF
--- a/src/bin/git-ai-test-git-shim.rs
+++ b/src/bin/git-ai-test-git-shim.rs
@@ -76,13 +76,27 @@ fn new_test_sync_session() -> String {
     format!("gt-shim-{}", git_ai::uuid::generate_v4())
 }
 
-fn delay_for_test() {
+fn delay_for_test(argv: &[String]) {
     let Ok(delay_ms) = env::var("GIT_AI_TEST_GIT_SHIM_DELAY_MS") else {
         return;
     };
     let Ok(delay_ms) = delay_ms.parse::<u64>() else {
         return;
     };
+    if let Ok(commands) = env::var("GIT_AI_TEST_GIT_SHIM_DELAY_COMMANDS") {
+        let Ok(cwd) = env::current_dir() else {
+            return;
+        };
+        let command = tracked_parsed_git_invocation_for_test_sync(argv, &cwd).command;
+        if !command.as_deref().is_some_and(|command| {
+            commands
+                .split(',')
+                .map(str::trim)
+                .any(|selected| selected == command)
+        }) {
+            return;
+        }
+    }
     std::thread::sleep(Duration::from_millis(delay_ms));
 }
 
@@ -156,7 +170,7 @@ fn exec_target(target: &str, argv: &[String]) -> ! {
 #[cfg(unix)]
 fn main() {
     let argv = env::args().skip(1).collect::<Vec<_>>();
-    delay_for_test();
+    delay_for_test(&argv);
     let target = select_target(&argv).unwrap_or_else(|error| panic!("{error}"));
     let mut effective_argv = argv.clone();
     let mut test_sync_session = None;
@@ -182,7 +196,7 @@ fn main() {
 #[cfg(not(unix))]
 fn main() {
     let argv = env::args().skip(1).collect::<Vec<_>>();
-    delay_for_test();
+    delay_for_test(&argv);
     let target = select_target(&argv).unwrap_or_else(|error| panic!("{error}"));
     let mut effective_argv = argv.clone();
     let mut test_sync_session = None;

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -707,7 +707,7 @@ impl CiContext {
 
     fn fetch_authorship_history(&self, remote: &str) -> Result<(), GitAiError> {
         if crate::config::Config::fresh().notes_backend_enabled() {
-            crate::git::notes_api::warm_cache_for_remote(&self.repo, remote)
+            crate::git::notes_api::warm_cache_for_remote(&self.repo, remote).map(|_| ())
         } else {
             fetch_authorship_notes(&self.repo, remote).map(|_| ())
         }

--- a/src/ci/ci_context.rs
+++ b/src/ci/ci_context.rs
@@ -7,8 +7,9 @@ use crate::git::refs::{
 };
 use crate::git::repository::{
     CommitRange, Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin,
+    exec_git_with_timeout,
 };
-use crate::git::sync_authorship::fetch_authorship_notes;
+use crate::git::sync_authorship::{fetch_authorship_notes, notes_transport_timeout};
 use std::fs;
 use std::path::PathBuf;
 
@@ -119,7 +120,7 @@ impl CiContext {
                 } else {
                     println!("Fetching authorship history");
                     // Ensure we have the full authorship history before checking for existing notes
-                    fetch_authorship_notes(&self.repo, "origin")?;
+                    self.fetch_authorship_history("origin")?;
                     println!("Fetched authorship history");
                 }
 
@@ -406,7 +407,7 @@ impl CiContext {
                     println!("Skipping authorship history fetch");
                 } else {
                     println!("Fetching authorship history");
-                    fetch_authorship_notes(&self.repo, "origin")?;
+                    self.fetch_authorship_history("origin")?;
                     println!("Fetched authorship history");
                 }
 
@@ -575,6 +576,12 @@ impl CiContext {
     /// Returns Ok(true) if notes were found and fetched,
     /// Ok(false) if no notes exist on the fork.
     fn fetch_fork_notes(repo: &Repository, fork_url: &str) -> Result<bool, GitAiError> {
+        if crate::config::Config::fresh().notes_backend_enabled() {
+            tracing::debug!(
+                "fetch_fork_notes: skipping refs/notes/ai transport (HTTP backend active)"
+            );
+            return Ok(false);
+        }
         let tracking_ref = AI_AUTHORSHIP_FORK_TRACKING_REF;
 
         // Check if the fork has notes
@@ -583,9 +590,9 @@ impl CiContext {
         ls_remote_args.push(fork_url.to_string());
         ls_remote_args.push("refs/notes/ai".to_string());
 
-        match exec_git(&ls_remote_args) {
+        match exec_git_with_timeout(&ls_remote_args, notes_transport_timeout()) {
             Ok(output) => {
-                let result = String::from_utf8_lossy(&output.stdout).to_string();
+                let result = output.stdout;
                 if result.trim().is_empty() {
                     return Ok(false);
                 }
@@ -612,7 +619,7 @@ impl CiContext {
         fetch_args.push(fork_url.to_string());
         fetch_args.push(fetch_refspec);
 
-        exec_git(&fetch_args)?;
+        exec_git_with_timeout(&fetch_args, notes_transport_timeout())?;
 
         Ok(true)
     }
@@ -629,6 +636,19 @@ impl CiContext {
         if commit_shas.is_empty() {
             println!("No PR commits found; skipping fork authorship note import");
             return Ok(0);
+        }
+
+        if crate::config::Config::fresh().notes_backend_enabled() {
+            if options.skip_fetch_fork_notes {
+                println!("Skipping fork authorship notes HTTP cache warm");
+                return Ok(0);
+            }
+            let cached = crate::git::notes_api::warm_cache_for_commits(commit_shas)?;
+            println!(
+                "Cached {} fork authorship note(s) from the HTTP backend",
+                cached.len()
+            );
+            return Ok(cached.len());
         }
 
         let source_ref_available = if options.skip_fetch_fork_notes {
@@ -683,6 +703,14 @@ impl CiContext {
         // Backend-aware: on the HTTP backend notes live in the notes-db cache,
         // so a refs/notes/ai-only check would always report "no notes".
         Ok(!crate::git::notes_api::commits_with_notes(&self.repo, commit_shas)?.is_empty())
+    }
+
+    fn fetch_authorship_history(&self, remote: &str) -> Result<(), GitAiError> {
+        if crate::config::Config::fresh().notes_backend_enabled() {
+            crate::git::notes_api::warm_cache_for_remote(&self.repo, remote)
+        } else {
+            fetch_authorship_notes(&self.repo, remote).map(|_| ())
+        }
     }
 
     fn original_pr_commits(

--- a/src/commands/fetch_notes.rs
+++ b/src/commands/fetch_notes.rs
@@ -94,7 +94,7 @@ pub fn handle_fetch_notes(args: &[String]) {
 
     // When the HTTP notes backend is enabled, warm the local notes-db cache
     // from the HTTP backend instead of fetching refs/notes/ai.
-    if crate::config::Config::get().notes_backend_kind() == NotesBackendKind::Http {
+    if crate::config::Config::fresh().notes_backend_kind() == NotesBackendKind::Http {
         match crate::git::notes_api::warm_cache_for_remote(&repo, &remote_name) {
             Ok(()) => {
                 let elapsed = start.elapsed();

--- a/src/commands/fetch_notes.rs
+++ b/src/commands/fetch_notes.rs
@@ -96,7 +96,7 @@ pub fn handle_fetch_notes(args: &[String]) {
     // from the HTTP backend instead of fetching refs/notes/ai.
     if crate::config::Config::fresh().notes_backend_kind() == NotesBackendKind::Http {
         match crate::git::notes_api::warm_cache_for_remote(&repo, &remote_name) {
-            Ok(()) => {
+            Ok(_) => {
                 let elapsed = start.elapsed();
                 if json_output {
                     let output = FetchNotesJsonOutput {

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -231,7 +231,7 @@ fn run_log(args: &[String]) -> Result<ExitStatus, LogError> {
 }
 
 fn run_plain_log(global_args: &[String], git_log_args: &[String]) -> Result<ExitStatus, LogError> {
-    if Config::get().notes_backend_kind() != NotesBackendKind::GitNotes {
+    if Config::fresh().notes_backend_kind() != NotesBackendKind::GitNotes {
         return Err(LogError::Message(
             "plain git log --notes=ai only supports the git_notes backend".to_string(),
         ));

--- a/src/commands/notes_migrate.rs
+++ b/src/commands/notes_migrate.rs
@@ -7,6 +7,10 @@
 //!
 //! The command refuses to run unless `notes_backend.kind == http` because migrating
 //! notes to the git-notes backend (the default) is a no-op.
+//!
+//! This explicitly invoked migration is the sole HTTP-mode exception to the runtime
+//! invariant that Git AI never inspects or mutates `refs/notes/*`. Ordinary reads,
+//! writes, rewrites, sync, transport, and CI paths must remain backend-isolated.
 
 use crate::api::client::{ApiClient, ApiContext};
 use crate::api::types::{NoteEntry, NotesUploadRequest};

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,6 +308,23 @@ struct CachedAuthorConfig {
 
 static AUTHOR_CONFIG_CACHE: OnceLock<Mutex<Option<CachedAuthorConfig>>> = OnceLock::new();
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NotesBackendKindCacheKey {
+    config_path: Option<PathBuf>,
+    config_fingerprint: Option<AuthorConfigFileFingerprint>,
+    env_kind: Option<String>,
+    #[cfg(any(test, feature = "test-support"))]
+    test_patch: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedNotesBackendKind {
+    key: NotesBackendKindCacheKey,
+    kind: NotesBackendKind,
+}
+
+static NOTES_BACKEND_KIND_CACHE: OnceLock<Mutex<Option<CachedNotesBackendKind>>> = OnceLock::new();
+
 #[cfg(any(test, feature = "test-support"))]
 static TEST_FEATURE_FLAGS_OVERRIDE: RwLock<Option<FeatureFlags>> = RwLock::new(None);
 
@@ -400,9 +417,42 @@ impl Config {
         build_config().author
     }
 
+    /// Return the current notes backend without rebuilding the full config on
+    /// every note lookup.
+    ///
+    /// The cache key fingerprints the config file and the backend environment
+    /// override, so long-lived daemon processes still observe backend changes
+    /// before dispatching a note operation.
+    pub fn fresh_notes_backend_kind_cached() -> NotesBackendKind {
+        let key = notes_backend_kind_cache_key();
+        let cache = NOTES_BACKEND_KIND_CACHE.get_or_init(|| Mutex::new(None));
+        if let Ok(mut guard) = cache.lock() {
+            if let Some(cached) = guard.as_ref()
+                && cached.key == key
+            {
+                return cached.kind;
+            }
+
+            let kind = build_config().notes_backend_kind();
+            *guard = Some(CachedNotesBackendKind { key, kind });
+            return kind;
+        }
+
+        build_config().notes_backend_kind()
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     pub fn clear_author_config_cache_for_tests() {
         if let Some(cache) = AUTHOR_CONFIG_CACHE.get()
+            && let Ok(mut guard) = cache.lock()
+        {
+            *guard = None;
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn clear_notes_backend_kind_cache_for_tests() {
+        if let Some(cache) = NOTES_BACKEND_KIND_CACHE.get()
             && let Ok(mut guard) = cache.lock()
         {
             *guard = None;
@@ -945,6 +995,21 @@ fn author_config_cache_key() -> AuthorConfigCacheKey {
     AuthorConfigCacheKey {
         config_path,
         config_fingerprint,
+        #[cfg(any(test, feature = "test-support"))]
+        test_patch: env::var("GIT_AI_TEST_CONFIG_PATCH").ok(),
+    }
+}
+
+fn notes_backend_kind_cache_key() -> NotesBackendKindCacheKey {
+    let config_path = config_file_path();
+    let config_fingerprint = config_path
+        .as_ref()
+        .and_then(|path| author_config_file_fingerprint(path));
+
+    NotesBackendKindCacheKey {
+        config_path,
+        config_fingerprint,
+        env_kind: env::var("GIT_AI_NOTES_BACKEND_KIND").ok(),
         #[cfg(any(test, feature = "test-support"))]
         test_patch: env::var("GIT_AI_TEST_CONFIG_PATCH").ok(),
     }
@@ -2699,6 +2764,31 @@ mod tests {
             NotesBackendKind::Http,
             "GIT_AI_NOTES_BACKEND_KIND=http should override the default git_notes"
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_cached_notes_backend_kind_observes_environment_changes() {
+        let old = std::env::var("GIT_AI_NOTES_BACKEND_KIND").ok();
+        Config::clear_notes_backend_kind_cache_for_tests();
+
+        unsafe { std::env::set_var("GIT_AI_NOTES_BACKEND_KIND", "git_notes") };
+        assert_eq!(
+            Config::fresh_notes_backend_kind_cached(),
+            NotesBackendKind::GitNotes
+        );
+
+        unsafe { std::env::set_var("GIT_AI_NOTES_BACKEND_KIND", "http") };
+        assert_eq!(
+            Config::fresh_notes_backend_kind_cached(),
+            NotesBackendKind::Http
+        );
+
+        match old {
+            Some(value) => unsafe { std::env::set_var("GIT_AI_NOTES_BACKEND_KIND", value) },
+            None => unsafe { std::env::remove_var("GIT_AI_NOTES_BACKEND_KIND") },
+        }
+        Config::clear_notes_backend_kind_cache_for_tests();
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1359,7 +1359,7 @@ fn apply_pull_notes_sync_side_effect(
     );
 
     if notes_backend == NotesBackendKind::Http {
-        return crate::git::notes_api::warm_cache_for_remote(&repo, &remote);
+        return crate::git::notes_api::warm_cache_for_remote(&repo, &remote).map(|_| ());
     }
 
     fetch_authorship_notes(&repo, &remote)?;
@@ -1382,7 +1382,7 @@ fn apply_clone_notes_sync_side_effect(worktree: &str) -> Result<(), GitAiError> 
     );
 
     if notes_backend == NotesBackendKind::Http {
-        return crate::git::notes_api::warm_cache_for_remote(&repo, remote);
+        return crate::git::notes_api::warm_cache_for_remote(&repo, remote).map(|_| ());
     }
 
     fetch_authorship_notes(&repo, remote)?;

--- a/src/git/authorship_traversal.rs
+++ b/src/git/authorship_traversal.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::error::GitAiError;
-use crate::git::notes_api::{commits_with_notes, read_note_blob_oids};
+use crate::git::notes_api::{commits_with_notes, read_notes_batch};
 #[cfg(test)]
 use crate::git::repository::exec_git;
 use crate::git::repository::{Repository, exec_git_stdin};
@@ -18,25 +18,14 @@ pub async fn load_ai_touched_files_for_commits(
             return Ok(HashSet::new());
         }
 
-        let note_blob_map = read_note_blob_oids(&repo, &commit_shas)?;
-        if note_blob_map.is_empty() {
+        let notes = read_notes_batch(&repo, &commit_shas)?;
+        if notes.is_empty() {
             return Ok(HashSet::new());
         }
 
-        let mut unique_blob_oids = HashSet::new();
-        for blob_oid in note_blob_map.values() {
-            unique_blob_oids.insert(blob_oid.clone());
-        }
-        let mut blob_oids: Vec<String> = unique_blob_oids.into_iter().collect();
-        blob_oids.sort();
-
-        let blob_contents = batch_read_blobs_with_oids(&repo.global_args_for_exec(), &blob_oids)?;
-
         let mut all_files = HashSet::new();
-        for blob_oid in note_blob_map.into_values() {
-            if let Some(content) = blob_contents.get(&blob_oid) {
-                extract_file_paths_from_note(content, &mut all_files);
-            }
+        for content in notes.into_values() {
+            extract_file_paths_from_note(&content, &mut all_files);
         }
 
         Ok(all_files)

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -19,7 +19,7 @@ pub use crate::git::refs::CommitAuthorship;
 // --- Writes ---
 
 pub fn write_note(repo: &Repository, commit_sha: &str, content: &str) -> Result<(), GitAiError> {
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         NotesBackendKind::Http => http_write_note(commit_sha, content),
         NotesBackendKind::GitNotes => crate::git::refs::notes_add(repo, commit_sha, content),
     }
@@ -32,7 +32,7 @@ pub fn write_notes_batch(
     if entries.is_empty() {
         return Ok(());
     }
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         NotesBackendKind::Http => http_write_batch(entries),
         NotesBackendKind::GitNotes => crate::git::refs::notes_add_batch(repo, entries),
     }
@@ -41,9 +41,8 @@ pub fn write_notes_batch(
 // --- Reads ---
 
 pub fn read_note(repo: &Repository, commit_sha: &str) -> Option<String> {
-    match Config::get().notes_backend_kind() {
-        NotesBackendKind::Http => http_read_note(commit_sha)
-            .or_else(|| crate::git::refs::show_authorship_note(repo, commit_sha)),
+    match Config::fresh().notes_backend_kind() {
+        NotesBackendKind::Http => http_read_note(commit_sha),
         NotesBackendKind::GitNotes => crate::git::refs::show_authorship_note(repo, commit_sha),
     }
 }
@@ -52,7 +51,7 @@ pub fn read_note(repo: &Repository, commit_sha: &str) -> Option<String> {
 /// Returns a map of commit_sha → note_content for commits that have notes.
 ///
 /// On the HTTP backend this checks the local cache, then fetches-and-caches any
-/// misses from the remote, and finally falls back to local git notes; on the
+/// misses from the remote, without consulting local git notes; on the
 /// GitNotes backend it reads directly via the batched `notes_for_commits` path.
 pub fn read_notes_batch(
     repo: &Repository,
@@ -62,7 +61,7 @@ pub fn read_notes_batch(
         return Ok(HashMap::new());
     }
 
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         NotesBackendKind::Http => {
             let mut notes = http_read_notes(commit_shas);
 
@@ -75,18 +74,6 @@ pub fn read_notes_batch(
                 notes.extend(http_fetch_and_cache_notes(&missing_after_cache));
             }
 
-            let missing_after_http: Vec<String> = commit_shas
-                .iter()
-                .filter(|sha| !notes.contains_key(*sha))
-                .cloned()
-                .collect();
-            if !missing_after_http.is_empty()
-                && let Ok(git_notes) =
-                    crate::git::refs::notes_for_commits(repo, &missing_after_http)
-            {
-                notes.extend(git_notes);
-            }
-
             Ok(notes)
         }
         NotesBackendKind::GitNotes => crate::git::refs::notes_for_commits(repo, commit_shas),
@@ -94,17 +81,12 @@ pub fn read_notes_batch(
 }
 
 pub fn read_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
-    match Config::get().notes_backend_kind() {
-        NotesBackendKind::Http => {
-            // Check the cache first; fall through to git notes on miss.
-            if let Some(content) = http_read_note(commit_sha) {
-                AuthorshipLog::deserialize_from_string(&content)
-                    .map_err(|e| tracing::debug!("notes deserialization error: {}", e))
-                    .ok()
-            } else {
-                crate::git::refs::get_authorship(repo, commit_sha)
-            }
-        }
+    match Config::fresh().notes_backend_kind() {
+        NotesBackendKind::Http => http_read_note(commit_sha).and_then(|content| {
+            AuthorshipLog::deserialize_from_string(&content)
+                .map_err(|e| tracing::debug!("notes deserialization error: {}", e))
+                .ok()
+        }),
         NotesBackendKind::GitNotes => crate::git::refs::get_authorship(repo, commit_sha),
     }
 }
@@ -113,14 +95,12 @@ pub fn read_authorship_v3(
     repo: &Repository,
     commit_sha: &str,
 ) -> Result<AuthorshipLog, GitAiError> {
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         NotesBackendKind::Http => {
-            if let Some(content) = http_read_note(commit_sha) {
-                AuthorshipLog::deserialize_from_string(&content)
-                    .map_err(|e| GitAiError::Generic(format!("notes deserialization error: {}", e)))
-            } else {
-                crate::git::refs::get_reference_as_authorship_log_v3(repo, commit_sha)
-            }
+            let content = http_read_note(commit_sha)
+                .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
+            AuthorshipLog::deserialize_from_string(&content)
+                .map_err(|e| GitAiError::Generic(format!("notes deserialization error: {}", e)))
         }
         NotesBackendKind::GitNotes => {
             crate::git::refs::get_reference_as_authorship_log_v3(repo, commit_sha)
@@ -130,29 +110,14 @@ pub fn read_authorship_v3(
 
 /// Return a map of commit SHA → note-blob OID for the given commits.
 ///
-/// # Audit results (Phase 2)
-///
-/// All callers of this function use the returned blob OIDs as *git object IDs*
-/// to subsequently read note content via `batch_read_blob_contents` /
-/// `batch_read_blobs_with_oids`.  They are NOT purely presence checks.
-///
-/// Call sites and how they use the OIDs:
-///
-/// 1. `authorship_traversal::load_ai_touched_files_for_commits` — passes OIDs
-///    to `batch_read_blobs_with_oids`; must be real git OIDs.
-/// 2. `rewrite::shift_authorship_notes` — reads notes by OID;
-///    must be real git OIDs.
-///
 /// **HTTP backend**: notes do not live in `refs/notes/ai`, so there are no
-/// git blob OIDs to return.  Returning an empty map causes callers to handle
-/// the "no notes available" case (skip or use slow-path reads).  This is
-/// safe and correct for the transition period — callers that need note content
-/// will fall back to `read_note` / `read_authorship` which hit the cache.
+/// git blob OIDs to return. Backend-neutral callers should use
+/// [`read_notes_batch`] to obtain note content instead.
 pub fn read_note_blob_oids(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, GitAiError> {
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         // For Http, notes are in notes-db not in git — no blob OIDs exist.
         // Return an empty map; callers handle this as "no notes in git".
         NotesBackendKind::Http => Ok(HashMap::new()),
@@ -166,22 +131,8 @@ pub fn commits_with_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashSet<String>, GitAiError> {
-    match Config::get().notes_backend_kind() {
-        NotesBackendKind::Http => {
-            // Check the cache first; fall through to git notes for misses.
-            let cached = http_check_exists(commit_shas);
-            if cached.len() == commit_shas.len() {
-                return Ok(cached);
-            }
-            // For commits not in the cache, check git notes as fallback.
-            let missing: Vec<String> = commit_shas
-                .iter()
-                .filter(|sha| !cached.contains(*sha))
-                .cloned()
-                .collect();
-            let from_git = crate::git::refs::commits_with_authorship_notes(repo, &missing)?;
-            Ok(cached.into_iter().chain(from_git).collect())
-        }
+    match Config::fresh().notes_backend_kind() {
+        NotesBackendKind::Http => Ok(http_check_exists(commit_shas)),
         NotesBackendKind::GitNotes => {
             crate::git::refs::commits_with_authorship_notes(repo, commit_shas)
         }
@@ -192,49 +143,34 @@ pub fn filter_commits_with_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<Vec<CommitAuthorship>, GitAiError> {
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         NotesBackendKind::Http => {
-            // `CommitAuthorship` requires a git_author that is only available from
-            // `git rev-list`. Call the underlying git function which handles author
-            // lookup, then patch in cache hits for commits whose `authorship_log`
-            // would otherwise be absent (because refs/notes/ai is empty).
-            //
-            // The git function calls `get_authorship(repo, sha)` (refs.rs, not
-            // notes_api), so for Http the results will be `CommitAuthorship::NoLog`
-            // for all commits. We promote any commit that has a cache entry to
-            // `CommitAuthorship::Log`.
-            let cached_map = http_read_notes(commit_shas);
-
-            let git_results =
-                crate::git::refs::get_commits_with_notes_from_list(repo, commit_shas)?;
-
-            // Promote NoLog entries that are in the cache to Log entries.
-            let results = git_results
-                .into_iter()
-                .map(|ca| match ca {
-                    CommitAuthorship::NoLog {
-                        ref sha,
-                        ref git_author,
-                    } => {
-                        if let Some(content) = cached_map.get(sha)
-                            && let Ok(authorship_log) =
-                                AuthorshipLog::deserialize_from_string(content)
-                                    .map_err(|e| GitAiError::Generic(e.to_string()))
-                        {
-                            return CommitAuthorship::Log {
+            let notes = read_notes_batch(repo, commit_shas)?;
+            let authors = crate::git::refs::commit_authors_for_list(repo, commit_shas)?;
+            Ok(commit_shas
+                .iter()
+                .map(|sha| {
+                    let git_author = authors
+                        .get(sha)
+                        .cloned()
+                        .unwrap_or_else(|| "Unknown".to_string());
+                    notes
+                        .get(sha)
+                        .and_then(|content| AuthorshipLog::deserialize_from_string(content).ok())
+                        .map(|mut authorship_log| {
+                            authorship_log.metadata.base_commit_sha = sha.clone();
+                            CommitAuthorship::Log {
                                 sha: sha.clone(),
                                 git_author: git_author.clone(),
                                 authorship_log,
-                            };
-                        }
-                        ca
-                    }
-                    // Already has a log (shouldn't happen for Http, but keep it).
-                    CommitAuthorship::Log { .. } => ca,
+                            }
+                        })
+                        .unwrap_or_else(|| CommitAuthorship::NoLog {
+                            sha: sha.clone(),
+                            git_author,
+                        })
                 })
-                .collect();
-
-            Ok(results)
+                .collect())
         }
         NotesBackendKind::GitNotes => {
             crate::git::refs::get_commits_with_notes_from_list(repo, commit_shas)
@@ -247,18 +183,17 @@ pub fn filter_commits_with_notes(
 /// Search authorship-note content for a literal substring and return matching
 /// commit SHAs, newest first.
 ///
-/// On the HTTP backend this searches the notes-db cache and unions in any
-/// matches from local git notes (transition-period repos may have both); on
+/// On the HTTP backend this searches only the notes-db cache; on
 /// the GitNotes backend it greps `refs/notes/ai` directly.
 pub fn search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
-    match Config::get().notes_backend_kind() {
+    match Config::fresh().notes_backend_kind() {
         NotesBackendKind::Http => http_search_notes(repo, pattern),
         NotesBackendKind::GitNotes => crate::git::refs::grep_ai_notes(repo, pattern),
     }
 }
 
 fn http_search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
-    let mut shas: HashSet<String> = {
+    let shas: HashSet<String> = {
         let db = crate::notes::db::NotesDatabase::global()?;
         let db_lock = db
             .lock()
@@ -266,104 +201,7 @@ fn http_search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
         db_lock.search_notes_content(pattern)?.into_iter().collect()
     };
 
-    // Union in matches from local git notes for transition-period repos.
-    if let Ok(git_shas) = crate::git::refs::grep_ai_notes(repo, pattern) {
-        shas.extend(git_shas);
-    }
-
     crate::git::refs::sort_commit_shas_by_date_desc(repo, shas)
-}
-
-// --- Materialization (for git ai log) ---
-
-/// Materialize notes from the local cache into a one-off git ref
-/// `refs/notes/ai-display` so that `git log --notes=ai-display` can render
-/// them without requiring them to be in `refs/notes/ai`.
-///
-/// Only the most recent `limit` commits reachable from HEAD are considered.
-///
-/// The ref is left in place after the call; callers use it with `--notes=ai-display`.
-/// It is safe to call repeatedly — each call starts from an empty tree via
-/// `from 0000...` so stale notes from prior calls are discarded.
-///
-/// Returns the number of notes that were written into `refs/notes/ai-display`.
-pub fn materialize_notes_for_display(repo: &Repository, limit: usize) -> Result<usize, GitAiError> {
-    use crate::git::repository::exec_git;
-    use crate::git::repository::exec_git_stdin;
-
-    // 1. Get recent commits via rev-list.
-    let rev_list_args: Vec<String> = repo
-        .global_args_for_exec()
-        .into_iter()
-        .chain([
-            "rev-list".to_string(),
-            format!("--max-count={}", limit),
-            "HEAD".to_string(),
-        ])
-        .collect();
-
-    let output = exec_git(&rev_list_args)?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let commit_shas: Vec<String> = stdout
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
-        .collect();
-
-    if commit_shas.is_empty() {
-        return Ok(0);
-    }
-
-    // 2. Look up which commits are in the local notes-db cache.
-    let cached_map = http_read_notes(&commit_shas);
-    if cached_map.is_empty() {
-        return Ok(0);
-    }
-
-    // 3. Build a git fast-import stream.
-    //    Structure:
-    //      - One `blob` stanza per note (each gets a mark ID).
-    //      - One `commit` stanza with `from 0000...` (empty tree) that attaches all blobs.
-    let mut stream = String::new();
-    let mut marks: Vec<(usize, String)> = Vec::new(); // (mark_id, commit_sha)
-
-    for (idx, (commit_sha, content)) in cached_map.iter().enumerate() {
-        let mark_id = idx + 1;
-        // Blob stanza: `data <exact-byte-count>\n<content-bytes>\n`
-        // The trailing \n after content is a fast-import stream separator, not part of the data.
-        stream.push_str(&format!(
-            "blob\nmark :{}\ndata {}\n{}\n",
-            mark_id,
-            content.len(),
-            content
-        ));
-        marks.push((mark_id, commit_sha.clone()));
-    }
-
-    // Commit stanza — mirrors the pattern used in refs.rs notes_add_batch().
-    // Use `from` with an all-zeros SHA to start from an empty tree, ensuring
-    // stale notes from prior materializations are removed.
-    stream.push_str("commit refs/notes/ai-display\n");
-    stream.push_str("committer git-ai <git-ai@localhost> 1000000000 +0000\n");
-    stream.push_str("data 0\n");
-    stream.push_str("from 0000000000000000000000000000000000000000\n");
-
-    let count = marks.len();
-    for (mark_id, commit_sha) in &marks {
-        stream.push_str(&format!("M 100644 :{} {}\n", mark_id, commit_sha));
-    }
-    stream.push('\n');
-
-    // 4. Feed to git fast-import.
-    let fast_import_args: Vec<String> = repo
-        .global_args_for_exec()
-        .into_iter()
-        .chain(["fast-import".to_string(), "--quiet".to_string()])
-        .collect();
-
-    exec_git_stdin(&fast_import_args, stream.as_bytes())?;
-
-    Ok(count)
 }
 
 // --- Cache warming ---
@@ -812,57 +650,6 @@ mod tests {
         assert!(
             result.is_err(),
             "git notes --ref=ai show should fail (note not in git) for Http backend"
-        );
-
-        unsafe {
-            env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
-        }
-    }
-
-    /// Integration test: `materialize_notes_for_display` writes notes from the
-    /// notes-db cache into `refs/notes/ai-display` so that `git log --notes=ai-display`
-    /// can show them.
-    #[test]
-    #[serial_test::serial(notes_db_env)]
-    fn integration_materialize_notes_for_display() {
-        use crate::git::repository::exec_git;
-        use crate::git::test_utils::TmpRepo;
-        use std::env;
-
-        // Isolated notes-db.
-        let tmp_db = tempfile::NamedTempFile::new().expect("tmp db file");
-        unsafe {
-            env::set_var("GIT_AI_TEST_NOTES_DB_PATH", tmp_db.path().to_str().unwrap());
-        }
-
-        let repo = TmpRepo::new().expect("TmpRepo::new");
-
-        // Create a real commit.
-        repo.write_file("b.txt", "world", false)
-            .expect("write file");
-        let sha = repo.commit_all("test commit").expect("commit");
-
-        // Put a note in the cache for this commit.
-        http_write_note(&sha, "display-note-content").expect("write note");
-
-        // Materialize the cache into refs/notes/ai-display.
-        let count = materialize_notes_for_display(repo.gitai_repo(), 50).expect("materialize");
-        assert_eq!(count, 1, "should have materialized 1 note");
-
-        // Confirm git can read the note from refs/notes/ai-display.
-        let mut args = repo.gitai_repo().global_args_for_exec();
-        args.extend([
-            "notes".to_string(),
-            "--ref=ai-display".to_string(),
-            "show".to_string(),
-            sha.clone(),
-        ]);
-        let output = exec_git(&args).expect("git notes show ai-display");
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(
-            stdout.trim() == "display-note-content",
-            "refs/notes/ai-display should contain the materialized note, got: {:?}",
-            stdout
         );
 
         unsafe {

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -86,6 +86,7 @@ pub fn read_authorship(repo: &Repository, commit_sha: &str) -> Option<Authorship
             AuthorshipLog::deserialize_from_string(&content)
                 .map_err(|e| tracing::debug!("notes deserialization error: {}", e))
                 .ok()
+                .and_then(|log| crate::git::refs::validate_authorship_log(log, commit_sha).ok())
         }),
         NotesBackendKind::GitNotes => crate::git::refs::get_authorship(repo, commit_sha),
     }
@@ -99,8 +100,9 @@ pub fn read_authorship_v3(
         NotesBackendKind::Http => {
             let content = http_read_note(commit_sha)
                 .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
-            AuthorshipLog::deserialize_from_string(&content)
-                .map_err(|e| GitAiError::Generic(format!("notes deserialization error: {}", e)))
+            let log = AuthorshipLog::deserialize_from_string(&content)
+                .map_err(|e| GitAiError::Generic(format!("notes deserialization error: {}", e)))?;
+            crate::git::refs::validate_authorship_log(log, commit_sha)
         }
         NotesBackendKind::GitNotes => {
             crate::git::refs::get_reference_as_authorship_log_v3(repo, commit_sha)
@@ -218,7 +220,8 @@ fn http_search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, Gi
 ///
 /// This function is a best-effort operation: errors are logged but not propagated
 /// (callers should treat failure as a cache miss, not a hard error).
-pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitAiError> {
+/// Returns whether at least one note is available in the cache afterward.
+pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<bool, GitAiError> {
     use crate::git::repository::exec_git;
 
     // 1. Walk recent history. Prefer the remote's default branch; fall back to HEAD.
@@ -264,7 +267,7 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
 
     if all_shas.is_empty() {
         tracing::debug!("warm_cache_for_remote: no commits in HEAD history; skipping");
-        return Ok(());
+        return Ok(false);
     }
 
     // 2. Filter out SHAs already in notes-db.
@@ -277,7 +280,7 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
 
     if uncached.is_empty() {
         tracing::debug!("warm_cache_for_remote: all commits already cached; skipping");
-        return Ok(());
+        return Ok(!already_cached.is_empty());
     }
 
     tracing::info!(
@@ -292,8 +295,8 @@ pub fn warm_cache_for_remote(repo: &Repository, remote: &str) -> Result<(), GitA
     );
 
     // 3+4. Batch-fetch from the HTTP backend and cache as synced rows.
-    http_fetch_and_cache_notes(&uncached);
-    Ok(())
+    let fetched = http_fetch_and_cache_notes(&uncached);
+    Ok(!already_cached.is_empty() || !fetched.is_empty())
 }
 
 /// Fetch authorship notes for the given commits from the HTTP notes backend
@@ -510,6 +513,56 @@ mod tests {
 
         unsafe {
             env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(notes_db_env)]
+    fn http_authorship_reads_validate_schema_and_align_commit() {
+        use crate::authorship::authorship_log_serialization::AuthorshipLog;
+        use crate::git::test_utils::TmpRepo;
+
+        let tmp_db = tempfile::NamedTempFile::new().expect("tmp notes-db");
+        unsafe {
+            std::env::set_var("GIT_AI_TEST_NOTES_DB_PATH", tmp_db.path());
+        }
+        let repo = TmpRepo::new().expect("TmpRepo::new");
+        repo.write_file("schema.txt", "unique schema test", false)
+            .expect("write file");
+        let sha = repo.commit_all("schema validation").expect("commit");
+
+        unsafe {
+            std::env::set_var("GIT_AI_NOTES_BACKEND_KIND", "http");
+        }
+        let mut valid = AuthorshipLog::default();
+        valid.metadata.base_commit_sha = "stale-attachment".to_string();
+        http_write_note(
+            &sha,
+            &valid.serialize_to_string().expect("serialize valid log"),
+        )
+        .expect("cache valid log");
+
+        let aligned = read_authorship_v3(repo.gitai_repo(), &sha).expect("read valid log");
+        assert_eq!(aligned.metadata.base_commit_sha, sha);
+
+        valid.metadata.schema_version = "authorship/999.0.0".to_string();
+        http_write_note(
+            &sha,
+            &valid.serialize_to_string().expect("serialize future log"),
+        )
+        .expect("cache future log");
+        let error = read_authorship_v3(repo.gitai_repo(), &sha)
+            .expect_err("unsupported schema must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("Unsupported authorship log version")
+        );
+        assert!(read_authorship(repo.gitai_repo(), &sha).is_none());
+
+        unsafe {
+            std::env::remove_var("GIT_AI_NOTES_BACKEND_KIND");
+            std::env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
         }
     }
 
@@ -776,6 +829,7 @@ mod tests {
         // Execute.
         let result = warm_cache_for_remote(repo.gitai_repo(), "origin");
         assert!(result.is_ok(), "warm_cache_for_remote failed: {:?}", result);
+        assert!(result.unwrap());
 
         // Verify via NotesDatabase::global() (the same DB the function wrote to).
         let db = NotesDatabase::global().expect("global db");
@@ -916,6 +970,7 @@ mod tests {
 
         let result = warm_cache_for_remote(repo.gitai_repo(), "origin");
         assert!(result.is_ok(), "warm_cache_for_remote failed: {:?}", result);
+        assert!(result.unwrap());
 
         // Verify via the global DB.
         let db = NotesDatabase::global().expect("global db");
@@ -943,6 +998,40 @@ mod tests {
         // Cleanup.
         unsafe {
             std::env::remove_var("GIT_AI_TEST_NOTES_DB_PATH");
+            std::env::remove_var("GIT_AI_API_KEY");
+            std::env::remove_var("GIT_AI_NOTES_BACKEND_URL");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(notes_db_env)]
+    fn warm_cache_for_remote_reports_when_backend_has_no_notes() {
+        use crate::git::test_utils::TmpRepo;
+
+        let repo = TmpRepo::new().expect("TmpRepo::new");
+        repo.write_file("empty-backend.txt", "no remote note", false)
+            .expect("write file");
+        repo.commit_all("empty backend commit").expect("commit");
+
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/worker/notes/".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"notes": {}}"#)
+            .create();
+        unsafe {
+            std::env::set_var("GIT_AI_NOTES_BACKEND_URL", server.url());
+            std::env::set_var("GIT_AI_API_KEY", "empty-backend-test-key");
+        }
+
+        assert!(!warm_cache_for_remote(repo.gitai_repo(), "origin").expect("warm cache"));
+        mock.assert();
+
+        unsafe {
             std::env::remove_var("GIT_AI_API_KEY");
             std::env::remove_var("GIT_AI_NOTES_BACKEND_URL");
         }

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -19,7 +19,7 @@ pub use crate::git::refs::CommitAuthorship;
 // --- Writes ---
 
 pub fn write_note(repo: &Repository, commit_sha: &str, content: &str) -> Result<(), GitAiError> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => http_write_note(commit_sha, content),
         NotesBackendKind::GitNotes => crate::git::refs::notes_add(repo, commit_sha, content),
     }
@@ -32,7 +32,7 @@ pub fn write_notes_batch(
     if entries.is_empty() {
         return Ok(());
     }
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => http_write_batch(entries),
         NotesBackendKind::GitNotes => crate::git::refs::notes_add_batch(repo, entries),
     }
@@ -41,7 +41,7 @@ pub fn write_notes_batch(
 // --- Reads ---
 
 pub fn read_note(repo: &Repository, commit_sha: &str) -> Option<String> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => http_read_note(commit_sha),
         NotesBackendKind::GitNotes => crate::git::refs::show_authorship_note(repo, commit_sha),
     }
@@ -61,7 +61,7 @@ pub fn read_notes_batch(
         return Ok(HashMap::new());
     }
 
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => {
             let mut notes = http_read_notes(commit_shas);
 
@@ -81,7 +81,7 @@ pub fn read_notes_batch(
 }
 
 pub fn read_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => http_read_note(commit_sha).and_then(|content| {
             AuthorshipLog::deserialize_from_string(&content)
                 .map_err(|e| tracing::debug!("notes deserialization error: {}", e))
@@ -95,7 +95,7 @@ pub fn read_authorship_v3(
     repo: &Repository,
     commit_sha: &str,
 ) -> Result<AuthorshipLog, GitAiError> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => {
             let content = http_read_note(commit_sha)
                 .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
@@ -117,7 +117,7 @@ pub fn read_note_blob_oids(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashMap<String, String>, GitAiError> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         // For Http, notes are in notes-db not in git — no blob OIDs exist.
         // Return an empty map; callers handle this as "no notes in git".
         NotesBackendKind::Http => Ok(HashMap::new()),
@@ -131,7 +131,7 @@ pub fn commits_with_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<HashSet<String>, GitAiError> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => Ok(http_check_exists(commit_shas)),
         NotesBackendKind::GitNotes => {
             crate::git::refs::commits_with_authorship_notes(repo, commit_shas)
@@ -143,7 +143,7 @@ pub fn filter_commits_with_notes(
     repo: &Repository,
     commit_shas: &[String],
 ) -> Result<Vec<CommitAuthorship>, GitAiError> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => {
             let notes = read_notes_batch(repo, commit_shas)?;
             let authors = crate::git::refs::commit_authors_for_list(repo, commit_shas)?;
@@ -186,7 +186,7 @@ pub fn filter_commits_with_notes(
 /// On the HTTP backend this searches only the notes-db cache; on
 /// the GitNotes backend it greps `refs/notes/ai` directly.
 pub fn search_notes(repo: &Repository, pattern: &str) -> Result<Vec<String>, GitAiError> {
-    match Config::fresh().notes_backend_kind() {
+    match Config::fresh_notes_backend_kind_cached() {
         NotesBackendKind::Http => http_search_notes(repo, pattern),
         NotesBackendKind::GitNotes => crate::git::refs::grep_ai_notes(repo, pattern),
     }

--- a/src/git/notes_api.rs
+++ b/src/git/notes_api.rs
@@ -86,7 +86,7 @@ pub fn read_authorship(repo: &Repository, commit_sha: &str) -> Option<Authorship
             AuthorshipLog::deserialize_from_string(&content)
                 .map_err(|e| tracing::debug!("notes deserialization error: {}", e))
                 .ok()
-                .and_then(|log| crate::git::refs::validate_authorship_log(log, commit_sha).ok())
+                .map(|log| crate::git::refs::align_authorship_log(log, commit_sha))
         }),
         NotesBackendKind::GitNotes => crate::git::refs::get_authorship(repo, commit_sha),
     }
@@ -558,7 +558,9 @@ mod tests {
                 .to_string()
                 .contains("Unsupported authorship log version")
         );
-        assert!(read_authorship(repo.gitai_repo(), &sha).is_none());
+        let lenient = read_authorship(repo.gitai_repo(), &sha)
+            .expect("display read should preserve lenient schema handling");
+        assert_eq!(lenient.metadata.base_commit_sha, sha);
 
         unsafe {
             std::env::remove_var("GIT_AI_NOTES_BACKEND_KIND");

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -753,7 +753,7 @@ pub(in crate::git) fn commits_with_authorship_notes(
 pub(in crate::git) fn get_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
     let content = show_authorship_note(repo, commit_sha)?;
     let authorship_log = AuthorshipLog::deserialize_from_string(&content).ok()?;
-    validate_authorship_log(authorship_log, commit_sha).ok()
+    Some(align_authorship_log(authorship_log, commit_sha))
 }
 
 pub(in crate::git) fn align_authorship_log(

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -629,43 +629,7 @@ pub(in crate::git) fn get_commits_with_notes_from_list(
         return Ok(Vec::new());
     }
 
-    // Get the git authors for all commits using git rev-list
-    // This approach works in both bare and normal repositories
-    let mut args = repo.global_args_for_exec();
-    args.push("rev-list".to_string());
-    args.push("--no-walk".to_string());
-    args.push("--pretty=format:%H%n%an%n%ae".to_string());
-    for sha in commit_shas {
-        args.push(sha.clone());
-    }
-
-    let output = exec_git(&args)?;
-    let stdout = String::from_utf8(output.stdout)
-        .map_err(|_| GitAiError::Generic("Failed to parse git rev-list output".to_string()))?;
-
-    let mut commit_authors = HashMap::new();
-    let lines: Vec<&str> = stdout.lines().collect();
-    let mut i = 0;
-    while i < lines.len() {
-        let line = lines[i];
-        // Skip commit headers (start with "commit ")
-        if line.starts_with("commit ") {
-            i += 1;
-            if i + 2 < lines.len() {
-                let sha = lines[i].to_string();
-                let name = lines[i + 1].to_string();
-                let email = lines[i + 2].to_string();
-                let author = format!("{} <{}>", name, email);
-                commit_authors.insert(sha, author);
-                i += 3;
-            } else {
-                break;
-            }
-        } else {
-            i += 1;
-        }
-    }
-
+    let commit_authors = commit_authors_for_list(repo, commit_shas)?;
     let note_blob_oids = note_blob_oids_for_commits(repo, commit_shas)?;
     let mut unique_blob_oids = Vec::new();
     let mut seen_blob_oids = HashSet::new();
@@ -703,6 +667,55 @@ pub(in crate::git) fn get_commits_with_notes_from_list(
     }
 
     Ok(result)
+}
+
+/// Resolve commit authors in one Git invocation without consulting any notes ref.
+pub(in crate::git) fn commit_authors_for_list(
+    repo: &Repository,
+    commit_shas: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    if commit_shas.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Get the git authors for all commits using git rev-list. This works in both
+    // bare and normal repositories and is independent of the configured notes backend.
+    let mut args = repo.global_args_for_exec();
+    args.push("rev-list".to_string());
+    args.push("--no-walk".to_string());
+    args.push("--pretty=format:%H%n%an%n%ae".to_string());
+    for sha in commit_shas {
+        args.push(sha.clone());
+    }
+
+    let output = exec_git(&args)?;
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|_| GitAiError::Generic("Failed to parse git rev-list output".to_string()))?;
+
+    let mut commit_authors = HashMap::new();
+    let lines: Vec<&str> = stdout.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        // Skip commit headers (start with "commit ")
+        if line.starts_with("commit ") {
+            i += 1;
+            if i + 2 < lines.len() {
+                let sha = lines[i].to_string();
+                let name = lines[i + 1].to_string();
+                let email = lines[i + 2].to_string();
+                let author = format!("{} <{}>", name, email);
+                commit_authors.insert(sha, author);
+                i += 3;
+            } else {
+                break;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    Ok(commit_authors)
 }
 
 // Show an authorship note and return its JSON content if found, or None if it doesn't exist.
@@ -1018,6 +1031,7 @@ pub(crate) fn sort_commit_shas_by_date_desc(
     let mut sha_vec: Vec<String> = shas.into_iter().collect();
     let mut args = repo.global_args_for_exec();
     args.push("log".to_string());
+    args.push("--no-notes".to_string());
     args.push("--format=%H".to_string());
     args.push("--date-order".to_string());
     args.push("--no-walk".to_string());

--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -752,10 +752,30 @@ pub(in crate::git) fn commits_with_authorship_notes(
 // Show an authorship note and return its JSON content if found, or None if it doesn't exist.
 pub(in crate::git) fn get_authorship(repo: &Repository, commit_sha: &str) -> Option<AuthorshipLog> {
     let content = show_authorship_note(repo, commit_sha)?;
-    let mut authorship_log = AuthorshipLog::deserialize_from_string(&content).ok()?;
-    // Keep metadata aligned with the commit where this note is attached.
+    let authorship_log = AuthorshipLog::deserialize_from_string(&content).ok()?;
+    validate_authorship_log(authorship_log, commit_sha).ok()
+}
+
+pub(in crate::git) fn align_authorship_log(
+    mut authorship_log: AuthorshipLog,
+    commit_sha: &str,
+) -> AuthorshipLog {
     authorship_log.metadata.base_commit_sha = commit_sha.to_string();
-    Some(authorship_log)
+    authorship_log
+}
+
+pub(in crate::git) fn validate_authorship_log(
+    authorship_log: AuthorshipLog,
+    commit_sha: &str,
+) -> Result<AuthorshipLog, GitAiError> {
+    if authorship_log.metadata.schema_version != AUTHORSHIP_LOG_VERSION {
+        return Err(GitAiError::Generic(format!(
+            "Unsupported authorship log version: {} (expected: {})",
+            authorship_log.metadata.schema_version, AUTHORSHIP_LOG_VERSION
+        )));
+    }
+
+    Ok(align_authorship_log(authorship_log, commit_sha))
 }
 
 #[allow(dead_code)]
@@ -777,7 +797,7 @@ pub(in crate::git) fn get_reference_as_authorship_log_v3(
         .ok_or_else(|| GitAiError::Generic("No authorship note found".to_string()))?;
 
     // Try to deserialize as AuthorshipLog
-    let mut authorship_log = match AuthorshipLog::deserialize_from_string(&content) {
+    let authorship_log = match AuthorshipLog::deserialize_from_string(&content) {
         Ok(log) => log,
         Err(_) => {
             return Err(GitAiError::Generic(
@@ -786,18 +806,7 @@ pub(in crate::git) fn get_reference_as_authorship_log_v3(
         }
     };
 
-    // Check version compatibility
-    if authorship_log.metadata.schema_version != AUTHORSHIP_LOG_VERSION {
-        return Err(GitAiError::Generic(format!(
-            "Unsupported authorship log version: {} (expected: {})",
-            authorship_log.metadata.schema_version, AUTHORSHIP_LOG_VERSION
-        )));
-    }
-
-    // Keep metadata aligned with the commit where this note is attached.
-    authorship_log.metadata.base_commit_sha = commit_sha.to_string();
-
-    Ok(authorship_log)
+    validate_authorship_log(authorship_log, commit_sha)
 }
 
 /// Sanitize a remote name to create a safe ref name

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2661,6 +2661,65 @@ pub fn exec_git(args: &[String]) -> Result<Output, GitAiError> {
     exec_git_with_profile(args, InternalGitProfile::General)
 }
 
+/// Execute an internal Git command with a hard wall-clock timeout.
+///
+/// This preserves the same disabled-hook and trace2-cleanup policy as `exec_git`.
+pub(crate) fn exec_git_with_timeout(
+    args: &[String],
+    timeout: std::time::Duration,
+) -> Result<crate::process_timeout::TimedCommandOutput, GitAiError> {
+    let effective_args = args_with_internal_git_profile(
+        &args_with_disabled_hooks_if_needed(args),
+        InternalGitProfile::General,
+    );
+    spawn_probe_log(&effective_args);
+    let arg_refs = effective_args
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let output = crate::process_timeout::run_command_with_timeout_and_env(
+        config::Config::get().git_cmd(),
+        &arg_refs,
+        None,
+        timeout,
+        std::time::Duration::from_millis(20),
+        INTERNAL_GIT_ENV_REMOVE,
+        INTERNAL_GIT_ENV_SET,
+    )
+    .map_err(|error| {
+        GitAiError::Generic(format!("failed to execute timed Git command: {error}"))
+    })?;
+
+    if output.timed_out {
+        tracing::error!(
+            component = "git_notes_sync",
+            phase = "timeout",
+            timeout_ms = timeout.as_millis() as u64,
+            stderr = %output.stderr,
+            diagnostics = ?output.diagnostics,
+            "internal Git notes transport timed out"
+        );
+        return Err(GitAiError::Generic(format!(
+            "Git command timed out after {}ms: {}",
+            timeout.as_millis(),
+            output.stderr
+        )));
+    }
+    if let Some(wait_error) = &output.wait_error {
+        return Err(GitAiError::Generic(format!(
+            "failed waiting for timed Git command: {wait_error}"
+        )));
+    }
+    if output.status != Some(0) {
+        return Err(GitAiError::GitCliError {
+            code: output.status,
+            stderr: output.stderr.clone(),
+            args: effective_args,
+        });
+    }
+    Ok(output)
+}
+
 /// Helper to execute a git command and return output regardless of exit status.
 /// Callers that need success-only behavior should use `exec_git*`.
 pub fn exec_git_allow_nonzero(args: &[String]) -> Result<Output, GitAiError> {
@@ -2685,21 +2744,31 @@ pub fn exec_git_allow_nonzero_with_env(
 
 #[cfg(feature = "test-support")]
 fn spawn_probe_log(effective_args: &[String]) {
-    let Ok(path) = std::env::var("GIT_AI_SPAWN_LOG") else {
-        return;
-    };
-    let sub = effective_args
-        .iter()
-        .find(|a| !a.starts_with('-') && !a.contains('=') && !a.contains('/') && !a.contains('\\'))
-        .cloned()
-        .unwrap_or_default();
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
+    if let Ok(path) = std::env::var("GIT_AI_SPAWN_LOG")
+        && let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
     {
         use std::io::Write;
+        let sub = effective_args
+            .iter()
+            .find(|a| {
+                !a.starts_with('-') && !a.contains('=') && !a.contains('/') && !a.contains('\\')
+            })
+            .cloned()
+            .unwrap_or_default();
         let _ = writeln!(f, "{}", sub);
+    }
+
+    if let Ok(path) = std::env::var("GIT_AI_SPAWN_ARGS_LOG")
+        && let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+    {
+        use std::io::Write;
+        let _ = writeln!(f, "{:?}", effective_args);
     }
 }
 
@@ -2741,6 +2810,7 @@ pub fn spawn_git_stdout(args: &[String]) -> Result<Child, GitAiError> {
         &args_with_disabled_hooks_if_needed(args),
         InternalGitProfile::General,
     );
+    spawn_probe_log(&effective_args);
     let mut cmd = Command::new(config::Config::get().git_cmd());
     cmd.args(&effective_args)
         .stdin(std::process::Stdio::null())
@@ -2767,6 +2837,7 @@ pub fn spawn_git_passthrough(args: &[String]) -> Result<Child, GitAiError> {
         &args_with_disabled_hooks_if_needed(args),
         InternalGitProfile::General,
     );
+    spawn_probe_log(&effective_args);
     let mut cmd = Command::new(config::Config::get().git_cmd());
     cmd.args(&effective_args)
         .stdin(std::process::Stdio::inherit())

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -4,7 +4,7 @@ use crate::git::refs::{
 };
 use crate::{
     error::GitAiError,
-    git::{cli_parser::ParsedGitInvocation, repository::exec_git},
+    git::{cli_parser::ParsedGitInvocation, repository::exec_git_with_timeout},
 };
 
 use super::repository::Repository;
@@ -145,17 +145,20 @@ pub fn fetch_missing_notes_for_commits(
     // every source note.
     if crate::config::Config::fresh().notes_backend_enabled() {
         let missing_owned: Vec<String> = missing.iter().map(|sha| sha.to_string()).collect();
-        match crate::git::notes_api::warm_cache_for_commits(&missing_owned) {
+        return match crate::git::notes_api::warm_cache_for_commits(&missing_owned) {
             Ok(cached) => {
                 let cached: HashSet<String> = cached.into_iter().collect();
                 if missing_owned.iter().all(|sha| cached.contains(sha)) {
-                    return Ok(());
+                    Ok(())
+                } else {
+                    Err(GitAiError::Generic(format!(
+                        "HTTP notes backend did not return source notes for {:?}",
+                        missing_owned
+                    )))
                 }
             }
-            Err(e) => {
-                tracing::debug!("HTTP backend fetch for missing source notes failed: {}", e);
-            }
-        }
+            Err(e) => Err(e),
+        };
     }
 
     tracing::debug!(
@@ -221,6 +224,12 @@ pub fn fetch_authorship_notes(
     repository: &Repository,
     remote_name: &str,
 ) -> Result<NotesExistence, GitAiError> {
+    if crate::config::Config::fresh().notes_backend_enabled() {
+        tracing::debug!(
+            "fetch_authorship_notes: skipping refs/notes/ai fetch (HTTP backend active)"
+        );
+        return Ok(NotesExistence::NotFound);
+    }
     // Generate tracking ref for this remote
     let tracking_ref = tracking_ref_for_remote(remote_name);
 
@@ -250,16 +259,10 @@ pub fn fetch_authorship_notes(
 
     tracing::debug!("fetch command: {:?}", fetch_authorship);
 
-    match exec_git(&fetch_authorship) {
+    match exec_git_with_timeout(&fetch_authorship, notes_transport_timeout()) {
         Ok(output) => {
-            tracing::debug!(
-                "fetch stdout: '{}'",
-                String::from_utf8_lossy(&output.stdout)
-            );
-            tracing::debug!(
-                "fetch stderr: '{}'",
-                String::from_utf8_lossy(&output.stderr)
-            );
+            tracing::debug!("fetch stdout: '{}'", output.stdout);
+            tracing::debug!("fetch stderr: '{}'", output.stderr);
         }
         Err(e) => {
             if is_missing_remote_notes_ref_error(&e) {
@@ -329,11 +332,23 @@ fn is_missing_remote_notes_ref_error(error: &GitAiError) -> bool {
 /// even after a successful merge, so we retry the full cycle.
 const PUSH_NOTES_MAX_ATTEMPTS: usize = 3;
 
+pub(crate) fn notes_transport_timeout() -> std::time::Duration {
+    #[cfg(any(test, feature = "test-support"))]
+    if let Ok(timeout_ms) = std::env::var("GIT_AI_TEST_NOTES_SYNC_TIMEOUT_MS")
+        && let Ok(timeout_ms) = timeout_ms.parse::<u64>()
+        && timeout_ms > 0
+    {
+        return std::time::Duration::from_millis(timeout_ms);
+    }
+    std::time::Duration::from_secs(30)
+}
+
 // for use with post-push hook
 pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Result<(), GitAiError> {
     // Belt-and-suspenders: when the HTTP backend is active, notes are not stored
     // in refs/notes/ai so there is nothing to push.
-    if crate::config::Config::get().notes_backend_kind() == crate::config::NotesBackendKind::Http {
+    if crate::config::Config::fresh().notes_backend_kind() == crate::config::NotesBackendKind::Http
+    {
         tracing::debug!("push_authorship_notes: skipping refs/notes/ai push (Http backend active)");
         return Ok(());
     }
@@ -356,7 +371,7 @@ pub fn push_authorship_notes(repository: &Repository, remote_name: &str) -> Resu
 
         tracing::debug!("pushing authorship refs (no force): {:?}", &push_args);
 
-        match exec_git(&push_args) {
+        match exec_git_with_timeout(&push_args, notes_transport_timeout()) {
             Ok(_) => return Ok(()),
             Err(e) => {
                 tracing::debug!("authorship push failed: {}", e);
@@ -389,7 +404,7 @@ fn fetch_and_merge_tracking_notes(repository: &Repository, remote_name: &str) {
     tracing::debug!("pre-push authorship fetch: {:?}", &fetch_args);
 
     // Fetch is best-effort; if it fails (e.g., no remote notes yet), continue
-    if exec_git(&fetch_args).is_err() {
+    if exec_git_with_timeout(&fetch_args, notes_transport_timeout()).is_err() {
         return;
     }
 

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -226,9 +226,10 @@ pub fn fetch_authorship_notes(
 ) -> Result<NotesExistence, GitAiError> {
     if crate::config::Config::fresh().notes_backend_enabled() {
         tracing::debug!(
-            "fetch_authorship_notes: skipping refs/notes/ai fetch (HTTP backend active)"
+            "fetch_authorship_notes: warming HTTP notes cache instead of fetching refs/notes/ai"
         );
-        return Ok(NotesExistence::NotFound);
+        crate::git::notes_api::warm_cache_for_remote(repository, remote_name)?;
+        return Ok(NotesExistence::Found);
     }
     // Generate tracking ref for this remote
     let tracking_ref = tracking_ref_for_remote(remote_name);

--- a/src/git/sync_authorship.rs
+++ b/src/git/sync_authorship.rs
@@ -228,8 +228,15 @@ pub fn fetch_authorship_notes(
         tracing::debug!(
             "fetch_authorship_notes: warming HTTP notes cache instead of fetching refs/notes/ai"
         );
-        crate::git::notes_api::warm_cache_for_remote(repository, remote_name)?;
-        return Ok(NotesExistence::Found);
+        return crate::git::notes_api::warm_cache_for_remote(repository, remote_name).map(
+            |found| {
+                if found {
+                    NotesExistence::Found
+                } else {
+                    NotesExistence::NotFound
+                }
+            },
+        );
     }
     // Generate tracking ref for this remote
     let tracking_ref = tracking_ref_for_remote(remote_name);

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -1,4 +1,6 @@
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -91,6 +93,8 @@ pub(crate) fn run_command_with_timeout_and_env(
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
+    #[cfg(unix)]
+    command.process_group(0);
 
     let mut child = command
         .spawn()
@@ -127,6 +131,18 @@ pub(crate) fn run_command_with_timeout_and_env(
                 return Ok(output.finish(status.code(), false, None));
             }
             Ok(None) if start.elapsed() >= timeout => {
+                #[cfg(unix)]
+                {
+                    // Kill the whole process group so an SSH transport cannot keep
+                    // inherited stdout/stderr pipes open after Git is reaped.
+                    let group = -(child.id() as i32);
+                    // SAFETY: `group` names the child-owned process group created above.
+                    if unsafe { libc::kill(group, libc::SIGKILL) } == 0 {
+                        output
+                            .diagnostics
+                            .push("sent kill to child process group".to_string());
+                    }
+                }
                 let kill_result = child.kill();
                 match &kill_result {
                     Ok(()) => output
@@ -264,5 +280,35 @@ fn drain_output_events(rx: &Receiver<OutputEvent>, output: &mut OutputState) {
                 output.stderr_done = true;
             }
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_kills_and_reaps_the_child_process_group() {
+        let started = Instant::now();
+        let output = run_command_with_timeout(
+            "sh",
+            &["-c", "sleep 30 & wait"],
+            None,
+            Duration::from_millis(100),
+            Duration::from_millis(10),
+            &[],
+        )
+        .expect("timed command should start");
+
+        assert!(output.timed_out);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|message| message.contains("process group")),
+            "timeout diagnostics should confirm process-group termination: {:?}",
+            output.diagnostics
+        );
     }
 }

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -1,6 +1,8 @@
 use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -96,6 +98,10 @@ pub(crate) fn run_command_with_timeout_and_env(
     }
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
+    }
+    #[cfg(windows)]
+    if !crate::utils::is_interactive_terminal() {
+        command.creation_flags(crate::utils::CREATE_NO_WINDOW);
     }
     #[cfg(unix)]
     command.process_group(0);

--- a/src/process_timeout.rs
+++ b/src/process_timeout.rs
@@ -82,6 +82,10 @@ pub(crate) fn run_command_with_timeout_and_env(
     let mut command = Command::new(program);
     command
         .args(args)
+        // Match Command::output() semantics used by the non-timed path. These
+        // internal best-effort transports must never compete for the caller's
+        // terminal or stall on a credential/passphrase prompt.
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     for key in env_remove {
@@ -286,6 +290,23 @@ fn drain_output_events(rx: &Receiver<OutputEvent>, output: &mut OutputState) {
 #[cfg(all(test, unix))]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn timed_commands_do_not_inherit_caller_stdin() {
+        let output = run_command_with_timeout(
+            "sh",
+            &["-c", "readlink /proc/self/fd/0"],
+            None,
+            Duration::from_secs(1),
+            Duration::from_millis(10),
+            &[],
+        )
+        .expect("timed command should start");
+
+        assert_eq!(output.status, Some(0));
+        assert_eq!(output.stdout, "/dev/null");
+    }
 
     #[test]
     fn timeout_kills_and_reaps_the_child_process_group() {

--- a/tests/integration/log.rs
+++ b/tests/integration/log.rs
@@ -2,6 +2,7 @@ use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use git_ai::config::{NotesBackendConfig, NotesBackendKind};
 use git_ai::notes::db::NotesDatabase;
+use std::fs;
 
 #[test]
 fn log_default_shows_stats_without_raw_note() {
@@ -194,5 +195,74 @@ fn log_http_backend_reads_notes_db_without_git_notes_ref() {
         output.contains("schema_version"),
         "raw note content should come from notes-db:\n{}",
         output
+    );
+}
+
+#[test]
+fn http_backend_cache_miss_never_consults_git_notes_refs() {
+    let mut repo = TestRepo::new();
+    let mut file = repo.filename("http-isolation.txt");
+    file.set_contents(lines!["AI content that only exists in Git notes".ai()]);
+    repo.stage_all_and_commit("feat: isolate HTTP notes")
+        .unwrap();
+    file.assert_lines_and_blame(lines!["AI content that only exists in Git notes".ai()]);
+
+    let sha = repo
+        .git(&["rev-parse", "HEAD"])
+        .expect("resolve committed SHA")
+        .trim()
+        .to_string();
+    assert!(
+        repo.read_authorship_note(&sha).is_some(),
+        "precondition failed: legacy authorship note should exist only in refs/notes/ai"
+    );
+
+    repo.patch_git_ai_config(|patch| {
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: None,
+        });
+    });
+
+    let notes_db = tempfile::NamedTempFile::new().expect("create isolated empty notes db");
+    let notes_db_path = notes_db.path().to_string_lossy().to_string();
+    let spawn_args = tempfile::NamedTempFile::new().expect("create internal Git argument log");
+    let spawn_args_path = spawn_args.path().to_string_lossy().to_string();
+    let env = [
+        ("GIT_AI_TEST_NOTES_DB_PATH", notes_db_path.as_str()),
+        ("GIT_AI_SPAWN_ARGS_LOG", spawn_args_path.as_str()),
+    ];
+
+    let log_output = repo
+        .git_ai_with_env(&["log", "--no-pager", "--raw", "-n", "1"], &env)
+        .expect("HTTP-backed log should succeed without cached authorship");
+    assert!(log_output.contains("feat: isolate HTTP notes"));
+    assert!(
+        !log_output.contains("schema_version")
+            && !log_output.contains("s_")
+            && log_output.contains("Authorship note:\n      (none)"),
+        "HTTP log must not fall back to the legacy Git note:\n{log_output}"
+    );
+
+    let show_output = repo
+        .git_ai_with_env(&["show", "HEAD"], &env)
+        .expect("HTTP-backed show should succeed without cached authorship");
+    assert!(
+        show_output.contains("No authorship data found"),
+        "HTTP show must not fall back to the legacy Git note:\n{show_output}"
+    );
+
+    repo.git_ai_with_env(&["stats", "HEAD", "--json"], &env)
+        .expect("HTTP-backed stats should succeed without cached authorship");
+    let _ = repo.git_ai_with_env(&["diff", "HEAD", "--json"], &env);
+    let _ = repo.git_ai_with_env(&["show-prompt", "s_missing_http_isolation"], &env);
+
+    let spawned_args =
+        fs::read_to_string(spawn_args.path()).expect("read internal Git argument log");
+    assert!(
+        !spawned_args
+            .lines()
+            .any(|line| line.contains("refs/notes/") || line.contains("--ref=ai")),
+        "ordinary HTTP paths must never target a Git notes ref; spawns:\n{spawned_args}"
     );
 }

--- a/tests/notes_sync_regression.rs
+++ b/tests/notes_sync_regression.rs
@@ -4,6 +4,7 @@ mod repos;
 
 use git_ai::notes::db::NotesDatabase;
 use git_ai::notes::reference_server::ReferenceServer;
+use repos::test_file::ExpectedLineExt;
 use repos::test_repo::{DaemonTestScope, TestRepo, real_git_executable};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -549,6 +550,74 @@ fn notes_sync_http_backend_clone_warms_notes_cache() {
         "daemon log should record the HTTP notes fetch\npath: {}\ncontents:\n{}",
         daemon_log_path.display(),
         daemon_log
+    );
+}
+
+#[test]
+fn notes_sync_http_backend_internal_fetch_warms_notes_cache() {
+    let server = ReferenceServer::start("127.0.0.1:0").expect("start notes reference server");
+    let backend_url = server.base_url();
+    let upstream = TestRepo::new_bare_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let seed = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let upstream_str = upstream.path().to_string_lossy().to_string();
+    seed.git_og(&["remote", "add", "origin", upstream_str.as_str()])
+        .expect("add seed origin");
+    fs::write(seed.path().join("internal-fetch.txt"), "seed\n").expect("write seed file");
+    seed.git_og(&["add", "internal-fetch.txt"])
+        .expect("stage seed file");
+    seed.git_og(&["commit", "-m", "internal fetch seed"])
+        .expect("commit seed file");
+    let mut seed_file = seed.filename("internal-fetch.txt");
+    seed_file.assert_committed_lines(vec!["seed".unattributed_human()]);
+    seed.git_og(&["push", "-u", "origin", "HEAD"])
+        .expect("push seed branch");
+    let seed_sha = seed
+        .git_og(&["rev-parse", "HEAD"])
+        .expect("resolve seed SHA")
+        .trim()
+        .to_string();
+    let remote_note = "internal-http-note".to_string();
+    server.store().put(seed_sha.clone(), remote_note.clone());
+
+    let local = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+        ("GIT_AI_NOTES_BACKEND_URL", backend_url.as_str()),
+        ("GIT_AI_API_KEY", "notes-sync-http-internal-fetch-test-key"),
+    ]);
+    local
+        .git_og(&["remote", "add", "origin", upstream_str.as_str()])
+        .expect("add local origin");
+    local
+        .git_og(&["fetch", "origin"])
+        .expect("fetch branch before warming notes");
+    local
+        .git_og(&["checkout", "--detach", seed_sha.as_str()])
+        .expect("check out fetched seed commit");
+
+    let notes_db_path = local.test_home_path().join(".git-ai/internal/notes-db");
+    let db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db before fetch");
+    assert_eq!(db.get_note(&seed_sha).expect("read empty cache"), None);
+    drop(db);
+
+    let request = serde_json::json!({ "remote_name": "origin" }).to_string();
+    let output = local
+        .git_ai_with_env(
+            &["fetch-authorship-notes", "--json", request.as_str()],
+            &[
+                ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+                ("GIT_AI_NOTES_BACKEND_URL", backend_url.as_str()),
+                ("GIT_AI_API_KEY", "notes-sync-http-internal-fetch-test-key"),
+            ],
+        )
+        .expect("internal HTTP fetch should succeed");
+    let response: serde_json::Value =
+        serde_json::from_str(output.trim()).expect("parse internal fetch response");
+    assert_eq!(response["notes_existence"], "found");
+
+    let db = NotesDatabase::open_at_path(&notes_db_path).expect("open notes db after fetch");
+    assert_eq!(
+        db.get_note(&seed_sha).expect("read warmed cache"),
+        Some(remote_note)
     );
 }
 


### PR DESCRIPTION
## Summary

- Route HTTP-backed reads, searches, traversal, fetches, and CI synchronization exclusively through SQLite and HTTP APIs.
- Remove Git-note fallbacks and display-ref materialization; `git-ai notes migrate` remains the sole explicit migration exception.
- Add hard timeouts and process-group cleanup for Git-notes fetch/push transport.
- Add regression coverage proving HTTP-mode commands never mention Git-notes refs.

## Verification

- `task build`
- `task test TEST_FILTER=http_backend`
- `task lint`

Stack 1/2; followed by #2117.

Part of #2099.