### PR TITLE
Drop unconsumed trace2 frames at ingestion

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8439,6 +8439,29 @@ fn handle_trace_connection_actor_reader<R: Read>(
     read_result.and(finalize_result)
 }
 
+/// Whether the trace readers keep a frame of this event type. Only the
+/// normalizer's consumed events (plus the daemon's own drain probe) ever
+/// leave the reader thread; everything else — the large majority of what a
+/// git process emits — is dropped here, before bookkeeping, sequence
+/// allocation, or an ingest-queue slot. Internally synthesized payloads
+/// (close markers) bypass the readers entirely and are unaffected.
+fn reader_should_ingest_trace_event(event: &str) -> bool {
+    event == TRACE_DRAIN_PROBE_EVENT
+        || crate::daemon::trace_normalizer::INGESTED_TRACE_EVENTS.contains(&event)
+}
+
+/// Extract the event type without a full JSON parse. Only trusted when the
+/// event key is the line's first field — git's trace2 writer always emits it
+/// first, and requiring the prefix means user-controlled content (e.g. a
+/// commit message containing `"event":"…"`) can never be mistaken for the
+/// event key. Any other shape returns None and falls through to the parsed
+/// check.
+fn raw_trace_event_type(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("{\"event\":\"")?;
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
 fn process_trace_connection_line(
     line: &str,
     coordinator: Arc<ActorDaemonCoordinator>,
@@ -8448,11 +8471,21 @@ fn process_trace_connection_line(
     if trimmed.is_empty() {
         return Ok(None);
     }
+    // Fast path: reject unconsumed frames before paying for the JSON parse.
+    if let Some(event) = raw_trace_event_type(trimmed)
+        && !reader_should_ingest_trace_event(event)
+    {
+        return Ok(None);
+    }
     let mut parsed: Value = match serde_json::from_str(trimmed) {
         Ok(v) => v,
         Err(_) => return Ok(None),
     };
-    if parsed.get("event").and_then(Value::as_str) == Some(TRACE_DRAIN_PROBE_EVENT) {
+    let event = parsed
+        .get("event")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if event == TRACE_DRAIN_PROBE_EVENT {
         if let Some(probe_id) = parsed
             .get(TRACE_DRAIN_PROBE_ID_FIELD)
             .and_then(Value::as_u64)
@@ -8462,6 +8495,11 @@ fn process_trace_connection_line(
         return Ok(Some(TraceLineOutcome {
             continue_reading: true,
         }));
+    }
+    // Covers frames the raw prefix couldn't classify (unusual key order or
+    // whitespace).
+    if !reader_should_ingest_trace_event(event) {
+        return Ok(None);
     }
     if let Some(sid) = parsed.get("sid").and_then(Value::as_str) {
         let was_unidentified = observed_roots.is_empty();
@@ -10916,6 +10954,94 @@ mod tests {
         assert!(!ingress.root_argv.contains_key(sid));
         assert!(!ingress.root_definitely_read_only.contains(sid));
         assert!(!ingress.root_open_connections.contains_key(sid));
+    }
+
+    #[test]
+    fn raw_trace_event_type_only_trusts_the_prefix_position() {
+        assert_eq!(
+            raw_trace_event_type(r#"{"event":"start","sid":"s1"}"#),
+            Some("start")
+        );
+        // User-controlled content can embed the pattern; only the prefix is
+        // the real event key.
+        assert_eq!(
+            raw_trace_event_type(
+                r#"{"event":"start","argv":["git","commit","-m","\"event\":\"data\""]}"#
+            ),
+            Some("start")
+        );
+        // Non-prefix shapes are not classified here (fall through to the
+        // parsed check).
+        assert_eq!(raw_trace_event_type(r#"{"sid":"s1","event":"data"}"#), None);
+        assert_eq!(raw_trace_event_type(r#"{ "event":"data"}"#), None);
+        assert_eq!(raw_trace_event_type("not json"), None);
+    }
+
+    #[test]
+    fn reader_ingests_only_consumed_events_and_probes() {
+        for event in [
+            "start",
+            "def_repo",
+            "cmd_name",
+            "def_param",
+            "exit",
+            "atexit",
+        ] {
+            assert!(
+                reader_should_ingest_trace_event(event),
+                "{event} is consumed by the normalizer and must be ingested"
+            );
+        }
+        assert!(reader_should_ingest_trace_event(TRACE_DRAIN_PROBE_EVENT));
+        for event in [
+            "version",
+            "cmd_path",
+            "cmd_ancestry",
+            "cmd_mode",
+            "child_start",
+            "child_exit",
+            "region_enter",
+            "region_leave",
+            "data",
+            "data_json",
+            "thread_start",
+            "error",
+            "signal",
+            "exec",
+            "",
+            // Close markers are synthesized internally and bypass the
+            // readers; one arriving over the socket is not ours.
+            TRACE_CONNECTION_CLOSED_EVENT,
+        ] {
+            assert!(
+                !reader_should_ingest_trace_event(event),
+                "{event:?} is not consumed and must be dropped at ingestion"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn noise_frame_is_dropped_before_any_bookkeeping() {
+        let coord = Arc::new(ActorDaemonCoordinator::new());
+        let mut observed_roots = std::collections::BTreeSet::new();
+
+        let outcome = process_trace_connection_line(
+            r#"{"event":"data","sid":"noise-root","category":"index","label":"x"}"#,
+            coord.clone(),
+            &mut observed_roots,
+        )
+        .unwrap();
+
+        assert!(outcome.is_none(), "noise frames are skipped lines");
+        assert!(
+            observed_roots.is_empty(),
+            "noise frames must not register roots"
+        );
+        let ingress = coord.trace_ingress_state.lock().unwrap();
+        assert!(
+            ingress.root_last_activity_ns.is_empty(),
+            "noise frames must not touch ingress bookkeeping"
+        );
     }
 
     #[tokio::test]

--- a/src/daemon/trace_normalizer.rs
+++ b/src/daemon/trace_normalizer.rs
@@ -60,6 +60,26 @@ pub struct TraceNormalizer<B: GitBackend> {
 
 const COMPLETED_ROOT_RETENTION_LIMIT: usize = 16_384;
 
+/// The trace2 event types `ingest_payload`'s dispatch actually consumes.
+///
+/// Everything else a git process emits (`version`, `cmd_path`,
+/// `cmd_ancestry`, `cmd_mode`, `child_*`, `region_*`, `data`, `data_json`,
+/// `thread_*`, `error`, `signal`, …) is discarded by the dispatch's default
+/// arm, so the trace readers drop those frames at ingestion instead of
+/// letting them occupy ingest-queue slots — only ~6 of the ~25-35 frames a
+/// commit emits are consumed, so this multiplies the queue's effective
+/// headroom. `exec` is matched by the dispatch but explicitly ignored, so it
+/// is dropped too. Keep this list in sync with the dispatch in
+/// `ingest_payload`.
+pub(crate) const INGESTED_TRACE_EVENTS: &[&str] = &[
+    "start",
+    "def_repo",
+    "cmd_name",
+    "def_param",
+    "exit",
+    "atexit",
+];
+
 impl<B: GitBackend> TraceNormalizer<B> {
     pub fn new(backend: Arc<B>) -> Self {
         Self {
@@ -230,6 +250,9 @@ impl<B: GitBackend> TraceNormalizer<B> {
         &mut self,
         payload: &Value,
     ) -> Result<Option<NormalizedCommand>, GitAiError> {
+        // NOTE: keep `INGESTED_TRACE_EVENTS` in sync with the dispatch below —
+        // the trace readers drop every other event type before it can occupy
+        // an ingest-queue slot.
         let event = payload
             .get("event")
             .and_then(Value::as_str)

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2781,6 +2781,96 @@ fn daemon_trace_family_resolution_io_does_not_block_other_readers() {
     );
 }
 
+/// Only ~6 of the ~25-35 frames a mutating git command emits are ever
+/// consumed downstream; the rest must be dropped at ingestion instead of
+/// occupying ingest-queue slots. A queue sized to hold just the consumed
+/// frames must survive a root padded with realistic trace2 noise.
+#[test]
+#[serial]
+#[cfg(not(windows))]
+fn daemon_noise_frames_do_not_consume_ingest_capacity() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    let control_socket_path = daemon_control_socket_path(&repo);
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            // Room for the consumed frames (start, def_repo, cmd_name, exit,
+            // atexit, close marker) but not for the noise.
+            ("GIT_AI_TEST_TRACE_INGEST_QUEUE_CAPACITY", "8"),
+            // Nothing drains while the frames arrive.
+            ("GIT_AI_TEST_TRACE_INGEST_WORKER_START_DELAY_MS", "4000"),
+            ("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS", "3600"),
+            ("GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL", "86400"),
+            ("GIT_AI_DAEMON_MAX_UPTIME_SECS", "86400"),
+        ],
+    );
+    let trace_socket = daemon_trace_socket_path(&repo);
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    let session = repos::test_repo::new_daemon_test_sync_session_id();
+    let session_arg = format!("git-ai.testSyncSession={session}");
+    let sid = "noise-heavy-root";
+    let mut frames = vec![
+        json!({"event": "version", "sid": sid, "evt": "3", "exe": "2.49.0"}),
+        json!({
+            "event": "start",
+            "sid": sid,
+            "argv": ["git", "-c", session_arg, "commit", "-m", "synthetic"],
+            "time_ns": 80_000u64,
+        }),
+        json!({"event": "cmd_path", "sid": sid, "path": "/usr/bin/git"}),
+        json!({"event": "cmd_ancestry", "sid": sid, "ancestry": ["zsh", "login"]}),
+        json!({
+            "event": "def_repo",
+            "sid": sid,
+            "worktree": worktree,
+            "repo": git_dir,
+            "time_ns": 80_001u64,
+        }),
+        json!({"event": "cmd_name", "sid": sid, "name": "commit", "hierarchy": "commit"}),
+    ];
+    for i in 0..10u64 {
+        frames.push(json!({
+            "event": if i % 2 == 0 { "region_enter" } else { "data" },
+            "sid": sid,
+            "time_ns": 80_010 + i,
+            "category": "index",
+            "label": "noise",
+        }));
+    }
+    frames.push(json!({"event": "child_start", "sid": sid, "child_id": 0, "argv": ["hook"]}));
+    frames.push(json!({"event": "child_exit", "sid": sid, "child_id": 0, "code": 0}));
+    frames.push(json!({"event": "exit", "sid": sid, "code": 0, "time_ns": 80_100u64}));
+    frames.push(trace_atexit_frame(sid, 0, 80_101));
+    send_trace_frames(&trace_socket, &frames);
+
+    // Once the worker wakes, the root must complete: noise frames must not
+    // have overflowed the queue (which would fail closed and kill the daemon).
+    let start = std::time::Instant::now();
+    let mut completed = false;
+    while start.elapsed() < Duration::from_secs(15) {
+        if repo
+            .daemon_completion_entries()
+            .iter()
+            .any(|entry| entry.test_sync_session.as_deref() == Some(session.as_str()))
+        {
+            completed = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        completed,
+        "noise frames must be filtered at ingestion, not fill the queue:\n{}",
+        daemon.stderr_contents()
+    );
+    let response = send_control_request(&control_socket_path, &ControlRequest::Ping)
+        .expect("daemon should still be serving after the noise-heavy root");
+    assert!(response.ok, "ping failed: {response:?}");
+    daemon.shutdown();
+}
+
 #[test]
 #[cfg(not(windows))]
 fn daemon_trace_accept_loop_not_serialized_by_silent_connections() {


### PR DESCRIPTION
Only six trace2 event types (start, def_repo, cmd_name, def_param, exit,
atexit) are ever consumed downstream - the normalizer's dispatch discards
everything else in its default arm. Yet the trace readers enqueued every
frame of a mutating root, so the large majority of what a git process emits
(version, cmd_path, cmd_ancestry, child/region/data/thread events, ...)
traveled through JSON parsing, ingress bookkeeping, sequence allocation, and
an ingest-queue slot only to be thrown away by the serial worker. Roughly
25-35 frames per commit, ~6 useful: the 16,384-slot queue effectively held
only ~500 in-flight commits, which is exactly where a 512-commit burst
against a busy worker tipped into fail-closed attribution loss.

Filter at the earliest possible point instead: the reader rejects
unconsumed event types before any bookkeeping, and a strict-prefix raw scan
(git's trace2 writer always emits the event key first; any other shape falls
through to the parsed check, so user-controlled content can never be
mistaken for the event key) rejects most noise before even paying for the
JSON parse. The allowlist lives next to the normalizer dispatch it mirrors.
Drain probes are kept; internally synthesized close markers bypass the
readers entirely and are unaffected. This strictly removes work from the
ingestion hot path and multiplies the queue's effective headroom ~3-5x.

Verified by a queue sized to hold only the consumed frames of one root: a
root padded with realistic trace2 noise previously overflowed it (fail-closed
shutdown, attribution lost); with the filter it completes and the daemon
stays healthy.

Part 5 for #2157.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Reviewer callouts.**
- The allowlist is derived from (and colocated with) the normalizer dispatch; a `NOTE` on the dispatch and the const doc tie them together. `exec` is matched by the dispatch but explicitly ignored, so it is dropped — flag if you want it kept.
- Drop happens before *all* reader-side work (bookkeeping, sequence allocation, ingress locks) and before the JSON parse when the event key is the line-leading field (git's trace2 writer always emits it first; any other shape falls through to the parsed check, so user-controlled content like a commit message containing `"event":"data"` can never be misclassified — unit-tested).
- Safety audit: `root_last_activity_ns` is only used as a liveness key (never read for staleness), GC does not reap roots by activity, `observed_child_commands` comes from child-sid `cmd_name` frames (kept), drain probes are kept, and close markers are synthesized internally and never traverse the reader path.
- This multiplies effective queue headroom (~500 → ~1,500-2,500 in-flight commits) but does not change the overflow policy; the spillover discussion for "never lose attribution" is a separate follow-up.
