### PR TITLE
Normalize lowercase HEAD revisions in git-ai commands

### DIFF
--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -4,6 +4,7 @@ use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
 use crate::commands::blame::GitAiBlameOptions;
+use crate::commands::revision::normalize_head_rev;
 use crate::error::GitAiError;
 use crate::git::notes_api::{read_authorship, read_note};
 use crate::git::repository::{InternalGitProfile, Repository, exec_git_with_profile};
@@ -239,7 +240,7 @@ pub fn parse_diff_args(args: &[String]) -> Result<ParsedDiffArgs, GitAiError> {
                         "--blame-deletions-since requires a value".to_string(),
                     ));
                 }
-                options.blame_deletions_since = Some(args[i + 1].clone());
+                options.blame_deletions_since = Some(normalize_head_rev(&args[i + 1]));
                 i += 2;
             }
             "--include-stats" => {
@@ -288,21 +289,21 @@ pub fn parse_diff_args(args: &[String]) -> Result<ParsedDiffArgs, GitAiError> {
                     "Invalid diff arguments. Expected: <commit>, <commit1>..<commit2>, or <commit1> <commit2>".to_string(),
                 ));
             }
-            DiffSpec::TwoCommit((*start).to_string(), (*end).to_string())
+            DiffSpec::TwoCommit(normalize_head_rev(start), normalize_head_rev(end))
         }
         [arg] => {
             // Check for commit range (start..end)
             if arg.contains("..") {
                 let parts: Vec<&str> = arg.split("..").collect();
                 if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-                    DiffSpec::TwoCommit(parts[0].to_string(), parts[1].to_string())
+                    DiffSpec::TwoCommit(normalize_head_rev(parts[0]), normalize_head_rev(parts[1]))
                 } else {
                     return Err(GitAiError::Generic(
                         "Invalid commit range format. Expected: <commit>..<commit>".to_string(),
                     ));
                 }
             } else {
-                DiffSpec::SingleCommit(positional_args[0].to_string())
+                DiffSpec::SingleCommit(normalize_head_rev(positional_args[0]))
             }
         }
         _ => {

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -1010,8 +1010,8 @@ fn handle_stats(args: &[String]) {
                         if parts.len() == 2 {
                             match CommitRange::new_infer_refname(
                                 &repo,
-                                normalize_head_rev(parts[0]),
-                                normalize_head_rev(parts[1]),
+                                commands::revision::normalize_head_rev(parts[0]),
+                                commands::revision::normalize_head_rev(parts[1]),
                                 // @todo this is probably fine, but we might want to give users an option to override from this command.
                                 None,
                             ) {
@@ -1028,7 +1028,7 @@ fn handle_stats(args: &[String]) {
                             std::process::exit(1);
                         }
                     } else {
-                        commit_sha = Some(normalize_head_rev(arg));
+                        commit_sha = Some(commands::revision::normalize_head_rev(arg));
                     }
                     i += 1;
                 } else {
@@ -1076,30 +1076,6 @@ fn handle_stats(args: &[String]) {
         }
         std::process::exit(1);
     }
-}
-
-/// Normalise a revision token that the user may have typed with a lowercase
-/// "head" prefix.  On case-insensitive file systems (macOS) git accepts both
-/// "head" and "HEAD", but in a linked worktree "head" can resolve to the
-/// *main* repository's HEAD file rather than the worktree's own HEAD, so the
-/// wrong commit is used.  On case-sensitive file systems (Linux) "head"
-/// simply fails with "Not a valid revision".  Normalising to uppercase "HEAD"
-/// before passing to git fixes both issues.
-///
-/// Only the four-character prefix is replaced; suffixes like `~2`, `^1` or
-/// `@{0}` are preserved verbatim.
-fn normalize_head_rev(rev: &str) -> String {
-    if rev.len() >= 4 && rev[..4].eq_ignore_ascii_case("head") {
-        let suffix = &rev[4..];
-        if suffix.is_empty()
-            || suffix.starts_with('~')
-            || suffix.starts_with('^')
-            || suffix.starts_with('@')
-        {
-            return format!("HEAD{}", suffix);
-        }
-    }
-    rev.to_string()
 }
 
 fn handle_git_hooks(args: &[String]) {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod login;
 pub mod logout;
 pub mod notes_migrate;
 pub mod personal_dashboard;
+pub mod revision;
 pub mod show;
 pub mod show_prompt;
 pub mod status;

--- a/src/commands/revision.rs
+++ b/src/commands/revision.rs
@@ -5,7 +5,10 @@
 /// Only the four-character prefix is replaced; suffixes like `~2`, `^1`, and
 /// `@{0}` are preserved verbatim.
 pub(crate) fn normalize_head_rev(rev: &str) -> String {
-    if rev.len() >= 4 && rev[..4].eq_ignore_ascii_case("head") {
+    if rev
+        .get(..4)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("head"))
+    {
         let suffix = &rev[4..];
         if suffix.is_empty()
             || suffix.starts_with('~')

--- a/src/commands/revision.rs
+++ b/src/commands/revision.rs
@@ -1,0 +1,19 @@
+/// Normalize a revision token that the user may have typed with a lowercase
+/// `head` prefix. On case-insensitive file systems, Git can resolve `head`
+/// through the common Git directory instead of a linked worktree's `HEAD`.
+///
+/// Only the four-character prefix is replaced; suffixes like `~2`, `^1`, and
+/// `@{0}` are preserved verbatim.
+pub(crate) fn normalize_head_rev(rev: &str) -> String {
+    if rev.len() >= 4 && rev[..4].eq_ignore_ascii_case("head") {
+        let suffix = &rev[4..];
+        if suffix.is_empty()
+            || suffix.starts_with('~')
+            || suffix.starts_with('^')
+            || suffix.starts_with('@')
+        {
+            return format!("HEAD{}", suffix);
+        }
+    }
+    rev.to_string()
+}

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,3 +1,4 @@
+use crate::commands::revision::normalize_head_rev;
 use crate::error::GitAiError;
 use crate::git::find_repository;
 use crate::git::notes_api::{CommitAuthorship, filter_commits_with_notes};
@@ -79,18 +80,20 @@ fn resolve_commits(repo: &Repository, spec: &str) -> Result<Vec<String>, GitAiEr
             ));
         }
 
-        let range = CommitRange::new_infer_refname(repo, start.to_string(), end.to_string(), None)?;
+        let start = normalize_head_rev(start);
+        let end = normalize_head_rev(end);
+        let range = CommitRange::new_infer_refname(repo, start, end.clone(), None)?;
 
         let mut commits: Vec<String> = range.into_iter().map(|commit| commit.id()).collect();
 
         if commits.is_empty() {
-            let end_commit = repo.revparse_single(end)?;
+            let end_commit = repo.revparse_single(&end)?;
             commits.push(end_commit.id());
         }
 
         Ok(commits)
     } else {
-        let commit = repo.revparse_single(spec)?;
+        let commit = repo.revparse_single(&normalize_head_rev(spec))?;
         Ok(vec![commit.id()])
     }
 }

