### PR TITLE
Resolve Claude model at commit time when the only checkpoint saw an unflushed transcript

### DIFF
--- a/src/authorship/virtual_attribution.rs
+++ b/src/authorship/virtual_attribution.rs
@@ -464,13 +464,13 @@ impl VirtualAttributions {
                             &agent_id.tool,
                         );
 
-                    let session_record = SessionRecord {
-                        agent_id: agent_id.clone(),
-                        human_author: human_author.clone(),
-                        custom_attributes: None,
-                    };
-
-                    sessions.insert(session_id.clone(), session_record);
+                    upsert_session_record(
+                        &mut sessions,
+                        session_id.clone(),
+                        checkpoint,
+                        agent_id,
+                        &human_author,
+                    );
 
                     // Track additions/deletions keyed by session_id
                     *session_additions.entry(session_id.clone()).or_insert(0) +=
@@ -661,13 +661,13 @@ impl VirtualAttributions {
                             &agent_id.tool,
                         );
 
-                    let session_record = SessionRecord {
-                        agent_id: agent_id.clone(),
-                        human_author: human_author.clone(),
-                        custom_attributes: None,
-                    };
-
-                    sessions.insert(session_id.clone(), session_record);
+                    upsert_session_record(
+                        &mut sessions,
+                        session_id.clone(),
+                        checkpoint,
+                        agent_id,
+                        &human_author,
+                    );
 
                     // Track additions/deletions keyed by session_id
                     *session_additions.entry(session_id.clone()).or_insert(0) +=
@@ -847,13 +847,13 @@ impl VirtualAttributions {
                             &agent_id.tool,
                         );
 
-                    let session_record = SessionRecord {
-                        agent_id: agent_id.clone(),
-                        human_author: human_author.clone(),
-                        custom_attributes: None,
-                    };
-
-                    sessions.insert(session_id.clone(), session_record);
+                    upsert_session_record(
+                        &mut sessions,
+                        session_id.clone(),
+                        checkpoint,
+                        agent_id,
+                        &human_author,
+                    );
 
                     // Track additions/deletions keyed by session_id
                     *session_additions.entry(session_id.clone()).or_insert(0) +=
@@ -3585,6 +3585,52 @@ pub fn restore_virtual_attribution_carryover(
     )?;
     Ok(())
 }
+
+/// Records a session from a checkpoint, keeping later checkpoints' `agent_id`
+/// but never letting a placeholder `unknown` model clobber a resolved one. If
+/// the model is still unknown, re-resolve it from the transcript path: short
+/// Claude sessions can fire their only hook before Claude Code flushes the
+/// first assistant line (which carries the model), but by commit time the
+/// transcript is complete.
+fn upsert_session_record(
+    sessions: &mut BTreeMap<String, SessionRecord>,
+    session_id: String,
+    checkpoint: &crate::authorship::working_log::Checkpoint,
+    agent_id: &crate::authorship::working_log::AgentId,
+    human_author: &Option<String>,
+) {
+    let mut agent_id = agent_id.clone();
+    if agent_id.model == UNKNOWN_MODEL
+        && let Some(existing) = sessions.get(&session_id)
+        && existing.agent_id.model != UNKNOWN_MODEL
+    {
+        agent_id.model = existing.agent_id.model.clone();
+    }
+    if agent_id.model == UNKNOWN_MODEL
+        && agent_id.tool == "claude"
+        && let Some(transcript_path) = checkpoint
+            .agent_metadata
+            .as_ref()
+            .and_then(|m| m.get("transcript_path"))
+        && let Ok(Some(model)) = crate::streams::model_extraction::extract_model(
+            std::path::Path::new(transcript_path),
+            crate::streams::sweep::StreamFormat::ClaudeJsonl,
+            None,
+        )
+    {
+        agent_id.model = model;
+    }
+    sessions.insert(
+        session_id,
+        SessionRecord {
+            agent_id,
+            human_author: human_author.clone(),
+            custom_attributes: None,
+        },
+    );
+}
+
+const UNKNOWN_MODEL: &str = "unknown";
 
 #[cfg(test)]
 mod tests {

--- a/tests/integration/claude_code.rs
+++ b/tests/integration/claude_code.rs
@@ -379,3 +379,47 @@ crate::reuse_tests_in_worktree!(
     test_claude_preset_ignores_unsupported_tool_when_transcript_path_is_claude,
     test_claude_e2e_prefers_latest_checkpoint_for_prompts,
 );
+
+/// Regression: a short Claude session may fire its only PostToolUse hook before
+/// Claude Code flushes the first assistant line (which carries `message.model`)
+/// to the transcript. The checkpoint records `model: unknown`, and with no later
+/// checkpoint to overwrite it the note used to keep `unknown` forever. At commit
+/// time the transcript is complete, so we re-resolve the model from it.
+#[test]
+fn test_claude_single_checkpoint_resolves_model_at_commit() {
+    use crate::repos::test_repo::TestRepo;
+
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    let file_path = repo_root.join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    // Transcript is empty when the only checkpoint fires.
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(&transcript_path, "").unwrap();
+    let hook_input = json!({
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "transcript_path": transcript_path.to_string_lossy().to_string(),
+        "tool_input": { "file_path": file_path.to_string_lossy().to_string() }
+    })
+    .to_string();
+    fs::write(&file_path, "fn main() {}\n// ai line one\n").unwrap();
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &hook_input])
+        .unwrap();
+
+    // Claude Code flushes the assistant turn afterwards; no further checkpoints.
+    fs::copy(fixture_path("example-claude-code.jsonl"), &transcript_path).unwrap();
+
+    let commit = repo.stage_all_and_commit("Add AI line").unwrap();
+    let session_record = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .expect("Session record should exist");
+    assert_eq!(session_record.agent_id.model, "claude-sonnet-4-20250514");
+}


### PR DESCRIPTION
## Problem
Short Claude Code sessions (1–2 messages) can fire their only PostToolUse hook before Claude Code flushes the first assistant line (which carries `message.model`) to the transcript. The Claude preset extracts the model at checkpoint time, so the checkpoint records `model: unknown`, and with no later checkpoint for that session the authorship note keeps `unknown` forever. Longer sessions self-heal because later checkpoints overwrite the session record.

## Fix
When assembling session records from working-log checkpoints at commit time (`virtual_attribution.rs`), route all three insertion sites through `upsert_session_record`, which:
- never lets a placeholder `unknown` model overwrite an already-resolved one, and
- if the model is still `unknown` for a `claude` session, re-extracts it from the checkpoint's `transcript_path` metadata (the transcript is complete by then). This is a single bounded file read outside the ingestion hot path; no git calls.

## Test
`test_claude_single_checkpoint_resolves_model_at_commit` — checkpoint against an empty transcript, then populate it, commit, assert the note's session model is resolved. Fails before, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->