### PR TITLE
fix/quiet flush skip logs

### DIFF
--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -874,9 +874,9 @@ fn flush_pending_metrics() {
     let should_upload = metrics_upload_allowed(&api_base_url, &client);
     METRICS_UPLOAD_AVAILABLE.store(should_upload, Ordering::Relaxed);
     if !should_upload {
-        // Info: pending metrics silently never uploading is an attribution-
-        // telemetry delivery failure; this line makes it diagnosable.
-        tracing::info!("metrics: skipping pending upload, not authenticated");
+        // Debug: the flush loop lands here every 3 seconds while
+        // unauthenticated, so anything louder floods the daemon log.
+        tracing::debug!("metrics: skipping pending upload, not authenticated");
         return;
     }
 
@@ -1516,19 +1516,19 @@ pub fn flush_notes() {
     use crate::api::types::{NoteEntry, NotesUploadRequest};
     use crate::config::NotesBackendKind;
 
-    // Skip reasons log at info: a note that silently never uploads is an
-    // attribution-delivery failure, and these lines are what make a
-    // "0 notes uploaded" report diagnosable from the daemon log.
+    // Skip reasons log at debug: the flush loop lands here every 3 seconds
+    // for daemons whose notes backend never uploads (GitNotes default,
+    // missing URL, unauthenticated), so anything louder floods the log.
     let cfg = Config::fresh();
     if cfg.notes_backend_kind() != NotesBackendKind::Http {
-        tracing::info!("notes: skipping flush, backend is not Http");
+        tracing::debug!("notes: skipping flush, backend is not Http");
         return;
     }
 
     let backend_url = match cfg.notes_backend_url() {
         Some(url) => url.to_string(),
         None => {
-            tracing::info!("notes: skipping flush, notes_backend.backend_url is not configured");
+            tracing::debug!("notes: skipping flush, notes_backend.backend_url is not configured");
             return;
         }
     };
@@ -1536,7 +1536,7 @@ pub fn flush_notes() {
     let client = ApiClient::new(context);
 
     if !client.is_logged_in() && !client.has_api_key() {
-        tracing::info!("notes: skipping flush, not authenticated");
+        tracing::debug!("notes: skipping flush, not authenticated");
         return;
     }
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7414,6 +7414,33 @@ fn await_reflects_triggered_notes_flush() {
     );
 }
 
+/// The telemetry flush loop runs every 3 seconds, so its skip reasons
+/// ("not authenticated", "backend is not Http", ...) must log at debug, not
+/// INFO — an unauthenticated or default-config daemon would otherwise write
+/// tens of thousands of identical INFO lines per day into its log file.
+#[test]
+fn daemon_flush_skip_reasons_do_not_log_at_info() {
+    // Default test repo: no API key, GitNotes backend — every flush pass
+    // skips both the metrics upload and the notes flush.
+    let repo = TestRepo::new();
+    let control_socket_path = daemon_control_socket_path(&repo);
+
+    // Each trigger runs one serialized flush pass in the telemetry loop.
+    for _ in 0..3 {
+        send_control_request(&control_socket_path, &ControlRequest::FlushNotes)
+            .expect("flush trigger should be accepted");
+        thread::sleep(Duration::from_millis(300));
+    }
+
+    let logs = repo.daemon_stderr_contents();
+    for needle in ["metrics: skipping pending upload", "notes: skipping flush"] {
+        assert!(
+            !logs.contains(needle),
+            "flush skip reason {needle:?} should not appear at the default log level:\n{logs}"
+        );
+    }
+}
+
 /// A control client that connects and vanishes (times out, dies mid-request)
 /// is routine under load — it must not produce ERROR-level noise or affect
 /// the daemon's health.


### PR DESCRIPTION
## Problem

Post-merge stress testing of the #2157 stack found the telemetry flush loop (3s cadence) logging its skip reasons at INFO unconditionally on every pass:

- `metrics: skipping pending upload, not authenticated` — every 3s for any not-logged-in daemon ≈ **~29k lines/day** in `~/.git-ai/internal/daemon/logs/` (measured 60 lines per 3-minute idle window; v1.6.23 idles at ~5 lines total).
- `notes: skipping flush, backend is not Http` — the default backend is `GitNotes`, so **every default-config user** hits this on each pass that flushes a telemetry batch.
- `notes: skipping flush, notes_backend.backend_url is not configured` / `notes: skipping flush, not authenticated` — same cadence for those configs.

## Fix

Demote the four skip lines to `tracing::debug!`. The reasons stay inspectable with `GIT_AI_DEBUG`/debug-level logging when diagnosing upload issues; the default-level log file stays quiet.

An audit of the other daemon loops (health check, update check, memory watchdog, ingest worker, stream workers) found no other per-iteration log output — they log once at startup, on anomalies, or already state-gate/rate-limit their lines.

Replaces #2193 with a simpler approach.

## Testing (TDD)

- New `daemon_flush_skip_reasons_do_not_log_at_info`: drives three serialized flush passes via `ControlRequest::FlushNotes` on an unauthenticated default-config daemon and asserts neither skip line reaches the default-level daemon log. Red before the change (line present), green after.
- Full suite: 5764 passed, 0 failed. `task lint` / `task fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)