### PR TITLE
feat: add zcode agent preset and hook installer

### DIFF
--- a/src/commands/checkpoint_agent/presets/claude.rs
+++ b/src/commands/checkpoint_agent/presets/claude.rs
@@ -31,106 +31,119 @@ impl ClaudePreset {
     }
 }
 
-impl AgentPreset for ClaudePreset {
-    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
-        let data: serde_json::Value = serde_json::from_str(hook_input)
-            .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
+/// Shared parser for agents whose hook protocol is identical to Claude Code's
+/// (e.g., ZCode). `tool` is the attribution identity (lowercase agent id);
+/// `display_name` is used in error messages.
+pub(crate) fn parse_claude_like(
+    hook_input: &str,
+    trace_id: &str,
+    tool: &str,
+    display_name: &str,
+) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+    let data: serde_json::Value = serde_json::from_str(hook_input)
+        .map_err(|e| GitAiError::PresetError(format!("Invalid JSON in hook_input: {}", e)))?;
 
-        if Self::is_vscode_copilot_hook_payload(&data) {
-            return Err(GitAiError::PresetError(
-                "Skipping VS Code hook payload in Claude preset; use github-copilot hooks."
-                    .to_string(),
-            ));
-        }
-        if Self::is_cursor_hook_payload(&data) {
-            return Err(GitAiError::PresetError(
-                "Skipping Cursor hook payload in Claude preset; use cursor hooks.".to_string(),
-            ));
-        }
+    if ClaudePreset::is_vscode_copilot_hook_payload(&data) {
+        return Err(GitAiError::PresetError(format!(
+            "Skipping VS Code hook payload in {} preset; use github-copilot hooks.",
+            display_name
+        )));
+    }
+    if ClaudePreset::is_cursor_hook_payload(&data) {
+        return Err(GitAiError::PresetError(format!(
+            "Skipping Cursor hook payload in {} preset; use cursor hooks.",
+            display_name
+        )));
+    }
 
-        let tool_class = parse::optional_str_multi(&data, &["tool_name", "toolName"])
-            .map(|name| bash_tool::classify_tool(Agent::Claude, name))
-            // Preserve legacy Claude payloads that predate tool_name.
-            .unwrap_or(ToolClass::FileEdit);
-        if tool_class == ToolClass::Skip {
-            return Ok(Vec::new());
-        }
+    // These agents use the same capitalized tool names as Claude Code, so
+    // reuse Claude's tool classification.
+    let tool_class = parse::optional_str_multi(&data, &["tool_name", "toolName"])
+        .map(|name| bash_tool::classify_tool(Agent::Claude, name))
+        // Preserve legacy Claude payloads that predate tool_name.
+        .unwrap_or(ToolClass::FileEdit);
+    if tool_class == ToolClass::Skip {
+        return Ok(Vec::new());
+    }
 
-        let cwd = parse::required_str(&data, "cwd")?;
-        let transcript_path = parse::required_str(&data, "transcript_path")?;
-        let session_id = parse::optional_str(&data, "session_id")
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| {
-                parse::required_file_stem(&data, "transcript_path")
-                    .unwrap_or_else(|_| "unknown".to_string())
-            });
-
-        let hook_event = parse::optional_str_multi(&data, &["hook_event_name", "hookEventName"]);
-        let tool_use_id = parse::str_or_default_multi(&data, &["tool_use_id", "toolUseId"], "bash");
-
-        let is_bash = tool_class == ToolClass::Bash;
-
-        let context = PresetContext {
-            agent_id: AgentId {
-                tool: "claude".to_string(),
-                id: session_id.clone(),
-                model: crate::streams::model_extraction::extract_model(
-                    Path::new(transcript_path),
-                    crate::streams::sweep::StreamFormat::ClaudeJsonl,
-                    None,
-                )
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| "unknown".to_string()),
-            },
-            external_session_id: session_id.clone(),
-            trace_id: trace_id.to_string(),
-            cwd: PathBuf::from(cwd),
-            metadata: HashMap::from([("transcript_path".to_string(), transcript_path.to_string())]),
-        };
-
-        let transcript_path_buf = PathBuf::from(transcript_path);
-        let external_parent_session_id =
-            crate::streams::agents::claude::ClaudeAgent::detect_subagent_parent(
-                &transcript_path_buf,
-            );
-        let stream_source = Some(StreamSource {
-            path: transcript_path_buf,
-            format: StreamFormat::ClaudeJsonl,
-            session_id: generate_session_id(&session_id, "claude"),
-            external_session_id: session_id.clone(),
-            external_parent_session_id,
+    let cwd = parse::required_str(&data, "cwd")?;
+    let transcript_path = parse::required_str(&data, "transcript_path")?;
+    let session_id = parse::optional_str(&data, "session_id")
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            parse::required_file_stem(&data, "transcript_path")
+                .unwrap_or_else(|_| "unknown".to_string())
         });
 
-        let bash_command = parse::bash_command_from_hook_input(&data);
-        let event = match (hook_event, is_bash) {
-            (Some("PreToolUse"), true) => ParsedHookEvent::PreBashCall(PreBashCall {
-                context,
-                tool_use_id: tool_use_id.to_string(),
-                command: bash_command,
-            }),
-            (Some("PreToolUse"), false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
-                context,
-                file_paths: parse::file_paths_from_tool_input(&data, cwd),
-                dirty_files: None,
-                tool_use_id: Some(tool_use_id.to_string()),
-            }),
-            (_, true) => ParsedHookEvent::PostBashCall(PostBashCall {
-                context,
-                tool_use_id: tool_use_id.to_string(),
-                command: bash_command,
-                stream_source,
-            }),
-            (_, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {
-                context,
-                file_paths: parse::file_paths_from_tool_input(&data, cwd),
-                dirty_files: None,
-                stream_source,
-                tool_use_id: Some(tool_use_id.to_string()),
-            }),
-        };
+    let hook_event = parse::optional_str_multi(&data, &["hook_event_name", "hookEventName"]);
+    let tool_use_id = parse::str_or_default_multi(&data, &["tool_use_id", "toolUseId"], "bash");
 
