### PR TITLE
ci/actions zizmor gate

### DIFF
--- a/.github/workflows/actions-security-check.yml
+++ b/.github/workflows/actions-security-check.yml
@@ -1,0 +1,41 @@
+name: Actions Security Check
+
+# Static analysis for GitHub Actions security, gated on PRs that touch
+# workflow or Dependabot configuration. Runs zizmor over all of .github/ and
+# fails on any finding of medium or higher severity, so credential leaks,
+# template injection, cache poisoning, and over-broad tokens can't regress.
+#
+# Runs offline (--no-online-audits) so results are deterministic and don't
+# depend on GitHub API state. To reproduce locally:
+#   pipx run zizmor==1.29.0 --no-online-audits --min-severity medium .github/
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor (fails on medium+ findings)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        # zizmor exits non-zero when any finding survives the severity
+        # filter, which fails this check.
+        run: pipx run zizmor==1.29.0 --no-online-audits --min-severity medium .github/


### PR DESCRIPTION
## What

Adds an `Actions Security Check` workflow that runs [zizmor](https://docs.zizmor.sh) — the GitHub Actions static analyzer — on any PR touching `.github/workflows/**` or `.github/dependabot.yml`, failing the check on **any finding of medium or higher severity**.

## Why

c08de56df hardened all existing workflows to zero medium/high zizmor findings (scoped App tokens, `persist-credentials: false` everywhere, step-scoped push auth, template-injection-free run scripts, no poisonable caches in publishing flows, Dependabot cooldown). This check keeps it that way: any workflow change that reintroduces one of those classes fails CI before review.

## Design notes

- **Deterministic**: zizmor is version-pinned (`==1.29.0`, via preinstalled `pipx`) and runs with `--no-online-audits`, so results don't vary with GitHub API state. The same command is documented in the workflow header for local reproduction.
- **Whole-tree scan**: scans all of `.github/` rather than just changed files — cheap (seconds), and catches cross-file regressions.
- **Gate semantics**: zizmor exits non-zero when any finding survives `--min-severity medium` (verified: exit 14 against the pre-hardening tree, exit 0 against current main). Low/informational findings (e.g. intentional ad-hoc agent-CLI installs in nightly workflows) don't block.
- The check workflow itself passes zizmor's pedantic persona with zero findings and follows the same hardening conventions (read-only token, `persist-credentials: false`, timeout, pinned action SHAs, concurrency group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)