### PR TITLE
Preserve attribution across rewritten content

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -197,6 +197,14 @@ struct CommitMetadataSessionSelection {
 pub(crate) struct AttributionRecoveryContext<'a> {
     pub(crate) file_timestamps: Option<&'a FileTimestampsByPath>,
     pub(crate) before_external_recovery: Option<&'a dyn Fn(&UnknownLinesByFile)>,
+    /// Exact wall-clock interval of a commit-producing Git command. This is
+    /// stronger evidence than filesystem mtimes for commands such as `git am`,
+    /// which can create multiple commits and can delete an early patch's files
+    /// before the command returns.
+    pub(crate) bash_command_window: Option<(u128, u128)>,
+    /// Require a pre-tool index boundary so unrelated pre-staged lines cannot
+    /// be claimed by a regular commit executed inside the Bash call.
+    pub(crate) bash_scope_to_pre_index: bool,
 }
 
 pub(crate) fn recover_attribution(
@@ -212,27 +220,85 @@ pub(crate) fn recover_attribution(
         return Ok(());
     }
 
+    // Every traced Git command has a start/finish window, but only a command
+    // actually enclosed by an AI Bash tool call has a pre-tool index boundary.
+    // Do not disable edge recovery merely because command timestamps exist.
+    let bash_scope_to_pre_index = if context.bash_scope_to_pre_index
+        && let Some((started_at_ns, finished_at_ns)) = context.bash_command_window
+    {
+        bash_index_baseline_candidate_exists(repo, started_at_ns, finished_at_ns)?
+    } else {
+        false
+    };
+
+    if bash_scope_to_pre_index
+        && let Some((started_at_ns, finished_at_ns)) = context.bash_command_window
+    {
+        enforce_bash_pre_index_boundary(
+            repo,
+            commit_sha,
+            authorship_log,
+            committed_hunks,
+            started_at_ns,
+            finished_at_ns,
+        )?;
+    }
+
     if unknown_lines_by_file(authorship_log, committed_hunks).is_empty() {
         return Ok(());
     }
 
-    recover_bash_mtime(
-        repo,
-        parent_sha,
-        commit_sha,
-        human_author,
-        authorship_log,
-        committed_hunks,
-        context.file_timestamps,
-    )?;
+    if let Some((started_at_ns, finished_at_ns)) = context.bash_command_window {
+        let (matched_command_window, saw_overlapping_bash_call) = recover_bash_command_window(
+            repo,
+            parent_sha,
+            commit_sha,
+            human_author,
+            authorship_log,
+            committed_hunks,
+            started_at_ns,
+            finished_at_ns,
+            bash_scope_to_pre_index,
+        )?;
+        // A traced `git commit` normally runs after the Bash tool call that
+        // edited the file, rather than inside it. Preserve the established
+        // mtime recovery path in that case. When a repository-compatible Bash
+        // call does overlap the Git command, its exact window (and optional
+        // pre-index boundary) is authoritative and must not be widened.
+        if !matched_command_window && !saw_overlapping_bash_call {
+            recover_bash_mtime(
+                repo,
+                parent_sha,
+                commit_sha,
+                human_author,
+                authorship_log,
+                committed_hunks,
+                context.file_timestamps,
+            )?;
+        }
+    } else {
+        recover_bash_mtime(
+            repo,
+            parent_sha,
+            commit_sha,
+            human_author,
+            authorship_log,
+            committed_hunks,
+            context.file_timestamps,
+        )?;
+    }
 
-    recover_adjacent_edges(
-        repo,
-        parent_sha,
-        commit_sha,
-        authorship_log,
-        committed_hunks,
-    );
+    // The pre-index tree is an exact provenance boundary. Extending AI ranges
+    // to adjacent unknown lines would cross back into pre-staged human work.
+    if !bash_scope_to_pre_index {
+        recover_adjacent_edges(
+            repo,
+            parent_sha,
+            commit_sha,
+            authorship_log,
+            committed_hunks,
+        );
+    }
     let unknown_after_edges = unknown_lines_by_file(authorship_log, committed_hunks);
     if unknown_after_edges.is_empty() {
         return Ok(());
@@ -273,6 +339,253 @@ pub(crate) fn recover_attribution(
     Ok(())
 }
 
+/// Remove claims made by the selected Bash session for committed lines that
+/// were already present in the index at PreToolUse. This also closes the race
+/// where PostToolUse checkpoints a whole worktree file before asynchronous
+/// commit finalization reaches it.
+fn enforce_bash_pre_index_boundary(
+    repo: &Repository,
+    commit_sha: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    started_at_ns: u128,
+    finished_at_ns: u128,
+) -> Result<(), GitAiError> {
+    let repo_work_dir = repo_worktree_key(repo)?;
+    let candidates = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(db) => db.candidates_overlapping_window(started_at_ns, finished_at_ns)?,
+            Err(_) => Vec::new(),
+        },
+        Err(_) => Vec::new(),
+    };
+    let existing_commit_sessions = existing_commit_session_ids(authorship_log);
+    let Some(candidate) = candidates
+        .iter()
+        .filter_map(|candidate| {
+            bash_command_window_candidate_tier(candidate, &existing_commit_sessions, &repo_work_dir)
+                .map(|tier| (candidate, tier))
+        })
+        .min_by(|(left, left_tier), (right, right_tier)| {
+            left_tier
+                .score()
+                .cmp(&right_tier.score())
+                .then_with(|| right.start_time_ns.cmp(&left.start_time_ns))
+                .then_with(|| right.id.cmp(&left.id))
+        })
+        .map(|(candidate, _)| candidate)
+    else {
+        return Ok(());
+    };
+    let Some(pre_index_tree) = candidate
+        .metadata
+        .get(crate::commands::checkpoint_agent::bash_tool::PRE_INDEX_TREE_METADATA_KEY)
+    else {
+        return Ok(());
+    };
+
+    let added_since_tool_start = repo.diff_added_lines(pre_index_tree, commit_sha, None)?;
+    let prompt_hashes = authorship_log
+        .metadata
+        .prompts
+        .iter()
+        .filter(|(_, prompt)| {
+            prompt.agent_id.tool == candidate.agent_id.tool
+                && prompt.agent_id.id == candidate.agent_id.id
+        })
+        .map(|(hash, _)| hash.clone())
+        .chain(
+            authorship_log
+                .metadata
+                .sessions
+                .iter()
+                .filter(|(_, session)| {
+                    session.agent_id.tool == candidate.agent_id.tool
+                        && session.agent_id.id == candidate.agent_id.id
+                })
+                .map(|(hash, _)| hash.clone()),
+        )
+        .collect::<HashSet<_>>();
+    if prompt_hashes.is_empty() {
+        return Ok(());
+    }
+
+    for file in &mut authorship_log.attestations {
+        let Some(committed_ranges) = committed_hunks.get(&file.file_path) else {
+            continue;
+        };
+        let allowed = added_since_tool_start
+            .get(&file.file_path)
+            .map(|lines| lines.iter().copied().collect::<HashSet<_>>())
+            .unwrap_or_default();
+        let disallowed = committed_ranges
+            .iter()
+            .flat_map(LineRange::expand)
+            .filter(|line| !allowed.contains(line))
+            .collect::<Vec<_>>();
+        let disallowed = LineRange::compress_lines(&disallowed);
+        if disallowed.is_empty() {
+            continue;
+        }
+        for entry in &mut file.entries {
+            let belongs_to_candidate = prompt_hashes
+                .iter()
+                .any(|hash| entry.hash == *hash || entry.hash.starts_with(&format!("{}::", hash)));
+            if belongs_to_candidate {
+                entry.remove_line_ranges(&disallowed);
+            }
+        }
+        file.entries.retain(|entry| !entry.line_ranges.is_empty());
+    }
+    authorship_log
+        .attestations
+        .retain(|file| !file.entries.is_empty());
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn recover_bash_command_window(
+    repo: &Repository,
+    parent_sha: &str,
+    commit_sha: &str,
+    human_author: &str,
+    authorship_log: &mut AuthorshipLog,
+    committed_hunks: &HashMap<String, Vec<LineRange>>,
+    started_at_ns: u128,
+    finished_at_ns: u128,
+    scope_to_pre_index: bool,
+) -> Result<(bool, bool), GitAiError> {
+    let repo_work_dir = repo_worktree_key(repo)?;
+    let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
+    if unknown_by_file.is_empty() {
+        return Ok((false, false));
+    }
+
+    let candidates = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(db) => db.candidates_overlapping_window(started_at_ns, finished_at_ns)?,
+            Err(_) => Vec::new(),
+        },
+        Err(_) => Vec::new(),
+    };
+    let existing_commit_sessions = existing_commit_session_ids(authorship_log);
+    let saw_overlapping_bash_call = !candidates.is_empty();
+    let Some((candidate, tier)) = candidates
+        .iter()
+        .filter_map(|candidate| {
+            bash_command_window_candidate_tier(candidate, &existing_commit_sessions, &repo_work_dir)
+                .map(|tier| (candidate, tier))
+        })
+        .min_by(|(left, left_tier), (right, right_tier)| {
+            left_tier
+                .score()
+                .cmp(&right_tier.score())
+                .then_with(|| right.start_time_ns.cmp(&left.start_time_ns))
+                .then_with(|| right.id.cmp(&left.id))
+        })
+    else {
+        // An overlapping Bash call that was authoritatively discovered in a
+        // different repository must also suppress the looser mtime fallback.
+        // Otherwise imported files can be stolen merely because their mtimes
+        // happen to land inside that unrelated call.
+        return Ok((false, saw_overlapping_bash_call));
+    };
+
+    let scoped_unknown_by_file = if let Some(pre_index_tree) = candidate
+        .metadata
+        .get(crate::commands::checkpoint_agent::bash_tool::PRE_INDEX_TREE_METADATA_KEY)
+    {
+        let added_since_tool_start = repo.diff_added_lines(pre_index_tree, commit_sha, None)?;
+        unknown_by_file
+            .into_iter()
+            .filter_map(|(file_path, unknown_lines)| {
+                let allowed = added_since_tool_start.get(&file_path)?;
+                let allowed = allowed.iter().copied().collect::<HashSet<_>>();
+                let scoped = unknown_lines
+                    .into_iter()
+                    .filter(|line| allowed.contains(line))
+                    .collect::<Vec<_>>();
+                (!scoped.is_empty()).then_some((file_path, scoped))
+            })
+            .collect::<BTreeMap<_, _>>()
+    } else if scope_to_pre_index {
+        // Without the baseline, a regular commit can contain work staged
+        // before the AI call. Prefer unknown attribution to a false claim.
+        return Ok((true, true));
+    } else {
+        unknown_by_file
+    };
+    if scoped_unknown_by_file.is_empty() {
+        return Ok((true, true));
+    }
+
+    let trace_id = generate_trace_id();
+    let session_id = generate_session_id(&candidate.agent_id.id, &candidate.agent_id.tool);
+    let author_id = format!("{}::{}", session_id, trace_id);
+    insert_session_record(
+        authorship_log,
+        &session_id,
+        &candidate.agent_id,
+        human_author,
+    );
+    for (file_path, unknown_lines) in scoped_unknown_by_file {
+        add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
+        record_recovery_metric(RecoveryMetricInput {
+            repo,
+            parent_sha,
+            commit_sha,
+            file_path: &file_path,
+            author_id: &author_id,
+            session_id: &session_id,
+            trace_id: &trace_id,
+            tool: &candidate.agent_id.tool,
+            model: &candidate.agent_id.model,
+            external_session_id: &candidate.agent_id.id,
+            external_tool_use_id: Some(&candidate.tool_use_id),
+            edit_kind: "bash",
+            checkpoint_type: "recovered_bash_command_window",
+            recovered_line_count: unknown_lines.len() as u32,
+            metadata: json!({
+                "solver": "bash_command_window",
+                "target_repo_work_dir": repo_work_dir,
+                "selected_bash_call_id": candidate.id,
+                "selected_tool_use_id": candidate.tool_use_id,
+                "selected_command": candidate.command,
+                "command_started_at_ns": started_at_ns,
+                "command_finished_at_ns": finished_at_ns,
+                "selection_tier": tier.as_str(),
+                "candidate_count": candidates.len(),
+                "pre_index_tree": candidate.metadata.get(
+                    crate::commands::checkpoint_agent::bash_tool::PRE_INDEX_TREE_METADATA_KEY
+                ),
+            }),
+            event_ts: Some((candidate.start_time_ns / 1_000_000_000) as u32),
+        });
+    }
+    Ok((true, true))
+}
+
+fn bash_command_window_candidate_tier(
+    candidate: &BashCheckpointCall,
+    existing_commit_sessions: &HashSet<String>,
+    target_repo_work_dir: &str,
+) -> Option<BashCandidateTier> {
+    // A discovered repo is authoritative. Do not fall back to a broad common
+    // parent cwd when the Bash hook explicitly identified a different repo.
+    let location_tier = match candidate.repo_work_dir.as_deref() {
+        Some(repo_work_dir) => path_is_equal_or_child(target_repo_work_dir, repo_work_dir)
+            .then_some(BashCandidateTier::WorkdirAncestor),
+        None => path_is_equal_or_child(target_repo_work_dir, &candidate.original_cwd)
+            .then_some(BashCandidateTier::CwdAncestor),
+    }?;
+    let session_id = bash_candidate_session_id(candidate);
+    if existing_commit_sessions.contains(&session_id) {
+        Some(BashCandidateTier::ExistingCommitSession)
+    } else {
+        Some(location_tier)
+    }
+}
+
 pub(crate) fn matching_session_event_candidate_exists(
     timestamps_ns: &[u128],
     target_repo_url: &str,
@@ -293,6 +606,27 @@ pub(crate) fn matching_session_event_candidate_exists(
     };
 
     Ok(select_best_session_event_candidate(&candidates, timestamps_ns, target_repo_url).is_some())
+}
+
+pub(crate) fn bash_index_baseline_candidate_exists(
+    repo: &Repository,
+    started_at_ns: u128,
+    finished_at_ns: u128,
+) -> Result<bool, GitAiError> {
+    let repo_work_dir = repo_worktree_key(repo)?;
+    let candidates = match crate::daemon::bash_history_db::BashHistoryDatabase::global() {
+        Ok(db) => match db.lock() {
+            Ok(db) => db.candidates_overlapping_window(started_at_ns, finished_at_ns)?,
+            Err(_) => Vec::new(),
+        },
+        Err(_) => Vec::new(),
+    };
+    Ok(candidates.iter().any(|candidate| {
+        bash_command_window_candidate_tier(candidate, &HashSet::new(), &repo_work_dir).is_some()
+            && candidate.metadata.contains_key(
+                crate::commands::checkpoint_agent::bash_tool::PRE_INDEX_TREE_METADATA_KEY,
+            )
+    }))
 }
 
 fn recover_bash_mtime(
@@ -1905,6 +2239,23 @@ mod tests {
             external_tool_use_id: Some(format!("tool-use-{row_id}")),
             repo_url: repo_url.map(ToString::to_string),
         }
+    }
+
+    #[test]
+    fn command_window_candidate_rejects_explicitly_different_repo() {
+        let sessions = HashSet::new();
+        let other_repo = bash_call(1, "session", "tool", "/workspace/other", 1, Some(10));
+        assert_eq!(
+            bash_command_window_candidate_tier(&other_repo, &sessions, "/workspace/target"),
+            None
+        );
+
+        let unresolved_parent =
+            unresolved_bash_attempt(2, "session", "tool", "/workspace", 1, Some(10));
+        assert_eq!(
+            bash_command_window_candidate_tier(&unresolved_parent, &sessions, "/workspace/target"),
+            Some(BashCandidateTier::CwdAncestor)
+        );
     }
 
     #[test]

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -88,6 +88,7 @@ pub fn post_commit_from_working_log(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
     repo: &Repository,
     base_commit: Option<String>,
@@ -96,6 +97,59 @@ pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
     supress_output: bool,
     recovery_file_timestamps: Option<&FileTimestampsByPath>,
     before_external_recovery: Option<&dyn Fn(&UnknownLinesByFile)>,
+    bash_command_window: Option<(u128, u128)>,
+) -> Result<(String, AuthorshipLog), GitAiError> {
+    post_commit_from_working_log_with_recovery_timestamps_and_empty_note_policy(
+        repo,
+        base_commit,
+        commit_sha,
+        human_author,
+        supress_output,
+        recovery_file_timestamps,
+        before_external_recovery,
+        bash_command_window,
+        true,
+    )
+}
+
+/// Finalize a daemon-observed merge commit without creating a schema-only note
+/// when the merge contains no attribution. Attributed and conflict-resolution
+/// merges still write their normal note.
+#[allow(dead_code, clippy::too_many_arguments)]
+pub(crate) fn post_merge_commit_from_working_log_with_recovery_timestamps(
+    repo: &Repository,
+    base_commit: Option<String>,
+    commit_sha: String,
+    human_author: String,
+    supress_output: bool,
+    recovery_file_timestamps: Option<&FileTimestampsByPath>,
+    before_external_recovery: Option<&dyn Fn(&UnknownLinesByFile)>,
+    bash_command_window: Option<(u128, u128)>,
+) -> Result<(String, AuthorshipLog), GitAiError> {
+    post_commit_from_working_log_with_recovery_timestamps_and_empty_note_policy(
+        repo,
+        base_commit,
+        commit_sha,
+        human_author,
+        supress_output,
+        recovery_file_timestamps,
+        before_external_recovery,
+        bash_command_window,
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn post_commit_from_working_log_with_recovery_timestamps_and_empty_note_policy(
+    repo: &Repository,
+    base_commit: Option<String>,
+    commit_sha: String,
+    human_author: String,
+    supress_output: bool,
+    recovery_file_timestamps: Option<&FileTimestampsByPath>,
+    before_external_recovery: Option<&dyn Fn(&UnknownLinesByFile)>,
+    bash_command_window: Option<(u128, u128)>,
+    write_empty_note: bool,
 ) -> Result<(String, AuthorshipLog), GitAiError> {
     post_commit_from_working_log_with_transform_context(
         repo,
@@ -106,11 +160,15 @@ pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
             supress_output,
             compute_stats: true,
             recover_attribution: true,
+            write_note: true,
         },
         PostCommitContext {
             precomputed_parent_diff: None,
             recovery_file_timestamps,
             before_external_recovery,
+            bash_command_window,
+            bash_scope_to_pre_index: bash_command_window.is_some(),
+            write_empty_note,
         },
         Ok,
     )
@@ -121,6 +179,7 @@ pub(crate) struct PostCommitOptions {
     pub supress_output: bool,
     pub compute_stats: bool,
     pub recover_attribution: bool,
+    pub write_note: bool,
 }
 
 pub(crate) struct PostCommitDetailedResult {
@@ -134,6 +193,9 @@ struct PostCommitContext<'a> {
     precomputed_parent_diff: Option<&'a DiffTreeResult>,
     recovery_file_timestamps: Option<&'a FileTimestampsByPath>,
     before_external_recovery: Option<&'a dyn Fn(&UnknownLinesByFile)>,
+    bash_command_window: Option<(u128, u128)>,
+    bash_scope_to_pre_index: bool,
+    write_empty_note: bool,
 }
 
 pub fn post_commit_from_working_log_with_transform<F>(
@@ -156,6 +218,7 @@ where
             supress_output,
             compute_stats: true,
             recover_attribution: true,
+            write_note: true,
         },
         transform,
     )
@@ -204,6 +267,9 @@ where
             precomputed_parent_diff: None,
             recovery_file_timestamps: None,
             before_external_recovery: None,
+            bash_command_window: None,
+            bash_scope_to_pre_index: false,
+            write_empty_note: true,
         },
         transform,
     )