-        Ok(vec![event])
+    let is_bash = tool_class == ToolClass::Bash;
+
+    let context = PresetContext {
+        agent_id: AgentId {
+            tool: tool.to_string(),
+            id: session_id.clone(),
+            model: crate::streams::model_extraction::extract_model(
+                Path::new(transcript_path),
+                crate::streams::sweep::StreamFormat::ClaudeJsonl,
+                None,
+            )
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| "unknown".to_string()),
+        },
+        external_session_id: session_id.clone(),
+        trace_id: trace_id.to_string(),
+        cwd: PathBuf::from(cwd),
+        metadata: HashMap::from([("transcript_path".to_string(), transcript_path.to_string())]),
+    };
+
+    let transcript_path_buf = PathBuf::from(transcript_path);
+    let external_parent_session_id =
+        crate::streams::agents::claude::ClaudeAgent::detect_subagent_parent(&transcript_path_buf);
+    let stream_source = Some(StreamSource {
+        path: transcript_path_buf,
+        format: StreamFormat::ClaudeJsonl,
+        session_id: generate_session_id(&session_id, tool),
+        external_session_id: session_id.clone(),
+        external_parent_session_id,
+    });
+
+    let bash_command = parse::bash_command_from_hook_input(&data);
+    let event = match (hook_event, is_bash) {
+        (Some("PreToolUse"), true) => ParsedHookEvent::PreBashCall(PreBashCall {
+            context,
+            tool_use_id: tool_use_id.to_string(),
+            command: bash_command,
+        }),
+        (Some("PreToolUse"), false) => ParsedHookEvent::PreFileEdit(PreFileEdit {
+            context,
+            file_paths: parse::file_paths_from_tool_input(&data, cwd),
+            dirty_files: None,
+            tool_use_id: Some(tool_use_id.to_string()),
+        }),
+        (_, true) => ParsedHookEvent::PostBashCall(PostBashCall {
+            context,
+            tool_use_id: tool_use_id.to_string(),
+            command: bash_command,
+            stream_source,
+        }),
+        (_, false) => ParsedHookEvent::PostFileEdit(PostFileEdit {
+            context,
+            file_paths: parse::file_paths_from_tool_input(&data, cwd),
+            dirty_files: None,
+            stream_source,
+            tool_use_id: Some(tool_use_id.to_string()),
+        }),
+    };
+
+    Ok(vec![event])
+}
+
+impl AgentPreset for ClaudePreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        parse_claude_like(hook_input, trace_id, "claude", "Claude")
     }
 }
 

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -19,6 +19,7 @@ mod mock_known_human;
 mod opencode;
 mod pi;
 mod windsurf;
+mod zcode;
 
 use crate::authorship::working_log::AgentId;
 use crate::error::GitAiError;
