### PR TITLE
Source usage cost estimates from the models.dev catalog

### DIFF
--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -9,7 +9,8 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+#[cfg(windows)]
+use std::time::Duration;
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -135,27 +136,17 @@ fn get_update_check_cache_path() -> Option<PathBuf> {
 }
 
 fn read_update_cache() -> Option<UpdateCache> {
-    let path = get_update_check_cache_path()?;
-    let bytes = fs::read(path).ok()?;
-    serde_json::from_slice(&bytes).ok()
+    crate::utils::read_json_file(&get_update_check_cache_path()?)
 }
 
 fn write_update_cache(cache: &UpdateCache) {
     if let Some(path) = get_update_check_cache_path() {
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-        if let Ok(json) = serde_json::to_vec(cache) {
-            let _ = fs::write(path, json);
-        }
+        crate::utils::write_json_file(&path, cache);
     }
 }
 
 fn current_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::from_secs(0))
-        .as_secs()
+    crate::utils::unix_timestamp_now()
 }
 
 #[cfg(windows)]

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -35,6 +35,10 @@ pub fn handle_usage(args: &[String]) {
         i += 1;
     }
 
+    // Best-effort refresh of the models.dev pricing cache (at most daily)
+    // before stats — and therefore cost estimates — are computed.
+    crate::metrics::model_pricing::refresh_cache_if_stale();
+
     // Fixed 30-day window.
     let since_ts = days_ago(30);
     let period_label = "last 30 days".to_string();

--- a/src/metrics/local_stats.rs
+++ b/src/metrics/local_stats.rs
@@ -8,6 +8,7 @@ use crate::error::GitAiError;
 use crate::metrics::attrs::attr_pos;
 use crate::metrics::db::{MetricHistoryRecord, MetricsDatabase};
 use crate::metrics::events::{checkpoint_pos, committed_pos, session_event_pos};
+use crate::metrics::model_pricing::{ModelPricing, pricing_for};
 use crate::metrics::pos_encoded::{
     sparse_get_string, sparse_get_u32, sparse_get_vec_string, sparse_get_vec_u32,
 };
@@ -578,54 +579,6 @@ impl CodexSessionAccum {
     }
 }
 
-/// Per-million-token pricing for a model (USD).
-struct ModelPricing {
-    input: f64,
-    output: f64,
-    cache_write: f64,
-    cache_read: f64,
-}
-
-/// Built-in pricing estimate, matched by substring of the model id.
-/// Rates are public Anthropic list prices (USD per million tokens) and are
-/// only an estimate — they go stale as pricing changes.
-fn pricing_for(model: &str) -> Option<ModelPricing> {
-    let m = model.to_lowercase();
-    if m.contains("opus") {
-        Some(ModelPricing {
-            input: 15.0,
-            output: 75.0,
-            cache_write: 18.75,
-            cache_read: 1.5,
-        })
-    } else if m.contains("sonnet") {
-        Some(ModelPricing {
-            input: 3.0,
-            output: 15.0,
-            cache_write: 3.75,
-            cache_read: 0.3,
-        })
-    } else if m.contains("haiku") {
-        Some(ModelPricing {
-            input: 0.8,
-            output: 4.0,
-            cache_write: 1.0,
-            cache_read: 0.08,
-        })
-    } else if m.contains("gpt") {
-        // OpenAI GPT-5 family estimate; cache_write unused (codex reports no
-        // cache-creation tokens).
-        Some(ModelPricing {
-            input: 1.25,
-            output: 10.0,
-            cache_write: 1.25,
-            cache_read: 0.125,
-        })
-    } else {
-        None
-    }
-}
-
 fn estimate_cost(acc: &TokenAccum, pricing: &ModelPricing) -> f64 {
     (acc.input as f64 * pricing.input
         + acc.output as f64 * pricing.output
@@ -658,7 +611,7 @@ fn cost_for_message_slice(entries: impl Iterator<Item = (String, TokenAccum)>) -
     }
     model_totals
         .iter()
-        .filter_map(|(model, acc)| pricing_for(model).map(|p| estimate_cost(acc, &p)))
+        .filter_map(|(model, acc)| pricing_for(model).map(|p| estimate_cost(acc, p)))
         .sum()
 }
 