@@ -237,6 +303,9 @@ where
             precomputed_parent_diff,
             recovery_file_timestamps: None,
             before_external_recovery: None,
+            bash_command_window: None,
+            bash_scope_to_pre_index: false,
+            write_empty_note: true,
         },
         transform,
     )
@@ -406,6 +475,8 @@ where
             AttributionRecoveryContext {
                 file_timestamps: context.recovery_file_timestamps,
                 before_external_recovery: context.before_external_recovery,
+                bash_command_window: context.bash_command_window,
+                bash_scope_to_pre_index: context.bash_scope_to_pre_index,
             },
         )?;
         authorship_log.metadata.base_commit_sha = commit_sha.clone();
@@ -431,7 +502,9 @@ where
         .serialize_to_string()
         .map_err(|_| GitAiError::Generic("Failed to serialize authorship log".to_string()))?;
 
-    write_note(repo, &commit_sha, &authorship_note_str)?;
+    if options.write_note && (context.write_empty_note || !authorship_log.attestations.is_empty()) {
+        write_note(repo, &commit_sha, &authorship_note_str)?;
+    }
 
     // Compute stats once (needed for both metrics and terminal output), unless preflight
     // estimate predicts this would be too expensive for the commit hook path.
@@ -567,6 +640,55 @@ where
         authorship_log,
         authorship_note: authorship_note_str,
     })
+}
+
+/// Finalize every commit created by one command while keeping external Git
+/// process count constant. Parent-to-commit diffs and note writes are batched;
+/// recovery is scoped to the exact command window so an enclosing AI Bash call
+/// can attribute imported lines even when an early patch's file no longer
+/// exists when the mailbox finishes.
+#[allow(dead_code)]
+pub(crate) fn post_commit_sequence_from_working_log_with_bash_command_window(
+    repo: &Repository,
+    transitions: &[(String, String)],
+    human_author: String,
+    bash_command_window: (u128, u128),
+) -> Result<Vec<(String, AuthorshipLog)>, GitAiError> {
+    if transitions.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let diffs = crate::authorship::rewrite::compute_diff_trees_batch(repo, transitions)?;
+    let mut results = Vec::with_capacity(transitions.len());
+    let mut note_writes = Vec::with_capacity(transitions.len());
+    for ((parent_sha, commit_sha), diff) in transitions.iter().zip(diffs.iter()) {
+        let detailed = post_commit_from_working_log_with_transform_context_detailed(
+            repo,
+            Some(parent_sha.clone()),
+            commit_sha.clone(),
+            human_author.clone(),
+            PostCommitOptions {
+                supress_output: true,
+                compute_stats: false,
+                recover_attribution: true,
+                write_note: false,
+            },
+            PostCommitContext {
+                precomputed_parent_diff: Some(diff),
+                recovery_file_timestamps: None,
+                before_external_recovery: None,
+                bash_command_window: Some(bash_command_window),
+                bash_scope_to_pre_index: false,
+                write_empty_note: true,
+            },
+            Ok,
+        )?;
+        debug_assert_eq!(detailed.commit_sha, *commit_sha);
+        note_writes.push((detailed.commit_sha.clone(), detailed.authorship_note));
+        results.push((detailed.commit_sha, detailed.authorship_log));
+    }
+    crate::git::notes_api::write_notes_batch(repo, &note_writes)?;
+    Ok(results)
 }
 
 fn commit_tree_snapshot_for_files(
@@ -784,6 +906,8 @@ pub(crate) fn post_commit_amend_with_recovery_timestamps_detailed(
         AttributionRecoveryContext {
             file_timestamps: recovery_file_timestamps,
             before_external_recovery,
+            bash_command_window: None,
+            bash_scope_to_pre_index: false,
         },
     )?;
     authorship_log.metadata.base_commit_sha = amended_commit.to_string();

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::authorship::authorship_log::LineRange;
 use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::authorship::hunk_shift::{DiffHunk, parse_hunk_header};
 use crate::config::Config;
@@ -396,7 +397,13 @@ pub(crate) fn handle_rewrite_event_with_metrics(
             ref source_head,
             ref squash_commit,
             ref onto,
-        } => handle_squash_merge(repo, source_head, squash_commit, onto),
+        } => handle_squash_merge(
+            repo,
+            source_head,
+            squash_commit,
+            onto,
+            RewriteMetricOperation::SquashMerge,
+        ),
         RewriteEvent::NonFastForward {
             ref old_tip,
             ref new_tip,
@@ -475,11 +482,266 @@ pub(crate) fn handle_non_fast_forward_rewrite_with_operation(
     ))
 }
 