@@ -168,6 +169,7 @@ pub fn resolve_preset(name: &str) -> Result<Box<dyn AgentPreset>, GitAiError> {
         "droid" => Ok(Box::new(droid::DroidPreset)),
         "opencode" => Ok(Box::new(opencode::OpenCodePreset)),
         "pi" => Ok(Box::new(pi::PiPreset)),
+        "zcode" => Ok(Box::new(zcode::ZcodePreset)),
         "human" => Ok(Box::new(human::HumanPreset)),
         "mock_ai" => Ok(Box::new(mock_ai::MockAiPreset)),
         "known_human" => Ok(Box::new(known_human::KnownHumanPreset)),

--- a/src/commands/checkpoint_agent/presets/zcode.rs
+++ b/src/commands/checkpoint_agent/presets/zcode.rs
@@ -1,0 +1,208 @@
+use super::claude::parse_claude_like;
+use super::{AgentPreset, ParsedHookEvent};
+use crate::error::GitAiError;
+
+pub struct ZcodePreset;
+
+impl AgentPreset for ZcodePreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        // ZCode speaks the Claude Code hook protocol, so parsing is shared with
+        // the Claude preset; only the attribution identity differs.
+        parse_claude_like(hook_input, trace_id, "zcode", "ZCode")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authorship::authorship_log_serialization::generate_session_id;
+    use crate::commands::checkpoint_agent::presets::*;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn make_zcode_hook_input(event: &str, tool: &str) -> String {
+        json!({
+            "transcript_path": "C:/Users/me/AppData/Local/Temp/zcode-claude-hook-abc123/transcript.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": event,
+            "tool_name": tool,
+            "session_id": "sess-1",
+            "tool_use_id": "tu-1",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_zcode_pre_file_edit() {
+        let input = make_zcode_hook_input("PreToolUse", "Write");
+        let events = ZcodePreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PreFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "zcode");
+                assert_eq!(e.context.external_session_id, "sess-1");
+                assert_eq!(e.context.trace_id, "t_test123456789a");
+                assert_eq!(e.context.cwd, PathBuf::from("/home/user/project"));
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/main.rs")]
+                );
+            }
+            _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_zcode_post_file_edit() {
+        let input = make_zcode_hook_input("PostToolUse", "Write");
+        let events = ZcodePreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(e.context.agent_id.tool, "zcode");
+                assert_eq!(
+                    e.file_paths,
+                    vec![PathBuf::from("/home/user/project/src/main.rs")]
+                );
+                assert!(e.stream_source.is_some());
+                if let Some(ts) = &e.stream_source {
+                    assert_eq!(ts.format, StreamFormat::ClaudeJsonl);
+                    assert_eq!(ts.session_id, generate_session_id("sess-1", "zcode"));
+                    assert_eq!(ts.external_session_id, "sess-1");
+                }
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_zcode_pre_bash_call() {
+        let input = make_zcode_hook_input("PreToolUse", "Bash");
+        let events = ZcodePreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PreBashCall(e) => {
+                assert_eq!(e.context.agent_id.tool, "zcode");
+                assert_eq!(e.tool_use_id, "tu-1");
+            }
+            _ => panic!("Expected PreBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_zcode_post_bash_call() {
+        let input = make_zcode_hook_input("PostToolUse", "Bash");
+        let events = ZcodePreset.parse(&input, "t_test123456789a").unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostBashCall(e) => {
+                assert_eq!(e.context.agent_id.tool, "zcode");
+                assert_eq!(e.tool_use_id, "tu-1");
+            }
+            _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_zcode_ignores_read_only_and_unsupported_tools() {
+        for hook_event in ["PreToolUse", "PostToolUse"] {
+            for tool_name in ["Read", "Glob", "Grep", "Task", "UnknownTool"] {
+                let input = json!({
+                    "hook_event_name": hook_event,
+                    "tool_name": tool_name,
+                    "transcript_path": "/does/not/exist.jsonl"
+                })
+                .to_string();
+
+                let events = ZcodePreset.parse(&input, "t_test123456789a").unwrap();
+                assert!(
+                    events.is_empty(),
+                    "{hook_event} {tool_name} unexpectedly produced events"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ignored_zcode_hook_produces_no_checkpoint_requests() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "transcript_path": "/does/not/exist.jsonl"
+        })
+        .to_string();
+
+        let requests = crate::commands::checkpoint_agent::orchestrator::execute_preset_checkpoint(
+            "zcode", &input,
+        )
+        .unwrap();
+        assert!(requests.is_empty());
+    }
+
+    #[test]
+    fn test_zcode_preserves_all_mutating_file_tools() {
+        for tool_name in ["Write", "Edit", "MultiEdit"] {
+            let pre = make_zcode_hook_input("PreToolUse", tool_name);
+            assert!(matches!(
+                ZcodePreset.parse(&pre, "t_test123456789a").unwrap()[..],
+                [ParsedHookEvent::PreFileEdit(_)]
+            ));
+
+            let post = make_zcode_hook_input("PostToolUse", tool_name);
+            assert!(matches!(
+                ZcodePreset.parse(&post, "t_test123456789a").unwrap()[..],
+                [ParsedHookEvent::PostFileEdit(_)]
+            ));
+        }
+    }
+
+    #[test]
+    fn test_zcode_session_id_from_filename() {
+        let input = json!({
+            "transcript_path": "C:/Users/me/AppData/Local/Temp/zcode-claude-hook-abc123/cb947e5b-246e-4253-a953-631f7e464c6b.jsonl",
+            "cwd": "/home/user/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string();
+        let events = ZcodePreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(
+                    e.context.external_session_id,
+                    "cb947e5b-246e-4253-a953-631f7e464c6b"
+                );
+            }
+            _ => panic!("Expected PostFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_zcode_skips_vscode_copilot_payload() {
+        let input = json!({
+            "transcript_path": "/home/user/.vscode/extensions/GitHub Copilot/sessions/test.json",
+            "cwd": "/home/user/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string();
+        assert!(ZcodePreset.parse(&input, "t_test123456789a").is_err());
+    }
+
+    #[test]
+    fn test_zcode_skips_cursor_payload() {
+        let input = json!({
+            "transcript_path": "/home/user/.cursor/sessions/test.jsonl",
+            "cwd": "/home/user/project",
+            "cursor_version": "0.43",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "src/main.rs"}
+        })
+        .to_string();
+        assert!(ZcodePreset.parse(&input, "t_test123456789a").is_err());
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -14,6 +14,7 @@ mod pi;
 mod visual_studio;
 mod vscode;
 mod windsurf;
+mod zcode;
 
 pub use amp::AmpInstaller;
 pub use claude_code::ClaudeCodeInstaller;
@@ -31,6 +32,7 @@ pub use pi::PiInstaller;
 pub use visual_studio::VisualStudioInstaller;
 pub use vscode::VSCodeInstaller;
 pub use windsurf::WindsurfInstaller;
+pub use zcode::ZcodeInstaller;
 
 use super::hook_installer::HookInstaller;
 
@@ -50,6 +52,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
         Box::new(DroidInstaller),
         Box::new(FirebenderInstaller),
         Box::new(JetBrainsInstaller),
+        Box::new(ZcodeInstaller),
     ];
 
     #[cfg(windows)]

--- a/src/mdm/agents/zcode.rs
+++ b/src/mdm/agents/zcode.rs
@@ -1,0 +1,749 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
+use crate::mdm::utils::{binary_exists, generate_diff, home_dir, write_atomic};
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// ZCode hook config lives at ~/.zcode/cli/config.json and uses a "process"
+/// hook schema (command = binary path, args = argument array), unlike the
+/// Claude Code "command" schema. Keep the matcher in sync with the tool names
+/// ZCode actually fires (capitalized Write/Edit/Bash).
+const ZCODE_MATCHER: &str = "Edit|Write|Bash";
+const ZCODE_HOOK_ARGS: [&str; 4] = ["checkpoint", "zcode", "--hook-input", "stdin"];
+
+pub struct ZcodeInstaller;
+
+impl ZcodeInstaller {
+    fn config_path() -> PathBuf {
+        home_dir().join(".zcode").join("cli").join("config.json")
+    }
+
+    /// True if a hook entry is one of our git-ai checkpoint process hooks.
+    /// Unlike the shell-command installers, ZCode stores checkpoint args in
+    /// the `args` array, so a plain command-string match is not sufficient.
+    fn is_git_ai_process_hook(hook: &Value) -> bool {
+        let is_git_ai = hook
+            .get("command")
+            .and_then(|c| c.as_str())
+            .map(|c| c.contains("git-ai"))
+            .unwrap_or(false);
+        let has_checkpoint = hook
+            .get("args")
+            .and_then(|a| a.as_array())
+            .map(|args| args.iter().any(|a| a.as_str() == Some("checkpoint")))
+            .unwrap_or(false);
+        is_git_ai && has_checkpoint
+    }
+
+    /// Whether a git-ai process hook already targets the zcode preset.
+    fn is_zcode_hook(hook: &Value) -> bool {
+        hook.get("args")
+            .and_then(|a| a.as_array())
+            .map(|args| args.iter().any(|a| a.as_str() == Some("zcode")))
+            .unwrap_or(false)
+    }
+
+    /// Returns `(hooks_installed, hooks_up_to_date)` from a parsed config value.
+    /// `hooks_installed` = any git-ai checkpoint process hook exists in either
+    /// hook event; `hooks_up_to_date` = such a hook already uses the zcode
+    /// preset (a claude-preset hook is installed but needs an update).
+    fn hook_status(config: &Value) -> (bool, bool) {
+        let Some(events) = config.get("hooks").and_then(|h| h.get("events")) else {
+            return (false, false);
+        };
+
+        let mut hooks_installed = false;
+        let mut hooks_up_to_date = false;
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            let Some(blocks) = events.get(hook_type).and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for block in blocks {
+                let Some(hooks) = block.get("hooks").and_then(|h| h.as_array()) else {
+                    continue;
+                };
+                for hook in hooks {
+                    if Self::is_git_ai_process_hook(hook) {
+                        hooks_installed = true;
+                        if Self::is_zcode_hook(hook) {
+                            hooks_up_to_date = true;
+                        }
+                    }
+                }
+            }
+        }
+        (hooks_installed, hooks_up_to_date)
+    }
+
+    /// The git-ai hook entry we want in the config.
+    fn desired_hook(params: &HookInstallerParams) -> Value {
+        json!({
+            "type": "process",
+            "command": params.binary_path.to_string_lossy().to_string(),
+            "enabled": true,
+            "args": ZCODE_HOOK_ARGS
+        })
+    }
+
+    fn install_hooks_at(
+        config_path: &Path,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        if let Some(dir) = config_path.parent() {
+            fs::create_dir_all(dir)?;
+        }
+
+        let existing_content = if config_path.exists() {
+            fs::read_to_string(config_path)?
+        } else {
+            String::new()
+        };
+
+        let existing: Value = if existing_content.trim().is_empty() {
+            json!({})
+        } else {
+            serde_json::from_str(&existing_content)?
+        };
+
+        // If the existing config has an unexpected top-level shape (e.g. a
+        // bare array/string), start from an empty object so hooks still get
+        // installed instead of silently reporting "already up to date".
+        let mut merged = if existing.is_object() {
+            existing.clone()
+        } else {
+            json!({})
+        };
+        let mut hooks_obj = merged.get("hooks").cloned().unwrap_or_else(|| json!({}));
+        if !hooks_obj.is_object() {
+            hooks_obj = json!({});
+        }
+
+        if let Some(obj) = hooks_obj.as_object_mut() {
+            obj.insert("enabled".to_string(), Value::Bool(true));
+        }
+        let mut events_obj = hooks_obj
+            .get("events")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            let mut blocks = events_obj
+                .get(hook_type)
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            // Find or create the matcher block that carries our hook.
+            let block_idx = blocks
+                .iter()
+                .position(|b| {
+                    b.get("matcher")
+                        .and_then(|m| m.as_str())
+                        .map(|m| m == ZCODE_MATCHER)
+                        .unwrap_or(false)
+                })
+                .unwrap_or_else(|| {
+                    blocks.push(json!({
+                        "matcher": ZCODE_MATCHER,
+                        "hooks": []
+                    }));
+                    blocks.len() - 1
+                });
+
+            // Keep user hooks, drop any duplicate git-ai entries, then ensure
+            // exactly one git-ai zcode hook remains (migrates an existing
+            // claude-preset hook to zcode).
+            let mut hooks_array = blocks[block_idx]
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            hooks_array.retain(|hook| !Self::is_git_ai_process_hook(hook));
+            hooks_array.push(Self::desired_hook(params));
+
+            if let Some(block) = blocks[block_idx].as_object_mut() {
+                block.insert("hooks".to_string(), Value::Array(hooks_array));
+            }
+
+            if let Some(obj) = events_obj.as_object_mut() {
+                obj.insert(hook_type.to_string(), Value::Array(blocks));
+            }
+        }
+
+        if let Some(obj) = hooks_obj.as_object_mut() {
+            obj.insert("events".to_string(), events_obj);
+        }
+
+        if let Some(root) = merged.as_object_mut() {
+            root.insert("hooks".to_string(), hooks_obj);
+        }
+
+        if existing == merged {
+            return Ok(None);
+        }
+
+        let new_content = serde_json::to_string_pretty(&merged)?;
+        let diff_output = generate_diff(config_path, &existing_content, &new_content);
+
+        if !dry_run {
+            write_atomic(config_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+
+    fn uninstall_hooks_at(config_path: &Path, dry_run: bool) -> Result<Option<String>, GitAiError> {
+        if !config_path.exists() {
+            return Ok(None);
+        }
+
+        let existing_content = fs::read_to_string(config_path)?;
+        let existing: Value = serde_json::from_str(&existing_content)?;
+
+        let mut merged = existing.clone();
+        let mut hooks_obj = match merged.get("hooks").cloned() {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+        let mut events_obj = match hooks_obj.get("events").cloned() {
+            Some(e) => e,
+            None => return Ok(None),
+        };
+
+        let mut changed = false;
+        for hook_type in &["PreToolUse", "PostToolUse"] {
+            if let Some(blocks) = events_obj
+                .get_mut(*hook_type)
+                .and_then(|v| v.as_array_mut())
+            {
+                for block in blocks.iter_mut() {
+                    if let Some(hooks_array) = block.get_mut("hooks").and_then(|h| h.as_array_mut())
+                    {
+                        let original_len = hooks_array.len();
+                        hooks_array.retain(|hook| !Self::is_git_ai_process_hook(hook));
+                        if hooks_array.len() != original_len {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if !changed {
+            return Ok(None);
+        }
+
+        if let Some(obj) = hooks_obj.as_object_mut() {
+            obj.insert("events".to_string(), events_obj);
+        }
+        if let Some(root) = merged.as_object_mut() {
+            root.insert("hooks".to_string(), hooks_obj);
+        }
+
+        let new_content = serde_json::to_string_pretty(&merged)?;
+        let diff_output = generate_diff(config_path, &existing_content, &new_content);
+
+        if !dry_run {
+            write_atomic(config_path, new_content.as_bytes())?;
+        }
+
+        Ok(Some(diff_output))
+    }
+}
+
+impl HookInstaller for ZcodeInstaller {
+    fn name(&self) -> &str {
+        "ZCode"
+    }
+
+    fn id(&self) -> &str {
+        "zcode"
+    }
+
+    fn check_hooks(&self, _params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        // Detect the tool via its config directory or binary on PATH (mirroring
+        // the other installers) so a fresh ZCode install that has not produced
+        // a config file yet is still reported as installed and gets hooks set up.
+        let tool_installed = home_dir().join(".zcode").exists() || binary_exists("zcode");
+        if !tool_installed {
+            return Ok(HookCheckResult {
+                tool_installed: false,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let config_path = Self::config_path();
+        if !config_path.exists() {
+            return Ok(HookCheckResult {
+                tool_installed: true,
+                hooks_installed: false,
+                hooks_up_to_date: false,
+            });
+        }
+
+        let content = fs::read_to_string(&config_path)?;
+        let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+        let (hooks_installed, hooks_up_to_date) = Self::hook_status(&existing);
+
+        Ok(HookCheckResult {
+            tool_installed: true,
+            hooks_installed,
+            hooks_up_to_date,
+        })
+    }
+
+    fn process_names(&self) -> Vec<&str> {
+        vec!["zcode"]
+    }
+
+    fn install_hooks(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Self::install_hooks_at(&Self::config_path(), params, dry_run)
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        Self::uninstall_hooks_at(&Self::config_path(), dry_run)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_test_env() -> (TempDir, PathBuf) {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir
+            .path()
+            .join(".zcode")
+            .join("cli")
+            .join("config.json");
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        (temp_dir, config_path)
+    }
+
+    fn binary_path() -> PathBuf {
+        PathBuf::from("/usr/local/bin/git-ai")
+    }
+
+    fn params() -> HookInstallerParams {
+        HookInstallerParams {
+            binary_path: binary_path(),
+        }
+    }
+
+    fn read_config(path: &Path) -> Value {
+        serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn hooks_in_matcher<'a>(config: &'a Value, hook_type: &str) -> Vec<&'a Value> {
+        config
+            .get("hooks")
+            .and_then(|h| h.get("events"))
+            .and_then(|e| e.get(hook_type))
+            .and_then(|v| v.as_array())
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .find(|b| {
+                        b.get("matcher")
+                            .and_then(|m| m.as_str())
+                            .map(|m| m == ZCODE_MATCHER)
+                            .unwrap_or(false)
+                    })
+                    .and_then(|b| b.get("hooks").and_then(|h| h.as_array()))
+                    .map(|v| v.iter().collect())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
+    fn args_of(hook: &Value) -> Vec<String> {
+        hook.get("args")
+            .and_then(|a| a.as_array())
+            .map(|args| {
+                args.iter()
+                    .filter_map(|a| a.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    // ---- Install scenarios ----
+
+    #[test]
+    fn s1_fresh_install_creates_process_hook() {
+        let (_td, path) = setup_test_env();
+        // File does not exist yet
+        fs::remove_file(&path).ok();
+
+        let diff = ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        assert!(diff.is_some(), "should produce a diff");
+
+        let config = read_config(&path);
+        assert_eq!(
+            config.get("hooks").and_then(|h| h.get("enabled")),
+            Some(&Value::Bool(true)),
+            "hooks.enabled should be true"
+        );
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            let hooks = hooks_in_matcher(&config, hook_type);
+            assert_eq!(
+                hooks.len(),
+                1,
+                "{hook_type}: expected 1 hook in matcher block"
+            );
+            let hook = hooks[0];
+            assert_eq!(hook.get("type").and_then(|t| t.as_str()), Some("process"));
+            assert_eq!(
+                hook.get("command").and_then(|c| c.as_str()),
+                Some("/usr/local/bin/git-ai")
+            );
+            assert_eq!(hook.get("enabled"), Some(&Value::Bool(true)));
+            assert_eq!(
+                args_of(hook),
+                vec!["checkpoint", "zcode", "--hook-input", "stdin"]
+            );
+        }
+    }
+
+    #[test]
+    fn s2_idempotent_already_on_zcode() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "enabled": true,
+                    "events": {
+                        "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":ZCODE_HOOK_ARGS}
+                        ]}],
+                        "PostToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":ZCODE_HOOK_ARGS}
+                        ]}]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let diff = ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        assert!(diff.is_none(), "should return None when already up-to-date");
+    }
+
+    #[test]
+    fn s3_migrates_claude_preset_hook_to_zcode() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "enabled": true,
+                    "events": {
+                        "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","claude","--hook-input","stdin"]}
+                        ]}],
+                        "PostToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","claude","--hook-input","stdin"]}
+                        ]}]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let config = read_config(&path);
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            let hooks = hooks_in_matcher(&config, hook_type);
+            assert_eq!(
+                hooks.len(),
+                1,
+                "{hook_type}: expected exactly 1 git-ai hook"
+            );
+            assert_eq!(
+                args_of(hooks[0]),
+                vec!["checkpoint", "zcode", "--hook-input", "stdin"]
+            );
+        }
+    }
+
+    #[test]
+    fn s4_preserves_other_top_level_keys() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "mcp": {"servers": {"my-server": {"type": "stdio"}}},
+                "plugins": {"enabledPlugins": {"my-plugin": true}}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let config = read_config(&path);
+        assert!(
+            config.get("mcp").and_then(|m| m.get("servers")).is_some(),
+            "mcp block should be preserved"
+        );
+        assert!(
+            config.get("plugins").is_some(),
+            "plugins block should be preserved"
+        );
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            assert_eq!(hooks_in_matcher(&config, hook_type).len(), 1);
+        }
+    }
+
+    #[test]
+    fn s5_preserves_user_hooks_in_matcher_block() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "enabled": true,
+                    "events": {
+                        "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/opt/my-audit-tool","enabled":true,"args":["--check"]}
+                        ]}],
+                        "PostToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/opt/my-audit-tool","enabled":true,"args":["--check"]}
+                        ]}]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let config = read_config(&path);
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            let hooks = hooks_in_matcher(&config, hook_type);
+            assert_eq!(hooks.len(), 2, "{hook_type}: user hook + git-ai");
+            assert!(
+                hooks.iter().any(|h| {
+                    h.get("command").and_then(|c| c.as_str()) == Some("/opt/my-audit-tool")
+                }),
+                "{hook_type}: user hook should be preserved"
+            );
+            assert!(
+                hooks
+                    .iter()
+                    .any(|h| args_of(h).first().map(|a| a.as_str()) == Some("checkpoint")),
+                "{hook_type}: git-ai hook should be present"
+            );
+        }
+    }
+
+    #[test]
+    fn s6_deduplicates_multiple_git_ai_hooks() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "enabled": true,
+                    "events": {
+                        "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","zcode","--hook-input","stdin"]},
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","zcode","--hook-input","stdin"]}
+                        ]}],
+                        "PostToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","zcode","--hook-input","stdin"]}
+                        ]}]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+
+        let config = read_config(&path);
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            assert_eq!(
+                hooks_in_matcher(&config, hook_type).len(),
+                1,
+                "{hook_type}: should have exactly 1 after dedup"
+            );
+        }
+    }
+
+    #[test]
+    fn s7_install_overwrites_unexpected_config_shape() {
+        let (_td, path) = setup_test_env();
+        // Top-level value is an array, not an object — install must still
+        // produce a valid hooks block instead of silently doing nothing.
+        fs::write(&path, "[]").unwrap();
+
+        let diff = ZcodeInstaller::install_hooks_at(&path, &params(), false).unwrap();
+        assert!(diff.is_some(), "should produce a diff for malformed config");
+
+        let config = read_config(&path);
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            assert_eq!(hooks_in_matcher(&config, hook_type).len(), 1);
+        }
+    }
+
+    // ---- Uninstall scenarios ----
+
+    #[test]
+    fn u1_uninstall_removes_git_ai_preserves_user_hook() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "enabled": true,
+                    "events": {
+                        "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/opt/my-audit-tool","enabled":true,"args":["--check"]},
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","zcode","--hook-input","stdin"]}
+                        ]}],
+                        "PostToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","zcode","--hook-input","stdin"]}
+                        ]}]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let diff = ZcodeInstaller::uninstall_hooks_at(&path, false).unwrap();
+        assert!(diff.is_some());
+
+        let config = read_config(&path);
+        for hook_type in ["PreToolUse", "PostToolUse"] {
+            let hooks = hooks_in_matcher(&config, hook_type);
+            assert!(
+                !hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| c.contains("git-ai"))
+                        .unwrap_or(false)
+                }),
+                "{hook_type}: git-ai should be removed"
+            );
+        }
+        let pre_hooks = hooks_in_matcher(&config, "PreToolUse");
+        assert!(
+            pre_hooks
+                .iter()
+                .any(|h| h.get("command").and_then(|c| c.as_str()) == Some("/opt/my-audit-tool")),
+            "user hook should be preserved"
+        );
+    }
+
+    #[test]
+    fn u2_noop_uninstall_when_no_git_ai() {
+        let (_td, path) = setup_test_env();
+        fs::write(
+            &path,
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "enabled": true,
+                    "events": {
+                        "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                            {"type":"process","command":"/opt/my-audit-tool","enabled":true,"args":["--check"]}
+                        ]}]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let diff = ZcodeInstaller::uninstall_hooks_at(&path, false).unwrap();
+        assert!(
+            diff.is_none(),
+            "should return None when nothing to uninstall"
+        );
+    }
+
+    // ---- check_hooks scenarios ----
+
+    #[test]
+    fn c1_no_hooks_returns_not_installed() {
+        let config = json!({});
+        let (installed, up_to_date) = ZcodeInstaller::hook_status(&config);
+        assert!(!installed);
+        assert!(!up_to_date);
+    }
+
+    #[test]
+    fn c2_zcode_hook_returns_up_to_date() {
+        let config = json!({
+            "hooks": {
+                "enabled": true,
+                "events": {
+                    "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                        {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","zcode","--hook-input","stdin"]}
+                    ]}]
+                }
+            }
+        });
+        let (installed, up_to_date) = ZcodeInstaller::hook_status(&config);
+        assert!(installed);
+        assert!(up_to_date);
+    }
+
+    #[test]
+    fn c3_claude_preset_hook_returns_installed_but_not_up_to_date() {
+        let config = json!({
+            "hooks": {
+                "enabled": true,
+                "events": {
+                    "PreToolUse": [{"matcher": ZCODE_MATCHER, "hooks": [
+                        {"type":"process","command":"/usr/local/bin/git-ai","enabled":true,"args":["checkpoint","claude","--hook-input","stdin"]}
+                    ]}]
+                }
+            }
+        });
+        let (installed, up_to_date) = ZcodeInstaller::hook_status(&config);
+        assert!(installed, "should be considered installed");
+        assert!(
+            !up_to_date,
+            "should not be up-to-date when on claude preset"
+        );
+    }
+
+    #[test]
+    fn c4_install_creates_missing_parent_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        // Point to a config.json inside a directory that does NOT exist yet
+        let config_path = temp_dir.path().join("missing_dir").join("config.json");
+        assert!(!config_path.parent().unwrap().exists());
+
+        let result = ZcodeInstaller::install_hooks_at(&config_path, &params(), false).unwrap();
+
+        assert!(result.is_some(), "should report changes for fresh install");
+        assert!(config_path.exists(), "config.json should be created");
+
+        let content: Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).expect("valid JSON");
+        assert!(content.get("hooks").and_then(|h| h.get("events")).is_some());
+    }
+}

