### PR TITLE
Add weekly workflow to refresh the models.dev pricing snapshot

### DIFF
--- a/.github/workflows/update-models-dev-pricing.yml
+++ b/.github/workflows/update-models-dev-pricing.yml
@@ -1,0 +1,86 @@
+name: Update models.dev Pricing Snapshot
+
+# Regenerates the embedded models.dev pricing snapshot weekly and opens a PR
+# when prices or the model catalog changed, so the offline fallback used by
+# `git-ai usage` never lags far behind the live catalog.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  SNAPSHOT_PATH: src/metrics/models_dev_pricing_snapshot.json
+  BRANCH: chore/update-models-dev-pricing-snapshot
+
+jobs:
+  update-pricing-snapshot:
+    name: Regenerate pricing snapshot
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Cache dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Regenerate snapshot from models.dev
+        run: cargo test --lib regenerate_models_dev_pricing_snapshot -- --ignored
+
+      - name: Open or update PR if the snapshot changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet "$SNAPSHOT_PATH"; then
+            echo "Snapshot is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Reuse a fixed branch so consecutive weeks update the open PR
+          # instead of accumulating new ones.
+          git checkout -B "$BRANCH"
+          git add "$SNAPSHOT_PATH"
+          git commit -m "chore: update models.dev pricing snapshot"
+          git push --force origin "$BRANCH"
+
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            cat > /tmp/pr-body.md <<'EOF'
+          Automated weekly refresh of the embedded models.dev pricing snapshot used as the offline fallback for `git-ai usage` cost estimates.
+
+          Regenerated from https://models.dev/api.json by the `update-models-dev-pricing` workflow. Review the diff for price changes and new/removed models.
+
+          Note: CI does not start automatically on PRs opened by `GITHUB_TOKEN` — close and reopen this PR to trigger it.
+          EOF
+            # Note: PRs opened with GITHUB_TOKEN don't trigger pull_request
+            # workflows; close and reopen the PR (or push to it) to run CI.
+            gh pr create \
+              --head "$BRANCH" \
+              --title "chore: update models.dev pricing snapshot" \
+              --body-file /tmp/pr-body.md
+          else
+            echo "Open PR for $BRANCH already exists; branch updated."
+          fi

--- a/.github/workflows/update-models-dev-pricing.yml
+++ b/.github/workflows/update-models-dev-pricing.yml
@@ -3,6 +3,15 @@ name: Update models.dev Pricing Snapshot
 # Regenerates the embedded models.dev pricing snapshot weekly and opens a PR
 # when prices or the model catalog changed, so the offline fallback used by
 # `git-ai usage` never lags far behind the live catalog.
+#
+# Security notes:
+# - The default GITHUB_TOKEN stays read-only; only the final push/PR step gets
+#   the write-scoped token, so the cargo build (which runs third-party
+#   build.rs/proc-macro code) never sees credentials (checkout uses
+#   persist-credentials: false).
+# - Fetched catalog data is only ever written to the snapshot file — nothing
+#   from models.dev is interpolated into shell commands, branch names, or PR
+#   text — and it ships exclusively through a human-reviewed PR.
 
 on:
   schedule:
@@ -11,8 +20,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 env:
   SNAPSHOT_PATH: src/metrics/models_dev_pricing_snapshot.json
@@ -22,12 +34,22 @@ jobs:
   update-pricing-snapshot:
     name: Regenerate pricing snapshot
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Don't run the cron (or attempt pushes/PRs) from forks.
+    if: github.repository == 'git-ai-project/git-ai'
+    permissions:
+      contents: write # push the snapshot branch
+      pull-requests: write # open/inspect the snapshot PR
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
+          # Keep the token out of .git/config: the build step below executes
+          # third-party crate build scripts. The push step authenticates
+          # explicitly instead.
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
@@ -59,6 +81,9 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Authenticate git via a credential helper reading GH_TOKEN, which
+          # is scoped to this step only.
+          gh auth setup-git
 
           # Reuse a fixed branch so consecutive weeks update the open PR
           # instead of accumulating new ones.


### PR DESCRIPTION
Regenerates src/metrics/models_dev_pricing_snapshot.json from the live
models.dev catalog every Monday (reusing the ignored regeneration test)
and opens/updates a PR when prices or the model catalog changed, so the
embedded offline fallback for `git-ai usage` never lags far behind.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->