### PR TITLE
Add end-to-end trace drain self-healing to the daemon

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -46,7 +46,7 @@ use std::os::fd::{AsFd, AsRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex as AsyncMutex, Notify, Semaphore, mpsc};
@@ -88,6 +88,12 @@ const TRACE_ROOT_STARTED_AT_NS_FIELD: &str = "git_ai_root_started_at_ns";
 const TRACE_ROOT_WORKTREE_FIELD: &str = "git_ai_root_worktree";
 pub(crate) const TRACE_ROOT_REFLOG_START_OFFSETS_FIELD: &str = "git_ai_root_reflog_start_offsets";
 const TRACE_CONNECTION_CLOSED_EVENT: &str = "git_ai_connection_closed";
+// Synthetic frame written by the socket-health loop; recognized at parse time
+// on the reader thread and never enqueued, so it proves the drain path
+// (accept → reader spawn → read → parse) without perturbing ingest ordering
+// or restarting a daemon that is merely busy with legitimate side effects.
+const TRACE_DRAIN_PROBE_EVENT: &str = "git_ai_drain_probe";
+const TRACE_DRAIN_PROBE_ID_FIELD: &str = "git_ai_probe_id";
 const DAEMON_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 const DAEMON_CONTROL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
 const DAEMON_CONTROL_RECEIVE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -2781,6 +2787,19 @@ pub struct ActorDaemonCoordinator {
     processed_trace_ingest_seq: AtomicUsize,
     trace_ingest_progress_notify: Notify,
     trace_ingress_state: Mutex<TraceIngressState>,
+    // Trace drain probe bookkeeping: ids issued by the socket-health loop and
+    // the highest id observed by a trace reader thread. A completed round
+    // trip proves accept → reader spawn → read → parse is still draining.
+    next_trace_drain_probe_id: AtomicU64,
+    observed_trace_drain_probe_id: AtomicU64,
+    // Duplicated fds of accepted trace connections, so shutdown can actively
+    // close them: a blocked git writer is released the instant its socket is
+    // shut down instead of waiting for process exit.
+    #[cfg(not(windows))]
+    trace_connection_registry: Mutex<HashMap<u64, std::os::fd::OwnedFd>>,
+    #[cfg(not(windows))]
+    next_trace_connection_id: AtomicU64,
+    teardown_complete: AtomicBool,
     shutting_down: AtomicBool,
     shutdown_action: AtomicU8,
     shutdown_notify: Notify,
@@ -2883,6 +2902,13 @@ impl ActorDaemonCoordinator {
             processed_trace_ingest_seq: AtomicUsize::new(0),
             trace_ingest_progress_notify: Notify::new(),
             trace_ingress_state: Mutex::new(TraceIngressState::default()),
+            next_trace_drain_probe_id: AtomicU64::new(0),
+            observed_trace_drain_probe_id: AtomicU64::new(0),
+            #[cfg(not(windows))]
+            trace_connection_registry: Mutex::new(HashMap::new()),
+            #[cfg(not(windows))]
+            next_trace_connection_id: AtomicU64::new(0),
+            teardown_complete: AtomicBool::new(false),
             shutting_down: AtomicBool::new(false),
             shutdown_action: AtomicU8::new(DaemonExitAction::Stop.as_u8()),
             shutdown_notify: Notify::new(),
@@ -3073,10 +3099,85 @@ impl ActorDaemonCoordinator {
         }
     }
 
+    fn issue_trace_drain_probe_id(&self) -> u64 {
+        self.next_trace_drain_probe_id
+            .fetch_add(1, Ordering::AcqRel)
+            + 1
+    }
+
+    fn record_trace_drain_probe(&self, probe_id: u64) {
+        // Only ids the health loop actually issued may advance the watermark.
+        // An arbitrary local writer forging a huge probe id would otherwise
+        // make every future drain probe appear satisfied, silently disabling
+        // self-healing.
+        if probe_id > self.next_trace_drain_probe_id.load(Ordering::Acquire) {
+            return;
+        }
+        self.observed_trace_drain_probe_id
+            .fetch_max(probe_id, Ordering::Release);
+    }
+
+    fn trace_drain_probe_watermark(&self) -> u64 {
+        self.observed_trace_drain_probe_id.load(Ordering::Acquire)
+    }
+
+    #[cfg(not(windows))]
+    fn register_trace_connection(&self, fd: std::os::fd::OwnedFd) -> Option<u64> {
+        let id = self
+            .next_trace_connection_id
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        let mut registry = self
+            .trace_connection_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        registry.insert(id, fd);
+        Some(id)
+    }
+
+    #[cfg(not(windows))]
+    fn deregister_trace_connection(&self, id: u64) {
+        let mut registry = self
+            .trace_connection_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        registry.remove(&id);
+    }
+
+    /// Actively close every accepted trace connection so blocked git writers
+    /// get EPIPE (git disables its trace2 target and completes) and reader
+    /// threads wake with EOF instead of parking in read until process exit.
+    ///
+    /// Platform note: Linux releases a blocked peer writer directly from this
+    /// shutdown; macOS only releases it once the reader's fd closes, so the
+    /// release path there is sever → reader wakes from read → stream dropped.
+    /// A reader wedged somewhere other than read keeps the writer blocked
+    /// until process exit, which the shutdown deadline enforcer bounds.
+    #[cfg(not(windows))]
+    fn shutdown_registered_trace_connections(&self) {
+        use std::os::fd::AsRawFd;
+
+        let registry = self
+            .trace_connection_registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        for fd in registry.values() {
+            unsafe {
+                libc::shutdown(fd.as_raw_fd(), libc::SHUT_RDWR);
+            }
+        }
+    }
+
     fn request_shutdown(&self) {
         // Release ensures that any writes made before this store are visible to
         // threads that subsequently load with Acquire (is_shutting_down).
         self.shutting_down.store(true, Ordering::Release);
+        // No shutdown path may keep accepting checkpoints it can no longer
+        // process; the graceful control handler closes this gate too, but
+        // internal shutdown requests must not depend on it.
+        self.accepting_checkpoints.store(false, Ordering::Release);
+        #[cfg(not(windows))]
+        self.shutdown_registered_trace_connections();
         // The ingest worker exits via its select! shutdown arm (watching
         // shutdown_notify); we no longer rely on channel closure to stop it.
         self.shutdown_notify.notify_waiters();
@@ -7854,7 +7955,10 @@ fn write_control_response<W: Write>(
 fn trace_listener_loop_actor(
     trace_socket_path: PathBuf,
     coordinator: Arc<ActorDaemonCoordinator>,
+    restart_history_path: PathBuf,
 ) -> Result<(), GitAiError> {
+    #[cfg(windows)]
+    let _ = restart_history_path;
     #[cfg(not(windows))]
     {
         remove_socket_if_exists(&trace_socket_path)?;
@@ -7875,6 +7979,8 @@ fn trace_listener_loop_actor(
             let Ok(stream) = stream else {
                 continue;
             };
+            #[cfg(feature = "test-support")]
+            maybe_stall_trace_accept_loop_for_test();
             match spawn_trace_connection_reader(stream, coordinator.clone()) {
                 Ok(()) => {
                     consecutive_spawn_failures = 0;
@@ -7886,7 +7992,7 @@ fn trace_listener_loop_actor(
                     tracing::error!(%error, "trace listener: failed to spawn handler thread");
                     consecutive_spawn_failures += 1;
                     if consecutive_spawn_failures >= TRACE_SPAWN_FAILURE_SHUTDOWN_THRESHOLD {
-                        if let Err(error) = spawn_self_restart() {
+                        if let Err(error) = spawn_self_restart(&restart_history_path) {
                             tracing::error!("failed to spawn self-restart: {}", error);
                         }
                         break;
@@ -8044,6 +8150,23 @@ fn maybe_stall_family_resolution_for_test(worktree: &Path) {
     }
 }
 
+/// Test hook: wedge the accept loop on the first accepted connection, the way
+/// a production stall does (the listening socket keeps queueing connects into
+/// the backlog while nothing drains them).
+#[cfg(all(not(windows), feature = "test-support"))]
+fn maybe_stall_trace_accept_loop_for_test() {
+    use std::sync::atomic::AtomicBool;
+
+    static STALLED: AtomicBool = AtomicBool::new(false);
+    if let Ok(raw_secs) = std::env::var("GIT_AI_TEST_TRACE_ACCEPT_STALL_SECS")
+        && let Ok(secs) = raw_secs.parse::<u64>()
+        && secs > 0
+        && !STALLED.swap(true, Ordering::SeqCst)
+    {
+        std::thread::sleep(std::time::Duration::from_secs(secs));
+    }
+}
+
 #[cfg(all(not(windows), feature = "test-support"))]
 fn test_trace_connection_spawn_failure_injected() -> bool {
     use std::sync::atomic::AtomicUsize;
@@ -8068,6 +8191,9 @@ fn run_trace_connection_reader(
     stream: LocalSocketStream,
     coordinator: Arc<ActorDaemonCoordinator>,
 ) {
+    // Register before anything that can delay this thread, so a shutdown can
+    // sever the connection even while the reader is still starting up.
+    let _registration = TraceConnectionRegistration::register(&stream, coordinator.clone());
     #[cfg(feature = "test-support")]
     if let Ok(raw_delay_ms) = std::env::var("GIT_AI_TEST_TRACE_READER_START_DELAY_MS")
         && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
@@ -8085,11 +8211,50 @@ fn run_trace_connection_reader(
         tracing::debug!(%error, "trace connection open bookkeeping error");
         return;
     }
+    // A shutdown requested before registration completed has already swept
+    // the registry; close this connection ourselves instead of parking in
+    // read until process exit.
+    if coordinator.is_shutting_down() {
+        let _ = finalize_trace_connection_roots(coordinator, std::collections::BTreeSet::new());
+        return;
+    }
     let reader = BufReader::new(stream);
     if let Err(error) =
         handle_trace_connection_actor_reader(reader, coordinator, std::collections::BTreeSet::new())
     {
         tracing::debug!(%error, "trace connection error");
+    }
+}
+
+/// Keeps a duplicated fd of an accepted trace connection in the coordinator's
+/// registry for the lifetime of its reader thread, so shutdown can actively
+/// close the socket out from under a blocked reader/writer.
+#[cfg(not(windows))]
+struct TraceConnectionRegistration {
+    coordinator: Arc<ActorDaemonCoordinator>,
+    id: Option<u64>,
+}
+
+#[cfg(not(windows))]
+impl TraceConnectionRegistration {
+    fn register(stream: &LocalSocketStream, coordinator: Arc<ActorDaemonCoordinator>) -> Self {
+        let id = match stream {
+            LocalSocketStream::UdSocket(inner) => inner
+                .as_fd()
+                .try_clone_to_owned()
+                .ok()
+                .and_then(|fd| coordinator.register_trace_connection(fd)),
+        };
+        Self { coordinator, id }
+    }
+}
+
+#[cfg(not(windows))]
+impl Drop for TraceConnectionRegistration {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            self.coordinator.deregister_trace_connection(id);
+        }
     }
 }
 
@@ -8133,6 +8298,17 @@ fn process_trace_connection_line(
         Ok(v) => v,
         Err(_) => return Ok(None),
     };
+    if parsed.get("event").and_then(Value::as_str) == Some(TRACE_DRAIN_PROBE_EVENT) {
+        if let Some(probe_id) = parsed
+            .get(TRACE_DRAIN_PROBE_ID_FIELD)
+            .and_then(Value::as_u64)
+        {
+            coordinator.record_trace_drain_probe(probe_id);
+        }
+        return Ok(Some(TraceLineOutcome {
+            continue_reading: true,
+        }));
+    }
     if let Some(sid) = parsed.get("sid").and_then(Value::as_str) {
         let was_unidentified = observed_roots.is_empty();
         let root_sid = trace_root_sid(sid).to_string();
@@ -8254,7 +8430,22 @@ fn daemon_socket_health_check_interval() -> u64 {
 /// daemon env vars (GIT_AI_DAEMON_HOME, etc.) so it targets the same
 /// instance.  Returns Ok if the process was spawned; the caller should
 /// still request_shutdown so the current daemon exits promptly.
-fn spawn_self_restart() -> Result<(), String> {
+///
+/// Every failure-driven restart is gated by the sliding-window budget here,
+/// so no caller can bypass crash-loop protection. The budget is consumed
+/// before spawning (fail-closed on unwritable storage) and refunded when the
+/// replacement process could not actually be started, so failed launch
+/// attempts do not burn the allowance a later stall needs to self-heal.
+fn spawn_self_restart(restart_history_path: &Path) -> Result<(), String> {
+    if !consume_self_restart_budget(restart_history_path) {
+        return Err("self-restart budget exhausted; not restarting".to_string());
+    }
+    spawn_self_restart_process().inspect_err(|_| {
+        refund_self_restart_budget(restart_history_path);
+    })
+}
+
+fn spawn_self_restart_process() -> Result<(), String> {
     let exe = crate::utils::current_git_ai_exe().map_err(|e| e.to_string())?;
     tracing::info!(?exe, "spawning detached restart process");
 
@@ -8282,34 +8473,132 @@ fn spawn_self_restart() -> Result<(), String> {
         .map_err(|e| format!("failed to spawn restart process: {}", e))
 }
 
-const DAEMON_MIN_UPTIME_FOR_SELF_RESTART_SECS: u64 = 60;
+/// Best-effort removal of the most recently recorded budget entry after a
+/// spawn that produced no replacement process.
+fn refund_self_restart_budget(history_path: &Path) {
+    let Ok(contents) = fs::read_to_string(history_path) else {
+        return;
+    };
+    let Ok(mut history) = serde_json::from_str::<Vec<u64>>(&contents) else {
+        return;
+    };
+    history.pop();
+    if let Ok(serialized) = serde_json::to_string(&history) {
+        let _ = crate::mdm::utils::write_atomic(history_path, serialized.as_bytes());
+    }
+}
 
-fn daemon_min_uptime_for_self_restart() -> u64 {
-    std::env::var("GIT_AI_DAEMON_MIN_UPTIME_FOR_RESTART_SECS")
+const DAEMON_SELF_RESTART_BUDGET_MAX: usize = 5;
+const DAEMON_SELF_RESTART_BUDGET_WINDOW_SECS: u64 = 3600;
+/// Consecutive health-check failures that may be deferred for outstanding
+/// checkpoints before restarting anyway. Checkpoints drain through the same
+/// congested machinery a stalled daemon cannot run, so deferring forever
+/// would leave blocked git writers hanging.
+const SOCKET_HEALTH_MAX_CONSECUTIVE_DEFERRALS: usize = 4;
+/// Consecutive health intervals with payloads queued but the processed
+/// watermark frozen before the ingest pipeline is declared wedged. The ingest
+/// worker runs side effects inline, and a single legitimate side effect is
+/// granted up to `DAEMON_CHECKPOINT_RESPONSE_TIMEOUT` (300s) elsewhere — the
+/// stall window (~6 minutes at the default 30s interval) must comfortably
+/// exceed that so a long-but-healthy operation is never mistaken for a wedge.
+const SOCKET_HEALTH_MAX_PROCESSING_STALL_INTERVALS: usize = 12;
+
+fn daemon_self_restart_budget_max() -> usize {
+    std::env::var("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DAEMON_SELF_RESTART_BUDGET_MAX)
+}
+
+fn daemon_self_restart_budget_window_secs() -> u64 {
+    std::env::var("GIT_AI_DAEMON_SELF_RESTART_BUDGET_WINDOW_SECS")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(DAEMON_MIN_UPTIME_FOR_SELF_RESTART_SECS)
+        .unwrap_or(DAEMON_SELF_RESTART_BUDGET_WINDOW_SECS)
+}
+
+/// Sliding-window self-restart budget, persisted across daemon generations in
+/// the daemon home. Returns true (and records the restart) while the window
+/// has budget left; returns false once exhausted, which is the crash-loop
+/// guard: a systemic failure (broken paths, filesystem permissions) stops
+/// producing new daemons instead of looping forever.
+///
+/// Fails closed: a history file that cannot be read (other than not existing
+/// yet), parsed, or persisted denies the restart. The budget exists to stop
+/// crash loops from systemic breakage (full/read-only disk, broken paths) —
+/// exactly the situations in which this file becomes unreadable or
+/// unwritable, so treating those as an empty budget would disable the guard
+/// when it matters most.
+fn consume_self_restart_budget(history_path: &Path) -> bool {
+    let now_secs = (now_unix_nanos() / 1_000_000_000) as u64;
+    let window_secs = daemon_self_restart_budget_window_secs();
+    let mut history: Vec<u64> = match fs::read_to_string(history_path) {
+        Ok(contents) => match serde_json::from_str(&contents) {
+            Ok(history) => history,
+            Err(error) => {
+                // Deny this restart, but remove the corrupt file so a future
+                // daemon generation starts with a fresh budget instead of
+                // being permanently unable to self-heal.
+                tracing::error!(%error, "self-restart history is corrupt; denying restart");
+                let _ = fs::remove_file(history_path);
+                return false;
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => {
+            tracing::error!(%error, "failed reading self-restart history; denying restart");
+            return false;
+        }
+    };
+    // Future timestamps (clock skew that has since been corrected — NTP
+    // step, VM restore) are pruned too: keeping them would deny every
+    // self-restart until wall clock catches up.
+    history.retain(|ts| *ts <= now_secs && now_secs - *ts < window_secs);
+
+    if history.len() >= daemon_self_restart_budget_max() {
+        // Persist the pruned view so stale/future entries don't linger.
+        if let Ok(serialized) = serde_json::to_string(&history) {
+            let _ = crate::mdm::utils::write_atomic(history_path, serialized.as_bytes());
+        }
+        return false;
+    }
+
+    history.push(now_secs);
+    let serialized = match serde_json::to_string(&history) {
+        Ok(serialized) => serialized,
+        Err(_) => return false,
+    };
+    // Atomic replace: a daemon hard-killed mid-write must not leave a
+    // truncated file behind (which would deny all future restarts).
+    if let Err(error) = crate::mdm::utils::write_atomic(history_path, serialized.as_bytes()) {
+        tracing::error!(%error, "failed persisting self-restart history; denying restart");
+        return false;
+    }
+    true
 }
 
 /// Background loop that verifies the daemon's sockets are reachable. The
 /// control probe performs a bounded Ping request so it also proves a handler
-/// can receive and respond, while the write-only trace2 socket is verified by
-/// connecting to its listener. If either probe fails (deleted file, stale
-/// socket, hung listener), the daemon spawns a detached restart process and
-/// shuts down.
-///
-/// To prevent restart loops when the underlying issue is systemic (e.g.
-/// filesystem permissions, broken paths), the daemon only self-restarts if
-/// it has been up for at least 60 seconds.  If sockets fail before that,
-/// it shuts down without restart — the next wrapper invocation will attempt
-/// to start a fresh daemon.
+/// can receive and respond. The trace2 socket is verified end-to-end with a
+/// drain probe: a synthetic frame must round-trip through accept, reader
+/// spawn, read, and parse within a deadline — a connect-only check cannot see
+/// a wedged accept loop, because the listen backlog keeps accepting connects
+/// while blocked git writers pile up behind it. On failure the daemon spawns
+/// a detached restart process (subject to the sliding-window restart budget)
+/// and shuts down.
 fn daemon_socket_health_check_loop(
     coordinator: Arc<ActorDaemonCoordinator>,
     control_socket_path: PathBuf,
     trace_socket_path: PathBuf,
+    restart_history_path: PathBuf,
 ) {
-    let started = std::time::Instant::now();
     let interval = daemon_socket_health_check_interval().max(1);
+    let mut consecutive_deferrals = 0usize;
+    // Processing-stall detection: payloads queued but the processed watermark
+    // not advancing means the ingest worker (or a side effect it runs, e.g. a
+    // hung git child) is wedged even though the socket legs look healthy.
+    let mut last_processed_seq = 0usize;
+    let mut stalled_intervals = 0usize;
     tracing::info!(
         interval,
         control = %control_socket_path.display(),
@@ -8350,48 +8639,140 @@ fn daemon_socket_health_check_loop(
                 })))
             }
         });
-        let trace_ok =
-            local_socket_connects_with_timeout(&trace_socket_path, DAEMON_SOCKET_PROBE_TIMEOUT);
+        let trace_ok = trace_drain_probe_round_trip(&coordinator, &trace_socket_path);
 
-        if control_ok.is_err() || trace_ok.is_err() {
+        let queued_payloads = coordinator.queued_trace_payloads.load(Ordering::Relaxed);
+        let processed_seq = coordinator
+            .processed_trace_ingest_seq
+            .load(Ordering::Acquire);
+        if queued_payloads > 0 && processed_seq == last_processed_seq {
+            stalled_intervals += 1;
+        } else {
+            stalled_intervals = 0;
+        }
+        last_processed_seq = processed_seq;
+        let processing_stalled = stalled_intervals >= SOCKET_HEALTH_MAX_PROCESSING_STALL_INTERVALS;
+
+        if control_ok.is_err() || trace_ok.is_err() || processing_stalled {
+            // A probe failure caused by a shutdown that started mid-check
+            // (readers severed, teardown underway) must not consume budget
+            // or resurrect a daemon the user just stopped.
+            if coordinator.is_shutting_down() {
+                return;
+            }
             let (outstanding_checkpoints, retained_checkpoint_bytes) =
                 coordinator.outstanding_checkpoint_state();
-            if outstanding_checkpoints > 0 {
+            if should_defer_restart_for_checkpoints(outstanding_checkpoints, consecutive_deferrals)
+            {
+                consecutive_deferrals += 1;
                 tracing::error!(
                     component = "daemon",
                     phase = "socket_health",
                     reason = "restart_deferred_for_checkpoints",
                     outstanding_checkpoints,
                     retained_checkpoint_bytes,
+                    consecutive_deferrals,
                     control = %control_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
                     trace = %trace_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
                     "socket health restart deferred while accepted checkpoints remain"
                 );
                 continue;
             }
-            let uptime = started.elapsed();
-            let min_uptime = std::time::Duration::from_secs(daemon_min_uptime_for_self_restart());
 
-            if uptime >= min_uptime {
-                tracing::warn!(
-                    control = %control_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
-                    trace = %trace_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
-                    "socket health check failed, spawning restart and shutting down"
-                );
-                if let Err(e) = spawn_self_restart() {
-                    tracing::error!("failed to spawn self-restart: {}", e);
+            match spawn_self_restart(&restart_history_path) {
+                Ok(()) => {
+                    tracing::warn!(
+                        control = %control_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
+                        trace = %trace_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
+                        processing_stalled,
+                        queued_payloads,
+                        stalled_intervals,
+                        "daemon health check failed, spawning restart and shutting down"
+                    );
                 }
-            } else {
-                tracing::warn!(
-                    control = %control_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
-                    trace = %trace_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
-                    uptime_secs = uptime.as_secs(),
-                    "socket health check failed within minimum uptime, shutting down without restart"
-                );
+                Err(e) => {
+                    tracing::error!(
+                        component = "daemon",
+                        phase = "socket_health",
+                        reason = "restart_not_spawned",
+                        control = %control_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
+                        trace = %trace_ok.err().map(|e| e.to_string()).unwrap_or_else(|| "ok".into()),
+                        processing_stalled,
+                        queued_payloads,
+                        stalled_intervals,
+                        "daemon health check failed; shutting down without restart: {}",
+                        e
+                    );
+                }
             }
             coordinator.request_shutdown();
             return;
         }
+        consecutive_deferrals = 0;
+    }
+}
+
+/// Whether a failed health check should be deferred because accepted
+/// checkpoints are still retained. Deferral is bounded: checkpoints drain
+/// through the same machinery a stalled daemon cannot run, so unbounded
+/// deferral would leave blocked git writers hanging forever.
+fn should_defer_restart_for_checkpoints(
+    outstanding_checkpoints: usize,
+    consecutive_deferrals: usize,
+) -> bool {
+    outstanding_checkpoints > 0 && consecutive_deferrals < SOCKET_HEALTH_MAX_CONSECUTIVE_DEFERRALS
+}
+
+const TRACE_DRAIN_PROBE_DEADLINE: Duration = Duration::from_secs(5);
+
+fn daemon_trace_drain_probe_deadline() -> Duration {
+    std::env::var("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(TRACE_DRAIN_PROBE_DEADLINE)
+}
+
+/// End-to-end trace drain health probe: connect to the trace socket, write
+/// one synthetic probe frame, and require a reader thread to have parsed it
+/// within the deadline. Proves the daemon is actually draining trace2 input,
+/// not merely holding a connectable listening socket.
+fn trace_drain_probe_round_trip(
+    coordinator: &Arc<ActorDaemonCoordinator>,
+    trace_socket_path: &Path,
+) -> Result<(), GitAiError> {
+    let deadline = daemon_trace_drain_probe_deadline();
+    let probe_id = coordinator.issue_trace_drain_probe_id();
+    let mut stream =
+        open_local_socket_stream_with_timeout(trace_socket_path, DAEMON_SOCKET_PROBE_TIMEOUT)?;
+    let payload = serde_json::json!({
+        "event": TRACE_DRAIN_PROBE_EVENT,
+        TRACE_DRAIN_PROBE_ID_FIELD: probe_id,
+    });
+    let line = format!("{}\n", payload);
+    write_all_daemon_client_stream(&mut stream, trace_socket_path, line.as_bytes())?;
+    drop(stream);
+
+    let started = std::time::Instant::now();
+    loop {
+        if coordinator.trace_drain_probe_watermark() >= probe_id {
+            return Ok(());
+        }
+        // A shutdown severs reader connections, so the probe can no longer
+        // complete; bail out instead of burning the rest of the deadline.
+        if coordinator.is_shutting_down() {
+            return Err(GitAiError::Generic(
+                "daemon began shutting down during trace drain probe".to_string(),
+            ));
+        }
+        if started.elapsed() >= deadline {
+            return Err(GitAiError::Generic(format!(
+                "trace drain probe {} not observed within {}ms",
+                probe_id,
+                deadline.as_millis()
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(25));
     }
 }
 
@@ -8613,9 +8994,10 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
 
     let trace_coord = coordinator.clone();
     let trace_shutdown_coord = coordinator.clone();
+    let trace_restart_history = self_restart_history_path(&config);
     let trace_thread = std::thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            trace_listener_loop_actor(trace_socket_path, trace_coord)
+            trace_listener_loop_actor(trace_socket_path, trace_coord, trace_restart_history)
         }));
         match result {
             Ok(Ok(())) => {}
@@ -8639,11 +9021,27 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     let health_coord = coordinator.clone();
     let health_control = config.control_socket_path.clone();
     let health_trace = config.trace_socket_path.clone();
+    let health_restart_history = self_restart_history_path(&config);
     let health_thread = std::thread::spawn(move || {
-        daemon_socket_health_check_loop(health_coord, health_control, health_trace);
+        daemon_socket_health_check_loop(
+            health_coord,
+            health_control,
+            health_trace,
+            health_restart_history,
+        );
     });
 
+    spawn_shutdown_deadline_enforcer(coordinator.clone(), self_restart_history_path(&config));
+
     coordinator.wait_for_shutdown().await;
+
+    #[cfg(feature = "test-support")]
+    if let Ok(raw_hang_secs) = std::env::var("GIT_AI_TEST_SHUTDOWN_HANG_SECS")
+        && let Ok(hang_secs) = raw_hang_secs.parse::<u64>()
+        && hang_secs > 0
+    {
+        std::thread::sleep(std::time::Duration::from_secs(hang_secs));
+    }
 
     // Best-effort wake listeners to allow clean process exit.
     // Connect to each socket to unblock `accept()`.  If the socket files
@@ -8692,9 +9090,74 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     remove_pid_metadata(&config)?;
 
     let action = coordinator.shutdown_action();
+    // Tells the shutdown deadline enforcer that teardown finished: whatever
+    // runs after this (restart spawn, pending self-update) must not be killed.
+    coordinator.teardown_complete.store(true, Ordering::Release);
     tracing::info!(?action, "daemon shutdown complete");
 
     Ok(action)
+}
+
+const DAEMON_SHUTDOWN_DEADLINE_SECS: u64 = 5;
+
+fn daemon_shutdown_deadline() -> Duration {
+    std::env::var("GIT_AI_DAEMON_SHUTDOWN_DEADLINE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(Duration::from_secs(DAEMON_SHUTDOWN_DEADLINE_SECS))
+}
+
+/// Terminal backstop for invariant "git is never blocked": once shutdown is
+/// requested, the process must actually exit so the OS closes every socket fd
+/// and releases any git process still blocked writing trace2. If graceful
+/// teardown wedges past the deadline, force the exit (spawning the restart
+/// the wedged teardown would have performed).
+fn spawn_shutdown_deadline_enforcer(
+    coordinator: Arc<ActorDaemonCoordinator>,
+    restart_history_path: PathBuf,
+) {
+    let _ = std::thread::Builder::new()
+        .name("git-ai-shutdown-enforcer".to_string())
+        .spawn(move || {
+            {
+                let mut guard = coordinator
+                    .shutdown_condvar_mutex
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                while !coordinator.is_shutting_down() {
+                    guard = coordinator
+                        .shutdown_condvar
+                        .wait(guard)
+                        .unwrap_or_else(|e| e.into_inner());
+                }
+            }
+            std::thread::sleep(daemon_shutdown_deadline());
+            if coordinator.teardown_complete.load(Ordering::Acquire) {
+                return;
+            }
+            tracing::error!(
+                component = "daemon",
+                phase = "shutdown",
+                "daemon teardown exceeded its deadline; forcing process exit"
+            );
+            if matches!(
+                coordinator.shutdown_action(),
+                DaemonExitAction::Restart | DaemonExitAction::RestartAfterUpdate
+            ) && let Err(e) = spawn_self_restart(&restart_history_path)
+            {
+                tracing::error!("failed to spawn self-restart: {}", e);
+            }
+            std::process::exit(70);
+        });
+}
+
+fn self_restart_history_path(config: &DaemonConfig) -> PathBuf {
+    config
+        .lock_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("self_restart_history.json")
 }
 
 fn checkpoint_control_timeout_uses_ci_or_test_budget() -> bool {
@@ -10191,6 +10654,156 @@ mod tests {
         assert!(!ingress.root_argv.contains_key(sid));
         assert!(!ingress.root_definitely_read_only.contains(sid));
         assert!(!ingress.root_open_connections.contains_key(sid));
+    }
+
+    #[tokio::test]
+    async fn drain_probe_frame_advances_watermark_without_root_bookkeeping() {
+        let coord = Arc::new(ActorDaemonCoordinator::new());
+        let mut observed_roots = std::collections::BTreeSet::new();
+
+        // A forged probe id that was never issued must not advance the
+        // watermark (it would permanently satisfy future health probes).
+        coord.record_trace_drain_probe(999);
+        assert_eq!(coord.trace_drain_probe_watermark(), 0);
+
+        for _ in 0..7 {
+            coord.issue_trace_drain_probe_id();
+        }
+        let outcome = process_trace_connection_line(
+            r#"{"event":"git_ai_drain_probe","git_ai_probe_id":7}"#,
+            coord.clone(),
+            &mut observed_roots,
+        )
+        .unwrap()
+        .expect("probe frame should produce an outcome");
+
+        assert!(outcome.continue_reading);
+        assert_eq!(coord.trace_drain_probe_watermark(), 7);
+        assert!(
+            observed_roots.is_empty(),
+            "probe frames must not register roots"
+        );
+        {
+            let ingress = coord.trace_ingress_state.lock().unwrap();
+            assert!(ingress.root_last_activity_ns.is_empty());
+            assert!(ingress.root_argv.is_empty());
+        }
+
+        // The watermark is monotonic: a stale probe id cannot move it back.
+        coord.record_trace_drain_probe(5);
+        assert_eq!(coord.trace_drain_probe_watermark(), 7);
+    }
+
+    #[test]
+    fn self_restart_budget_allows_within_window_then_denies() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("self_restart_history.json");
+
+        for _ in 0..DAEMON_SELF_RESTART_BUDGET_MAX {
+            assert!(consume_self_restart_budget(&history_path));
+        }
+        assert!(
+            !consume_self_restart_budget(&history_path),
+            "restart budget should be exhausted after {} restarts",
+            DAEMON_SELF_RESTART_BUDGET_MAX
+        );
+
+        // Entries older than the window are pruned, freeing budget again.
+        let stale_ts =
+            (now_unix_nanos() / 1_000_000_000) as u64 - DAEMON_SELF_RESTART_BUDGET_WINDOW_SECS - 1;
+        let stale = vec![stale_ts; DAEMON_SELF_RESTART_BUDGET_MAX];
+        fs::write(&history_path, serde_json::to_string(&stale).unwrap()).unwrap();
+        assert!(consume_self_restart_budget(&history_path));
+    }
+
+    #[test]
+    fn self_restart_budget_prunes_future_timestamps_from_clock_skew() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("self_restart_history.json");
+
+        // A skewed-ahead clock that was later corrected leaves future
+        // timestamps behind; they must not deny restarts until wall clock
+        // catches up.
+        let future_ts = (now_unix_nanos() / 1_000_000_000) as u64 + 86_400;
+        let skewed = vec![future_ts; DAEMON_SELF_RESTART_BUDGET_MAX];
+        fs::write(&history_path, serde_json::to_string(&skewed).unwrap()).unwrap();
+
+        assert!(
+            consume_self_restart_budget(&history_path),
+            "future timestamps must be pruned, not counted against the budget"
+        );
+        let rewritten: Vec<u64> = serde_json::from_str(
+            &fs::read_to_string(&history_path).expect("history should be rewritten"),
+        )
+        .unwrap();
+        assert!(
+            rewritten.iter().all(|ts| *ts <= future_ts - 86_400 + 60),
+            "rewritten history must not retain future timestamps: {rewritten:?}"
+        );
+        assert_eq!(rewritten.len(), 1, "only the new entry should remain");
+    }
+
+    #[test]
+    fn deferral_for_checkpoints_is_bounded() {
+        assert!(!should_defer_restart_for_checkpoints(0, 0));
+        assert!(should_defer_restart_for_checkpoints(1, 0));
+        assert!(should_defer_restart_for_checkpoints(
+            1,
+            SOCKET_HEALTH_MAX_CONSECUTIVE_DEFERRALS - 1
+        ));
+        assert!(!should_defer_restart_for_checkpoints(
+            1,
+            SOCKET_HEALTH_MAX_CONSECUTIVE_DEFERRALS
+        ));
+    }
+
+    #[test]
+    fn refunded_self_restart_budget_entry_frees_the_allowance() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("self_restart_history.json");
+
+        for _ in 0..DAEMON_SELF_RESTART_BUDGET_MAX {
+            assert!(consume_self_restart_budget(&history_path));
+        }
+        assert!(!consume_self_restart_budget(&history_path));
+
+        // A consumed entry whose spawn produced no replacement process is
+        // refunded, so it does not count against the window.
+        refund_self_restart_budget(&history_path);
+        assert!(
+            consume_self_restart_budget(&history_path),
+            "a refunded entry must free budget for a later restart"
+        );
+    }
+
+    #[test]
+    fn self_restart_budget_fails_closed_when_history_is_unusable() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Corrupt history: deny rather than treating it as an empty budget,
+        // but clear the file so a future generation can self-heal again.
+        let corrupt_path = dir.path().join("self_restart_history.json");
+        fs::write(&corrupt_path, "not json").unwrap();
+        assert!(
+            !consume_self_restart_budget(&corrupt_path),
+            "a corrupt history must deny the restart"
+        );
+        assert!(
+            !corrupt_path.exists(),
+            "a corrupt history must be cleared so self-healing is not bricked forever"
+        );
+        assert!(
+            consume_self_restart_budget(&corrupt_path),
+            "after clearing the corrupt history the budget must be fresh"
+        );
+
+        // Unpersistable history (path is a directory): deny as well.
+        let unwritable_path = dir.path().join("history-as-dir");
+        fs::create_dir(&unwritable_path).unwrap();
+        assert!(
+            !consume_self_restart_budget(&unwritable_path),
+            "an unpersistable history must deny the restart"
+        );
     }
 
     #[tokio::test]

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -457,6 +457,32 @@ fn configure_test_daemon_env(
     command.env("GIT_AI_DAEMON_TRACE_SOCKET", trace_socket_path);
 }
 
+/// Cleanup for self-restarted replacement daemons that no `DaemonGuard`
+/// owns: sends a best-effort Shutdown on drop so an assertion failure in the
+/// test body cannot strand a daemon (max uptime is 24h) on the machine.
+/// Gated like its users (the self-restart tests are unix-only): an unused
+/// struct fails the Windows dead-code lint.
+#[cfg(not(windows))]
+struct StrayDaemonGuard {
+    control_socket_path: PathBuf,
+}
+
+#[cfg(not(windows))]
+impl StrayDaemonGuard {
+    fn for_repo(repo: &TestRepo) -> Self {
+        Self {
+            control_socket_path: daemon_control_socket_path(repo),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+impl Drop for StrayDaemonGuard {
+    fn drop(&mut self) {
+        let _ = send_control_request(&self.control_socket_path, &ControlRequest::Shutdown);
+    }
+}
+
 struct DaemonGuard {
     child: Child,
     control_socket_path: PathBuf,
@@ -6250,7 +6276,6 @@ fn daemon_self_heals_after_socket_deletion() {
             ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
             ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
             ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
-            ("GIT_AI_DAEMON_MIN_UPTIME_FOR_RESTART_SECS", "0"),
         ],
     );
 
@@ -6320,6 +6345,789 @@ fn daemon_self_heals_after_socket_deletion() {
         }
         thread::sleep(Duration::from_millis(50));
     }
+}
+
+/// A wedged trace accept loop leaves the listening socket connectable (the
+/// backlog keeps queueing connects) while nothing drains trace2 input, so a
+/// connect-only health probe cannot see it. The drain probe must detect the
+/// wedge end-to-end and self-restart the daemon.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_self_restarts_when_trace_accept_loop_wedges() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            // The readiness wait's trace connect is the first accepted
+            // connection: the stall hook wedges the accept loop right there.
+            ("GIT_AI_TEST_TRACE_ACCEPT_STALL_SECS", "60"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
+            ("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS", "500"),
+            // One restart only: the replacement inherits the wedge hook, and
+            // without this cap it would churn through more generations past
+            // the end of the test.
+            ("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX", "1"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    // The budgeted restart spawns a replacement daemon DaemonGuard does not
+    // own; make sure it is shut down even when an assertion fails.
+    let _stray_daemon = StrayDaemonGuard::for_repo(&repo);
+
+    // The listening socket still accepts connects while the accept loop is
+    // wedged, so a connect-only probe would pass here.
+    assert!(
+        local_socket_connects_with_timeout(&trace_socket_path, DAEMON_TEST_PROBE_TIMEOUT).is_ok(),
+        "trace socket should still be connectable while the accept loop is wedged"
+    );
+
+    let mut original_exited = false;
+    for _ in 0..100 {
+        if daemon
+            .child
+            .try_wait()
+            .expect("failed to poll daemon")
+            .is_some()
+        {
+            original_exited = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        original_exited,
+        "daemon should detect the wedged trace drain and shut down"
+    );
+
+    let mut new_daemon_reachable = false;
+    for _ in 0..200 {
+        if control_socket_path.exists()
+            && send_control_request(
+                &control_socket_path,
+                &ControlRequest::StatusFamily {
+                    repo_working_dir: repo_workdir_string(&repo),
+                },
+            )
+            .is_ok()
+        {
+            new_daemon_reachable = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        new_daemon_reachable,
+        "a new daemon should be reachable after the wedged one self-restarted"
+    );
+
+    let _ = send_control_request(&control_socket_path, &ControlRequest::Shutdown);
+    for _ in 0..100 {
+        if !control_socket_path.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// A git process blocked writing trace2 into an undrained socket must be
+/// released as soon as the wedged daemon gives up: closing the socket fds
+/// turns the blocked write into an error, which git treats as "disable the
+/// trace2 target and continue".
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_drain_probe_wedge_releases_blocked_trace_writer() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_ACCEPT_STALL_SECS", "60"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
+            ("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS", "500"),
+            // No restart: this test only verifies that giving up releases the
+            // blocked writer.
+            ("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX", "0"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+
+    // The accept loop is already wedged (the readiness wait's trace connect
+    // was the first accepted connection). This writer's connection sits in
+    // the listen backlog; once the kernel buffers fill, writes block, exactly
+    // like git inside tr2_dst_write_line.
+    let writer_socket = trace_socket_path.clone();
+    let writer = thread::spawn(move || {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&writer_socket, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open writer trace connection");
+        let line = format!(
+            "{}\n",
+            json!({
+                "event": "data",
+                "sid": "blocked-writer",
+                "payload": "x".repeat(8192),
+            })
+        );
+        loop {
+            if stream
+                .write_all(line.as_bytes())
+                .and_then(|_| stream.flush())
+                .is_err()
+            {
+                return;
+            }
+        }
+    });
+
+    let started = std::time::Instant::now();
+    while started.elapsed() < Duration::from_secs(20) {
+        if writer.is_finished() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        writer.is_finished(),
+        "blocked trace writer should be released when the wedged daemon shuts down"
+    );
+    writer.join().unwrap();
+    daemon.shutdown();
+}
+
+/// Reader-thread spawn failure past the threshold takes the same budgeted
+/// restart path as every other failure-driven restart: under systemic
+/// thread-spawn failure (pids.max, RLIMIT_NPROC) the daemon must not
+/// crash-loop through unlimited generations.
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn daemon_spawn_failure_restart_consumes_budget() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+    let restart_history_path = daemon_lock_path(&repo)
+        .parent()
+        .expect("daemon lock path should have a parent")
+        .join("self_restart_history.json");
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_CONNECTION_SPAWN_FAILURES", "40"),
+            ("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX", "1"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "3600"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    // The budgeted restart spawns a replacement daemon DaemonGuard does not
+    // own; make sure it is shut down even when an assertion fails.
+    let _stray_daemon = StrayDaemonGuard::for_repo(&repo);
+
+    // Readiness consumed one injected failure; enough further connections
+    // reach the consecutive-failure threshold.
+    for _ in 0..17 {
+        let _ =
+            open_local_socket_stream_with_timeout(&trace_socket_path, DAEMON_TEST_PROBE_TIMEOUT);
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let mut original_exited = false;
+    for _ in 0..100 {
+        if daemon
+            .child
+            .try_wait()
+            .expect("failed to poll daemon")
+            .is_some()
+        {
+            original_exited = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        original_exited,
+        "daemon should shut down after persistent reader-spawn failures"
+    );
+
+    // Exactly one budgeted restart: a replacement daemon appears...
+    let mut replacement_reachable = false;
+    for _ in 0..200 {
+        if control_socket_path.exists()
+            && send_control_request(&control_socket_path, &ControlRequest::Ping).is_ok()
+        {
+            replacement_reachable = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(replacement_reachable, "one budgeted restart should occur");
+
+    // ...and when driven over the threshold again, the exhausted budget must
+    // stop the chain instead of spawning a third generation.
+    for _ in 0..20 {
+        let _ =
+            open_local_socket_stream_with_timeout(&trace_socket_path, DAEMON_TEST_PROBE_TIMEOUT);
+        thread::sleep(Duration::from_millis(10));
+    }
+    for _ in 0..150 {
+        if !control_socket_path.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        !control_socket_path.exists(),
+        "the replacement daemon should shut down once the restart budget is exhausted"
+    );
+    thread::sleep(Duration::from_secs(2));
+    assert!(
+        !control_socket_path.exists(),
+        "no third daemon may start after the restart budget is exhausted"
+    );
+
+    let history: Vec<u64> = serde_json::from_str(
+        &fs::read_to_string(&restart_history_path).expect("restart history should exist"),
+    )
+    .expect("restart history should be valid JSON");
+    assert_eq!(
+        history.len(),
+        1,
+        "exactly one spawn-failure self-restart should have consumed budget"
+    );
+}
+
+/// A `bg shutdown` racing an in-flight drain probe must not consume restart
+/// budget or resurrect the daemon the user just stopped.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_shutdown_mid_probe_does_not_restart() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let restart_history_path = daemon_lock_path(&repo)
+        .parent()
+        .expect("daemon lock path should have a parent")
+        .join("self_restart_history.json");
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            // Wedge the accept loop so every drain probe hangs in its poll
+            // window, then keep teardown (and thus the health thread) alive
+            // long enough for the probe to resolve after shutdown.
+            ("GIT_AI_TEST_TRACE_ACCEPT_STALL_SECS", "60"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
+            ("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS", "5000"),
+            ("GIT_AI_TEST_SHUTDOWN_HANG_SECS", "8"),
+            ("GIT_AI_DAEMON_SHUTDOWN_DEADLINE_SECS", "10"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+
+    // Let a health tick begin its (doomed) probe, then shut down mid-probe.
+    thread::sleep(Duration::from_millis(2000));
+    let _ = send_control_request(&control_socket_path, &ControlRequest::Shutdown);
+
+    let started = std::time::Instant::now();
+    let mut exited = false;
+    while started.elapsed() < Duration::from_secs(15) {
+        if daemon
+            .child
+            .try_wait()
+            .expect("failed to poll daemon")
+            .is_some()
+        {
+            exited = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(exited, "daemon should exit after the requested shutdown");
+
+    thread::sleep(Duration::from_secs(3));
+    assert!(
+        !control_socket_path.exists(),
+        "a shutdown racing a drain probe must not resurrect the daemon"
+    );
+    assert!(
+        !restart_history_path.exists(),
+        "a shutdown racing a drain probe must not consume restart budget"
+    );
+}
+
+/// The drain probe only proves the socket legs; a wedged ingest pipeline
+/// (payloads queued, processed watermark frozen) must also trigger the same
+/// budgeted self-restart, or attribution silently stops while health stays
+/// green.
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn daemon_processing_stall_triggers_budgeted_restart() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+    let restart_history_path = daemon_lock_path(&repo)
+        .parent()
+        .expect("daemon lock path should have a parent")
+        .join("self_restart_history.json");
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_INGEST_WORKER_START_DELAY_MS", "120000"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
+            ("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX", "1"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    // The budgeted restart spawns a replacement daemon DaemonGuard does not
+    // own; make sure it is shut down even when an assertion fails.
+    let _stray_daemon = StrayDaemonGuard::for_repo(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    // Queue mutating payloads that the (wedged) ingest worker never processes.
+    send_trace_frames(
+        &trace_socket_path,
+        &[
+            json!({
+                "event": "start",
+                "sid": "processing-stall-root",
+                "argv": ["git", "commit", "-m", "stalled pipeline"],
+                "time_ns": 70_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "processing-stall-root",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 70_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "processing-stall-root",
+                "code": 0,
+                "time_ns": 70_100u64,
+            }),
+            trace_atexit_frame("processing-stall-root", 0, 70_101u64),
+        ],
+    );
+
+    // The stall window is 12 health intervals (12s at the 1s test cadence);
+    // the wide 90s deadline absorbs heavily loaded CI runners.
+    let mut original_exited = false;
+    for _ in 0..900 {
+        if daemon
+            .child
+            .try_wait()
+            .expect("failed to poll daemon")
+            .is_some()
+        {
+            original_exited = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        original_exited,
+        "daemon should self-restart when the ingest pipeline stops making progress"
+    );
+
+    let mut replacement_reachable = false;
+    for _ in 0..200 {
+        if control_socket_path.exists()
+            && send_control_request(&control_socket_path, &ControlRequest::Ping).is_ok()
+        {
+            replacement_reachable = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        replacement_reachable,
+        "a replacement daemon should serve after the processing stall"
+    );
+    let history: Vec<u64> = serde_json::from_str(
+        &fs::read_to_string(&restart_history_path).expect("restart history should exist"),
+    )
+    .expect("restart history should be valid JSON");
+    assert_eq!(history.len(), 1, "the restart must consume budget");
+
+    let _ = send_control_request(&control_socket_path, &ControlRequest::Shutdown);
+    for _ in 0..100 {
+        if !control_socket_path.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Shutdown must sever accepted trace connections immediately (releasing any
+/// blocked writer), not merely rely on the socket fds closing at process
+/// exit.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_shutdown_severs_trace_connections_before_process_exit() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            // Readers register, then sleep: writes pile into kernel buffers
+            // until the writer blocks, like git inside tr2_dst_write_line.
+            ("GIT_AI_TEST_TRACE_READER_START_DELAY_MS", "30000"),
+            // Keep the process alive well past the shutdown request so the
+            // writer's release can only come from the registry sever.
+            ("GIT_AI_TEST_SHUTDOWN_HANG_SECS", "8"),
+            ("GIT_AI_DAEMON_SHUTDOWN_DEADLINE_SECS", "10"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "3600"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+
+    let writer_socket = trace_socket_path.clone();
+    let writer = thread::spawn(move || {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&writer_socket, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open writer trace connection");
+        let line = format!(
+            "{}\n",
+            json!({
+                "event": "data",
+                "sid": "sever-blocked-writer",
+                "payload": "x".repeat(8192),
+            })
+        );
+        loop {
+            if stream
+                .write_all(line.as_bytes())
+                .and_then(|_| stream.flush())
+                .is_err()
+            {
+                return;
+            }
+        }
+    });
+    thread::sleep(Duration::from_millis(500));
+
+    let _ = send_control_request(&control_socket_path, &ControlRequest::Shutdown);
+
+    // Linux wakes a blocked peer writer as soon as the daemon's end is shut
+    // down, so release must precede process exit. On macOS a blocked writer
+    // is only released once the reader's fd closes — the sever wakes a reader
+    // parked in read, but this test's reader is deliberately asleep, so the
+    // release is bounded by the shutdown deadline enforcer instead.
+    #[cfg(target_os = "linux")]
+    {
+        let started = std::time::Instant::now();
+        while started.elapsed() < Duration::from_secs(3) {
+            if writer.is_finished() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            writer.is_finished(),
+            "the blocked writer must be released by the registry sever, not by process exit"
+        );
+        assert!(
+            daemon
+                .child
+                .try_wait()
+                .expect("failed to poll daemon")
+                .is_none(),
+            "the daemon process should still be alive when the writer is released"
+        );
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let started = std::time::Instant::now();
+        while started.elapsed() < Duration::from_secs(15) {
+            if writer.is_finished() {
+                break;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            writer.is_finished(),
+            "the blocked writer must be released within the shutdown deadline"
+        );
+    }
+    writer.join().unwrap();
+    daemon.shutdown();
+}
+
+/// Outstanding checkpoints defer a failing health check — but only up to the
+/// cap, after which the daemon restarts anyway. Drives the health loop's
+/// deferral increment and cap wiring end to end: a checkpoint body dribbled
+/// over the control socket holds a quota reservation while the wedged accept
+/// loop keeps every drain probe failing.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_health_restart_deferred_for_checkpoints_until_cap() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_ACCEPT_STALL_SECS", "60"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
+            ("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS", "500"),
+            ("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX", "1"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    let _stray_daemon = StrayDaemonGuard::for_repo(&repo);
+
+    // Hold a checkpoint ingress reservation: announce a large body, read the
+    // ready ack, then dribble bytes so the body read never times out.
+    let dribble_socket = control_socket_path.clone();
+    let dribbler = thread::spawn(move || {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&dribble_socket, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open checkpoint control connection");
+        stream
+            .write_all(b"{\"method\":\"checkpoint.run\",\"params\":{\"body_bytes\":100000}}\n")
+            .expect("failed to write checkpoint header");
+        stream.flush().expect("failed to flush checkpoint header");
+        // Read the ready ack line.
+        use std::io::Read as _;
+        let mut byte = [0u8; 1];
+        loop {
+            match stream.read(&mut byte) {
+                Ok(0) | Err(_) => return,
+                Ok(_) if byte[0] == b'\n' => break,
+                Ok(_) => {}
+            }
+        }
+        // Dribble the body: one byte per 200ms keeps the reservation alive.
+        let started = std::time::Instant::now();
+        while started.elapsed() < Duration::from_secs(20) {
+            if stream.write_all(b"x").and_then(|_| stream.flush()).is_err() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+    });
+
+    // The health loop must defer while the reservation is outstanding, hit
+    // the cap, and then restart anyway.
+    let started = std::time::Instant::now();
+    loop {
+        let logs = daemon.stderr_contents();
+        if logs.contains("consecutive_deferrals=4") {
+            assert!(
+                logs.contains("restart_deferred_for_checkpoints"),
+                "deferral log should carry its reason:\n{logs}"
+            );
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "health loop never reached the deferral cap:\n{logs}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let mut original_exited = false;
+    for _ in 0..300 {
+        if daemon
+            .child
+            .try_wait()
+            .expect("failed to poll daemon")
+            .is_some()
+        {
+            original_exited = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        original_exited,
+        "the daemon must restart once the deferral cap is exhausted"
+    );
+    dribbler.join().unwrap();
+}
+
+/// A persistent wedge (e.g. systemic filesystem breakage) must not produce an
+/// endless restart loop: the sliding-window budget lets the daemon self-heal
+/// a bounded number of times and then stay down.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_restart_budget_prevents_crash_loop() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let restart_history_path = daemon_lock_path(&repo)
+        .parent()
+        .expect("daemon lock path should have a parent")
+        .join("self_restart_history.json");
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_ACCEPT_STALL_SECS", "60"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "1"),
+            ("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS", "500"),
+            ("GIT_AI_DAEMON_SELF_RESTART_BUDGET_MAX", "1"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+
+    // First daemon wedges (readiness trace connect) and restarts once.
+    let mut original_exited = false;
+    for _ in 0..100 {
+        if daemon
+            .child
+            .try_wait()
+            .expect("failed to poll daemon")
+            .is_some()
+        {
+            original_exited = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(original_exited, "wedged daemon should shut down");
+
+    // The replacement daemon wedges on its own first health probe and, with
+    // the budget exhausted, must shut down without spawning a third daemon.
+    let started = std::time::Instant::now();
+    let mut saw_replacement = false;
+    while started.elapsed() < Duration::from_secs(30) {
+        if control_socket_path.exists() {
+            saw_replacement = true;
+        } else if saw_replacement {
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        saw_replacement,
+        "one replacement daemon should have started"
+    );
+    for _ in 0..100 {
+        if !control_socket_path.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        !control_socket_path.exists(),
+        "the replacement daemon should shut down once the restart budget is exhausted"
+    );
+    thread::sleep(Duration::from_secs(2));
+    assert!(
+        !control_socket_path.exists(),
+        "no third daemon may start after the restart budget is exhausted"
+    );
+
+    let history: Vec<u64> = serde_json::from_str(
+        &fs::read_to_string(&restart_history_path).expect("restart history should exist"),
+    )
+    .expect("restart history should be valid JSON");
+    assert_eq!(
+        history.len(),
+        1,
+        "exactly one self-restart should have been recorded"
+    );
+}
+
+/// Once shutdown is requested, the process must exit within the deadline even
+/// if graceful teardown wedges: process exit is what closes the socket fds
+/// and releases any git still blocked on trace2 writes.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn daemon_shutdown_deadline_forces_exit() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_SHUTDOWN_HANG_SECS", "30"),
+            ("GIT_AI_DAEMON_SHUTDOWN_DEADLINE_SECS", "1"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+
+    let _ = send_control_request(&control_socket_path, &ControlRequest::Shutdown);
+
+    let started = std::time::Instant::now();
+    let mut exit_status = None;
+    while started.elapsed() < Duration::from_secs(5) {
+        if let Some(status) = daemon.child.try_wait().expect("failed to poll daemon") {
+            exit_status = Some(status);
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    let exit_status = exit_status
+        .expect("daemon should be force-exited by the shutdown deadline enforcer within 5s");
+    assert_eq!(
+        exit_status.code(),
+        Some(70),
+        "forced exit should use the enforcer's exit code"
+    );
+}
+
+/// Drain probes must be invisible to ingest ordering and attribution.
+#[test]
+#[cfg(not(windows))]
+fn daemon_drain_probes_do_not_disturb_attribution() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+
+    let stop_probes = Arc::new(AtomicBool::new(false));
+    let probe_stop = Arc::clone(&stop_probes);
+    let probe_socket = trace_socket_path.clone();
+    let prober = thread::spawn(move || {
+        let mut probe_id = 0u64;
+        while !probe_stop.load(Ordering::SeqCst) {
+            probe_id += 1;
+            if let Ok(mut stream) =
+                open_local_socket_stream_with_timeout(&probe_socket, DAEMON_TEST_PROBE_TIMEOUT)
+            {
+                let line = format!(
+                    "{}\n",
+                    json!({ "event": "git_ai_drain_probe", "git_ai_probe_id": probe_id })
+                );
+                let _ = stream.write_all(line.as_bytes());
+                let _ = stream.flush();
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    });
+
+    let mut file = repo.filename("probe-noise.txt");
+    file.set_contents(lines!["human line", "ai line".ai()]);
+    repo.stage_all_and_commit("commit under probe noise")
+        .unwrap();
+    file.assert_lines_and_blame(lines!["human line".human(), "ai line".ai()]);
+
+    stop_probes.store(true, Ordering::SeqCst);
+    prober.join().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
A daemon that stops draining trace2 input blocks every traced git process:
git writes trace2 synchronously and parks in write() once the listen backlog
and socket buffers fill. The socket health check could not see this - it only
probed the trace socket with connect(), which keeps succeeding while the
accept loop is wedged because the backlog keeps queueing connects. Production
machines stayed stalled until someone ran `git-ai bg shutdown --hard`.

Replace the connect-only probe with an end-to-end drain probe: the health
loop writes a synthetic frame that must round-trip through accept, reader
spawn, read, and parse within a deadline (5s default,
GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS override). The probe is
recognized at parse time on the reader thread and never enqueued, so it
cannot perturb ingest ordering and cannot false-positive-restart a daemon
that is merely busy with legitimate side effects (the queue/worker legs
already fail closed on their own).

Self-healing changes on probe failure:
- The under-60s-uptime "shut down without restart" branch is replaced by a
  sliding-window restart budget (5 per hour, persisted in the daemon home),
  so a wedge right after startup still self-heals while a systemic failure
  cannot crash-loop.
- Restart deferral for outstanding checkpoints is capped at 4 consecutive
  health failures; checkpoints drain through the same machinery a stalled
  daemon cannot run, so deferring forever left git writers blocked.

Two release guarantees are added so giving up always frees blocked writers:
- request_shutdown() now actively shuts down every accepted trace connection
  (tracked in a registry of duplicated fds), releasing blocked git writers
  and parked reader threads immediately instead of at process exit.
- A shutdown deadline enforcer thread force-exits the process (spawning the
  pending self-restart if one was intended) if graceful teardown wedges past
  5 seconds (GIT_AI_DAEMON_SHUTDOWN_DEADLINE_SECS override).

Part 2/4 for #2157.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
