### PR TITLE
Export OpenCode plugin module with id so the UI shows its name

### DIFF
--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -17,7 +17,7 @@
  * @see https://opencode.ai/docs/plugins/
  */
 
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Plugin, PluginModule } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
 import { readFile, stat } from "fs/promises"
 import { dirname, isAbsolute, join, resolve } from "path"
@@ -512,4 +512,13 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
   }
 }
 
-export default GitAiPlugin
+// OpenCode reads a file-based plugin's display name from the `id` of a
+// default-exported plugin module; without it the UI falls back to the plugin's
+// file:// path. The named GitAiPlugin export above must stay: older OpenCode
+// loaders call every export as a function and register the plugin through it.
+const GitAiPluginModule: PluginModule = {
+  id: "git-ai",
+  server: GitAiPlugin,
+}
+
+export default GitAiPluginModule

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -299,10 +299,10 @@ mod tests {
     fn test_opencode_plugin_content_is_valid_typescript() {
         let content = OPENCODE_PLUGIN_CONTENT;
 
-        assert!(content.contains("import type { Plugin }"));
+        assert!(content.contains("import type { Plugin, PluginModule }"));
         assert!(content.contains("@opencode-ai/plugin"));
         assert!(content.contains("export const GitAiPlugin: Plugin"));
-        assert!(content.contains("export default GitAiPlugin"));
+        assert!(content.contains("export default GitAiPluginModule"));
         assert!(content.contains("child_process"));
         assert!(content.contains("\"tool.execute.before\""));
         assert!(content.contains("\"tool.execute.after\""));
@@ -315,6 +315,22 @@ mod tests {
         assert!(content.contains("session_id"));
         assert!(content.contains("PreToolUse"));
         assert!(content.contains("PostToolUse"));
+    }
+
+    #[test]
+    fn test_opencode_plugin_default_export_is_module_with_id() {
+        // OpenCode resolves a file-based plugin's display name from the `id` of a
+        // default-exported plugin module; without it the UI falls back to the
+        // plugin's file:// path (https://github.com/git-ai-project/git-ai/issues/2153).
+        let content = OPENCODE_PLUGIN_CONTENT;
+
+        assert!(content.contains(r#"id: "git-ai""#));
+        assert!(content.contains("server: GitAiPlugin"));
+        assert!(content.contains("const GitAiPluginModule: PluginModule"));
+        assert!(content.contains("export default GitAiPluginModule"));
+        // Older OpenCode loaders call every export as a function, so the named
+        // plugin function export must remain for backwards compatibility.
+        assert!(content.contains("export const GitAiPlugin: Plugin"));
     }
 
     #[test]

--- a/tests/integration/opencode.rs
+++ b/tests/integration/opencode.rs
@@ -483,6 +483,59 @@ fn test_opencode_e2e_checkpoint_and_commit() {
     );
 }
 
+/// Markdown files created through OpenCode's write tool must get AI attribution
+/// and count toward AI stats like any other file
+/// (https://github.com/git-ai-project/git-ai/issues/2162).
+#[test]
+fn test_opencode_new_markdown_file_gets_ai_attribution() {
+    use crate::repos::test_file::ExpectedLineExt;
+    use crate::repos::test_repo::TestRepo;
+
+    let repo = TestRepo::new();
+    let repo_root = repo.canonical_path();
+
+    fs::write(repo_root.join("README.md"), "# Project\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let skill_path = repo_root.join("skill.md");
+    let pre_hook_input = json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "md-session-1",
+        "tool_use_id": "call-md-1",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "tool_name": "write",
+        "tool_input": {
+            "filePath": skill_path.to_string_lossy().to_string()
+        }
+    })
+    .to_string();
+    repo.git_ai(&["checkpoint", "opencode", "--hook-input", &pre_hook_input])
+        .unwrap();
+
+    fs::write(&skill_path, "# Skill\nAI generated instructions\n").unwrap();
+
+    let post_hook_input = json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": "md-session-1",
+        "tool_use_id": "call-md-1",
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "tool_name": "write",
+        "tool_input": {
+            "filePath": skill_path.to_string_lossy().to_string()
+        }
+    })
+    .to_string();
+    repo.git_ai(&["checkpoint", "opencode", "--hook-input", &post_hook_input])
+        .unwrap();
+
+    repo.stage_all_and_commit("Add skill.md").unwrap();
+    let mut file = repo.filename("skill.md");
+    file.assert_committed_lines(crate::lines![
+        "# Skill".ai(),
+        "AI generated instructions".ai(),
+    ]);
+}
+
 #[test]
 fn test_opencode_transcript_ids_extracted_from_fixture() {
     use chrono::{DateTime, Utc};

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -15,6 +15,7 @@ const AI_AUTHOR_NAMES: &[&str] = &[
     "codex",
     "gemini",
     "amp",
+    "opencode",
     "windsurf",
     "devin",
     "cloud-agent",


### PR DESCRIPTION
Fixes #2153

## Problem

The OpenCode plugin only exported a plain plugin function (what OpenCode now calls the legacy format), so OpenCode had no `id` to display and fell back to showing the plugin as `file:///.../.config/opencode/plugins/git-ai.ts` in its UI.

## Why not the v2 plugin API

The issue suggests migrating to `define({ id, setup })` from `@opencode-ai/plugin/v2/promise`. I verified against OpenCode's source that the shipped v2 plugin context only exposes domain transforms (`agent`, `catalog`, `command`, `integration`, `reference`, `skill`) and `aisdk` hooks — **it has no `tool.execute.before/after` hooks**. Those are only on OpenCode's v2 roadmap (`packages/plugin/src/v2/effect/PLAN.md`, "Migrate Runtime Hooks → Tool execution hooks"). A pure v2 plugin would therefore lose all checkpointing, which is the plugin's entire purpose.

## Fix

Use OpenCode's supported module format instead, which is exactly where its loader reads a plugin's display name from (`resolvePluginId`/`readPluginId` in `packages/opencode/src/plugin/shared.ts` — file-based plugins are expected to export an `id`):

```ts
const GitAiPluginModule: PluginModule = {
  id: "git-ai",
  server: GitAiPlugin,
}

export default GitAiPluginModule
```

The named `GitAiPlugin` export is kept for backwards compatibility: OpenCode versions predating the module format iterate a plugin module's exports and call each one as a function, and module namespace ordering puts `GitAiPlugin` before `default`, so the plugin still registers there. Current OpenCode detects the default-exported module, uses its `id`, and registers `server()` exactly once (no double registration; verified the loader history — server-object unwrapping and module detection shipped together).

The plugin typechecks cleanly against the latest published `@opencode-ai/plugin` package (`tsc --strict`). The `import type` is erased at runtime, so older installed type packages without `PluginModule` are unaffected.

## Related: #2162

Investigated whether git-ai drops `.md` files from AI stats: it does not — default stats ignore patterns have no Markdown entries, and the OpenCode preset does no extension filtering. Added an integration test (`test_opencode_new_markdown_file_gets_ai_attribution`) proving a new `skill.md` written through OpenCode's `write` tool hooks gets full AI attribution. While writing it, found the test blame helper's `AI_AUTHOR_NAMES` didn't recognize `opencode` as an AI author; fixed. If #2162 reproduces for the reporter, a plugin that failed to load/display correctly (this issue) is a plausible cause.

## Test coverage

- `test_opencode_plugin_default_export_is_module_with_id` (new, TDD — failed before the fix): asserts the module default export with `id: "git-ai"` and the retained named export.
- `test_opencode_plugin_content_is_valid_typescript` updated for the new imports/default export.
- `test_opencode_new_markdown_file_gets_ai_attribution` (new): end-to-end OpenCode-preset checkpoint flow on a new `.md` file, asserting committed line attribution.
- Full test suite, `task lint`, and `task fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->