--- a/src/streams/agent.rs
+++ b/src/streams/agent.rs
@@ -196,7 +196,12 @@ const ALL_AGENT_TYPES: &[&str] = &[
 /// Returns None for agents without sweep/read support (e.g., "human", "mock_ai").
 pub fn get_agent(agent_type: &str) -> Option<Box<dyn Agent>> {
     match agent_type {
-        "claude" => Some(Box::new(super::agents::ClaudeAgent::new())),
+        // ZCode speaks the Claude Code hook protocol, so it reuses the Claude
+        // transcript reader. It is intentionally NOT in ALL_AGENT_TYPES: the
+        // Claude sweep would otherwise discover ~/.claude transcripts under the
+        // zcode name. ZCode transcripts are ingested incrementally from each
+        // checkpoint's stream path instead.
+        "claude" | "zcode" => Some(Box::new(super::agents::ClaudeAgent::new())),
         "cursor" => Some(Box::new(super::agents::CursorAgent::new())),
         "droid" => Some(Box::new(super::agents::DroidAgent::new())),
         "copilot" | "github-copilot" => Some(Box::new(super::agents::CopilotAgent::new())),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -150,3 +150,4 @@ mod utf8_filenames;
 mod virtual_attribution_unit;
 mod windsurf;
 mod worktrees;
+mod zcode;

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1030,6 +1030,7 @@ fn is_known_checkpoint_preset(arg: &str) -> bool {
             | "known_human"
             | "droid"
             | "agent-v1"
+            | "zcode"
     )
 }
 

--- a/tests/integration/zcode.rs
+++ b/tests/integration/zcode.rs
@@ -1,0 +1,187 @@
+use crate::repos::test_repo::TestRepo;
+use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
+use serde_json::json;
+use std::fs;
+
+#[test]
+#[serial_test::serial]
+fn test_zcode_e2e_prefers_latest_checkpoint_for_prompts() {
+    let mut repo = TestRepo::new();
+
+    // Enable prompt sharing for all repositories (empty blacklist = no exclusions)
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]); // No exclusions = share everywhere
+        // Record checkpoint debug logs so a failure below shows what the
+        // checkpoint command actually emitted (preset, event count, requests).
+        patch.feature_flags = Some(serde_json::json!({"checkpoint_debug_log": true}));
+    });
+
+    let repo_root = repo.canonical_path();
+
+    // Create initial file and commit
+    let src_dir = repo_root.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let file_path = src_dir.join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // Use a stable transcript path so both checkpoints share the same agent_id
+    let transcript_path = repo_root.join("zcode-session.jsonl");
+
+    // First checkpoint: empty transcript (simulates race where data isn't ready yet)
+    fs::write(&transcript_path, "").unwrap();
+    let hook_input = json!({
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "transcript_path": transcript_path.to_string_lossy().to_string(),
+        "tool_input": {
+            "file_path": file_path.to_string_lossy().to_string()
+        }
+    })
+    .to_string();
+
+    // First AI edit and checkpoint with empty transcript/model
+    fs::write(&file_path, "fn main() {}\n// ai line one\n").unwrap();
+    repo.git_ai(&["checkpoint", "zcode", "--hook-input", &hook_input])
+        .unwrap();
+
+    // Second AI edit with the real transcript content
+    let fixture = crate::test_utils::fixture_path("example-claude-code.jsonl");
+    fs::copy(&fixture, &transcript_path).unwrap();
+    fs::write(&file_path, "fn main() {}\n// ai line one\n// ai line two\n").unwrap();
+    repo.git_ai(&["checkpoint", "zcode", "--hook-input", &hook_input])
+        .unwrap();
+
+    // Commit the changes
+    let commit = repo.stage_all_and_commit("Add AI lines").unwrap();
+
+    // Dump the checkpoint debug log to stderr so CI failures show exactly what
+    // the checkpoint command emitted (preset_name / event_count / requests).
+    let log_dir = repo
+        .test_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("checkpoint-debug-logs");
+    if let Ok(entries) = fs::read_dir(&log_dir) {
+        for entry in entries.flatten() {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                eprintln!(
+                    "=== checkpoint debug log: {} ===\n{}",
+                    entry.path().display(),
+                    content
+                );
+            }
+        }
+    }
+
+    // We should have exactly one session record keyed by the zcode agent_id
+    assert_eq!(
+        commit.authorship_log.metadata.sessions.len(),
+        1,
+        "Expected a single session record"
+    );
+    let session_record = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("Session record should exist");
+
+    assert_eq!(session_record.agent_id.tool, "zcode");
+    // Model is extracted from the real transcript fixture copied in the second checkpoint
+    assert_eq!(
+        session_record.agent_id.model, "claude-sonnet-4-20250514",
+        "Session record model should come from the latest checkpoint's transcript"
+    );
+}
+
+#[test]
+fn test_zcode_preset_extracts_edited_filepath() {
+    let hook_input = r##"{
+        "cwd": "/Users/svarlamov/projects/testing-git",
+        "hook_event_name": "PostToolUse",
+        "session_id": "23aad27c-175d-427f-ac5f-a6830b8e6e65",
+        "tool_input": {
+            "file_path": "/Users/svarlamov/projects/testing-git/README.md",
+            "new_string": "# Testing Git Repository",
+            "old_string": "# Testing Git"
+        },
+        "tool_name": "Edit",
+        "transcript_path": "tests/fixtures/example-claude-code.jsonl"
+    }"##;
+
+    let events = resolve_preset("zcode")
+        .unwrap()
+        .parse(hook_input, "t_test")
+        .expect("Failed to run ZcodePreset");
+
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        ParsedHookEvent::PostFileEdit(e) => {
+            assert_eq!(e.context.agent_id.tool, "zcode");
+            assert!(!e.file_paths.is_empty());
+            assert!(
+                e.file_paths
+                    .iter()
+                    .any(|p| p.to_string_lossy().contains("README.md"))
+            );
+        }
+        _ => panic!("Expected PostFileEdit"),
+    }
+}
+
+#[test]
+fn test_zcode_preset_ignores_vscode_copilot_payload() {
+    let hook_input = json!({
+        "hookEventName": "PreToolUse",
+        "cwd": "/Users/test/project",
+        "toolName": "copilot_replaceString",
+        "transcript_path": "/Users/test/Library/Application Support/Code/User/workspaceStorage/workspace-id/GitHub.copilot-chat/transcripts/copilot-session-1.jsonl",
+        "toolInput": {
+            "file_path": "/Users/test/project/src/main.ts"
+        },
+        "sessionId": "copilot-session-1",
+        "model": "copilot/claude-sonnet-4"
+    })
+    .to_string();
+
+    let result = resolve_preset("zcode")
+        .unwrap()
+        .parse(&hook_input, "t_test");
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Skipping VS Code hook payload in ZCode preset")
+    );
+}
+
+#[test]
+fn test_zcode_preset_ignores_cursor_payload() {
+    let hook_input = json!({
+        "conversation_id": "dff2bf79-6a53-446c-be41-f33512532fb0",
+        "model": "default",
+        "tool_name": "Write",
+        "tool_input": {
+            "file_path": "/Users/test/project/jokes.csv"
+        },
+        "transcript_path": "/Users/test/.cursor/projects/Users-test-project/agent-transcripts/dff2bf79-6a53-446c-be41-f33512532fb0/dff2bf79-6a53-446c-be41-f33512532fb0.jsonl",
+        "hook_event_name": "postToolUse",
+        "cursor_version": "2.5.26",
+        "workspace_roots": ["/Users/test/project"]
+    })
+    .to_string();
+
+    let result = resolve_preset("zcode")
+        .unwrap()
+        .parse(&hook_input, "t_test");
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Skipping Cursor hook payload in ZCode preset")
+    );
+}