--- a/src/commands/show_prompt.rs
+++ b/src/commands/show_prompt.rs
@@ -1,4 +1,5 @@
 use crate::authorship::prompt_utils::find_prompt;
+use crate::commands::revision::normalize_head_rev;
 use crate::git::find_repository;
 
 /// Handle the `show-prompt` command
@@ -71,7 +72,7 @@ pub fn parse_args(args: &[String]) -> Result<ParsedArgs, String> {
                 return Err("--commit requires a value".to_string());
             }
             i += 1;
-            commit = Some(args[i].clone());
+            commit = Some(normalize_head_rev(&args[i]));
         } else if arg == "--offset" {
             if i + 1 >= args.len() {
                 return Err("--offset requires a value".to_string());

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -121,6 +121,7 @@ mod refs_unit;
 mod repo_storage_unit;
 mod repository_unit;
 mod reset;
+mod revision_normalization;
 mod rewrite_ops_attribution;
 mod secrets_benchmark;
 mod session_event_attribution;

--- a/tests/integration/revision_normalization.rs
+++ b/tests/integration/revision_normalization.rs
@@ -1,0 +1,124 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use serde_json::Value;
+use std::fs;
+
+struct DivergedWorktree {
+    repo: TestRepo,
+    primary_commit: String,
+    linked_commit: String,
+    linked_prompt_id: String,
+}
+
+fn diverged_worktree_with_lowercase_head() -> DivergedWorktree {
+    let repo = TestRepo::new_worktree();
+    let mut file = repo.filename("test.txt");
+
+    file.set_contents(crate::lines!["primary AI line".ai()]);
+    let primary = repo.stage_all_and_commit("Primary branch commit").unwrap();
+
+    // Keep the primary worktree's branch at the first attributed commit while
+    // advancing the linked worktree's branch to a distinct attributed commit.
+    repo.git(&["update-ref", "refs/heads/main", &primary.commit_sha])
+        .unwrap();
+    file.insert_at(1, crate::lines!["linked AI line".ai()]);
+    let linked = repo.stage_all_and_commit("Linked worktree commit").unwrap();
+
+    let linked_prompt_id = linked
+        .authorship_log
+        .metadata
+        .sessions
+        .keys()
+        .next()
+        .expect("linked commit should contain an AI session")
+        .clone();
+
+    // On a case-insensitive filesystem, `head` can resolve through the common
+    // Git directory's HEAD. Create that spelling explicitly so this macOS bug
+    // is reproduced on every test platform.
+    let common_dir = repo.git(&["rev-parse", "--git-common-dir"]).unwrap();
+    let common_dir = repo.path().join(common_dir.trim());
+    fs::copy(common_dir.join("HEAD"), common_dir.join("head")).unwrap();
+
+    DivergedWorktree {
+        repo,
+        primary_commit: primary.commit_sha,
+        linked_commit: linked.commit_sha,
+        linked_prompt_id,
+    }
+}
+
+#[test]
+fn user_revision_commands_normalize_lowercase_head_in_linked_worktree() {
+    let fixture = diverged_worktree_with_lowercase_head();
+    let repo = &fixture.repo;
+
+    assert_eq!(
+        repo.git_ai(&["show", "head"]).unwrap(),
+        repo.git_ai(&["show", "HEAD"]).unwrap()
+    );
+    assert_eq!(
+        repo.git_ai(&["diff", "head"]).unwrap(),
+        repo.git_ai(&["diff", "HEAD"]).unwrap()
+    );
+    assert_eq!(
+        repo.git_ai(&["stats", "head", "--json"]).unwrap(),
+        repo.git_ai(&["stats", "HEAD", "--json"]).unwrap()
+    );
+
+    let show_prompt = |rev: &str| -> Value {
+        let output = repo
+            .git_ai(&["show-prompt", &fixture.linked_prompt_id, "--commit", rev])
+            .unwrap();
+        serde_json::from_str(output.trim()).unwrap()
+    };
+    assert_eq!(show_prompt("head"), show_prompt("HEAD"));
+}
+
+#[test]
+fn show_normalizes_both_range_endpoints_and_preserves_head_suffixes() {
+    let fixture = diverged_worktree_with_lowercase_head();
+    let repo = &fixture.repo;
+
+    assert_eq!(
+        repo.git_ai(&["show", "head~1..head"]).unwrap(),
+        repo.git_ai(&["show", "HEAD~1..HEAD"]).unwrap()
+    );
+    assert_eq!(
+        repo.git_ai(&["diff", "head~1..head"]).unwrap(),
+        repo.git_ai(&["diff", "HEAD~1..HEAD"]).unwrap()
+    );
+    assert_eq!(
+        repo.git_ai(&["stats", "head~1..head", "--json"]).unwrap(),
+        repo.git_ai(&["stats", "HEAD~1..HEAD", "--json"]).unwrap()
+    );
+
+    for (lowercase, uppercase) in [
+        ("head~1", "HEAD~1"),
+        ("head^1", "HEAD^1"),
+        ("head@{0}", "HEAD@{0}"),
+    ] {
+        assert_eq!(
+            repo.git_ai(&["show", lowercase]).unwrap(),
+            repo.git_ai(&["show", uppercase]).unwrap(),
+            "{lowercase} should preserve its revision suffix"
+        );
+    }
+}
+
+#[test]
+fn revision_names_that_merely_begin_with_head_are_not_rewritten() {
+    let fixture = diverged_worktree_with_lowercase_head();
+    let repo = &fixture.repo;
+    repo.git(&["branch", "header", &fixture.primary_commit])
+        .unwrap();
+
+    let header = repo.git_ai(&["show", "header"]).unwrap();
+    let linked_head = repo.git_ai(&["show", "HEAD"]).unwrap();
+
+    assert_ne!(fixture.primary_commit, fixture.linked_commit);
+    assert_ne!(
+        header, linked_head,
+        "the branch named `header` must remain intact"
+    );
+}

--- a/tests/integration/revision_normalization.rs
+++ b/tests/integration/revision_normalization.rs
@@ -122,3 +122,16 @@ fn revision_names_that_merely_begin_with_head_are_not_rewritten() {
         "the branch named `header` must remain intact"
     );
 }
+
+#[test]
+fn non_ascii_revision_names_are_not_rewritten_or_sliced_mid_character() {
+    let fixture = diverged_worktree_with_lowercase_head();
+    let repo = &fixture.repo;
+    repo.git(&["branch", "中文分支", &fixture.primary_commit])
+        .unwrap();
+
+    assert_eq!(
+        repo.git_ai(&["show", "中文分支"]).unwrap(),
+        repo.git_ai(&["show", &fixture.primary_commit]).unwrap()
+    );
+}

--- a/tests/integration/revision_normalization.rs
+++ b/tests/integration/revision_normalization.rs
@@ -38,7 +38,10 @@ fn diverged_worktree_with_lowercase_head() -> DivergedWorktree {
     // is reproduced on every test platform.
     let common_dir = repo.git(&["rev-parse", "--git-common-dir"]).unwrap();
     let common_dir = repo.path().join(common_dir.trim());
-    fs::copy(common_dir.join("HEAD"), common_dir.join("head")).unwrap();
+    let lowercase_head = common_dir.join("head");
+    if !lowercase_head.exists() {
+        fs::copy(common_dir.join("HEAD"), lowercase_head).unwrap();
+    }
 
     DivergedWorktree {
         repo,


### PR DESCRIPTION
## Summary

- normalize lowercase `head` revision tokens at parsed git-ai command boundaries
- preserve revision suffixes and normalize both sides of ranges
- add linked-worktree regressions for `show`, `diff`, `stats`, and `show-prompt --commit`

## Root cause

On case-insensitive filesystems, lowercase `head` can resolve through the common Git directory’s `HEAD` instead of the linked worktree-local `HEAD`, selecting the primary worktree branch.

## Validation

- `task test TEST_FILTER=revision_normalization`
- `task fmt`
- `task lint`
- `task test`