### PR TITLE
Contain control-plane peer errors and make ingest loss loud

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2619,16 +2619,20 @@ fn read_checkpoint_body<R: BufRead>(
     reader: &mut R,
     body_bytes: usize,
 ) -> Result<Vec<u8>, GitAiError> {
+    // Preserve the io::ErrorKind: a peer that vanished mid-body (EOF, reset)
+    // must classify as a routine disconnect, not a daemon error.
     let mut body = vec![0; body_bytes];
     reader.read_exact(&mut body).map_err(|error| {
-        GitAiError::Generic(format!(
-            "failed receiving {body_bytes}-byte checkpoint body: {error}"
+        GitAiError::IoError(std::io::Error::new(
+            error.kind(),
+            format!("failed receiving {body_bytes}-byte checkpoint body: {error}"),
         ))
     })?;
     let mut delimiter = [0u8; 1];
     reader.read_exact(&mut delimiter).map_err(|error| {
-        GitAiError::Generic(format!(
-            "failed receiving checkpoint body delimiter: {error}"
+        GitAiError::IoError(std::io::Error::new(
+            error.kind(),
+            format!("failed receiving checkpoint body delimiter: {error}"),
         ))
     })?;
     if delimiter != [b'\n'] {
@@ -2792,6 +2796,21 @@ pub struct ActorDaemonCoordinator {
     // trip proves accept → reader spawn → read → parse is still draining.
     next_trace_drain_probe_id: AtomicU64,
     observed_trace_drain_probe_id: AtomicU64,
+    // Loss accounting: attribution loss must be loud, never silent. Trace
+    // payloads dropped on a full ingest queue and trace connections dropped
+    // before a reader could serve them both mean lost attribution for the
+    // affected commands.
+    trace_payloads_dropped_queue_full: AtomicU64,
+    trace_connections_dropped: AtomicU64,
+    checkpoints_dropped: AtomicU64,
+    // Retained checkpoints are abandoned at most once per daemon lifetime
+    // (whichever of teardown or the shutdown enforcer gets there first);
+    // this guard keeps the loss from being double-counted.
+    checkpoints_loss_counted: AtomicBool,
+    // Snapshot of the loss counters at the last successful DaemonIngestAnomaly
+    // report, shared by the health loop, teardown, and the shutdown enforcer
+    // so deltas are reported exactly once.
+    last_reported_ingest_losses: Mutex<IngestLossSnapshot>,
     // Duplicated fds of accepted trace connections, so shutdown can actively
     // close them: a blocked git writer is released the instant its socket is
     // shut down instead of waiting for process exit.
@@ -2904,6 +2923,11 @@ impl ActorDaemonCoordinator {
             trace_ingress_state: Mutex::new(TraceIngressState::default()),
             next_trace_drain_probe_id: AtomicU64::new(0),
             observed_trace_drain_probe_id: AtomicU64::new(0),
+            trace_payloads_dropped_queue_full: AtomicU64::new(0),
+            trace_connections_dropped: AtomicU64::new(0),
+            checkpoints_dropped: AtomicU64::new(0),
+            checkpoints_loss_counted: AtomicBool::new(false),
+            last_reported_ingest_losses: Mutex::new(IngestLossSnapshot::default()),
             #[cfg(not(windows))]
             trace_connection_registry: Mutex::new(HashMap::new()),
             #[cfg(not(windows))]
@@ -3171,6 +3195,22 @@ impl ActorDaemonCoordinator {
             unsafe {
                 libc::shutdown(fd.as_raw_fd(), libc::SHUT_RDWR);
             }
+        }
+    }
+
+    /// Count checkpoints that are still retained at the moment the process
+    /// actually gives up on them — exactly once, whichever of graceful
+    /// teardown or the shutdown enforcer reaches that point first. Counting
+    /// earlier (e.g. when a restart is decided) would report checkpoints that
+    /// teardown still manages to drain.
+    fn count_abandoned_checkpoints_once(&self) {
+        if self.checkpoints_loss_counted.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let (outstanding_checkpoints, _) = self.outstanding_checkpoint_state();
+        if outstanding_checkpoints > 0 {
+            self.checkpoints_dropped
+                .fetch_add(outstanding_checkpoints as u64, Ordering::Relaxed);
         }
     }
 
@@ -4415,11 +4455,18 @@ impl ActorDaemonCoordinator {
                 ));
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(())) => {
+                self.trace_payloads_dropped_queue_full
+                    .fetch_add(1, Ordering::Relaxed);
+                let dropped_root =
+                    Self::trace_payload_root_sid(&payload).unwrap_or_else(|| "unknown".to_string());
                 tracing::error!(
                     component = "daemon",
                     phase = "enqueue_trace_payload",
                     reason = "ingest_worker_queue_full",
-                    "trace ingest queue is full"
+                    dropped_root = %dropped_root,
+                    queue_capacity = Self::trace_ingest_queue_capacity(),
+                    queued_payloads = self.queued_trace_payloads.load(Ordering::Relaxed),
+                    "trace ingest queue is full; dropping payload and shutting down (attribution for this root is lost)"
                 );
                 self.request_shutdown();
                 return Err(GitAiError::Generic(
@@ -7155,6 +7202,20 @@ impl ActorDaemonCoordinator {
                 }
                 Ok(ControlResponse::ok(None, None))
             }
+            ControlRequest::StatsIngest => Ok(ControlResponse::ok(
+                None,
+                Some(json!({
+                    "trace_payloads_dropped_queue_full": self
+                        .trace_payloads_dropped_queue_full
+                        .load(Ordering::Relaxed),
+                    "trace_connections_dropped": self
+                        .trace_connections_dropped
+                        .load(Ordering::Relaxed),
+                    "telemetry_metric_batches_dropped":
+                        crate::daemon::telemetry_worker::metric_batches_dropped(),
+                    "checkpoints_dropped": self.checkpoints_dropped.load(Ordering::Relaxed),
+                })),
+            )),
             ControlRequest::Await { timeout_secs } => {
                 let result = self.await_completion(timeout_secs).await;
                 serde_json::to_value(result)
@@ -7451,13 +7512,7 @@ fn control_listener_loop_actor(
             if std::thread::Builder::new()
                 .spawn(move || {
                     if let Err(e) = handle_control_connection_actor(stream, coord, handle) {
-                        tracing::error!(
-                            component = "daemon",
-                            phase = "control_receive",
-                            reason = "connection_error",
-                            error = %e,
-                            "daemon control connection failed"
-                        );
+                        log_control_connection_failure(&e);
                     }
                 })
                 .is_err()
@@ -7622,13 +7677,7 @@ fn handle_windows_control_pipe_connection(
     let mut reader = BufReader::new(server);
     if let Err(e) = handle_control_connection_actor_reader(&mut reader, coordinator, runtime_handle)
     {
-        tracing::error!(
-            component = "daemon",
-            phase = "control_receive",
-            reason = "connection_error",
-            error = %e,
-            "daemon control connection failed"
-        );
+        log_control_connection_failure(&e);
     }
 }
 
@@ -7647,11 +7696,10 @@ impl ControlConnection for WindowsPipeServer {
 #[cfg(not(windows))]
 impl ControlConnection for LocalSocketStream {
     fn set_receive_timeout(&mut self, timeout: Option<Duration>) -> Result<(), GitAiError> {
-        self.set_recv_timeout(timeout).map_err(|error| {
-            GitAiError::Generic(format!(
-                "failed setting daemon control receive timeout: {error}"
-            ))
-        })
+        // Preserve the io::ErrorKind: callers classify peer-gone failures
+        // (e.g. macOS EINVAL on a peer-closed socket) apart from systemic
+        // ones, which a stringified Generic error would erase.
+        self.set_recv_timeout(timeout).map_err(GitAiError::IoError)
     }
 }
 
@@ -7666,6 +7714,49 @@ fn control_receive_timed_out(error: &GitAiError) -> bool {
     )
 }
 
+/// A control connection failing because the peer went away (client timed out
+/// and closed, process died mid-request) is routine under load — the
+/// connection is simply dropped. Only unexpected failures deserve ERROR.
+fn connection_error_is_peer_disconnect(error: &GitAiError) -> bool {
+    // Composes with the read-timeout classifier: TimedOut/WouldBlock are the
+    // same "peer stopped participating" family. InvalidInput covers macOS
+    // EINVAL from setsockopt on a socket whose peer already shut down.
+    control_receive_timed_out(error)
+        || matches!(
+            error,
+            GitAiError::IoError(io_error)
+                if matches!(
+                    io_error.kind(),
+                    std::io::ErrorKind::BrokenPipe
+                        | std::io::ErrorKind::ConnectionReset
+                        | std::io::ErrorKind::ConnectionAborted
+                        | std::io::ErrorKind::UnexpectedEof
+                        | std::io::ErrorKind::InvalidInput
+                )
+        )
+}
+
+/// Log a failed control connection at a severity matching its cause.
+fn log_control_connection_failure(error: &GitAiError) {
+    if connection_error_is_peer_disconnect(error) {
+        tracing::warn!(
+            component = "daemon",
+            phase = "control_receive",
+            reason = "peer_gone",
+            error = %error,
+            "daemon control connection dropped by peer"
+        );
+    } else {
+        tracing::error!(
+            component = "daemon",
+            phase = "control_receive",
+            reason = "connection_error",
+            error = %error,
+            "daemon control connection failed"
+        );
+    }
+}
+
 #[cfg(not(windows))]
 fn handle_control_connection_actor(
     stream: LocalSocketStream,
@@ -7676,14 +7767,49 @@ fn handle_control_connection_actor(
     handle_control_connection_actor_reader(&mut reader, coordinator, runtime_handle)
 }
 
+/// Apply a receive timeout to a control connection, treating failure as a
+/// routine peer-gone drop rather than a daemon error: macOS `setsockopt`
+/// returns EINVAL once the peer has already shut the socket down, which
+/// happens whenever a client times out and abandons its connection under
+/// load. Returns false when the connection should simply be dropped.
+fn apply_control_receive_timeout<R: ControlConnection>(
+    reader: &mut BufReader<R>,
+    timeout: Duration,
+) -> bool {
+    if let Err(error) = reader.get_mut().set_receive_timeout(Some(timeout)) {
+        // The connection is dropped either way; only the severity differs. A
+        // peer that vanished (or macOS EINVAL on its dead socket) is routine,
+        // while a systemic setsockopt failure deserves attention.
+        if connection_error_is_peer_disconnect(&error) {
+            tracing::warn!(
+                component = "daemon",
+                phase = "control_receive",
+                reason = "receive_timeout_setup_failed",
+                %error,
+                "dropping control connection; peer likely already disconnected"
+            );
+        } else {
+            tracing::error!(
+                component = "daemon",
+                phase = "control_receive",
+                reason = "receive_timeout_setup_failed",
+                %error,
+                "dropping control connection; receive timeout could not be applied"
+            );
+        }
+        return false;
+    }
+    true
+}
+
 fn handle_control_connection_actor_reader<R: ControlConnection>(
     reader: &mut BufReader<R>,
     coordinator: Arc<ActorDaemonCoordinator>,
     runtime_handle: tokio::runtime::Handle,
 ) -> Result<(), GitAiError> {
-    reader
-        .get_mut()
-        .set_receive_timeout(Some(DAEMON_CONTROL_RECEIVE_TIMEOUT))?;
+    if !apply_control_receive_timeout(reader, DAEMON_CONTROL_RECEIVE_TIMEOUT) {
+        return Ok(());
+    }
     let mut uses_idle_timeout = false;
     loop {
         let line = match read_json_line(reader) {
@@ -7703,9 +7829,9 @@ fn handle_control_connection_actor_reader<R: ControlConnection>(
                 Ok(request) if !matches!(request, ControlRequest::CheckpointRun { .. })
             )
         {
-            reader
-                .get_mut()
-                .set_receive_timeout(Some(DAEMON_CONTROL_IDLE_TIMEOUT))?;
+            if !apply_control_receive_timeout(reader, DAEMON_CONTROL_IDLE_TIMEOUT) {
+                return Ok(());
+            }
             uses_idle_timeout = true;
         }
         let mut shutdown_after_response = false;
@@ -7790,29 +7916,40 @@ fn handle_control_connection_actor_reader<R: ControlConnection>(
                     return Err(error);
                 }
 
-                if uses_idle_timeout {
-                    reader
-                        .get_mut()
-                        .set_receive_timeout(Some(DAEMON_CONTROL_RECEIVE_TIMEOUT))?;
+                if uses_idle_timeout
+                    && !apply_control_receive_timeout(reader, DAEMON_CONTROL_RECEIVE_TIMEOUT)
+                {
+                    return Ok(());
                 }
                 let body = match read_checkpoint_body(reader, reservation.body_bytes()) {
                     Ok(body) => body,
                     Err(error) => {
-                        tracing::error!(
-                            component = "daemon",
-                            phase = "checkpoint_receive",
-                            reason = "body_receive_failed",
-                            body_bytes,
-                            %error,
-                            "failed receiving checkpoint body"
-                        );
+                        if connection_error_is_peer_disconnect(&error) {
+                            tracing::warn!(
+                                component = "daemon",
+                                phase = "checkpoint_receive",
+                                reason = "body_receive_failed",
+                                body_bytes,
+                                %error,
+                                "checkpoint sender disconnected mid-body"
+                            );
+                        } else {
+                            tracing::error!(
+                                component = "daemon",
+                                phase = "checkpoint_receive",
+                                reason = "body_receive_failed",
+                                body_bytes,
+                                %error,
+                                "failed receiving checkpoint body"
+                            );
+                        }
                         return Err(error);
                     }
                 };
-                if uses_idle_timeout {
-                    reader
-                        .get_mut()
-                        .set_receive_timeout(Some(DAEMON_CONTROL_IDLE_TIMEOUT))?;
+                if uses_idle_timeout
+                    && !apply_control_receive_timeout(reader, DAEMON_CONTROL_IDLE_TIMEOUT)
+                {
+                    return Ok(());
                 }
                 let Some(checkpoint_tx) = coordinator.checkpoint_ingress_tx.get().cloned() else {
                     tracing::error!(
@@ -7997,7 +8134,10 @@ fn trace_listener_loop_actor(
                     // The stream is dropped with the failed spawn, closing the
                     // fd: the writing git process sees EPIPE, disables its
                     // trace2 target, and completes instead of blocking.
-                    tracing::error!(%error, "trace listener: failed to spawn handler thread");
+                    coordinator
+                        .trace_connections_dropped
+                        .fetch_add(1, Ordering::Relaxed);
+                    tracing::error!(%error, "trace listener: failed to spawn handler thread; dropping connection (attribution for its roots is lost)");
                     consecutive_spawn_failures += 1;
                     if consecutive_spawn_failures >= TRACE_SPAWN_FAILURE_SHUTDOWN_THRESHOLD {
                         if let Err(error) = spawn_self_restart(&restart_history_path) {
@@ -8104,7 +8244,10 @@ fn handle_windows_trace_pipe_connection(
     coordinator: Arc<ActorDaemonCoordinator>,
 ) {
     if let Err(e) = coordinator.trace_unidentified_connection_opened() {
-        tracing::debug!(%e, "trace connection open bookkeeping error");
+        coordinator
+            .trace_connections_dropped
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(%e, "trace connection open bookkeeping error; dropping connection");
         return;
     }
     let reader = BufReader::new(&mut server);
@@ -8216,7 +8359,10 @@ fn run_trace_connection_reader(
         tracing::debug!(%error, "trace connection recv buffer setup failed");
     }
     if let Err(error) = coordinator.trace_unidentified_connection_opened() {
-        tracing::debug!(%error, "trace connection open bookkeeping error");
+        coordinator
+            .trace_connections_dropped
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(%error, "trace connection open bookkeeping error; dropping connection");
         return;
     }
     // A shutdown requested before registration completed has already swept
@@ -8661,6 +8807,8 @@ fn daemon_socket_health_check_loop(
         last_processed_seq = processed_seq;
         let processing_stalled = stalled_intervals >= SOCKET_HEALTH_MAX_PROCESSING_STALL_INTERVALS;
 
+        report_ingest_losses(&coordinator);
+
         if control_ok.is_err() || trace_ok.is_err() || processing_stalled {
             // A probe failure caused by a shutdown that started mid-check
             // (readers severed, teardown underway) must not consume budget
@@ -8695,6 +8843,7 @@ fn daemon_socket_health_check_loop(
                         processing_stalled,
                         queued_payloads,
                         stalled_intervals,
+                        outstanding_checkpoints,
                         "daemon health check failed, spawning restart and shutting down"
                     );
                 }
@@ -8729,6 +8878,80 @@ fn should_defer_restart_for_checkpoints(
     consecutive_deferrals: usize,
 ) -> bool {
     outstanding_checkpoints > 0 && consecutive_deferrals < SOCKET_HEALTH_MAX_CONSECUTIVE_DEFERRALS
+}
+
+/// Snapshot of the ingest-loss counters for delta reporting.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+struct IngestLossSnapshot {
+    payloads_dropped_queue_full: u64,
+    connections_dropped: u64,
+    metric_batches_dropped: u64,
+    checkpoints_dropped: u64,
+}
+
+impl IngestLossSnapshot {
+    fn capture(coordinator: &ActorDaemonCoordinator) -> Self {
+        Self {
+            payloads_dropped_queue_full: coordinator
+                .trace_payloads_dropped_queue_full
+                .load(Ordering::Relaxed),
+            connections_dropped: coordinator
+                .trace_connections_dropped
+                .load(Ordering::Relaxed),
+            metric_batches_dropped: crate::daemon::telemetry_worker::metric_batches_dropped(),
+            checkpoints_dropped: coordinator.checkpoints_dropped.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Persist a DaemonIngestAnomaly metric with the loss deltas since the
+/// previous report, so silent attribution loss becomes visible in fleet
+/// telemetry. Called from the health loop, from graceful teardown (so a
+/// queue-full shutdown still reports its loss), and from the shutdown
+/// enforcer.
+///
+/// Unlike sibling emitters this stores straight to the metrics DB instead of
+/// going through `crate::metrics::record`: the persistence queue is exactly
+/// the lossy component whose drops are being reported, and the snapshot must
+/// only advance when the write was actually accepted (otherwise a dropped
+/// emission permanently unreports its window).
+fn report_ingest_losses(coordinator: &Arc<ActorDaemonCoordinator>) {
+    use crate::metrics::pos_encoded::PosEncoded as _;
+
+    // try_lock: the shutdown enforcer calls this right before a forced exit
+    // and must never block; a contended lock just means another reporter is
+    // already delivering the same deltas.
+    let mut last_reported = match coordinator.last_reported_ingest_losses.try_lock() {
+        Ok(guard) => guard,
+        Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+        Err(std::sync::TryLockError::WouldBlock) => return,
+    };
+    let current = IngestLossSnapshot::capture(coordinator);
+    if current == *last_reported {
+        return;
+    }
+    let values = crate::metrics::events::DaemonIngestAnomalyValues::new(
+        current
+            .payloads_dropped_queue_full
+            .saturating_sub(last_reported.payloads_dropped_queue_full),
+        current
+            .connections_dropped
+            .saturating_sub(last_reported.connections_dropped),
+        current
+            .metric_batches_dropped
+            .saturating_sub(last_reported.metric_batches_dropped),
+        current
+            .checkpoints_dropped
+            .saturating_sub(last_reported.checkpoints_dropped),
+    );
+    let attrs = crate::metrics::EventAttributes::with_version(env!("CARGO_PKG_VERSION"));
+    let event = crate::metrics::MetricEvent::from_values(values, attrs.to_sparse());
+    match crate::daemon::telemetry_worker::persist_metrics_now(&[event]) {
+        Ok(()) => *last_reported = current,
+        Err(error) => {
+            tracing::warn!(%error, "failed persisting ingest-loss metric; will retry next report");
+        }
+    }
 }
 
 const TRACE_DRAIN_PROBE_DEADLINE: Duration = Duration::from_secs(5);
@@ -9061,6 +9284,13 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
         tracing::warn!("telemetry metrics persist queue was not fully drained at shutdown");
     }
 
+    // Final loss report: a shutdown caused by a full ingest queue is the
+    // severest attribution-loss event; persisting the deltas here lets the
+    // next daemon generation upload them. Checkpoints still retained at this
+    // point will never be processed — count them (once) before reporting.
+    coordinator.count_abandoned_checkpoints_once();
+    report_ingest_losses(&coordinator);
+
     // Best-effort wake listeners to allow clean process exit.
     // Connect to each socket to unblock `accept()`.  If the socket files
     // were deleted (which is exactly what the health-check detects), the
@@ -9154,11 +9384,25 @@ fn spawn_shutdown_deadline_enforcer(
             if coordinator.teardown_complete.load(Ordering::Acquire) {
                 return;
             }
+            let (outstanding_checkpoints, retained_checkpoint_bytes) =
+                coordinator.outstanding_checkpoint_state();
+            coordinator.count_abandoned_checkpoints_once();
             tracing::error!(
                 component = "daemon",
                 phase = "shutdown",
-                "daemon teardown exceeded its deadline; forcing process exit"
+                outstanding_checkpoints,
+                retained_checkpoint_bytes,
+                "daemon teardown exceeded its deadline; forcing process exit (retained checkpoints are lost)"
             );
+            // Best-effort, bounded: the loss report does a synchronous SQLite
+            // write that must not postpone the forced exit this thread exists
+            // to guarantee (the DB's busy_timeout alone is 5s).
+            let report_coordinator = coordinator.clone();
+            let report = std::thread::spawn(move || report_ingest_losses(&report_coordinator));
+            let report_deadline = std::time::Instant::now() + Duration::from_millis(500);
+            while !report.is_finished() && std::time::Instant::now() < report_deadline {
+                std::thread::sleep(Duration::from_millis(10));
+            }
             if matches!(
                 coordinator.shutdown_action(),
                 DaemonExitAction::Restart | DaemonExitAction::RestartAfterUpdate
@@ -10759,6 +11003,113 @@ mod tests {
             "rewritten history must not retain future timestamps: {rewritten:?}"
         );
         assert_eq!(rewritten.len(), 1, "only the new entry should remain");
+    }
+
+    #[tokio::test]
+    async fn abandoned_checkpoints_are_counted_exactly_once() {
+        let coord = ActorDaemonCoordinator::new();
+        let _reservation = coord
+            .checkpoint_ingress_quota
+            .reserve(128)
+            .expect("reservation should be granted");
+
+        // Teardown and the shutdown enforcer can both reach the abandonment
+        // point; only the first may count the retained checkpoints.
+        coord.count_abandoned_checkpoints_once();
+        coord.count_abandoned_checkpoints_once();
+        assert_eq!(
+            coord.checkpoints_dropped.load(Ordering::Relaxed),
+            1,
+            "retained checkpoints must be counted exactly once"
+        );
+    }
+
+    #[test]
+    fn connection_error_classifier_separates_peer_gone_from_systemic() {
+        use std::io::ErrorKind;
+
+        let peer_kinds = [
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionReset,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::UnexpectedEof,
+            ErrorKind::TimedOut,
+            ErrorKind::WouldBlock,
+            // macOS setsockopt EINVAL on a peer-closed socket.
+            ErrorKind::InvalidInput,
+        ];
+        for kind in peer_kinds {
+            assert!(
+                connection_error_is_peer_disconnect(&GitAiError::IoError(std::io::Error::new(
+                    kind, "peer"
+                ))),
+                "{kind:?} should classify as peer-gone"
+            );
+        }
+
+        let systemic = [
+            GitAiError::IoError(std::io::Error::other("EBADF-ish")),
+            GitAiError::IoError(std::io::Error::new(ErrorKind::PermissionDenied, "denied")),
+            GitAiError::Generic("stringified".to_string()),
+        ];
+        for error in systemic {
+            assert!(
+                !connection_error_is_peer_disconnect(&error),
+                "{error} should not classify as peer-gone"
+            );
+        }
+    }
+
+    struct MockControlConnection {
+        timeout_error: Option<std::io::ErrorKind>,
+    }
+
+    impl std::io::Read for MockControlConnection {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    impl std::io::Write for MockControlConnection {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl ControlConnection for MockControlConnection {
+        fn set_receive_timeout(&mut self, _timeout: Option<Duration>) -> Result<(), GitAiError> {
+            match self.timeout_error {
+                Some(kind) => Err(GitAiError::IoError(std::io::Error::new(kind, "mock"))),
+                None => Ok(()),
+            }
+        }
+    }
+
+    #[test]
+    fn receive_timeout_failure_drops_the_connection() {
+        let mut healthy = BufReader::new(MockControlConnection {
+            timeout_error: None,
+        });
+        assert!(apply_control_receive_timeout(
+            &mut healthy,
+            Duration::from_secs(2)
+        ));
+
+        for kind in [
+            std::io::ErrorKind::InvalidInput,
+            std::io::ErrorKind::PermissionDenied,
+        ] {
+            let mut failing = BufReader::new(MockControlConnection {
+                timeout_error: Some(kind),
+            });
+            assert!(
+                !apply_control_receive_timeout(&mut failing, Duration::from_secs(2)),
+                "a {kind:?} setsockopt failure must drop the connection"
+            );
+        }
     }
 
     #[test]

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -23,6 +23,9 @@ pub enum ControlRequest {
     /// Signal the daemon that new notes are pending in notes-db and should be flushed.
     #[serde(rename = "notes.flush")]
     FlushNotes,
+    /// Report ingest loss counters (dropped trace payloads/connections).
+    #[serde(rename = "stats.ingest")]
+    StatsIngest,
     #[serde(rename = "snapshot.watermarks")]
     SnapshotWatermarks { repo_working_dir: String },
     #[serde(rename = "bash_session.start")]

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -208,6 +208,21 @@ pub fn metric_batches_dropped() -> u64 {
     METRIC_BATCHES_DROPPED.load(Ordering::Relaxed)
 }
 
+/// Persist metric events straight to SQLite, bypassing the persistence
+/// queue. For reporters that must know the write was accepted and must not
+/// depend on the queue whose loss they report (DaemonIngestAnomaly). Mirrors
+/// the test gating of `observability::log_metrics`.
+pub(crate) fn persist_metrics_now(events: &[MetricEvent]) -> Result<(), GitAiError> {
+    #[cfg(any(test, feature = "test-support"))]
+    {
+        if std::env::var_os("GIT_AI_TEST_METRICS_DB_PATH").is_none() {
+            return Ok(());
+        }
+    }
+
+    store_metrics_in_db(events).map(|_| ())
+}
+
 /// Budget for waiting on the persist worker to catch up when an `await` or
 /// teardown needs the queue's contents to be visible in SQLite.
 const METRICS_PERSIST_DRAIN_DEADLINE: Duration = Duration::from_secs(10);

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -1047,10 +1047,134 @@ impl EventValues for CheckpointValues {
     }
 }
 
+/// Value positions for "daemon_ingest_anomaly" event.
+pub mod daemon_ingest_anomaly_pos {
+    pub const TRACE_PAYLOADS_DROPPED_QUEUE_FULL: usize = 0; // u64 - delta since last report
+    pub const TRACE_CONNECTIONS_DROPPED: usize = 1; // u64 - delta since last report
+    pub const TELEMETRY_METRIC_BATCHES_DROPPED: usize = 2; // u64 - delta since last report
+    pub const CHECKPOINTS_DROPPED: usize = 3; // u64 - delta since last report
+}
+
+/// Values for Event ID 8: daemon_ingest_anomaly
+///
+/// Emitted by the daemon's socket-health loop whenever trace payloads,
+/// trace connections, or telemetry metric batches were dropped since the
+/// previous report. Attribution loss must be loud, never silent.
+///
+/// **Fields:**
+/// | Position | Name | Type |
+/// |----------|------|------|
+/// | 0 | trace_payloads_dropped_queue_full | u64 |
+/// | 1 | trace_connections_dropped | u64 |
+/// | 2 | telemetry_metric_batches_dropped | u64 |
+/// | 3 | checkpoints_dropped | u64 |
+#[derive(Debug, Clone, Default)]
+pub struct DaemonIngestAnomalyValues {
+    pub trace_payloads_dropped_queue_full: PosField<u64>,
+    pub trace_connections_dropped: PosField<u64>,
+    pub telemetry_metric_batches_dropped: PosField<u64>,
+    pub checkpoints_dropped: PosField<u64>,
+}
+
+impl DaemonIngestAnomalyValues {
+    pub fn new(
+        trace_payloads_dropped_queue_full: u64,
+        trace_connections_dropped: u64,
+        telemetry_metric_batches_dropped: u64,
+        checkpoints_dropped: u64,
+    ) -> Self {
+        Self {
+            trace_payloads_dropped_queue_full: Some(Some(trace_payloads_dropped_queue_full)),
+            trace_connections_dropped: Some(Some(trace_connections_dropped)),
+            telemetry_metric_batches_dropped: Some(Some(telemetry_metric_batches_dropped)),
+            checkpoints_dropped: Some(Some(checkpoints_dropped)),
+        }
+    }
+}
+
+impl PosEncoded for DaemonIngestAnomalyValues {
+    fn to_sparse(&self) -> SparseArray {
+        let mut map = SparseArray::new();
+
+        sparse_set(
+            &mut map,
+            daemon_ingest_anomaly_pos::TRACE_PAYLOADS_DROPPED_QUEUE_FULL,
+            u64_to_json(&self.trace_payloads_dropped_queue_full),
+        );
+        sparse_set(
+            &mut map,
+            daemon_ingest_anomaly_pos::TRACE_CONNECTIONS_DROPPED,
+            u64_to_json(&self.trace_connections_dropped),
+        );
+        sparse_set(
+            &mut map,
+            daemon_ingest_anomaly_pos::TELEMETRY_METRIC_BATCHES_DROPPED,
+            u64_to_json(&self.telemetry_metric_batches_dropped),
+        );
+        sparse_set(
+            &mut map,
+            daemon_ingest_anomaly_pos::CHECKPOINTS_DROPPED,
+            u64_to_json(&self.checkpoints_dropped),
+        );
+
+        map
+    }
+
+    fn from_sparse(arr: &SparseArray) -> Self {
+        Self {
+            trace_payloads_dropped_queue_full: sparse_get_u64(
+                arr,
+                daemon_ingest_anomaly_pos::TRACE_PAYLOADS_DROPPED_QUEUE_FULL,
+            ),
+            trace_connections_dropped: sparse_get_u64(
+                arr,
+                daemon_ingest_anomaly_pos::TRACE_CONNECTIONS_DROPPED,
+            ),
+            telemetry_metric_batches_dropped: sparse_get_u64(
+                arr,
+                daemon_ingest_anomaly_pos::TELEMETRY_METRIC_BATCHES_DROPPED,
+            ),
+            checkpoints_dropped: sparse_get_u64(
+                arr,
+                daemon_ingest_anomaly_pos::CHECKPOINTS_DROPPED,
+            ),
+        }
+    }
+}
+
+impl EventValues for DaemonIngestAnomalyValues {
+    fn event_id() -> MetricEventId {
+        MetricEventId::DaemonIngestAnomaly
+    }
+
+    fn to_sparse(&self) -> SparseArray {
+        PosEncoded::to_sparse(self)
+    }
+
+    fn from_sparse(arr: &SparseArray) -> Self {
+        PosEncoded::from_sparse(arr)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::Value;
+
+    #[test]
+    fn daemon_ingest_anomaly_values_round_trip() {
+        use super::PosEncoded;
+
+        let values = DaemonIngestAnomalyValues::new(3, 1, 7, 2);
+        let sparse = PosEncoded::to_sparse(&values);
+        let decoded = <DaemonIngestAnomalyValues as PosEncoded>::from_sparse(&sparse);
+
+        assert_eq!(decoded.trace_payloads_dropped_queue_full, Some(Some(3)));
+        assert_eq!(decoded.trace_connections_dropped, Some(Some(1)));
+        assert_eq!(decoded.telemetry_metric_batches_dropped, Some(Some(7)));
+        assert_eq!(decoded.checkpoints_dropped, Some(Some(2)));
+        assert_eq!(DaemonIngestAnomalyValues::event_id() as u16, 8);
+    }
 
     #[test]
     fn test_committed_values_builder() {

--- a/src/metrics/types.rs
+++ b/src/metrics/types.rs
@@ -23,6 +23,7 @@ pub enum MetricEventId {
     SessionEvent = 5,
     OtelTrace = 6,
     RewriteCommitted = 7,
+    DaemonIngestAnomaly = 8,
 }
 
 /// Trait for event-specific values.

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7324,6 +7324,290 @@ fn await_reflects_triggered_notes_flush() {
     );
 }
 
+/// A control client that connects and vanishes (times out, dies mid-request)
+/// is routine under load — it must not produce ERROR-level noise or affect
+/// the daemon's health.
+#[test]
+#[serial]
+#[cfg(unix)]
+fn control_peer_disconnect_not_logged_as_error() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let mut daemon = DaemonGuard::start_with_env(&repo, &[]);
+    let control_socket_path = daemon_control_socket_path(&repo);
+
+    // Deterministic peer-gone: announce a checkpoint body and vanish before
+    // sending it. The daemon's body read hits EOF mid-request, which must be
+    // classified as a routine peer disconnect, not a daemon error.
+    {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&control_socket_path, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open control connection");
+        stream
+            .write_all(b"{\"method\":\"checkpoint.run\",\"params\":{\"body_bytes\":1000}}\n")
+            .expect("failed to write checkpoint header");
+        stream.flush().expect("failed to flush checkpoint header");
+        // Wait for the ready ack so the daemon is definitely inside the body
+        // read when the connection drops.
+        let mut ready = [0u8; 1];
+        use std::io::Read as _;
+        let _ = stream.read(&mut ready);
+    }
+
+    // Also hammer it with valid pings that never read their responses.
+    for _ in 0..20 {
+        if let Ok(mut stream) =
+            open_local_socket_stream_with_timeout(&control_socket_path, DAEMON_TEST_PROBE_TIMEOUT)
+        {
+            let _ = stream.write_all(b"{\"method\":\"ping\"}\n");
+            let _ = stream.flush();
+        }
+    }
+
+    let started = std::time::Instant::now();
+    loop {
+        if daemon
+            .stderr_contents()
+            .contains("daemon control connection dropped by peer")
+        {
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "peer-gone classification never ran:\n{}",
+            daemon.stderr_contents()
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let response = send_control_request(&control_socket_path, &ControlRequest::Ping)
+        .expect("daemon should still serve control requests after abandoned peers");
+    assert!(
+        response.ok,
+        "ping after abandoned peers failed: {response:?}"
+    );
+
+    let logs = daemon.stderr_contents();
+    assert!(
+        !logs.contains("daemon control connection failed"),
+        "abandoned control peers must not be logged as connection failures:\n{logs}"
+    );
+    daemon.shutdown();
+}
+
+/// Every ingest loss must reach fleet telemetry: the teardown report persists
+/// a DaemonIngestAnomaly event with delta values straight to the metrics DB,
+/// even when the daemon never survived until a periodic health report.
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn daemon_ingest_losses_reported_to_metrics_db_on_shutdown() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+    let metrics_db_dir = tempfile::tempdir().expect("failed to create metrics db dir");
+    let metrics_db_path = metrics_db_dir.path().join("metrics.db");
+
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_CONNECTION_SPAWN_FAILURES", "3"),
+            (
+                "GIT_AI_TEST_METRICS_DB_PATH",
+                metrics_db_path.to_str().unwrap(),
+            ),
+        ],
+    );
+
+    // Readiness consumed one injected failure; drop two more connections.
+    for _ in 0..2 {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&trace_socket_path, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open trace connection");
+        let started = std::time::Instant::now();
+        while started.elapsed() < Duration::from_secs(2) {
+            if stream
+                .write_all(b"\n")
+                .and_then(|_| stream.flush())
+                .is_err()
+            {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    let _ = send_control_request(&control_socket_path, &ControlRequest::Shutdown);
+    daemon.shutdown();
+
+    let db = MetricsDatabase::open_at_path(&metrics_db_path)
+        .expect("metrics db should open at isolated path");
+    let records = db
+        .get_metric_history(0, None, &[8u16])
+        .expect("metric history should load");
+    assert_eq!(
+        records.len(),
+        1,
+        "exactly one DaemonIngestAnomaly report expected, got {}",
+        records.len()
+    );
+    let values = &records[0].event.values;
+    let connections_dropped = values.get("1").and_then(Value::as_u64);
+    assert_eq!(
+        connections_dropped,
+        Some(3),
+        "the report must carry delta values: {values:?}"
+    );
+    drop(db);
+
+    // Control scenario: a daemon with no losses must not emit the event.
+    let clean_repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let clean_metrics_db_path = metrics_db_dir.path().join("clean-metrics.db");
+    let mut clean_daemon = DaemonGuard::start_with_env(
+        &clean_repo,
+        &[(
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            clean_metrics_db_path.to_str().unwrap(),
+        )],
+    );
+    let _ = send_control_request(
+        &daemon_control_socket_path(&clean_repo),
+        &ControlRequest::Shutdown,
+    );
+    clean_daemon.shutdown();
+
+    let clean_db = MetricsDatabase::open_at_path(&clean_metrics_db_path)
+        .expect("clean metrics db should open");
+    let clean_records = clean_db
+        .get_metric_history(0, None, &[8u16])
+        .expect("metric history should load");
+    assert!(
+        clean_records.is_empty(),
+        "a daemon with no losses must not emit DaemonIngestAnomaly: {} records",
+        clean_records.len()
+    );
+}
+
+/// Dropped trace connections are counted and reported through stats.ingest,
+/// so attribution loss is observable instead of silent.
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn trace_connection_drops_reported_via_stats_ingest() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    // Readiness consumes one injected failure; the two test connections
+    // below consume the rest.
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[("GIT_AI_TEST_TRACE_CONNECTION_SPAWN_FAILURES", "3")],
+    );
+    let trace_socket_path = daemon_trace_socket_path(&repo);
+    let control_socket_path = daemon_control_socket_path(&repo);
+
+    for _ in 0..2 {
+        let mut stream =
+            open_local_socket_stream_with_timeout(&trace_socket_path, DAEMON_TEST_PROBE_TIMEOUT)
+                .expect("failed to open trace connection");
+        let started = std::time::Instant::now();
+        while started.elapsed() < Duration::from_secs(2) {
+            if stream
+                .write_all(b"\n")
+                .and_then(|_| stream.flush())
+                .is_err()
+            {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    let response = send_control_request(&control_socket_path, &ControlRequest::StatsIngest)
+        .expect("stats.ingest request failed");
+    assert!(response.ok, "stats.ingest returned error: {response:?}");
+    let data = response.data.expect("stats.ingest should return data");
+    let connections_dropped = data
+        .get("trace_connections_dropped")
+        .and_then(Value::as_u64)
+        .expect("stats.ingest data should include trace_connections_dropped");
+    assert!(
+        connections_dropped >= 2,
+        "expected at least 2 dropped trace connections, got {connections_dropped}: {data}"
+    );
+    assert_eq!(
+        data.get("trace_payloads_dropped_queue_full")
+            .and_then(Value::as_u64),
+        Some(0),
+        "no queue-full drops expected in this scenario: {data}"
+    );
+    daemon.shutdown();
+}
+
+/// A queue-full drop must name the root whose attribution was lost.
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn trace_queue_full_drop_logs_the_dropped_root() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_INGEST_QUEUE_CAPACITY", "1"),
+            ("GIT_AI_TEST_TRACE_INGEST_WORKER_START_DELAY_MS", "5000"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    let mut stream =
+        open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
+            .expect("failed to connect trace socket");
+    write_trace_frames_to_stream(
+        &mut stream,
+        &[
+            json!({
+                "event": "start",
+                "sid": "queue-full-loss-root",
+                "argv": ["git", "commit", "-m", "synthetic"],
+                "time_ns": 40_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "queue-full-loss-root",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 40_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "queue-full-loss-root",
+                "code": 0,
+                "time_ns": 40_100u64,
+            }),
+            trace_atexit_frame("queue-full-loss-root", 0, 40_101u64),
+        ],
+    );
+
+    let started = std::time::Instant::now();
+    loop {
+        let logs = daemon.stderr_contents();
+        if logs.contains("ingest_worker_queue_full") {
+            assert!(
+                logs.contains("queue-full-loss-root"),
+                "queue-full log should name the dropped root:\n{logs}"
+            );
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "daemon never reported the queue-full drop:\n{logs}"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    daemon.shutdown();
+}
+
 #[test]
 fn await_waits_for_metrics_and_notes_flush() {
     let mut mock_api = MockApiServer::start();


### PR DESCRIPTION
Two observability fixes for the failure class in #2157.

Control-plane containment: abandoned control clients are routine under load
(clients have 100ms-2s timeouts and drop connections when the daemon is
busy), and macOS setsockopt returns EINVAL once the peer has already shut
the socket down. Those failures previously escaped as ERROR "daemon control
connection failed" noise - the issue's headline symptom - and a failed
set_receive_timeout aborted the connection through the generic error path.
Now: a receive-timeout setup failure drops just that connection at WARN, and
remaining connection errors are classified so peer-disconnect kinds
(BrokenPipe/ConnectionReset/EOF/timeout) log at WARN with reason=peer_gone
while unexpected failures stay at ERROR.

Loud loss accounting: attribution loss was invisible (a machine could drop
38 of 41 commits' notes in a day with nothing pointing at it). The daemon
now counts trace payloads dropped on a full ingest queue and trace
connections dropped before a reader could serve them; the queue-full log
names the dropped root plus queue capacity/depth so a burst-day loss is
diagnosable from one line. Counters are reported three ways: structured
logs at each increment, a new DaemonIngestAnomaly metric (event id 8)
emitted by the socket-health loop with deltas since the last report, and a
new stats.ingest control request for tests and support diagnostics.

Part 4/4 for #2157.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
