### PR TITLE
Make the trace accept loop accept-and-spawn only

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -107,8 +107,6 @@ const CHECKPOINT_FAMILY_DRAIN_CONCURRENCY: usize = 2;
 #[cfg(not(windows))]
 const TRACE_SOCKET_RECV_BUFFER_BYTES: usize = 512 * 1024;
 const TRACE_INGEST_QUEUE_CAPACITY: usize = 16_384;
-#[cfg(not(windows))]
-const TRACE_CONNECTION_BOOTSTRAP_READ_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(windows)]
 const WINDOWS_TRACE_PIPE_WORKERS: usize = 16;
 #[cfg(windows)]
@@ -4468,6 +4466,18 @@ impl ActorDaemonCoordinator {
             trace_payload_primary_command(payload).or_else(|| trace_argv_primary_command(&argv));
         let event_is_read_only =
             trace_invocation_is_definitely_read_only(early_primary.as_deref(), &argv);
+        // Family resolution reads `.git` and canonicalizes the path —
+        // filesystem I/O that must run before taking the process-wide ingress
+        // lock every trace reader serializes on (one hung filesystem must not
+        // stall trace draining for every other repository).
+        let resolved_family = worktree_hint.as_ref().and_then(|worktree| {
+            #[cfg(feature = "test-support")]
+            maybe_stall_family_resolution_for_test(worktree);
+            common_dir_for_worktree(worktree).map(|common_dir| {
+                let family = common_dir.canonicalize().unwrap_or(common_dir);
+                family.to_string_lossy().to_string()
+            })
+        });
 
         let mut ingress = match self.trace_ingress_state.lock() {
             Ok(guard) => guard,
@@ -4486,11 +4496,8 @@ impl ActorDaemonCoordinator {
         }
 
         if let Some(worktree) = worktree_hint.clone() {
-            if let Some(common_dir) = common_dir_for_worktree(&worktree) {
-                let family = common_dir.canonicalize().unwrap_or(common_dir);
-                ingress
-                    .root_families
-                    .insert(root.clone(), family.to_string_lossy().to_string());
+            if let Some(family) = resolved_family {
+                ingress.root_families.insert(root.clone(), family);
             }
             ingress.root_worktrees.insert(root.clone(), worktree);
         }
@@ -4524,18 +4531,44 @@ impl ActorDaemonCoordinator {
         }
 
         let terminal = is_terminal_root_trace_event(&event, &sid, &root);
-        if command_mutates_refs
+        let capture_worktree = if command_mutates_refs
             && !terminal
             && !ingress.root_reflog_start_offsets.contains_key(&root)
-            && let Some(worktree) = worktree_hint
+        {
+            worktree_hint
                 .clone()
                 .or_else(|| ingress.root_worktrees.get(&root).cloned())
-        {
+        } else {
+            None
+        };
+        if let Some(worktree) = capture_worktree {
+            // The reflog walk does filesystem I/O; release the process-wide
+            // ingress lock around it so one slow filesystem cannot stall every
+            // trace reader thread at once.
+            drop(ingress);
+            #[cfg(feature = "test-support")]
+            if let Ok(raw_delay_ms) = std::env::var("GIT_AI_TEST_REFLOG_CAPTURE_DELAY_MS")
+                && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
+                && delay_ms > 0
+            {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
             let offsets =
                 crate::daemon::ref_cursor::capture_reflog_start_offsets_for_worktree(&worktree);
-            ingress
-                .root_reflog_start_offsets
-                .insert(root.clone(), offsets);
+            ingress = match self.trace_ingress_state.lock() {
+                Ok(guard) => guard,
+                Err(_) => return false,
+            };
+            // Another connection for this root may have processed its terminal
+            // event while the lock was released; inserting offsets for a
+            // closed root would leak state, so only keep them for a root that
+            // is still live. First insert wins if two frames raced.
+            if ingress.root_last_activity_ns.contains_key(&root) {
+                ingress
+                    .root_reflog_start_offsets
+                    .entry(root.clone())
+                    .or_insert(offsets);
+            }
         }
 
         let read_only_root =
@@ -7830,6 +7863,11 @@ fn trace_listener_loop_actor(
             .create_sync()
             .map_err(|e| GitAiError::Generic(format!("failed binding trace socket: {}", e)))?;
         set_socket_owner_only(&trace_socket_path)?;
+        // The accept loop must never do per-connection work: any read, lock,
+        // or filesystem access here lets one slow or silent peer stall every
+        // other traced git process behind the listen backlog (git writes
+        // trace2 synchronously and blocks in write() until we drain it).
+        let mut consecutive_spawn_failures = 0usize;
         for stream in listener.incoming() {
             if coordinator.is_shutting_down() {
                 break;
@@ -7837,98 +7875,23 @@ fn trace_listener_loop_actor(
             let Ok(stream) = stream else {
                 continue;
             };
-            // Raise the receive buffer on each accepted connection. Unlike TCP,
-            // a Unix-domain listener's SO_RCVBUF is not inherited by accepted
-            // connections, so this per-connection call is what takes effect.
-            if let Err(error) = set_trace_socket_recv_buffer(&stream) {
-                tracing::debug!(%error, "trace connection recv buffer setup failed");
-            }
-            if let Err(error) = coordinator.trace_unidentified_connection_opened() {
-                tracing::debug!(%error, "trace connection open bookkeeping error");
-                continue;
-            }
-            if let Err(error) =
-                stream.set_recv_timeout(Some(TRACE_CONNECTION_BOOTSTRAP_READ_TIMEOUT))
-            {
-                tracing::debug!(%error, "trace connection bootstrap timeout setup failed");
-            }
-            let mut reader = BufReader::new(stream);
-            let mut observed_roots = std::collections::BTreeSet::new();
-            match bootstrap_trace_connection_actor_reader(
-                &mut reader,
-                coordinator.clone(),
-                &mut observed_roots,
-            ) {
-                Ok(TraceConnectionBootstrap::Eof) => {
-                    if let Err(error) =
-                        finalize_trace_connection_roots(coordinator.clone(), observed_roots)
-                    {
-                        tracing::debug!(
-                            %error,
-                            "trace connection close bookkeeping error"
-                        );
-                    }
-                    continue;
+            match spawn_trace_connection_reader(stream, coordinator.clone()) {
+                Ok(()) => {
+                    consecutive_spawn_failures = 0;
                 }
-                Ok(TraceConnectionBootstrap::Stop) => {
-                    if let Err(error) =
-                        finalize_trace_connection_roots(coordinator.clone(), observed_roots)
-                    {
-                        tracing::debug!(
-                            %error,
-                            "trace connection close bookkeeping error"
-                        );
-                    }
-                    continue;
-                }
-                Ok(TraceConnectionBootstrap::Continue) => {}
                 Err(error) => {
-                    tracing::debug!(%error, "trace connection bootstrap error");
-                    if let Err(error) =
-                        finalize_trace_connection_roots(coordinator.clone(), observed_roots)
-                    {
-                        tracing::debug!(
-                            %error,
-                            "trace connection close bookkeeping error"
-                        );
+                    // The stream is dropped with the failed spawn, closing the
+                    // fd: the writing git process sees EPIPE, disables its
+                    // trace2 target, and completes instead of blocking.
+                    tracing::error!(%error, "trace listener: failed to spawn handler thread");
+                    consecutive_spawn_failures += 1;
+                    if consecutive_spawn_failures >= TRACE_SPAWN_FAILURE_SHUTDOWN_THRESHOLD {
+                        if let Err(error) = spawn_self_restart() {
+                            tracing::error!("failed to spawn self-restart: {}", error);
+                        }
+                        break;
                     }
-                    continue;
                 }
-            }
-            if let Err(error) = reader.get_ref().set_recv_timeout(None) {
-                tracing::debug!(%error, "trace connection bootstrap timeout clear failed");
-            }
-            #[cfg(feature = "test-support")]
-            if let Ok(raw_delay_ms) =
-                std::env::var("GIT_AI_TEST_TRACE_LISTENER_WORKER_SPAWN_DELAY_MS")
-                && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
-                && delay_ms > 0
-            {
-                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-            }
-            let coord = coordinator.clone();
-            let observed_roots_on_spawn_failure = observed_roots.clone();
-            if std::thread::Builder::new()
-                .spawn(move || {
-                    if let Err(e) =
-                        handle_trace_connection_actor_reader(reader, coord, observed_roots)
-                    {
-                        tracing::debug!(%e, "trace connection error");
-                    }
-                })
-                .is_err()
-            {
-                tracing::error!("trace listener: failed to spawn handler thread");
-                if let Err(error) = finalize_trace_connection_roots(
-                    coordinator.clone(),
-                    observed_roots_on_spawn_failure,
-                ) {
-                    tracing::debug!(
-                        %error,
-                        "trace connection close bookkeeping error"
-                    );
-                }
-                break;
             }
         }
         Ok(())
@@ -8038,73 +8001,100 @@ fn handle_windows_trace_pipe_connection(
     }
 }
 
+/// Number of consecutive reader-thread spawn failures after which the daemon
+/// gives up and hands off to a fresh instance via self-restart. A single
+/// failure only drops that connection; persistent failure means the process
+/// can no longer serve trace connections at all.
 #[cfg(not(windows))]
-#[allow(dead_code)]
-fn handle_trace_connection_actor(
+const TRACE_SPAWN_FAILURE_SHUTDOWN_THRESHOLD: usize = 16;
+
+/// Spawn the dedicated reader thread for an accepted trace connection. On
+/// spawn failure the stream is dropped (fd closed) so the writing git process
+/// is released instead of blocking on an unread socket.
+#[cfg(not(windows))]
+fn spawn_trace_connection_reader(
     stream: LocalSocketStream,
     coordinator: Arc<ActorDaemonCoordinator>,
-) -> Result<(), GitAiError> {
-    coordinator.trace_unidentified_connection_opened()?;
-    let reader = BufReader::new(stream);
-    handle_trace_connection_actor_reader(reader, coordinator, std::collections::BTreeSet::new())
+) -> std::io::Result<()> {
+    #[cfg(feature = "test-support")]
+    if test_trace_connection_spawn_failure_injected() {
+        return Err(std::io::Error::other(
+            "injected trace connection spawn failure",
+        ));
+    }
+    std::thread::Builder::new()
+        .name("git-ai-trace-conn".to_string())
+        .spawn(move || run_trace_connection_reader(stream, coordinator))
+        .map(|_| ())
+}
+
+/// Test hook: simulate a hung filesystem during family resolution, but only
+/// for worktree paths carrying the `git-ai-family-resolve-stall` marker so
+/// test-infrastructure traffic is unaffected.
+#[cfg(feature = "test-support")]
+fn maybe_stall_family_resolution_for_test(worktree: &Path) {
+    if let Ok(raw_delay_ms) = std::env::var("GIT_AI_TEST_FAMILY_RESOLVE_DELAY_MS")
+        && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
+        && delay_ms > 0
+        && worktree
+            .to_string_lossy()
+            .contains("git-ai-family-resolve-stall")
+    {
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+    }
+}
+
+#[cfg(all(not(windows), feature = "test-support"))]
+fn test_trace_connection_spawn_failure_injected() -> bool {
+    use std::sync::atomic::AtomicUsize;
+
+    static REMAINING: std::sync::OnceLock<AtomicUsize> = std::sync::OnceLock::new();
+    let remaining = REMAINING.get_or_init(|| {
+        let configured = std::env::var("GIT_AI_TEST_TRACE_CONNECTION_SPAWN_FAILURES")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(0);
+        AtomicUsize::new(configured)
+    });
+    remaining
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
+            value.checked_sub(1)
+        })
+        .is_ok()
 }
 
 #[cfg(not(windows))]
-enum TraceConnectionBootstrap {
-    Continue,
-    Stop,
-    Eof,
+fn run_trace_connection_reader(
+    stream: LocalSocketStream,
+    coordinator: Arc<ActorDaemonCoordinator>,
+) {
+    #[cfg(feature = "test-support")]
+    if let Ok(raw_delay_ms) = std::env::var("GIT_AI_TEST_TRACE_READER_START_DELAY_MS")
+        && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
+        && delay_ms > 0
+    {
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+    }
+    // Raise the receive buffer on each accepted connection. Unlike TCP,
+    // a Unix-domain listener's SO_RCVBUF is not inherited by accepted
+    // connections, so this per-connection call is what takes effect.
+    if let Err(error) = set_trace_socket_recv_buffer(&stream) {
+        tracing::debug!(%error, "trace connection recv buffer setup failed");
+    }
+    if let Err(error) = coordinator.trace_unidentified_connection_opened() {
+        tracing::debug!(%error, "trace connection open bookkeeping error");
+        return;
+    }
+    let reader = BufReader::new(stream);
+    if let Err(error) =
+        handle_trace_connection_actor_reader(reader, coordinator, std::collections::BTreeSet::new())
+    {
+        tracing::debug!(%error, "trace connection error");
+    }
 }
 
 struct TraceLineOutcome {
     continue_reading: bool,
-    #[cfg(not(windows))]
-    bootstrap_complete: bool,
-}
-
-#[cfg(not(windows))]
-const TRACE_CONNECTION_BOOTSTRAP_MAX_LINES: usize = 8;
-
-#[cfg(not(windows))]
-fn bootstrap_trace_connection_actor_reader<R: Read>(
-    reader: &mut BufReader<R>,
-    coordinator: Arc<ActorDaemonCoordinator>,
-    observed_roots: &mut std::collections::BTreeSet<String>,
-) -> Result<TraceConnectionBootstrap, GitAiError> {
-    for _ in 0..TRACE_CONNECTION_BOOTSTRAP_MAX_LINES {
-        let line = match read_json_line(reader) {
-            Ok(Some(line)) => line,
-            Ok(None) => return Ok(TraceConnectionBootstrap::Eof),
-            Err(error) if trace_bootstrap_read_timed_out(&error) => {
-                return Ok(TraceConnectionBootstrap::Continue);
-            }
-            Err(error) => return Err(error),
-        };
-        let Some(outcome) =
-            process_trace_connection_line(&line, coordinator.clone(), observed_roots)?
-        else {
-            continue;
-        };
-        if !outcome.continue_reading {
-            return Ok(TraceConnectionBootstrap::Stop);
-        }
-        if outcome.bootstrap_complete {
-            return Ok(TraceConnectionBootstrap::Continue);
-        }
-    }
-    Ok(TraceConnectionBootstrap::Continue)
-}
-
-#[cfg(not(windows))]
-fn trace_bootstrap_read_timed_out(error: &GitAiError) -> bool {
-    matches!(
-        error,
-        GitAiError::IoError(io_error)
-            if matches!(
-                io_error.kind(),
-                std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
-            )
-    )
 }
 
 fn handle_trace_connection_actor_reader<R: Read>(
@@ -8112,15 +8102,22 @@ fn handle_trace_connection_actor_reader<R: Read>(
     coordinator: Arc<ActorDaemonCoordinator>,
     mut observed_roots: std::collections::BTreeSet<String>,
 ) -> Result<(), GitAiError> {
-    while let Some(line) = read_json_line(&mut reader)? {
-        if process_trace_connection_line(&line, coordinator.clone(), &mut observed_roots)?
-            .is_some_and(|outcome| !outcome.continue_reading)
-        {
-            break;
+    let read_result = (|| {
+        while let Some(line) = read_json_line(&mut reader)? {
+            if process_trace_connection_line(&line, coordinator.clone(), &mut observed_roots)?
+                .is_some_and(|outcome| !outcome.continue_reading)
+            {
+                break;
+            }
         }
-    }
+        Ok(())
+    })();
 
-    finalize_trace_connection_roots(coordinator, observed_roots)
+    // Close bookkeeping must run no matter how the read loop ended (EOF,
+    // invalid UTF-8, connection reset): a root left registered as open blocks
+    // this family's sequencer and checkpoint fences forever.
+    let finalize_result = finalize_trace_connection_roots(coordinator, observed_roots);
+    read_result.and(finalize_result)
 }
 
 fn process_trace_connection_line(
@@ -8136,25 +8133,9 @@ fn process_trace_connection_line(
         Ok(v) => v,
         Err(_) => return Ok(None),
     };
-    #[cfg(not(windows))]
-    let event = parsed
-        .get("event")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
-    #[cfg(not(windows))]
-    let mut bootstrap_complete = false;
     if let Some(sid) = parsed.get("sid").and_then(Value::as_str) {
         let was_unidentified = observed_roots.is_empty();
         let root_sid = trace_root_sid(sid).to_string();
-        // `start` carries argv but not the worktree. Keep bootstrapping on the
-        // listener thread until the root `def_repo` event has been processed;
-        // that is the first point where trace augmentation can capture reflog
-        // start offsets with a concrete worktree.
-        #[cfg(not(windows))]
-        if event == "def_repo" && sid == root_sid {
-            bootstrap_complete = true;
-        }
         if observed_roots.insert(root_sid.clone()) {
             let _ = coordinator.trace_root_connection_opened(&root_sid);
         }
@@ -8169,11 +8150,7 @@ fn process_trace_connection_line(
     // issue dozens of read-only git commands per second.
     let continue_reading = !(coordinator.prepare_trace_payload_for_ingest(&mut parsed)
         && coordinator.enqueue_trace_payload(parsed).is_err());
-    Ok(Some(TraceLineOutcome {
-        continue_reading,
-        #[cfg(not(windows))]
-        bootstrap_complete,
-    }))
+    Ok(Some(TraceLineOutcome { continue_reading }))
 }
 
 fn finalize_trace_connection_roots(
@@ -10214,6 +10191,47 @@ mod tests {
         assert!(!ingress.root_argv.contains_key(sid));
         assert!(!ingress.root_definitely_read_only.contains(sid));
         assert!(!ingress.root_open_connections.contains_key(sid));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn late_reflog_capture_after_terminal_event_does_not_leak_root_state() {
+        // The reflog start-offset capture runs with the ingress lock released.
+        // If the root's terminal event is processed during that window, the
+        // late capture must not re-insert offsets for the closed root.
+        let _delay_guard = EnvVarGuard::set("GIT_AI_TEST_REFLOG_CAPTURE_DELAY_MS", "200");
+        let coord = Arc::new(ActorDaemonCoordinator::new());
+        let sid = "20260411T120000.000000-Plateoffsets";
+        coord.trace_root_connection_opened(sid).unwrap();
+
+        let mut start = make_start_payload(&["git", "commit", "-m", "late capture"]);
+        start["sid"] = serde_json::json!(sid);
+        assert!(coord.prepare_trace_payload_for_ingest(&mut start));
+
+        let capture_coord = coord.clone();
+        let capture_sid = sid.to_string();
+        let capture_thread = std::thread::spawn(move || {
+            let mut def_repo = serde_json::json!({
+                "event": "def_repo",
+                "sid": capture_sid,
+                "worktree": std::env::temp_dir().join("late-offsets-worktree"),
+            });
+            capture_coord.prepare_trace_payload_for_ingest(&mut def_repo);
+        });
+        // Let the capture thread enter the unlocked capture window, then
+        // process the root's terminal event.
+        std::thread::sleep(Duration::from_millis(50));
+        let mut atexit = make_atexit_payload(sid);
+        assert!(coord.prepare_trace_payload_for_ingest(&mut atexit));
+        capture_thread.join().unwrap();
+
+        let ingress = coord.trace_ingress_state.lock().unwrap();
+        assert!(
+            !ingress.root_reflog_start_offsets.contains_key(sid),
+            "late reflog capture must not leak offsets for a closed root"
+        );
+        assert!(!ingress.root_worktrees.contains_key(sid));
+        assert!(!ingress.root_last_activity_ns.contains_key(sid));
     }
 
     #[tokio::test]

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -224,6 +224,35 @@ fn raw_traced_git_with_session(repo: &TestRepo, args: &[&str], session: &str) ->
     combined_output(stdout, stderr)
 }
 
+#[cfg(not(windows))]
+fn raw_traced_git_in_dir(dir: &Path, test_home: &Path, trace_socket: &Path, args: &[&str]) {
+    let mut command = Command::new(real_git_executable());
+    command.arg("-C").arg(dir).args(args);
+    command.env("HOME", test_home);
+    command.env("GIT_CONFIG_GLOBAL", test_home.join(".gitconfig"));
+    command.env("XDG_CONFIG_HOME", test_home.join(".config"));
+    command.env("GIT_CONFIG_NOSYSTEM", "1");
+    command.env(
+        "GIT_TRACE2_EVENT",
+        git_ai::daemon::DaemonConfig::trace2_event_target_for_path(trace_socket),
+    );
+    command.env(
+        "GIT_TRACE2_EVENT_NESTING",
+        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
+    );
+
+    let output = command
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run raw traced git {:?}: {}", args, error));
+    assert!(
+        output.status.success(),
+        "raw traced git {:?} failed\nstdout: {}\nstderr: {}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn raw_untraced_git(repo: &TestRepo, args: &[&str]) -> String {
     repo.git_og_with_env(args, &[("GIT_TRACE2_EVENT", "0")])
         .unwrap_or_else(|error| panic!("raw untraced git {:?} failed: {}", args, error))
@@ -709,26 +738,138 @@ fn test_delayed_commit_trace_replay_attributes_matching_commit_not_later_commit(
 
 #[cfg(not(windows))]
 #[test]
-fn test_trace_listener_bootstrap_captures_commit_ref_transition_before_worker_spawn_delay() {
-    let repo = TestRepo::new_with_daemon_env(&[(
-        "GIT_AI_TEST_TRACE_LISTENER_WORKER_SPAWN_DELAY_MS",
-        "200",
-    )]);
+fn test_delayed_trace_reader_start_fails_closed_and_never_misattributes() {
+    // A trace reader thread that starts late captures reflog start offsets
+    // late. Per the ingestion spec (§Seeding), late capture is conservative:
+    // the delayed command may lose attribution but must never steal a later
+    // commit's reflog entries.
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_TRACE_READER_START_DELAY_MS", "200")]);
     fs::write(repo.path().join("README.md"), "base\n").unwrap();
     repo.git_og(&["add", "README.md"]).unwrap();
     repo.git_og(&["commit", "-m", "base"]).unwrap();
 
-    fs::write(
-        repo.path().join("bootstrap-race.txt"),
-        "bootstrap race ai\n",
-    )
-    .unwrap();
-    repo.git_ai(&["checkpoint", "mock_ai", "bootstrap-race.txt"])
+    fs::write(repo.path().join("reader-race.txt"), "reader race ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "reader-race.txt"])
         .unwrap();
-    repo.git(&["add", "bootstrap-race.txt"]).unwrap();
-    let committed = repo.commit("bootstrap race").unwrap();
+    repo.git(&["add", "reader-race.txt"]).unwrap();
+    let committed = repo.commit("reader race").unwrap();
 
-    assert_note_has_ai_for_file(&repo, &committed.commit_sha, "bootstrap-race.txt");
+    if repo.read_authorship_note(&committed.commit_sha).is_some() {
+        assert_note_has_ai_for_file(&repo, &committed.commit_sha, "reader-race.txt");
+    }
+
+    fs::write(repo.path().join("later-untracked.txt"), "later untracked\n").unwrap();
+    raw_untraced_git(&repo, &["add", "later-untracked.txt"]);
+    raw_untraced_git(&repo, &["commit", "-m", "later untracked commit"]);
+    let later_commit = head_sha(&repo);
+    assert!(
+        repo.read_authorship_note(&later_commit).is_none(),
+        "a delayed trace reader must never attach attribution to a later commit"
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn test_concurrent_worktree_commits_attribute_exactly() {
+    // Two linked worktrees of one family committing near-simultaneously
+    // exercise concurrent trace reader threads capturing reflog start
+    // offsets (the capture runs outside the shared ingress lock).
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+
+    // Random per-run path (mirrors the test framework's worktree naming) with
+    // cleanup on all exits, including assertion failures.
+    struct WorktreeDirGuard(std::path::PathBuf);
+    impl Drop for WorktreeDirGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+    use rand::RngExt;
+    let worktree_path = std::env::temp_dir().join(format!(
+        "{}-wt",
+        rand::rng().random_range(0..10_000_000_000u64)
+    ));
+    let _worktree_cleanup = WorktreeDirGuard(worktree_path.clone());
+    raw_untraced_git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "concurrent-wt",
+            worktree_path.to_str().unwrap(),
+        ],
+    );
+
+    fs::write(repo.path().join("main-ai.txt"), "main ai line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "main-ai.txt"])
+        .unwrap();
+    raw_untraced_git(&repo, &["add", "main-ai.txt"]);
+    fs::write(worktree_path.join("wt-file.txt"), "worktree line\n").unwrap();
+    raw_traced_git_in_dir(
+        &worktree_path,
+        repo.test_home_path(),
+        &repo.daemon_trace_socket_path(),
+        &["add", "wt-file.txt"],
+    );
+    repo.sync_daemon();
+    let baseline = repo.daemon_total_completion_count();
+
+    let repo_dir = repo.path().to_path_buf();
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let main_barrier = barrier.clone();
+    let wt_barrier = barrier.clone();
+    let main_repo_dir = repo_dir.clone();
+    let (test_home, trace_socket) = (
+        repo.test_home_path().to_path_buf(),
+        repo.daemon_trace_socket_path(),
+    );
+    let (wt_test_home, wt_trace_socket) = (test_home.clone(), trace_socket.clone());
+    let wt_dir = worktree_path.clone();
+
+    let main_thread = std::thread::spawn(move || {
+        main_barrier.wait();
+        raw_traced_git_in_dir(
+            &main_repo_dir,
+            &test_home,
+            &trace_socket,
+            &["commit", "-m", "concurrent main commit"],
+        );
+    });
+    let wt_thread = std::thread::spawn(move || {
+        wt_barrier.wait();
+        raw_traced_git_in_dir(
+            &wt_dir,
+            &wt_test_home,
+            &wt_trace_socket,
+            &["commit", "-m", "concurrent worktree commit"],
+        );
+    });
+    main_thread.join().unwrap();
+    wt_thread.join().unwrap();
+
+    repo.wait_for_daemon_total_completion_count(baseline, baseline + 2);
+
+    let main_commit = head_sha(&repo);
+    assert_note_has_ai_for_file(&repo, &main_commit, "main-ai.txt");
+    let mut file = repo.filename("main-ai.txt");
+    file.assert_committed_lines(lines!["main ai line".ai()]);
+
+    // The worktree commit carried no AI checkpoint; it must never receive
+    // the main commit's attribution.
+    let wt_commit = raw_untraced_git(&repo, &["rev-parse", "concurrent-wt"])
+        .trim()
+        .to_string();
+    if let Some(note) = repo.read_authorship_note(&wt_commit) {
+        let log = AuthorshipLog::deserialize_from_string(&note).expect("parse worktree note");
+        assert!(
+            !log.attestations
+                .iter()
+                .any(|attestation| attestation.file_path == "main-ai.txt"),
+            "worktree commit must not steal the main worktree's attribution"
+        );
+    }
 }
 
 #[test]

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2618,6 +2618,298 @@ fn daemon_trace_listener_partial_line_does_not_block_later_trace_connections() {
 
 #[test]
 #[cfg(not(windows))]
+fn daemon_trace_read_error_does_not_leave_root_open_forever() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let control_socket = daemon_control_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    let mut stream =
+        open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
+            .expect("failed to connect to trace socket");
+    write_trace_frames_to_stream(
+        &mut stream,
+        &[
+            json!({
+                "event": "start",
+                "sid": "read-error-open-root",
+                "argv": ["git", "commit", "-m", "interrupted by bad bytes"],
+                "time_ns": 50_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "read-error-open-root",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 50_001u64,
+            }),
+        ],
+    );
+    // Invalid UTF-8 makes the reader's read_line fail. The connection's roots
+    // must still be finalized, or this family's fences block forever.
+    stream
+        .write_all(&[0xFF, 0xFE, 0xFD, b'\n'])
+        .expect("failed to write invalid bytes");
+    stream.flush().expect("failed to flush invalid bytes");
+    thread::sleep(Duration::from_millis(200));
+
+    let response = send_control_request_with_timeout(
+        &control_socket,
+        &ControlRequest::SyncFamily {
+            repo_working_dir: repo_workdir_string(&repo),
+        },
+        Duration::from_secs(3),
+    )
+    .expect("sync.family must not hang after a trace connection read error");
+    assert!(response.ok, "sync.family failed: {response:?}");
+    drop(stream);
+}
+
+/// Family resolution reads `.git` and canonicalizes paths — filesystem I/O.
+/// One repo on a hung/slow filesystem must not stall trace draining for
+/// every other repository (the I/O must run outside the shared ingress lock).
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn daemon_trace_family_resolution_io_does_not_block_other_readers() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let mut daemon =
+        DaemonGuard::start_with_env(&repo, &[("GIT_AI_TEST_FAMILY_RESOLVE_DELAY_MS", "3000")]);
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    // Connection A: a def_repo whose worktree path carries the stall marker;
+    // its family resolution sleeps 3s, simulating a hung filesystem. The root
+    // is read-only so the only thing that could delay other repos is the
+    // ingress lock the reader holds while resolving.
+    let mut slow_repo_stream =
+        open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
+            .expect("failed to connect slow-repo trace socket");
+    write_trace_frames_to_stream(
+        &mut slow_repo_stream,
+        &[
+            json!({
+                "event": "start",
+                "sid": "family-resolve-slow-root",
+                "argv": ["git", "status", "--short"],
+                "time_ns": 60_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "family-resolve-slow-root",
+                "worktree": "/tmp/git-ai-family-resolve-stall/repo",
+                "time_ns": 60_001u64,
+            }),
+        ],
+    );
+    thread::sleep(Duration::from_millis(200));
+
+    // Connection B: a healthy repo must still be processed promptly.
+    let session = repos::test_repo::new_daemon_test_sync_session_id();
+    let session_arg = format!("git-ai.testSyncSession={session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "family-resolve-healthy-root",
+                "argv": ["git", "-c", session_arg, "commit", "-m", "synthetic"],
+                "time_ns": 61_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "family-resolve-healthy-root",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 61_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "family-resolve-healthy-root",
+                "code": 0,
+                "time_ns": 61_100u64,
+            }),
+            trace_atexit_frame("family-resolve-healthy-root", 0, 61_101u64),
+        ],
+    );
+
+    let start = std::time::Instant::now();
+    let mut healthy_completed = false;
+    while start.elapsed() < Duration::from_millis(1500) {
+        if repo
+            .daemon_completion_entries()
+            .iter()
+            .any(|entry| entry.test_sync_session.as_deref() == Some(session.as_str()))
+        {
+            healthy_completed = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    daemon.shutdown();
+    assert!(
+        healthy_completed,
+        "a healthy repository's trace traffic must not wait behind another repo's family-resolution I/O"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_trace_accept_loop_not_serialized_by_silent_connections() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    // Connections that never send a byte must not hold the accept loop
+    // hostage: a later connection's frames have to be read promptly.
+    let mut silent_streams = Vec::new();
+    for _ in 0..20 {
+        silent_streams.push(
+            open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open silent trace connection"),
+        );
+    }
+
+    let session = repos::test_repo::new_daemon_test_sync_session_id();
+    let session_arg = format!("git-ai.testSyncSession={session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "silent-conn-followup",
+                "argv": ["git", "-c", session_arg, "commit", "-m", "synthetic"],
+                "time_ns": 20_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "silent-conn-followup",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 20_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "silent-conn-followup",
+                "code": 0,
+                "time_ns": 20_100u64,
+            }),
+            trace_atexit_frame("silent-conn-followup", 0, 20_101u64),
+        ],
+    );
+
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(1) {
+        if repo
+            .daemon_completion_entries()
+            .iter()
+            .any(|entry| entry.test_sync_session.as_deref() == Some(session.as_str()))
+        {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    panic!(
+        "daemon did not process a trace connection within 1s while 20 silent connections were open; \
+         the accept loop must hand connections to reader threads without doing per-connection reads"
+    );
+}
+
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn daemon_trace_reader_spawn_failure_drops_connection_and_keeps_accepting() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    // The readiness wait makes exactly one successful trace-socket connect,
+    // consuming one injected failure; the two test connections below consume
+    // the rest.
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[("GIT_AI_TEST_TRACE_CONNECTION_SPAWN_FAILURES", "3")],
+    );
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    // The first two connections hit the injected reader-spawn failure. The
+    // daemon must close them promptly (a blocked git writer would otherwise
+    // hang forever) instead of wedging or exiting.
+    for connection in 0..2 {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open trace connection");
+        let started = std::time::Instant::now();
+        let mut dropped = false;
+        while started.elapsed() < Duration::from_secs(2) {
+            if stream
+                .write_all(b"\n")
+                .and_then(|_| stream.flush())
+                .is_err()
+            {
+                dropped = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            dropped,
+            "connection {connection} should be dropped promptly when the reader thread cannot be spawned"
+        );
+    }
+
+    // With the injected failures exhausted, the daemon must still be alive
+    // and process new trace connections normally.
+    let session = repos::test_repo::new_daemon_test_sync_session_id();
+    let session_arg = format!("git-ai.testSyncSession={session}");
+    send_trace_frames(
+        &trace_socket,
+        &[
+            json!({
+                "event": "start",
+                "sid": "post-spawn-failure",
+                "argv": ["git", "-c", session_arg, "commit", "-m", "synthetic"],
+                "time_ns": 30_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "post-spawn-failure",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 30_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "post-spawn-failure",
+                "code": 0,
+                "time_ns": 30_100u64,
+            }),
+            trace_atexit_frame("post-spawn-failure", 0, 30_101u64),
+        ],
+    );
+
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_secs(2) {
+        if repo
+            .daemon_completion_entries()
+            .iter()
+            .any(|entry| entry.test_sync_session.as_deref() == Some(session.as_str()))
+        {
+            daemon.shutdown();
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    daemon.shutdown();
+    panic!("daemon did not process a trace connection after injected reader-spawn failures");
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_trace_connection_close_without_atexit_does_not_block_later_trace() {
     let repo = TestRepo::new_dedicated_daemon();
     let trace_socket = daemon_trace_socket_path(&repo);


### PR DESCRIPTION
The trace2 accept loop did per-connection work inline before handing the
connection to its reader thread: SO_RCVBUF setup, ingress bookkeeping, and a
bootstrap read of up to 8 JSON lines under a 100ms recv timeout. This
serialized all accepts behind each connection's bootstrap (one silent peer
cost 100ms of accept time; a failed set_recv_timeout - macOS returns EINVAL
from setsockopt when the peer has already shut down - silently removed the
timeout entirely and let a single quiet connection wedge the accept loop
forever). Git writes trace2 synchronously, so a wedged or slow accept loop
blocks every traced git process in write() once the listen backlog and
socket buffers fill (macOS: ~128 backlog, 8 KiB default buffers).

The bootstrap phase existed only because that work ran on the accept thread
and had to be bounded. Spawn the reader thread immediately instead and let
it do the per-connection setup and plain blocking reads (exactly what the
post-bootstrap reader already did), deleting the bootstrap machinery and its
timeout dance outright. A reader-thread spawn failure now drops just that
connection (closing the fd releases the writing git process) and only hands
off to a self-restart after 16 consecutive failures instead of tearing the
daemon down on the first one.

Also stop holding the process-wide trace ingress mutex across the reflog
start-offset capture (a .git/logs filesystem walk): every reader thread
serializes on that lock per line, so one slow filesystem stalled all trace
draining at once. The capture now runs unlocked; re-insertion is guarded so
a root whose terminal event raced the capture window cannot leak state.
Offset capture semantics are unchanged per the ingestion spec (Seeding):
offsets remain conservative, validated hints - late capture can lose
attribution for the delayed command but can never steal another command's
reflog entries.

Test hook GIT_AI_TEST_TRACE_LISTENER_WORKER_SPAWN_DELAY_MS (a delay on the
accept thread, which no longer does per-connection work) is replaced by
GIT_AI_TEST_TRACE_READER_START_DELAY_MS (a delay at reader-thread start),
and its test is re-scoped to the fail-closed guarantee.

Part 1/4 for #2157.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Reviewer callout — reflog offset capture semantics.** The bootstrap phase captured reflog start offsets on the accept thread before handing the connection to its reader. With the bootstrap deleted, capture still happens when the worktree-bearing frame is *processed* — only the processing thread changes (reader instead of accept thread, µs of spawn latency in the normal case, strictly better under load since bootstraps no longer serialize across connections). Per `docs/daemon-trace2-ingestion-spec.md` §Seeding, these offsets are conservative validated hints: late capture can lose attribution for the delayed command but can never steal another command's reflog entries, so fail-closed is preserved. The old accept-thread guarantee was only observable via the artificial `GIT_AI_TEST_TRACE_LISTENER_WORKER_SPAWN_DELAY_MS` hook; its test is re-scoped to the fail-closed guarantee.