+/// Reconstruct notes for whole-history filters whose rewritten graph can be
+/// disconnected from the original graph (notably root-commit rewrites).
+/// `range-diff` requires a merge base, so pair the two reachable histories by
+/// stable patch id with the existing ordered fallback used by cherry-pick.
+#[allow(dead_code)]
+pub(crate) fn handle_filter_history_rewrite(
+    repo: &Repository,
+    old_tip: &str,
+    new_tip: &str,
+) -> Result<RewriteOutcome, GitAiError> {
+    fn reachable(repo: &Repository, tip: &str) -> Result<Vec<String>, GitAiError> {
+        let mut args = repo.global_args_for_exec();
+        args.extend([
+            "rev-list".to_string(),
+            "--reverse".to_string(),
+            "--topo-order".to_string(),
+            tip.to_string(),
+        ]);
+        let output = exec_git(&args)?;
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|oid| !oid.is_empty())
+            .map(ToOwned::to_owned)
+            .collect())
+    }
+
+    let old_commits = reachable(repo, old_tip)?;
+    let new_commits = reachable(repo, new_tip)?;
+    let mappings = crate::authorship::rewrite_cherry_pick::match_cherry_pick_pairs(
+        repo,
+        &old_commits,
+        &new_commits,
+    )?;
+    if mappings.is_empty() {
+        return Ok(RewriteOutcome::empty());
+    }
+    let source_shas = mappings
+        .iter()
+        .map(|(source, _)| source.clone())
+        .collect::<Vec<_>>();
+    crate::git::sync_authorship::fetch_missing_notes_for_commits(repo, &source_shas)?;
+    let shifted_notes = shift_authorship_notes_merging_existing_with_notes(repo, &mappings)?;
+    if !rewrite_metrics_enabled() {
+        return Ok(RewriteOutcome::empty());
+    }
+    let metric_commits =
+        metric_commits_from_mappings(&mappings, RewriteMetricOperation::NonFastForward);
+    Ok(RewriteOutcome::from_metric_commits(
+        attach_authorship_notes(metric_commits, shifted_notes),
+    ))
+}
+
+#[allow(dead_code)]
+pub(crate) struct CherryPickMainlineSpec {
+    pub source_merge: String,
+    pub new_commit: String,
+    pub mainline_parent: String,
+    pub destination_parent: String,
+}
+
+/// History-aware mainline cherry-pick reconstruction with a constant Git
+/// process count. A merge commit's own note often omits lines inherited from a
+/// side parent, so exact source->destination note shifting is insufficient.
+#[allow(dead_code)]
+pub(crate) fn handle_cherry_pick_mainlines(
+    repo: &Repository,
+    specs: &[CherryPickMainlineSpec],
+) -> Result<RewriteOutcome, GitAiError> {
+    use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
+
+    if specs.is_empty() {
+        return Ok(RewriteOutcome::empty());
+    }
+
+    let mut rev_args = repo.global_args_for_exec();
+    rev_args.extend([
+        "rev-list".to_string(),
+        "--topo-order".to_string(),
+        "--parents".to_string(),
+    ]);
+    rev_args.extend(specs.iter().map(|spec| spec.source_merge.clone()));
+    let rev_output = exec_git(&rev_args)?;
+    let mut history_order = Vec::new();
+    let mut parents_by_commit: HashMap<String, Vec<String>> = HashMap::new();
+    for line in String::from_utf8_lossy(&rev_output.stdout).lines() {
+        let mut fields = line.split_whitespace();
+        let Some(commit) = fields.next() else {
+            continue;
+        };
+        history_order.push(commit.to_string());
+        parents_by_commit.insert(commit.to_string(), fields.map(ToOwned::to_owned).collect());
+    }
+
+    fn reachable_from(
+        tip: &str,
+        parents_by_commit: &HashMap<String, Vec<String>>,
+    ) -> HashSet<String> {
+        let mut reachable = HashSet::new();
+        let mut stack = vec![tip.to_string()];
+        while let Some(commit) = stack.pop() {
+            if !reachable.insert(commit.clone()) {
+                continue;
+            }
+            if let Some(parents) = parents_by_commit.get(&commit) {
+                stack.extend(parents.iter().cloned());
+            }
+        }
+        reachable
+    }
+
+    let mut ranges = Vec::with_capacity(specs.len());
+    let mut all_source_commits = Vec::new();
+    for spec in specs {
+        let source_reachable = reachable_from(&spec.source_merge, &parents_by_commit);
+        let excluded = reachable_from(&spec.mainline_parent, &parents_by_commit);
+        let range = history_order
+            .iter()
+            .filter(|commit| source_reachable.contains(*commit) && !excluded.contains(*commit))
+            .cloned()
+            .collect::<Vec<_>>();
+        for commit in &range {
+            if !all_source_commits.contains(commit) {
+                all_source_commits.push(commit.clone());
+            }
+        }
+        ranges.push(range);
+    }
+
+    crate::git::sync_authorship::fetch_missing_notes_for_commits(repo, &all_source_commits)?;
+    let source_notes = notes_api::read_notes_batch(repo, &all_source_commits)?;
+    let destination_shas = specs
+        .iter()
+        .map(|spec| spec.new_commit.clone())
+        .collect::<Vec<_>>();
+    let target_notes = notes_api::read_notes_batch(repo, &destination_shas)?;
+
+    let mut diff_pairs = Vec::new();
+    let mut shift_index = HashMap::new();
+    let mut added_index = Vec::with_capacity(specs.len());
+    for (spec_index, spec) in specs.iter().enumerate() {
+        for source in ranges[spec_index]
+            .iter()
+            .filter(|source| source_notes.contains_key(*source))
+        {
+            shift_index.insert((spec_index, source.clone()), diff_pairs.len());
+            diff_pairs.push((source.clone(), spec.new_commit.clone()));
+        }
+        added_index.push(diff_pairs.len());
+        diff_pairs.push((spec.destination_parent.clone(), spec.new_commit.clone()));
+    }
+    let diffs = compute_diff_trees_batch(repo, &diff_pairs)?;
+
+    let mut writes = Vec::new();
+    let mut metrics = Vec::new();
+    for (spec_index, spec) in specs.iter().enumerate() {
+        let mut source_log = AuthorshipLog::default();
+        for source in &ranges[spec_index] {
+            let Some(raw) = source_notes.get(source) else {
+                continue;
+            };
+            let Ok(mut log) = AuthorshipLog::deserialize_from_string(raw) else {
+                continue;
+            };
+            let Some(index) = shift_index.get(&(spec_index, source.clone())).copied() else {
+                continue;
+            };
+            let shift = &diffs[index];
+            for (old_path, new_path) in &shift.renames {
+                for attestation in &mut log.attestations {
+                    if attestation.file_path == *old_path {
+                        attestation.file_path = new_path.clone();
+                    }
+                }
+            }
+            if !shift.hunks_by_file.is_empty() {
+                log.attestations = log
+                    .attestations
+                    .iter()
+                    .filter_map(|file| match shift.hunks_by_file.get(&file.file_path) {
+                        Some(hunks) => apply_hunk_shifts_to_file_attestation(file, hunks),
+                        None => Some(file.clone()),
+                    })
+                    .collect();
+            }
+            merge_authorship_logs(&mut source_log, &log);
+        }
+
+        let added_lines = &diffs[added_index[spec_index]].added_lines_by_file;
+        clip_authorship_log_to_lines(&mut source_log, added_lines);
+        source_log.metadata.base_commit_sha = spec.new_commit.clone();
+        let final_log = target_notes
+            .get(&spec.new_commit)
+            .and_then(|raw| AuthorshipLog::deserialize_from_string(raw).ok())
+            .map(|resolution| {
+                crate::authorship::conflict_resolution::merge_conflict_resolution_authorship(
+                    Some(source_log.clone()),
+                    resolution,
+                    &spec.new_commit,
+                )
+            })
+            .unwrap_or(source_log);
+        if final_log.attestations.is_empty() {
+            continue;
+        }
+        let note = final_log.serialize_to_string().map_err(|error| {
+            GitAiError::Generic(format!(
+                "failed to serialize mainline cherry-pick authorship log: {error}"
+            ))
+        })?;
+        writes.push((spec.new_commit.clone(), note.clone()));
+        if rewrite_metrics_enabled() {
+            metrics.push(
+                RewriteMetricCommit::new(
+                    spec.new_commit.clone(),
+                    ranges[spec_index].clone(),
+                    RewriteMetricOperation::CherryPick,
+                )
+                .with_parent_sha(spec.destination_parent.clone())
+                .with_parent_diff(diffs[added_index[spec_index]].clone())
+                .with_authorship_note(note),
+            );
+        }
+    }
+    if !writes.is_empty() {
+        notes_api::write_notes_batch(repo, &writes)?;
+    }
+    Ok(RewriteOutcome::from_metric_commits(metrics))
+}
+
+#[allow(dead_code)]
+fn clip_authorship_log_to_lines(
+    log: &mut AuthorshipLog,
+    allowed_by_file: &HashMap<String, Vec<u32>>,
+) {
+    for file in &mut log.attestations {
+        let allowed = allowed_by_file
+            .get(&file.file_path)
+            .map(|lines| lines.iter().copied().collect::<HashSet<_>>())
+            .unwrap_or_default();
+        for entry in &mut file.entries {
+            let retained = entry
+                .line_ranges
+                .iter()
+                .flat_map(LineRange::expand)
+                .filter(|line| allowed.contains(line))
+                .collect::<Vec<_>>();
+            entry.line_ranges = LineRange::compress_lines(&retained);
+        }
+        file.entries.retain(|entry| !entry.line_ranges.is_empty());
+    }
+    log.attestations.retain(|file| !file.entries.is_empty());
+}
+
 fn handle_squash_merge(
     repo: &Repository,
     source_head: &str,
     squash_commit: &str,
     onto: &str,
+    operation: RewriteMetricOperation,
 ) -> Result<RewriteOutcome, GitAiError> {
     use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
 
@@ -535,11 +797,23 @@ fn handle_squash_merge(
             && !repo.storage.has_working_log(onto)
         {
             let note = write_authorship_log_for_metrics(repo, squash_commit, existing_log)?;
-            return Ok(squash_metric_outcome(squash_commit, &sources, onto, note));
+            return Ok(squash_metric_outcome(
+                squash_commit,
+                &sources,
+                onto,
+                note,
+                operation,
+            ));
         }
         let note =
             post_squash_resolution_working_log(repo, onto, squash_commit, existing_target_log)?;
-        return Ok(squash_metric_outcome(squash_commit, &sources, onto, note));
+        return Ok(squash_metric_outcome(
+            squash_commit,
+            &sources,
+            onto,
+            note,
+            operation,
+        ));
     }
 
     // Add the final source_head→squash_commit pair
@@ -624,10 +898,22 @@ fn handle_squash_merge(
     if repo.storage.has_working_log(onto) {
         let note =
             post_squash_resolution_working_log(repo, onto, squash_commit, Some(shifted_log))?;
-        Ok(squash_metric_outcome(squash_commit, &sources, onto, note))
+        Ok(squash_metric_outcome(
+            squash_commit,
+            &sources,
+            onto,
+            note,
+            operation,
+        ))
     } else {
         let note = write_authorship_log_for_metrics(repo, squash_commit, &shifted_log)?;
-        Ok(squash_metric_outcome(squash_commit, &sources, onto, note))
+        Ok(squash_metric_outcome(
+            squash_commit,
+            &sources,
+            onto,
+            note,
+            operation,
+        ))
     }
 }
 
@@ -636,16 +922,14 @@ fn squash_metric_outcome(
     sources: &[String],
     onto: &str,
     note: Option<String>,
+    operation: RewriteMetricOperation,
 ) -> RewriteOutcome {
     if !rewrite_metrics_enabled() {
         return RewriteOutcome::empty();
     }
-    let mut metric_commit = RewriteMetricCommit::new(
-        squash_commit.to_string(),
-        sources.to_vec(),
-        RewriteMetricOperation::SquashMerge,
-    )
-    .with_parent_sha(onto.to_string());
+    let mut metric_commit =
+        RewriteMetricCommit::new(squash_commit.to_string(), sources.to_vec(), operation)
+            .with_parent_sha(onto.to_string());
     metric_commit = attach_authorship_note(metric_commit, note);
     RewriteOutcome::from_metric_commits(vec![metric_commit])
 }
@@ -675,6 +959,7 @@ fn post_squash_resolution_working_log(
                 supress_output: true,
                 compute_stats: false,
                 recover_attribution: false,
+                write_note: true,
             },
             move |resolution_log| {
                 Ok(
@@ -740,6 +1025,107 @@ const DIFF_TREE_STREAM_CHUNK_SIZE: usize = 50;
 struct PendingShift {
     new_sha: String,
     log: AuthorshipLog,
+}
+
+/// Transfer the full line provenance of selected paths from a source tree to a
+/// commit created after `git restore --source`. Unlike cherry-pick, restore
+/// copies a tree snapshot, so provenance must include lines last touched by any
+/// source ancestor rather than only the source tip's note.
+#[allow(dead_code)]
+pub(crate) fn apply_restore_source_paths(
+    repo: &Repository,
+    source_sha: &str,
+    target_sha: &str,
+    paths: &[String],
+) -> Result<(), GitAiError> {
+    let mappings = paths
+        .iter()
+        .map(|path| (path.clone(), path.clone()))
+        .collect::<Vec<_>>();
+    apply_copied_path_mappings(repo, source_sha, target_sha, &mappings, "restore")
+}
+
+/// Transfer full history-aware provenance from source paths to different
+/// destination paths. This covers copy-like workspace operations whose final
+/// commit is not necessarily represented by Git as a rename (notably
+/// `git mv --force` over an already tracked destination).
+#[allow(dead_code)]
+pub(crate) fn apply_copied_path_mappings(
+    repo: &Repository,
+    source_sha: &str,
+    target_sha: &str,
+    mappings: &[(String, String)],
+    operation: &str,
+) -> Result<(), GitAiError> {
+    use crate::authorship::hunk_shift::apply_hunk_shifts_to_file_attestation;
+    use crate::authorship::virtual_attribution::{
+        VirtualAttributions, diff_hunks_between_contents,
+    };
+    use std::path::Path;
+
+    if source_sha.is_empty() || target_sha.is_empty() || mappings.is_empty() {
+        return Ok(());
+    }
+    let repo_clone = repo.clone();
+    let source_paths = mappings
+        .iter()
+        .map(|(source, _)| source.clone())
+        .collect::<Vec<_>>();
+    let source_va = crate::tokio_runtime::block_on(async {
+        VirtualAttributions::new_for_base_commit(
+            repo_clone,
+            source_sha.to_string(),
+            &source_paths,
+            None,
+        )
+        .await
+    })?;
+    let mut source_log = source_va.to_authorship_log()?;
+    source_log
+        .attestations
+        .retain(|file| mappings.iter().any(|(source, _)| source == &file.file_path));
+    if source_log.attestations.is_empty() {
+        return Ok(());
+    }
+
+    let source_tree = repo.find_commit(source_sha.to_string())?.tree()?.id();
+    let target_tree = repo.find_commit(target_sha.to_string())?.tree()?.id();
+    source_log.attestations = source_log
+        .attestations
+        .iter()
+        .filter_map(|file| {
+            let (_, destination) = mappings
+                .iter()
+                .find(|(source, _)| source == &file.file_path)?;
+            let old_content = repo
+                .read_file_blob_at_tree(&source_tree, Path::new(&file.file_path))
+                .ok()?;
+            let new_content = repo
+                .read_file_blob_at_tree(&target_tree, Path::new(destination))
+                .ok()?;
+            let hunks = diff_hunks_between_contents(
+                &String::from_utf8_lossy(&old_content),
+                &String::from_utf8_lossy(&new_content),
+            );
+            let mut shifted = apply_hunk_shifts_to_file_attestation(file, &hunks)?;
+            shifted.file_path = destination.clone();
+            Some(shifted)
+        })
+        .collect();
+    if source_log.attestations.is_empty() {
+        return Ok(());
+    }
+    source_log.metadata.base_commit_sha = target_sha.to_string();
+
+    let mut target_log = notes_api::read_authorship_v3(repo, target_sha).unwrap_or_default();
+    merge_authorship_logs(&mut target_log, &source_log);
+    target_log.metadata.base_commit_sha = target_sha.to_string();
+    let serialized = target_log.serialize_to_string().map_err(|error| {
+        GitAiError::Generic(format!(
+            "failed to serialize {operation} authorship log: {error}"
+        ))
+    })?;
+    notes_api::write_note(repo, target_sha, &serialized)
 }
 
 fn shift_authorship_notes_with_existing_mode(
@@ -861,7 +1247,7 @@ fn shift_authorship_notes_with_existing_mode(
     Ok(all_writes)
 }
 
-fn merge_authorship_logs(target: &mut AuthorshipLog, source: &AuthorshipLog) {
+pub(crate) fn merge_authorship_logs(target: &mut AuthorshipLog, source: &AuthorshipLog) {
     for src_fa in &source.attestations {
         if let Some(existing_fa) = target
             .attestations

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -8,7 +8,8 @@ use crate::error::GitAiError;
 use crate::git::notes_api;
 use crate::git::repo_state::is_valid_git_oid;
 use crate::git::repository::{
-    Repository, exec_git, exec_git_allow_nonzero, exec_git_stdin_streaming,
+    Repository, batch_read_paths_at_treeishes, exec_git, exec_git_allow_nonzero,
+    exec_git_stdin_streaming,
 };
 
 const EMPTY_TREE_SHA: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
@@ -1061,8 +1062,6 @@ pub(crate) fn apply_copied_path_mappings(
     use crate::authorship::virtual_attribution::{
         VirtualAttributions, diff_hunks_between_contents,
     };
-    use std::path::Path;
-
     if source_sha.is_empty() || target_sha.is_empty() || mappings.is_empty() {
         return Ok(());
     }
@@ -1090,6 +1089,18 @@ pub(crate) fn apply_copied_path_mappings(
 
     let source_tree = repo.find_commit(source_sha.to_string())?.tree()?.id();
     let target_tree = repo.find_commit(target_sha.to_string())?.tree()?.id();
+    let source_treeish = source_tree.to_string();
+    let target_treeish = target_tree.to_string();
+    let content_requests = mappings
+        .iter()
+        .flat_map(|(source, destination)| {
+            [
+                (source_treeish.clone(), source.clone()),
+                (target_treeish.clone(), destination.clone()),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let contents = batch_read_paths_at_treeishes(repo, &content_requests)?;
     source_log.attestations = source_log
         .attestations
         .iter()
@@ -1097,16 +1108,9 @@ pub(crate) fn apply_copied_path_mappings(
             let (_, destination) = mappings
                 .iter()
                 .find(|(source, _)| source == &file.file_path)?;
-            let old_content = repo
-                .read_file_blob_at_tree(&source_tree, Path::new(&file.file_path))
-                .ok()?;
-            let new_content = repo
-                .read_file_blob_at_tree(&target_tree, Path::new(destination))
-                .ok()?;
-            let hunks = diff_hunks_between_contents(
-                &String::from_utf8_lossy(&old_content),
-                &String::from_utf8_lossy(&new_content),
-            );
+            let old_content = contents.get(&(source_treeish.clone(), file.file_path.clone()))?;
+            let new_content = contents.get(&(target_treeish.clone(), destination.clone()))?;
+            let hunks = diff_hunks_between_contents(old_content, new_content);
             let mut shifted = apply_hunk_shifts_to_file_attestation(file, &hunks)?;
             shifted.file_path = destination.clone();
             Some(shifted)

--- a/src/authorship/rewrite_reset.rs
+++ b/src/authorship/rewrite_reset.rs
@@ -18,6 +18,14 @@ pub fn reconstruct_working_log_after_backward_reset(
     old_tip: &str,
     new_tip: &str,
 ) -> Result<(), GitAiError> {
+    // Pending checkpoints are normally keyed by the command's pre-move HEAD.
+    // Move them before reconstructing attribution from the commits being
+    // unwound. The destination can already contain a log (for example after a
+    // branch was previously checked out), and rename_working_log deliberately
+    // merges in that case. Doing this up front also preserves pending edits
+    // when the unwound commits have no usable authorship notes.
+    repo.storage.rename_working_log(old_tip, new_tip)?;
+
     // List all commits being "un-done" (between new_tip exclusive and old_tip inclusive)
     let commits = list_commits_in_range(repo, new_tip, old_tip);
     if commits.is_empty() {

--- a/src/authorship/rewrite_reset.rs
+++ b/src/authorship/rewrite_reset.rs
@@ -140,6 +140,7 @@ pub fn reconstruct_working_log_after_backward_reset(
     // written between the time the reset happened and when the daemon processes
     // this event. Clearing checkpoints.jsonl would lose that data.
     let working_log = repo.storage.working_log_for_base_commit(new_tip)?;
+    let mut carried = working_log.read_initial_attributions();
 
     working_log.write_initial_attributions_with_contents(
         file_attributions,
@@ -148,6 +149,27 @@ pub fn reconstruct_working_log_after_backward_reset(
         file_blobs,
         sessions,
     )?;
+
+    // rename_working_log may have carried an existing INITIAL state to the
+    // destination. It describes newer uncommitted work and therefore wins for
+    // overlapping paths; reconstruction only fills paths that were absent.
+    let reconstructed = working_log.read_initial_attributions();
+    for (path, attrs) in reconstructed.files {
+        carried.files.entry(path).or_insert(attrs);
+    }
+    for (path, blob) in reconstructed.file_blobs {
+        carried.file_blobs.entry(path).or_insert(blob);
+    }
+    for (id, prompt) in reconstructed.prompts {
+        carried.prompts.entry(id).or_insert(prompt);
+    }
+    for (id, human) in reconstructed.humans {
+        carried.humans.entry(id).or_insert(human);
+    }
+    for (id, session) in reconstructed.sessions {
+        carried.sessions.entry(id).or_insert(session);
+    }
+    working_log.write_initial(carried)?;
 
     // Delete old working log if it exists
     let _ = repo.storage.delete_working_log_for_base_commit(old_tip);

--- a/src/authorship/rewrite_revert.rs
+++ b/src/authorship/rewrite_revert.rs
@@ -203,11 +203,7 @@ pub(crate) fn handle_revert_commits_with_metrics(
             target.sort_unstable();
             target.dedup();
         }
-        if log.attestations.is_empty() {
-            reconstructed_by_commit
-                .entry(r.revert_commit.clone())
-                .or_default();
-        } else {
+        if !log.attestations.is_empty() {
             match reconstructed_by_commit.get_mut(&r.revert_commit) {
                 Some(existing) => crate::authorship::rewrite::merge_authorship_logs(existing, &log),
                 None => {
@@ -240,21 +236,39 @@ pub(crate) fn handle_revert_commits_with_metrics(
             .is_none_or(|log| !uncovered_added_lines(added, log).is_empty())
     });
     if needs_history_fallback {
-        let history_tip = resolved
-            .first()
-            .map(|r| r.parent_sha.as_str())
-            .unwrap_or_default();
-        let history_commits = rev_list_for_revert_fallback(repo, history_tip)?;
-        let history_notes = notes_api::read_notes_batch(repo, &history_commits)?;
-        let noted_commits = history_commits
+        let history_tips = resolved
             .iter()
-            .filter(|commit| history_notes.contains_key(*commit))
-            .cloned()
+            .map(|r| r.parent_sha.clone())
+            .collect::<Vec<_>>();
+        let relevant_paths = added_lines_by_commit
+            .values()
+            .flat_map(|added| added.keys().cloned())
+            .collect::<HashSet<_>>();
+        let history_commits = rev_list_for_revert_fallback(repo, &history_tips, &relevant_paths)?;
+        let history_notes = notes_api::read_notes_batch(repo, &history_commits)?;
+        let history_logs = history_commits
+            .iter()
+            .filter_map(|commit| {
+                let note = history_notes.get(commit)?;
+                let log = AuthorshipLog::deserialize_from_string(note).ok()?;
+                log.attestations
+                    .iter()
+                    .any(|file| relevant_paths.contains(&file.file_path))
+                    .then(|| (commit.clone(), log))
+            })
             .collect::<Vec<_>>();
         let mut fallback_pairs = Vec::new();
         let mut fallback_pair_index = HashMap::new();
-        for destination in added_lines_by_commit.keys() {
-            for source in &noted_commits {
+        for (destination, added) in &added_lines_by_commit {
+            for (source, log) in &history_logs {
+                if source == destination
+                    || !log
+                        .attestations
+                        .iter()
+                        .any(|file| added.contains_key(&file.file_path))
+                {
+                    continue;
+                }
                 fallback_pair_index
                     .insert((destination.clone(), source.clone()), fallback_pairs.len());
                 fallback_pairs.push((source.clone(), destination.clone()));
@@ -266,25 +280,23 @@ pub(crate) fn handle_revert_commits_with_metrics(
             let target = reconstructed_by_commit
                 .entry(destination.clone())
                 .or_default();
-            for source in &noted_commits {
+            for (source, log) in &history_logs {
                 let missing = uncovered_added_lines(added, target);
                 if missing.is_empty() {
                     break;
                 }
-                let Some(note) = history_notes.get(source) else {
-                    continue;
-                };
-                let Ok(log) = AuthorshipLog::deserialize_from_string(note) else {
-                    continue;
-                };
                 let Some(index) = fallback_pair_index
                     .get(&(destination.clone(), source.clone()))
                     .copied()
                 else {
                     continue;
                 };
-                let shifted =
-                    shift_and_clip_revert_log(log, &fallback_diffs[index], &missing, destination);
+                let shifted = shift_and_clip_revert_log(
+                    log.clone(),
+                    &fallback_diffs[index],
+                    &missing,
+                    destination,
+                );
                 crate::authorship::rewrite::merge_authorship_logs(target, &shifted);
             }
         }
@@ -325,9 +337,12 @@ pub(crate) fn handle_revert_commits_with_metrics(
 
 fn rev_list_for_revert_fallback(
     repo: &Repository,
-    history_tip: &str,
+    history_tips: &[String],
+    relevant_paths: &HashSet<String>,
 ) -> Result<Vec<String>, GitAiError> {
-    if history_tip.is_empty() {
+    const MAX_REVERT_FALLBACK_COMMITS: usize = 256;
+
+    if history_tips.is_empty() || relevant_paths.is_empty() {
         return Ok(Vec::new());
     }
     let mut args = repo.global_args_for_exec();
@@ -335,8 +350,11 @@ fn rev_list_for_revert_fallback(
         "rev-list".to_string(),
         "--topo-order".to_string(),
         "--date-order".to_string(),
-        history_tip.to_string(),
+        format!("--max-count={MAX_REVERT_FALLBACK_COMMITS}"),
     ]);
+    args.extend(history_tips.iter().filter(|tip| !tip.is_empty()).cloned());
+    args.push("--".to_string());
+    args.extend(relevant_paths.iter().cloned());
     let output = exec_git(&args)?;
     Ok(String::from_utf8_lossy(&output.stdout)
         .lines()

--- a/src/authorship/rewrite_revert.rs
+++ b/src/authorship/rewrite_revert.rs
@@ -132,13 +132,16 @@ pub(crate) fn handle_revert_commits_with_metrics(
     }
 
     // Batch-read all source notes in one call.
-    let source_base_shas: Vec<String> = {
-        let mut v: Vec<String> = resolved.iter().map(|r| r.source_base_sha.clone()).collect();
+    let note_shas: Vec<String> = {
+        let mut v: Vec<String> = resolved
+            .iter()
+            .flat_map(|r| [r.source_base_sha.clone(), r.revert_commit.clone()])
+            .collect();
         v.sort();
         v.dedup();
         v
     };
-    let notes = notes_api::read_notes_batch(repo, &source_base_shas)?;
+    let notes = notes_api::read_notes_batch(repo, &note_shas)?;
 
     // Build one batched diff-tree request covering, for each reverted commit:
     //  - (source_base, revert_commit): hunks to shift the source note forward,
@@ -148,13 +151,13 @@ pub(crate) fn handle_revert_commits_with_metrics(
     let mut shift_idx: Vec<Option<usize>> = Vec::new();
     let mut added_idx: Vec<usize> = Vec::new();
     for r in &resolved {
-        // Only need the shift pair if the source note exists.
-        let shift = if notes.contains_key(&r.source_base_sha) {
+        // The direct-note path and the history-aware fallback both shift from
+        // the source base into the revert commit. Keep all pairs in this one
+        // batched diff invocation.
+        let shift = {
             let idx = diff_pairs.len();
             diff_pairs.push((r.source_base_sha.clone(), r.revert_commit.clone()));
             Some(idx)
-        } else {
-            None
         };
         shift_idx.push(shift);
         let aidx = diff_pairs.len();
@@ -164,19 +167,10 @@ pub(crate) fn handle_revert_commits_with_metrics(
     let diff_results = compute_diff_trees_batch(repo, &diff_pairs)?;
 
     // Per-commit reconstruction is now pure in-memory.
-    let mut writes: Vec<(String, String)> = Vec::new();
+    let mut reconstructed_by_commit: HashMap<String, AuthorshipLog> = HashMap::new();
+    let mut added_lines_by_commit: HashMap<String, HashMap<String, Vec<u32>>> = HashMap::new();
     let mut metric_commits: Vec<RewriteMetricCommit> = Vec::new();
     for (i, r) in resolved.iter().enumerate() {
-        let Some(shift) = shift_idx[i] else {
-            continue;
-        };
-        let Some(source_note) = notes.get(&r.source_base_sha) else {
-            continue;
-        };
-        let Ok(mut log) = AuthorshipLog::deserialize_from_string(source_note) else {
-            continue;
-        };
-
         // Added lines re-introduced by the revert (new-side hunk ranges of the
         // parent->revert diff), keyed by file.
         let added_lines = added_lines_from_diff_result(&diff_results[added_idx[i]]);
@@ -184,39 +178,43 @@ pub(crate) fn handle_revert_commits_with_metrics(
             continue;
         }
 
-        let shift_result = &diff_results[shift];
-        for (old_path, new_path) in &shift_result.renames {
-            for attestation in &mut log.attestations {
-                if attestation.file_path == *old_path {
-                    attestation.file_path = new_path.clone();
+        let log = shift_idx[i]
+            .and_then(|shift| {
+                notes
+                    .get(&r.source_base_sha)
+                    .and_then(|note| AuthorshipLog::deserialize_from_string(note).ok())
+                    .map(|log| {
+                        shift_and_clip_revert_log(
+                            log,
+                            &diff_results[shift],
+                            &added_lines,
+                            &r.revert_commit,
+                        )
+                    })
+            })
+            .unwrap_or_default();
+
+        let commit_added = added_lines_by_commit
+            .entry(r.revert_commit.clone())
+            .or_default();
+        for (path, lines) in &added_lines {
+            let target = commit_added.entry(path.clone()).or_default();
+            target.extend(lines.iter().copied());
+            target.sort_unstable();
+            target.dedup();
+        }
+        if log.attestations.is_empty() {
+            reconstructed_by_commit
+                .entry(r.revert_commit.clone())
+                .or_default();
+        } else {
+            match reconstructed_by_commit.get_mut(&r.revert_commit) {
+                Some(existing) => crate::authorship::rewrite::merge_authorship_logs(existing, &log),
+                None => {
+                    reconstructed_by_commit.insert(r.revert_commit.clone(), log);
                 }
             }
         }
-        if !shift_result.hunks_by_file.is_empty() {
-            log.attestations = log
-                .attestations
-                .iter()
-                .filter_map(|fa| match shift_result.hunks_by_file.get(&fa.file_path) {
-                    Some(hunks) => apply_hunk_shifts_to_file_attestation(fa, hunks),
-                    None => Some(fa.clone()),
-                })
-                .collect();
-        }
-
-        log.metadata.base_commit_sha = r.revert_commit.clone();
-        log.attestations = log
-            .attestations
-            .iter()
-            .filter_map(|file| clip_file_attestation_to_lines(file, &added_lines))
-            .collect();
-        if log.attestations.is_empty() {
-            continue;
-        }
-
-        let Ok(note_str) = log.serialize_to_string() else {
-            continue;
-        };
-        writes.push((r.revert_commit.clone(), note_str.clone()));
         if collect_metrics {
             metric_commits.push(
                 RewriteMetricCommit::new(
@@ -225,16 +223,188 @@ pub(crate) fn handle_revert_commits_with_metrics(
                     RewriteMetricOperation::Revert,
                 )
                 .with_parent_sha(r.parent_sha.clone())
-                .with_authorship_note(note_str)
                 .with_parent_diff(diff_results[added_idx[i]].clone()),
             );
         }
+    }
+
+    // Direct source-base notes are intentionally the constant-time fast path.
+    // If they do not cover every restored line, scan the ORIGINAL pre-revert
+    // history once, batch-read all reachable notes, and batch-compute every
+    // required note->destination shift. Processing notes newest-first and only
+    // filling uncovered ranges reproduces blame precedence without spawning a
+    // git process per reverted commit or per file.
+    let needs_history_fallback = added_lines_by_commit.iter().any(|(commit, added)| {
+        reconstructed_by_commit
+            .get(commit)
+            .is_none_or(|log| !uncovered_added_lines(added, log).is_empty())
+    });
+    if needs_history_fallback {
+        let history_tip = resolved
+            .first()
+            .map(|r| r.parent_sha.as_str())
+            .unwrap_or_default();
+        let history_commits = rev_list_for_revert_fallback(repo, history_tip)?;
+        let history_notes = notes_api::read_notes_batch(repo, &history_commits)?;
+        let noted_commits = history_commits
+            .iter()
+            .filter(|commit| history_notes.contains_key(*commit))
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut fallback_pairs = Vec::new();
+        let mut fallback_pair_index = HashMap::new();
+        for destination in added_lines_by_commit.keys() {
+            for source in &noted_commits {
+                fallback_pair_index
+                    .insert((destination.clone(), source.clone()), fallback_pairs.len());
+                fallback_pairs.push((source.clone(), destination.clone()));
+            }
+        }
+        let fallback_diffs = compute_diff_trees_batch(repo, &fallback_pairs)?;
+
+        for (destination, added) in &added_lines_by_commit {
+            let target = reconstructed_by_commit
+                .entry(destination.clone())
+                .or_default();
+            for source in &noted_commits {
+                let missing = uncovered_added_lines(added, target);
+                if missing.is_empty() {
+                    break;
+                }
+                let Some(note) = history_notes.get(source) else {
+                    continue;
+                };
+                let Ok(log) = AuthorshipLog::deserialize_from_string(note) else {
+                    continue;
+                };
+                let Some(index) = fallback_pair_index
+                    .get(&(destination.clone(), source.clone()))
+                    .copied()
+                else {
+                    continue;
+                };
+                let shifted =
+                    shift_and_clip_revert_log(log, &fallback_diffs[index], &missing, destination);
+                crate::authorship::rewrite::merge_authorship_logs(target, &shifted);
+            }
+        }
+    }
+
+    let mut writes = Vec::new();
+    for (commit, source_log) in reconstructed_by_commit {
+        let final_log = notes
+            .get(&commit)
+            .and_then(|note| AuthorshipLog::deserialize_from_string(note).ok())
+            .map(|resolution_log| {
+                crate::authorship::conflict_resolution::merge_conflict_resolution_authorship(
+                    Some(source_log.clone()),
+                    resolution_log,
+                    &commit,
+                )
+            })
+            .unwrap_or(source_log);
+        let note = final_log.serialize_to_string().map_err(|error| {
+            GitAiError::Generic(format!(
+                "failed to serialize revert authorship log: {error}"
+            ))
+        })?;
+        for metric in metric_commits
+            .iter_mut()
+            .filter(|metric| metric.new_sha == commit)
+        {
+            metric.authorship_note = Some(note.clone());
+        }
+        writes.push((commit, note));
     }
 
     if !writes.is_empty() {
         notes_api::write_notes_batch(repo, &writes)?;
     }
     Ok(metric_commits)
+}
+
+fn rev_list_for_revert_fallback(
+    repo: &Repository,
+    history_tip: &str,
+) -> Result<Vec<String>, GitAiError> {
+    if history_tip.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut args = repo.global_args_for_exec();
+    args.extend([
+        "rev-list".to_string(),
+        "--topo-order".to_string(),
+        "--date-order".to_string(),
+        history_tip.to_string(),
+    ]);
+    let output = exec_git(&args)?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn uncovered_added_lines(
+    added_lines: &HashMap<String, Vec<u32>>,
+    log: &AuthorshipLog,
+) -> HashMap<String, Vec<u32>> {
+    let mut covered: HashMap<&str, HashSet<u32>> = HashMap::new();
+    for file in &log.attestations {
+        let lines = covered.entry(&file.file_path).or_default();
+        for entry in &file.entries {
+            for range in &entry.line_ranges {
+                lines.extend(range.expand());
+            }
+        }
+    }
+    added_lines
+        .iter()
+        .filter_map(|(path, lines)| {
+            let covered = covered.get(path.as_str());
+            let missing = lines
+                .iter()
+                .copied()
+                .filter(|line| covered.is_none_or(|covered| !covered.contains(line)))
+                .collect::<Vec<_>>();
+            (!missing.is_empty()).then(|| (path.clone(), missing))
+        })
+        .collect()
+}
+
+fn shift_and_clip_revert_log(
+    mut log: AuthorshipLog,
+    shift_result: &crate::authorship::rewrite::DiffTreeResult,
+    added_lines: &HashMap<String, Vec<u32>>,
+    revert_commit: &str,
+) -> AuthorshipLog {
+    for (old_path, new_path) in &shift_result.renames {
+        for attestation in &mut log.attestations {
+            if attestation.file_path == *old_path {
+                attestation.file_path = new_path.clone();
+            }
+        }
+    }
+    if !shift_result.hunks_by_file.is_empty() {
+        log.attestations = log
+            .attestations
+            .iter()
+            .filter_map(
+                |file| match shift_result.hunks_by_file.get(&file.file_path) {
+                    Some(hunks) => apply_hunk_shifts_to_file_attestation(file, hunks),
+                    None => Some(file.clone()),
+                },
+            )
+            .collect();
+    }
+    log.metadata.base_commit_sha = revert_commit.to_string();
+    log.attestations = log
+        .attestations
+        .iter()
+        .filter_map(|file| clip_file_attestation_to_lines(file, added_lines))
+        .collect();
+    log
 }
 
 fn legacy_revert_metric_original_sha(parent_sha: &str) -> Option<String> {

--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -1,13 +1,12 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
-use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::authorship::attribution_tracker::LineAttribution;
 use crate::authorship::authorship_log::{HumanRecord, PromptRecord, SessionRecord};
 use crate::authorship::imara_diff_utils::{DiffOp, capture_diff_slices};
-use crate::authorship::working_log::{Checkpoint, CheckpointKind};
+use crate::authorship::working_log::CheckpointKind;
 use crate::error::GitAiError;
 use crate::git::repo_storage::{InitialAttributions, PersistedWorkingLog};
 use crate::git::repository::{
@@ -46,10 +45,6 @@ fn stash_metadata_path(repo: &Repository, stash_sha: &str) -> PathBuf {
     stash_entry_dir(repo, stash_sha).join("metadata.json")
 }
 
-fn filtered_stash_working_log_base(stash_sha: &str) -> String {
-    format!("_stash_filter_{}", stash_sha)
-}
-
 fn working_log_for_dir(repo: &Repository, dir: PathBuf, base_commit: &str) -> PersistedWorkingLog {
     let canonical_workdir = repo
         .storage
@@ -67,52 +62,32 @@ fn working_log_for_dir(repo: &Repository, dir: PathBuf, base_commit: &str) -> Pe
 
 fn path_matches_any(path: &str, pathspecs: &[String]) -> bool {
     pathspecs.iter().any(|spec| {
-        // Trailing-`*` prefix glob (e.g. `src/foo*`, or a bare `*`), matching
-        // the pathspec semantics the pre-rewrite stash matcher supported.
         if let Some(prefix) = spec.strip_suffix('*') {
             return path.starts_with(prefix);
         }
         let normalized = spec.trim_end_matches('/');
-        path == spec || path == normalized || {
-            let prefix = format!("{}/", normalized);
-            path.starts_with(&prefix)
-        }
+        path == spec || path == normalized || path.starts_with(&format!("{normalized}/"))
     })
 }
 
-fn clean_working_log_for_stash(
+fn remove_stashed_paths_from_live_log(
     repo: &Repository,
     head_sha: &str,
     pathspecs: &[String],
 ) -> Result<(), GitAiError> {
-    if !repo.storage.has_working_log(head_sha) {
-        return Ok(());
-    }
-
     let persisted = repo.storage.working_log_for_base_commit(head_sha)?;
     let mut initial = persisted.read_initial_attributions();
-
-    if pathspecs.is_empty() {
-        initial.files.clear();
-        initial.file_blobs.clear();
-    } else {
-        initial
-            .files
-            .retain(|path, _| !path_matches_any(path, pathspecs));
-        initial
-            .file_blobs
-            .retain(|path, _| !path_matches_any(path, pathspecs));
-    }
-
+    initial
+        .files
+        .retain(|path, _| !path_matches_any(path, pathspecs));
+    initial
+        .file_blobs
+        .retain(|path, _| !path_matches_any(path, pathspecs));
     trim_initial_metadata_to_referenced_authors(&mut initial);
     persisted.write_initial(initial)?;
 
-    if pathspecs.is_empty() {
-        return persisted.write_all_checkpoints(&[]);
-    }
-
-    let checkpoints = persisted.read_all_checkpoints()?;
-    let filtered = checkpoints
+    let checkpoints = persisted
+        .read_all_checkpoints()?
         .into_iter()
         .map(|mut checkpoint| {
             checkpoint
@@ -122,8 +97,7 @@ fn clean_working_log_for_stash(
         })
         .filter(|checkpoint| !checkpoint.entries.is_empty())
         .collect::<Vec<_>>();
-    persisted.write_all_checkpoints(&filtered)?;
-    Ok(())
+    persisted.write_all_checkpoints(&checkpoints)
 }
 
 pub fn handle_stash_create(
@@ -131,6 +105,7 @@ pub fn handle_stash_create(
     stash_sha: &str,
     head_sha: &str,
     pathspecs: Vec<String>,
+    partition_live_by_tree: bool,
 ) -> Result<(), GitAiError> {
     cleanup_legacy_stashes_dir(repo);
 
@@ -150,12 +125,158 @@ pub fn handle_stash_create(
     let json = serde_json::to_string_pretty(&metadata)?;
     fs::write(&metadata_path, json)?;
 
-    // Save compact stashed file attributions before cleaning them from the working log.
-    save_stash_attributions(repo, stash_sha, head_sha, &pathspecs)?;
-
-    clean_working_log_for_stash(repo, head_sha, &pathspecs)?;
+    // Partition provenance by the contents Git actually put in the stash and
+    // left in the worktree. Pathspecs alone are insufficient for --staged,
+    // --keep-index, and --patch because those modes split a file by index or
+    // hunk rather than only by pathname.
+    partition_stash_attributions(
+        repo,
+        stash_sha,
+        head_sha,
+        &pathspecs,
+        partition_live_by_tree,
+    )?;
 
     Ok(())
+}
+
+fn partition_stash_attributions(
+    repo: &Repository,
+    stash_sha: &str,
+    head_sha: &str,
+    pathspecs: &[String],
+    partition_live_by_tree: bool,
+) -> Result<(), GitAiError> {
+    use crate::authorship::virtual_attribution::VirtualAttributions;
+
+    if !repo.storage.has_working_log(head_sha) {
+        return Ok(());
+    }
+
+    let va =
+        VirtualAttributions::from_persisted_working_log(repo.clone(), head_sha.to_string(), None)?;
+    let source_initial = va.to_initial_working_log_only();
+    if source_initial.files.is_empty() {
+        return Ok(());
+    }
+
+    let source_contents = source_initial
+        .files
+        .keys()
+        .filter_map(|path| {
+            va.get_file_content(path)
+                .cloned()
+                .map(|content| (path.clone(), content))
+        })
+        .collect::<HashMap<_, _>>();
+    let paths = source_initial.files.keys().cloned().collect::<Vec<_>>();
+
+    let mut stashed_contents = stash_snapshot_contents(repo, stash_sha, &paths)?;
+    if !pathspecs.is_empty() {
+        // A path-limited stash can still record a full WIP tree internally;
+        // only the explicit pathspecs are restored by Git.
+        stashed_contents.retain(|path, _| path_matches_any(path, pathspecs));
+    }
+    let stash_initial = shift_initial_to_target_contents(
+        source_initial.clone(),
+        &source_contents,
+        &stashed_contents,
+    );
+    let stash_log = working_log_for_dir(repo, stash_entry_dir(repo, stash_sha), head_sha);
+    write_initial_with_contents(&stash_log, stash_initial, stashed_contents)?;
+
+    if !pathspecs.is_empty() && !partition_live_by_tree {
+        return remove_stashed_paths_from_live_log(repo, head_sha, pathspecs);
+    }
+
+    let workdir = repo.workdir()?;
+    let live_contents = paths
+        .iter()
+        .filter_map(|path| {
+            fs::read_to_string(workdir.join(path))
+                .ok()
+                .map(|content| (path.clone(), content))
+        })
+        .collect::<HashMap<_, _>>();
+    let live_initial =
+        shift_initial_to_target_contents(source_initial, &source_contents, &live_contents);
+    let live_log = repo.storage.working_log_for_base_commit(head_sha)?;
+    write_initial_with_contents(&live_log, live_initial, live_contents)?;
+    live_log.write_all_checkpoints(&[])?;
+    Ok(())
+}
+
+fn stash_snapshot_contents(
+    repo: &Repository,
+    stash_sha: &str,
+    paths: &[String],
+) -> Result<HashMap<String, String>, GitAiError> {
+    let untracked_parent = format!("{stash_sha}^3");
+    let requests = paths
+        .iter()
+        .flat_map(|path| {
+            [
+                (stash_sha.to_string(), path.clone()),
+                (untracked_parent.clone(), path.clone()),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let mut snapshots = batch_read_paths_at_treeishes(repo, &requests)?;
+    let mut result = HashMap::new();
+    for path in paths {
+        if let Some(content) = snapshots.remove(&(stash_sha.to_string(), path.clone())) {
+            result.insert(path.clone(), content);
+        } else if let Some(content) = snapshots.remove(&(untracked_parent.clone(), path.clone())) {
+            // `stash --include-untracked/--all` stores new files in the third
+            // parent rather than the main WIP tree.
+            result.insert(path.clone(), content);
+        }
+    }
+    Ok(result)
+}
+
+fn shift_initial_to_target_contents(
+    mut initial: InitialAttributions,
+    source_contents: &HashMap<String, String>,
+    target_contents: &HashMap<String, String>,
+) -> InitialAttributions {
+    initial.files = initial
+        .files
+        .into_iter()
+        .filter_map(|(path, attrs)| {
+            let source = source_contents.get(&path)?;
+            let target = target_contents.get(&path)?;
+            let shifted = if source == target {
+                attrs
+            } else {
+                let hunks = crate::authorship::virtual_attribution::diff_hunks_between_contents(
+                    source, target,
+                );
+                crate::authorship::hunk_shift::apply_hunk_shifts_to_line_attributions(
+                    &attrs, &hunks,
+                )
+            };
+            (!shifted.is_empty()).then_some((path, shifted))
+        })
+        .collect();
+    initial.file_blobs.clear();
+    trim_initial_metadata_to_referenced_authors(&mut initial);
+    initial
+}
+
+fn write_initial_with_contents(
+    log: &PersistedWorkingLog,
+    initial: InitialAttributions,
+    mut contents: HashMap<String, String>,
+) -> Result<(), GitAiError> {
+    contents.retain(|path, _| initial.files.contains_key(path));
+    log.write_initial_attributions_with_contents(
+        initial.files,
+        initial.prompts,
+        initial.humans,
+        contents,
+        initial.sessions,
+    )
 }
 
 pub fn handle_stash_pop_or_apply_with_head(
@@ -198,162 +319,9 @@ pub fn handle_stash_drop(repo: &Repository, stash_sha: &str) -> Result<(), GitAi
     Ok(())
 }
 
-fn save_stash_attributions(
-    repo: &Repository,
-    stash_sha: &str,
-    head_sha: &str,
-    pathspecs: &[String],
-) -> Result<(), GitAiError> {
-    if !repo.storage.has_working_log(head_sha) {
-        return Ok(());
-    }
-
-    let filtered_base = if pathspecs.is_empty() {
-        None
-    } else {
-        let filtered_base = filtered_stash_working_log_base(stash_sha);
-        if let Err(err) = write_path_filtered_working_log(repo, head_sha, &filtered_base, pathspecs)
-        {
-            let _ = fs::remove_dir_all(repo.storage.working_logs.join(&filtered_base));
-            return Err(err);
-        }
-        Some(filtered_base)
-    };
-
-    let base_commit = filtered_base.as_deref().unwrap_or(head_sha);
-    let result =
-        compact_stash_attributions_from_working_log(repo, stash_sha, head_sha, base_commit);
-
-    if let Some(filtered_base) = filtered_base {
-        let _ = fs::remove_dir_all(repo.storage.working_logs.join(filtered_base));
-    }
-
-    result
-}
-
-fn compact_stash_attributions_from_working_log(
-    repo: &Repository,
-    stash_sha: &str,
-    stash_base_commit: &str,
-    working_log_base_commit: &str,
-) -> Result<(), GitAiError> {
-    use crate::authorship::virtual_attribution::VirtualAttributions;
-
-    let va = VirtualAttributions::from_persisted_working_log(
-        repo.clone(),
-        working_log_base_commit.to_string(),
-        None,
-    )?;
-    let initial = va.to_initial_working_log_only();
-
-    if initial.files.is_empty() {
-        return Ok(());
-    }
-
-    let mut file_contents = HashMap::new();
-    for file_path in initial.files.keys() {
-        if let Some(content) = va.get_file_content(file_path).cloned() {
-            file_contents.insert(file_path.clone(), content);
-        }
-    }
-
-    let stash_log = working_log_for_dir(repo, stash_entry_dir(repo, stash_sha), stash_base_commit);
-    stash_log.write_initial_attributions_with_contents(
-        initial.files,
-        initial.prompts,
-        initial.humans,
-        file_contents,
-        initial.sessions,
-    )
-}
-
-fn write_path_filtered_working_log(
-    repo: &Repository,
-    source_base_commit: &str,
-    filtered_base_commit: &str,
-    pathspecs: &[String],
-) -> Result<(), GitAiError> {
-    let source_log = repo
-        .storage
-        .working_log_for_base_commit(source_base_commit)?;
-    let filtered_dir = repo.storage.working_logs.join(filtered_base_commit);
-    let _ = fs::remove_dir_all(&filtered_dir);
-    let filtered_log = repo
-        .storage
-        .working_log_for_base_commit(filtered_base_commit)?;
-
-    let mut initial = source_log.read_initial_attributions();
-    initial
-        .files
-        .retain(|path, _| path_matches_any(path, pathspecs));
-    initial
-        .file_blobs
-        .retain(|path, _| path_matches_any(path, pathspecs));
-    trim_initial_metadata_to_referenced_authors(&mut initial);
-    copy_initial_blobs(&source_log, &filtered_log, &initial)?;
-    filtered_log.write_initial(initial)?;
-
-    write_path_filtered_checkpoints(&source_log, &filtered_log, pathspecs)
-}
-
-fn write_path_filtered_checkpoints(
-    source_log: &PersistedWorkingLog,
-    filtered_log: &PersistedWorkingLog,
-    pathspecs: &[String],
-) -> Result<(), GitAiError> {
-    let source_checkpoints = source_log.dir.join("checkpoints.jsonl");
-    let filtered_checkpoints = filtered_log.dir.join("checkpoints.jsonl");
-    source_log.ensure_checkpoints_file_size_limit()?;
-    if !source_checkpoints.exists() {
-        return filtered_log.write_all_checkpoints(&[]);
-    }
-
-    fs::create_dir_all(&filtered_log.dir)?;
-    let input = fs::File::open(source_checkpoints)?;
-    let mut output = BufWriter::new(fs::File::create(filtered_checkpoints)?);
-    let mut copied_blobs = HashSet::new();
-
-    for line in BufReader::new(input).lines() {
-        let line = line?;
-        if line.trim().is_empty() {
-            continue;
-        }
-
-        let mut checkpoint: Checkpoint = serde_json::from_str(&line)?;
-        checkpoint
-            .entries
-            .retain(|entry| path_matches_any(&entry.file, pathspecs));
-        if checkpoint.entries.is_empty() {
-            continue;
-        }
-
-        checkpoint.diff.clear();
-        for entry in &checkpoint.entries {
-            copy_blob_sha(source_log, filtered_log, &entry.blob_sha, &mut copied_blobs)?;
-        }
-
-        serde_json::to_writer(&mut output, &checkpoint)?;
-        output.write_all(b"\n")?;
-    }
-
-    output.flush()?;
-    Ok(())
-}
-
-fn copy_blob_sha(
-    source_log: &PersistedWorkingLog,
-    target_log: &PersistedWorkingLog,
-    blob_sha: &str,
-    copied_blobs: &mut HashSet<String>,
-) -> Result<(), GitAiError> {
-    if blob_sha.is_empty() || !copied_blobs.insert(blob_sha.to_string()) {
-        return Ok(());
-    }
-
-    let source = source_log.dir.join("blobs").join(blob_sha);
-    let target_blobs = target_log.dir.join("blobs");
-    fs::create_dir_all(&target_blobs)?;
-    fs::copy(source, target_blobs.join(blob_sha))?;
+pub fn handle_stash_clear(repo: &Repository) -> Result<(), GitAiError> {
+    cleanup_legacy_stashes_dir(repo);
+    let _ = fs::remove_dir_all(stashes_v2_dir(repo));
     Ok(())
 }
 
@@ -749,54 +717,6 @@ fn run_isolated_git(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_path_matches_any_exact() {
-        let specs = vec!["src/main.rs".to_string()];
-        assert!(path_matches_any("src/main.rs", &specs));
-        assert!(!path_matches_any("src/lib.rs", &specs));
-    }
-
-    #[test]
-    fn test_path_matches_any_directory_prefix() {
-        let specs = vec!["src/".to_string()];
-        assert!(path_matches_any("src/main.rs", &specs));
-        assert!(path_matches_any("src/lib.rs", &specs));
-        assert!(!path_matches_any("tests/main.rs", &specs));
-    }
-
-    #[test]
-    fn test_path_matches_any_directory_without_slash() {
-        let specs = vec!["src".to_string()];
-        assert!(path_matches_any("src/main.rs", &specs));
-        assert!(!path_matches_any("src2/main.rs", &specs));
-    }
-
-    #[test]
-    fn test_path_matches_any_trailing_slash_normalized() {
-        let specs = vec!["dir/".to_string()];
-        assert!(path_matches_any("dir", &specs));
-        assert!(path_matches_any("dir/file.txt", &specs));
-    }
-
-    #[test]
-    fn test_path_matches_any_empty_specs() {
-        let specs: Vec<String> = vec![];
-        assert!(!path_matches_any("anything", &specs));
-    }
-
-    #[test]
-    fn test_path_matches_any_trailing_glob() {
-        // Regression (#5): the pre-rewrite matcher honored a trailing `*`
-        // prefix-glob; path_matches_any dropped it, so `git stash push --
-        // 'src/foo*'` no longer matched src/foobar.txt.
-        let specs = vec!["src/foo*".to_string()];
-        assert!(path_matches_any("src/foobar.txt", &specs));
-        assert!(path_matches_any("src/foo.rs", &specs));
-        assert!(!path_matches_any("src/bar.rs", &specs));
-        // A bare `*` matches anything.
-        assert!(path_matches_any("anything/at/all.txt", &["*".to_string()]));
-    }
 
     #[test]
     fn test_stash_metadata_serialization_roundtrip() {

--- a/src/authorship/rewrite_stash.rs
+++ b/src/authorship/rewrite_stash.rs
@@ -105,7 +105,7 @@ pub fn handle_stash_create(
     stash_sha: &str,
     head_sha: &str,
     pathspecs: Vec<String>,
-    partition_live_by_tree: bool,
+    keep_index: bool,
 ) -> Result<(), GitAiError> {
     cleanup_legacy_stashes_dir(repo);
 
@@ -125,17 +125,7 @@ pub fn handle_stash_create(
     let json = serde_json::to_string_pretty(&metadata)?;
     fs::write(&metadata_path, json)?;
 
-    // Partition provenance by the contents Git actually put in the stash and
-    // left in the worktree. Pathspecs alone are insufficient for --staged,
-    // --keep-index, and --patch because those modes split a file by index or
-    // hunk rather than only by pathname.
-    partition_stash_attributions(
-        repo,
-        stash_sha,
-        head_sha,
-        &pathspecs,
-        partition_live_by_tree,
-    )?;
+    partition_stash_attributions(repo, stash_sha, head_sha, &pathspecs, keep_index)?;
 
     Ok(())
 }
@@ -145,7 +135,7 @@ fn partition_stash_attributions(
     stash_sha: &str,
     head_sha: &str,
     pathspecs: &[String],
-    partition_live_by_tree: bool,
+    keep_index: bool,
 ) -> Result<(), GitAiError> {
     use crate::authorship::virtual_attribution::VirtualAttributions;
 
@@ -183,19 +173,43 @@ fn partition_stash_attributions(
         &stashed_contents,
     );
     let stash_log = working_log_for_dir(repo, stash_entry_dir(repo, stash_sha), head_sha);
-    write_initial_with_contents(&stash_log, stash_initial, stashed_contents)?;
+    write_initial_with_contents(&stash_log, stash_initial, stashed_contents.clone())?;
 
-    if !pathspecs.is_empty() && !partition_live_by_tree {
+    // Path-limited stashes leave every non-matching path untouched. Preserve
+    // those exact persisted checkpoints instead of rebuilding from the live
+    // worktree, which may already contain edits made after the stash command.
+    if !pathspecs.is_empty() {
         return remove_stashed_paths_from_live_log(repo, head_sha, pathspecs);
     }
 
-    let workdir = repo.workdir()?;
+    // Reconstruct the post-stash worktree from immutable snapshots. The stash
+    // tree is the selected change, source_contents is the complete pre-command
+    // worktree, and the target baseline is HEAD (or the index parent for
+    // --keep-index / the default --patch behavior). Rebasing the un-stashed
+    // delta onto that baseline avoids observing later edits from disk.
+    let live_baseline = if keep_index {
+        format!("{stash_sha}^2")
+    } else {
+        head_sha.to_string()
+    };
+    let baseline_requests = paths
+        .iter()
+        .map(|path| (live_baseline.clone(), path.clone()))
+        .collect::<Vec<_>>();
+    let baseline_contents = batch_read_paths_at_treeishes(repo, &baseline_requests)?;
     let live_contents = paths
         .iter()
         .filter_map(|path| {
-            fs::read_to_string(workdir.join(path))
-                .ok()
-                .map(|content| (path.clone(), content))
+            let source = source_contents.get(path)?;
+            let stashed = stashed_contents.get(path).map(String::as_str).unwrap_or("");
+            let baseline = baseline_contents
+                .get(&(live_baseline.clone(), path.clone()))
+                .map(String::as_str)
+                .unwrap_or("");
+            let live = crate::authorship::virtual_attribution::checkout_merge_rebased_content(
+                stashed, baseline, source,
+            );
+            (!live.is_empty()).then(|| (path.clone(), live))
         })
         .collect::<HashMap<_, _>>();
     let live_initial =
@@ -262,6 +276,22 @@ fn shift_initial_to_target_contents(
     initial.file_blobs.clear();
     trim_initial_metadata_to_referenced_authors(&mut initial);
     initial
+}
+
+#[cfg(test)]
+mod pathspec_tests {
+    use super::path_matches_any;
+
+    #[test]
+    fn stash_pathspec_matching_covers_exact_directories_and_prefix_globs() {
+        assert!(path_matches_any("src/lib.rs", &["src/lib.rs".into()]));
+        assert!(path_matches_any("src/nested/lib.rs", &["src".into()]));
+        assert!(path_matches_any("src/nested/lib.rs", &["src/".into()]));
+        assert!(path_matches_any("src/foo.rs", &["src/foo*".into()]));
+        assert!(path_matches_any("anything", &["*".into()]));
+        assert!(!path_matches_any("src/lib.rs", &[]));
+        assert!(!path_matches_any("other/lib.rs", &["src".into()]));
+    }
 }
 
 fn write_initial_with_contents(

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1464,7 +1464,7 @@ fn split_lines_preserving_terminators(s: &str) -> Vec<&str> {
     lines
 }
 
-fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
+pub(crate) fn diff_hunks_between_contents(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
     let normalized_old = normalize_line_endings(old_content);
     let normalized_new = normalize_line_endings(new_content);
     let old_lines = split_lines_preserving_terminators(&normalized_old);

--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -1846,7 +1846,7 @@ fn fill_line_ending_only_mappings(
     }
 }
 
-fn checkout_merge_rebased_content(
+pub(crate) fn checkout_merge_rebased_content(
     base_content: &str,
     target_content: &str,
     observed_content: &str,

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -125,6 +125,11 @@ const MTIME_GRACE_WINDOW_NS: u128 = (MTIME_GRACE_WINDOW_SECS as u128) * 1_000_00
 /// seconds of latency to every Bash tool call.
 const MAX_TRACKED_FILES: usize = 50_000;
 
+/// Internal Bash-call metadata key containing the tree represented by the
+/// index immediately before the tool invocation. Recovery uses this boundary
+/// to distinguish index mutations made by the tool from work staged earlier.
+pub(crate) const PRE_INDEX_TREE_METADATA_KEY: &str = "git_ai_pre_index_tree";
+
 // ---------------------------------------------------------------------------
 // Core types
 // ---------------------------------------------------------------------------
@@ -955,7 +960,13 @@ pub fn signal_daemon_bash_hook_attempt(
     let session_id = signal.session_id.to_string();
     let tool_use_id = signal.tool_use_id.to_string();
     let agent_id = signal.agent_id.clone();
-    let metadata = signal.metadata.clone();
+    let mut metadata = signal.metadata.clone();
+    if matches!(phase, BashHookAttemptPhase::Start)
+        && let Some(repo_work_dir) = signal.discovered_repo_work_dir
+        && let Some(tree) = capture_index_tree(repo_work_dir)
+    {
+        metadata.insert(PRE_INDEX_TREE_METADATA_KEY.to_string(), tree);
+    }
     let trace_id = signal.trace_id.to_string();
     let command = signal.command.map(ToString::to_string);
 
@@ -989,6 +1000,23 @@ pub fn signal_daemon_bash_hook_attempt(
     {
         tracing::debug!("Failed to signal bash hook attempt {:?}: {}", phase, e);
     }
+}
+
+/// Materialize the current index as a tree object without changing the index
+/// or worktree. Failure (for example, an unmerged index) degrades to the
+/// existing timestamp recovery path.
+pub(crate) fn capture_index_tree(repo_root: &Path) -> Option<String> {
+    let args = vec![
+        "-C".to_string(),
+        repo_root.to_string_lossy().into_owned(),
+        "write-tree".to_string(),
+    ];
+    let output = crate::git::repository::exec_git_allow_nonzero(&args).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let tree = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    crate::git::repo_state::is_valid_git_oid(&tree).then_some(tree)
 }
 
 struct BashSessionEndSignal<'a> {
@@ -1099,13 +1127,17 @@ pub fn handle_bash_pre_tool_use_with_context_and_cwd(
         GitAiError::Generic("no daemon socket available for BashSessionStart".into())
     })?;
 
+    let mut metadata = context.agent_metadata.cloned().unwrap_or_default();
+    if let Some(tree) = capture_index_tree(repo_root) {
+        metadata.insert(PRE_INDEX_TREE_METADATA_KEY.to_string(), tree);
+    }
     let request = ControlRequest::BashSessionStart {
         repo_work_dir: repo_working_dir,
         original_cwd: Some(original_cwd.to_string_lossy().to_string()),
         session_id: context.session_id.to_string(),
         tool_use_id: context.tool_use_id.to_string(),
         agent_id: context.agent_id.clone(),
-        metadata: context.agent_metadata.cloned().unwrap_or_default(),
+        metadata,
         stat_snapshot: Box::new(snap),
         trace_id: context.trace_id.to_string(),
         started_at_ns,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5332,6 +5332,19 @@ impl ActorDaemonCoordinator {
         pathspecs
     }
 
+    fn stash_keeps_index(cmd: &crate::daemon::domain::NormalizedCommand) -> bool {
+        let parsed = parsed_invocation_for_normalized_command(cmd);
+        let has_no_keep_index = parsed
+            .command_args
+            .iter()
+            .any(|arg| arg == "--no-keep-index");
+        !has_no_keep_index
+            && parsed
+                .command_args
+                .iter()
+                .any(|arg| matches!(arg.as_str(), "-k" | "--keep-index" | "-p" | "--patch"))
+    }
+
     /// Detects non-fast-forward ref moves and fires handle_rewrite_event.
     fn detect_and_handle_non_ff_rewrites(
         &self,
@@ -6139,8 +6152,9 @@ impl ActorDaemonCoordinator {
                                         stash_base_head(&repo, stash_sha).or_else(|| head.clone());
                                     if let Some(head_sha) = push_head.as_deref() {
                                         let pathspecs = Self::stash_pathspecs_from_command(cmd);
+                                        let keep_index = Self::stash_keeps_index(cmd);
                                         crate::authorship::rewrite_stash::handle_stash_create(
-                                            &repo, stash_sha, head_sha, pathspecs, true,
+                                            &repo, stash_sha, head_sha, pathspecs, keep_index,
                                         )?;
                                     }
                                 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -970,6 +970,7 @@ fn post_conflict_resolution_working_log(
             supress_output: true,
             compute_stats: false,
             recover_attribution: false,
+            write_note: true,
         },
         precomputed_parent_diff,
         move |resolution_log| {
@@ -6139,7 +6140,7 @@ impl ActorDaemonCoordinator {
                                     if let Some(head_sha) = push_head.as_deref() {
                                         let pathspecs = Self::stash_pathspecs_from_command(cmd);
                                         crate::authorship::rewrite_stash::handle_stash_create(
-                                            &repo, stash_sha, head_sha, pathspecs,
+                                            &repo, stash_sha, head_sha, pathspecs, true,
                                         )?;
                                     }
                                 }
@@ -6304,6 +6305,7 @@ impl ActorDaemonCoordinator {
                                     true,
                                     recovery_file_timestamps.as_ref(),
                                     Some(&recovery_preflight),
+                                    None,
                                 )
                             })?;
 

--- a/src/daemon/bash_history_db.rs
+++ b/src/daemon/bash_history_db.rs
@@ -393,8 +393,12 @@ impl BashHistoryDatabase {
         self.prune_old_calls_if_due()?;
 
         let now = unix_now_secs();
-        let metadata_json =
-            serde_json::to_string(&call.metadata).unwrap_or_else(|_| "{}".to_string());
+        // PostToolUse payloads repeat agent metadata but do not contain the
+        // internal index baseline captured at PreToolUse. Preserve start-only
+        // keys while allowing end metadata to update ordinary agent fields.
+        let mut metadata = self.existing_metadata_for_end(call)?;
+        metadata.extend(call.metadata.clone());
+        let metadata_json = serde_json::to_string(&metadata).unwrap_or_else(|_| "{}".to_string());
         let end_time_ns = ns_to_i64(call.ended_at_ns)?;
 
         let updated = if let Some(start_trace_id) = call.start_trace_id.as_ref() {
@@ -512,6 +516,44 @@ impl BashHistoryDatabase {
         Ok(())
     }
 
+    fn existing_metadata_for_end(
+        &self,
+        call: &BashCallEnd,
+    ) -> Result<HashMap<String, String>, GitAiError> {
+        let metadata_json = if let Some(start_trace_id) = call.start_trace_id.as_ref() {
+            self.conn
+                .query_row(
+                    r#"
+                    SELECT metadata_json
+                    FROM bash_checkpoint_calls
+                    WHERE session_id = ?1 AND tool_use_id = ?2 AND start_trace_id = ?3
+                    LIMIT 1
+                    "#,
+                    params![call.session_id, call.tool_use_id, start_trace_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+        } else {
+            self.conn
+                .query_row(
+                    r#"
+                    SELECT metadata_json
+                    FROM bash_checkpoint_calls
+                    WHERE session_id = ?1 AND tool_use_id = ?2 AND end_time_ns IS NULL
+                    ORDER BY id DESC
+                    LIMIT 1
+                    "#,
+                    params![call.session_id, call.tool_use_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+        };
+        Ok(metadata_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok())
+            .unwrap_or_default())
+    }
+
     pub fn candidates_near_timestamps(
         &self,
         timestamps_ns: &[u128],
@@ -563,6 +605,39 @@ impl BashHistoryDatabase {
             }
         }
         Ok(calls)
+    }
+
+    /// Return Bash tool calls whose actual invocation window overlaps a traced
+    /// Git command window. Unlike mtime recovery, an open call has no synthetic
+    /// duration cap: if the Git command began after the Bash pre-hook and before
+    /// its post-hook, it is part of that call even when the command ran for more
+    /// than the normal recovery grace period.
+    pub fn candidates_overlapping_window(
+        &self,
+        started_at_ns: u128,
+        finished_at_ns: u128,
+    ) -> Result<Vec<BashCheckpointCall>, GitAiError> {
+        if !self.enabled || finished_at_ns < started_at_ns {
+            return Ok(Vec::new());
+        }
+
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, invocation_key, original_cwd, repo_work_dir, repo_discovery_error,
+                   session_id, tool_use_id, agent_tool, agent_external_id, agent_model,
+                   start_trace_id, end_trace_id, start_time_ns, end_time_ns,
+                   command, metadata_json
+            FROM bash_checkpoint_calls
+            WHERE start_time_ns <= ?1
+              AND COALESCE(end_time_ns, ?1) >= ?2
+            ORDER BY id ASC
+            "#,
+        )?;
+        let rows = stmt.query_map(
+            params![ns_to_i64(finished_at_ns)?, ns_to_i64(started_at_ns)?],
+            row_to_call,
+        )?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
     pub fn all_calls_for_test(&self) -> Result<Vec<BashCheckpointCall>, GitAiError> {
@@ -719,6 +794,10 @@ mod tests {
         let (mut db, _dir) = test_db();
         let mut metadata = HashMap::new();
         metadata.insert("transcript_path".to_string(), "/tmp/t.jsonl".to_string());
+        metadata.insert(
+            crate::commands::checkpoint_agent::bash_tool::PRE_INDEX_TREE_METADATA_KEY.to_string(),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+        );
 
         db.record_start(&BashCallStart {
             original_cwd: "/repo/subdir".to_string(),
@@ -745,7 +824,10 @@ mod tests {
             started_at_ns: Some(1_000),
             ended_at_ns: 2_000,
             command: Some("echo hi".to_string()),
-            metadata,
+            metadata: HashMap::from([(
+                "transcript_path".to_string(),
+                "/tmp/t-updated.jsonl".to_string(),
+            )]),
         })
         .unwrap();
 
@@ -765,7 +847,13 @@ mod tests {
         assert_eq!(call.command.as_deref(), Some("echo hi"));
         assert_eq!(
             call.metadata.get("transcript_path").map(String::as_str),
-            Some("/tmp/t.jsonl")
+            Some("/tmp/t-updated.jsonl")
+        );
+        assert_eq!(
+            call.metadata
+                .get(crate::commands::checkpoint_agent::bash_tool::PRE_INDEX_TREE_METADATA_KEY)
+                .map(String::as_str),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         );
     }
 
@@ -888,6 +976,33 @@ mod tests {
         let calls = db.candidates_near_timestamps(&[5_000], 3_000).unwrap();
         let ids: Vec<_> = calls.iter().map(|c| c.tool_use_id.as_str()).collect();
         assert_eq!(ids, vec!["near-before", "near-after"]);
+    }
+
+    #[test]
+    fn overlapping_window_keeps_long_running_open_call_without_synthetic_cap() {
+        let (mut db, _dir) = test_db();
+        db.record_start(&BashCallStart {
+            original_cwd: "/repo".to_string(),
+            repo_work_dir: Some("/repo".to_string()),
+            repo_discovery_error: None,
+            session_id: "long-session".to_string(),
+            tool_use_id: "long-tool".to_string(),
+            agent_id: test_agent(),
+            start_trace_id: "t_long".to_string(),
+            started_at_ns: 1_000,
+            command: Some("git am series.patch".to_string()),
+            metadata: HashMap::new(),
+        })
+        .unwrap();
+
+        let calls = db
+            .candidates_overlapping_window(10_000_000_000, 11_000_000_000)
+            .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].tool_use_id, "long-tool");
+
+        let before = db.candidates_overlapping_window(100, 999).unwrap();
+        assert!(before.is_empty());
     }
 
     #[test]

--- a/tests/integration/rewrite_ops_attribution.rs
+++ b/tests/integration/rewrite_ops_attribution.rs
@@ -239,15 +239,8 @@ fn test_revert_multiple_commits_restores_each_original_attribution() {
     let del_c = repo.git(&["rev-parse", "HEAD"]).unwrap().trim().to_string();
 
     // Revert all three deletes in ONE command → one revert command, three
-    // destination commits processed by the batched revert path. The revert
-    // CONTENT is restored for every file (each AI line comes back), and the
-    // FIRST reverted commit recovers its original AI attribution. Attribution
-    // recovery for the 2nd+ reverted commit in a single multi-commit revert is a
-    // known pre-existing limitation (the source note is located via
-    // first-parent of the reverted commit, which for chained deletes does not
-    // hold that file's original attestation — see the deferred #13 note in
-    // ref_cursor.rs). This test pins the batched path's behavior so the
-    // spawn-count reduction is verified behavior-preserving.
+    // destination commits processed by the batched revert path. Every restored
+    // file must recover the attribution reachable from its own pre-revert tip.
     repo.git(&["revert", "--no-edit", &del_a, &del_b, &del_c])
         .unwrap();
 
@@ -259,9 +252,12 @@ fn test_revert_multiple_commits_restores_each_original_attribution() {
     assert!(b.contains("AI b"), "b.txt content restored");
     assert!(c.contains("AI c"), "c.txt content restored");
 
-    // First reverted commit recovers original AI attribution.
     repo.filename("a.txt")
         .assert_committed_lines(crate::lines!["a base".human(), "AI a".ai()]);
+    repo.filename("b.txt")
+        .assert_committed_lines(crate::lines!["b base".human(), "AI b".ai()]);
+    repo.filename("c.txt")
+        .assert_committed_lines(crate::lines!["c base".human(), "AI c".ai()]);
 }
 
 #[test]


### PR DESCRIPTION
- Preserves attribution through rewrite, reset, revert, stash, and copied or restored path transformations.
- Adds Bash command-window recovery bounded by pre-index snapshots.
- Supports batched commit-sequence notes and merge-specific empty-note suppression.