### PR TITLE
Isolate telemetry from core daemon processing

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -242,6 +242,7 @@ pub(crate) fn recover_attribution(
         before_external_recovery(&unknown_after_edges);
     }
 
+    let mut metrics_db_unavailable = false;
     recover_session_event_mtime(
         repo,
         parent_sha,
@@ -250,6 +251,7 @@ pub(crate) fn recover_attribution(
         authorship_log,
         committed_hunks,
         context.file_timestamps,
+        &mut metrics_db_unavailable,
     )?;
 
     let unknown_after_session_events = unknown_lines_by_file(authorship_log, committed_hunks);
@@ -265,7 +267,21 @@ pub(crate) fn recover_attribution(
         authorship_log,
         &unknown_after_session_events,
         context.file_timestamps,
+        &mut metrics_db_unavailable,
     )? {
+        return Ok(());
+    }
+
+    // The metrics DB could not be consulted (busy/broken): "no matching AI
+    // session" was never established, so assigning the remaining lines to the
+    // human author would be misattribution, not a conservative default. Leave
+    // them unattributed instead; losing attribution is acceptable, inventing
+    // it is not.
+    if metrics_db_unavailable {
+        tracing::warn!(
+            commit = %commit_sha,
+            "metrics DB unavailable during attribution recovery; leaving unknown lines unattributed"
+        );
         return Ok(());
     }
 
@@ -273,26 +289,60 @@ pub(crate) fn recover_attribution(
     Ok(())
 }
 
+/// Budget for acquiring the metrics DB mutex on the post-commit path. Session
+/// event recovery is best-effort: when telemetry holds the database busy,
+/// give up quickly (the caller treats "no candidate" conservatively) instead
+/// of stalling commit processing behind telemetry work.
+const SESSION_EVENT_CANDIDATE_LOCK_BUDGET: std::time::Duration =
+    std::time::Duration::from_millis(500);
+
+/// Try to acquire a mutex within a bounded budget, polling instead of
+/// blocking, so a contended lock cannot stall the caller indefinitely.
+pub(crate) fn try_lock_with_budget<T>(
+    mutex: &std::sync::Mutex<T>,
+    budget: std::time::Duration,
+) -> Option<std::sync::MutexGuard<'_, T>> {
+    let started = std::time::Instant::now();
+    loop {
+        match mutex.try_lock() {
+            Ok(guard) => return Some(guard),
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => {
+                return Some(poisoned.into_inner());
+            }
+            Err(std::sync::TryLockError::WouldBlock) => {}
+        }
+        if started.elapsed() >= budget {
+            return None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+/// Whether a matching session-event recovery candidate exists.
+///
+/// `Some(true)`/`Some(false)` are definitive answers; `None` means the
+/// metrics DB could not be consulted (lock budget expired because telemetry
+/// is holding it busy, the DB failed to open, or the query errored) and the
+/// caller must not treat that as "no candidate" — doing so would trigger
+/// sweep-and-wait work exactly when the commit path should not stall behind
+/// telemetry.
 pub(crate) fn matching_session_event_candidate_exists(
     timestamps_ns: &[u128],
     target_repo_url: &str,
-) -> Result<bool, GitAiError> {
+) -> Option<bool> {
     if timestamps_ns.is_empty() || target_repo_url.is_empty() {
-        return Ok(false);
+        return Some(false);
     }
 
-    let candidates = match crate::metrics::db::MetricsDatabase::global() {
-        Ok(db) => match db.lock() {
-            Ok(db) => db.session_event_candidates_near_timestamps(
-                timestamps_ns,
-                SESSION_EVENT_RECOVERY_WINDOW_NS,
-            )?,
-            Err(_) => Vec::new(),
-        },
-        Err(_) => Vec::new(),
-    };
+    let db = crate::metrics::db::MetricsDatabase::global().ok()?;
+    let candidates = try_lock_with_budget(db, SESSION_EVENT_CANDIDATE_LOCK_BUDGET)?
+        .session_event_candidates_near_timestamps(timestamps_ns, SESSION_EVENT_RECOVERY_WINDOW_NS)
+        .map_err(|error| {
+            tracing::debug!(%error, "session-event candidate query failed");
+        })
+        .ok()?;
 
-    Ok(select_best_session_event_candidate(&candidates, timestamps_ns, target_repo_url).is_some())
+    Some(select_best_session_event_candidate(&candidates, timestamps_ns, target_repo_url).is_some())
 }
 
 fn recover_bash_mtime(
@@ -415,6 +465,7 @@ fn recover_bash_mtime(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn recover_session_event_mtime(
     repo: &Repository,
     parent_sha: &str,
@@ -423,6 +474,7 @@ fn recover_session_event_mtime(
     authorship_log: &mut AuthorshipLog,
     committed_hunks: &HashMap<String, Vec<LineRange>>,
     captured_file_timestamps: Option<&FileTimestampsByPath>,
+    metrics_db_unavailable: &mut bool,
 ) -> Result<(), GitAiError> {
     let workdir = repo.workdir()?;
     let unknown_by_file = unknown_lines_by_file(authorship_log, committed_hunks);
@@ -450,14 +502,30 @@ fn recover_session_event_mtime(
     all_timestamps.dedup();
 
     let candidates = match crate::metrics::db::MetricsDatabase::global() {
-        Ok(db) => match db.lock() {
-            Ok(db) => db.session_event_candidates_near_timestamps(
+        // Bounded acquire: recovery is best-effort and must not stall commit
+        // processing behind telemetry holding the metrics DB. An expired
+        // budget is recorded as "unavailable", never as "no candidates".
+        Ok(db) => match try_lock_with_budget(db, SESSION_EVENT_CANDIDATE_LOCK_BUDGET) {
+            Some(db) => match db.session_event_candidates_near_timestamps(
                 &all_timestamps,
                 SESSION_EVENT_RECOVERY_WINDOW_NS,
-            )?,
-            Err(_) => Vec::new(),
+            ) {
+                Ok(candidates) => candidates,
+                Err(error) => {
+                    tracing::debug!(%error, "session-event candidate query failed");
+                    *metrics_db_unavailable = true;
+                    return Ok(());
+                }
+            },
+            None => {
+                *metrics_db_unavailable = true;
+                return Ok(());
+            }
         },
-        Err(_) => Vec::new(),
+        Err(_) => {
+            *metrics_db_unavailable = true;
+            return Ok(());
+        }
     };
     if candidates.is_empty() {
         return Ok(());
@@ -528,6 +596,7 @@ fn recover_session_event_mtime(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn recover_commit_metadata(
     repo: &Repository,
     parent_sha: &str,
@@ -536,6 +605,7 @@ fn recover_commit_metadata(
     authorship_log: &mut AuthorshipLog,
     unknown_by_file: &UnknownLinesByFile,
     captured_file_timestamps: Option<&FileTimestampsByPath>,
+    metrics_db_unavailable: &mut bool,
 ) -> Result<bool, GitAiError> {
     if unknown_by_file.is_empty() {
         return Ok(true);
@@ -556,6 +626,7 @@ fn recover_commit_metadata(
         &detections,
         &latest_timestamps,
         target_repo_url.as_deref(),
+        metrics_db_unavailable,
     )?
     else {
         return Ok(false);
@@ -896,6 +967,7 @@ fn select_commit_metadata_session(
     detections: &[CommitAgentDetection],
     latest_timestamps: &[u128],
     target_repo_url: Option<&str>,
+    metrics_db_unavailable: &mut bool,
 ) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
     if detections.is_empty() {
         return Ok(None);
@@ -908,13 +980,24 @@ fn select_commit_metadata_session(
         detections,
         latest_timestamps,
         target_repo_url,
+        metrics_db_unavailable,
     )? {
         return Ok(Some(selection));
     }
-    if let Some(selection) =
-        select_latest_commit_metadata_metric_session(detections, target_repo_url)?
-    {
+    if let Some(selection) = select_latest_commit_metadata_metric_session(
+        detections,
+        target_repo_url,
+        metrics_db_unavailable,
+    )? {
         return Ok(Some(selection));
+    }
+
+    // The metrics DB could not be consulted: "no matching session" was never
+    // established, so minting a synthesized session would be misattribution.
+    // Reporting no-selection lets recover_attribution's unavailable guard
+    // leave the lines unattributed instead.
+    if *metrics_db_unavailable {
+        return Ok(None);
     }
 
     Ok(Some(synthesized_commit_metadata_session(
@@ -1009,20 +1092,37 @@ fn select_nearest_commit_metadata_metric_session(
     detections: &[CommitAgentDetection],
     latest_timestamps: &[u128],
     target_repo_url: Option<&str>,
+    metrics_db_unavailable: &mut bool,
 ) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
     if latest_timestamps.is_empty() {
         return Ok(None);
     }
 
     let candidates = match crate::metrics::db::MetricsDatabase::global() {
-        Ok(db) => match db.lock() {
-            Ok(db) => db.session_event_candidates_near_timestamps(
+        // Bounded acquire: recovery is best-effort and must not stall commit
+        // processing behind telemetry holding the metrics DB. An expired
+        // budget is recorded as "unavailable", never as "no candidates".
+        Ok(db) => match try_lock_with_budget(db, SESSION_EVENT_CANDIDATE_LOCK_BUDGET) {
+            Some(db) => match db.session_event_candidates_near_timestamps(
                 latest_timestamps,
                 SESSION_EVENT_RECOVERY_WINDOW_NS,
-            )?,
-            Err(_) => Vec::new(),
+            ) {
+                Ok(candidates) => candidates,
+                Err(error) => {
+                    tracing::debug!(%error, "session-event candidate query failed");
+                    *metrics_db_unavailable = true;
+                    return Ok(None);
+                }
+            },
+            None => {
+                *metrics_db_unavailable = true;
+                return Ok(None);
+            }
         },
-        Err(_) => Vec::new(),
+        Err(_) => {
+            *metrics_db_unavailable = true;
+            return Ok(None);
+        }
     };
 
     let mut best: Option<(
@@ -1083,18 +1183,32 @@ fn select_nearest_commit_metadata_metric_session(
 fn select_latest_commit_metadata_metric_session(
     detections: &[CommitAgentDetection],
     target_repo_url: Option<&str>,
+    metrics_db_unavailable: &mut bool,
 ) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
     let db = match crate::metrics::db::MetricsDatabase::global() {
         Ok(db) => db,
-        Err(_) => return Ok(None),
+        Err(_) => {
+            *metrics_db_unavailable = true;
+            return Ok(None);
+        }
     };
-    let db = match db.lock() {
-        Ok(db) => db,
-        Err(_) => return Ok(None),
+    // Bounded acquire: recovery is best-effort and must not stall commit
+    // processing behind telemetry holding the metrics DB. An expired budget
+    // is recorded as "unavailable", never as "no candidates".
+    let Some(db) = try_lock_with_budget(db, SESSION_EVENT_CANDIDATE_LOCK_BUDGET) else {
+        *metrics_db_unavailable = true;
+        return Ok(None);
     };
 
     for detection in detections {
-        let candidates = db.latest_session_event_candidates_for_tools(detection.kind.tools)?;
+        let candidates = match db.latest_session_event_candidates_for_tools(detection.kind.tools) {
+            Ok(candidates) => candidates,
+            Err(error) => {
+                tracing::debug!(%error, "latest session-event candidate query failed");
+                *metrics_db_unavailable = true;
+                return Ok(None);
+            }
+        };
         if let Some((candidate, _)) = candidates
             .iter()
             .filter_map(|candidate| {
@@ -1826,6 +1940,210 @@ mod tests {
         AttestationEntry, AuthorshipLog, FileAttestation,
     };
     use crate::authorship::working_log::AgentId;
+
+    #[test]
+    #[serial_test::serial]
+    fn preflight_reports_unknown_when_metrics_db_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialized via #[serial]; the metrics DB singleton is
+        // pointed at a temp path before its first initialization.
+        unsafe {
+            std::env::set_var("GIT_AI_TEST_METRICS_DB_PATH", dir.path().join("metrics-db"));
+        }
+        let db = crate::metrics::db::MetricsDatabase::global().unwrap();
+        // The singleton keeps this path for the process lifetime; leak the
+        // temp dir so the open connection never points at a deleted file.
+        std::mem::forget(dir);
+
+        let _held = db.lock().unwrap();
+        let checker = std::thread::spawn(|| {
+            matching_session_event_candidate_exists(
+                &[1_000_000_000u128],
+                "https://example.com/repo.git",
+            )
+        });
+        let result = checker.join().unwrap();
+        // SAFETY: serialized via #[serial].
+        unsafe {
+            std::env::remove_var("GIT_AI_TEST_METRICS_DB_PATH");
+        }
+        assert_eq!(
+            result, None,
+            "a busy metrics DB must report unknown, not a definitive absence"
+        );
+    }
+
+    fn claude_marker_detections() -> Vec<CommitAgentDetection> {
+        let detections = detect_commit_metadata_agents(&CommitMetadata {
+            message: "Add feature\n\nCo-Authored-By: Claude <noreply@anthropic.com>".to_string(),
+            author_name: "Dev".to_string(),
+            author_email: "dev@example.com".to_string(),
+        });
+        assert!(
+            !detections.is_empty(),
+            "the marker commit message should produce agent detections"
+        );
+        detections
+    }
+
+    fn point_metrics_db_at_temp_path()
+    -> &'static std::sync::Mutex<crate::metrics::db::MetricsDatabase> {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: callers are serialized via #[serial]; the metrics DB
+        // singleton is pointed at a temp path before its first initialization.
+        unsafe {
+            std::env::set_var("GIT_AI_TEST_METRICS_DB_PATH", dir.path().join("metrics-db"));
+        }
+        let db = crate::metrics::db::MetricsDatabase::global().unwrap();
+        // The singleton keeps this path for the process lifetime; leak the
+        // temp dir so the open connection never points at a deleted file.
+        std::mem::forget(dir);
+        db
+    }
+
+    fn clear_metrics_db_env() {
+        // SAFETY: callers are serialized via #[serial].
+        unsafe {
+            std::env::remove_var("GIT_AI_TEST_METRICS_DB_PATH");
+        }
+    }
+
+    /// A busy metrics DB means "no matching session" was never established:
+    /// minting a synthesized session anyway would credit lines to a session
+    /// that never existed — misattribution, strictly worse than leaving the
+    /// lines unattributed.
+    #[test]
+    #[serial_test::serial]
+    fn commit_metadata_session_is_not_synthesized_when_metrics_db_is_busy() {
+        let db = point_metrics_db_at_temp_path();
+        let detections = claude_marker_detections();
+
+        let _held = db.lock().unwrap();
+        let checker = std::thread::spawn(move || {
+            let log = AuthorshipLog::new();
+            let mut unavailable = false;
+            let selection = select_commit_metadata_session(
+                &log,
+                &detections,
+                &[1_000_000_000u128],
+                None,
+                &mut unavailable,
+            );
+            (selection, unavailable)
+        });
+        let (selection, unavailable) = checker.join().unwrap();
+        clear_metrics_db_env();
+
+        assert!(unavailable, "the busy DB must be reported as unavailable");
+        assert!(
+            selection.unwrap().is_none(),
+            "a busy metrics DB must not mint a synthesized session"
+        );
+    }
+
+    /// The synthesized fallback is legitimate when the DB was consulted and
+    /// genuinely has no candidate rows.
+    #[test]
+    #[serial_test::serial]
+    fn commit_metadata_session_synthesized_when_db_is_healthy_but_empty() {
+        let _db = point_metrics_db_at_temp_path();
+        let detections = claude_marker_detections();
+
+        let log = AuthorshipLog::new();
+        let mut unavailable = false;
+        let selection = select_commit_metadata_session(
+            &log,
+            &detections,
+            &[1_000_000_000u128],
+            None,
+            &mut unavailable,
+        )
+        .unwrap();
+        clear_metrics_db_env();
+
+        assert!(!unavailable, "an uncontended DB must count as consulted");
+        let selection =
+            selection.expect("a consulted-but-empty DB must still mint the synthesized fallback");
+        assert_eq!(selection.tier, "synthesized_session");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn commit_metadata_selector_reports_db_unavailable_when_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        // SAFETY: serialized via #[serial]; the metrics DB singleton is
+        // pointed at a temp path before its first initialization.
+        unsafe {
+            std::env::set_var("GIT_AI_TEST_METRICS_DB_PATH", dir.path().join("metrics-db"));
+        }
+        let db = crate::metrics::db::MetricsDatabase::global().unwrap();
+        // The singleton keeps this path for the process lifetime; leak the
+        // temp dir so the open connection never points at a deleted file.
+        std::mem::forget(dir);
+
+        // Uncontended: the DB is consulted and the flag stays clear.
+        let mut unavailable = false;
+        let selection =
+            select_latest_commit_metadata_metric_session(&[], None, &mut unavailable).unwrap();
+        assert!(selection.is_none());
+        assert!(!unavailable, "an uncontended DB must count as consulted");
+
+        // Contended: the selector must report "unavailable", never let the
+        // caller mistake a busy DB for "no matching AI session" (which would
+        // end in AI lines being attributed to the human author).
+        let _held = db.lock().unwrap();
+        let checker = std::thread::spawn(|| {
+            let mut unavailable = false;
+            let selection =
+                select_latest_commit_metadata_metric_session(&[], None, &mut unavailable);
+            (selection, unavailable)
+        });
+        let (selection, unavailable) = checker.join().unwrap();
+        // SAFETY: serialized via #[serial].
+        unsafe {
+            std::env::remove_var("GIT_AI_TEST_METRICS_DB_PATH");
+        }
+        assert!(selection.unwrap().is_none());
+        assert!(
+            unavailable,
+            "a busy metrics DB must be reported as unavailable"
+        );
+    }
+
+    #[test]
+    fn try_lock_with_budget_returns_within_budget_when_contended() {
+        let mutex = std::sync::Arc::new(std::sync::Mutex::new(()));
+        let held = std::sync::Arc::clone(&mutex);
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let holder = std::thread::spawn(move || {
+            let _guard = held.lock().unwrap();
+            let _ = acquired_tx.send(());
+            let _ = release_rx.recv();
+        });
+        acquired_rx
+            .recv()
+            .expect("holder thread should acquire the lock");
+
+        let started = std::time::Instant::now();
+        let budget = std::time::Duration::from_millis(100);
+        assert!(
+            try_lock_with_budget(&mutex, budget).is_none(),
+            "a contended lock must not be acquired"
+        );
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= budget && elapsed < std::time::Duration::from_millis(1000),
+            "bounded acquire took {elapsed:?}, expected roughly the {budget:?} budget"
+        );
+
+        let _ = release_tx.send(());
+        holder.join().unwrap();
+        assert!(
+            try_lock_with_budget(&mutex, budget).is_some(),
+            "an uncontended lock must be acquired immediately"
+        );
+    }
 
     fn test_agent(external_session_id: &str) -> AgentId {
         AgentId {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3018,18 +3018,22 @@ impl ActorDaemonCoordinator {
             return;
         };
 
-        let has_candidate = || {
+        let candidate_check = || {
             crate::authorship::attribution_recovery::matching_session_event_candidate_exists(
                 &timestamps,
                 &target_repo_url,
             )
-            .unwrap_or_else(|error| {
-                tracing::debug!(%error, "failed checking session-event recovery candidates");
-                false
-            })
         };
-        if has_candidate() {
-            return;
+        // Only a definitive "no candidate" justifies the sweep-and-wait below.
+        // An unknown answer (metrics DB busy under telemetry load) must not
+        // add sweep work and preflight latency to the commit path.
+        match candidate_check() {
+            Some(false) => {}
+            Some(true) => return,
+            None => {
+                tracing::debug!("session-event recovery preflight skipped; metrics DB busy");
+                return;
+            }
         }
 
         let deadline = std::time::Instant::now() + SESSION_EVENT_RECOVERY_PREFLIGHT_WAIT;
@@ -3083,7 +3087,9 @@ impl ActorDaemonCoordinator {
                 return;
             }
             std::thread::sleep(remaining.min(SESSION_EVENT_RECOVERY_PREFLIGHT_POLL));
-            if has_candidate() {
+            // A definitive hit or an unknown (busy DB) both end the wait: the
+            // preflight must never hold the commit path hostage to telemetry.
+            if !matches!(candidate_check(), Some(false)) {
                 tracing::debug!(
                     "session-event recovery candidate became visible before post-commit"
                 );
@@ -7140,11 +7146,13 @@ impl ActorDaemonCoordinator {
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::FlushNotes => {
-                // Trigger an immediate notes flush in a blocking task.
-                // Fire-and-forget: the periodic flush loop is the safety net.
-                tokio::task::spawn_blocking(|| {
-                    crate::daemon::telemetry_worker::flush_notes();
-                });
+                // Fire-and-forget trigger routed through the serialized flush
+                // loop (the periodic loop is the safety net); see
+                // `request_flush` for why a bare concurrent `flush_notes`
+                // here would let `await` certify mid-upload.
+                if let Some(worker) = &self.telemetry_worker {
+                    worker.request_flush();
+                }
                 Ok(ControlResponse::ok(None, None))
             }
             ControlRequest::Await { timeout_secs } => {
@@ -9041,6 +9049,16 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
         && hang_secs > 0
     {
         std::thread::sleep(std::time::Duration::from_secs(hang_secs));
+    }
+
+    // Metric batches still sitting in the persistence queue must reach SQLite
+    // before this process exits, or a restart silently loses them.
+    if let Some(worker) = &coordinator.telemetry_worker
+        && !worker
+            .drain_metrics_persist_queue(std::time::Duration::from_secs(2))
+            .await
+    {
+        tracing::warn!("telemetry metrics persist queue was not fully drained at shutdown");
     }
 
     // Best-effort wake listeners to allow clean process exit.

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -195,21 +195,106 @@ impl TelemetryBuffer {
     }
 }
 
+/// Capacity of the bounded metrics-persistence queue. A telemetry burst past
+/// this bound drops metric batches (loudly) instead of creating unbounded
+/// blocking tasks or back-pressuring core daemon processing.
+const METRICS_PERSIST_QUEUE_CAPACITY: usize = 256;
+
+/// Metric batches dropped because the persistence queue was full. Telemetry
+/// is best-effort by design; the counter keeps the loss observable.
+static METRIC_BATCHES_DROPPED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+pub fn metric_batches_dropped() -> u64 {
+    METRIC_BATCHES_DROPPED.load(Ordering::Relaxed)
+}
+
+/// Budget for waiting on the persist worker to catch up when an `await` or
+/// teardown needs the queue's contents to be visible in SQLite.
+const METRICS_PERSIST_DRAIN_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Work items for the metrics persistence worker.
+enum MetricsPersistRequest {
+    Store(Vec<MetricEvent>),
+    /// Flush marker: when the ack fires, every `Store` enqueued before this
+    /// marker has been written to SQLite.
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
+/// Send a flush marker through the persist queue and wait for its ack, so
+/// callers that read pending metrics from SQLite (await status, uploads,
+/// teardown) observe every batch enqueued before the call. Bounded by
+/// `deadline` in case the persist worker is wedged. Returns true when the
+/// queue was drained.
+async fn drain_metrics_persist_requests(
+    persist_tx: &tokio::sync::mpsc::Sender<MetricsPersistRequest>,
+    deadline: Duration,
+) -> bool {
+    let drain = async {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        if persist_tx
+            .send(MetricsPersistRequest::Flush(ack_tx))
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        ack_rx.await.is_ok()
+    };
+    tokio::time::timeout(deadline, drain).await.unwrap_or(false)
+}
+
 /// Handle for submitting telemetry directly within the daemon process.
 #[derive(Clone)]
 pub struct DaemonTelemetryWorkerHandle {
     buffer: Arc<Mutex<TelemetryBuffer>>,
     flush_tx: tokio::sync::mpsc::UnboundedSender<FlushRequest>,
+    metrics_persist_tx: tokio::sync::mpsc::Sender<MetricsPersistRequest>,
 }
 
 impl DaemonTelemetryWorkerHandle {
     #[cfg(test)]
     pub fn new_noop() -> Self {
         let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (metrics_persist_tx, persist_rx) =
+            tokio::sync::mpsc::channel(METRICS_PERSIST_QUEUE_CAPACITY);
+        // Keep the receiver alive so noop submissions look like a full-but-
+        // healthy queue instead of a dead persist worker.
+        std::mem::forget(persist_rx);
         Self {
             buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
             flush_tx,
+            metrics_persist_tx,
         }
+    }
+
+    /// Queue a metric batch for persistence on the telemetry runtime. Never
+    /// blocks the caller: core daemon paths submit metrics from latency-
+    /// sensitive contexts, so a full queue drops the batch and counts it.
+    fn enqueue_metrics_persist(&self, metric_events: Vec<MetricEvent>) {
+        if metric_events.is_empty() {
+            return;
+        }
+        match self
+            .metrics_persist_tx
+            .try_send(MetricsPersistRequest::Store(metric_events))
+        {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                METRIC_BATCHES_DROPPED.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!("telemetry: metrics persistence queue full; dropping batch");
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                METRIC_BATCHES_DROPPED.fetch_add(1, Ordering::Relaxed);
+                tracing::error!("telemetry: metrics persistence worker is gone; dropping batch");
+            }
+        }
+    }
+
+    /// Wait until every metric batch enqueued before this call is persisted
+    /// to SQLite (bounded). Used at daemon teardown so queued batches are not
+    /// lost across a restart.
+    pub async fn drain_metrics_persist_queue(&self, deadline: Duration) -> bool {
+        drain_metrics_persist_requests(&self.metrics_persist_tx, deadline).await
     }
 
     /// Submit telemetry envelopes for batched processing.
@@ -222,13 +307,7 @@ impl DaemonTelemetryWorkerHandle {
                 .ingest_envelopes(buffered_envelopes);
         }
 
-        if !metric_events.is_empty() {
-            std::mem::drop(tokio::task::spawn_blocking(move || {
-                if let Err(e) = store_metrics_in_db(&metric_events) {
-                    tracing::warn!(%e, "telemetry: failed to persist metrics locally");
-                }
-            }));
-        }
+        self.enqueue_metrics_persist(metric_events);
     }
 
     /// Submit CAS records for batched upload.
@@ -242,6 +321,20 @@ impl DaemonTelemetryWorkerHandle {
             return;
         }
         self.buffer.lock().await.ingest_daemon_logs(events);
+    }
+
+    /// Fire-and-forget flush trigger through the serialized flush loop.
+    ///
+    /// Callers that just want "flush soon" (e.g. `notes.flush`) must go
+    /// through here rather than calling `flush_notes` directly: a concurrent
+    /// flusher dequeue-locks note rows out from under an awaited flush, whose
+    /// pending count excludes locked rows — letting `await` certify while the
+    /// triggered upload is still in flight.
+    pub fn request_flush(&self) {
+        let (completion_tx, _completion_rx) = tokio::sync::oneshot::channel();
+        let _ = self.flush_tx.send(FlushRequest {
+            completion: completion_tx,
+        });
     }
 
     /// Request an immediate telemetry flush and wait for the worker to complete.
@@ -311,11 +404,7 @@ impl DaemonTelemetryWorkerHandle {
             buf.ingest_envelopes(buffered_envelopes);
         }
 
-        if !metric_events.is_empty()
-            && let Err(e) = store_metrics_in_db(&metric_events)
-        {
-            tracing::warn!(%e, "telemetry: failed to persist daemon metrics locally");
-        }
+        self.enqueue_metrics_persist(metric_events);
     }
 
     /// Submit CAS records synchronously (best-effort, non-blocking).
@@ -433,30 +522,72 @@ pub fn submit_daemon_internal_daemon_logs(events: Vec<DaemonLogEvent>) -> bool {
 ///
 /// The worker runs a flush loop every 3 seconds, sending accumulated events
 /// to their respective destinations (Sentry, PostHog, metrics API, CAS API).
+///
+/// Everything spawned here — the flush loop, its synchronous upload jobs, the
+/// metrics persistence worker, and the metadata backfill — runs on the
+/// dedicated telemetry runtime, so slow uploads or a contended metrics DB can
+/// never occupy the daemon runtime that command/checkpoint processing uses.
 pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
     let buffer = Arc::new(Mutex::new(TelemetryBuffer::new()));
     let (flush_tx, flush_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (metrics_persist_tx, metrics_persist_rx) =
+        tokio::sync::mpsc::channel(METRICS_PERSIST_QUEUE_CAPACITY);
     let handle = DaemonTelemetryWorkerHandle {
         buffer: buffer.clone(),
         flush_tx,
+        metrics_persist_tx: metrics_persist_tx.clone(),
     };
     let daemon_id = daemon_run_id().to_string();
+    let telemetry_runtime = crate::tokio_runtime::telemetry_runtime();
 
-    spawn_metrics_metadata_backfill();
+    spawn_metrics_metadata_backfill(telemetry_runtime);
 
-    tokio::spawn(async move {
-        telemetry_flush_loop(buffer, daemon_id, flush_rx).await;
+    telemetry_runtime.spawn(metrics_persist_loop(metrics_persist_rx));
+    telemetry_runtime.spawn(async move {
+        telemetry_flush_loop(buffer, daemon_id, flush_rx, metrics_persist_tx).await;
     });
 
     handle
 }
 
-fn spawn_metrics_metadata_backfill() {
+/// Drains the bounded metrics-persistence queue: one SQLite write at a time,
+/// on the telemetry runtime's blocking pool.
+async fn metrics_persist_loop(mut rx: tokio::sync::mpsc::Receiver<MetricsPersistRequest>) {
+    while let Some(request) = rx.recv().await {
+        match request {
+            MetricsPersistRequest::Store(metric_events) => {
+                #[cfg(feature = "test-support")]
+                if let Ok(raw_delay_ms) = std::env::var("GIT_AI_TEST_METRICS_PERSIST_DELAY_MS")
+                    && let Ok(delay_ms) = raw_delay_ms.parse::<u64>()
+                    && delay_ms > 0
+                {
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                let result =
+                    tokio::task::spawn_blocking(move || store_metrics_in_db(&metric_events))
+                        .await
+                        .unwrap_or_else(|e| {
+                            Err(GitAiError::Generic(format!(
+                                "metrics persistence task panicked: {e}"
+                            )))
+                        });
+                if let Err(e) = result {
+                    tracing::warn!(%e, "telemetry: failed to persist metrics locally");
+                }
+            }
+            MetricsPersistRequest::Flush(ack) => {
+                let _ = ack.send(());
+            }
+        }
+    }
+}
+
+fn spawn_metrics_metadata_backfill(telemetry_runtime: &tokio::runtime::Runtime) {
     if METRICS_METADATA_BACKFILL_STARTED.swap(true, Ordering::Relaxed) {
         return;
     }
 
-    std::mem::drop(tokio::task::spawn_blocking(|| {
+    std::mem::drop(telemetry_runtime.spawn_blocking(|| {
         if let Err(e) = backfill_metrics_event_metadata() {
             tracing::warn!(%e, "telemetry: failed to backfill metrics event metadata");
         }
@@ -492,6 +623,7 @@ async fn telemetry_flush_loop(
     buffer: Arc<Mutex<TelemetryBuffer>>,
     daemon_id: String,
     mut flush_rx: tokio::sync::mpsc::UnboundedReceiver<FlushRequest>,
+    metrics_persist_tx: tokio::sync::mpsc::Sender<MetricsPersistRequest>,
 ) {
     let started_at = std::time::Instant::now();
     let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
@@ -520,6 +652,16 @@ async fn telemetry_flush_loop(
         } else {
             FlushMode::Await
         };
+        // An awaited flush certifies "everything submitted so far is flushed
+        // or counted as pending": batches still sitting in the persist queue
+        // must reach SQLite first, or the DB-based pending count under-reports
+        // and a restart loses them after `await` reported success.
+        if flush_mode == FlushMode::Await
+            && !drain_metrics_persist_requests(&metrics_persist_tx, METRICS_PERSIST_DRAIN_DEADLINE)
+                .await
+        {
+            tracing::warn!("telemetry: awaited flush proceeding without a full persist drain");
+        }
         let snapshot = {
             let mut buf = buffer.lock().await;
             if let Some(event) = heartbeat {
@@ -532,6 +674,8 @@ async fn telemetry_flush_loop(
         let daemon_id_for_flush = daemon_id.clone();
         let flush_started_at = std::time::Instant::now();
         let flush_result = tokio::task::spawn_blocking(move || {
+            #[cfg(feature = "test-support")]
+            maybe_stall_telemetry_upload_for_test();
             let requeue_daemon_logs = if let Some(snapshot) = snapshot {
                 flush_telemetry_batch(snapshot, &daemon_id_for_flush)
             } else {
@@ -583,6 +727,18 @@ fn take_telemetry_flush_snapshot(
 
 fn next_telemetry_flush_at(completed_at: Instant) -> Instant {
     completed_at + FLUSH_INTERVAL
+}
+
+/// Test hook: simulate a hung upload backend inside the flush cycle.
+#[cfg(feature = "test-support")]
+fn maybe_stall_telemetry_upload_for_test() {
+    if let Ok(raw_stall_ms) = std::env::var("GIT_AI_TEST_TELEMETRY_UPLOAD_STALL_MS")
+        && let Ok(stall_ms) = raw_stall_ms.parse::<u64>()
+        && stall_ms > 0
+    {
+        tracing::warn!("test telemetry upload stall engaged");
+        std::thread::sleep(std::time::Duration::from_millis(stall_ms));
+    }
 }
 
 fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
@@ -703,6 +859,9 @@ fn flush_pending_metrics() {
     let should_upload = metrics_upload_allowed(&api_base_url, &client);
     METRICS_UPLOAD_AVAILABLE.store(should_upload, Ordering::Relaxed);
     if !should_upload {
+        // Info: pending metrics silently never uploading is an attribution-
+        // telemetry delivery failure; this line makes it diagnosable.
+        tracing::info!("metrics: skipping pending upload, not authenticated");
         return;
     }
 
@@ -1342,16 +1501,19 @@ pub fn flush_notes() {
     use crate::api::types::{NoteEntry, NotesUploadRequest};
     use crate::config::NotesBackendKind;
 
+    // Skip reasons log at info: a note that silently never uploads is an
+    // attribution-delivery failure, and these lines are what make a
+    // "0 notes uploaded" report diagnosable from the daemon log.
     let cfg = Config::fresh();
     if cfg.notes_backend_kind() != NotesBackendKind::Http {
-        tracing::debug!("notes: skipping flush, backend is not Http");
+        tracing::info!("notes: skipping flush, backend is not Http");
         return;
     }
 
     let backend_url = match cfg.notes_backend_url() {
         Some(url) => url.to_string(),
         None => {
-            tracing::debug!("notes: skipping flush, notes_backend.backend_url is not configured");
+            tracing::info!("notes: skipping flush, notes_backend.backend_url is not configured");
             return;
         }
     };
@@ -1359,7 +1521,7 @@ pub fn flush_notes() {
     let client = ApiClient::new(context);
 
     if !client.is_logged_in() && !client.has_api_key() {
-        tracing::debug!("notes: skipping flush, not authenticated");
+        tracing::info!("notes: skipping flush, not authenticated");
         return;
     }
 
@@ -1388,6 +1550,18 @@ pub fn flush_notes() {
         return;
     }
 
+    // Test hook: simulate a slow notes upload while the dequeued rows are
+    // locked (`processing_started_at`), the window an awaited flush must not
+    // certify across.
+    #[cfg(feature = "test-support")]
+    if let Ok(raw_stall_ms) = std::env::var("GIT_AI_TEST_NOTES_UPLOAD_STALL_MS")
+        && let Ok(stall_ms) = raw_stall_ms.parse::<u64>()
+        && stall_ms > 0
+    {
+        tracing::warn!("test notes upload stall engaged");
+        std::thread::sleep(std::time::Duration::from_millis(stall_ms));
+    }
+
     let commit_shas: Vec<String> = pending.iter().map(|p| p.commit_sha.clone()).collect();
 
     let entries: Vec<NoteEntry> = pending
@@ -1402,7 +1576,8 @@ pub fn flush_notes() {
 
     match client.upload_notes(request) {
         Ok(resp) => {
-            tracing::debug!(
+            tracing::info!(
+                batch = commit_shas.len(),
                 success = resp.success_count,
                 failure = resp.failure_count,
                 "notes: uploaded batch"
@@ -1606,6 +1781,32 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs()
+    }
+
+    #[tokio::test]
+    async fn metrics_persist_queue_drops_loudly_when_full() {
+        let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (metrics_persist_tx, _persist_rx) = tokio::sync::mpsc::channel(1);
+        let handle = DaemonTelemetryWorkerHandle {
+            buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
+            flush_tx,
+            metrics_persist_tx,
+        };
+        let event: MetricEvent = serde_json::from_str(&event_json(1)).unwrap();
+
+        let before = metric_batches_dropped();
+        handle.enqueue_metrics_persist(vec![event.clone()]);
+        assert_eq!(
+            metric_batches_dropped(),
+            before,
+            "a batch within capacity must not be dropped"
+        );
+        handle.enqueue_metrics_persist(vec![event]);
+        assert_eq!(
+            metric_batches_dropped(),
+            before + 1,
+            "a batch past capacity must be dropped and counted"
+        );
     }
 
     #[test]

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,9 +1,15 @@
 use rusqlite::{Connection, OpenFlags};
 use std::path::Path;
+use std::time::Duration;
 
 /// Negative SQLite cache_size values are kibibytes. Keep each connection's
 /// page cache capped at 2 MiB unless a caller deliberately changes it later.
 pub const MEMORY_LIMIT_CACHE_SIZE_KIB: i32 = -2000;
+
+/// How long a connection retries on SQLITE_BUSY before surfacing the error.
+/// Without this, cross-process contention on a shared database file fails
+/// immediately instead of riding out a short writer.
+pub const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn apply_memory_limits(conn: &Connection) -> rusqlite::Result<()> {
     conn.pragma_update(None, "cache_size", MEMORY_LIMIT_CACHE_SIZE_KIB)
@@ -11,6 +17,7 @@ pub fn apply_memory_limits(conn: &Connection) -> rusqlite::Result<()> {
 
 pub fn open_with_memory_limits(path: impl AsRef<Path>) -> rusqlite::Result<Connection> {
     let conn = Connection::open(path)?;
+    conn.busy_timeout(BUSY_TIMEOUT)?;
     apply_memory_limits(&conn)?;
     Ok(conn)
 }
@@ -20,6 +27,7 @@ pub fn open_with_flags_and_memory_limits(
     flags: OpenFlags,
 ) -> rusqlite::Result<Connection> {
     let conn = Connection::open_with_flags(path, flags)?;
+    conn.busy_timeout(BUSY_TIMEOUT)?;
     apply_memory_limits(&conn)?;
     Ok(conn)
 }
@@ -39,6 +47,19 @@ mod tests {
             .pragma_query_value(None, "cache_size", |row| row.get(0))
             .unwrap();
         assert_eq!(cache_size, MEMORY_LIMIT_CACHE_SIZE_KIB);
+    }
+
+    #[test]
+    fn open_with_memory_limits_sets_busy_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("busy.db");
+
+        let conn = open_with_memory_limits(&db_path).unwrap();
+
+        let busy_timeout_ms: i64 = conn
+            .pragma_query_value(None, "busy_timeout", |row| row.get(0))
+            .unwrap();
+        assert_eq!(busy_timeout_ms, BUSY_TIMEOUT.as_millis() as i64);
     }
 
     #[test]

--- a/src/tokio_runtime.rs
+++ b/src/tokio_runtime.rs
@@ -13,6 +13,11 @@ const HELPER_RUNTIME_MAX_BLOCKING_THREADS: usize = 4;
 // runtime small prevents CPU-count-sized worker and allocator arena growth.
 const DAEMON_RUNTIME_WORKER_THREADS: usize = 4;
 const DAEMON_RUNTIME_MAX_BLOCKING_THREADS: usize = 16;
+// Telemetry (SQLite persistence and synchronous HTTP uploads) runs on its own
+// tiny runtime so a slow upload backend can never occupy the daemon runtime's
+// workers or blocking threads that command/checkpoint processing depends on.
+const TELEMETRY_RUNTIME_WORKER_THREADS: usize = 1;
+const TELEMETRY_RUNTIME_MAX_BLOCKING_THREADS: usize = 2;
 const BLOCKING_THREAD_KEEP_ALIVE: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Constrain glibc's per-thread allocation arenas before the daemon creates
@@ -94,6 +99,19 @@ fn runtime() -> &'static tokio::runtime::Runtime {
             HELPER_RUNTIME_MAX_BLOCKING_THREADS,
         )
         .expect("failed to create Tokio runtime")
+    })
+}
+
+/// Dedicated runtime for the daemon's telemetry worker (flush loop, metrics
+/// persistence, upload jobs). Lazily built on first use inside the daemon.
+pub(crate) fn telemetry_runtime() -> &'static tokio::runtime::Runtime {
+    static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        build_bounded_runtime(
+            TELEMETRY_RUNTIME_WORKER_THREADS,
+            TELEMETRY_RUNTIME_MAX_BLOCKING_THREADS,
+        )
+        .expect("failed to create telemetry Tokio runtime")
     })
 }
 
@@ -193,6 +211,23 @@ mod tests {
             peak_blocking_concurrency(runtime(), 8, 4),
             4,
             "helper runtime must activate exactly four blocking threads under load"
+        );
+    }
+
+    #[test]
+    fn telemetry_runtime_is_small_and_bounded() {
+        assert_eq!(
+            telemetry_runtime().metrics().num_workers(),
+            TELEMETRY_RUNTIME_WORKER_THREADS
+        );
+        assert_eq!(
+            peak_blocking_concurrency(
+                telemetry_runtime(),
+                6,
+                TELEMETRY_RUNTIME_MAX_BLOCKING_THREADS
+            ),
+            TELEMETRY_RUNTIME_MAX_BLOCKING_THREADS,
+            "telemetry runtime must cap its blocking pool"
         );
     }
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7130,6 +7130,200 @@ fn daemon_drain_probes_do_not_disturb_attribution() {
     prober.join().unwrap();
 }
 
+/// Telemetry runs on its own runtime: an upload backend that stalls for the
+/// whole test must not delay checkpoint/commit processing or attribution.
+#[test]
+#[cfg(not(windows))]
+fn commit_attribution_unaffected_by_stalled_telemetry_uploads() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_TELEMETRY_UPLOAD_STALL_MS", "60000")]);
+
+    // Deterministic: the stall hook logs when the flush loop enters the
+    // stalled upload; only then does the commit work begin.
+    let started = std::time::Instant::now();
+    loop {
+        if repo
+            .daemon_stderr_contents()
+            .contains("test telemetry upload stall engaged")
+        {
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "telemetry upload stall never engaged:\n{}",
+            repo.daemon_stderr_contents()
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let mut file = repo.filename("stalled-telemetry.txt");
+    file.set_contents(lines!["human line", "ai line".ai()]);
+    repo.stage_all_and_commit("commit under stalled telemetry")
+        .unwrap();
+    file.assert_lines_and_blame(lines!["human line".human(), "ai line".ai()]);
+}
+
+/// An awaited flush must not certify completion while metric batches still
+/// sit in the persistence queue: they have to reach SQLite (and thus the
+/// upload path and the pending count) before `await` reports finished.
+/// Root cause of the macOS CI failure "expected at least one metrics upload,
+/// got 0" on this stack.
+#[test]
+#[cfg(not(windows))]
+fn await_blocks_until_queued_metrics_are_persisted() {
+    let mut mock_api = MockApiServer::start();
+    // tempdir: cleans up the DB and its WAL/SHM sidecars on all exits,
+    // including assertion failures.
+    let metrics_db_dir = tempfile::tempdir().expect("failed to create metrics db dir");
+    let metrics_db_path = metrics_db_dir.path().join("metrics.db");
+    let mut repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+        // Every queued metric batch takes 1s to persist: an await issued
+        // right after a commit races still-queued batches (kept below the
+        // 10s drain deadline even with several batches on a slow runner).
+        ("GIT_AI_TEST_METRICS_PERSIST_DELAY_MS", "1000"),
+    ]);
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+        patch.prompt_storage = Some("default".to_string());
+        patch.telemetry_oss_disabled = Some(true);
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("test.ts");
+    fs::write(&file_path, "const x = 1;\n").expect("failed to write initial file");
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.ts"])
+        .expect("known-human checkpoint should succeed");
+    fs::write(&file_path, "const x = 2;\n").expect("failed to write update");
+    repo.git_ai(&["checkpoint", "mock_ai", "test.ts"])
+        .expect("ai checkpoint should succeed");
+    repo.git(&["add", "-A"]).expect("add should succeed");
+    repo.git(&["commit", "-m", "Commit with delayed metric persistence"])
+        .expect("commit should succeed");
+
+    let output = repo
+        .git_ai(&["await", "--timeout", "60"])
+        .expect("await should succeed");
+    assert!(
+        output.contains("finished"),
+        "await should report finished: {}",
+        output
+    );
+
+    let requests = mock_api.collect_requests();
+    let metrics_requests = requests
+        .iter()
+        .filter(|r| r["path"].as_str() == Some("/worker/metrics/upload"))
+        .count();
+    assert!(
+        metrics_requests > 0,
+        "await certified the flush while metric batches were still queued: got {} metrics uploads\nawait output:\n{}\ndaemon log:\n{}",
+        metrics_requests,
+        output,
+        repo.daemon_stderr_contents()
+    );
+}
+
+/// The `notes.flush` control trigger must route through the serialized flush
+/// loop. A bare concurrent `flush_notes` dequeue-locks the note rows
+/// (`processing_started_at`) out from under an awaited flush, whose pending
+/// count excludes locked rows — so `await` certifies "0 notes remaining"
+/// while the triggered upload has not reached the backend yet. This test
+/// sends the trigger the way production does (an external control client,
+/// since the daemon's own in-process `submit_notes` is a deliberate no-op)
+/// and awaits during the stalled upload. Timing caveat: the 3s periodic
+/// cycle can occasionally win the dequeue instead of the trigger, in which
+/// case the run does not exercise the race — it still asserts the invariant.
+#[test]
+#[cfg(not(windows))]
+fn await_reflects_triggered_notes_flush() {
+    let mut mock_api = MockApiServer::start();
+    let metrics_db_dir = tempfile::tempdir().expect("failed to create metrics db dir");
+    let metrics_db_path = metrics_db_dir.path().join("metrics.db");
+    let mut repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+        ("GIT_AI_NOTES_BACKEND_URL", mock_api.base_url()),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+        // The triggered flush holds the dequeued note rows locked for 8s
+        // before uploading — the window `await` must not certify across.
+        ("GIT_AI_TEST_NOTES_UPLOAD_STALL_MS", "8000"),
+    ]);
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+        patch.prompt_storage = Some("default".to_string());
+        patch.telemetry_oss_disabled = Some(true);
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::Http,
+            backend_url: Some(mock_api.base_url().to_string()),
+        });
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("test.ts");
+    fs::write(&file_path, "const x = 1;\n").expect("failed to write initial file");
+    repo.git_ai(&["checkpoint", "mock_known_human", "test.ts"])
+        .expect("known-human checkpoint should succeed");
+    fs::write(&file_path, "const x = 2;\n").expect("failed to write update");
+    repo.git_ai(&["checkpoint", "mock_ai", "test.ts"])
+        .expect("ai checkpoint should succeed");
+    repo.git(&["add", "-A"]).expect("add should succeed");
+    repo.git(&["commit", "-m", "Commit whose note flush is in flight"])
+        .expect("commit should succeed");
+
+    // Fire the notes.flush trigger from outside the daemon (as production
+    // clients do) until the note row exists and a flush enters its stalled
+    // upload; triggers before the row lands are cheap no-ops (the stall hook
+    // only engages with rows dequeued).
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let started = std::time::Instant::now();
+    loop {
+        let _ = send_control_request(&control_socket_path, &ControlRequest::FlushNotes);
+        if repo
+            .daemon_stderr_contents()
+            .contains("test notes upload stall engaged")
+        {
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(15),
+            "notes upload stall never engaged:\n{}",
+            repo.daemon_stderr_contents()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    // Await while the triggered upload is stalled with the note rows locked.
+    let output = repo
+        .git_ai(&["await", "--timeout", "60"])
+        .expect("await should succeed");
+    assert!(
+        output.contains("finished"),
+        "await should report finished: {}",
+        output
+    );
+
+    let requests = mock_api.collect_requests();
+    let notes_requests = requests
+        .iter()
+        .filter(|r| r["path"].as_str() == Some("/worker/notes/upload"))
+        .count();
+    assert!(
+        notes_requests > 0,
+        "await certified while the triggered notes upload was still in flight: got {} notes uploads\ndaemon log:\n{}",
+        notes_requests,
+        repo.daemon_stderr_contents()
+    );
+}
+
 #[test]
 fn await_waits_for_metrics_and_notes_flush() {
     let mut mock_api = MockApiServer::start();
@@ -7205,13 +7399,15 @@ fn await_waits_for_metrics_and_notes_flush() {
         .count();
     assert!(
         metrics_requests > 0,
-        "expected at least one metrics upload, got {}",
-        metrics_requests
+        "expected at least one metrics upload, got {}\ndaemon log:\n{}",
+        metrics_requests,
+        repo.daemon_stderr_contents()
     );
     assert!(
         notes_requests > 0,
-        "expected at least one notes upload, got {}",
-        notes_requests
+        "expected at least one notes upload, got {}\ndaemon log:\n{}",
+        notes_requests,
+        repo.daemon_stderr_contents()
     );
 }
 


### PR DESCRIPTION
Telemetry shared everything with command/checkpoint processing: its 3s flush
loop ran all synchronous HTTP uploads (metrics, Sentry, PostHog, CAS, notes)
in spawn_blocking on the daemon runtime's 16-thread blocking pool, every
metrics submission fired an unbounded fire-and-forget spawn_blocking SQLite
write (or wrote inline on the calling thread in sync contexts), and the
SQLite databases had no busy_timeout. Under upload congestion this starved
the pool and the process-wide metrics DB mutex that post-commit processing
also locks - the chronic "telemetry flush exceeded its scheduling interval"
signature that preceded the trace-ingest overload and silent attribution
loss in #2157.

Make the isolation structural:

- All telemetry work (flush loop, upload jobs, metrics persistence, metadata
  backfill) moves to a dedicated tiny runtime (1 worker / 2 blocking
  threads), so a slow upload backend can never occupy daemon-runtime threads
  that attribution work depends on.
- Metric submissions go through a bounded queue (256 batches) drained by a
  single persistence task. Submission never blocks the caller: a full queue
  drops the batch and counts it (telemetry is best-effort by design; the
  counter keeps the loss observable).
- All daemon SQLite connections get a 5s busy_timeout via the shared open
  helpers.
- The post-commit session-event recovery lookup acquires the metrics DB
  mutex with a bounded 500ms budget and conservatively reports "no
  candidate" instead of stalling commit processing behind telemetry writes.

Part 3/4 for #2157.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
