### PR TITLE
Fix config command output streams

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1017,13 +1017,13 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 backend.kind = kind;
                 file_config.notes_backend = Some(backend);
                 crate::config::save_file_config(&file_config)?;
-                eprintln!("[notes_backend.kind]: {}", kind.as_str());
+                println!("[notes_backend.kind]: {}", kind.as_str());
             }
             "backend_url" => {
                 backend.backend_url = Some(value.to_string());
                 file_config.notes_backend = Some(backend);
                 crate::config::save_file_config(&file_config)?;
-                eprintln!("[notes_backend.backend_url]: {}", value);
+                println!("[notes_backend.backend_url]: {}", value);
             }
             other => return Err(format!("Unknown notes_backend field: {}", other)),
         }
@@ -1377,7 +1377,7 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 backend.kind = NotesBackendKind::GitNotes; // reset to default
                 file_config.notes_backend = Some(backend);
                 crate::config::save_file_config(&file_config)?;
-                eprintln!("- [notes_backend.kind]: {}", old.as_str());
+                println!("- [notes_backend.kind]: {}", old.as_str());
             }
             "backend_url" => {
                 if let Some(old_url) = backend.backend_url.take() {
@@ -1387,7 +1387,7 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                         Some(backend)
                     };
                     crate::config::save_file_config(&file_config)?;
-                    eprintln!("- [notes_backend.backend_url]: {}", old_url);
+                    println!("- [notes_backend.backend_url]: {}", old_url);
                 }
             }
             other => return Err(format!("Unknown notes_backend field: {}", other)),

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -10,6 +10,48 @@ use git_ai::config::{AuthorConfig, FileConfig, NotesBackendConfig};
 use serde_json::Value;
 use std::collections::HashMap;
 
+fn run_config(repo: &TestRepo, args: &[&str]) -> std::process::Output {
+    repo.git_ai_command_without_pre_sync_for_test(args, &[])
+        .output()
+        .unwrap_or_else(|e| panic!("git-ai {args:?} failed to run: {e}"))
+}
+
+#[test]
+fn test_config_set_and_get_normal_output_uses_stdout() {
+    let repo = TestRepo::new();
+
+    for args in [
+        ["config", "set", "notes_backend.kind", "http"].as_slice(),
+        [
+            "config",
+            "set",
+            "notes_backend.backend_url",
+            "https://example.com",
+        ]
+        .as_slice(),
+        ["config", "notes_backend.kind"].as_slice(),
+        ["config", "notes_backend.backend_url"].as_slice(),
+        ["config", "unset", "notes_backend.kind"].as_slice(),
+        ["config", "unset", "notes_backend.backend_url"].as_slice(),
+    ] {
+        let output = run_config(&repo, args);
+        assert!(
+            output.status.success(),
+            "git-ai {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !output.stdout.is_empty(),
+            "git-ai {args:?} should write normal output to stdout"
+        );
+        assert!(
+            output.stderr.is_empty(),
+            "git-ai {args:?} wrote normal output to stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
 /// Parse the JSON emitted by `git-ai config <key>` into a serde value.
 fn get_json(repo: &TestRepo, key: &str) -> Value {
     let out = repo


### PR DESCRIPTION
## Summary

- route successful `git-ai config` output to stdout
- keep stderr reserved for actual config errors
- add integration coverage that checks stdout and stderr independently

## Testing

- `task test`
- `task fmt`
- `task lint`

<sub>Created with [GitHub Stacks CLI](https://github.com/github/gh-stack)</sub>