### PR TITLE
Use install-hooks --env in the MSI and macOS PKG installers

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -5,7 +5,8 @@ This directory contains MSI and PKG installer scaffolding for Git AI.
 Package outputs must install `git-ai` only. They must not install a `git`
 wrapper, `git.exe` shim, `git-og`, or any other executable that changes Git
 command routing. Per-user trace2 and editor/agent setup remains the
-responsibility of `git-ai install-hooks`.
+responsibility of `git-ai install-hooks`, which both installers invoke with
+`--env` to also apply the per-user shell/PATH configuration.
 
 The release workflow builds signed/notarized production packages when the
 required Apple and Azure signing secrets are configured. Dry-run releases can
@@ -13,10 +14,13 @@ build unsigned packages for validation. macOS releases include Intel, Apple
 Silicon, and universal PKGs.
 
 The Windows MSI is per-user: it installs under
-`%USERPROFILE%\\.git-ai\\bin` and changes only that user's `PATH`. It has no
-all-users or Administrator install mode. The macOS PKG copies its bundled
+`%USERPROFILE%\\.git-ai\\bin` and changes only that user's `PATH` (the MSI
+owns the user PATH entry and removes it on uninstall; `install-hooks --env`
+additionally configures Git Bash profiles when Git Bash is installed). It has
+no all-users or Administrator install mode. The macOS PKG copies its bundled
 binary into the active console user's `~/.git-ai/bin`, then runs setup as that
-user. It fails if no valid console user is logged in or per-user setup fails.
+user, including adding `~/.git-ai/bin` to the user's shell PATH configs. It
+fails if no valid console user is logged in or per-user setup fails.
 
 For an enterprise endpoint, pass configuration to the MSI when installing:
 

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -34,6 +34,9 @@ GIT_AI_BIN="$GIT_AI_BIN_DIR/git-ai"
 /usr/bin/install -d -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$GIT_AI_BIN_DIR"
 /usr/sbin/chown "$CONSOLE_USER:$USER_GROUP" "$GIT_AI_HOME" "$GIT_AI_BIN_DIR"
 /usr/bin/install -o "$CONSOLE_USER" -g "$USER_GROUP" -m 0755 "$SOURCE_BINARY" "$GIT_AI_BIN"
-/usr/bin/su - "$CONSOLE_USER" -c "\"$GIT_AI_BIN\" install-hooks"
+# --env also adds ~/.git-ai/bin to the user's shell PATH configs. `su -`
+# gives a login environment, so HOME/SHELL are the console user's and any
+# created rc files are owned by them.
+/usr/bin/su - "$CONSOLE_USER" -c "\"$GIT_AI_BIN\" install-hooks --env"
 
 exit 0

--- a/packaging/windows/git-ai.wxs
+++ b/packaging/windows/git-ai.wxs
@@ -41,10 +41,17 @@
 
     <SetProperty
       Id="ConfigureGitAi"
-      Value="install-hooks --api-base &quot;[API_BASE]&quot; --api-key &quot;[API_KEY]&quot;"
+      Value="install-hooks --env --api-base &quot;[API_BASE]&quot; --api-key &quot;[API_KEY]&quot;"
       Before="ConfigureGitAi"
       Sequence="execute"
       Condition="NOT Installed" />
+    <!--
+      ConfigureGitAi runs after WriteEnvironmentStrings so the PATH entry the
+      Environment element above writes is already in place: the env flag then
+      dedupes against it (leaving the MSI as the sole owner of the
+      uninstallable user PATH entry) and only adds the Git Bash shell config.
+    -->
+
     <CustomAction
       Id="ConfigureGitAi"
       FileRef="GitAiExe"
@@ -54,7 +61,7 @@
       Return="check"
       HideTarget="yes" />
     <InstallExecuteSequence>
-      <Custom Action="ConfigureGitAi" After="InstallFiles" Condition="NOT Installed" />
+      <Custom Action="ConfigureGitAi" After="WriteEnvironmentStrings" Condition="NOT Installed" />
     </InstallExecuteSequence>
   </Package>
 </Wix>


### PR DESCRIPTION
## Summary

Follow-up to the `install-hooks --env` stack (#2172–#2174, merged): the packaged installers now invoke `install-hooks --env` so MSI and PKG installs get the same per-user shell/PATH configuration as the shell-script installers.

- **macOS PKG** (`packaging/macos/scripts/postinstall`): previously did no PATH setup at all — users had to add `~/.git-ai/bin` to PATH manually. Setup already runs via `su - "$CONSOLE_USER"`, a login environment, so `--env` sees the right HOME/SHELL and any rc files it creates are owned by the console user (no chown handoff needed).
- **Windows MSI** (`packaging/windows/git-ai.wxs`): the MSI's `Environment` element already owns the user PATH entry (and removes it on uninstall), but Git Bash shadows that PATH with `/mingw64/bin/git` — `--env` closes that gap by configuring Git Bash profiles. To avoid a duplicate PATH entry, the `ConfigureGitAi` custom action is rescheduled from `After="InstallFiles"` to `After="WriteEnvironmentStrings"`: by the time `--env` runs, the MSI's PATH entry is already in `HKCU\Environment`, so the binary's normalized dedupe no-ops on PATH and the MSI remains the sole owner of the uninstallable entry. The action stays `Impersonate="yes"`, so the registry/profile writes target the installing user's hive/home.
- `packaging/README.md` updated to match.

## Deliberately excluded

- **flake.nix**: Nix/home-manager put the package on PATH declaratively; mutating rc files from an activation script would be an anti-pattern.
- **scripts/dev.sh** (`task dev`): dev installs shouldn't edit developer rc files; released installers will already have configured PATH on dev machines.

## Verification

- `sh -n` on the postinstall script; XML validation on the `.wxs`.
- `--env` is idempotent (marker-based), so PKG reinstalls/upgrades re-running postinstall are safe; the MSI action keeps its `NOT Installed` condition.
- The release workflow's MSI/PKG install smoke tests (`test-msi`, `test-pkg`) assert config persistence, ownership, and versioning — none conflict with the added shell config; a dry-run release exercises them end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->