@@ -695,7 +648,7 @@ fn build_token_summary(
         if let Some(pricing) = pricing_for(&short) {
             *cost_by_day
                 .entry(ts_to_local(ts).date_naive())
-                .or_insert(0.0) += estimate_cost(&acc, &pricing);
+                .or_insert(0.0) += estimate_cost(&acc, pricing);
         }
 
         let entry = model_tokens.entry(short.clone()).or_default();
@@ -733,7 +686,7 @@ fn build_token_summary(
         if let Some(pricing) = pricing_for(&short) {
             *cost_by_day
                 .entry(ts_to_local(acc.last_usage_ts).date_naive())
-                .or_insert(0.0) += estimate_cost(&mapped, &pricing);
+                .or_insert(0.0) += estimate_cost(&mapped, pricing);
         }
 
         let entry = model_tokens.entry(short.clone()).or_default();
@@ -789,7 +742,7 @@ fn build_token_summary(
         summary.cache_read += acc.cache_read;
         summary.cache_creation += acc.cache_creation;
 
-        let cost = pricing_for(&model).map(|p| estimate_cost(&acc, &p));
+        let cost = pricing_for(&model).map(|p| estimate_cost(&acc, p));
         if let Some(c) = cost {
             summary.estimated_cost_usd += c;
         }
@@ -1362,11 +1315,20 @@ mod tests {
     }
 
     fn claude_session(ts: u32, repo_url: Option<&str>, session_id: &str) -> MetricHistoryRecord {
+        claude_session_with_model(ts, repo_url, session_id, "claude-sonnet-4-6-20250101")
+    }
+
+    fn claude_session_with_model(
+        ts: u32,
+        repo_url: Option<&str>,
+        session_id: &str,
+        model: &str,
+    ) -> MetricHistoryRecord {
         let values = SessionEventValues::new(json!({
             "message": {
                 "id": "msg-1",
                 "role": "assistant",
-                "model": "claude-sonnet-4-6-20250101",
+                "model": model,
                 "usage": {
                     "input_tokens": 100,
                     "output_tokens": 50,
@@ -1427,6 +1389,46 @@ mod tests {
         assert_eq!(stats.tokens.cache_creation, 10);
         assert_eq!(stats.tokens.by_model[0].model, "claude-sonnet-4-6");
         assert!(stats.buckets.iter().any(|bucket| bucket.ai_lines == 10));
+    }
+
+    #[test]
+    fn token_costs_come_from_models_dev_catalog() {
+        let now = now_ts();
+        let repo = "github.com/acme/project";
+        // A date-suffixed model id that only the models.dev catalog can price
+        // (the id resolves to "claude-fable-5" after the date suffix is stripped).
+        let records = [claude_session_with_model(
+            now.saturating_sub(600),
+            Some(repo),
+            "session-1",
+            "claude-fable-5-20260607",
+        )];
+        let refs: Vec<&MetricHistoryRecord> = records.iter().collect();
+
+        let stats = compute_activity_from_records(
+            &refs,
+            now.saturating_sub(24 * 3600),
+            "last 1 day".to_string(),
+            BucketGranularity::Daily,
+        )
+        .unwrap();
+
+        let pricing = crate::metrics::model_pricing::pricing_for("claude-fable-5")
+            .expect("models.dev catalog must price claude-fable-5");
+        // Token counts from claude_session_with_model: 100 input, 50 output,
+        // 20 cache read, 10 cache creation.
+        let expected = (100.0 * pricing.input
+            + 50.0 * pricing.output
+            + 20.0 * pricing.cache_read
+            + 10.0 * pricing.cache_write)
+            / 1_000_000.0;
+        assert!(expected > 0.0);
+        assert!((stats.tokens.estimated_cost_usd - expected).abs() < 1e-12);
+        assert_eq!(stats.tokens.by_model[0].model, "claude-fable-5");
+        assert_eq!(
+            stats.tokens.by_model[0].estimated_cost_usd,
+            Some(stats.tokens.estimated_cost_usd)
+        );
     }
 
     fn day(y: i32, m: u32, d: u32) -> NaiveDate {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -9,6 +9,7 @@ pub mod attrs;
 pub mod db;
 pub mod events;
 pub mod local_stats;
+pub mod model_pricing;
 pub mod pos_encoded;
 pub mod types;
 

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -6,20 +6,26 @@
 //!
 //! 1. A local cache (`~/.git-ai/internal/models_dev_pricing.json`), refreshed
 //!    from models.dev by `git-ai usage` at most once per day (best-effort —
-//!    failures fall through silently).
+//!    failures fall through silently). The cache only ever holds fetched
+//!    data, so machines that can never reach models.dev keep using the
+//!    embedded snapshot of whatever binary they run.
 //! 2. An embedded snapshot (`models_dev_pricing_snapshot.json`) baked into the
 //!    binary at compile time. Regenerate it with:
 //!    `cargo test regenerate_models_dev_pricing_snapshot -- --ignored`
+//!
+//! Within a catalog, a model id is matched by exact id, then by the longest
+//! catalog id at token boundaries, then by family-base fallback (see
+//! [`PricingCatalog::pricing_for`]).
 //!
 //! Tiered pricing (e.g. higher rates above 200k context) is intentionally
 //! ignored: recorded token usage carries no per-request context size, and the
 //! resulting figures are estimates either way.
 
+use crate::utils::{read_json_file, unix_timestamp_now, write_json_file};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
-use std::sync::OnceLock;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Mutex, OnceLock};
 
 const EMBEDDED_SNAPSHOT: &str = include_str!("models_dev_pricing_snapshot.json");
 const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
@@ -42,6 +48,13 @@ const PROVIDER_ALLOWLIST: [&str; 8] = [
     "moonshotai",
     "zai",
 ];
+
+/// Family tokens used as a last-resort pricing fallback for model ids the
+/// catalog doesn't know (legacy ids like "claude-3-5-sonnet-20241022" or
+/// successors newer than the catalog like "claude-opus-4-9"). Covers the
+/// model families the supported agents emit.
+const FAMILY_FALLBACK_TOKENS: [&str; 7] =
+    ["opus", "sonnet", "haiku", "fable", "gpt", "gemini", "grok"];
 
 /// Per-million-token pricing for a model (USD). Cache fields default to 0 —
 /// models.dev omits them for models without prompt caching.
@@ -75,11 +88,15 @@ impl PricingCatalog {
         ))
     }
 
-    /// Look up pricing for a model id. Exact (case-insensitive) matches win;
-    /// otherwise the longest catalog id that appears in the model id at token
-    /// boundaries is used, which handles date-suffixed snapshots
-    /// ("claude-sonnet-4-6-20250101") and provider-prefixed ids
-    /// ("us.anthropic.claude-fable-5") without hardcoded family rules.
+    /// Look up pricing for a model id (case-insensitive). Resolution order:
+    ///
+    /// 1. Exact id match.
+    /// 2. Longest catalog id occurring in the model id at token boundaries —
+    ///    covers date-suffixed snapshots ("claude-sonnet-4-6-20250101") and
+    ///    provider-prefixed ids ("us.anthropic.claude-fable-5").
+    /// 3. Family-base fallback: ids the catalog doesn't know at all (legacy
+    ///    or too new) are priced like the base model of their family, so
+    ///    they estimate at family rates instead of silently costing $0.
     pub fn pricing_for(&self, model: &str) -> Option<&ModelPricing> {
         let model = model.to_lowercase();
         if let Some(pricing) = self.entries.get(&model) {
@@ -89,6 +106,21 @@ impl PricingCatalog {
             .iter()
             .filter(|(id, _)| contains_at_token_boundary(&model, id))
             .max_by_key(|(id, _)| id.len())
+            .map(|(_, pricing)| pricing)
+            .or_else(|| self.family_fallback(&model))
+    }
+
+    /// Price an unknown model id like the base model of its family: the
+    /// shortest (tie-broken lexicographically) catalog id sharing a family
+    /// token, e.g. "claude-opus-4-1" → "claude-opus-5" rates.
+    fn family_fallback(&self, model: &str) -> Option<&ModelPricing> {
+        let token = FAMILY_FALLBACK_TOKENS
+            .iter()
+            .find(|token| contains_at_token_boundary(model, token))?;
+        self.entries
+            .iter()
+            .filter(|(id, _)| contains_at_token_boundary(id, token))
+            .min_by_key(|(id, _)| (id.len(), id.as_str()))
             .map(|(_, pricing)| pricing)
     }
 }
@@ -111,18 +143,37 @@ fn contains_at_token_boundary(haystack: &str, needle: &str) -> bool {
 }
 
 /// Look up pricing for a model id in the global catalog (local cache when
-/// present, embedded snapshot otherwise).
+/// present, embedded snapshot otherwise). Memoized per distinct id: misses of
+/// the exact-match fast path scan the catalog linearly, and callers invoke
+/// this once per recorded message.
 pub fn pricing_for(model: &str) -> Option<&'static ModelPricing> {
-    catalog().pricing_for(model)
+    static MEMO: OnceLock<Mutex<HashMap<String, Option<&'static ModelPricing>>>> = OnceLock::new();
+    let memo = MEMO.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(cache) = memo.lock()
+        && let Some(cached) = cache.get(model)
+    {
+        return *cached;
+    }
+    let result = catalog().pricing_for(model);
+    if let Ok(mut cache) = memo.lock() {
+        cache.insert(model.to_string(), result);
+    }
+    result
+}
+
+/// True when the process must not touch the user-level pricing cache: unit
+/// tests run in-process (cfg!(test)) and integration-test subprocesses carry
+/// the codebase-wide GIT_AI_TEST_DB_PATH marker. Both always use the embedded
+/// snapshot so results don't depend on developer-machine state.
+fn use_embedded_only() -> bool {
+    cfg!(test) || std::env::var_os("GIT_AI_TEST_DB_PATH").is_some()
 }
 
 fn catalog() -> &'static PricingCatalog {
     static CATALOG: OnceLock<PricingCatalog> = OnceLock::new();
     CATALOG.get_or_init(|| {
-        // In-process unit tests always use the embedded snapshot so results
-        // don't depend on the developer's local pricing cache.
-        if !cfg!(test)
-            && let Some(cache) = cache_path().and_then(|path| read_cache(&path))
+        if !use_embedded_only()
+            && let Some(cache) = cache_path().and_then(|path| read_json_file::<PricingCache>(&path))
             && !cache.models.is_empty()
         {
             return PricingCatalog::from_entries(cache.models);
@@ -148,59 +199,53 @@ fn cache_path() -> Option<PathBuf> {
     crate::config::internal_dir_path().map(|dir| dir.join(CACHE_FILE_NAME))
 }
 
-fn read_cache(path: &std::path::Path) -> Option<PricingCache> {
-    let bytes = std::fs::read(path).ok()?;
-    serde_json::from_slice(&bytes).ok()
-}
-
-fn write_cache(path: &std::path::Path, cache: &PricingCache) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(json) = serde_json::to_vec(cache) {
-        let _ = std::fs::write(path, json);
-    }
-}
-
-fn current_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-}
-
 /// Best-effort refresh of the on-disk pricing cache from models.dev, called
 /// by `git-ai usage` before stats are computed (i.e. before the global
 /// catalog is first read). Skipped in tests and when the last attempt was
-/// less than a day ago; on fetch failure the previous catalog is kept and the
-/// attempt timestamp is still advanced.
+/// less than a day ago.
 pub fn refresh_cache_if_stale() {
-    if std::env::var_os("GIT_AI_TEST_DB_PATH").is_some() {
+    if use_embedded_only() {
         return;
     }
     let Some(path) = cache_path() else {
         return;
     };
-    let now = current_timestamp();
-    let existing = read_cache(&path);
+    let now = unix_timestamp_now();
+    let existing: Option<PricingCache> = read_json_file(&path);
     if let Some(cache) = &existing
-        && now.saturating_sub(cache.last_attempt_at) < REFRESH_INTERVAL_SECS
+        && is_fresh(cache.last_attempt_at, now)
     {
         return;
     }
-    let models = match fetch_and_trim_catalog() {
+    write_json_file(&path, &next_cache(existing, fetch_and_trim_catalog(), now));
+}
+
+/// A refresh attempt at `last_attempt_at` is still fresh at `now` when it
+/// lies within the past refresh interval. Future timestamps (clock skew, a
+/// since-corrected clock) count as stale so a bogus timestamp can't block
+/// refreshes indefinitely.
+fn is_fresh(last_attempt_at: u64, now: u64) -> bool {
+    last_attempt_at <= now && now - last_attempt_at < REFRESH_INTERVAL_SECS
+}
+
+/// Fold a fetch result into the next cache state. On failure the previously
+/// fetched models are kept, but the embedded snapshot is never copied into
+/// the cache: an empty cache keeps falling through to the (possibly newer)
+/// snapshot shipped with the running binary, while the bumped attempt
+/// timestamp still throttles the next fetch.
+fn next_cache(
+    existing: Option<PricingCache>,
+    fetched: Result<BTreeMap<String, ModelPricing>, String>,
+    now: u64,
+) -> PricingCache {
+    let models = match fetched {
         Ok(models) => models,
-        Err(_) => existing
-            .map(|cache| cache.models)
-            .unwrap_or_else(|| embedded_catalog().entries),
+        Err(_) => existing.map(|cache| cache.models).unwrap_or_default(),
     };
-    write_cache(
-        &path,
-        &PricingCache {
-            last_attempt_at: now,
-            models,
-        },
-    );
+    PricingCache {
+        last_attempt_at: now,
+        models,
+    }
 }
 
 fn fetch_and_trim_catalog() -> Result<BTreeMap<String, ModelPricing>, String> {
@@ -302,11 +347,36 @@ mod tests {
     }
 
     #[test]
+    fn lookup_falls_back_to_family_base_pricing() {
+        let catalog = embedded_catalog();
+        // These ids are absent from the catalog (legacy, or newer than the
+        // snapshot) but must estimate at family-base rates rather than $0.
+        // Equality assertions pin the current family base (shortest id).
+        assert_eq!(
+            catalog.pricing_for("claude-3-5-sonnet-20241022"),
+            catalog.pricing_for("claude-sonnet-5"),
+            "legacy sonnet ids price at the sonnet family base"
+        );
+        assert_eq!(
+            catalog.pricing_for("claude-opus-4-1"),
+            catalog.pricing_for("claude-opus-5"),
+            "uncataloged opus ids price at the opus family base"
+        );
+        assert!(
+            catalog.pricing_for("claude-opus-4-9").is_some(),
+            "dash-versioned successors newer than the catalog must not price as $0"
+        );
+        assert!(
+            catalog.pricing_for("gpt-51").is_some(),
+            "unknown gpt-family ids price at the gpt family base"
+        );
+    }
+
+    #[test]
     fn lookup_rejects_non_boundary_substrings_and_unknown_models() {
         let catalog = embedded_catalog();
-        // "gpt-5" appears in both, but not at a token boundary.
+        // "gpt" appears in "somegpt-5", but not at a token boundary.
         assert_eq!(catalog.pricing_for("somegpt-5"), None);
-        assert_eq!(catalog.pricing_for("gpt-51"), None);
         assert_eq!(catalog.pricing_for("totally-unknown-model"), None);
         assert_eq!(catalog.pricing_for(""), None);
     }
@@ -368,10 +438,7 @@ mod tests {
         assert!(trim_catalog(r#"{"anthropic": {"models": {}}}"#).is_err());
     }
 
-    #[test]
-    fn cache_round_trips_through_disk() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(CACHE_FILE_NAME);
+    fn fetched_models() -> BTreeMap<String, ModelPricing> {
         let mut models = BTreeMap::new();
         models.insert(
             "claude-test-1".to_string(),
@@ -382,26 +449,63 @@ mod tests {
                 cache_write: 12.5,
             },
         );
-        write_cache(
-            &path,
-            &PricingCache {
-                last_attempt_at: 1234567890,
-                models: models.clone(),
-            },
-        );
-
-        let cache = read_cache(&path).unwrap();
-        assert_eq!(cache.last_attempt_at, 1234567890);
-        assert_eq!(cache.models, models);
+        models
     }
 
     #[test]
-    fn read_cache_returns_none_for_missing_or_corrupt_files() {
+    fn refresh_failure_never_copies_embedded_data_into_the_cache() {
+        // First-ever attempt fails: the cache records the attempt but stays
+        // empty, so catalog() keeps using the running binary's snapshot.
+        let cache = next_cache(None, Err("offline".to_string()), 100);
+        assert_eq!(cache.last_attempt_at, 100);
+        assert!(cache.models.is_empty());
+
+        // A later failure keeps previously *fetched* models.
+        let existing = PricingCache {
+            last_attempt_at: 100,
+            models: fetched_models(),
+        };
+        let cache = next_cache(Some(existing), Err("offline".to_string()), 200);
+        assert_eq!(cache.last_attempt_at, 200);
+        assert_eq!(cache.models, fetched_models());
+
+        // Success replaces the models outright.
+        let existing = PricingCache {
+            last_attempt_at: 200,
+            models: BTreeMap::new(),
+        };
+        let cache = next_cache(Some(existing), Ok(fetched_models()), 300);
+        assert_eq!(cache.last_attempt_at, 300);
+        assert_eq!(cache.models, fetched_models());
+    }
+
+    #[test]
+    fn staleness_treats_future_timestamps_as_stale() {
+        let now = 1_000_000_000;
+        assert!(is_fresh(now, now));
+        assert!(is_fresh(now - REFRESH_INTERVAL_SECS + 1, now));
+        assert!(!is_fresh(now - REFRESH_INTERVAL_SECS, now));
+        // A clock that was skewed ahead when the cache was written must not
+        // block refreshes after it is corrected.
+        assert!(!is_fresh(now + 1, now));
+        assert!(!is_fresh(u64::MAX, now));
+    }
+
+    #[test]
+    fn cache_round_trips_through_disk() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(CACHE_FILE_NAME);
-        assert!(read_cache(&path).is_none());
-        std::fs::write(&path, "not json").unwrap();
-        assert!(read_cache(&path).is_none());
+        write_json_file(
+            &path,
+            &PricingCache {
+                last_attempt_at: 1234567890,
+                models: fetched_models(),
+            },
+        );
+
+        let cache: PricingCache = read_json_file(&path).unwrap();
+        assert_eq!(cache.last_attempt_at, 1234567890);
+        assert_eq!(cache.models, fetched_models());
     }
 
     /// Regenerates the embedded snapshot from the live models.dev catalog.

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -14,7 +14,7 @@
 //!    `cargo test regenerate_models_dev_pricing_snapshot -- --ignored`
 //!
 //! Within a catalog, a model id is matched by exact id, then by the longest
-//! catalog id at token boundaries, then by family-base fallback (see
+//! catalog id at token boundaries, then by family fallback (see
 //! [`PricingCatalog::pricing_for`]).
 //!
 //! Tiered pricing (e.g. higher rates above 200k context) is intentionally
@@ -94,9 +94,9 @@ impl PricingCatalog {
     /// 2. Longest catalog id occurring in the model id at token boundaries —
     ///    covers date-suffixed snapshots ("claude-sonnet-4-6-20250101") and
     ///    provider-prefixed ids ("us.anthropic.claude-fable-5").
-    /// 3. Family-base fallback: ids the catalog doesn't know at all (legacy
-    ///    or too new) are priced like the base model of their family, so
-    ///    they estimate at family rates instead of silently costing $0.
+    /// 3. Family fallback: ids the catalog doesn't know at all (legacy or
+    ///    too new) are priced like the median-priced model of their family,
+    ///    so they estimate at family rates instead of silently costing $0.
     pub fn pricing_for(&self, model: &str) -> Option<&ModelPricing> {
         let model = model.to_lowercase();
         if let Some(pricing) = self.entries.get(&model) {
@@ -110,18 +110,27 @@ impl PricingCatalog {
             .or_else(|| self.family_fallback(&model))
     }
 
-    /// Price an unknown model id like the base model of its family: the
-    /// shortest (tie-broken lexicographically) catalog id sharing a family
-    /// token, e.g. "claude-opus-4-1" → "claude-opus-5" rates.
+    /// Price an unknown model id like the median-priced catalog model of its
+    /// family (by input rate, tie-broken by output rate then id). The median
+    /// gives a representative family rate that's robust to outliers in either
+    /// direction — legacy expensive entries (gpt-4 at ~24x gpt-5's input
+    /// rate) as much as nano/mini variants — without parsing version numbers.
     fn family_fallback(&self, model: &str) -> Option<&ModelPricing> {
         let token = FAMILY_FALLBACK_TOKENS
             .iter()
             .find(|token| contains_at_token_boundary(model, token))?;
-        self.entries
+        let mut family: Vec<(&String, &ModelPricing)> = self
+            .entries
             .iter()
             .filter(|(id, _)| contains_at_token_boundary(id, token))
-            .min_by_key(|(id, _)| (id.len(), id.as_str()))
-            .map(|(_, pricing)| pricing)
+            .collect();
+        family.sort_by(|(id_a, a), (id_b, b)| {
+            a.input
+                .total_cmp(&b.input)
+                .then(a.output.total_cmp(&b.output))
+                .then(id_a.cmp(id_b))
+        });
+        family.get(family.len() / 2).map(|(_, pricing)| *pricing)
     }
 }
 
@@ -347,28 +356,34 @@ mod tests {
     }
 
     #[test]
-    fn lookup_falls_back_to_family_base_pricing() {
+    fn lookup_falls_back_to_median_family_pricing() {
         let catalog = embedded_catalog();
         // These ids are absent from the catalog (legacy, or newer than the
-        // snapshot) but must estimate at family-base rates rather than $0.
-        // Equality assertions pin the current family base (shortest id).
+        // snapshot) but must estimate at family rates rather than $0. The
+        // equality assertions pin the current family medians.
         assert_eq!(
             catalog.pricing_for("claude-3-5-sonnet-20241022"),
-            catalog.pricing_for("claude-sonnet-5"),
-            "legacy sonnet ids price at the sonnet family base"
+            catalog.pricing_for("claude-sonnet-4-6"),
+            "legacy sonnet ids price at the median sonnet rate"
         );
         assert_eq!(
             catalog.pricing_for("claude-opus-4-1"),
             catalog.pricing_for("claude-opus-5"),
-            "uncataloged opus ids price at the opus family base"
+            "uncataloged opus ids price at the median opus rate"
         );
         assert!(
             catalog.pricing_for("claude-opus-4-9").is_some(),
             "dash-versioned successors newer than the catalog must not price as $0"
         );
+        // The median must not resolve to a family outlier: legacy gpt-4 costs
+        // ~24x the input rate of current gpt-5-generation models.
+        let unknown_gpt = catalog
+            .pricing_for("gpt-51")
+            .expect("gpt family must price");
+        let gpt4 = catalog.pricing_for("gpt-4").expect("snapshot has gpt-4");
         assert!(
-            catalog.pricing_for("gpt-51").is_some(),
-            "unknown gpt-family ids price at the gpt family base"
+            unknown_gpt.input < gpt4.input,
+            "unknown gpt ids must not price at legacy gpt-4 outlier rates"
         );
     }
 

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -1,0 +1,420 @@
+//! Model pricing sourced from the models.dev catalog.
+//!
+//! Pricing data comes from <https://models.dev/api.json>, reduced to a flat
+//! model-id → per-million-token cost map over a first-party provider
+//! allowlist. Lookup resolves from, in order:
+//!
+//! 1. A local cache (`~/.git-ai/internal/models_dev_pricing.json`), refreshed
+//!    from models.dev by `git-ai usage` at most once per day (best-effort —
+//!    failures fall through silently).
+//! 2. An embedded snapshot (`models_dev_pricing_snapshot.json`) baked into the
+//!    binary at compile time. Regenerate it with:
+//!    `cargo test regenerate_models_dev_pricing_snapshot -- --ignored`
+//!
+//! Tiered pricing (e.g. higher rates above 200k context) is intentionally
+//! ignored: recorded token usage carries no per-request context size, and the
+//! resulting figures are estimates either way.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const EMBEDDED_SNAPSHOT: &str = include_str!("models_dev_pricing_snapshot.json");
+const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
+const CACHE_FILE_NAME: &str = "models_dev_pricing.json";
+/// Minimum interval between refresh *attempts* (successful or not), so
+/// offline machines don't stall on the fetch timeout at every invocation.
+const REFRESH_INTERVAL_SECS: u64 = 24 * 3600;
+const FETCH_TIMEOUT_SECS: u64 = 5;
+
+/// Providers whose models are kept when trimming the full models.dev catalog.
+/// Restricted to first-party providers so aggregator/reseller listings can't
+/// shadow canonical model ids with different prices.
+const PROVIDER_ALLOWLIST: [&str; 8] = [
+    "anthropic",
+    "openai",
+    "google",
+    "xai",
+    "deepseek",
+    "mistral",
+    "moonshotai",
+    "zai",
+];
+
+/// Per-million-token pricing for a model (USD). Cache fields default to 0 —
+/// models.dev omits them for models without prompt caching.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModelPricing {
+    pub input: f64,
+    pub output: f64,
+    #[serde(default)]
+    pub cache_read: f64,
+    #[serde(default)]
+    pub cache_write: f64,
+}
+
+/// A set of model pricing entries keyed by lowercased model id.
+pub struct PricingCatalog {
+    entries: BTreeMap<String, ModelPricing>,
+}
+
+impl PricingCatalog {
+    fn from_entries(entries: BTreeMap<String, ModelPricing>) -> Self {
+        Self { entries }
+    }
+
+    fn from_snapshot_json(json: &str) -> Result<Self, serde_json::Error> {
+        let entries: BTreeMap<String, ModelPricing> = serde_json::from_str(json)?;
+        Ok(Self::from_entries(
+            entries
+                .into_iter()
+                .map(|(id, pricing)| (id.to_lowercase(), pricing))
+                .collect(),
+        ))
+    }
+
+    /// Look up pricing for a model id. Exact (case-insensitive) matches win;
+    /// otherwise the longest catalog id that appears in the model id at token
+    /// boundaries is used, which handles date-suffixed snapshots
+    /// ("claude-sonnet-4-6-20250101") and provider-prefixed ids
+    /// ("us.anthropic.claude-fable-5") without hardcoded family rules.
+    pub fn pricing_for(&self, model: &str) -> Option<&ModelPricing> {
+        let model = model.to_lowercase();
+        if let Some(pricing) = self.entries.get(&model) {
+            return Some(pricing);
+        }
+        self.entries
+            .iter()
+            .filter(|(id, _)| contains_at_token_boundary(&model, id))
+            .max_by_key(|(id, _)| id.len())
+            .map(|(_, pricing)| pricing)
+    }
+}
+
+/// True when `needle` occurs in `haystack` with non-alphanumeric characters
+/// (or the string ends) on both sides, so "gpt-5" matches "openai/gpt-5" but
+/// not "chatgpt-5" or "gpt-51".
+fn contains_at_token_boundary(haystack: &str, needle: &str) -> bool {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.is_empty() || n.len() > h.len() {
+        return false;
+    }
+    (0..=h.len() - n.len()).any(|start| {
+        let end = start + n.len();
+        h[start..end] == *n
+            && (start == 0 || !h[start - 1].is_ascii_alphanumeric())
+            && (end == h.len() || !h[end].is_ascii_alphanumeric())
+    })
+}
+
+/// Look up pricing for a model id in the global catalog (local cache when
+/// present, embedded snapshot otherwise).
+pub fn pricing_for(model: &str) -> Option<&'static ModelPricing> {
+    catalog().pricing_for(model)
+}
+
+fn catalog() -> &'static PricingCatalog {
+    static CATALOG: OnceLock<PricingCatalog> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        // In-process unit tests always use the embedded snapshot so results
+        // don't depend on the developer's local pricing cache.
+        if !cfg!(test)
+            && let Some(cache) = cache_path().and_then(|path| read_cache(&path))
+            && !cache.models.is_empty()
+        {
+            return PricingCatalog::from_entries(cache.models);
+        }
+        embedded_catalog()
+    })
+}
+
+fn embedded_catalog() -> PricingCatalog {
+    PricingCatalog::from_snapshot_json(EMBEDDED_SNAPSHOT)
+        .expect("embedded models.dev pricing snapshot must parse")
+}
+
+/// On-disk cache: the trimmed catalog plus the timestamp of the last refresh
+/// attempt (used for throttling, so failed attempts are also spaced out).
+#[derive(Serialize, Deserialize)]
+struct PricingCache {
+    last_attempt_at: u64,
+    models: BTreeMap<String, ModelPricing>,
+}
+
+fn cache_path() -> Option<PathBuf> {
+    crate::config::internal_dir_path().map(|dir| dir.join(CACHE_FILE_NAME))
+}
+
+fn read_cache(path: &std::path::Path) -> Option<PricingCache> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn write_cache(path: &std::path::Path, cache: &PricingCache) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_vec(cache) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+fn current_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Best-effort refresh of the on-disk pricing cache from models.dev, called
+/// by `git-ai usage` before stats are computed (i.e. before the global
+/// catalog is first read). Skipped in tests and when the last attempt was
+/// less than a day ago; on fetch failure the previous catalog is kept and the
+/// attempt timestamp is still advanced.
+pub fn refresh_cache_if_stale() {
+    if std::env::var_os("GIT_AI_TEST_DB_PATH").is_some() {
+        return;
+    }
+    let Some(path) = cache_path() else {
+        return;
+    };
+    let now = current_timestamp();
+    let existing = read_cache(&path);
+    if let Some(cache) = &existing
+        && now.saturating_sub(cache.last_attempt_at) < REFRESH_INTERVAL_SECS
+    {
+        return;
+    }
+    let models = match fetch_and_trim_catalog() {
+        Ok(models) => models,
+        Err(_) => existing
+            .map(|cache| cache.models)
+            .unwrap_or_else(|| embedded_catalog().entries),
+    };
+    write_cache(
+        &path,
+        &PricingCache {
+            last_attempt_at: now,
+            models,
+        },
+    );
+}
+
+fn fetch_and_trim_catalog() -> Result<BTreeMap<String, ModelPricing>, String> {
+    let agent = crate::http::build_agent(Some(FETCH_TIMEOUT_SECS));
+    let response = crate::http::send(agent.get(MODELS_DEV_API_URL))?;
+    if response.status_code != 200 {
+        return Err(format!("HTTP {}", response.status_code));
+    }
+    let body = response.as_str().map_err(|e| e.to_string())?;
+    trim_catalog(body)
+}
+
+/// Reduce a full models.dev `api.json` document to a flat model-id → pricing
+/// map over the provider allowlist. Models without a parseable cost entry
+/// (missing, or lacking input/output rates) are skipped.
+fn trim_catalog(api_json: &str) -> Result<BTreeMap<String, ModelPricing>, String> {
+    let providers: serde_json::Value = serde_json::from_str(api_json).map_err(|e| e.to_string())?;
+    let mut entries = BTreeMap::new();
+    for provider in PROVIDER_ALLOWLIST {
+        let Some(models) = providers
+            .get(provider)
+            .and_then(|p| p.get("models"))
+            .and_then(|m| m.as_object())
+        else {
+            continue;
+        };
+        for (model_id, model) in models {
+            let Some(cost) = model.get("cost") else {
+                continue;
+            };
+            if let Ok(pricing) = serde_json::from_value::<ModelPricing>(cost.clone()) {
+                entries.insert(model_id.to_lowercase(), pricing);
+            }
+        }
+    }
+    if entries.is_empty() {
+        return Err("no priced models found in models.dev catalog".to_string());
+    }
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_snapshot_parses_and_covers_current_models() {
+        let catalog = embedded_catalog();
+        for model in [
+            "claude-fable-5",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "gpt-5.6-sol",
+        ] {
+            let pricing = catalog
+                .pricing_for(model)
+                .unwrap_or_else(|| panic!("snapshot must price {model}"));
+            assert!(pricing.input > 0.0, "{model} input rate must be positive");
+            assert!(pricing.output > 0.0, "{model} output rate must be positive");
+        }
+    }
+
+    #[test]
+    fn lookup_is_case_insensitive() {
+        let catalog = embedded_catalog();
+        assert_eq!(
+            catalog.pricing_for("Claude-Fable-5"),
+            catalog.pricing_for("claude-fable-5")
+        );
+    }
+
+    #[test]
+    fn lookup_matches_date_suffixed_model_ids() {
+        let catalog = embedded_catalog();
+        assert_eq!(
+            catalog.pricing_for("claude-fable-5-20260607"),
+            catalog.pricing_for("claude-fable-5")
+        );
+    }
+
+    #[test]
+    fn lookup_matches_provider_prefixed_model_ids() {
+        let catalog = embedded_catalog();
+        assert_eq!(
+            catalog.pricing_for("us.anthropic.claude-fable-5"),
+            catalog.pricing_for("claude-fable-5")
+        );
+    }
+
+    #[test]
+    fn lookup_prefers_longest_boundary_match() {
+        // "gpt-5.6-sol" contains catalog ids "gpt-5", "gpt-5.6", and
+        // "gpt-5.6-sol" at token boundaries; the exact (longest) one must win.
+        let catalog = embedded_catalog();
+        let sol = catalog.pricing_for("gpt-5.6-sol").unwrap();
+        let base = catalog.pricing_for("gpt-5").unwrap();
+        assert_ne!(sol, base, "gpt-5.6-sol must not fall back to gpt-5 rates");
+    }
+
+    #[test]
+    fn lookup_rejects_non_boundary_substrings_and_unknown_models() {
+        let catalog = embedded_catalog();
+        // "gpt-5" appears in both, but not at a token boundary.
+        assert_eq!(catalog.pricing_for("somegpt-5"), None);
+        assert_eq!(catalog.pricing_for("gpt-51"), None);
+        assert_eq!(catalog.pricing_for("totally-unknown-model"), None);
+        assert_eq!(catalog.pricing_for(""), None);
+    }
+
+    #[test]
+    fn trim_catalog_keeps_allowlisted_priced_models_only() {
+        let api_json = serde_json::json!({
+            "anthropic": {
+                "models": {
+                    "Claude-Test-1": {
+                        "cost": {"input": 1.0, "output": 2.0, "cache_read": 0.1, "cache_write": 1.25}
+                    },
+                    "claude-no-cost": {},
+                    "claude-partial-cost": {"cost": {"input": 1.0}}
+                }
+            },
+            "some-reseller": {
+                "models": {
+                    "claude-test-1": {"cost": {"input": 99.0, "output": 99.0}}
+                }
+            }
+        })
+        .to_string();
+
+        let entries = trim_catalog(&api_json).unwrap();
+        assert_eq!(
+            entries.keys().collect::<Vec<_>>(),
+            vec!["claude-test-1"],
+            "only allowlisted models with full cost entries are kept, keyed lowercase"
+        );
+        let pricing = &entries["claude-test-1"];
+        assert_eq!(pricing.input, 1.0);
+        assert_eq!(pricing.output, 2.0);
+        assert_eq!(pricing.cache_read, 0.1);
+        assert_eq!(pricing.cache_write, 1.25);
+    }
+
+    #[test]
+    fn trim_catalog_defaults_missing_cache_rates_to_zero() {
+        let api_json = serde_json::json!({
+            "openai": {
+                "models": {
+                    "gpt-test-pro": {"cost": {"input": 15.0, "output": 120.0}}
+                }
+            }
+        })
+        .to_string();
+
+        let entries = trim_catalog(&api_json).unwrap();
+        let pricing = &entries["gpt-test-pro"];
+        assert_eq!(pricing.cache_read, 0.0);
+        assert_eq!(pricing.cache_write, 0.0);
+    }
+
+    #[test]
+    fn trim_catalog_rejects_invalid_or_empty_documents() {
+        assert!(trim_catalog("not json").is_err());
+        assert!(trim_catalog("{}").is_err());
+        assert!(trim_catalog(r#"{"anthropic": {"models": {}}}"#).is_err());
+    }
+
+    #[test]
+    fn cache_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CACHE_FILE_NAME);
+        let mut models = BTreeMap::new();
+        models.insert(
+            "claude-test-1".to_string(),
+            ModelPricing {
+                input: 10.0,
+                output: 50.0,
+                cache_read: 1.0,
+                cache_write: 12.5,
+            },
+        );
+        write_cache(
+            &path,
+            &PricingCache {
+                last_attempt_at: 1234567890,
+                models: models.clone(),
+            },
+        );
+
+        let cache = read_cache(&path).unwrap();
+        assert_eq!(cache.last_attempt_at, 1234567890);
+        assert_eq!(cache.models, models);
+    }
+
+    #[test]
+    fn read_cache_returns_none_for_missing_or_corrupt_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CACHE_FILE_NAME);
+        assert!(read_cache(&path).is_none());
+        std::fs::write(&path, "not json").unwrap();
+        assert!(read_cache(&path).is_none());
+    }
+
+    /// Regenerates the embedded snapshot from the live models.dev catalog.
+    /// Run manually when new models ship or prices change:
+    /// `cargo test regenerate_models_dev_pricing_snapshot -- --ignored`
+    #[test]
+    #[ignore]
+    fn regenerate_models_dev_pricing_snapshot() {
+        let entries = fetch_and_trim_catalog().expect("fetching models.dev catalog must succeed");
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/metrics/models_dev_pricing_snapshot.json");
+        let mut json = serde_json::to_string_pretty(&entries).expect("snapshot must serialize");
+        json.push('\n');
+        std::fs::write(&path, json).expect("snapshot file must be writable");
+    }
+}

--- a/src/metrics/models_dev_pricing_snapshot.json
+++ b/src/metrics/models_dev_pricing_snapshot.json
@@ -1,0 +1,938 @@
+{
+  "claude-fable-5": {
+    "input": 10.0,
+    "output": 50.0,
+    "cache_read": 1.0,
+    "cache_write": 12.5
+  },
+  "claude-haiku-4-5": {
+    "input": 1.0,
+    "output": 5.0,
+    "cache_read": 0.1,
+    "cache_write": 1.25
+  },
+  "claude-haiku-4-5-20251001": {
+    "input": 1.0,
+    "output": 5.0,
+    "cache_read": 0.1,
+    "cache_write": 1.25
+  },
+  "claude-opus-4-5": {
+    "input": 5.0,
+    "output": 25.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "claude-opus-4-5-20251101": {
+    "input": 5.0,
+    "output": 25.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "claude-opus-4-6": {
+    "input": 5.0,
+    "output": 25.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "claude-opus-4-7": {
+    "input": 5.0,
+    "output": 25.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "claude-opus-4-8": {
+    "input": 5.0,
+    "output": 25.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "claude-opus-5": {
+    "input": 5.0,
+    "output": 25.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "claude-sonnet-4-5": {
+    "input": 3.0,
+    "output": 15.0,
+    "cache_read": 0.3,
+    "cache_write": 3.75
+  },
+  "claude-sonnet-4-5-20250929": {
+    "input": 3.0,
+    "output": 15.0,
+    "cache_read": 0.3,
+    "cache_write": 3.75
+  },
+  "claude-sonnet-4-6": {
+    "input": 3.0,
+    "output": 15.0,
+    "cache_read": 0.3,
+    "cache_write": 3.75
+  },
+  "claude-sonnet-5": {
+    "input": 2.0,
+    "output": 10.0,
+    "cache_read": 0.2,
+    "cache_write": 2.5
+  },
+  "codestral-latest": {
+    "input": 0.3,
+    "output": 0.9,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "deep-research-max-preview-04-2026": {
+    "input": 2.0,
+    "output": 12.0,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "deep-research-preview-04-2026": {
+    "input": 2.0,
+    "output": 12.0,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "deepseek-chat": {
+    "input": 0.14,
+    "output": 0.28,
+    "cache_read": 0.0028,
+    "cache_write": 0.0
+  },
+  "deepseek-reasoner": {
+    "input": 0.14,
+    "output": 0.28,
+    "cache_read": 0.0028,
+    "cache_write": 0.0
+  },
+  "deepseek-v4-flash": {
+    "input": 0.14,
+    "output": 0.28,
+    "cache_read": 0.0028,
+    "cache_write": 0.0
+  },
+  "deepseek-v4-pro": {
+    "input": 0.435,
+    "output": 0.87,
+    "cache_read": 0.003625,
+    "cache_write": 0.0
+  },
+  "devstral-2512": {
+    "input": 0.4,
+    "output": 2.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "devstral-latest": {
+    "input": 0.4,
+    "output": 2.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "devstral-medium-2507": {
+    "input": 0.4,
+    "output": 2.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "devstral-medium-latest": {
+    "input": 0.4,
+    "output": 2.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "devstral-small-2505": {
+    "input": 0.1,
+    "output": 0.3,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "devstral-small-2507": {
+    "input": 0.1,
+    "output": 0.3,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-computer-use-preview-10-2025": {
+    "input": 1.25,
+    "output": 10.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-flash": {
+    "input": 0.3,
+    "output": 2.5,
+    "cache_read": 0.03,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-flash-image": {
+    "input": 0.3,
+    "output": 30.0,
+    "cache_read": 0.075,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-flash-lite": {
+    "input": 0.1,
+    "output": 0.4,
+    "cache_read": 0.01,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "input": 0.5,
+    "output": 10.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-pro": {
+    "input": 1.25,
+    "output": 10.0,
+    "cache_read": 0.125,
+    "cache_write": 0.0
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "input": 1.0,
+    "output": 20.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3-flash-preview": {
+    "input": 0.5,
+    "output": 3.0,
+    "cache_read": 0.05,
+    "cache_write": 0.0
+  },
+  "gemini-3-pro-image": {
+    "input": 2.0,
+    "output": 120.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3-pro-image-preview": {
+    "input": 2.0,
+    "output": 120.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-image": {
+    "input": 0.5,
+    "output": 60.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-image-preview": {
+    "input": 0.5,
+    "output": 60.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-lite": {
+    "input": 0.25,
+    "output": 1.5,
+    "cache_read": 0.025,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-lite-image": {
+    "input": 0.25,
+    "output": 30.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "input": 0.25,
+    "output": 1.5,
+    "cache_read": 0.025,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-live-preview": {
+    "input": 0.75,
+    "output": 4.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-flash-tts-preview": {
+    "input": 1.0,
+    "output": 20.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-pro-preview": {
+    "input": 2.0,
+    "output": 12.0,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "input": 2.0,
+    "output": 12.0,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "gemini-3.5-flash": {
+    "input": 1.5,
+    "output": 9.0,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "gemini-3.5-flash-lite": {
+    "input": 0.3,
+    "output": 2.5,
+    "cache_read": 0.03,
+    "cache_write": 0.0
+  },
+  "gemini-3.5-live-translate-preview": {
+    "input": 3.5,
+    "output": 21.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-3.6-flash": {
+    "input": 1.5,
+    "output": 7.5,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "gemini-3.7-flash": {
+    "input": 0.75,
+    "output": 3.75,
+    "cache_read": 0.075,
+    "cache_write": 0.0
+  },
+  "gemini-embedding-001": {
+    "input": 0.15,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-embedding-2": {
+    "input": 0.2,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-flash-latest": {
+    "input": 1.5,
+    "output": 9.0,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "gemini-flash-lite-latest": {
+    "input": 0.25,
+    "output": 1.5,
+    "cache_read": 0.025,
+    "cache_write": 0.0
+  },
+  "gemini-omni-flash-preview": {
+    "input": 1.5,
+    "output": 17.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gemini-robotics-er-1.6-preview": {
+    "input": 1.0,
+    "output": 5.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "glm-4.5": {
+    "input": 0.6,
+    "output": 2.2,
+    "cache_read": 0.11,
+    "cache_write": 0.0
+  },
+  "glm-4.5-air": {
+    "input": 0.2,
+    "output": 1.1,
+    "cache_read": 0.03,
+    "cache_write": 0.0
+  },
+  "glm-4.5-flash": {
+    "input": 0.0,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "glm-4.5v": {
+    "input": 0.6,
+    "output": 1.8,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "glm-4.6": {
+    "input": 0.6,
+    "output": 2.2,
+    "cache_read": 0.11,
+    "cache_write": 0.0
+  },
+  "glm-4.6v": {
+    "input": 0.3,
+    "output": 0.9,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "glm-4.7": {
+    "input": 0.6,
+    "output": 2.2,
+    "cache_read": 0.11,
+    "cache_write": 0.0
+  },
+  "glm-4.7-flash": {
+    "input": 0.0,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "glm-4.7-flashx": {
+    "input": 0.07,
+    "output": 0.4,
+    "cache_read": 0.01,
+    "cache_write": 0.0
+  },
+  "glm-5": {
+    "input": 1.0,
+    "output": 3.2,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "glm-5-turbo": {
+    "input": 1.2,
+    "output": 4.0,
+    "cache_read": 0.24,
+    "cache_write": 0.0
+  },
+  "glm-5.1": {
+    "input": 1.4,
+    "output": 4.4,
+    "cache_read": 0.26,
+    "cache_write": 0.0
+  },
+  "glm-5.2": {
+    "input": 1.4,
+    "output": 4.4,
+    "cache_read": 0.26,
+    "cache_write": 0.0
+  },
+  "glm-5v-turbo": {
+    "input": 1.2,
+    "output": 4.0,
+    "cache_read": 0.24,
+    "cache_write": 0.0
+  },
+  "gpt-3.5-turbo": {
+    "input": 0.5,
+    "output": 1.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-4": {
+    "input": 30.0,
+    "output": 60.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-4-turbo": {
+    "input": 10.0,
+    "output": 30.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-4.1": {
+    "input": 2.0,
+    "output": 8.0,
+    "cache_read": 0.5,
+    "cache_write": 0.0
+  },
+  "gpt-4.1-mini": {
+    "input": 0.4,
+    "output": 1.6,
+    "cache_read": 0.1,
+    "cache_write": 0.0
+  },
+  "gpt-4.1-nano": {
+    "input": 0.1,
+    "output": 0.4,
+    "cache_read": 0.025,
+    "cache_write": 0.0
+  },
+  "gpt-4o": {
+    "input": 2.5,
+    "output": 10.0,
+    "cache_read": 1.25,
+    "cache_write": 0.0
+  },
+  "gpt-4o-2024-05-13": {
+    "input": 5.0,
+    "output": 15.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-4o-2024-08-06": {
+    "input": 2.5,
+    "output": 10.0,
+    "cache_read": 1.25,
+    "cache_write": 0.0
+  },
+  "gpt-4o-2024-11-20": {
+    "input": 2.5,
+    "output": 10.0,
+    "cache_read": 1.25,
+    "cache_write": 0.0
+  },
+  "gpt-4o-mini": {
+    "input": 0.15,
+    "output": 0.6,
+    "cache_read": 0.075,
+    "cache_write": 0.0
+  },
+  "gpt-5": {
+    "input": 1.25,
+    "output": 10.0,
+    "cache_read": 0.125,
+    "cache_write": 0.0
+  },
+  "gpt-5-mini": {
+    "input": 0.25,
+    "output": 2.0,
+    "cache_read": 0.025,
+    "cache_write": 0.0
+  },
+  "gpt-5-nano": {
+    "input": 0.05,
+    "output": 0.4,
+    "cache_read": 0.005,
+    "cache_write": 0.0
+  },
+  "gpt-5-pro": {
+    "input": 15.0,
+    "output": 120.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-5.1": {
+    "input": 1.25,
+    "output": 10.0,
+    "cache_read": 0.125,
+    "cache_write": 0.0
+  },
+  "gpt-5.2": {
+    "input": 1.75,
+    "output": 14.0,
+    "cache_read": 0.175,
+    "cache_write": 0.0
+  },
+  "gpt-5.2-chat-latest": {
+    "input": 1.75,
+    "output": 14.0,
+    "cache_read": 0.175,
+    "cache_write": 0.0
+  },
+  "gpt-5.2-pro": {
+    "input": 21.0,
+    "output": 168.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-5.3-chat-latest": {
+    "input": 1.75,
+    "output": 14.0,
+    "cache_read": 0.175,
+    "cache_write": 0.0
+  },
+  "gpt-5.3-codex": {
+    "input": 1.75,
+    "output": 14.0,
+    "cache_read": 0.175,
+    "cache_write": 0.0
+  },
+  "gpt-5.3-codex-spark": {
+    "input": 1.75,
+    "output": 14.0,
+    "cache_read": 0.175,
+    "cache_write": 0.0
+  },
+  "gpt-5.4": {
+    "input": 2.5,
+    "output": 15.0,
+    "cache_read": 0.25,
+    "cache_write": 0.0
+  },
+  "gpt-5.4-mini": {
+    "input": 0.75,
+    "output": 4.5,
+    "cache_read": 0.075,
+    "cache_write": 0.0
+  },
+  "gpt-5.4-nano": {
+    "input": 0.2,
+    "output": 1.25,
+    "cache_read": 0.02,
+    "cache_write": 0.0
+  },
+  "gpt-5.4-pro": {
+    "input": 30.0,
+    "output": 180.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-5.5": {
+    "input": 5.0,
+    "output": 30.0,
+    "cache_read": 0.5,
+    "cache_write": 0.0
+  },
+  "gpt-5.5-pro": {
+    "input": 30.0,
+    "output": 180.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "gpt-5.6": {
+    "input": 5.0,
+    "output": 30.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "gpt-5.6-luna": {
+    "input": 0.2,
+    "output": 1.2,
+    "cache_read": 0.02,
+    "cache_write": 0.25
+  },
+  "gpt-5.6-sol": {
+    "input": 5.0,
+    "output": 30.0,
+    "cache_read": 0.5,
+    "cache_write": 6.25
+  },
+  "gpt-5.6-terra": {
+    "input": 2.0,
+    "output": 12.0,
+    "cache_read": 0.2,
+    "cache_write": 2.5
+  },
+  "gpt-image-2": {
+    "input": 5.0,
+    "output": 30.0,
+    "cache_read": 1.25,
+    "cache_write": 0.0
+  },
+  "gpt-realtime-2.1": {
+    "input": 4.0,
+    "output": 24.0,
+    "cache_read": 0.4,
+    "cache_write": 0.0
+  },
+  "grok-4.20-0309-non-reasoning": {
+    "input": 1.25,
+    "output": 2.5,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "grok-4.20-0309-reasoning": {
+    "input": 1.25,
+    "output": 2.5,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "grok-4.20-multi-agent-0309": {
+    "input": 1.25,
+    "output": 2.5,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "grok-4.3": {
+    "input": 1.25,
+    "output": 2.5,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "grok-4.5": {
+    "input": 2.0,
+    "output": 6.0,
+    "cache_read": 0.3,
+    "cache_write": 0.0
+  },
+  "grok-4.6": {
+    "input": 2.0,
+    "output": 6.0,
+    "cache_read": 0.5,
+    "cache_write": 0.0
+  },
+  "grok-build-0.1": {
+    "input": 1.0,
+    "output": 2.0,
+    "cache_read": 0.2,
+    "cache_write": 0.0
+  },
+  "kimi-k2-0711-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "kimi-k2-0905-preview": {
+    "input": 0.6,
+    "output": 2.5,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "kimi-k2-thinking": {
+    "input": 0.6,
+    "output": 2.5,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "kimi-k2-thinking-turbo": {
+    "input": 1.15,
+    "output": 8.0,
+    "cache_read": 0.15,
+    "cache_write": 0.0
+  },
+  "kimi-k2-turbo-preview": {
+    "input": 2.4,
+    "output": 10.0,
+    "cache_read": 0.6,
+    "cache_write": 0.0
+  },
+  "kimi-k2.5": {
+    "input": 0.6,
+    "output": 3.0,
+    "cache_read": 0.1,
+    "cache_write": 0.0
+  },
+  "kimi-k2.6": {
+    "input": 0.95,
+    "output": 4.0,
+    "cache_read": 0.16,
+    "cache_write": 0.0
+  },
+  "kimi-k2.7-code": {
+    "input": 0.95,
+    "output": 4.0,
+    "cache_read": 0.19,
+    "cache_write": 0.0
+  },
+  "kimi-k2.7-code-highspeed": {
+    "input": 1.9,
+    "output": 8.0,
+    "cache_read": 0.38,
+    "cache_write": 0.0
+  },
+  "kimi-k3": {
+    "input": 3.0,
+    "output": 15.0,
+    "cache_read": 0.3,
+    "cache_write": 0.0
+  },
+  "labs-devstral-small-2512": {
+    "input": 0.0,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "lyria-3-clip-preview": {
+    "input": 0.0,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "lyria-3-pro-preview": {
+    "input": 0.0,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "magistral-medium-latest": {
+    "input": 2.0,
+    "output": 5.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "magistral-small": {
+    "input": 0.5,
+    "output": 1.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "ministral-3b-latest": {
+    "input": 0.04,
+    "output": 0.04,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "ministral-8b-latest": {
+    "input": 0.1,
+    "output": 0.1,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-embed": {
+    "input": 0.1,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-large-2411": {
+    "input": 2.0,
+    "output": 6.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-large-2512": {
+    "input": 0.5,
+    "output": 1.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-large-latest": {
+    "input": 0.5,
+    "output": 1.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-medium-2505": {
+    "input": 0.4,
+    "output": 2.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-medium-2508": {
+    "input": 0.4,
+    "output": 2.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-medium-2604": {
+    "input": 1.5,
+    "output": 7.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-medium-latest": {
+    "input": 1.5,
+    "output": 7.5,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-nemo": {
+    "input": 0.15,
+    "output": 0.15,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-small-2506": {
+    "input": 0.1,
+    "output": 0.3,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-small-2603": {
+    "input": 0.15,
+    "output": 0.6,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "mistral-small-latest": {
+    "input": 0.15,
+    "output": 0.6,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "o1": {
+    "input": 15.0,
+    "output": 60.0,
+    "cache_read": 7.5,
+    "cache_write": 0.0
+  },
+  "o1-pro": {
+    "input": 150.0,
+    "output": 600.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "o3": {
+    "input": 2.0,
+    "output": 8.0,
+    "cache_read": 0.5,
+    "cache_write": 0.0
+  },
+  "o3-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cache_read": 0.55,
+    "cache_write": 0.0
+  },
+  "o3-pro": {
+    "input": 20.0,
+    "output": 80.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "o4-mini": {
+    "input": 1.1,
+    "output": 4.4,
+    "cache_read": 0.275,
+    "cache_write": 0.0
+  },
+  "open-mistral-7b": {
+    "input": 0.25,
+    "output": 0.25,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "open-mistral-nemo": {
+    "input": 0.15,
+    "output": 0.15,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "open-mixtral-8x22b": {
+    "input": 2.0,
+    "output": 6.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "open-mixtral-8x7b": {
+    "input": 0.7,
+    "output": 0.7,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "pixtral-12b": {
+    "input": 0.15,
+    "output": 0.15,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "pixtral-large-latest": {
+    "input": 2.0,
+    "output": 6.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "text-embedding-3-large": {
+    "input": 0.13,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "text-embedding-3-small": {
+    "input": 0.02,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "text-embedding-ada-002": {
+    "input": 0.1,
+    "output": 0.0,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  },
+  "voxtral-small-latest": {
+    "input": 0.1,
+    "output": 0.3,
+    "cache_read": 0.0,
+    "cache_write": 0.0
+  }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -446,9 +446,74 @@ pub fn unescape_git_path(path: &str) -> String {
     })
 }
 
+/// Current Unix time in seconds.
+pub fn unix_timestamp_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Read and deserialize a JSON file, returning None on any error (missing
+/// file, unreadable, or unparseable). For best-effort local caches.
+pub fn read_json_file<T: serde::de::DeserializeOwned>(path: &std::path::Path) -> Option<T> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Best-effort atomic JSON write for local cache files: serialize, write to a
+/// sibling temp file, then rename over the target so concurrent readers never
+/// observe a partial file. Parent directories are created as needed; failures
+/// are silently ignored.
+pub fn write_json_file<T: serde::Serialize>(path: &std::path::Path, value: &T) {
+    let Ok(json) = serde_json::to_vec(value) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    if std::fs::write(&tmp, json).is_ok() && std::fs::rename(&tmp, path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // JSON cache file helpers
+    // =========================================================================
+
+    #[test]
+    fn test_json_file_round_trip_and_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("cache.json");
+
+        write_json_file(&path, &serde_json::json!({"a": 1}));
+        assert_eq!(
+            read_json_file::<serde_json::Value>(&path),
+            Some(serde_json::json!({"a": 1})),
+            "write must create parent dirs and round-trip"
+        );
+
+        write_json_file(&path, &serde_json::json!({"a": 2}));
+        assert_eq!(
+            read_json_file::<serde_json::Value>(&path),
+            Some(serde_json::json!({"a": 2})),
+            "write must atomically replace an existing file"
+        );
+    }
+
+    #[test]
+    fn test_read_json_file_none_for_missing_or_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache.json");
+        assert_eq!(read_json_file::<serde_json::Value>(&path), None);
+        std::fs::write(&path, "not json").unwrap();
+        assert_eq!(read_json_file::<serde_json::Value>(&path), None);
+    }
 
     // =========================================================================
     // LockFile Tests


### PR DESCRIPTION
## Problem

`git-ai usage` estimated token spend from a hand-rolled pricing table in `local_stats.rs` that matched only four model families (`opus`/`sonnet`/`haiku`/`gpt`) by substring, at stale list prices. Any model outside those families — notably `claude-fable-5` — was silently priced at $0, so headline spend, the per-day spend strip, per-repo costs, and $/committed-line could be wildly wrong (e.g. ~$59 reported where ~$2k of usage occurred).

## Change

Pricing now comes from the [models.dev](https://models.dev) catalog, reduced to a flat model-id → per-million-token cost map over a first-party provider allowlist (anthropic, openai, google, xai, deepseek, mistral, moonshotai, zai — resellers/aggregators are excluded so they can't shadow canonical ids with different prices).

- **Embedded snapshot**: `src/metrics/models_dev_pricing_snapshot.json` is baked into the binary via `include_str!`, so pricing always works offline. Regenerate with `cargo test regenerate_models_dev_pricing_snapshot -- --ignored`.
- **Daily best-effort refresh**: `git-ai usage` refreshes an on-disk cache (`~/.git-ai/internal/models_dev_pricing.json`) from `https://models.dev/api.json` at most once per day (5s timeout). The cache records the last *attempt* timestamp, so offline machines don't stall on the fetch at every invocation; on failure the previously fetched catalog is kept. Reuses the shared JSON cache helpers also used by `upgrade.rs`'s update check.
- **Lookup semantics**: exact (case-insensitive) id match first, then the longest catalog id occurring in the model id at token boundaries, then a family-base fallback. This covers date-suffixed snapshots (`claude-sonnet-4-6-20250101`), provider-prefixed ids (`us.anthropic.claude-fable-5`), and legacy/too-new ids (`claude-3-5-sonnet-20241022`, `claude-opus-4-9`) without pricing non-boundary substrings (`somegpt-5`).
- Tiered pricing (e.g. >200k-context rates) is intentionally ignored — recorded usage has no per-request context size, and these are estimates.

The refresh runs only in the `usage` command (not the daemon), so nothing is added to any ingestion or latency-sensitive path, and there are no git spawns.

## Testing

TDD: `token_costs_come_from_models_dev_catalog` in `local_stats.rs` was written first and fails against the old table (fable priced at $0), passing with the new catalog. New unit tests in `model_pricing.rs` cover snapshot parsing/coverage, exact/date-suffixed/provider-prefixed/longest-boundary/family-fallback matching, boundary-substring rejection, catalog trimming (allowlist, partial/missing cost entries, missing cache rates), refresh failure/staleness semantics, and cache round-trips. Full `task test`, `task lint`, `task fmt` pass locally.

## Review follow-ups

A second review pass surfaced 8 findings, all addressed in the follow-up commit:

- **Fetch-failure cache pinning**: the embedded snapshot is no longer copied into the disk cache on failure — the cache only ever holds fetched data, so fetch-blocked machines follow their binary's embedded snapshot across upgrades.
- **Legacy/unknown model coverage**: ids the catalog doesn't know (e.g. `claude-3-5-sonnet-20241022`, `claude-opus-4-1`, or successors newer than the snapshot) now price at family-base rates via a family-token fallback instead of silently $0. This also makes dot- vs dash-versioned unknown ids behave consistently.
- **Clock skew**: a future `last_attempt_at` now counts as stale, so a bogus timestamp can't block refreshes.
- **Code reuse + atomic writes**: shared `read_json_file`/`write_json_file` (temp file + rename)/`unix_timestamp_now` helpers extracted into `utils.rs` and reused by both this cache and `upgrade.rs`'s update-check cache.
- **Test gating**: one `use_embedded_only()` check (`cfg!(test)` + `GIT_AI_TEST_DB_PATH`) gates both cache reads and refreshes.
- **Lookup cost**: `pricing_for` is memoized per distinct model id (it runs once per recorded message; fallback scans are linear over the catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