### PR DESCRIPTION
## Summary

Add first-class support for **ZCode** (a Claude Code-compatible CLI coding agent) to git-ai:

- `git-ai checkpoint zcode` parses ZCode's hook payload. ZCode's hook protocol is identical to Claude Code's (same JSON shape, capitalized `Write`/`Edit`/`Bash` tool names, Claude-format transcript), so the new preset mirrors the existing Claude preset and attributes work to `zcode` instead of `claude`.
- `git ai install-hooks` now supports ZCode via a new installer that writes the process-style checkpoint hook into `~/.zcode/cli/config.json` (`hooks.events.PreToolUse`/`PostToolUse`, matcher `Edit|Write|Bash`, `type: "process"` with checkpoint args in the `args` array). It preserves existing top-level config keys (`mcp`, `plugins`, ...) and migrates an existing `checkpoint claude` hook to `checkpoint zcode`.

## Changes

- `src/commands/checkpoint_agent/presets/zcode.rs` — new `ZcodePreset` (mirrors `claude.rs`, agent id `zcode`) + unit tests
- `src/commands/checkpoint_agent/presets/mod.rs` — register the `zcode` preset
- `src/mdm/agents/zcode.rs` — new `ZcodeInstaller` (writes/updates/removes the ZCode hook config) + unit tests
- `src/mdm/agents/mod.rs` — register `ZcodeInstaller`

## Testing

- Unit tests for the preset (parse events, session id derivation, skip guards) and the installer (fresh install, idempotency, claude->zcode migration, top-level key preservation, uninstall, hook status)
- CI: Lint & Format (fmt/clippy/doc) green; Test core jobs green on ubuntu/windows/macos (all zcode tests pass); Ubuntu integration green

## Notes

- ZCode's hook config file is `~/.zcode/cli/config.json` and uses a different hook schema than Claude Code (`process` type + `args` array), which is why a dedicated installer is needed.
- Transcript/model extraction reuses the existing Claude JSONL stream format.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->