### PR TITLE
Log periodic flush-skip reasons on state change, not every pass

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -34,6 +34,53 @@ const MAX_DAEMON_LOG_BUFFER_EVENTS: usize = 5000;
 
 static METRICS_UPLOAD_AVAILABLE: AtomicBool = AtomicBool::new(false);
 static METRICS_METADATA_BACKFILL_STARTED: AtomicBool = AtomicBool::new(false);
+static METRICS_SKIP_LOG_GATE: TransitionLogGate = TransitionLogGate::new();
+static NOTES_SKIP_LOG_GATE: TransitionLogGate = TransitionLogGate::new();
+
+/// Gates a log line that a periodic loop would otherwise emit every pass.
+///
+/// The flush loop runs every 3 seconds, so an unconditional INFO skip line
+/// ("not authenticated", "backend is not Http", ...) writes tens of
+/// thousands of identical lines per day into the daemon log file. The skip
+/// reason still has to be diagnosable from the log, so `log_skip` emits INFO
+/// when the message differs from the previous pass (including the first
+/// occurrence and after `clear`), and demotes unchanged repeats to debug.
+/// Call `clear` when the gated stage proceeds, so a later regression to a
+/// skipping state logs at INFO again.
+struct TransitionLogGate {
+    last_message: std::sync::Mutex<Option<&'static str>>,
+}
+
+impl TransitionLogGate {
+    const fn new() -> Self {
+        Self {
+            last_message: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn log_skip(&self, message: &'static str) {
+        if self.transitioned_to(message) {
+            tracing::info!("{}", message);
+        } else {
+            tracing::debug!("{}", message);
+        }
+    }
+
+    /// Records `message` as the current state; returns whether it changed.
+    fn transitioned_to(&self, message: &'static str) -> bool {
+        let mut last = self.last_message.lock().unwrap_or_else(|e| e.into_inner());
+        if *last == Some(message) {
+            false
+        } else {
+            *last = Some(message);
+            true
+        }
+    }
+
+    fn clear(&self) {
+        *self.last_message.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+}
 static DAEMON_RUN_ID: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 static DAEMON_LOG_UPLOAD_IN_FLIGHT: std::sync::OnceLock<Arc<AtomicBool>> =
     std::sync::OnceLock::new();
@@ -874,11 +921,13 @@ fn flush_pending_metrics() {
     let should_upload = metrics_upload_allowed(&api_base_url, &client);
     METRICS_UPLOAD_AVAILABLE.store(should_upload, Ordering::Relaxed);
     if !should_upload {
-        // Info: pending metrics silently never uploading is an attribution-
-        // telemetry delivery failure; this line makes it diagnosable.
-        tracing::info!("metrics: skipping pending upload, not authenticated");
+        // Pending metrics silently never uploading is an attribution-
+        // telemetry delivery failure; the gate keeps it diagnosable (INFO on
+        // first occurrence) without logging every 3-second flush pass.
+        METRICS_SKIP_LOG_GATE.log_skip("metrics: skipping pending upload, not authenticated");
         return;
     }
+    METRICS_SKIP_LOG_GATE.clear();
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     if let Err(e) = flush_pending_metrics_from_db(&client, deadline) {
@@ -1516,19 +1565,21 @@ pub fn flush_notes() {
     use crate::api::types::{NoteEntry, NotesUploadRequest};
     use crate::config::NotesBackendKind;
 
-    // Skip reasons log at info: a note that silently never uploads is an
-    // attribution-delivery failure, and these lines are what make a
-    // "0 notes uploaded" report diagnosable from the daemon log.
+    // A note that silently never uploads is an attribution-delivery failure,
+    // and these skip lines are what make a "0 notes uploaded" report
+    // diagnosable from the daemon log — but the flush loop calls this every
+    // 3 seconds, so unchanged skip reasons log INFO once, then debug.
     let cfg = Config::fresh();
     if cfg.notes_backend_kind() != NotesBackendKind::Http {
-        tracing::info!("notes: skipping flush, backend is not Http");
+        NOTES_SKIP_LOG_GATE.log_skip("notes: skipping flush, backend is not Http");
         return;
     }
 
     let backend_url = match cfg.notes_backend_url() {
         Some(url) => url.to_string(),
         None => {
-            tracing::info!("notes: skipping flush, notes_backend.backend_url is not configured");
+            NOTES_SKIP_LOG_GATE
+                .log_skip("notes: skipping flush, notes_backend.backend_url is not configured");
             return;
         }
     };
@@ -1536,9 +1587,10 @@ pub fn flush_notes() {
     let client = ApiClient::new(context);
 
     if !client.is_logged_in() && !client.has_api_key() {
-        tracing::info!("notes: skipping flush, not authenticated");
+        NOTES_SKIP_LOG_GATE.log_skip("notes: skipping flush, not authenticated");
         return;
     }
+    NOTES_SKIP_LOG_GATE.clear();
 
     // Dequeue up to 50 pending notes.
     let pending = match crate::notes::db::NotesDatabase::global() {
@@ -1789,6 +1841,27 @@ mod tests {
 
     fn event_json(ts: u32) -> String {
         format!(r#"{{"t":{ts},"e":1,"v":{{}},"a":{{}}}}"#)
+    }
+
+    #[test]
+    fn transition_log_gate_reports_change_only_on_new_message() {
+        let gate = TransitionLogGate::new();
+        assert!(gate.transitioned_to("not authenticated"));
+        assert!(!gate.transitioned_to("not authenticated"));
+        assert!(gate.transitioned_to("backend is not Http"));
+        assert!(!gate.transitioned_to("backend is not Http"));
+        // Flipping back to a previously seen message is still a change.
+        assert!(gate.transitioned_to("not authenticated"));
+    }
+
+    #[test]
+    fn transition_log_gate_clear_rearms_the_gate() {
+        let gate = TransitionLogGate::new();
+        assert!(gate.transitioned_to("not authenticated"));
+        // The skip resolved (e.g. the user logged in)...
+        gate.clear();
+        // ...so a later regression to the same skip reason logs again.
+        assert!(gate.transitioned_to("not authenticated"));
     }
 
     fn unix_now() -> u64 {

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7414,6 +7414,55 @@ fn await_reflects_triggered_notes_flush() {
     );
 }
 
+/// Flush passes that skip for the same unchanged reason must not log INFO
+/// per pass: an unauthenticated daemon runs a flush every 3 seconds, so a
+/// per-pass INFO line writes ~29k lines/day into the daemon log file. The
+/// skip reason logs at INFO once when it first applies (and again when it
+/// changes); unchanged repeats are debug-only.
+#[test]
+fn daemon_flush_skip_reason_logs_once_not_per_pass() {
+    // Default test repo: no API key, not logged in — every flush pass skips
+    // the metrics upload for the same "not authenticated" reason.
+    let repo = TestRepo::new();
+    let control_socket_path = daemon_control_socket_path(&repo);
+
+    // Each trigger runs one serialized flush pass in the telemetry loop.
+    for _ in 0..3 {
+        send_control_request(&control_socket_path, &ControlRequest::FlushNotes)
+            .expect("flush trigger should be accepted");
+        thread::sleep(Duration::from_millis(300));
+    }
+
+    let needle = "metrics: skipping pending upload, not authenticated";
+    let started = std::time::Instant::now();
+    while !repo.daemon_stderr_contents().contains(needle) {
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "skip reason was never logged:\n{}",
+            repo.daemon_stderr_contents()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+    // Let any in-flight flush passes finish before counting occurrences.
+    thread::sleep(Duration::from_millis(500));
+
+    let logs = repo.daemon_stderr_contents();
+    let occurrences = logs.matches(needle).count();
+    assert_eq!(
+        occurrences, 1,
+        "unchanged skip reason should log once, not once per flush pass:\n{}",
+        logs
+    );
+    // The notes-flush skip reason (default backend is GitNotes, not Http) is
+    // gated the same way; passes that flush a telemetry batch hit it.
+    let notes_skips = logs.matches("notes: skipping flush").count();
+    assert!(
+        notes_skips <= 1,
+        "unchanged notes skip reason should log at most once:\n{}",
+        logs
+    );
+}
+
 /// A control client that connects and vanishes (times out, dies mid-request)
 /// is routine under load — it must not produce ERROR-level noise or affect
 /// the daemon's health.


### PR DESCRIPTION
## Problem

Post-merge stress testing of the #2157 stack surfaced one regression: the telemetry flush loop (3s cadence) logs its skip reasons at INFO unconditionally on every pass.

- `metrics: skipping pending upload, not authenticated` — every 3s for any not-logged-in daemon ≈ **29,000 lines/day** in `~/.git-ai/internal/daemon/logs/` (measured: 60 lines per 3-minute idle window; v1.6.23 idles at ~5 lines total).
- `notes: skipping flush, backend is not Http` — the default backend is `GitNotes`, so **every default-config user** hits this on every pass that flushes a telemetry batch, authenticated or not.
- `notes: skipping flush, notes_backend.backend_url is not configured` / `notes: skipping flush, not authenticated` — same cadence for the corresponding configs.

These lines were added for diagnosability (a note/metric that silently never uploads should be explainable from the daemon log), so deleting or blanket-demoting them would trade one problem for another.

## Fix

`TransitionLogGate`: the skip reason logs at INFO when it first applies or **changes**, logs at debug for unchanged repeats, and the gate re-arms when the gated stage proceeds — so a later regression back into a skipping state logs at INFO again. Diagnosability is preserved (the reason is always in the log once), the repetition is gone.

Verified with a release build: an unauthenticated idle daemon now writes 6 log lines per 3 minutes (was 65), matching the v1.6.23 baseline.

## Audit of other periodic log output

Dug through every daemon loop for the same fire-per-iteration pattern:

| Loop | Cadence | Verdict |
|---|---|---|
| Telemetry flush loop | 3s | **the 4 lines fixed here**; upload/batch lines only fire on actual uploads |
| Socket health check | 30s | INFO once at startup; in-loop logs are anomaly-gated (probe failure/restart), where repetition is deliberate loudness |
| Update check | 3600s | ~24 lines/day, negligible |
| Memory watchdog | poll interval | already state-transition gated (warn once on failure, info once on recovery) |
| Ingest worker / family actors / stream workers | per event | activity-proportional per-checkpoint/per-git-op lines, pre-date the #2157 stack (log volumes measured equal between v1.6.23 and main under identical load) |
| `await` progress | while awaiting | already rate-limited by `log_interval` |

## Testing (TDD)

- `daemon_flush_skip_reason_logs_once_not_per_pass` (integration): drives 3 serialized flush passes through `ControlRequest::FlushNotes` on an unauthenticated default-config daemon and asserts the skip line appears exactly once. Red on the previous code (`left: 3, right: 1`), green with the gate.
- `transition_log_gate_*` unit tests: first occurrence → INFO, repeat → debug, reason change → INFO, `clear` re-arms.
- Full suite: 5766 passed, 0 failed. `task lint` / `task fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)