### PR TITLE
Fix OpenCode model lookup on Windows

### DIFF
--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -587,7 +587,7 @@ mod tests {
         std::fs::create_dir_all(&live_path).unwrap();
 
         let stale_db = stale_path.join("opencode.db");
-        let stale_conn = rusqlite::Connection::open(&stale_db).unwrap();
+        let stale_conn = crate::sqlite::open_with_memory_limits(&stale_db).unwrap();
         stale_conn
             .execute(
                 "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT)",

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -127,15 +127,16 @@ impl OpenCodePreset {
     }
 
     fn resolve_stream_source(session_id: &str) -> Option<(StreamSource, PathBuf)> {
-        let opencode_path = if let Ok(test_path) = std::env::var("GIT_AI_OPENCODE_STORAGE_PATH") {
-            PathBuf::from(test_path)
+        let opencode_paths = if let Ok(test_path) = std::env::var("GIT_AI_OPENCODE_STORAGE_PATH") {
+            vec![PathBuf::from(test_path)]
         } else {
-            Self::opencode_data_path().ok()?
+            Self::opencode_data_paths().ok()?
         };
 
-        // Try sqlite first
-        let db_path = Self::resolve_sqlite_db_path(&opencode_path);
-        if let Some(db_path) = db_path {
+        for opencode_path in opencode_paths {
+            let Some(db_path) = Self::resolve_sqlite_db_path(&opencode_path) else {
+                continue;
+            };
             let parent_id = Self::lookup_parent_session(&db_path, session_id);
             return Some((
                 StreamSource {
@@ -163,38 +164,34 @@ impl OpenCodePreset {
         .flatten()
     }
 
-    fn opencode_data_path() -> Result<PathBuf, GitAiError> {
+    fn opencode_data_paths() -> Result<Vec<PathBuf>, GitAiError> {
         #[cfg(target_os = "macos")]
         {
             let home = dirs::home_dir().ok_or_else(|| {
                 GitAiError::Generic("Could not determine home directory".to_string())
             })?;
-            Ok(home.join(".local").join("share").join("opencode"))
+            Ok(vec![home.join(".local").join("share").join("opencode")])
         }
 
         #[cfg(target_os = "linux")]
         {
             if let Ok(xdg_data) = std::env::var("XDG_DATA_HOME") {
-                Ok(PathBuf::from(xdg_data).join("opencode"))
+                Ok(vec![PathBuf::from(xdg_data).join("opencode")])
             } else {
                 let home = dirs::home_dir().ok_or_else(|| {
                     GitAiError::Generic("Could not determine home directory".to_string())
                 })?;
-                Ok(home.join(".local").join("share").join("opencode"))
+                Ok(vec![home.join(".local").join("share").join("opencode")])
             }
         }
 
         #[cfg(target_os = "windows")]
         {
-            if let Ok(app_data) = std::env::var("APPDATA") {
-                Ok(PathBuf::from(app_data).join("opencode"))
-            } else if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
-                Ok(PathBuf::from(local_app_data).join("opencode"))
-            } else {
-                Err(GitAiError::Generic(
-                    "Neither APPDATA nor LOCALAPPDATA is set".to_string(),
-                ))
-            }
+            Ok(Self::windows_data_paths(
+                crate::mdm::utils::home_dir(),
+                std::env::var_os("APPDATA").map(PathBuf::from),
+                std::env::var_os("LOCALAPPDATA").map(PathBuf::from),
+            ))
         }
 
         #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -203,6 +200,18 @@ impl OpenCodePreset {
                 "OpenCode storage path not supported on this platform".to_string(),
             ))
         }
+    }
+
+    #[cfg(any(target_os = "windows", test))]
+    fn windows_data_paths(
+        home: PathBuf,
+        app_data: Option<PathBuf>,
+        local_app_data: Option<PathBuf>,
+    ) -> Vec<PathBuf> {
+        let mut paths = vec![home.join(".local").join("share").join("opencode")];
+        paths.extend(app_data.into_iter().map(|path| path.join("opencode")));
+        paths.extend(local_app_data.into_iter().map(|path| path.join("opencode")));
+        paths
     }
 
     fn resolve_sqlite_db_path(path: &Path) -> Option<PathBuf> {
@@ -517,5 +526,25 @@ mod tests {
             }
             _ => panic!("Expected PreBashCall"),
         }
+    }
+
+    #[test]
+    fn test_windows_opencode_data_paths_prefer_xdg_layout() {
+        let home = PathBuf::from(r"C:\Users\test");
+        let app_data = PathBuf::from(r"C:\Users\test\AppData\Roaming");
+        let local_app_data = PathBuf::from(r"C:\Users\test\AppData\Local");
+
+        assert_eq!(
+            OpenCodePreset::windows_data_paths(
+                home.clone(),
+                Some(app_data.clone()),
+                Some(local_app_data.clone()),
+            ),
+            vec![
+                home.join(".local").join("share").join("opencode"),
+                app_data.join("opencode"),
+                local_app_data.join("opencode"),
+            ]
+        );
     }
 }

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -133,27 +133,40 @@ impl OpenCodePreset {
             Self::opencode_data_paths().ok()?
         };
 
+        Self::resolve_stream_source_from_paths(session_id, opencode_paths)
+    }
+
+    fn resolve_stream_source_from_paths(
+        session_id: &str,
+        opencode_paths: Vec<PathBuf>,
+    ) -> Option<(StreamSource, PathBuf)> {
+        let mut fallback = None;
+
         for opencode_path in opencode_paths {
             let Some(db_path) = Self::resolve_sqlite_db_path(&opencode_path) else {
                 continue;
             };
-            let parent_id = Self::lookup_parent_session(&db_path, session_id);
-            return Some((
-                StreamSource {
-                    path: db_path,
-                    format: StreamFormat::OpenCodeSqlite,
-                    session_id: generate_session_id(session_id, "opencode"),
-                    external_session_id: session_id.to_string(),
-                    external_parent_session_id: parent_id,
-                },
-                opencode_path,
-            ));
+
+            if fallback.is_none() {
+                fallback = Some((db_path.clone(), opencode_path.clone()));
+            }
+
+            if let Some(parent_id) = Self::lookup_session_parent(&db_path, session_id) {
+                return Some(Self::stream_source(
+                    session_id,
+                    db_path,
+                    opencode_path,
+                    parent_id,
+                ));
+            }
         }
 
-        None
+        fallback.map(|(db_path, opencode_path)| {
+            Self::stream_source(session_id, db_path, opencode_path, None)
+        })
     }
 
-    fn lookup_parent_session(db_path: &Path, session_id: &str) -> Option<String> {
+    fn lookup_session_parent(db_path: &Path, session_id: &str) -> Option<Option<String>> {
         let conn = crate::streams::agents::opencode::open_sqlite_readonly(db_path).ok()?;
         conn.query_row(
             "SELECT parent_id FROM session WHERE id = ?",
@@ -161,7 +174,24 @@ impl OpenCodePreset {
             |row| row.get::<_, Option<String>>(0),
         )
         .ok()
-        .flatten()
+    }
+
+    fn stream_source(
+        session_id: &str,
+        db_path: PathBuf,
+        opencode_path: PathBuf,
+        parent_id: Option<String>,
+    ) -> (StreamSource, PathBuf) {
+        (
+            StreamSource {
+                path: db_path,
+                format: StreamFormat::OpenCodeSqlite,
+                session_id: generate_session_id(session_id, "opencode"),
+                external_session_id: session_id.to_string(),
+                external_parent_session_id: parent_id,
+            },
+            opencode_path,
+        )
     }
 
     fn opencode_data_paths() -> Result<Vec<PathBuf>, GitAiError> {
@@ -546,5 +576,47 @@ mod tests {
                 local_app_data.join("opencode"),
             ]
         );
+    }
+
+    #[test]
+    fn test_resolve_stream_source_prefers_database_containing_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let stale_path = temp.path().join("stale");
+        let live_path = temp.path().join("live");
+        std::fs::create_dir_all(&stale_path).unwrap();
+        std::fs::create_dir_all(&live_path).unwrap();
+
+        let stale_db = stale_path.join("opencode.db");
+        let stale_conn = rusqlite::Connection::open(&stale_db).unwrap();
+        stale_conn
+            .execute(
+                "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT)",
+                [],
+            )
+            .unwrap();
+        drop(stale_conn);
+
+        let fixture_db = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("opencode-sqlite")
+            .join("opencode.db");
+        std::fs::copy(&fixture_db, live_path.join("opencode.db")).unwrap();
+
+        let (source, resolved_path) = OpenCodePreset::resolve_stream_source_from_paths(
+            "test-session-123",
+            vec![stale_path.clone(), live_path.clone()],
+        )
+        .expect("the database containing the session should be selected");
+
+        assert_eq!(resolved_path, live_path);
+        assert_eq!(source.path, live_path.join("opencode.db"));
+
+        let (_, fallback_path) = OpenCodePreset::resolve_stream_source_from_paths(
+            "missing-session",
+            vec![stale_path.clone(), live_path],
+        )
+        .expect("the first existing database should remain the fallback");
+        assert_eq!(fallback_path, stale_path);
     }
 }

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -485,7 +485,8 @@ fn test_opencode_e2e_checkpoint_and_commit() {
 }
 
 #[test]
-fn test_opencode_checkpoint_finds_model_in_xdg_data_path() {
+#[serial_test::serial]
+fn test_opencode_checkpoint_finds_model_in_platform_data_path() {
     let repo = TestRepo::new();
     let repo_root = repo.canonical_path();
     let file_path = repo_root.join("index.ts");
@@ -507,6 +508,13 @@ fn test_opencode_checkpoint_finds_model_in_xdg_data_path() {
     )
     .unwrap();
     let xdg_data_home = storage_path.parent().unwrap().to_str().unwrap();
+    // Linux resolves OpenCode data through XDG_DATA_HOME. On macOS and Windows,
+    // TestRepo redirects HOME/USERPROFILE to the same isolated test home.
+    let checkpoint_env = if cfg!(target_os = "linux") {
+        vec![("XDG_DATA_HOME", xdg_data_home)]
+    } else {
+        vec![]
+    };
 
     let pre_hook_input = json!({
         "hook_event_name": "PreToolUse",
@@ -518,7 +526,7 @@ fn test_opencode_checkpoint_finds_model_in_xdg_data_path() {
     .to_string();
     repo.git_ai_with_env(
         &["checkpoint", "opencode", "--hook-input", &pre_hook_input],
-        &[("XDG_DATA_HOME", xdg_data_home)],
+        &checkpoint_env,
     )
     .unwrap();
 
@@ -534,7 +542,7 @@ fn test_opencode_checkpoint_finds_model_in_xdg_data_path() {
     .to_string();
     repo.git_ai_with_env(
         &["checkpoint", "opencode", "--hook-input", &post_hook_input],
-        &[("XDG_DATA_HOME", xdg_data_home)],
+        &checkpoint_env,
     )
     .unwrap();
 

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -1,4 +1,5 @@
 use crate::test_utils::fixture_path;
+use crate::{repos::test_file::ExpectedLineExt, repos::test_repo::TestRepo};
 use git_ai::authorship::authorship_log_serialization::generate_session_id;
 use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
 use git_ai::error::GitAiError;
@@ -480,6 +481,76 @@ fn test_opencode_e2e_checkpoint_and_commit() {
     assert_eq!(
         session_record.agent_id.model, "gpt-5",
         "Session record model should be extracted from OpenCode SQLite fixture"
+    );
+}
+
+#[test]
+fn test_opencode_checkpoint_finds_model_in_xdg_data_path() {
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("index.ts");
+    fs::write(&file_path, "// initial\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let mut file = repo.filename("index.ts");
+    file.assert_committed_lines(lines!["// initial".unattributed_human()]);
+
+    let storage_path = repo
+        .test_home_path()
+        .join(".local")
+        .join("share")
+        .join("opencode");
+    fs::create_dir_all(&storage_path).unwrap();
+    fs::copy(
+        opencode_sqlite_fixture_path().join("opencode.db"),
+        storage_path.join("opencode.db"),
+    )
+    .unwrap();
+    let xdg_data_home = storage_path.parent().unwrap().to_str().unwrap();
+
+    let pre_hook_input = json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "test-session-123",
+        "cwd": repo_root,
+        "tool_name": "edit",
+        "tool_input": { "filePath": file_path }
+    })
+    .to_string();
+    repo.git_ai_with_env(
+        &["checkpoint", "opencode", "--hook-input", &pre_hook_input],
+        &[("XDG_DATA_HOME", xdg_data_home)],
+    )
+    .unwrap();
+
+    fs::write(&file_path, "// initial\n// AI edit\n").unwrap();
+
+    let post_hook_input = json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": "test-session-123",
+        "cwd": repo_root,
+        "tool_name": "edit",
+        "tool_input": { "filePath": file_path }
+    })
+    .to_string();
+    repo.git_ai_with_env(
+        &["checkpoint", "opencode", "--hook-input", &post_hook_input],
+        &[("XDG_DATA_HOME", xdg_data_home)],
+    )
+    .unwrap();
+
+    let commit = repo.stage_all_and_commit("Add AI line").unwrap();
+    file.assert_committed_lines(lines!["// initial".unattributed_human(), "// AI edit".ai(),]);
+
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("OpenCode checkpoint should record a session");
+    assert_eq!(
+        session.agent_id.model, "gpt-5",
+        "OpenCode should load its model from ~/.local/share/opencode/opencode.db"
     );
 }
 

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -15,6 +15,7 @@ const AI_AUTHOR_NAMES: &[&str] = &[
     "codex",
     "gemini",
     "amp",
+    "opencode",
     "windsurf",
     "devin",
     "cloud-agent",


### PR DESCRIPTION
Fixes #2119

## Summary
- prefer `%USERPROFILE%\.local\share\opencode` when locating the OpenCode database on Windows
- choose the first candidate database containing the requested session, with the first existing database retained as a bounded compatibility fallback
- retain `%APPDATA%\opencode` and `%LOCALAPPDATA%\opencode` as fallback locations
- reuse the existing SQLite resolver and recognize OpenCode as an AI author in line-level integration assertions

## Test coverage
- added path-ordering and stale-database/session-selection unit regressions
- added a serialized `TestRepo` end-to-end checkpoint/commit regression that verifies line attribution and model extraction from the platform data directory
- `task test TEST_FILTER=opencode` (38 unit and 15 integration tests passed)
- `task lint`
- `task fmt`

## Full-suite note
`task test` reaches three unrelated daemon telemetry/await failures in `tests/daemon_mode.rs`. The exact `await_is_marked_beta_and_returns_promptly_when_idle` failure reproduces on an unmodified detached `origin/main` worktree in this environment.